### PR TITLE
Account for differences in WebSocket minimum buffer sizes between Core and Framework 

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -18,7 +18,7 @@ namespace System.Net.WebSockets.Client.Tests
 {
     public partial class ClientWebSocketOptionsTests : ClientWebSocketTestBase
     {
-        // Reacreate the minimum WebSocket buffer size values from the Framework version of WebSocket.
+        // Recreate the minimum WebSocket buffer size values from the Framework version of WebSocket.
         // We need these values to test when the minimums are violated, but the values set in Framework
         // are internal to the WebSocketBuffer class.
         private const int MinSendBufferSize = 16;
@@ -54,19 +54,25 @@ namespace System.Net.WebSockets.Client.Tests
         {
             var cws = new ClientWebSocket();
             AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, 0));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, MinSendBufferSize));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("sendBufferSize", () => cws.Options.SetBuffer(MinReceiveBufferSize, 0));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, 0, new ArraySegment<byte>(new byte[1])));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, MinSendBufferSize, new ArraySegment<byte>(new byte[1])));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("sendBufferSize", () => cws.Options.SetBuffer(MinReceiveBufferSize, 0, new ArraySegment<byte>(new byte[1])));
-            AssertExtensions.Throws<ArgumentNullException>("buffer.Array", () => cws.Options.SetBuffer(MinReceiveBufferSize, MinSendBufferSize, default(ArraySegment<byte>)));
             if (PlatformDetection.IsFullFramework)
             {
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, MinSendBufferSize));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("sendBufferSize", () => cws.Options.SetBuffer(MinReceiveBufferSize, 0));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, 0, new ArraySegment<byte>(new byte[1])));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, MinSendBufferSize, new ArraySegment<byte>(new byte[1])));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("sendBufferSize", () => cws.Options.SetBuffer(MinReceiveBufferSize, 0, new ArraySegment<byte>(new byte[1])));
+                AssertExtensions.Throws<ArgumentNullException>("buffer.Array", () => cws.Options.SetBuffer(MinReceiveBufferSize, MinSendBufferSize, default(ArraySegment<byte>)));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("internalBuffer", () => cws.Options.SetBuffer(MinReceiveBufferSize, MinSendBufferSize, new ArraySegment<byte>(new byte[0])));
             }
             else
             {
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("buffer", () => cws.Options.SetBuffer(MinReceiveBufferSize, MinSendBufferSize, new ArraySegment<byte>(new byte[0])));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, 1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("sendBufferSize", () => cws.Options.SetBuffer(1, 0));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, 0, new ArraySegment<byte>(new byte[1])));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, 1, new ArraySegment<byte>(new byte[1])));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("sendBufferSize", () => cws.Options.SetBuffer(1, 0, new ArraySegment<byte>(new byte[1])));
+                AssertExtensions.Throws<ArgumentNullException>("buffer.Array", () => cws.Options.SetBuffer(1, 1, default(ArraySegment<byte>)));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("buffer", () => cws.Options.SetBuffer(1, 1, new ArraySegment<byte>(new byte[0])));
             }
         }
 

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -18,6 +18,12 @@ namespace System.Net.WebSockets.Client.Tests
 {
     public partial class ClientWebSocketOptionsTests : ClientWebSocketTestBase
     {
+        // Reacreate the minimum WebSocket buffer size values from the Framework version of WebSocket.
+        // We need these values to test when the minimums are violated, but the values set in Framework
+        // are internal to the WebSocketBuffer class.
+        private const int MinSendBufferSize = 16;
+        private const int MinReceiveBufferSize = 256;
+
         public static bool CanTestCertificates =>
             Capability.IsTrustedRootCertificateInstalled() &&
             (BackendSupportsCustomCertificateHandling || Capability.AreHostsFileNamesInstalled());
@@ -43,19 +49,25 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.False(cws.Options.UseDefaultCredentials);
         }
 
-        [ActiveIssue(20358, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(WebSocketsSupported))]
         public static void SetBuffer_InvalidArgs_Throws()
         {
             var cws = new ClientWebSocket();
             AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, 0));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, 1));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("sendBufferSize", () => cws.Options.SetBuffer(1, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, MinSendBufferSize));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("sendBufferSize", () => cws.Options.SetBuffer(MinReceiveBufferSize, 0));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, 0, new ArraySegment<byte>(new byte[1])));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, 1, new ArraySegment<byte>(new byte[1])));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("sendBufferSize", () => cws.Options.SetBuffer(1, 0, new ArraySegment<byte>(new byte[1])));
