### PR TITLE
Remove check against delegate creation from partial in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -70,7 +70,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_LiteralDoubleCast = 664,
         ERR_ConvertToStaticClass = 716,
         ERR_GenericArgIsStaticClass = 718,
-        ERR_PartialMethodToDelegate = 762,
         ERR_IncrementLvalueExpected = 1059,
         ERR_NoSuchMemberOrExtension = 1061,
         ERR_ValueTypeExtDelegate = 1113,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -206,9 +206,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case ErrorCode.ERR_GenericArgIsStaticClass:
                     codeStr = SR.GenericArgIsStaticClass;
                     break;
-                case ErrorCode.ERR_PartialMethodToDelegate:
-                    codeStr = SR.PartialMethodToDelegate;
-                    break;
                 case ErrorCode.ERR_IncrementLvalueExpected:
                     codeStr = SR.IncrementLvalueExpected;
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -750,10 +750,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // Check method type variable constraints.
                 TypeBind.CheckMethConstraints(GetSemanticChecker(), GetErrorContext(), mwiWrap);
             }
-            if (mwiWrap.Meth().MethKind() == MethodKindEnum.Latent)
-            {
-                ErrorContext.ErrorRef(ErrorCode.ERR_PartialMethodToDelegate, mwiWrap);
-            }
 
             if (!needDest)
                 return true;

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
@@ -314,10 +314,6 @@
           <source>'{0}': static types cannot be used as type arguments</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">{0}: Statische Typen können nicht als Typargumente verwendet werden.</target>
         </trans-unit>
-        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
-          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Aus der {0}-Methode kann kein Delegat erstellt werden, da es sich um eine partielle Methode ohne implementierende Deklaration handelt.</target>
-        </trans-unit>
         <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
           <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Der Operand eines Inkrement- oder Dekrementoperators muss eine Variable, eine Eigenschaft oder ein Indexer sein.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
@@ -314,10 +314,6 @@
           <source>'{0}': static types cannot be used as type arguments</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': los tipos estáticos no se pueden usar como argumentos de tipo</target>
         </trans-unit>
-        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
-          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede crear un delegado a partir del método '{0}' porque es un método parcial sin una declaración de implementación.</target>
-        </trans-unit>
         <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
           <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">El operando de un operador de incremento o decremento debe ser una variable, una propiedad o un indizador</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
@@ -314,10 +314,6 @@
           <source>'{0}': static types cannot be used as type arguments</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' : impossible d'utiliser les types static en tant qu'arguments de type</target>
         </trans-unit>
-        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
-          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible de créer un délégué à partir de la méthode '{0}', car il s'agit d'une méthode partielle sans déclaration d'implémentation</target>
-        </trans-unit>
         <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
           <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">L'opérande d'un opérateur d'incrémentation ou de décrémentation doit être une variable, une propriété ou un indexeur</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
@@ -314,10 +314,6 @@
           <source>'{0}': static types cannot be used as type arguments</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': i tipi statici non possono essere utilizzati come argomenti di tipi</target>
         </trans-unit>
-        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
-          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile creare un delegato dal metodo '{0}' perché è un metodo parziale senza una dichiarazione di implementazione</target>
-        </trans-unit>
         <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
           <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">L'operando di un operatore di incremento o decremento deve essere una variabile, una proprietà o un indicizzatore</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
@@ -314,10 +314,6 @@
           <source>'{0}': static types cannot be used as type arguments</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': スタティック型を型引数として使用することはできません</target>
         </trans-unit>
-        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
-          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">メソッド '{0}' は実装宣言がない部分メソッドであるため、このメソッドからデリゲートを作成できません</target>
-        </trans-unit>
         <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
           <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">インクリメント演算子またはデクリメント演算子のオペランドには、変数、プロパティ、またはインデクサーを指定してください。</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
@@ -314,10 +314,6 @@
           <source>'{0}': static types cannot be used as type arguments</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': 정적 형식은 형식 인수로 사용할 수 없습니다.</target>
         </trans-unit>
