### PR TITLE
Re enable ArrayPool tests for UapAot

### DIFF
--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -414,7 +414,6 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20511", TargetFrameworkMonikers.UapAot)]
         public static void RentBufferFiresRentedDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
@@ -432,7 +431,6 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20511", TargetFrameworkMonikers.UapAot)]
         public static void ReturnBufferFiresDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
@@ -447,7 +445,6 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20511", TargetFrameworkMonikers.UapAot)]
         public static void RentingNonExistentBufferFiresAllocatedDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
@@ -455,7 +452,6 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20511", TargetFrameworkMonikers.UapAot)]
         public static void RentingBufferOverConfiguredMaximumSizeFiresDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
@@ -463,7 +459,6 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20511", TargetFrameworkMonikers.UapAot)]
         public static void RentingManyBuffersFiresExpectedDiagnosticEvents()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 10);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/20511

Finally we consumed the projectN build that has my changes. The tests now pass locally for me. 

This will need to be ported to UWP6.0 rel branch.

cc: @danmosemsft 