### PR TITLE
add test variations for simulating sync operations over a nonblocking socket

### DIFF
--- a/src/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
+++ b/src/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
@@ -23,5 +23,15 @@ namespace System.Net.Sockets.Tests
             port = ((IPEndPoint)listener.LocalEndpoint).Port;
             return listener;
         }
+
+        // On non-Windows platforms, once non-blocking is turned on (either explicitly
+        // or by performing an async operation), we always stay in non-blocking mode.
+        // Therefore, sync operation have to be simulated via async and explicit blocking.
+        // Force us into this mode for testing purposes.
+        public static void ForceNonBlocking(this Socket socket)
+        {
+            socket.Blocking = false;
+            socket.Blocking = true;
+        }
     }
 }

--- a/src/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
+++ b/src/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
@@ -28,10 +28,13 @@ namespace System.Net.Sockets.Tests
         // or by performing an async operation), we always stay in non-blocking mode.
         // Therefore, sync operation have to be simulated via async and explicit blocking.
         // Force us into this mode for testing purposes.
-        public static void ForceNonBlocking(this Socket socket)
+        public static void ForceNonBlocking(this Socket socket, bool force)
         {
-            socket.Blocking = false;
-            socket.Blocking = true;
+            if (force)
+            {
+                socket.Blocking = false;
+                socket.Blocking = true;
+            }
         }
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
@@ -23,18 +23,12 @@ namespace System.Net.Sockets.Tests
                     int port = receiver.BindToAnonymousPort(IPAddress.Loopback);
                     receiver.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.PacketInformation, true);
 
-                    if (forceNonBlocking)
-                    {
-                        receiver.ForceNonBlocking();
-                    }
+                    receiver.ForceNonBlocking(forceNonBlocking);
 
                     Socket sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
                     sender.Bind(new IPEndPoint(IPAddress.Loopback, 0));
 
-                    if (forceNonBlocking)
-                    {
-                        sender.ForceNonBlocking();
-                    }
+                    sender.ForceNonBlocking(forceNonBlocking);
 
                     for (int i = 0; i < TestSettings.UDPRedundancy; i++)
                     {
@@ -69,18 +63,12 @@ namespace System.Net.Sockets.Tests
                     int port = receiver.BindToAnonymousPort(IPAddress.IPv6Loopback);
                     receiver.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.PacketInformation, true);
 
-                    if (forceNonBlocking)
-                    {
-                        receiver.ForceNonBlocking();
-                    }
+                    receiver.ForceNonBlocking(forceNonBlocking);
 
                     Socket sender = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
                     sender.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
 
