### PR TITLE
Linux Sockets: fix timeout handling by forcing into nonblocking mode

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1044,15 +1044,17 @@ namespace System.Net.Sockets
             {
                 if (optionName == SocketOptionName.ReceiveTimeout)
                 {
+                    // Note, setting a non-infinite timeout will force the handle into nonblocking mode
                     handle.ReceiveTimeout = optionValue == 0 ? -1 : optionValue;
-                    err = Interop.Sys.SetReceiveTimeout(handle, optionValue);
-                    return GetErrorAndTrackSetting(handle, optionLevel, optionName, err);
+                    handle.TrackOption(optionLevel, optionName);
+                    return SocketError.Success;
                 }
                 else if (optionName == SocketOptionName.SendTimeout)
                 {
+                    // Note, setting a non-infinite timeout will force the handle into nonblocking mode
                     handle.SendTimeout = optionValue == 0 ? -1 : optionValue;
-                    err = Interop.Sys.SetSendTimeout(handle, optionValue);
-                    return GetErrorAndTrackSetting(handle, optionLevel, optionName, err);
+                    handle.TrackOption(optionLevel, optionName);
+                    return SocketError.Success;
                 }
             }
             else if (optionLevel == SocketOptionLevel.IP)

--- a/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
@@ -42,7 +42,7 @@ namespace System.Net.Sockets.Tests
 
         // Use a Timeout large enough so that we can effectively detect when it's not accurate,
         // but also not so large that it takes too long to run.
-        const int Timeout = 500;
+        const int Timeout = 2000;
 
         [OuterLoop] // TODO: Issue #11345
         [Theory]
@@ -70,11 +70,11 @@ namespace System.Net.Sockets.Tests
 
                 SocketException sockEx = Assert.Throws<SocketException>(() =>
                 {
-                    start = DateTime.Now;
+                    start = DateTime.UtcNow;
                     acceptedSocket.Receive(new byte[1]);
                 });
 
-                double elapsed = (DateTime.Now - start).TotalMilliseconds;
+                double elapsed = (DateTime.UtcNow - start).TotalMilliseconds;
 
                 Assert.Equal(SocketError.TimedOut, sockEx.SocketErrorCode);
                 Assert.True(acceptedSocket.Connected);
@@ -114,12 +114,12 @@ namespace System.Net.Sockets.Tests
                 {
                     while (true)
                     {
-                        start = DateTime.Now;
+                        start = DateTime.UtcNow;
                         acceptedSocket.Send(sendBuffer);
                     }
                 }));
 
-                double elapsed = (DateTime.Now - start).TotalMilliseconds;
+                double elapsed = (DateTime.UtcNow - start).TotalMilliseconds;
 
                 Assert.Equal(SocketError.TimedOut, sockEx.SocketErrorCode);
                 Assert.True(acceptedSocket.Connected);

--- a/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
@@ -40,6 +40,10 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        // Use a Timeout large enough so that we can effectively detect when it's not accurate,
+        // but also not so large that it takes too long to run.
+        const int Timeout = 500;
+
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(true)]
@@ -58,17 +62,25 @@ namespace System.Net.Sockets.Tests
                 remoteSocket.Connect(IPAddress.IPv6Loopback, port);
 
                 Socket acceptedSocket = localSocket.EndAccept(localAsync);
-                acceptedSocket.ReceiveTimeout = TestSettings.FailingTestTimeout;
+                acceptedSocket.ReceiveTimeout = Timeout;
 
                 acceptedSocket.ForceNonBlocking(forceNonBlocking);
 
+                DateTime start = default(DateTime);
+
                 SocketException sockEx = Assert.Throws<SocketException>(() =>
                 {
+                    start = DateTime.Now;
                     acceptedSocket.Receive(new byte[1]);
                 });
 
+                double elapsed = (DateTime.Now - start).TotalMilliseconds;
+
                 Assert.Equal(SocketError.TimedOut, sockEx.SocketErrorCode);
                 Assert.True(acceptedSocket.Connected);
+
+                // Try to ensure that the elapsed timeout is reasonably correct
+                Assert.InRange(elapsed, Timeout * 0.75, Timeout * 1.5);
             }
         }
 
@@ -76,7 +88,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void SocketSendTimeout_Send_Success(bool forceNonBlocking)
+        public void SendTimesOut_Throws(bool forceNonBlocking)
         {
             using (Socket localSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
             using (Socket remoteSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
@@ -90,9 +102,11 @@ namespace System.Net.Sockets.Tests
                 remoteSocket.Connect(IPAddress.IPv6Loopback, port);
 
                 Socket acceptedSocket = localSocket.EndAccept(localAsync);
-                acceptedSocket.SendTimeout = TestSettings.FailingTestTimeout;
+                acceptedSocket.SendTimeout = Timeout;
 
                 acceptedSocket.ForceNonBlocking(forceNonBlocking);
+
+                DateTime start = default(DateTime);
 
                 // Force Send to timeout by filling the kernel buffer.
                 var sendBuffer = new byte[16 * 1024];
@@ -100,12 +114,18 @@ namespace System.Net.Sockets.Tests
                 {
                     while (true)
                     {
+                        start = DateTime.Now;
                         acceptedSocket.Send(sendBuffer);
                     }
                 }));
 
+                double elapsed = (DateTime.Now - start).TotalMilliseconds;
+
                 Assert.Equal(SocketError.TimedOut, sockEx.SocketErrorCode);
                 Assert.True(acceptedSocket.Connected);
+
+                // Try to ensure that the elapsed timeout is reasonably correct
+                Assert.InRange(elapsed, Timeout * 0.75, Timeout * 1.5);
             }
         }
     }


### PR DESCRIPTION
Fixes #22587 

Currently, we can't reliably support send/receive timeouts because we can't distinguish between an EAGAIN caused by a nonblocking socket, and one caused by a timeout on a synchronous system call.

Fix this by forcing us into AsyncContext mode when a timeout is set.  This handles the timeout semantics correctly.

@stephentoub 