### PR TITLE
Remove two checks for EXPRFLAG values in Microsoft.CSharp that are never set

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -67,7 +67,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_CantCallSpecialMethod = 571,
         ERR_BogusType = 648,
         ERR_MissingPredefinedMember = 656,
-        ERR_LiteralDoubleCast = 664,
         ERR_ConvertToStaticClass = 716,
         ERR_GenericArgIsStaticClass = 718,
         ERR_PartialMethodToDelegate = 762,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -197,9 +197,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case ErrorCode.ERR_MissingPredefinedMember:
                     codeStr = SR.MissingPredefinedMember;
                     break;
-                case ErrorCode.ERR_LiteralDoubleCast:
-                    codeStr = SR.LiteralDoubleCast;
-                    break;
                 case ErrorCode.ERR_ConvertToStaticClass:
                     codeStr = SR.ConvertToStaticClass;
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -395,16 +395,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         exprResult.SetError();
                         return exprResult;
                     }
-                    else if (ftSrc == FUNDTYPE.FT_R8 && (0 != (expr.Flags & EXPRFLAG.EXF_LITERALCONST)) &&
-                             (dest.isPredefType(PredefinedType.PT_FLOAT) || dest.isPredefType(PredefinedType.PT_DECIMAL)))
-                    {
-                        // Tried to assign a literal of type double (the default) to a float or decimal. Suggest use
-                        // of a 'F' or 'M' suffix.
-                        ErrorContext.Error(ErrorCode.ERR_LiteralDoubleCast, dest.isPredefType(PredefinedType.PT_DECIMAL) ? "M" : "F", dest);
-                        exprResult = ExprFactory.CreateCast(0, destExpr, expr);
-                        exprResult.SetError();
-                        return exprResult;
-                    }
                 }
 
                 if (expr.Type is NullType && dest.fundType() != FUNDTYPE.FT_REF)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1617,15 +1617,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (isStatic)
             {
-                // If we're static and we don't have an object, or we have an implicit this, 
-                // then we're ok. The reason implicit this is ok is because if the user is
-                // just typing something like:
-                //
-                //      Equals(
-                //
-                // then the implicit this can bind to statics.
-
-                if (pObject == null || ((pObject.Flags & EXPRFLAG.EXF_IMPLICITTHIS) != 0))
+                // If we're static and we don't have an object then we're ok.
+                if (pObject == null)
                 {
                     return true;
                 }

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
@@ -302,10 +302,6 @@
           <source>Missing compiler required member '{0}.{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Der vom Compiler angeforderte Member "{0}.{1}" fehlt.</target>
         </trans-unit>
-        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
-          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Literale vom Typ "double" können nicht implizit in den {1}-Typ konvertiert werden. Verwenden Sie ein {0}-Suffix, um ein Literal mit diesem Typ zu erstellen.</target>
-        </trans-unit>
         <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
           <source>Cannot convert to static type '{0}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Die Konvertierung in den statischen {0}-Typ ist nicht möglich.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
@@ -302,10 +302,6 @@
           <source>Missing compiler required member '{0}.{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Falta el miembro '{0}.{1}' que requiere el compilador.</target>
         </trans-unit>
-        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
-          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">El literal de tipo double no se puede convertir implícitamente en el tipo '{1}'; use un sufijo '{0}' para crear un literal de este tipo</target>
-        </trans-unit>
         <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
           <source>Cannot convert to static type '{0}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede convertir en el tipo estático '{0}'</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
@@ -302,10 +302,6 @@
           <source>Missing compiler required member '{0}.{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Membre requis par le compilateur '{0}.{1}' manquant</target>
         </trans-unit>
-        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
-          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir implicitement un littéral de type double en type '{1}' ; utilisez un suffixe '{0}' pour créer un littéral de ce type</target>
-        </trans-unit>
         <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
           <source>Cannot convert to static type '{0}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de convertir en type static '{0}'</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
@@ -302,10 +302,6 @@
           <source>Missing compiler required member '{0}.{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Manca il membro '{0}.{1}', necessario per il compilatore.</target>
         </trans-unit>
-        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
-          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile convertire in modo implicito il valore letterale di tipo double nel tipo '{1}'. Utilizzare un suffisso '{0}' per creare un valore letterale di questo tipo</target>
-        </trans-unit>
         <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
           <source>Cannot convert to static type '{0}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile convertire nel tipo statico '{0}'</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
@@ -302,10 +302,6 @@
           <source>Missing compiler required member '{0}.{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">コンパイラが必要とするメンバー '{0}.{1}' がありません</target>
         </trans-unit>
-        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
-          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">型 double のリテラルを暗黙的に型 '{1}' に変換することはできません。'{0}' サフィックスを使用して、この型のリテラルを作成してください</target>
-        </trans-unit>
         <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
           <source>Cannot convert to static type '{0}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">スタティック型 '{0}' へ変換できません</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
@@ -302,10 +302,6 @@
           <source>Missing compiler required member '{0}.{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}.{1}' 멤버를 필요로 하는 컴파일러가 없습니다.</target>
         </trans-unit>
-        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
-          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">double 형식의 리터럴을 암시적으로 '{1}' 형식으로 변환할 수 없습니다. 이 형식의 리터럴을 만들려면 '{0}' 접미사를 사용하십시오.</target>
-        </trans-unit>
         <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
           <source>Cannot convert to static type '{0}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' 정적 형식으로 변환할 수 없습니다.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
@@ -302,10 +302,6 @@
           <source>Missing compiler required member '{0}.{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Отсутствует обязательный для компилятора член "{0}.{1}"</target>
         </trans-unit>
-        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
-          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Литерал с типом double не может быть неявно преобразован к типу "{1}"; для создания литерала этого типа следует воспользоваться суффиксом "{0}"</target>
-        </trans-unit>
         <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
           <source>Cannot convert to static type '{0}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удается выполнить преобразование к статическому типу "{0}"</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
@@ -302,10 +302,6 @@
           <source>Missing compiler required member '{0}.{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">缺少编译器要求的成员“{0}.{1}”</target>
         </trans-unit>
-        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
-          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法将 Double 类型隐式转换为“{1}”类型；请使用“{0}”后缀创建此类型</target>
-        </trans-unit>
         <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
           <source>Cannot convert to static type '{0}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">无法转换为静态类型“{0}”</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
@@ -302,10 +302,6 @@
           <source>Missing compiler required member '{0}.{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">遺漏編譯器所需的成員 '{0}.{1}'</target>
         </trans-unit>
-        <trans-unit id="LiteralDoubleCast" translate="yes" xml:space="preserve">
-          <source>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">不能隱含將型別 double 的常值轉換為型別 '{1}'; 請使用 '{0}' 後置字元來建立此型別的常值</target>
-        </trans-unit>
         <trans-unit id="ConvertToStaticClass" translate="yes" xml:space="preserve">
           <source>Cannot convert to static type '{0}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">無法轉換為靜態型別 '{0}'</target>

--- a/src/Microsoft.CSharp/src/Resources/Strings.de.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.de.resx
@@ -234,9 +234,6 @@
   <data name="MissingPredefinedMember" xml:space="preserve">
     <value>Der vom Compiler angeforderte Member "{0}.{1}" fehlt.</value>
   </data>
-  <data name="LiteralDoubleCast" xml:space="preserve">
-    <value>Literale vom Typ "double" können nicht implizit in den {1}-Typ konvertiert werden. Verwenden Sie ein {0}-Suffix, um ein Literal mit diesem Typ zu erstellen.</value>
-  </data>
   <data name="ConvertToStaticClass" xml:space="preserve">
     <value>Die Konvertierung in den statischen {0}-Typ ist nicht möglich.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.es.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.es.resx
@@ -234,9 +234,6 @@
   <data name="MissingPredefinedMember" xml:space="preserve">
     <value>Falta el miembro '{0}.{1}' que requiere el compilador.</value>
   </data>
-  <data name="LiteralDoubleCast" xml:space="preserve">
-    <value>El literal de tipo double no se puede convertir implícitamente en el tipo '{1}'; use un sufijo '{0}' para crear un literal de este tipo</value>
-  </data>
   <data name="ConvertToStaticClass" xml:space="preserve">
     <value>No se puede convertir en el tipo estático '{0}'</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
@@ -234,9 +234,6 @@
   <data name="MissingPredefinedMember" xml:space="preserve">
     <value>Membre requis par le compilateur '{0}.{1}' manquant</value>
   </data>
-  <data name="LiteralDoubleCast" xml:space="preserve">
-    <value>Impossible de convertir implicitement un littéral de type double en type '{1}' ; utilisez un suffixe '{0}' pour créer un littéral de ce type</value>
-  </data>
   <data name="ConvertToStaticClass" xml:space="preserve">
     <value>Impossible de convertir en type static '{0}'</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.it.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.it.resx
@@ -234,9 +234,6 @@
   <data name="MissingPredefinedMember" xml:space="preserve">
     <value>Manca il membro '{0}.{1}', necessario per il compilatore.</value>
   </data>
-  <data name="LiteralDoubleCast" xml:space="preserve">
-    <value>Impossibile convertire in modo implicito il valore letterale di tipo double nel tipo '{1}'. Utilizzare un suffisso '{0}' per creare un valore letterale di questo tipo</value>
-  </data>
   <data name="ConvertToStaticClass" xml:space="preserve">
     <value>Impossibile convertire nel tipo statico '{0}'</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
@@ -234,9 +234,6 @@
   <data name="MissingPredefinedMember" xml:space="preserve">
     <value>コンパイラが必要とするメンバー '{0}.{1}' がありません</value>
   </data>
-  <data name="LiteralDoubleCast" xml:space="preserve">
-    <value>型 double のリテラルを暗黙的に型 '{1}' に変換することはできません。'{0}' サフィックスを使用して、この型のリテラルを作成してください</value>
-  </data>
   <data name="ConvertToStaticClass" xml:space="preserve">
     <value>スタティック型 '{0}' へ変換できません</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
@@ -234,9 +234,6 @@
   <data name="MissingPredefinedMember" xml:space="preserve">
     <value>'{0}.{1}' 멤버를 필요로 하는 컴파일러가 없습니다.</value>
   </data>
-  <data name="LiteralDoubleCast" xml:space="preserve">
-    <value>double 형식의 리터럴을 암시적으로 '{1}' 형식으로 변환할 수 없습니다. 이 형식의 리터럴을 만들려면 '{0}' 접미사를 사용하십시오.</value>
-  </data>
   <data name="ConvertToStaticClass" xml:space="preserve">
     <value>'{0}' 정적 형식으로 변환할 수 없습니다.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -280,9 +280,6 @@
   <data name="MissingPredefinedMember" xml:space="preserve">
     <value>Missing compiler required member '{0}.{1}'</value>
   </data>
-  <data name="LiteralDoubleCast" xml:space="preserve">
-    <value>Literal of type double cannot be implicitly converted to type '{1}'; use an '{0}' suffix to create a literal of this type</value>
-  </data>
   <data name="ConvertToStaticClass" xml:space="preserve">
     <value>Cannot convert to static type '{0}'</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
@@ -234,9 +234,6 @@
   <data name="MissingPredefinedMember" xml:space="preserve">
     <value>Отсутствует обязательный для компилятора член "{0}.{1}"</value>
   </data>
-  <data name="LiteralDoubleCast" xml:space="preserve">
-    <value>Литерал с типом double не может быть неявно преобразован к типу "{1}"; для создания литерала этого типа следует воспользоваться суффиксом "{0}"</value>
-  </data>
   <data name="ConvertToStaticClass" xml:space="preserve">
     <value>Не удается выполнить преобразование к статическому типу "{0}"</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
@@ -234,9 +234,6 @@
   <data name="MissingPredefinedMember" xml:space="preserve">
     <value>缺少编译器要求的成员“{0}.{1}”</value>
   </data>
-  <data name="LiteralDoubleCast" xml:space="preserve">
-    <value>无法将 Double 类型隐式转换为“{1}”类型；请使用“{0}”后缀创建此类型</value>
-  </data>
   <data name="ConvertToStaticClass" xml:space="preserve">
     <value>无法转换为静态类型“{0}”</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
@@ -234,9 +234,6 @@
   <data name="MissingPredefinedMember" xml:space="preserve">
     <value>遺漏編譯器所需的成員 '{0}.{1}'</value>
   </data>
-  <data name="LiteralDoubleCast" xml:space="preserve">
-    <value>不能隱含將型別 double 的常值轉換為型別 '{1}'; 請使用 '{0}' 後置字元來建立此型別的常值</value>
-  </data>
   <data name="ConvertToStaticClass" xml:space="preserve">
     <value>無法轉換為靜態型別 '{0}'</value>
   </data>


### PR DESCRIPTION
* Remove checks for implicit this.

We never have an implicit this within a dynamic expression (if an argument to an expression with implicit this has a dynamic argument, then the static binder has already selected the correct object or type argument), so don't check for it when checking static-ness (*stasis*? :wink:) is correct

* Remove check for literal constant.

Literal status is never set (and rather meaningless after static compilation), so remove branch depending on it.

Entails removal of `ERR_LiteralDoubleCast`, contributes to #22470
