### PR TITLE
WebRequest.DefaultWebProxy: Set doesn't work without a previous Get

### DIFF
--- a/src/System.Net.Requests/src/System/Net/WebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/WebRequest.cs
@@ -573,6 +573,7 @@ namespace System.Net
                 lock (s_internalSyncObject)
                 {
                     s_DefaultWebProxy = value;
+                    s_DefaultWebProxyInitialized = true;
                 }
             }
         }


### PR DESCRIPTION
Unless we do an unnecessary Get() on WebRequest.DefaultWebProxy, any Set() done will not be honored.

This is especially a problem on Linux, where DefaultWebProxy throws PlatformNotSupportedException(). This in turn breaks libraries like WindowsAzure.Storage which fail unless the Get() is called first and then WebRequest.DefaultWebProxy is set to null.

This fix avoids the unnecessary Get() by setting the already initialized flag sent to the LazyInitializer.

@davidsh 