### PR TITLE
Improve directory deletion stack pressure

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2282,7 +2282,8 @@
     },
     "System.Memory": {
       "InboxOn": {
-        "netcoreapp2.0": "4.0.1.0"
+        "netcoreapp2.0": "4.0.1.0",
+        "uap10.0.15138": "4.0.1.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
@@ -3356,7 +3357,8 @@
       ],
       "BaselineVersion": "4.4.0",
       "InboxOn":  {
-        "netcoreapp2.0": "4.0.4.0"
+        "netcoreapp2.0": "4.0.4.0",
+        "uap10.0.15138": "4.0.1.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -3358,7 +3358,7 @@
       "BaselineVersion": "4.4.0",
       "InboxOn":  {
         "netcoreapp2.0": "4.0.4.0",
-        "uap10.0.15138": "4.0.1.0"
+        "uap10.0.15138": "4.0.4.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2281,7 +2281,9 @@
       }
     },
     "System.Memory": {
-      "InboxOn": {},
+      "InboxOn": {
+        "netcoreapp2.0": "4.0.1.0"
+      },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
         "4.0.1.0": "4.5.0"
@@ -3353,7 +3355,9 @@
         "4.4.0"
       ],
       "BaselineVersion": "4.4.0",
-      "InboxOn": {},
+      "InboxOn":  {
+        "netcoreapp2.0": "4.0.4.0"
+      },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.2.0": "4.3.0",

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetFileAttributesEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetFileAttributesEx.cs
@@ -67,8 +67,13 @@ internal partial class Interop
             internal uint nFileSizeLow;
             internal uint dwReserved0;
             internal uint dwReserved1;
-            internal FixedString.Size260 cFileName;
-            internal FixedString.Size14 cAlternateFileName;
+            private fixed char _cFileName[260];
+            private fixed char _cAlternateFileName[14];
+
+            internal Span<char> cFileName
+            {
+                get { fixed (char* c = _cFileName) return new Span<char>(c, 260); }
+            }
         }
 
         internal struct FILE_TIME

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetFileAttributesEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetFileAttributesEx.cs
@@ -57,7 +57,6 @@ internal partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        [BestFitMapping(false)]
         internal unsafe struct WIN32_FIND_DATA
         {
             internal uint dwFileAttributes;
@@ -68,10 +67,8 @@ internal partial class Interop
             internal uint nFileSizeLow;
             internal uint dwReserved0;
             internal uint dwReserved1;
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
-            internal string cFileName;
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 14)]
-            internal string cAlternateFileName;
+            internal FixedString.Size260 cFileName;
+            internal FixedString.Size14 cAlternateFileName;
         }
 
         internal struct FILE_TIME

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetFileAttributesEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetFileAttributesEx.cs
@@ -70,9 +70,9 @@ internal partial class Interop
             private fixed char _cFileName[260];
             private fixed char _cAlternateFileName[14];
 
-            internal Span<char> cFileName
+            internal ReadOnlySpan<char> cFileName
             {
-                get { fixed (char* c = _cFileName) return new Span<char>(c, 260); }
+                get { fixed (char* c = _cFileName) return new ReadOnlySpan<char>(c, 260); }
             }
         }
 

--- a/src/Common/src/System/Memory/FixedBufferExtensions.cs
+++ b/src/Common/src/System/Memory/FixedBufferExtensions.cs
@@ -35,11 +35,17 @@ namespace System
             if (value == null || value.Length > span.Length)
                 return false;
 
-            int stringLength = span.GetFixedBufferStringLength();
-            if (stringLength != value.Length)
-                return false;
+            int i = 0;
+            for (; i < value.Length; i++)
+            {
+                // Strings with embedded nulls can never match as the fixed buffer always null terminates.
+                if (value[i] == '\0' || value[i] != span[i])
+                    return false;
+            }
 
-            return span.StartsWith(value.AsReadOnlySpan());
+            // If we've maxed out the buffer or reached the
+            // null terminator, we're equal.
+            return i == span.Length || span[i] == '\0';
         }
     }
 }

