### PR TITLE
Add helper function for retrieving SniContext enum names, since SniContext is an internal enum and its name cannot be retrieved via reflection on uapaot. (#22579)

### DIFF
--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -931,7 +931,7 @@
   <data name="Snix_Connect" xml:space="preserve">
     <value>A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections.</value>
   </data>
-  <data name="Snix_PreLoginBeforeSuccessfullWrite" xml:space="preserve">
+  <data name="Snix_PreLoginBeforeSuccessfulWrite" xml:space="preserve">
     <value>The client was unable to establish a connection because of an error during connection initialization process before login. Possible causes include the following:  the client tried to connect to an unsupported version of SQL Server; the server was too busy to accept new connections; or there was a resource limitation (insufficient memory or maximum allowed connections) on the server.</value>
   </data>
   <data name="Snix_PreLogin" xml:space="preserve">

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsEnums.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsEnums.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-
-//------------------------------------------------------------------------------
-
+using System.Diagnostics;
 
 namespace System.Data.SqlClient
 {
@@ -870,13 +867,54 @@ namespace System.Data.SqlClient
         internal static readonly int[] WHIDBEY_TIME_LENGTH = { 8, 10, 11, 12, 13, 14, 15, 16 };
         internal static readonly int[] WHIDBEY_DATETIME2_LENGTH = { 19, 21, 22, 23, 24, 25, 26, 27 };
         internal static readonly int[] WHIDBEY_DATETIMEOFFSET_LENGTH = { 26, 28, 29, 30, 31, 32, 33, 34 };
+
+        // Needed for UapAot, since we cannot use Enum.GetName() on SniContext.
+        // Enum.GetName() uses reflection, which is blocked on UapAot for internal types
+        // like SniContext.
+        internal static string GetSniContextEnumName(SniContext sniContext)
+        {
+            switch (sniContext)
+            {
+                case SniContext.Undefined:
+                    return "Undefined";
+                case SniContext.Snix_Connect:
+                    return "Snix_Connect";
+                case SniContext.Snix_PreLoginBeforeSuccessfulWrite:
+                    return "Snix_PreLoginBeforeSuccessfulWrite";
+                case SniContext.Snix_PreLogin:
+                    return "Snix_PreLogin";
+                case SniContext.Snix_LoginSspi:
+                    return "Snix_LoginSspi";
+                case SniContext.Snix_ProcessSspi:
+                    return "Snix_ProcessSspi";
+                case SniContext.Snix_Login:
+                    return "Snix_Login";
+                case SniContext.Snix_EnableMars:
+                    return "Snix_EnableMars";
+                case SniContext.Snix_AutoEnlist:
+                    return "Snix_AutoEnlist";
+                case SniContext.Snix_GetMarsSession:
+                    return "Snix_GetMarsSession";
+                case SniContext.Snix_Execute:
+                    return "Snix_Execute";
+                case SniContext.Snix_Read:
+                    return "Snix_Read";
+                case SniContext.Snix_Close:
+                    return "Snix_Close";
+                case SniContext.Snix_SendRows:
+                    return "Snix_SendRows";
+                default:
+                    Debug.Fail($"Received unknown SniContext enum. Value: {sniContext}");
+                    return null;
+            }
+        }
     }
 
     internal enum SniContext
     {
         Undefined = 0,
         Snix_Connect,
-        Snix_PreLoginBeforeSuccessfullWrite,
+        Snix_PreLoginBeforeSuccessfulWrite,
         Snix_PreLogin,
         Snix_LoginSspi,
         Snix_ProcessSspi,

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -350,7 +350,7 @@ namespace System.Data.SqlClient
                     serverInfo.ResolvedServerName : serverInfo.PreRoutingServerName);
             }
             _state = TdsParserState.OpenNotLoggedIn;
-            _physicalStateObj.SniContext = SniContext.Snix_PreLoginBeforeSuccessfullWrite;
+            _physicalStateObj.SniContext = SniContext.Snix_PreLoginBeforeSuccessfulWrite;
             _physicalStateObj.TimeoutTime = timerExpire;
 
             bool marsCapable = false;
@@ -1166,7 +1166,9 @@ namespace System.Data.SqlClient
             else
                 Debug.Assert(!string.IsNullOrEmpty(details.errorMessage), "Empty error message received from SNI");
 
-            string sqlContextInfo = SR.GetResourceString(Enum.GetName(typeof(SniContext), stateObj.SniContext), Enum.GetName(typeof(SniContext), stateObj.SniContext));
+            string sniContextEnumName = TdsEnums.GetSniContextEnumName(stateObj.SniContext);
+
+            string sqlContextInfo = SR.GetResourceString(sniContextEnumName, sniContextEnumName);
             string providerRid = String.Format((IFormatProvider)null, "SNI_PN{0}", details.provider);
             string providerName = SR.GetResourceString(providerRid, providerRid);
             Debug.Assert(!string.IsNullOrEmpty(providerName), String.Format((IFormatProvider)null, "invalid providerResourceId '{0}'", providerRid));


### PR DESCRIPTION
Porting change to release/UWP6.0