-        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
-          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'은(는) 구현 선언이 없는 부분 메서드(Partial Method)이므로 이 메서드로부터 대리자를 만들 수 없습니다.</target>
-        </trans-unit>
         <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
           <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">증가 연산자 또는 감소 연산자의 피연산자는 변수, 속성 또는 인덱서여야 합니다.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
@@ -314,10 +314,6 @@
           <source>'{0}': static types cannot be used as type arguments</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}": нельзя использовать статические типы в качестве аргументов-типов</target>
         </trans-unit>
-        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
-          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно создать делегат на основе метода "{0}", поскольку он является разделяемым методом без реализующего объявления</target>
-        </trans-unit>
         <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
           <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Операндом оператора инкремента или декремента должна быть переменная, свойство или индексатор</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
@@ -314,10 +314,6 @@
           <source>'{0}': static types cannot be used as type arguments</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">“{0}”: 静态类型不能用作类型参数</target>
         </trans-unit>
-        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
-          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法通过方法“{0}”创建委托，因为该方法是没有实现声明的分部方法</target>
-        </trans-unit>
         <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
           <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">递增或递减运算符的操作数必须是变量、属性或索引器</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
@@ -314,10 +314,6 @@
           <source>'{0}': static types cannot be used as type arguments</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}': 靜態型別不能當做型別引數使用</target>
         </trans-unit>
-        <trans-unit id="PartialMethodToDelegate" translate="yes" xml:space="preserve">
-          <source>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">無法從方法 '{0}' 建立委派，因為它是沒有實作宣告的部分方法</target>
-        </trans-unit>
         <trans-unit id="IncrementLvalueExpected" translate="yes" xml:space="preserve">
           <source>The operand of an increment or decrement operator must be a variable, property or indexer</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">遞增或遞減運算子的運算元必須是變數、屬性或索引子。</target>

--- a/src/Microsoft.CSharp/src/Resources/Strings.de.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.de.resx
@@ -243,9 +243,6 @@
   <data name="GenericArgIsStaticClass" xml:space="preserve">
     <value>{0}: Statische Typen können nicht als Typargumente verwendet werden.</value>
   </data>
-  <data name="PartialMethodToDelegate" xml:space="preserve">
-    <value>Aus der {0}-Methode kann kein Delegat erstellt werden, da es sich um eine partielle Methode ohne implementierende Deklaration handelt.</value>
-  </data>
   <data name="IncrementLvalueExpected" xml:space="preserve">
     <value>Der Operand eines Inkrement- oder Dekrementoperators muss eine Variable, eine Eigenschaft oder ein Indexer sein.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.es.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.es.resx
@@ -243,9 +243,6 @@
   <data name="GenericArgIsStaticClass" xml:space="preserve">
     <value>'{0}': los tipos estáticos no se pueden usar como argumentos de tipo</value>
   </data>
-  <data name="PartialMethodToDelegate" xml:space="preserve">
-    <value>No se puede crear un delegado a partir del método '{0}' porque es un método parcial sin una declaración de implementación.</value>
-  </data>
   <data name="IncrementLvalueExpected" xml:space="preserve">
     <value>El operando de un operador de incremento o decremento debe ser una variable, una propiedad o un indizador</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
@@ -243,9 +243,6 @@
   <data name="GenericArgIsStaticClass" xml:space="preserve">
     <value>'{0}' : impossible d'utiliser les types static en tant qu'arguments de type</value>
   </data>
-  <data name="PartialMethodToDelegate" xml:space="preserve">
-    <value>Impossible de créer un délégué à partir de la méthode '{0}', car il s'agit d'une méthode partielle sans déclaration d'implémentation</value>
-  </data>
   <data name="IncrementLvalueExpected" xml:space="preserve">
     <value>L'opérande d'un opérateur d'incrémentation ou de décrémentation doit être une variable, une propriété ou un indexeur</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.it.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.it.resx
@@ -243,9 +243,6 @@
   <data name="GenericArgIsStaticClass" xml:space="preserve">
     <value>'{0}': i tipi statici non possono essere utilizzati come argomenti di tipi</value>
   </data>
