### PR TITLE
Remove Microsoft.CSharp paths for collection initialization

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -97,8 +97,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_BadCtorArgCount = 1729,
         ERR_BadExtensionArgTypes = 1928,
         ERR_BadInstanceArgType = 1929,
-        ERR_BadArgTypesForCollectionAdd = 1950,
-        ERR_InitializerAddHasParamModifiers = 1954,
         ERR_NonInvocableMemberCalled = 1955,
         ERR_NamedArgumentSpecificationBeforeFixedArgument = 5002,
         ERR_BadNamedArgument = 5003,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -287,12 +287,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case ErrorCode.ERR_BadInstanceArgType:
                     codeStr = SR.BadInstanceArgType;
                     break;
-                case ErrorCode.ERR_BadArgTypesForCollectionAdd:
-                    codeStr = SR.BadArgTypesForCollectionAdd;
-                    break;
-                case ErrorCode.ERR_InitializerAddHasParamModifiers:
-                    codeStr = SR.InitializerAddHasParamModifiers;
-                    break;
                 case ErrorCode.ERR_NonInvocableMemberCalled:
                     codeStr = SR.NonInvocableMemberCalled;
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1104,7 +1104,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // Given a method group or indexer group, bind it to the arguments for an 
         // invocation. This method can change the arguments to bind with Extension 
         // Methods
-        private bool BindMethodGroupToArgumentsCore(out GroupToArgsBinderResult pResults, BindingFlag bindFlags, ExprMemberGroup grp, ref Expr args, int carg, bool bindingCollectionAdd, bool bHasNamedArgumentSpecifiers)
+        private bool BindMethodGroupToArgumentsCore(out GroupToArgsBinderResult pResults, BindingFlag bindFlags, ExprMemberGroup grp, ref Expr args, int carg, bool bHasNamedArgumentSpecifiers)
         {
             ArgInfos pargInfo = new ArgInfos {carg = carg};
             FillInArgInfoFromArgList(pargInfo, args);
@@ -1113,7 +1113,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             FillInArgInfoFromArgList(pOriginalArgInfo, args);
 
             GroupToArgsBinder binder = new GroupToArgsBinder(this, bindFlags, grp, pargInfo, pOriginalArgInfo, bHasNamedArgumentSpecifiers, null/*atsDelegate*/);
-            bool retval = bindingCollectionAdd ? binder.BindCollectionAddArgs() : binder.Bind(true /*ReportErrors*/);
+            bool retval = binder.Bind(bReportErrors: true);
 
             pResults = binder.GetResultsOfBind();
             return retval;
@@ -1155,7 +1155,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             GroupToArgsBinderResult result;
-            if (!BindMethodGroupToArgumentsCore(out result, bindFlags, grp, ref args, carg, false, bSeenNamed))
+            if (!BindMethodGroupToArgumentsCore(out result, bindFlags, grp, ref args, carg, bSeenNamed))
             {
                 Debug.Assert(false, "Why didn't BindMethodGroupToArgumentsCore throw an error?");
                 return null;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -45,7 +45,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private int _nWrongCount;
             private bool _bIterateToEndOfNsList;               // we have found an appliacable extension method only itereate to 
             // end of current namespaces extension method list
-            private bool _bBindingCollectionAddArgs;           // Report parameter modifiers as error 
             private readonly GroupToArgsBinderResult _results;
             private readonly List<CandidateFunctionMember> _methList;
             private readonly MethPropWithInst _mpwiParamTypeConstraints;
@@ -84,7 +83,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 _nArgBest = -1;
                 _nWrongCount = 0;
                 _bIterateToEndOfNsList = false;
-                _bBindingCollectionAddArgs = false;
                 _results = new GroupToArgsBinderResult();
                 _methList = new List<CandidateFunctionMember>();
                 _mpwiParamTypeConstraints = new MethPropWithInst();
@@ -122,11 +120,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return _results;
             }
 
-            public bool BindCollectionAddArgs()
-            {
-                _bBindingCollectionAddArgs = true;
-                return Bind(true /* bReportErrors */);
-            }
             private SymbolLoader GetSymbolLoader()
             {
                 return _pExprBinder.GetSymbolLoader();
@@ -1460,14 +1453,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return;
                 }
 
-                if (_bBindingCollectionAddArgs)
-                {
-                    if (ReportErrorsForCollectionAdd())
-                    {
-                        return;
-                    }
-                }
-
                 if (bUseDelegateErrors)
                 {
                     // Point to the Delegate, not the Invoke method
@@ -1478,10 +1463,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if (_results.GetBestResult().Sym.IsMethodSymbol() && _results.GetBestResult().Sym.AsMethodSymbol().IsExtension() && _pGroup.OptionalObject != null)
                     {
                         GetErrorContext().Error(ErrorCode.ERR_BadExtensionArgTypes, _pGroup.OptionalObject.Type, _pGroup.Name, _results.GetBestResult().Sym);
-                    }
-                    else if (_bBindingCollectionAddArgs)
-                    {
-                        GetErrorContext().Error(ErrorCode.ERR_BadArgTypesForCollectionAdd, _results.GetBestResult());
                     }
                     else
                     {
@@ -1534,20 +1515,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
                     }
                 }
-            }
-
-            private bool ReportErrorsForCollectionAdd()
-            {
-                for (int ivar = 0; ivar < _pArguments.carg; ivar++)
-                {
-                    CType var = _pBestParameters[ivar];
-                    if (var is ParameterModifierType)
-                    {
-                        GetErrorContext().ErrorRef(ErrorCode.ERR_InitializerAddHasParamModifiers, _results.GetBestResult());
-                        return true;
-                    }
-                }
-                return false;
             }
         }
     }

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
@@ -422,14 +422,6 @@
           <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Instanzenargument: Konvertierung von {0} in {1} ist nicht möglich.</target>
         </trans-unit>
