### PR TITLE
Add .NET Framework compat package

### DIFF
--- a/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.builds
+++ b/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.builds
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <!-- only build during the AllConfigurations leg because it depends on other nupkgs from this leg -->
+  <ItemGroup Condition="'$(BuildAllConfigurations)' == 'true'">
+    <Project Include="$(MSBuildProjectName).pkgproj" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+
+</Project>

--- a/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.pkgproj
+++ b/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.pkgproj
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageVersion>2.1.0</PackageVersion>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <LibraryPackage>
+      <Version>4.5.0</Version>
+    </LibraryPackage>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <LibraryPackage Include="System.CodeDom" />
+    <LibraryPackage Include="System.ComponentModel.Annotations" />
+    <LibraryPackage Include="System.Configuration.ConfigurationManager" />
+    <LibraryPackage Include="System.Data.SqlClient" />
+    <LibraryPackage Include="System.DirectoryServices" />
+    <LibraryPackage Include="System.DirectoryServices.AccountManagement" />
+    <LibraryPackage Include="System.DirectoryServices.Protocols" />
+    <LibraryPackage Include="System.Drawing.Common" />
+    <LibraryPackage Include="System.IO.FileSystem.AccessControl" />
+    <LibraryPackage Include="System.IO.Packaging" />
+    <LibraryPackage Include="System.IO.Pipes.AccessControl" />
+    <LibraryPackage Include="System.IO.Ports" />
+    <LibraryPackage Include="System.Numerics.Vectors" />
+    <LibraryPackage Include="System.Reflection.TypeExtensions" />
+    <LibraryPackage Include="System.Security.AccessControl" />
+    <LibraryPackage Include="System.Security.Cryptography.Cng" />
+    <LibraryPackage Include="System.Security.Cryptography.Pkcs" />
+    <LibraryPackage Include="System.Security.Cryptography.ProtectedData" />
+    <LibraryPackage Include="System.Security.Cryptography.Xml" />
+    <LibraryPackage Include="System.Security.Permissions" />
+    <LibraryPackage Include="System.Security.Principal.Windows" />
+    <LibraryPackage Include="System.ServiceProcess.ServiceController" />
+    <LibraryPackage Include="System.Text.Encoding.CodePages" />
+    <LibraryPackage Include="System.Threading.AccessControl" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Dependency Include="@(LibraryPackage)" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -123,6 +123,9 @@
       "BaselineVersion": "2.0.0",
       "InboxOn": {}
     },
+    "Microsoft.NETFramework.Compatibility": {
+      "InboxOn": {}
+    },
     "Microsoft.Phone": {
       "InboxOn": {
         "wp8": "8.0.0.0"

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -51,6 +51,11 @@
     "CommonTypes": []
   },
   {
+    "Name": "Microsoft.NETFramework.Compatibility",
+    "Description": "References a number of .NET Core libraries that are intended to provide support for more APIs that exist on .NET Framework.",
+    "CommonTypes": []
+  },
+  {
     "Name": "Microsoft.NETCore.Runtime",
     "Description": "The .NET Core runtime.",
     "CommonTypes": []
@@ -1577,7 +1582,7 @@
   {
     "Name": "System.Security.Cryptography.Xml",
     "Description": "Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, \"XML-Signature Syntax and Processing\", described at http://www.w3.org/TR/xmldsig-core/.",
-    "CommonTypes": [ 
+    "CommonTypes": [
       "System.Security.Cryptography.Xml.CipherData",
       "System.Security.Cryptography.Xml.CipherReference",
       "System.Security.Cryptography.Xml.DataObject",


### PR DESCRIPTION
This meta-package will make it easier for .NET Core developers to add a set of
library packages to help them port code from .NET Framework to .NET Core.

resolves https://github.com/dotnet/corefx/issues/21664. 

PTAL @ericstj @Petermarcu @terrajobst 