### PR TITLE
Exlude Unix clrcompression packages from build

### DIFF
--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -42,30 +42,29 @@
       <OSGroup>opensuse.42.1</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-  </ItemGroup>
-  <ItemGroup>
-    <Project Include="runtime.native.System.IO.Compression.pkgproj">
+  </ItemGroup>    
+  <ItemDefinitionGroup>
+    <Project>
       <UndefineProperties>SkipUnix</UndefineProperties>
     </Project>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Project Include="runtime.native.System.IO.Compression.pkgproj"/>
     <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>x86</Platform>
-      <UndefineProperties>SkipUnix</UndefineProperties>
     </Project>
     <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>amd64</Platform>
-      <UndefineProperties>SkipUnix</UndefineProperties>
     </Project>
     <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>arm</Platform>
-      <UndefineProperties>SkipUnix</UndefineProperties>
     </Project>
     <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>arm64</Platform>
-      <UndefineProperties>SkipUnix</UndefineProperties>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <ItemGroup>
-    <Project Include="runtime.native.System.IO.Compression.pkgproj"/>
+  <ItemGroup Condition="'$(SkipUnix)'!='true'">
     <Project Include="rhel\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>
@@ -43,21 +42,30 @@
       <OSGroup>opensuse.42.1</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+  </ItemGroup>
+  <ItemGroup>
+    <Project Include="runtime.native.System.IO.Compression.pkgproj">
+      <UndefineProperties>SkipUnix</UndefineProperties>
+    </Project>
     <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>x86</Platform>
+      <UndefineProperties>SkipUnix</UndefineProperties>
     </Project>
     <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>amd64</Platform>
+      <UndefineProperties>SkipUnix</UndefineProperties>
     </Project>
     <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>arm</Platform>
+      <UndefineProperties>SkipUnix</UndefineProperties>
     </Project>
     <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>arm64</Platform>
+      <UndefineProperties>SkipUnix</UndefineProperties>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -34,7 +34,7 @@
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >   
     <!-- add specific native builds / pkgproj's here to include in servicing builds -->
     <Project Include=".\Native\pkg\runtime.native.System.IO.Compression\runtime.native.System.IO.Compression.builds">
-      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true;SkipUnix=true</AdditionalProperties>
     </Project>
     <Project Include=".\Native\pkg\runtime.native.System.Security.Cryptography.Apple\runtime.native.System.Security.Cryptography.Apple.builds">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>


### PR DESCRIPTION
This excludes the runtime.native.system.io.compression non-windows packages from being built when BuildAllPackages == false. 

resolves https://github.com/dotnet/corefx/issues/22721