### PR TITLE
Revert PackageBaseline 1.0.0 stabilization

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/stable.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/stable.packages.props
@@ -487,9 +487,6 @@
     <StablePackage Include="Microsoft.NETCore.Targets">
       <Version>1.0.1</Version>
     </StablePackage>
-    <StablePackage Include="Microsoft.Private.PackageBaseline">
-      <Version>1.0.0</Version>
-    </StablePackage>
     <StablePackage Include="Microsoft.VisualBasic">
       <Version>10.0.1</Version>
     </StablePackage>


### PR DESCRIPTION
Always produce a prerelease to represent versions produced in the latest servicing build.

Without this change, release/1.0.0 always produces 1.0.0, which makes the official build fail when MyGet feed overwrites are disabled.