### PR TITLE
Re-enable some HttpListener tests for UAPAOT

### DIFF
--- a/src/System.Net.HttpListener/tests/Configurations.props
+++ b/src/System.Net.HttpListener/tests/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp-OSX;
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -379,7 +379,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22066, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task CanWrite_Get_ReturnsFalse()
         {

--- a/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -137,7 +137,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task SimpleRequest_WriteSynchronouslyInParts_Succeeds()
         {
@@ -167,7 +166,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task SimpleRequest_WriteAynchronouslyEmpty_Succeeds()
         {
@@ -232,7 +230,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22066, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task CanRead_Get_ReturnsFalse()
         {
@@ -285,7 +282,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
         [InlineData(0, 3)]
         [InlineData(1, 2)]
@@ -539,7 +535,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -553,7 +548,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task EndWrite_InvalidAsyncResult_ThrowsArgumentException()
         {


### PR DESCRIPTION
Closes #22066
Contributes to #22110

~~For now, HttpListener tests don't run for[ UAPAOT and UAP mode](https://github.com/dotnet/corefx/pull/22340#discussion_r129180860), but I have tested locally.~~
I have pushed new commit to fix the issue.