### PR TITLE
Remove ILCBuildType=chk for Microsoft.VisualBasic.Tests

### DIFF
--- a/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
+++ b/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
@@ -3,8 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}</ProjectGuid>
-    <!-- CodeGen bug is causing two tests to fail if ILC builds ret -->
-    <ILCBuildType>chk</ILCBuildType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />


### PR DESCRIPTION
This tests doesn't fail anymore for me locally when ILCBuildType=ret so I will remove this and will keep an eye on the next Helix runs. If they don't fail, then I will port it to rel branch. 

cc: @joperezr @danmosemsft 