### PR TITLE
Remove redundancy from ExprZeroInit in MicrosoftCSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
@@ -956,10 +956,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 }
                 else if (pExpr is ExprZeroInit zeroInit)
                 {
-                    if ((pExpr = zeroInit.OptionalArgument) == null)
-                    {
-                        return Activator.CreateInstance(zeroInit.Type.AssociatedSystemType);
-                    }
+                    return Activator.CreateInstance(zeroInit.Type.AssociatedSystemType);
                 }
                 else
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
@@ -124,7 +124,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public Expr CreateZeroInit(CType type)
         {
             Debug.Assert(type != null);
-            bool isError = false;
 
             if (type.isEnumType())
             {
@@ -133,6 +132,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return CreateConstant(type, ConstVal.Get(Activator.CreateInstance(type.AssociatedSystemType)));
             }
 
+            Debug.Assert(type.fundType() > FUNDTYPE.FT_NONE);
+            Debug.Assert(type.fundType() < FUNDTYPE.FT_COUNT);
             switch (type.fundType())
             {
                 case FUNDTYPE.FT_PTR:
@@ -141,35 +142,20 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         return CreateCast(0, CreateClass(type), CreateNull());
                     }
 
-                case FUNDTYPE.FT_REF:
-                case FUNDTYPE.FT_I1:
-                case FUNDTYPE.FT_U1:
-                case FUNDTYPE.FT_I2:
-                case FUNDTYPE.FT_U2:
-                case FUNDTYPE.FT_I4:
-                case FUNDTYPE.FT_U4:
-                case FUNDTYPE.FT_I8:
-                case FUNDTYPE.FT_U8:
-                case FUNDTYPE.FT_R4:
-                case FUNDTYPE.FT_R8:
-                    return CreateConstant(type, ConstVal.GetDefaultValue(type.constValKind()));
                 case FUNDTYPE.FT_STRUCT:
                     if (type.isPredefType(PredefinedType.PT_DECIMAL))
                     {
-                        goto case FUNDTYPE.FT_R8;
+                        goto default;
                     }
 
-                    break;
+                    goto case FUNDTYPE.FT_VAR;
 
                 case FUNDTYPE.FT_VAR:
-                    break;
+                    return new ExprZeroInit(type);
 
                 default:
-                    isError = true;
-                    break;
+                    return CreateConstant(type, ConstVal.GetDefaultValue(type.constValKind()));
             }
-
-            return new ExprZeroInit(type, isError);
         }
 
         public ExprConstant CreateConstant(CType type, ConstVal constVal) => new ExprConstant(type, constVal);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
@@ -121,9 +121,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         //
         // This returns a null for reference types and an EXPRZEROINIT for all others.
 
-        public Expr CreateZeroInit(CType type) => CreateZeroInit(CreateClass(type), null, false);
+        public Expr CreateZeroInit(CType type) => CreateZeroInit(CreateClass(type), null);
 
-        private Expr CreateZeroInit(ExprClass typeExpr, Expr originalConstructorCall, bool isConstructor)
+        private Expr CreateZeroInit(ExprClass typeExpr, Expr originalConstructorCall)
         {
             Debug.Assert(typeExpr != null);
             CType type = typeExpr.Type;
@@ -181,7 +181,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
             }
 
-            return new ExprZeroInit(type, originalConstructorCall, isConstructor, isError);
+            return new ExprZeroInit(type, originalConstructorCall, isError);
         }
 
         public ExprConstant CreateConstant(CType type, ConstVal constVal) => new ExprConstant(type, constVal);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
@@ -121,9 +121,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         //
         // This returns a null for reference types and an EXPRZEROINIT for all others.
 
-        public Expr CreateZeroInit(CType type) => CreateZeroInit(CreateClass(type), null);
+        public Expr CreateZeroInit(CType type) => CreateZeroInit(CreateClass(type));
 
-        private Expr CreateZeroInit(ExprClass typeExpr, Expr originalConstructorCall)
+        private Expr CreateZeroInit(ExprClass typeExpr)
         {
             Debug.Assert(typeExpr != null);
             CType type = typeExpr.Type;
@@ -181,7 +181,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
             }
 
-            return new ExprZeroInit(type, originalConstructorCall, isError);
+            return new ExprZeroInit(type, isError);
         }
 
         public ExprConstant CreateConstant(CType type, ConstVal constVal) => new ExprConstant(type, constVal);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
@@ -121,12 +121,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         //
         // This returns a null for reference types and an EXPRZEROINIT for all others.
 
-        public Expr CreateZeroInit(CType type) => CreateZeroInit(CreateClass(type));
-
-        private Expr CreateZeroInit(ExprClass typeExpr)
+        public Expr CreateZeroInit(CType type)
         {
-            Debug.Assert(typeExpr != null);
-            CType type = typeExpr.Type;
+            Debug.Assert(type != null);
             bool isError = false;
 
             if (type.isEnumType())
@@ -150,7 +147,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
 
                         // Just allocate a new node and fill it in.
-                        return CreateCast(0, typeExpr, CreateNull());
+                        return CreateCast(0, CreateClass(type), CreateNull());
                     }
 
                 case FUNDTYPE.FT_REF:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
