### PR TITLE
Fixed build break issue in armel test builds

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -5,6 +5,8 @@
     <!-- Given that xunit packages bring with them part of the framework, we need to specify a runtime in order to get the assets
          The only asset that we copy which is RID-specific is sni.dll which is only used in windows, which is why we default to Windows as the RID -->
     <NugetRuntimeIdentifier>win10-$(ArchGroup)</NugetRuntimeIdentifier>
+    <!-- Use xunit for arm packages because of not providing armel package in win10 -->
+    <NugetRuntimeIdentifier Condition="'$(ArchGroup)' == 'armel'">win10-arm</NugetRuntimeIdentifier>
     <RidSpecificAssets>true</RidSpecificAssets>
     <OutputPath>$(RuntimePath)</OutputPath>
     <XUnitRunnerPackageId Condition="'$(TargetGroup)' != 'netfx'">xunit.console.netcore</XUnitRunnerPackageId>


### PR DESCRIPTION
This patch allows to use xunit for arm packages because of not providing armel package in win10.

Related patch: bea73c5ffdf8b188fd71facff831e92f2ad97c9e

Build command:
```
# native build
$ docker run -v $(pwd):/opt/code -w /opt/code -e 'ROOTFS_DIR=/crossrootfs/armel.tizen.build' hqueue/dotnetcore:ubuntu1404_cross_prereqs_v4-tizen_rootfs ./build-native.sh -buildArch=armel -release
# managed build
$ docker run -v $(pwd):/opt/code -w /opt/code -e 'ROOTFS_DIR=/crossrootfs/armel.tizen.build' hqueue/dotnetcore:ubuntu1404_cross_prereqs_v4-tizen_rootfs ./build-managed.sh -buildArch=armel -release -RuntimeOS=tizen.4.0.0 -portable=false -- /p:BinPlaceNETCoreAppPackage=true /p:OverridePackageSource=https://tizen.myget.org/F/dotnet-core/api/v3/index.json
# test build
$ docker run -v $(pwd):/opt/code -w /opt/code -e 'ROOTFS_DIR=/crossrootfs/armel.tizen.build' hqueue/dotnetcore:ubuntu1404_cross_prereqs_v4-tizen_rootfs ./build-tests.sh -buildArch=armel -release -Outerloop -SkipTest
```

The last stage(build-test.sh) is failed with the following error messages:
```
/var/jenkins/workspace/netcore/build/build_corefx_release/repo/code/Tools/publishtest.targets(32,5): error MSB3030: Could not copy the file "/var/jenkins/workspace/netcore/build/build_corefx_release/repo/code/bin/runtime/netcoreapp-Linux-Release-armel/xunit.console.netcore.exe" because it was not found. [/var/jenkins/workspace/netcore/build/build_corefx_release/repo/code/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCompiler.Tests.csproj]
```

Currently there is no win10-armel package for xunit.console so the XUnit.Runtime.depproj can not be resolved normally. This causes an error saying that the xunit.console.netcore.exe file cannot be copied.

/cc @hseok-oh @hqueue @ragmani 