### PR TITLE
Make Expr.Type in Microsoft.CSharp non-virtual.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Assignment.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Assignment.cs
@@ -6,6 +6,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal sealed class ExprAssignment : Expr
     {
+        private Expr _lhs;
+
         public ExprAssignment(Expr lhs, Expr rhs)
             : base(ExpressionKind.Assignment)
         {
@@ -14,10 +16,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Flags = EXPRFLAG.EXF_ASSGOP;
         }
 
-        public Expr LHS { get; set; }
+        public Expr LHS
+        {
+            get => _lhs;
+            set => Type = (_lhs = value).Type;
+        }
 
         public Expr RHS { get; set; }
-
-        public override CType Type => LHS.Type;
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Cast.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Cast.cs
@@ -8,6 +8,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal sealed class ExprCast : Expr
     {
+        private ExprClass _destinationType;
+
         public ExprCast(EXPRFLAG flags, ExprClass destinationType, Expr argument)
             : base(ExpressionKind.Cast)
         {
@@ -21,9 +23,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public Expr Argument { get; set; }
 
-        public ExprClass DestinationType { get; set; }
-
-        public override CType Type => DestinationType.Type;
+        public ExprClass DestinationType
+        {
+            get => _destinationType;
+            set => Type = (_destinationType = value).Type;
+        }
 
         public bool IsBoxingCast => (Flags & (EXPRFLAG.EXF_BOX | EXPRFLAG.EXF_FORCE_BOX)) != 0;
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/EXPR.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/EXPR.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public string ErrorString { get; set; }
 
-        public virtual CType Type => null;
+        public CType Type { get; protected set; }
 
         public bool IsOK => !HasError;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ExprWithType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ExprWithType.cs
@@ -11,7 +11,5 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Type = type;
         }
-
-        public override CType Type { get; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/LocalVariable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/LocalVariable.cs
@@ -13,10 +13,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Flags = EXPRFLAG.EXF_LVALUE;
             Local = local;
+            Type = local?.GetType();
         }
 
         public LocalVariableSymbol Local { get; }
-
-        public override CType Type => Local?.GetType();
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/NamedArgumentSpecification.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/NamedArgumentSpecification.cs
@@ -8,6 +8,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal sealed class ExprNamedArgumentSpecification : Expr
     {
+        private Expr _value;
+
         public ExprNamedArgumentSpecification(Name name, Expr value)
             : base(ExpressionKind.NamedArgumentSpecification)
         {
@@ -17,8 +19,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public Name Name { get; }
 
-        public Expr Value { get; set; }
-
-        public override CType Type => Value.Type;
+        public Expr Value
+        {
+            get => _value;
+            set => Type = (_value = value).Type;
+        }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Temporary.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Temporary.cs
@@ -10,11 +10,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             : base(ExpressionKind.Wrap)
         {
             OptionalExpression = expression;
+            Type = expression?.Type;
             Flags = EXPRFLAG.EXF_LVALUE;
         }
 
         public Expr OptionalExpression { get; }
-
-        public override CType Type => OptionalExpression?.Type;
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/UserDefinedConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/UserDefinedConversion.cs
@@ -8,6 +8,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal sealed class ExprUserDefinedConversion : Expr
     {
+        private Expr _userDefinedCall;
+
         public ExprUserDefinedConversion(Expr argument, Expr call, MethWithInst method)
             : base(ExpressionKind.UserDefinedConversion)
         {
@@ -24,9 +26,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public Expr Argument { get; set; }
 
-        public Expr UserDefinedCall { get; set; }
-
-        public override CType Type => UserDefinedCall.Type;
+        public Expr UserDefinedCall
+        {
+            get => _userDefinedCall;
+            set => Type = (_userDefinedCall = value).Type;
+        }
 
         public MethWithInst UserDefinedCallMethod { get; }
     }


### PR DESCRIPTION
Since those types that compute this do so in a limited number of places and can pre-emptively do so, and since only a small number never set it, the advantage of having the member virtual is low.

Conversely, since the property is accessed a very large number of times the advantage of having the getter a simple (hidden) field access which would be fast and more easily inlined, is greater.