### PR TITLE
Re enable ArrayPool event listener tests for UapAot

### DIFF
--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -414,7 +414,6 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20511", TargetFrameworkMonikers.UapAot)]
         public static void RentBufferFiresRentedDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
@@ -432,7 +431,6 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20511", TargetFrameworkMonikers.UapAot)]
         public static void ReturnBufferFiresDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
@@ -447,7 +445,6 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20511", TargetFrameworkMonikers.UapAot)]
         public static void RentingNonExistentBufferFiresAllocatedDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
@@ -455,7 +452,6 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20511", TargetFrameworkMonikers.UapAot)]
         public static void RentingBufferOverConfiguredMaximumSizeFiresDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
@@ -463,7 +459,6 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20511", TargetFrameworkMonikers.UapAot)]
         public static void RentingManyBuffersFiresExpectedDiagnosticEvents()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 10);


### PR DESCRIPTION
Related to: https://github.com/dotnet/corefx/issues/20511

The missing ArrayPoolEventSource class was ported to ProjectN and the build was ingested in corefx. I tested this locally and the tests don't fail anymore. Also verified manually by inspecting the dll that the new class is in there correctly. 