### PR TITLE
Detect VS2017 in the run script

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -16,18 +16,21 @@ setlocal
 :: is already configured to use that toolset. Otherwise, we will fallback to using the VS2015
 :: toolset if it is installed. Finally, we will fail the script if no supported VS instance
 :: can be found.
-if not defined VisualStudioVersion (
-  if defined VS150COMNTOOLS (
-    call "%VS150COMNTOOLS%\VsDevCmd.bat"
-    goto :Run
-  ) else if defined VS140COMNTOOLS (
-    call "%VS140COMNTOOLS%\VsDevCmd.bat"
-    goto :Run
-  )
+
+if defined VisualStudioVersion goto :Run
+
+set _VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist %_VSWHERE% (
+  for /f "usebackq tokens=*" %%i in (`%_VSWHERE% -latest -property installationPath`) do set _VSCOMNTOOLS=%%i\Common7\Tools
+)
+if not exist "%_VSCOMNTOOLS%" set _VSCOMNTOOLS=%VS140COMNTOOLS%
+if not exist "%_VSCOMNTOOLS%" (
   echo Error: Visual Studio 2015 or 2017 required.
   echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
   exit /b 1
 )
+
+call "%_VSCOMNTOOLS%\VsDevCmd.bat"
 
 :Run
 :: Clear the 'Platform' env variable for this session, as it's a per-project setting within the build, and

--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -53,17 +53,19 @@ goto :Arg_Loop
 :: is already configured to use that toolset. Otherwise, we will fallback to using the VS2015
 :: toolset if it is installed. Finally, we will fail the script if no supported VS instance
 :: can be found.
-if not defined VisualStudioVersion (
-    if defined VS150COMNTOOLS (
-        call "%VS150COMNTOOLS%VsDevCmd.bat"
-        goto :VS2017
-    ) else if defined VS140COMNTOOLS (
-        call "%VS140COMNTOOLS%VsDevCmd.bat"
-        goto :VS2015
-    )
-    goto :MissingVersion
-)
 
+if defined VisualStudioVersion goto :RunVCVars
+
+set _VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist %_VSWHERE% (
+  for /f "usebackq tokens=*" %%i in (`%_VSWHERE% -latest -property installationPath`) do set _VSCOMNTOOLS=%%i\Common7\Tools
+)
+if not exist "%_VSCOMNTOOLS%" set _VSCOMNTOOLS=%VS140COMNTOOLS%
+if not exist "%_VSCOMNTOOLS%" goto :MissingVersion
+
+call "%_VSCOMNTOOLS%\VsDevCmd.bat"
+
+:RunVCVars
 if "%VisualStudioVersion%"=="15.0" (
     goto :VS2017
 ) else if "%VisualStudioVersion%"=="14.0" (
@@ -72,7 +74,7 @@ if "%VisualStudioVersion%"=="15.0" (
 
 :MissingVersion
 :: Can't find VS 2015 or 2017
-echo Error: Visual Studio 2015 or 2017 required  
+echo Error: Visual Studio 2015 or 2017 required
 echo        Please see https://github.com/dotnet/corefx/tree/master/Documentation for build instructions.
 exit /b 1
 


### PR DESCRIPTION
VS150COMNTOOLS is no longer set by VS2017 installs globally so we need a way to detect VS2017 so we can run the scripts from a normal cmd prompt. That is where vswhere comes in which will find the latest version of VS2017 and point us to it.