@@ -137,15 +137,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 case FUNDTYPE.FT_PTR:
                     {
-                        CType nullType = Types.GetNullType();
-
-                        // It looks like this if is always false ...
-                        if (nullType.fundType() == type.fundType())
-                        {
-                            // Create a constant here.
-                            return CreateConstant(type, ConstVal.GetDefaultValue(ConstValKind.IntPtr));
-                        }
-
                         // Just allocate a new node and fill it in.
                         return CreateCast(0, CreateClass(type), CreateNull());
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
@@ -350,8 +350,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
 
                 case ExpressionKind.ZeroInit:
-                    exprRet = Visit((pExpr as ExprZeroInit).OptionalArgument);
-                    (pExpr as ExprZeroInit).OptionalArgument = exprRet;
                     break;
 
                 case ExpressionKind.Block:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
@@ -352,10 +352,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case ExpressionKind.ZeroInit:
                     exprRet = Visit((pExpr as ExprZeroInit).OptionalArgument);
                     (pExpr as ExprZeroInit).OptionalArgument = exprRet;
-
-                    // Used for when we zeroinit 0 parameter constructors for structs/enums.
-                    exprRet = Visit((pExpr as ExprZeroInit).OptionalConstructorCall);
-                    (pExpr as ExprZeroInit).OptionalConstructorCall = exprRet;
                     break;
 
                 case ExpressionKind.Block:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -353,13 +353,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(expr != null);
             Debug.Assert(expr.OptionalArgument == null);
-
-            if (expr.IsConstructor)
-            {
-                // We have a parameterless "new MyStruct()" which has been realized as a zero init.
-                ExprTypeOf pTypeOf = CreateTypeOf(expr.Type);
-                return GenerateCall(PREDEFMETH.PM_EXPRESSION_NEW_TYPE, pTypeOf);
-            }
             return GenerateConstant(expr);
         }
         protected override Expr VisitTYPEOF(ExprTypeOf expr)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -352,7 +352,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         protected override Expr VisitZEROINIT(ExprZeroInit expr)
         {
             Debug.Assert(expr != null);
-            Debug.Assert(expr.OptionalArgument == null);
             return GenerateConstant(expr);
         }
         protected override Expr VisitTYPEOF(ExprTypeOf expr)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ZeroInitialize.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ZeroInitialize.cs
@@ -6,11 +6,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal sealed class ExprZeroInit : ExprWithType
     {
-        public ExprZeroInit(CType type, Expr originalConstructorCall, bool isConstructor, bool isError)
+        public ExprZeroInit(CType type, Expr originalConstructorCall, bool isError)
             : base(ExpressionKind.ZeroInit, type)
         {
             OptionalConstructorCall = originalConstructorCall;
-            IsConstructor = isConstructor;
             if (isError)
             {
                 SetError();
@@ -20,7 +19,5 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public Expr OptionalArgument { get; set; }
 
         public Expr OptionalConstructorCall { get; set; }
-
-        public bool IsConstructor { get; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ZeroInitialize.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ZeroInitialize.cs
@@ -6,13 +6,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal sealed class ExprZeroInit : ExprWithType
     {
-        public ExprZeroInit(CType type, bool isError)
+        public ExprZeroInit(CType type)
             : base(ExpressionKind.ZeroInit, type)
         {
-            if (isError)
-            {
-                SetError();
-            }
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ZeroInitialize.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ZeroInitialize.cs
@@ -6,10 +6,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal sealed class ExprZeroInit : ExprWithType
     {
-        public ExprZeroInit(CType type, Expr originalConstructorCall, bool isError)
+        public ExprZeroInit(CType type, bool isError)
             : base(ExpressionKind.ZeroInit, type)
         {
-            OptionalConstructorCall = originalConstructorCall;
             if (isError)
             {
                 SetError();
@@ -17,7 +16,5 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         public Expr OptionalArgument { get; set; }
-
-        public Expr OptionalConstructorCall { get; set; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ZeroInitialize.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ZeroInitialize.cs
@@ -14,7 +14,5 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 SetError();
             }
         }
-
-        public Expr OptionalArgument { get; set; }
     }
 }


### PR DESCRIPTION
* Remove `ExprZeroInit.IsConstructor`

Only ever false (in static code this could be e.g. `new int()` or similar for any value type without an explicit nullary ctor, but in dynamic code we won't see that as different to any other way to get the default as we're receiving the result of that).

* Remove `ExprZeroInit.OptionalConstructorCall`

Only ever null

* Remove `ExprZeroInit.OptionalArgument`

Only ever null.

* Don't create `ExprClass` for `CreateZeroInit` only to discard it.

Create only if it's used.

* Remove unreachable branch.

We're in a branch for `type.fundType()` being `FT_PTR` and comparing that with something that will always be `FT_REF`, so that branch is unreachable.

* Remove error branch in `CreateZeroInit`

Could only happen if called with a type like void that doesn't have a fundamental type, but no callsite attempts this.

Add appropriate assertion in this regard.