-        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
-          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die beste Übereinstimmung für die überladene {0}-Methode für den Auflistungsinitialisierer enthält einige ungültige Argumente.</target>
-        </trans-unit>
-        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
-          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Die beste Übereinstimmung für die überladene {0}-Methode für das Auflistungsinitialisiererelement kann nicht verwendet werden. Die Add-Methoden von Auflistungsinitialisierern dürfen keine ref- oder out-Parameter enthalten.</target>
-        </trans-unit>
         <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
           <source>Non-invocable member '{0}' cannot be used like a method.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Der nicht aufrufbare Member "{0}" kann nicht wie eine Methode verwendet werden.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
@@ -422,14 +422,6 @@
           <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Argumento de instancia: no se puede convertir de '{0}' a '{1}'</target>
         </trans-unit>
-        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
-          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">El mejor método Add sobrecargado '{0}' del inicializador de colección tiene algunos argumentos no válidos</target>
-        </trans-unit>
-        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
-          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">La mejor coincidencia de método sobrecargado '{0}' para el elemento inicializador de la colección no se puede usar. Los métodos 'Add' inicializadores de colección no pueden tener parámetros out o ref.</target>
-        </trans-unit>
         <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
           <source>Non-invocable member '{0}' cannot be used like a method.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede usar como método el miembro '{0}' no invocable.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
@@ -422,14 +422,6 @@
           <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Argument d'instance : impossible de convertir '{0}' en '{1}'</target>
         </trans-unit>
-        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
-          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">La méthode Add surchargée '{0}' correspondant le mieux à l'initialiseur de collection a des arguments non valides</target>
-        </trans-unit>
-        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
-          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">La méthode surchargée '{0}' correspondant le mieux à l'élément de l'initialiseur de collection ne peut pas être utilisée. Les méthodes 'Add' de l'initialiseur de collection ne peuvent pas avoir de paramètres ref ou out.</target>
-        </trans-unit>
         <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
           <source>Non-invocable member '{0}' cannot be used like a method.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'utiliser un membre '{0}' ne pouvant pas être appelé comme une méthode.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
@@ -422,14 +422,6 @@
           <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Argomento dell'istanza: impossibile eseguire la conversione da '{0}' a '{1}'</target>
         </trans-unit>
