### PR TITLE
Refactor init methods into ctors in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GlobalSymbolContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GlobalSymbolContext.cs
@@ -22,7 +22,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             GlobalSymbols = new BSYMMGR(namemgr);
             _predefTypes = new PredefinedTypes(GlobalSymbols);
             TypeManager.Init(GlobalSymbols, _predefTypes);
-            GlobalSymbols.Init();
 
             _nameManager = namemgr;
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GlobalSymbolContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GlobalSymbolContext.cs
@@ -18,10 +18,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public GlobalSymbolContext(NameManager namemgr)
         {
-            TypeManager = new TypeManager();
             GlobalSymbols = new BSYMMGR(namemgr);
             _predefTypes = new PredefinedTypes(GlobalSymbols);
-            TypeManager.Init(GlobalSymbols, _predefTypes);
+            TypeManager = new TypeManager(GlobalSymbols, _predefTypes);
 
             _nameManager = namemgr;
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -33,10 +33,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private readonly StdTypeVarColl _stvcMethod;
         private readonly StdTypeVarColl _stvcClass;
 
-        public TypeManager()
+        public TypeManager(BSYMMGR bsymmgr, PredefinedTypes predefTypes)
         {
-            _predefTypes = null; // Initialized via the Init call.
-            _BSymmgr = null; // Initialized via the Init call.
             _typeFactory = new TypeFactory();
             _typeTable = new TypeTable();
 
@@ -60,6 +58,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             _stvcMethod = new StdTypeVarColl();
             _stvcClass = new StdTypeVarColl();
+            _BSymmgr = bsymmgr;
+            _predefTypes = predefTypes;
         }
 
         public void InitTypeFactory(SymbolTable table)
@@ -1015,12 +1015,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             return pTypeParameter;
-        }
-
-        internal void Init(BSYMMGR bsymmgr, PredefinedTypes predefTypes)
-        {
-            _BSymmgr = bsymmgr;
-            _predefTypes = predefTypes;
         }
 
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -47,14 +47,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _typeMethGrp = _typeFactory.CreateMethodGroup();
             _argListType = _typeFactory.CreateArgList();
 
-            InitType(_errorType);
             _errorType.SetErrors(true);
-
-            InitType(_voidType);
-            InitType(_nullType);
-            InitType(_typeUnit);
-            InitType(_typeAnonMeth);
-            InitType(_typeMethGrp);
 
             _stvcMethod = new StdTypeVarColl();
             _stvcClass = new StdTypeVarColl();
@@ -65,10 +58,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public void InitTypeFactory(SymbolTable table)
         {
             _symbolTable = table;
-        }
-
-        private void InitType(CType at)
-        {
         }
 
         private sealed class StdTypeVarColl


### PR DESCRIPTION
Move `BSYMMGR` init methods into ctor

Move `TypeManager` init method into ctor

Remove no-op calls to `TypeManager.InitType`