-                    if (forceNonBlocking)
-                    {
-                        sender.ForceNonBlocking();
-                    }
+                    sender.ForceNonBlocking(forceNonBlocking);
 
                     for (int i = 0; i < TestSettings.UDPRedundancy; i++)
                     {

--- a/src/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
@@ -11,8 +11,10 @@ namespace System.Net.Sockets.Tests
     public class ReceiveMessageFrom
     {
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void Success()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Success(bool forceNonBlocking)
         {
             if (Socket.OSSupportsIPv4)
             {
@@ -21,8 +23,18 @@ namespace System.Net.Sockets.Tests
                     int port = receiver.BindToAnonymousPort(IPAddress.Loopback);
                     receiver.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.PacketInformation, true);
 
+                    if (forceNonBlocking)
+                    {
+                        receiver.ForceNonBlocking();
+                    }
+
                     Socket sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
                     sender.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+                    if (forceNonBlocking)
+                    {
+                        sender.ForceNonBlocking();
+                    }
 
                     for (int i = 0; i < TestSettings.UDPRedundancy; i++)
                     {
@@ -45,8 +57,10 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void Success_IPv6()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Success_IPv6(bool forceNonBlocking)
         {
             if (Socket.OSSupportsIPv6)
             {
@@ -55,8 +69,18 @@ namespace System.Net.Sockets.Tests
                     int port = receiver.BindToAnonymousPort(IPAddress.IPv6Loopback);
                     receiver.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.PacketInformation, true);
 
+                    if (forceNonBlocking)
+                    {
+                        receiver.ForceNonBlocking();
+                    }
+
                     Socket sender = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
                     sender.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
+
+                    if (forceNonBlocking)
+                    {
+                        sender.ForceNonBlocking();
+                    }
 
                     for (int i = 0; i < TestSettings.UDPRedundancy; i++)
                     {

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -125,10 +125,7 @@ namespace System.Net.Sockets.Tests
 
             server.Listen(ListenBacklog);
 
-            if (forceNonBlocking)
-            {
-                server.ForceNonBlocking();
-            }
+            server.ForceNonBlocking(forceNonBlocking);
 
             int bytesReceived = 0;
             var receivedChecksum = new Fletcher32();
@@ -139,10 +136,7 @@ namespace System.Net.Sockets.Tests
                     Socket remote = server.Accept();
                     Assert.NotNull(remote);
 
-                    if (forceNonBlocking)
-                    {
-                        remote.ForceNonBlocking();
-                    }
+                    remote.ForceNonBlocking(forceNonBlocking);
 
                     using (remote)
                     {
@@ -167,10 +161,7 @@ namespace System.Net.Sockets.Tests
             EndPoint clientEndpoint = server.LocalEndPoint;
             var client = new Socket(clientEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
-            if (forceNonBlocking)
-            {
-                client.ForceNonBlocking();
-            }
+            client.ForceNonBlocking(forceNonBlocking);
 
             client.Connect(clientEndpoint);
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,6 +25,15 @@ namespace System.Net.Sockets.Tests
                         yield return new object[] { listenAt, sendPreAndPostBuffers, bytesToSend };
                     }
                 }
+            }
+        }
+
+        public static IEnumerable<object[]> SendFileSync_MemberData()
+        {
+            foreach (object[] memberData in SendFile_MemberData())
+            {
+                yield return memberData.Concat(new object[] { true }).ToArray();
+                yield return memberData.Concat(new object[] { false }).ToArray();
             }
         }
 
@@ -97,8 +107,8 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [MemberData(nameof(SendFile_MemberData))]
-        public void SendFile_Synchronous(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend)
+        [MemberData(nameof(SendFileSync_MemberData))]
+        public void SendFile_Synchronous(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend, bool forceNonBlocking)
         {
             const int ListenBacklog = 1;
             const int TestTimeout = 30000;
@@ -115,6 +125,11 @@ namespace System.Net.Sockets.Tests
 
             server.Listen(ListenBacklog);
 
+            if (forceNonBlocking)
+            {
+                server.ForceNonBlocking();
+            }
+
             int bytesReceived = 0;
             var receivedChecksum = new Fletcher32();
             var serverThread = new Thread(() =>
@@ -123,6 +138,11 @@ namespace System.Net.Sockets.Tests
                 {
                     Socket remote = server.Accept();
                     Assert.NotNull(remote);
+
+                    if (forceNonBlocking)
+                    {
+                        remote.ForceNonBlocking();
+                    }
 
                     using (remote)
                     {
@@ -146,6 +166,12 @@ namespace System.Net.Sockets.Tests
             // Run client
             EndPoint clientEndpoint = server.LocalEndPoint;
             var client = new Socket(clientEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+            if (forceNonBlocking)
+            {
+                client.ForceNonBlocking();
+            }
+
             client.Connect(clientEndpoint);
 
             using (client)

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1014,7 +1014,7 @@ namespace System.Net.Sockets.Tests
         }
     }
 
-    public sealed class SendReceiveSync : SendReceive
+    public class SendReceiveSync : SendReceive
     {
         public SendReceiveSync(ITestOutputHelper output) : base(output) { }
         public override Task<Socket> AcceptAsync(Socket s) =>
@@ -1044,6 +1044,15 @@ namespace System.Net.Sockets.Tests
 
         public override bool GuaranteedSendOrdering => false;
         public override bool UsesSync => true;
+    }
+
+    public sealed class SendReceiveSyncForceNonBlocking : SendReceiveSync
+    {
+        public SendReceiveSyncForceNonBlocking(ITestOutputHelper output) : base(output) { }
+        public override Task<Socket> AcceptAsync(Socket s) =>
+            Task.Run(() => { s.ForceNonBlocking(); Socket accepted = s.Accept(); accepted.ForceNonBlocking(); return accepted; });
+        public override Task ConnectAsync(Socket s, EndPoint endPoint) =>
+            Task.Run(() => { s.ForceNonBlocking(); s.Connect(endPoint); });
     }
 
     public sealed class SendReceiveApm : SendReceive

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1050,9 +1050,9 @@ namespace System.Net.Sockets.Tests
     {
         public SendReceiveSyncForceNonBlocking(ITestOutputHelper output) : base(output) { }
         public override Task<Socket> AcceptAsync(Socket s) =>
-            Task.Run(() => { s.ForceNonBlocking(); Socket accepted = s.Accept(); accepted.ForceNonBlocking(); return accepted; });
+            Task.Run(() => { s.ForceNonBlocking(true); Socket accepted = s.Accept(); accepted.ForceNonBlocking(true); return accepted; });
         public override Task ConnectAsync(Socket s, EndPoint endPoint) =>
-            Task.Run(() => { s.ForceNonBlocking(); s.Connect(endPoint); });
+            Task.Run(() => { s.ForceNonBlocking(true); s.Connect(endPoint); });
     }
 
     public sealed class SendReceiveApm : SendReceive

--- a/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
@@ -41,8 +41,10 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void ReceiveTimesOut_Throws()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReceiveTimesOut_Throws(bool forceNonBlocking)
         {
             using (Socket localSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
             using (Socket remoteSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
@@ -51,15 +53,25 @@ namespace System.Net.Sockets.Tests
                 localSocket.Listen(1);
                 IAsyncResult localAsync = localSocket.BeginAccept(null, null);
 
+                if (forceNonBlocking)
+                {
+                    remoteSocket.ForceNonBlocking();
+                }
+
                 remoteSocket.Connect(IPAddress.IPv6Loopback, port);
 
                 Socket acceptedSocket = localSocket.EndAccept(localAsync);
                 acceptedSocket.ReceiveTimeout = TestSettings.FailingTestTimeout;
 
+                if (forceNonBlocking)
+                {
+                    acceptedSocket.ForceNonBlocking();
+                }
+
                 SocketException sockEx = Assert.Throws<SocketException>(() =>
-               {
-                   acceptedSocket.Receive(new byte[1]);
-               });
+                {
+                    acceptedSocket.Receive(new byte[1]);
+                });
 
                 Assert.Equal(SocketError.TimedOut, sockEx.SocketErrorCode);
                 Assert.True(acceptedSocket.Connected);
@@ -67,8 +79,10 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SocketSendTimeout_Send_Success()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SocketSendTimeout_Send_Success(bool forceNonBlocking)
         {
             using (Socket localSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
             using (Socket remoteSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
@@ -77,14 +91,32 @@ namespace System.Net.Sockets.Tests
                 localSocket.Listen(1);
                 IAsyncResult localAsync = localSocket.BeginAccept(null, null);
 
+                if (forceNonBlocking)
+                {
+                    remoteSocket.ForceNonBlocking();
+                }
+
                 remoteSocket.Connect(IPAddress.IPv6Loopback, port);
 
                 Socket acceptedSocket = localSocket.EndAccept(localAsync);
-                acceptedSocket.SendTimeout = TestSettings.PassingTestTimeout;
+                acceptedSocket.SendTimeout = TestSettings.FailingTestTimeout;
 
-                // Note that Send almost never times out because it only has to copy the data to the native buffer.
-                int bytes = acceptedSocket.Send(new byte[100]);
-                Assert.Equal(100, bytes);
+                if (forceNonBlocking)
+                {
+                    acceptedSocket.ForceNonBlocking();
+                }
+
+                // Force Send to timeout by filling the kernel buffer.
+                var sendBuffer = new byte[16 * 1024];
+                SocketException sockEx = Assert.Throws<SocketException>((Action) (() =>
+                {
+                    while (true)
+                    {
+                        acceptedSocket.Send(sendBuffer);
+                    }
+                }));
+
+                Assert.Equal(SocketError.TimedOut, sockEx.SocketErrorCode);
                 Assert.True(acceptedSocket.Connected);
             }
         }

--- a/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
@@ -53,20 +53,14 @@ namespace System.Net.Sockets.Tests
                 localSocket.Listen(1);
                 IAsyncResult localAsync = localSocket.BeginAccept(null, null);
 
-                if (forceNonBlocking)
-                {
-                    remoteSocket.ForceNonBlocking();
-                }
+                remoteSocket.ForceNonBlocking(forceNonBlocking);
 
                 remoteSocket.Connect(IPAddress.IPv6Loopback, port);
 
                 Socket acceptedSocket = localSocket.EndAccept(localAsync);
                 acceptedSocket.ReceiveTimeout = TestSettings.FailingTestTimeout;
 
-                if (forceNonBlocking)
-                {
-                    acceptedSocket.ForceNonBlocking();
-                }
+                acceptedSocket.ForceNonBlocking(forceNonBlocking);
 
                 SocketException sockEx = Assert.Throws<SocketException>(() =>
                 {
@@ -91,20 +85,14 @@ namespace System.Net.Sockets.Tests
                 localSocket.Listen(1);
                 IAsyncResult localAsync = localSocket.BeginAccept(null, null);
 
-                if (forceNonBlocking)
-                {
-                    remoteSocket.ForceNonBlocking();
-                }
+                remoteSocket.ForceNonBlocking(forceNonBlocking);
 
                 remoteSocket.Connect(IPAddress.IPv6Loopback, port);
 
                 Socket acceptedSocket = localSocket.EndAccept(localAsync);
                 acceptedSocket.SendTimeout = TestSettings.FailingTestTimeout;
 
-                if (forceNonBlocking)
-                {
-                    acceptedSocket.ForceNonBlocking();
-                }
+                acceptedSocket.ForceNonBlocking(forceNonBlocking);
 
                 // Force Send to timeout by filling the kernel buffer.
                 var sendBuffer = new byte[16 * 1024];


### PR DESCRIPTION
On non-Windows platforms, once non-blocking is turned on (either explicitly or by performing an async operation), we always stay in non-blocking mode.  Therefore, any subsequent sync operation have to be simulated via async and explicit blocking.

Add some test variations that cover this scenario.

Also fix the Send timeout test to actually test for Send timeout.

@stephentoub 