-        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
-          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Il miglior metodo Add di overload '{0}' per l'inizializzatore di raccolta presenta alcuni argomenti non validi</target>
-        </trans-unit>
-        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
-          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare la corrispondenza migliore del metodo di overload '{0}' per l'elemento inizializzatore della raccolta. I metodi 'Add' dell'inizializzatore di raccolta non possono includere parametri ref o out.</target>
-        </trans-unit>
         <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
           <source>Non-invocable member '{0}' cannot be used like a method.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile utilizzare il membro non richiamabile '{0}' come metodo.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
@@ -422,14 +422,6 @@
           <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">インスタンス引数: '{0}' から '{1}' へ変換できません</target>
         </trans-unit>
-        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
-          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">コレクション初期化子に最も適しているオーバーロード Add メソッド '{0}' には無効な引数がいくつか含まれています</target>
-        </trans-unit>
-        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
-          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">コレクション初期化子要素の '{0}' に最も適しているオーバーロード メソッドは使用できません。コレクション初期化子 'Add' メソッドには、ref パラメーターまたは out パラメーターを使用できません。</target>
-        </trans-unit>
         <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
           <source>Non-invocable member '{0}' cannot be used like a method.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">実行不可能なメンバー '{0}' をメソッドのように使用することはできません。</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
@@ -422,14 +422,6 @@
           <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">인스턴스 인수: '{0}'에서 '{1}'(으)로 변환할 수 없습니다.</target>
         </trans-unit>
-        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
-          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">오버로드된 Add 메서드 중 해당 컬렉션 이니셜라이저에 가장 적합한 '{0}'에 잘못된 인수가 있습니다.</target>
-        </trans-unit>
-        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
-          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">컬렉션 이니셜라이저에 대해 '{0}'에 가장 일치하는 오버로드된 메서드를 사용할 수 없습니다. 컬렉션 이니셜라이저 'Add' 메서드에는 ref 또는 out 매개 변수를 사용할 수 없습니다.</target>
-        </trans-unit>
         <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
           <source>Non-invocable member '{0}' cannot be used like a method.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">호출할 수 없는 멤버인 '{0}'은(는) 메서드처럼 사용할 수 없습니다.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
@@ -422,14 +422,6 @@
           <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Instance argument: невозможно преобразовать из "{0}" в "{1}"</target>
         </trans-unit>
-        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
-          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Наиболее подходящий перегруженный метод Add "{0}" для инициализатора коллекции содержит недопустимые аргументы</target>
-        </trans-unit>
-        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
-          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Наиболее подходящий перегруженный метод, соответствующий "{0}" для элемента инициализации коллекции не может быть использован. Методы инициализации коллекции "Add" не имеют ссылочных и выходных параметров.</target>
-        </trans-unit>
         <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
           <source>Non-invocable member '{0}' cannot be used like a method.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Невызываемый член "{0}" не может использоваться как метод.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
@@ -422,14 +422,6 @@
           <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">实例参数: 无法从“{0}”转换为“{1}”</target>
         </trans-unit>
-        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
-          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">集合初始值设定项的最佳重载 Add 方法“{0}”具有一些无效参数</target>
-        </trans-unit>
-        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
-          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法使用集合初始值设定项元素的最佳重载方法匹配项“{0}”。集合初始值设定项“Add”方法不能具有 ref 或 out 参数。</target>
-        </trans-unit>
         <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
           <source>Non-invocable member '{0}' cannot be used like a method.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">不可调用的成员“{0}”不能像方法一样使用。</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
@@ -422,14 +422,6 @@
           <source>Instance argument: cannot convert from '{0}' to '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">執行個體引數: 無法從 '{0}' 轉換為 '{1}'</target>
         </trans-unit>
-        <trans-unit id="BadArgTypesForCollectionAdd" translate="yes" xml:space="preserve">
-          <source>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">集合初始設定式的最佳多載 Add 方法 '{0}' 有一些無效的引數</target>
-        </trans-unit>
-        <trans-unit id="InitializerAddHasParamModifiers" translate="yes" xml:space="preserve">
-          <source>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法使用集合初始設定式項目之最符合的多載方法 '{0}'。集合初始設定式 'Add' 方法不能具有 ref 或 out 參數。</target>
-        </trans-unit>
         <trans-unit id="NonInvocableMemberCalled" translate="yes" xml:space="preserve">
           <source>Non-invocable member '{0}' cannot be used like a method.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">非可叫用 (Non-invocable) 成員 '{0}' 不能做為方法使用。</target>

