### PR TITLE
Check PSNE on corefx deserialization, check round-trip on netfx

### DIFF
--- a/src/Common/tests/System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs
+++ b/src/Common/tests/System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs
@@ -118,5 +118,19 @@ namespace System.Runtime.Serialization.Formatters.Tests
             Exception ex = Assert.Throws<TargetInvocationException>(() => constructor.Invoke(new object[] { info, new StreamingContext() }));
             Assert.IsType<PlatformNotSupportedException>(ex.InnerException);
         }
+
+        public static void AssertExceptionDeserializationFailsOrRoundtrips<T>(T exception) where T : Exception
+        {
+            // .NET Core and .NET Native throw PlatformNotSupportedExceptions when deserializing many exceptions.
+            // The .NET Framework has full serialization support. Test whichever is available.
+            if (PlatformDetection.IsFullFramework)
+            {
+                AssertRoundtrips(exception);
+            }
+            else
+            {
+                AssertExceptionDeserializationFails<T>();
+            }
+        }
     }
 }

--- a/src/Microsoft.CSharp/tests/RuntimeBinderExceptionTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderExceptionTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             Assert.Empty(rbe.Data);
             Assert.True((rbe.HResult & 0xFFFF0000) == 0x80130000); // Error from .NET
             Assert.Contains(rbe.GetType().FullName, rbe.Message); // Localized, but should contain type name.
+            BinaryFormatterHelpers.AssertExceptionDeserializationFailsOrRoundtrips(rbe);
         }
 
         [Fact]
@@ -34,6 +35,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             Assert.Same(message, rbe.Message);
             rbe = new RuntimeBinderException(null);
             Assert.Equal(new RuntimeBinderException().Message, rbe.Message);
+            BinaryFormatterHelpers.AssertExceptionDeserializationFailsOrRoundtrips(rbe);
         }
 
 
@@ -44,6 +46,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             Exception inner = new Exception("This is a test exception");
             RuntimeBinderException rbe = new RuntimeBinderException(message, inner);
             Assert.Same(inner, rbe.InnerException);
+            BinaryFormatterHelpers.AssertExceptionDeserializationFailsOrRoundtrips(rbe);
         }
 
         [Fact]

--- a/src/Microsoft.CSharp/tests/RuntimeBinderInternalCompilerExceptionTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderInternalCompilerExceptionTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             Assert.Empty(rbe.Data);
             Assert.True((rbe.HResult & 0xFFFF0000) == 0x80130000); // Error from .NET
             Assert.Contains(rbe.GetType().FullName, rbe.Message); // Localized, but should contain type name.
+            BinaryFormatterHelpers.AssertExceptionDeserializationFailsOrRoundtrips(rbe);
         }
 
         [Fact]
@@ -31,6 +32,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             Assert.Same(message, rbe.Message);
             rbe = new RuntimeBinderInternalCompilerException(null);
             Assert.Equal(new RuntimeBinderInternalCompilerException().Message, rbe.Message);
+            BinaryFormatterHelpers.AssertExceptionDeserializationFailsOrRoundtrips(rbe);
         }
 
 
@@ -41,6 +43,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             Exception inner = new Exception("This is a test exception");
             RuntimeBinderInternalCompilerException rbe = new RuntimeBinderInternalCompilerException(message, inner);
             Assert.Same(inner, rbe.InnerException);
+            BinaryFormatterHelpers.AssertExceptionDeserializationFailsOrRoundtrips(rbe);
         }
     }
 }

--- a/src/Microsoft.Win32.Primitives/tests/Win32ExceptionTests.cs
+++ b/src/Microsoft.Win32.Primitives/tests/Win32ExceptionTests.cs
@@ -100,9 +100,9 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void Deserialize_NetCore_ThrowsPlatformNotSupportedException()
+        public static void DeserializeNetCoreThrowsPlatformNotSupportedExceptionNetFXRoundTrips()
         {
-            BinaryFormatterHelpers.AssertExceptionDeserializationFails<Win32Exception>();
+            BinaryFormatterHelpers.AssertExceptionDeserializationFailsOrRoundtrips(new Win32Exception(0x268));
         }
     }
 }


### PR DESCRIPTION
This extends @hughbe's helper from #20984 for testing that exceptions throw PSNE on deserialization, so that for `IsFullFramework` rather than abort the test, it tests round-tripping.

The test that PR included is changed to use this adaptive test, and some round-trip tests that @morganbr removed in #19742 are brought back using this new helper.