### PR TITLE
Enabling HttpClient EKU tests.

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientEKUTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientEKUTest.cs
@@ -15,7 +15,6 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    [ActiveIssue(21738, TargetFrameworkMonikers.Uap)] // If Capability.IsTrustedRootCertificateInstalled()==true, the tests are hanging.
     public class HttpClientEKUTest
     {
         // Curl + OSX SecureTransport doesn't support the custom certificate callback.


### PR DESCRIPTION
For UWP, the tests require both the Root as well as all the client certificates to be correctly installed. 
These tests require client side prerequisites and cannot be executed in CI at this time.

Fixes #21738