--- a/src/Microsoft.CSharp/src/Resources/Strings.de.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.de.resx
@@ -324,12 +324,6 @@
   <data name="BadInstanceArgType" xml:space="preserve">
     <value>Instanzenargument: Konvertierung von {0} in {1} ist nicht möglich.</value>
   </data>
-  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
-    <value>Die beste Übereinstimmung für die überladene {0}-Methode für den Auflistungsinitialisierer enthält einige ungültige Argumente.</value>
-  </data>
-  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
-    <value>Die beste Übereinstimmung für die überladene {0}-Methode für das Auflistungsinitialisiererelement kann nicht verwendet werden. Die Add-Methoden von Auflistungsinitialisierern dürfen keine ref- oder out-Parameter enthalten.</value>
-  </data>
   <data name="NonInvocableMemberCalled" xml:space="preserve">
     <value>Der nicht aufrufbare Member "{0}" kann nicht wie eine Methode verwendet werden.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.es.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.es.resx
@@ -324,12 +324,6 @@
   <data name="BadInstanceArgType" xml:space="preserve">
     <value>Argumento de instancia: no se puede convertir de '{0}' a '{1}'</value>
   </data>
-  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
-    <value>El mejor método Add sobrecargado '{0}' del inicializador de colección tiene algunos argumentos no válidos</value>
-  </data>
-  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
-    <value>La mejor coincidencia de método sobrecargado '{0}' para el elemento inicializador de la colección no se puede usar. Los métodos 'Add' inicializadores de colección no pueden tener parámetros out o ref.</value>
-  </data>
   <data name="NonInvocableMemberCalled" xml:space="preserve">
     <value>No se puede usar como método el miembro '{0}' no invocable.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
@@ -324,12 +324,6 @@
   <data name="BadInstanceArgType" xml:space="preserve">
     <value>Argument d'instance : impossible de convertir '{0}' en '{1}'</value>
   </data>
-  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
-    <value>La méthode Add surchargée '{0}' correspondant le mieux à l'initialiseur de collection a des arguments non valides</value>
-  </data>
-  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
-    <value>La méthode surchargée '{0}' correspondant le mieux à l'élément de l'initialiseur de collection ne peut pas être utilisée. Les méthodes 'Add' de l'initialiseur de collection ne peuvent pas avoir de paramètres ref ou out.</value>
-  </data>
   <data name="NonInvocableMemberCalled" xml:space="preserve">
     <value>Impossible d'utiliser un membre '{0}' ne pouvant pas être appelé comme une méthode.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.it.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.it.resx
@@ -324,12 +324,6 @@
   <data name="BadInstanceArgType" xml:space="preserve">
     <value>Argomento dell'istanza: impossibile eseguire la conversione da '{0}' a '{1}'</value>
   </data>
-  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
-    <value>Il miglior metodo Add di overload '{0}' per l'inizializzatore di raccolta presenta alcuni argomenti non validi</value>
-  </data>
-  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
-    <value>Impossibile utilizzare la corrispondenza migliore del metodo di overload '{0}' per l'elemento inizializzatore della raccolta. I metodi 'Add' dell'inizializzatore di raccolta non possono includere parametri ref o out.</value>
-  </data>
   <data name="NonInvocableMemberCalled" xml:space="preserve">
     <value>Impossibile utilizzare il membro non richiamabile '{0}' come metodo.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
@@ -324,12 +324,6 @@
   <data name="BadInstanceArgType" xml:space="preserve">
     <value>インスタンス引数: '{0}' から '{1}' へ変換できません</value>
   </data>
-  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
-    <value>コレクション初期化子に最も適しているオーバーロード Add メソッド '{0}' には無効な引数がいくつか含まれています</value>
-  </data>
-  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
-    <value>コレクション初期化子要素の '{0}' に最も適しているオーバーロード メソッドは使用できません。コレクション初期化子 'Add' メソッドには、ref パラメーターまたは out パラメーターを使用できません。</value>
-  </data>
   <data name="NonInvocableMemberCalled" xml:space="preserve">
     <value>実行不可能なメンバー '{0}' をメソッドのように使用することはできません。</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
