### PR TITLE
M.CSharp: Improve error handling with CSharpInvokeConstructorBinder

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                             typeof(RuntimeBinderException).GetConstructor(new Type[] { typeof(string) }),
                             Expression.Constant(e.Message)
                         ),
-                        GetTypeForErrorMetaObject(action, args.Length == 0 ? null : args[0])
+                        GetTypeForErrorMetaObject(action, args)
                     ),
                     restrictions
                 );
@@ -304,21 +304,16 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        private static Type GetTypeForErrorMetaObject(DynamicMetaObjectBinder action, DynamicMetaObject arg0)
+        private static Type GetTypeForErrorMetaObject(DynamicMetaObjectBinder action, DynamicMetaObject[] args)
         {
             // This is similar to ConvertResult but has fewer things to worry about.
 
-            var invokeConstructor = action as CSharpInvokeConstructorBinder;
-            if (invokeConstructor != null)
+            if (action is CSharpInvokeConstructorBinder)
             {
-                Type result = arg0.Value as Type;
-                if (result == null)
-                {
-                    Debug.Assert(false);
-                    return typeof(object);
-                }
-
-                return result;
+                Debug.Assert(args != null);
+                Debug.Assert(args.Length != 0);
+                Debug.Assert(args[0].Value is Type);
+                return args[0].Value as Type;
             }
 
             return action.ReturnType;

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -374,6 +374,6 @@
     <value>Named argument '{0}' specifies a parameter for which a positional argument has already been given</value>
   </data>
   <data name="TypeArgumentRequiredForStaticCall" xml:space="preserve">
-    <value>The first argument to dynamically-bound static call must be a Type</value>
+    <value>The first argument to dynamically-bound static or constructor call must be a Type</value>
   </data>
 </root>

--- a/src/Microsoft.CSharp/tests/RuntimeBinderExceptionTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderExceptionTests.cs
@@ -94,7 +94,23 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
                         }));
             Func<CallSite, object, object, object, object> target = site.Target;
-            Assert.Throws<ArgumentException>("Type Argument", () => target.Invoke(site, null, 2, 2));
+            AssertExtensions.Throws<ArgumentException>("Type Argument", () => target.Invoke(site, null, 2, 2));
+        }
+
+        [Fact]
+        public void NonTypeToCtor()
+        {
+            CallSite<Func<CallSite, object, object>> site = CallSite<Func<CallSite, object, object>>.Create(
+                Binder.InvokeConstructor(
+                    CSharpBinderFlags.None, GetType(),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "Type Argument")
+                    }
+                )
+            );
+            Func<CallSite, object, object> targ = site.Target;
+            AssertExtensions.Throws<ArgumentException>("Type Argument", () => targ.Invoke(site, 23));
         }
     }
 }


### PR DESCRIPTION
* Better message for ctor called by non-type.

`TypeArgumentRequiredForStaticCall` can be used for constructor calls as well as static type calls, so reword to cover that case.

Fixes #22695

* Refactor `GetTypeForErrorMetaObject`

We only need to extract the first item in `args` in one case, so pass the array rather than that first element.

Replace `as` used just as test with `is`.

In `action is CSharpInvokeConstructorBinder` branch, first argument is guaranteed to be a Type, or there would have been an `ArgumentException` earlier, so no need to guard against it being otherwise.