### PR TITLE
Fix csproj file casing

### DIFF
--- a/src/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
+++ b/src/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
@@ -17,10 +17,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="System\DirectoryServices\AccountManagement\externdll.cs" />
+    <Compile Include="System\DirectoryServices\AccountManagement\ExternDll.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\interopt.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\PrincipalSearcher.cs" />
-    <Compile Include="System\DirectoryServices\AccountManagement\utils.cs" />
+    <Compile Include="System\DirectoryServices\AccountManagement\Utils.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\constants.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\Context.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\StoreCtx.cs" />
@@ -67,7 +67,7 @@
     <Compile Include="System\DirectoryServices\AccountManagement\AD\QBEMatchType.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\AD\SidList.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\AD\ADDNConstraintLinkedAttrSet.cs" />
-    <Compile Include="System\DirectoryServices\AccountManagement\AD\dspropertycollection.cs" />
+    <Compile Include="System\DirectoryServices\AccountManagement\AD\DSPropertyCollection.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\AD\ADStoreCtx.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\AD\ADStoreCtx_Query.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\AD\ADStoreCtx_LoadStore.cs" />

--- a/src/System.DirectoryServices/src/System.DirectoryServices.csproj
+++ b/src/System.DirectoryServices/src/System.DirectoryServices.csproj
@@ -18,7 +18,7 @@
     <Compile Include="FxCopBaseline.AnyOS.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="System\DirectoryServices\externdll.cs" />
+    <Compile Include="System\DirectoryServices\ExternDll.cs" />
     <Compile Include="System\DirectoryServices\ActiveDirectorySecurity.cs" />
     <Compile Include="System\DirectoryServices\AdsVLV.cs" />
     <Compile Include="System\DirectoryServices\AuthenticationTypes.cs" />


### PR DESCRIPTION
This fixes up the casing of some `<Compile Include>`'s to match the on disk casing of the files that are being referenced.  This allows building the NETStandard.Library.NETFramework support package on *NIX (via `./build.sh -Framework=netfx -OSGroup=Windows_NT`).

@weshaggard do you think we should harness this build in CI or is the benefit not worth the cost? 