-  <data name="PartialMethodToDelegate" xml:space="preserve">
-    <value>Impossibile creare un delegato dal metodo '{0}' perché è un metodo parziale senza una dichiarazione di implementazione</value>
-  </data>
   <data name="IncrementLvalueExpected" xml:space="preserve">
     <value>L'operando di un operatore di incremento o decremento deve essere una variabile, una proprietà o un indicizzatore</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
@@ -243,9 +243,6 @@
   <data name="GenericArgIsStaticClass" xml:space="preserve">
     <value>'{0}': スタティック型を型引数として使用することはできません</value>
   </data>
-  <data name="PartialMethodToDelegate" xml:space="preserve">
-    <value>メソッド '{0}' は実装宣言がない部分メソッドであるため、このメソッドからデリゲートを作成できません</value>
-  </data>
   <data name="IncrementLvalueExpected" xml:space="preserve">
     <value>インクリメント演算子またはデクリメント演算子のオペランドには、変数、プロパティ、またはインデクサーを指定してください。</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
@@ -243,9 +243,6 @@
   <data name="GenericArgIsStaticClass" xml:space="preserve">
     <value>'{0}': 정적 형식은 형식 인수로 사용할 수 없습니다.</value>
   </data>
-  <data name="PartialMethodToDelegate" xml:space="preserve">
-    <value>'{0}'은(는) 구현 선언이 없는 부분 메서드(Partial Method)이므로 이 메서드로부터 대리자를 만들 수 없습니다.</value>
-  </data>
   <data name="IncrementLvalueExpected" xml:space="preserve">
     <value>증가 연산자 또는 감소 연산자의 피연산자는 변수, 속성 또는 인덱서여야 합니다.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -289,9 +289,6 @@
   <data name="GenericArgIsStaticClass" xml:space="preserve">
     <value>'{0}': static types cannot be used as type arguments</value>
   </data>
-  <data name="PartialMethodToDelegate" xml:space="preserve">
-    <value>Cannot create delegate from method '{0}' because it is a partial method without an implementing declaration</value>
-  </data>
   <data name="IncrementLvalueExpected" xml:space="preserve">
     <value>The operand of an increment or decrement operator must be a variable, property or indexer</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
@@ -243,9 +243,6 @@
   <data name="GenericArgIsStaticClass" xml:space="preserve">
     <value>"{0}": нельзя использовать статические типы в качестве аргументов-типов</value>
   </data>
-  <data name="PartialMethodToDelegate" xml:space="preserve">
-    <value>Невозможно создать делегат на основе метода "{0}", поскольку он является разделяемым методом без реализующего объявления</value>
-  </data>
   <data name="IncrementLvalueExpected" xml:space="preserve">
     <value>Операндом оператора инкремента или декремента должна быть переменная, свойство или индексатор</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
@@ -243,9 +243,6 @@
   <data name="GenericArgIsStaticClass" xml:space="preserve">
     <value>“{0}”: 静态类型不能用作类型参数</value>
   </data>
-  <data name="PartialMethodToDelegate" xml:space="preserve">
-    <value>无法通过方法“{0}”创建委托，因为该方法是没有实现声明的分部方法</value>
-  </data>
   <data name="IncrementLvalueExpected" xml:space="preserve">
     <value>递增或递减运算符的操作数必须是变量、属性或索引器</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
@@ -243,9 +243,6 @@
   <data name="GenericArgIsStaticClass" xml:space="preserve">
     <value>'{0}': 靜態型別不能當做型別引數使用</value>
   </data>
-  <data name="PartialMethodToDelegate" xml:space="preserve">
-    <value>無法從方法 '{0}' 建立委派，因為它是沒有實作宣告的部分方法</value>
-  </data>
   <data name="IncrementLvalueExpected" xml:space="preserve">
     <value>遞增或遞減運算子的運算元必須是變數、屬性或索引子。</value>
   </data>


### PR DESCRIPTION
At runtime a method is never partial, so this can never be hit.

Contributes to #22470