### PR TITLE
Adding few libraries to UWP Metapackage

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1133,6 +1133,7 @@
         "net461": "4.1.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
+        "uap10.0.15138": "4.3.0.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -3805,7 +3806,9 @@
         "4.3.0"
       ],
       "BaselineVersion": "4.4.0",
-      "InboxOn": {},
+      "InboxOn": {
+        "uap10.0.15138": "4.1.1.0"
+      },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",
@@ -3869,7 +3872,9 @@
         "4.3.0"
       ],
       "BaselineVersion": "4.3.0",
-      "InboxOn": {},
+      "InboxOn": {
+        "uap10.0.15138": "4.3.1.0",
+      },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.2.0",
         "4.1.0.0": "4.2.0",
@@ -4081,7 +4086,9 @@
         "4.3.0"
       ],
       "BaselineVersion": "4.4.0",
-      "InboxOn": {},
+      "InboxOn": {
+        "uap10.0.15138": "4.1.1.0"
+      },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0",

--- a/src/System.Data.SqlClient/dir.props
+++ b/src/System.Data.SqlClient/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.3.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
+++ b/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
@@ -6,6 +6,10 @@
       <SupportedFramework>net461;netcoreapp2.0;$(UAPvNextTFM);$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Data.SqlClient.csproj" />
+    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>runtimes/win/lib/$(UAPvNextTFM)</TargetPath>
+    </File>
     <HarvestIncludePaths Include="ref/net451;lib/net451;runtimes/win/lib/net451" />
     <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
     <HarvestIncludePaths Include="ref/netstandard1.2">

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.csproj
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{D58E8D2B-3331-4660-8DFB-512D66F8EC63}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
-    <!-- UAPvNext is not yet mapped to netstandard2.0, manually duplicate this ref -->
-    <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard'">netstandard2.0;$(UAPvNextTFM)</PackageTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />

--- a/src/System.Data.SqlClient/src/Configurations.props
+++ b/src/System.Data.SqlClient/src/Configurations.props
@@ -1,14 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
-      uap-Windows_NT;
+    <PackageConfigurations>
       netstandard-Unix;
       netstandard-Windows_NT;
       netstandard1.2;
       netstandard1.3;
       netstandard;
       netfx-Windows_NT;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations)
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.AccessControl/dir.props
+++ b/src/System.Security.AccessControl/dir.props
@@ -6,5 +6,6 @@
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
+++ b/src/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
@@ -5,6 +5,10 @@
     <ProjectReference Include="..\ref\System.Security.AccessControl.csproj">
       <SupportedFramework>net461;netcoreapp2.0;$(UAPvNextTFM);$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>runtimes/win/lib/$(UAPvNextTFM)</TargetPath>
+    </File>
+    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
     <ProjectReference Include="..\src\System.Security.AccessControl.csproj" />
     <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
     <HarvestIncludePaths Include="ref/netstandard1.3">

--- a/src/System.Security.AccessControl/ref/System.Security.AccessControl.csproj
+++ b/src/System.Security.AccessControl/ref/System.Security.AccessControl.csproj
@@ -3,8 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{F80C478C-48EE-46A5-89C4-EE0CFB23A14F}</ProjectGuid>
-    <!-- UAPvNext is not yet mapped to netstandard2.0, manually duplicate this ref -->
-    <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard'">netstandard2.0;$(UAPvNextTFM)</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />

--- a/src/System.Security.AccessControl/src/Configurations.props
+++ b/src/System.Security.AccessControl/src/Configurations.props
@@ -1,11 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netfx-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
       netstandard;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations)
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Security.Cryptography.Cng/dir.props
+++ b/src/System.Security.Cryptography.Cng/dir.props
@@ -7,6 +7,5 @@
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
     <IsUAP>true</IsUAP>
-    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
+++ b/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
@@ -6,7 +6,10 @@
       <SupportedFramework>net461;netcoreapp2.0;$(UAPvNextTFM);$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Cng.csproj" />
-
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>runtimes/win/lib/$(UAPvNextTFM)</TargetPath>
+    </File>
+    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
     <!-- All elements from previous packages that will be included in the newly built package -->
     <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
     <HarvestIncludePaths Include="ref/netstandard1.3" />

--- a/src/System.Security.Cryptography.Cng/ref/Configurations.props
+++ b/src/System.Security.Cryptography.Cng/ref/Configurations.props
@@ -1,13 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netcoreapp;
       netfx;
-      uap;
       netstandard;
       net462;
       net47;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations)
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Cng/src/Configurations.props
+++ b/src/System.Security.Cryptography.Cng/src/Configurations.props
@@ -1,15 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
       netstandard1.3;
       netstandard1.4;
       netfx-Windows_NT;
       netcoreapp-Windows_NT;
-      uap-Windows_NT;
       net462-Windows_NT;
       net47-Windows_NT;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations)
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Principal.Windows/dir.props
+++ b/src/System.Security.Principal.Windows/dir.props
@@ -7,6 +7,5 @@
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
     <IsUAP>true</IsUAP>
-    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Principal.Windows/pkg/System.Security.Principal.Windows.pkgproj
+++ b/src/System.Security.Principal.Windows/pkg/System.Security.Principal.Windows.pkgproj
@@ -6,6 +6,10 @@
       <SupportedFramework>net461;netcoreapp2.0;$(UAPvNextTFM);$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Principal.Windows.csproj" />
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>runtimes/win/lib/$(UAPvNextTFM)</TargetPath>
+    </File>
+    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
     <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
     <HarvestIncludePaths Include="ref/netstandard1.3;runtimes/win/lib/netstandard1.3" />
     <HarvestIncludePaths Include="runtimes/unix/lib/netstandard1.3">

--- a/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.csproj
@@ -3,8 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{25A02E40-D12C-4184-B599-E4F954D142DB}</ProjectGuid>
-    <!-- UAPvNext is not yet mapped to netstandard2.0, manually duplicate this ref -->
-    <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard'">netstandard2.0;$(UAPvNextTFM)</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />

--- a/src/System.Security.Principal.Windows/src/Configurations.props
+++ b/src/System.Security.Principal.Windows/src/Configurations.props
@@ -1,12 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
-      uap-Windows_NT;
+    <PackageConfigurations>
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
       netstandard;
       netfx-Windows_NT;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations)
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #22670

cc: @Petermarcu @weshaggard @ericstj @joshfree 

These changes will add some libraries to the UWP Metapackage. The libraries were selected as part of the investigation done by #22670, which essentially are assemblies that have a specific build configuration for uap but are not part of the metapackage currently. By adding them to UWP Metapackage, we won't have to ship individual packages containing them.