-            AssertExtensions.Throws<ArgumentNullException>("buffer.Array", () => cws.Options.SetBuffer(1, 1, default(ArraySegment<byte>)));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("buffer", () => cws.Options.SetBuffer(1, 1, new ArraySegment<byte>(new byte[0])));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("receiveBufferSize", () => cws.Options.SetBuffer(0, MinSendBufferSize, new ArraySegment<byte>(new byte[1])));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("sendBufferSize", () => cws.Options.SetBuffer(MinReceiveBufferSize, 0, new ArraySegment<byte>(new byte[1])));
+            AssertExtensions.Throws<ArgumentNullException>("buffer.Array", () => cws.Options.SetBuffer(MinReceiveBufferSize, MinSendBufferSize, default(ArraySegment<byte>)));
+            if (PlatformDetection.IsFullFramework)
+            {
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("internalBuffer", () => cws.Options.SetBuffer(MinReceiveBufferSize, MinSendBufferSize, new ArraySegment<byte>(new byte[0])));
+            }
+            else
+            {
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("buffer", () => cws.Options.SetBuffer(MinReceiveBufferSize, MinSendBufferSize, new ArraySegment<byte>(new byte[0])));
+            }
         }
 
         [ConditionalFact(nameof(WebSocketsSupported))]

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -18,7 +18,6 @@ namespace System.Net.WebSockets.Client.Tests
 {
     public partial class ClientWebSocketOptionsTests : ClientWebSocketTestBase
     {
-
         public static bool CanTestCertificates =>
             Capability.IsTrustedRootCertificateInstalled() &&
             (BackendSupportsCustomCertificateHandling || Capability.AreHostsFileNamesInstalled());
@@ -47,7 +46,7 @@ namespace System.Net.WebSockets.Client.Tests
         [ConditionalFact(nameof(WebSocketsSupported))]
         public static void SetBuffer_InvalidArgs_Throws()
         {
-            // Recreate the minimum WebSocket buffer size values from the Framework version of WebSocket,
+            // Recreate the minimum WebSocket buffer size values from the .NET Framework version of WebSocket,
             // and pick the correct name of the buffer used when throwing an ArgumentOutOfRangeException.
             int minSendBufferSize = PlatformDetection.IsFullFramework ? 16 : 1;
             int minReceiveBufferSize = PlatformDetection.IsFullFramework ? 256 : 1;
@@ -63,7 +62,6 @@ namespace System.Net.WebSockets.Client.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("sendBufferSize", () => cws.Options.SetBuffer(minReceiveBufferSize, 0, new ArraySegment<byte>(new byte[1])));
             AssertExtensions.Throws<ArgumentNullException>("buffer.Array", () => cws.Options.SetBuffer(minReceiveBufferSize, minSendBufferSize, default(ArraySegment<byte>)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>(bufferName, () => cws.Options.SetBuffer(minReceiveBufferSize, minSendBufferSize, new ArraySegment<byte>(new byte[0])));
-            
         }
 
         [ConditionalFact(nameof(WebSocketsSupported))]


### PR DESCRIPTION
Client.WebSocketOptions.SetBuffer(...) has different validation between the .Net Core and Framework versions. The previous tests assumed that ClientWebSocket.Options.SetBuffer would accept a minimum buffer size of one, which is not the case in the Framework implementation. Unlike .Net core, the Framework expects a minimum size of 16 for the send buffer and 256 for the receive buffer.

This meant that tests intended to pass a _valid_ minimum receive buffer size (of 1) and an _invalid_ minimum send buffer size (of 0) would trigger an exception with the wrong message, as the (accidentally) incorrect minimum receive buffer size of 1 failed validation.

Additionally, the test would fail because of a slight difference in the name used for the internal buffer, and as such a conditional was added to ensure that the correct name is checked on each version.

Fix: #20358