--- a/src/Common/src/System/Runtime/InteropServices/FixedString.cs
+++ b/src/Common/src/System/Runtime/InteropServices/FixedString.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// Contains definitions for various fixed size strings for creating blittable
+    /// structs. Provides easy string property access. Set strings are always null
+    /// terminated and will truncate if too large.
+    /// 
+    /// Usage: Instead of "fixed char _buffer[12]" use "FixedBuffer.Size12 _buffer"
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal unsafe struct FixedString
+    {
+        // We cant derive structs in C#, this is the next best thing. Nested
+        // class/struct defines have visibility to the nesting class/struct
+        // privates, and given the pointer manipulation we must do we can
+        // leverage it for a similar effect. It isn't perfect, but it reduces
+        // copying of the riskier blocks of code.
+
+        private const int BaseSize = 1;
+        private char _firstChar;
+
+        private string GetString(int maxSize)
+        {
+            fixed (char* c = &_firstChar)
+            {
+                // Go to null or end of buffer
+                int end = 0;
+                while (end < maxSize && c[end] != (char)0)
+                    end++;
+                return new string(c, 0, end);
+            }
+        }
+
+        private bool Equals(string value, int maxSize)
+        {
+            if (value == null || value.Length > maxSize)
+                return false;
+
+            fixed (char* c = &_firstChar)
+            {
+                int i = 0;
+                for (; i < value.Length; i++)
+                {
+                    // Fixed strings are always terminated at null
+                    // and therefore can never match embedded nulls.
+                    if (value[i] != c[i] || value[i] == '\0')
+                        return false;
+                }
+
+                // If we've maxed out the buffer or reached the
+                // null terminator, we're equal.
+                return i == maxSize || c[i] == '\0';
+            }
+        }
+
+        private void SetString(string value, int maxSize)
+        {
+            fixed (char* c = &_firstChar)
+                StringToBuffer(value, c, maxSize - 1, nullTerminate: true);
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct Size14
+        {
+            private const int Size = 14;
+            private FixedString _buffer;
+            private unsafe fixed char _bufferExtension[Size - BaseSize];
+
+            public string Value
+            {
+                get => _buffer.GetString(Size);
+                set => _buffer.SetString(value, Size);
+            }
+
+            public override string ToString() => Value;
+            public bool Equals(string value) => _buffer.Equals(value, Size);
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct Size260
+        {
+            private const int Size = 260;
+            private FixedString _buffer;
+            private unsafe fixed char _bufferExtension[Size - BaseSize];
+
+            public string Value
+            {
+                get => _buffer.GetString(Size);
+                set => _buffer.SetString(value, Size);
+            }
+
+            public override string ToString() => Value;
+            public bool Equals(string value) => _buffer.Equals(value, Size);
+        }
+
+        /// <summary>
+        /// Copy up to the specified number of characters to the designated buffer with an
+        /// additional null terminator if not otherwise specified.
+        /// </summary>
+        /// <param name="value">The string to copy from.</param>
+        /// <param name="destination">The buffer to copy to.</param>
+        /// <param name="maxCharacters">Max number of characters to copy.</param>
+        /// <param name="nullTerminate">Add a null to the end of the string (not counted in <paramref name="maxCharacters"/>).</param>
+        public unsafe static void StringToBuffer(string value, char* destination, int maxCharacters, bool nullTerminate = true)
+        {
+            int count = maxCharacters;
+            if (count == 0 || value == null || value.Length == 0)
+            {
+                if (nullTerminate)
+                    *destination = '\0';
+                return;
+            }
+
+            if (count < 0)
+                count = value.Length;
+            else if (value.Length < count)
+                count = value.Length;
+
+            fixed (char* start = value)
+            {
+                Buffer.MemoryCopy(
+                    source: start,
+                    destination: destination,
+                    destinationSizeInBytes: count * sizeof(char),
+                    sourceBytesToCopy: count * sizeof(char)
+                );
+            }
+
+            if (nullTerminate)
+            {
+                destination += count = '\0';
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Runtime/InteropServices/FixedString.cs
+++ b/src/Common/src/System/Runtime/InteropServices/FixedString.cs
@@ -9,7 +9,7 @@ namespace System.Runtime.InteropServices
     /// structs. Provides easy string property access. Set strings are always null
     /// terminated and will truncate if too large.
     /// 
-    /// Usage: Instead of "fixed char _buffer[12]" use "FixedBuffer.Size12 _buffer"
+    /// Usage: Instead of "fixed char _buffer[12]" use "FixedString.Size12 _buffer"
     /// </summary>
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal unsafe struct FixedString

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -365,6 +365,7 @@
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -191,8 +191,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ReplaceFile.cs">
       <Link>Common\Interop\Windows\Interop.ReplaceFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\FixedString.cs">
-      <Link>Common\System\Runtime\InteropServices\FixedString.cs</Link>
+    <Compile Include="$(CommonPath)\System\Memory\FixedBufferExtensions.cs">
+      <Link>Common\System\Memory\FixedBufferExtensions.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Windows : Win32 only -->

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -191,6 +191,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ReplaceFile.cs">
       <Link>Common\Interop\Windows\Interop.ReplaceFile.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\FixedString.cs">
+      <Link>Common\System\Runtime\InteropServices\FixedString.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Windows : Win32 only -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(UWPCompatible)' != 'true'">

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.Windows.cs
@@ -11,9 +11,9 @@ namespace System.IO
     {
         [SecurityCritical]
         internal DirectoryInfo(string fullPath, ref Interop.Kernel32.WIN32_FIND_DATA findData)
-            : this(fullPath, findData.cFileName)
+            : this(fullPath, findData.cFileName.Value)
         {
-            Debug.Assert(string.Equals(findData.cFileName, Path.GetFileName(fullPath), StringComparison.Ordinal));
+            Debug.Assert(findData.cFileName.Equals(Path.GetFileName(fullPath)));
             Init(ref findData);
         }
     }

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.Windows.cs
@@ -11,9 +11,9 @@ namespace System.IO
     {
         [SecurityCritical]
         internal DirectoryInfo(string fullPath, ref Interop.Kernel32.WIN32_FIND_DATA findData)
-            : this(fullPath, findData.cFileName.Value)
+            : this(fullPath, findData.cFileName.GetString())
         {
-            Debug.Assert(findData.cFileName.Equals(Path.GetFileName(fullPath)));
+            Debug.Assert(findData.cFileName.EqualsString(Path.GetFileName(fullPath)));
             Init(ref findData);
         }
     }

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.Windows.cs
@@ -11,9 +11,9 @@ namespace System.IO
     {
         [SecurityCritical]
         internal DirectoryInfo(string fullPath, ref Interop.Kernel32.WIN32_FIND_DATA findData)
-            : this(fullPath, findData.cFileName.GetString())
+            : this(fullPath, findData.cFileName.GetStringFromFixedBuffer())
         {
-            Debug.Assert(findData.cFileName.EqualsString(Path.GetFileName(fullPath)));
+            Debug.Assert(findData.cFileName.FixedBufferEqualsString(Path.GetFileName(fullPath)));
             Init(ref findData);
         }
     }

--- a/src/System.IO.FileSystem/src/System/IO/FileInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileInfo.Windows.cs
@@ -11,9 +11,9 @@ namespace System.IO
     {
         [SecurityCritical]
         internal FileInfo(string fullPath, ref Interop.Kernel32.WIN32_FIND_DATA findData)
-            : this(fullPath, findData.cFileName.GetString())
+            : this(fullPath, findData.cFileName.GetStringFromFixedBuffer())
         {
-            Debug.Assert(findData.cFileName.EqualsString(Path.GetFileName(fullPath)));
+            Debug.Assert(findData.cFileName.FixedBufferEqualsString(Path.GetFileName(fullPath)));
             Init(ref findData);
         }
     }

--- a/src/System.IO.FileSystem/src/System/IO/FileInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileInfo.Windows.cs
@@ -11,9 +11,9 @@ namespace System.IO
     {
         [SecurityCritical]
         internal FileInfo(string fullPath, ref Interop.Kernel32.WIN32_FIND_DATA findData)
-            : this(fullPath, findData.cFileName.Value)
+            : this(fullPath, findData.cFileName.GetString())
         {
-            Debug.Assert(findData.cFileName.Equals(Path.GetFileName(fullPath)));
+            Debug.Assert(findData.cFileName.EqualsString(Path.GetFileName(fullPath)));
             Init(ref findData);
         }
     }

--- a/src/System.IO.FileSystem/src/System/IO/FileInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileInfo.Windows.cs
@@ -11,9 +11,9 @@ namespace System.IO
     {
         [SecurityCritical]
         internal FileInfo(string fullPath, ref Interop.Kernel32.WIN32_FIND_DATA findData)
-            : this(fullPath, findData.cFileName)
+            : this(fullPath, findData.cFileName.Value)
         {
-            Debug.Assert(string.Equals(findData.cFileName, Path.GetFileName(fullPath), StringComparison.Ordinal));
+            Debug.Assert(findData.cFileName.Equals(Path.GetFileName(fullPath)));
             Init(ref findData);
         }
     }

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -469,7 +469,7 @@ namespace System.IO
                     if ((findData.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY) == 0)
                     {
                         // File
-                        string fileName = findData.cFileName.Value;
+                        string fileName = findData.cFileName.GetString();
                         if (!Interop.Kernel32.DeleteFile(Path.Combine(fullPath, fileName)) && exception == null)
                         {
                             errorCode = Marshal.GetLastWin32Error();
@@ -484,10 +484,10 @@ namespace System.IO
                     else
                     {
                         // Directory, skip ".", "..".
-                        if (findData.cFileName.Equals(".") || findData.cFileName.Equals(".."))
+                        if (findData.cFileName.EqualsString(".") || findData.cFileName.EqualsString(".."))
                             continue;
 
-                        string fileName = findData.cFileName.Value;
+                        string fileName = findData.cFileName.GetString();
                         if ((findData.dwFileAttributes & (int)FileAttributes.ReparsePoint) == 0)
                         {
                             // Not a reparse point, recurse.

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -421,180 +421,150 @@ namespace System.IO
             }
             return handle;
         }
+
         public override void RemoveDirectory(string fullPath, bool recursive)
         {
-            // Do not recursively delete through reparse points.  Perhaps in a 
-            // future version we will add a new flag to control this behavior, 
-            // but for now we're much safer if we err on the conservative side.
-            // This applies to symbolic links and mount points.
+            // Do not recursively delete through reparse points.
+            if (!recursive || IsReparsePoint(fullPath))
+            {
+                RemoveDirectoryInternal(fullPath, topLevel: true);
+                return;
+            }
+
+            // We want extended syntax so we can delete "extended" subdirectories and files
+            // (most notably ones with trailing whitespace or periods)
+            fullPath = PathInternal.EnsureExtendedPrefix(fullPath);
+
+            Interop.Kernel32.WIN32_FIND_DATA findData = new Interop.Kernel32.WIN32_FIND_DATA();
+            RemoveDirectoryRecursive(fullPath, ref findData, topLevel: true);
+        }
+
+        private static bool IsReparsePoint(string fullPath)
+        {
             Interop.Kernel32.WIN32_FILE_ATTRIBUTE_DATA data = new Interop.Kernel32.WIN32_FILE_ATTRIBUTE_DATA();
             int errorCode = FillAttributeInfo(fullPath, ref data, returnErrorOnNotFound: true);
-            if (errorCode != 0)
+            if (errorCode != Interop.Errors.ERROR_SUCCESS)
             {
-                // Ensure we throw a DirectoryNotFoundException.
+                // File not found doesn't make much sense coming from a directory delete.
                 if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND)
                     errorCode = Interop.Errors.ERROR_PATH_NOT_FOUND;
                 throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
             }
 
-            if (((FileAttributes)data.fileAttributes & FileAttributes.ReparsePoint) != 0)
-                recursive = false;
-
-            // We want extended syntax so we can delete "extended" subdirectories and files
-            // (most notably ones with trailing whitespace or periods)
-            RemoveDirectoryHelper(PathInternal.EnsureExtendedPrefix(fullPath), recursive, true);
+            return (((FileAttributes)data.fileAttributes & FileAttributes.ReparsePoint) != 0);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
-        private static void RemoveDirectoryHelper(string fullPath, bool recursive, bool throwOnTopLevelDirectoryNotFound)
+        private static void RemoveDirectoryRecursive(string fullPath, ref Interop.Kernel32.WIN32_FIND_DATA findData, bool topLevel)
         {
-            bool r;
             int errorCode;
-            Exception ex = null;
+            Exception exception = null;
 
-            // Do not recursively delete through reparse points.  Perhaps in a 
-            // future version we will add a new flag to control this behavior, 
-            // but for now we're much safer if we err on the conservative side.
-            // This applies to symbolic links and mount points.
-            // Note the logic to check whether fullPath is a reparse point is
-            // in Delete(string, string, bool), and will set "recursive" to false.
-            // Note that Win32's DeleteFile and RemoveDirectory will just delete
-            // the reparse point itself.
-
-            if (recursive)
+            using (SafeFindHandle handle = Interop.Kernel32.FindFirstFile(Directory.EnsureTrailingDirectorySeparator(fullPath) + "*", ref findData))
             {
-                Interop.Kernel32.WIN32_FIND_DATA data = new Interop.Kernel32.WIN32_FIND_DATA();
+                if (handle.IsInvalid)
+                    throw Win32Marshal.GetExceptionForLastWin32Error(fullPath);
 
-                // Open a Find handle
-                using (SafeFindHandle hnd = Interop.Kernel32.FindFirstFile(Directory.EnsureTrailingDirectorySeparator(fullPath) + "*", ref data))
+                do
                 {
-                    if (hnd.IsInvalid)
-                        throw Win32Marshal.GetExceptionForLastWin32Error(fullPath);
-
-                    do
+                    if ((findData.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY) == 0)
                     {
-                        bool isDir = (0 != (data.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY));
-                        if (isDir)
+                        // File
+                        string fileName = findData.cFileName.Value;
+                        if (!Interop.Kernel32.DeleteFile(Path.Combine(fullPath, fileName)) && exception == null)
                         {
-                            // Skip ".", "..".
-                            if (data.cFileName.Equals(".") || data.cFileName.Equals(".."))
-                                continue;
-
-                            // Recurse for all directories, unless they are 
-                            // reparse points.  Do not follow mount points nor
-                            // symbolic links, but do delete the reparse point 
-                            // itself.
-                            bool shouldRecurse = (0 == (data.dwFileAttributes & (int)FileAttributes.ReparsePoint));
-                            if (shouldRecurse)
+                            errorCode = Marshal.GetLastWin32Error();
+                            if (errorCode != Interop.Errors.ERROR_FILE_NOT_FOUND)
                             {
-                                string newFullPath = Path.Combine(fullPath, data.cFileName);
-                                try
-                                {
-                                    RemoveDirectoryHelper(newFullPath, recursive, false);
-                                }
-                                catch (Exception e)
-                                {
-                                    if (ex == null)
-                                        ex = e;
-                                }
+                                exception = Win32Marshal.GetExceptionForWin32Error(errorCode, fileName);
                             }
-                            else
-                            {
-                                // Check to see if this is a mount point, and
-                                // unmount it.
-                                if (data.dwReserved0 == Interop.Kernel32.IOReparseOptions.IO_REPARSE_TAG_MOUNT_POINT)
-                                {
-                                    // Use full path plus a trailing '\'
-                                    string mountPoint = Path.Combine(fullPath, data.cFileName + PathHelpers.DirectorySeparatorCharAsString);
-                                    if (!Interop.Kernel32.DeleteVolumeMountPoint(mountPoint))
-                                    {
-                                         errorCode = Marshal.GetLastWin32Error();
-                                    
-                                        if (errorCode != Interop.Errors.ERROR_SUCCESS && 
-                                            errorCode != Interop.Errors.ERROR_PATH_NOT_FOUND)
-                                        {
-                                            try
-                                            {
-                                                throw Win32Marshal.GetExceptionForWin32Error(errorCode, data.cFileName);
-                                            }
-                                            catch (Exception e)
-                                            {
-                                                if (ex == null)
-                                                    ex = e;
-                                            }
-                                        }
-                                    }
-                                }
+                        }
+                    }
+                    else
+                    {
+                        // Directory, skip ".", "..".
+                        if (findData.cFileName.Equals(".") || findData.cFileName.Equals(".."))
+                            continue;
 
-                                // RemoveDirectory on a symbolic link will
-                                // remove the link itself.
-                                string reparsePoint = Path.Combine(fullPath, data.cFileName);
-                                r = Interop.Kernel32.RemoveDirectory(reparsePoint);
-                                if (!r)
-                                {
-                                    errorCode = Marshal.GetLastWin32Error();
-                                    if (errorCode != Interop.Errors.ERROR_PATH_NOT_FOUND)
-                                    {
-                                        try
-                                        {
-                                            throw Win32Marshal.GetExceptionForWin32Error(errorCode, data.cFileName);
-                                        }
-                                        catch (Exception e)
-                                        {
-                                            if (ex == null)
-                                                ex = e;
-                                        }
-                                    }
-                                }
+                        string fileName = findData.cFileName.Value;
+                        if ((findData.dwFileAttributes & (int)FileAttributes.ReparsePoint) == 0)
+                        {
+                            // Not a reparse point, recurse.
+                            try
+                            {
+                                RemoveDirectoryRecursive(
+                                    Path.Combine(fullPath, fileName),
+                                    findData: ref findData,
+                                    topLevel: false);
+                            }
+                            catch (Exception e)
+                            {
+                                if (exception == null)
+                                    exception = e;
                             }
                         }
                         else
                         {
-                            string fileName = Path.Combine(fullPath, data.cFileName);
-                            r = Interop.Kernel32.DeleteFile(fileName);
-                            if (!r)
+                            // Reparse point, don't recurse, just remove.
+                            if (findData.dwReserved0 == Interop.Kernel32.IOReparseOptions.IO_REPARSE_TAG_MOUNT_POINT)
                             {
-                                errorCode = Marshal.GetLastWin32Error();
-                                if (errorCode != Interop.Errors.ERROR_FILE_NOT_FOUND)
+                                // Mount point. Unmount using full path plus a trailing '\'.
+                                // (Note: This doesn't remove the underlying directory)
+                                string mountPoint = Path.Combine(fullPath, fileName + PathHelpers.DirectorySeparatorCharAsString);
+                                if (!Interop.Kernel32.DeleteVolumeMountPoint(mountPoint) && exception == null)
                                 {
-                                    try
+                                    errorCode = Marshal.GetLastWin32Error();
+                                    if (errorCode != Interop.Errors.ERROR_SUCCESS && 
+                                        errorCode != Interop.Errors.ERROR_PATH_NOT_FOUND)
                                     {
-                                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, data.cFileName);
-                                    }
-                                    catch (Exception e)
-                                    {
-                                        if (ex == null)
-                                            ex = e;
+                                        exception = Win32Marshal.GetExceptionForWin32Error(errorCode, fileName);
                                     }
                                 }
                             }
-                        }
-                    } while (Interop.Kernel32.FindNextFile(hnd, ref data));
-                    // Make sure we quit with a sensible error.
-                    errorCode = Marshal.GetLastWin32Error();
-                }
 
-                if (ex != null)
-                    throw ex;
-                if (errorCode != 0 && errorCode != Interop.Errors.ERROR_NO_MORE_FILES)
+                            // Note that RemoveDirectory on a symbolic link will remove the link itself.
+                            if (!Interop.Kernel32.RemoveDirectory(Path.Combine(fullPath, fileName)) && exception == null)
+                            {
+                                errorCode = Marshal.GetLastWin32Error();
+                                if (errorCode != Interop.Errors.ERROR_PATH_NOT_FOUND)
+                                {
+                                    exception = Win32Marshal.GetExceptionForWin32Error(errorCode, fileName);
+                                }
+                            }
+                        }
+                    }
+                } while (Interop.Kernel32.FindNextFile(handle, ref findData));
+
+                if (exception != null)
+                    throw exception;
+
+                errorCode = Marshal.GetLastWin32Error();
+                if (errorCode != Interop.Errors.ERROR_SUCCESS && errorCode != Interop.Errors.ERROR_NO_MORE_FILES)
                     throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
             }
 
-            r = Interop.Kernel32.RemoveDirectory(fullPath);
+            RemoveDirectoryInternal(fullPath, topLevel: topLevel);
+        }
 
-            if (!r)
+        private static void RemoveDirectoryInternal(string fullPath, bool topLevel)
+        {
+            if (!Interop.Kernel32.RemoveDirectory(fullPath))
             {
-                errorCode = Marshal.GetLastWin32Error();
-                if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND) // A dubious error code.
-                    errorCode = Interop.Errors.ERROR_PATH_NOT_FOUND;
-                // This check was originally put in for Win9x (unfortunately without special casing it to be for Win9x only). We can't change the NT codepath now for backcomp reasons.
-                if (errorCode == Interop.Errors.ERROR_ACCESS_DENIED)
-                    throw new IOException(SR.Format(SR.UnauthorizedAccess_IODenied_Path, fullPath));
-
-                // don't throw the DirectoryNotFoundException since this is a subdir and 
-                // there could be a race condition between two Directory.Delete callers
-                if (errorCode == Interop.Errors.ERROR_PATH_NOT_FOUND && !throwOnTopLevelDirectoryNotFound)
-                    return;
+                int errorCode = Marshal.GetLastWin32Error();
+                switch (errorCode)
+                {
+                    case Interop.Errors.ERROR_FILE_NOT_FOUND:
+                        // File not found doesn't make much sense coming from a directory delete.
+                        errorCode = Interop.Errors.ERROR_PATH_NOT_FOUND;
+                        goto case Interop.Errors.ERROR_PATH_NOT_FOUND;
+                    case Interop.Errors.ERROR_PATH_NOT_FOUND:
+                        // We only throw for the top level directory not found, not for any contents.
+                        if (!topLevel)
+                            return;
+                        break;
+                    case Interop.Errors.ERROR_ACCESS_DENIED:
+                        // This conversion was originally put in for Win9x. Keeping for compatibility.
+                        throw new IOException(SR.Format(SR.UnauthorizedAccess_IODenied_Path, fullPath));
+                }
 
                 throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
             }

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -469,7 +469,7 @@ namespace System.IO
                     if ((findData.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY) == 0)
                     {
                         // File
-                        string fileName = findData.cFileName.GetString();
+                        string fileName = findData.cFileName.GetStringFromFixedBuffer();
                         if (!Interop.Kernel32.DeleteFile(Path.Combine(fullPath, fileName)) && exception == null)
                         {
                             errorCode = Marshal.GetLastWin32Error();
@@ -484,10 +484,10 @@ namespace System.IO
                     else
                     {
                         // Directory, skip ".", "..".
-                        if (findData.cFileName.EqualsString(".") || findData.cFileName.EqualsString(".."))
+                        if (findData.cFileName.FixedBufferEqualsString(".") || findData.cFileName.FixedBufferEqualsString(".."))
                             continue;
 
-                        string fileName = findData.cFileName.GetString();
+                        string fileName = findData.cFileName.GetStringFromFixedBuffer();
                         if ((findData.dwFileAttributes & (int)FileAttributes.ReparsePoint) == 0)
                         {
                             // Not a reparse point, recurse.

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -473,6 +473,8 @@ namespace System.IO
                         if (!Interop.Kernel32.DeleteFile(Path.Combine(fullPath, fileName)) && exception == null)
                         {
                             errorCode = Marshal.GetLastWin32Error();
+
+                            // We don't care if something else deleted the file first
                             if (errorCode != Interop.Errors.ERROR_FILE_NOT_FOUND)
                             {
                                 exception = Win32Marshal.GetExceptionForWin32Error(errorCode, fileName);
@@ -504,7 +506,7 @@ namespace System.IO
                         }
                         else
                         {
-                            // Reparse point, don't recurse, just remove.
+                            // Reparse point, don't recurse, just remove. (dwReserved0 is documented for this flag)
                             if (findData.dwReserved0 == Interop.Kernel32.IOReparseOptions.IO_REPARSE_TAG_MOUNT_POINT)
                             {
                                 // Mount point. Unmount using full path plus a trailing '\'.

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
@@ -399,7 +399,7 @@ namespace System.IO
         [SecurityCritical]
         private bool IsResultIncluded(ref Interop.Kernel32.WIN32_FIND_DATA findData, out TSource result)
         {
-            Debug.Assert(findData.cFileName.Value.Length != 0 && !Path.IsPathRooted(findData.cFileName.Value),
+            Debug.Assert(findData.cFileName.Length != 0 && !Path.IsPathRooted(findData.cFileName.GetString()),
                 "Expected file system enumeration to not have empty file/directory name and not have rooted name");
 
             return _resultHandler.IsResultIncluded(_searchData.FullPath, _searchData.UserPath, ref findData, out result);
@@ -451,7 +451,7 @@ namespace System.IO
                 {
                     if (Win32FileSystemEnumerableHelpers.IsDir(ref data))
                     {
-                        string fileName = data.cFileName.Value;
+                        string fileName = data.cFileName.GetString();
 
                         Debug.Assert(fileName.Length != 0 && !Path.IsPathRooted(fileName),
                             "Expected file system enumeration to not have empty file/directory name and not have rooted name");
@@ -568,7 +568,7 @@ namespace System.IO
                 if ((_includeFiles && Win32FileSystemEnumerableHelpers.IsFile(ref findData)) ||
                     (_includeDirs && Win32FileSystemEnumerableHelpers.IsDir(ref findData)))
                 {
-                    result = Path.Combine(userPath, findData.cFileName.Value);
+                    result = Path.Combine(userPath, findData.cFileName.GetString());
                     return true;
                 }
 
@@ -584,7 +584,7 @@ namespace System.IO
             {
                 if (Win32FileSystemEnumerableHelpers.IsFile(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.Value);
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetString());
                     result = new FileInfo(fullPathFinal, ref findData);
                     return true;
                 }
@@ -601,7 +601,7 @@ namespace System.IO
             {
                 if (Win32FileSystemEnumerableHelpers.IsDir(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.Value);
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetString());
                     result = new DirectoryInfo(fullPathFinal, ref findData);
                     return true;
                 }
@@ -618,13 +618,13 @@ namespace System.IO
             {
                 if (Win32FileSystemEnumerableHelpers.IsFile(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.Value);
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetString());
                     result = new FileInfo(fullPathFinal, ref findData);
                     return true;
                 }
                 else if (Win32FileSystemEnumerableHelpers.IsDir(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.Value);
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetString());
                     result = new DirectoryInfo(fullPathFinal, ref findData);
                     return true;
                 }
@@ -642,7 +642,7 @@ namespace System.IO
         {
             // Don't add "." nor ".."
             return (0 != (data.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY))
-                                                && !data.cFileName.Equals(".") && !data.cFileName.Equals("..");
+                                                && !data.cFileName.EqualsString(".") && !data.cFileName.EqualsString("..");
         }
 
         [SecurityCritical]  // auto-generated

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
@@ -399,7 +399,7 @@ namespace System.IO
         [SecurityCritical]
         private bool IsResultIncluded(ref Interop.Kernel32.WIN32_FIND_DATA findData, out TSource result)
         {
-            Debug.Assert(findData.cFileName.Length != 0 && !Path.IsPathRooted(findData.cFileName.GetString()),
+            Debug.Assert(findData.cFileName.Length != 0 && !Path.IsPathRooted(findData.cFileName.GetStringFromFixedBuffer()),
                 "Expected file system enumeration to not have empty file/directory name and not have rooted name");
 
             return _resultHandler.IsResultIncluded(_searchData.FullPath, _searchData.UserPath, ref findData, out result);
@@ -451,7 +451,7 @@ namespace System.IO
                 {
                     if (Win32FileSystemEnumerableHelpers.IsDir(ref data))
                     {
-                        string fileName = data.cFileName.GetString();
+                        string fileName = data.cFileName.GetStringFromFixedBuffer();
 
                         Debug.Assert(fileName.Length != 0 && !Path.IsPathRooted(fileName),
                             "Expected file system enumeration to not have empty file/directory name and not have rooted name");
@@ -568,7 +568,7 @@ namespace System.IO
                 if ((_includeFiles && Win32FileSystemEnumerableHelpers.IsFile(ref findData)) ||
                     (_includeDirs && Win32FileSystemEnumerableHelpers.IsDir(ref findData)))
                 {
-                    result = Path.Combine(userPath, findData.cFileName.GetString());
+                    result = Path.Combine(userPath, findData.cFileName.GetStringFromFixedBuffer());
                     return true;
                 }
 
@@ -584,7 +584,7 @@ namespace System.IO
             {
                 if (Win32FileSystemEnumerableHelpers.IsFile(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetString());
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetStringFromFixedBuffer());
                     result = new FileInfo(fullPathFinal, ref findData);
                     return true;
                 }
@@ -601,7 +601,7 @@ namespace System.IO
             {
                 if (Win32FileSystemEnumerableHelpers.IsDir(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetString());
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetStringFromFixedBuffer());
                     result = new DirectoryInfo(fullPathFinal, ref findData);
                     return true;
                 }
@@ -618,13 +618,13 @@ namespace System.IO
             {
                 if (Win32FileSystemEnumerableHelpers.IsFile(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetString());
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetStringFromFixedBuffer());
                     result = new FileInfo(fullPathFinal, ref findData);
                     return true;
                 }
                 else if (Win32FileSystemEnumerableHelpers.IsDir(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetString());
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.GetStringFromFixedBuffer());
                     result = new DirectoryInfo(fullPathFinal, ref findData);
                     return true;
                 }
@@ -642,7 +642,7 @@ namespace System.IO
         {
             // Don't add "." nor ".."
             return (0 != (data.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY))
-                                                && !data.cFileName.EqualsString(".") && !data.cFileName.EqualsString("..");
+                                                && !data.cFileName.FixedBufferEqualsString(".") && !data.cFileName.FixedBufferEqualsString("..");
         }
 
         [SecurityCritical]  // auto-generated

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
@@ -99,8 +99,8 @@ namespace System.IO
         private SafeFindHandle _hnd = null;
 
         // empty means we know in advance that we won?t find any search results, which can happen if:
-        // 1. we don?t have a search pattern
-        // 2. we?re enumerating only the top directory and found no matches during the first call
+        // 1. we don't have a search pattern
+        // 2. we're enumerating only the top directory and found no matches during the first call
         // This flag allows us to return early for these cases. We can?t know this in advance for
         // SearchOption.AllDirectories because we do a ?*? search for subdirs and then use the
         // searchPattern at each directory level.
@@ -287,6 +287,7 @@ namespace System.IO
                     {
                         Debug.Assert(_searchOption != SearchOption.TopDirectoryOnly, "should not reach this code path if searchOption == TopDirectoryOnly");
                         Debug.Assert(_searchList != null, "_searchList should not be null");
+
                         // Traverse directory structure. We need to get '*'
                         while (_searchList.Count > 0)
                         {
@@ -398,7 +399,7 @@ namespace System.IO
         [SecurityCritical]
         private bool IsResultIncluded(ref Interop.Kernel32.WIN32_FIND_DATA findData, out TSource result)
         {
-            Debug.Assert(findData.cFileName.Length != 0 && !Path.IsPathRooted(findData.cFileName),
+            Debug.Assert(findData.cFileName.Value.Length != 0 && !Path.IsPathRooted(findData.cFileName.Value),
                 "Expected file system enumeration to not have empty file/directory name and not have rooted name");
 
             return _resultHandler.IsResultIncluded(_searchData.FullPath, _searchData.UserPath, ref findData, out result);
@@ -450,11 +451,13 @@ namespace System.IO
                 {
                     if (Win32FileSystemEnumerableHelpers.IsDir(ref data))
                     {
-                        Debug.Assert(data.cFileName.Length != 0 && !Path.IsPathRooted(data.cFileName),
+                        string fileName = data.cFileName.Value;
+
+                        Debug.Assert(fileName.Length != 0 && !Path.IsPathRooted(fileName),
                             "Expected file system enumeration to not have empty file/directory name and not have rooted name");
 
-                        string tempFullPath = Path.Combine(localSearchData.FullPath, data.cFileName);
-                        string tempUserPath = Path.Combine(localSearchData.UserPath, data.cFileName);
+                        string tempFullPath = Path.Combine(localSearchData.FullPath, fileName);
+                        string tempUserPath = Path.Combine(localSearchData.UserPath, fileName);
 
                         // Setup search data for the sub directory and push it into the list
                         PathPair searchDataSubDir = new PathPair(tempUserPath, tempFullPath);
@@ -565,7 +568,7 @@ namespace System.IO
                 if ((_includeFiles && Win32FileSystemEnumerableHelpers.IsFile(ref findData)) ||
                     (_includeDirs && Win32FileSystemEnumerableHelpers.IsDir(ref findData)))
                 {
-                    result = Path.Combine(userPath, findData.cFileName);
+                    result = Path.Combine(userPath, findData.cFileName.Value);
                     return true;
                 }
 
@@ -581,7 +584,7 @@ namespace System.IO
             {
                 if (Win32FileSystemEnumerableHelpers.IsFile(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName);
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.Value);
                     result = new FileInfo(fullPathFinal, ref findData);
                     return true;
                 }
@@ -598,7 +601,7 @@ namespace System.IO
             {
                 if (Win32FileSystemEnumerableHelpers.IsDir(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName);
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.Value);
                     result = new DirectoryInfo(fullPathFinal, ref findData);
                     return true;
                 }
@@ -615,13 +618,13 @@ namespace System.IO
             {
                 if (Win32FileSystemEnumerableHelpers.IsFile(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName);
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.Value);
                     result = new FileInfo(fullPathFinal, ref findData);
                     return true;
                 }
                 else if (Win32FileSystemEnumerableHelpers.IsDir(ref findData))
                 {
-                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName);
+                    string fullPathFinal = Path.Combine(fullPath, findData.cFileName.Value);
                     result = new DirectoryInfo(fullPathFinal, ref findData);
                     return true;
                 }

--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text;
 using Xunit;
 using Xunit.NetCore.Extensions;
 
@@ -247,6 +248,33 @@ namespace System.IO.Tests
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
             Delete(testDir.FullName + Path.DirectorySeparatorChar, true);
             Assert.False(testDir.Exists);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [OuterLoop("This test is very slow.")]
+        public void RecursiveDelete_DeepNesting()
+        {
+            // Create a 2000 level deep directory and recursively delete from the root.
+            // This number can be dropped if we find it problematic on low memory machines
+            // and/or we can look at skipping in such environments.
+            //
+            // On debug we were overflowing the stack with directories that were under 1000
+            // levels deep. Testing on a 32GB box I consistently fell over around 1300.
+            // With optimizations to the Delete helper I was able to raise this to around 3200.
+            // Release binaries don't stress the stack nearly as much (10K+ is doable, but can
+            // take 5 minutes on an SSD).
+
+            string rootDirectory = GetTestFilePath();
+            StringBuilder sb = new StringBuilder(5000);
+            sb.Append(rootDirectory);
+            for (int i = 0; i < 2000; i++)
+            {
+                sb.Append(@"\a");
+            }
+            string path = sb.ToString();
+            Directory.CreateDirectory(path);
+            Delete(rootDirectory, recursive: true);
         }
 
         [Fact]

--- a/src/System.Memory/dir.props
+++ b/src/System.Memory/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Memory/dir.props
+++ b/src/System.Memory/dir.props
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
-    <!-- DO NOT ship this as stable for .NET Core 2.0. -->
-    <BlockStable>true</BlockStable>
-    <IsNETCoreApp>false</IsNETCoreApp>
+    <IsNETCoreApp>true</IsNETCoreApp>
   </PropertyGroup>
 </Project>

--- a/src/System.Memory/pkg/System.Memory.pkgproj
+++ b/src/System.Memory/pkg/System.Memory.pkgproj
@@ -7,6 +7,8 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Memory.csproj" />
+    <InboxOnTargetFramework Include="netcoreapp2.0" />
+    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Memory/ref/Configurations.props
+++ b/src/System.Memory/ref/Configurations.props
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
-      netstandard;
+    <PackageConfigurations>
       netstandard1.0;
+      netstandard;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
       netcoreapp;
       uap;
     </BuildConfigurations>

--- a/src/System.Memory/src/Configurations.props
+++ b/src/System.Memory/src/Configurations.props
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard1.0;
       netstandard;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
       uap-Windows_NT;

--- a/src/System.Runtime.CompilerServices.Unsafe/dir.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
+    <IsNETCoreApp>true</IsNETCoreApp>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/dir.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
@@ -7,6 +7,8 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
+    <InboxOnTargetFramework Include="netcoreapp2.0" />
+    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Recursive directory deletion used particularly large frames and would easily stack overflow with deeply nested directories (especially so when running unoptimized bits).

Reduced the stack frame size by passing the native struct used by ref and removing unnecessary throw/catch blocks. Other optimizations and logic clarifications.

Made the native struct blittable and introduced a helper struct set for fixed size blittable strings.

See #22443