@@ -324,12 +324,6 @@
   <data name="BadInstanceArgType" xml:space="preserve">
     <value>인스턴스 인수: '{0}'에서 '{1}'(으)로 변환할 수 없습니다.</value>
   </data>
-  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
-    <value>오버로드된 Add 메서드 중 해당 컬렉션 이니셜라이저에 가장 적합한 '{0}'에 잘못된 인수가 있습니다.</value>
-  </data>
-  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
-    <value>컬렉션 이니셜라이저에 대해 '{0}'에 가장 일치하는 오버로드된 메서드를 사용할 수 없습니다. 컬렉션 이니셜라이저 'Add' 메서드에는 ref 또는 out 매개 변수를 사용할 수 없습니다.</value>
-  </data>
   <data name="NonInvocableMemberCalled" xml:space="preserve">
     <value>호출할 수 없는 멤버인 '{0}'은(는) 메서드처럼 사용할 수 없습니다.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -370,12 +370,6 @@
   <data name="BadInstanceArgType" xml:space="preserve">
     <value>Instance argument: cannot convert from '{0}' to '{1}'</value>
   </data>
-  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
-    <value>The best overloaded Add method '{0}' for the collection initializer has some invalid arguments</value>
-  </data>
-  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
-    <value>The best overloaded method match '{0}' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.</value>
-  </data>
   <data name="NonInvocableMemberCalled" xml:space="preserve">
     <value>Non-invocable member '{0}' cannot be used like a method.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
@@ -324,12 +324,6 @@
   <data name="BadInstanceArgType" xml:space="preserve">
     <value>Instance argument: невозможно преобразовать из "{0}" в "{1}"</value>
   </data>
-  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
-    <value>Наиболее подходящий перегруженный метод Add "{0}" для инициализатора коллекции содержит недопустимые аргументы</value>
-  </data>
-  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
-    <value>Наиболее подходящий перегруженный метод, соответствующий "{0}" для элемента инициализации коллекции не может быть использован. Методы инициализации коллекции "Add" не имеют ссылочных и выходных параметров.</value>
-  </data>
   <data name="NonInvocableMemberCalled" xml:space="preserve">
     <value>Невызываемый член "{0}" не может использоваться как метод.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
@@ -324,12 +324,6 @@
   <data name="BadInstanceArgType" xml:space="preserve">
     <value>实例参数: 无法从“{0}”转换为“{1}”</value>
   </data>
-  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
-    <value>集合初始值设定项的最佳重载 Add 方法“{0}”具有一些无效参数</value>
-  </data>
-  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
-    <value>无法使用集合初始值设定项元素的最佳重载方法匹配项“{0}”。集合初始值设定项“Add”方法不能具有 ref 或 out 参数。</value>
-  </data>
   <data name="NonInvocableMemberCalled" xml:space="preserve">
     <value>不可调用的成员“{0}”不能像方法一样使用。</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
@@ -324,12 +324,6 @@
   <data name="BadInstanceArgType" xml:space="preserve">
     <value>執行個體引數: 無法從 '{0}' 轉換為 '{1}'</value>
   </data>
-  <data name="BadArgTypesForCollectionAdd" xml:space="preserve">
-    <value>集合初始設定式的最佳多載 Add 方法 '{0}' 有一些無效的引數</value>
-  </data>
-  <data name="InitializerAddHasParamModifiers" xml:space="preserve">
-    <value>無法使用集合初始設定式項目之最符合的多載方法 '{0}'。集合初始設定式 'Add' 方法不能具有 ref 或 out 參數。</value>
-  </data>
   <data name="NonInvocableMemberCalled" xml:space="preserve">
     <value>非可叫用 (Non-invocable) 成員 '{0}' 不能做為方法使用。</value>
   </data>


### PR DESCRIPTION
There's no way to express this to the dynamic binder (any use of `dynamic` in an initializer is turned into `Add` calls at the static compilation stage), so `BindMethodGroupToArgumentsCore` is only ever called with `bindingCollectionAdd` as false).

Remove this parameter and those paths that depend on it being true.

Entails the deletion of `ERR_BadArgTypesForCollectionAdd` and `ERR_InitializerAddHasParamModifiers`, contributes to #22470