### PR TITLE
Remove ILCBuildType=chk for Microsoft.VisualBasic.Tests (#22652)

### DIFF
--- a/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
+++ b/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
@@ -3,8 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}</ProjectGuid>
-    <!-- CodeGen bug is causing two tests to fail if ILC builds ret -->
-    <ILCBuildType>chk</ILCBuildType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />


### PR DESCRIPTION
Port the ILCBuildType removal for Microsoft.VisualBasic.Tests as this was a workaround since this tests where hitting a codegen bug which is now fixed.