### PR TITLE
Bump up the NoGCRegion budget to 4mb to hopefully put this test to rest

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.cs
+++ b/src/System.Runtime/tests/System/GCTests.cs
@@ -626,15 +626,13 @@ namespace System.Tests
             options.TimeOut = TimeoutMilliseconds;
             RemoteInvoke(() =>
             {
-                // 40kb budget, see below comment
-                Assert.True(GC.TryStartNoGCRegion(40 * 1024, true));
-                Assert.Equal(GCSettings.LatencyMode, GCLatencyMode.NoGCRegion);
-
-                // PLEASE NOTE: the xunit Assert.Throws combinator allocates a lot and you should measure
-                // how large the GC budget should be *manually* if you use it while in a no GC region.
+                // The budget for this test is 4mb, because the act of throwing an exception with a message
+                // contained in a resource file has to potential to allocate a lot on CoreRT. In particular, when compiling
+                // in multi-file mode, this will trigger a resource lookup in System.Private.CoreLib.
                 //
-                // In this case, this particular one allocates 23720 bytes, so a budget of 40k should be
-                // large enough to keep us in a no GC region.
+                // In addition to this, the Assert.Throws xunit combinator tends to also allocate a lot.
+                Assert.True(GC.TryStartNoGCRegion(4000 * 1024, true));
+                Assert.Equal(GCSettings.LatencyMode, GCLatencyMode.NoGCRegion);
                 Assert.Throws<InvalidOperationException>(() => GCSettings.LatencyMode = GCLatencyMode.LowLatency);
 
                 GC.EndNoGCRegion();


### PR DESCRIPTION
The act of throwing an exception when attempting to change the GC mode while in a No GC exception (the intended behavior, and the behavior that the test is validating) has the potential to trigger a resource lookup. On non-AOT runtimes, the implementation of resource lookup is mostly unmanaged and does not allocate on the managed heap. On single-file AOT runtimes, resources are resolved statically during compilation and resource lookup is significantly cheaper. On multi-file AOT runtimes, resource lookups are done dynamically in managed code, which *does* allocate on the managed heap.

By default, a local run of CoreFX tests with UAPAOT results in a single-file compilation, which causes this test to pass. Our CI systems do a multi-file compile, which causes the test to fail due to the heavy allocation penalty incurred by the runtime resource lookup. I have bumped up the budget further to 4mb and have tested this on the Helix repro that I have, so I'm *really* hoping that this will put this issue to rest.

cc @sergiy-k 