### PR TITLE
Remove pIsMatchingStatic out parameter from AdjustMemberObject

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -726,14 +726,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             Expr obj = !isExtensionMethod ? grp.OptionalObject: null;
-            bool bIsMatchingStatic;
             bool constrained;
             PostBindMethod(ref mwiWrap, obj);
-            obj = AdjustMemberObject(mwiWrap, obj, out constrained, out bIsMatchingStatic);
-            if (!bIsMatchingStatic)
-            {
-                grp.SetMismatchedStaticBit();
-            }
+            obj = AdjustMemberObject(mwiWrap, obj, out constrained);
             obj = isExtensionMethod ? grp.OptionalObject: obj;
             Debug.Assert(mwiWrap.Meth().getKind() == SYMKIND.SK_MethodSymbol);
             if (mwiWrap.TypeArgs.Count > 0)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Call.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Call.cs
@@ -42,11 +42,5 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public Expr CastOfNonLiftedResultToLiftedType { get; set; }
 
         SymWithType IExprWithArgs.GetSymWithType() => MethWithInst;
-
-        public override void SetMismatchedStaticBit()
-        {
-            MemberGroup?.SetMismatchedStaticBit();
-            base.SetMismatchedStaticBit();
-        }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/EXPR.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/EXPR.cs
@@ -21,11 +21,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool IsOptionalArgument { get; set; }
 
-        public virtual void SetMismatchedStaticBit()
-        {
-            HasError = true;
-        }
-
         public string ErrorString { get; set; }
 
         public virtual CType Type => null;


### PR DESCRIPTION
If this parameter is ever set to false it is either set to true again before the method returns, or an exception is thrown which is not caught at the caller.

Remove it, and all paths for it being false.