### PR TITLE
Tidy some nullable-handling in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -629,7 +629,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             }
             else if (callingObjectType is NullableType callingNub)
             {
-                callingType = callingNub.GetAts(_semanticChecker.SymbolLoader.GetErrorContext());
+                callingType = callingNub.GetAts();
             }
             else
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -195,12 +195,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if (_needsExprDest)
                     {
                         Expr valueSrc = _exprSrc;
-                        // This is a holdover from the days when you could have nullable of nullable.
-                        // Can we remove this loop?
-                        while (valueSrc.Type is NullableType)
+                        if (valueSrc.Type is NullableType)
                         {
                             valueSrc = _binder.BindNubValue(valueSrc);
                         }
+
                         Debug.Assert(valueSrc.Type == _typeSrc.StripNubs());
                         if (!_binder.BindExplicitConversion(valueSrc, valueSrc.Type, _exprTypeDest, _pDestinationTypeForLambdaErrorReporting, _needsExprDest, out _exprDest, _flags | CONVERTTYPE.NOUDC))
                         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
@@ -33,9 +33,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public ExprArrayInit CreateArrayInit(CType type, Expr arguments, Expr argumentDimensions, int[] dimSizes, int dimSize) => 
             new ExprArrayInit(type, arguments, argumentDimensions, dimSizes, dimSize);
 
-        public ExprProperty CreateProperty(CType type, Expr optionalObject) => 
-            CreateProperty(type, null, null, CreateMemGroup(optionalObject, new MethPropWithInst()), null, null);
-
         public ExprProperty CreateProperty(CType type, Expr optionalObjectThrough, Expr arguments, ExprMemberGroup memberGroup, PropWithType property, MethWithType setMethod) => 
             new ExprProperty(type, optionalObjectThrough, arguments, memberGroup, property, setMethod);
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1390,7 +1390,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             CType typeObj = pObject.Type;
             CType typeTmp;
 
-            if (typeObj is NullableType nubTypeObj && (typeTmp = nubTypeObj.GetAts(GetErrorContext())) != null && typeTmp != swt.GetType())
+            if (typeObj is NullableType nubTypeObj && (typeTmp = nubTypeObj.GetAts()) != swt.GetType())
             {
                 typeObj = typeTmp;
             }
@@ -1503,12 +1503,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // Don't remap static or interface methods.
             if (typeObj is NullableType nubTypeObj)
             {
-                typeObj = nubTypeObj.GetAts(symbolLoader.GetErrorContext());
-                if (typeObj == null)
-                {
-                    VSFAIL("Why did GetAts return null?");
-                    return;
-                }
+                typeObj = nubTypeObj.GetAts();
             }
 
             // Don't remap non-virtual members

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -306,9 +306,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(_exprSrc == null || _exprSrc.Type == _typeSrc);
                 Debug.Assert(!_needsExprDest || _exprSrc != null);
                 Debug.Assert(_typeSrc != nubDst); // BindImplicitConversion should have taken care of this already.
-                AggregateType atsDst = nubDst.GetAts(GetErrorContext());
-                if (atsDst == null)
-                    return false;
+                AggregateType atsDst = nubDst.GetAts();
 
                 // Check for the unboxing conversion. This takes precedence over the wrapping conversions.
                 if (GetSymbolLoader().HasBaseConversion(nubDst.GetUnderlyingType(), _typeSrc) && !CConversions.FWrappingConv(_typeSrc, nubDst))
@@ -489,11 +487,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // Otherwise, the result is obtained by boxing the result of evaluating the Value property on
                 // the nullable value.
 
-                AggregateType atsNub = nubSrc.GetAts(GetErrorContext());
-                if (atsNub == null)
-                {
-                    return false;
-                }
+                AggregateType atsNub = nubSrc.GetAts();
                 if (atsNub == _typeDest)
                 {
                     if (_needsExprDest)
@@ -876,10 +870,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private ExprFactory GetExprFactory()
             {
                 return _binder.GetExprFactory();
-            }
-            private ErrorHandling GetErrorContext()
-            {
-                return _binder.GetErrorContext();
             }
         }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
@@ -69,14 +69,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             NullableType nubSrc = (NullableType)exprSrc.Type;
             CType typeBase = nubSrc.GetUnderlyingType();
-            AggregateType ats = nubSrc.GetAts(GetErrorContext());
-            if (ats == null)
-            {
-                ExprProperty rval = GetExprFactory().CreateProperty(typeBase, exprSrc);
-                rval.SetError();
-                return rval;
-            }
-
+            AggregateType ats = nubSrc.GetAts();
             PropertySymbol prop = GetSymbolLoader().getBSymmgr().propNubValue;
             if (prop == null)
             {
@@ -97,16 +90,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             NullableType pNubSourceType = GetSymbolLoader().GetTypeManager().GetNullable(pExprSrc.Type);
 
-            AggregateType pSourceType = pNubSourceType.GetAts(GetErrorContext());
-            if (pSourceType == null)
-            {
-                MethWithInst mwi = new MethWithInst(null, null);
-                ExprMemberGroup pMemGroup = GetExprFactory().CreateMemGroup(pExprSrc, mwi);
-                ExprCall rval = GetExprFactory().CreateCall(0, pNubSourceType, null, pMemGroup, null);
-                rval.SetError();
-                return rval;
-            }
-
+            AggregateType pSourceType = pNubSourceType.GetAts();
             MethodSymbol meth = GetSymbolLoader().getBSymmgr().methNubCtor;
             if (meth == null)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
@@ -81,20 +81,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (prop == null)
             {
                 prop = GetSymbolLoader().getPredefinedMembers().GetProperty(PREDEFPROP.PP_G_OPTIONAL_VALUE);
+                Debug.Assert(prop != null);
                 GetSymbolLoader().getBSymmgr().propNubValue = prop;
             }
 
             PropWithType pwt = new PropWithType(prop, ats);
             MethPropWithInst mpwi = new MethPropWithInst(prop, ats);
             ExprMemberGroup pMemGroup = GetExprFactory().CreateMemGroup(exprSrc, mpwi);
-            ExprProperty exprRes = GetExprFactory().CreateProperty(typeBase, null, null, pMemGroup, pwt, null);
-
-            if (prop == null)
-            {
-                exprRes.SetError();
-            }
-
-            return exprRes;
+            return GetExprFactory().CreateProperty(typeBase, null, null, pMemGroup, pwt, null);
         }
 
         public ExprCall BindNew(Expr pExprSrc)
@@ -117,19 +111,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (meth == null)
             {
                 meth = GetSymbolLoader().getPredefinedMembers().GetMethod(PREDEFMETH.PM_G_OPTIONAL_CTOR);
+                Debug.Assert(meth != null);
                 GetSymbolLoader().getBSymmgr().methNubCtor = meth;
             }
 
             MethWithInst methwithinst = new MethWithInst(meth, pSourceType, BSYMMGR.EmptyTypeArray());
             ExprMemberGroup memgroup = GetExprFactory().CreateMemGroup(null, methwithinst);
-            ExprCall pExprRes = GetExprFactory().CreateCall(EXPRFLAG.EXF_NEWOBJCALL | EXPRFLAG.EXF_CANTBENULL, pNubSourceType, pExprSrc, memgroup, methwithinst);
-
-            if (meth == null)
-            {
-                pExprRes.SetError();
-            }
-
-            return pExprRes;
+            return GetExprFactory().CreateCall(EXPRFLAG.EXF_NEWOBJCALL | EXPRFLAG.EXF_CANTBENULL, pNubSourceType, pExprSrc, memgroup, methwithinst);
         }
         public CNullable(SymbolLoader symbolLoader, ErrorHandling errorContext, ExprFactory exprFactory)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case TypeKind.TK_TypeParameterType:
                     return ((TypeParameterType)typeSym).GetEffectiveBaseClass();
                 case TypeKind.TK_NullableType:
-                    return ((NullableType)typeSym).GetAts(ErrorContext);
+                    return ((NullableType)typeSym).GetAts();
             }
             Debug.Assert(false, "Bad typeSym!");
             return null;
@@ -184,11 +184,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             if (pDerived is NullableType derivedNub)
             {
-                pDerived = derivedNub.GetAts(ErrorContext);
-                if (pDerived == null)
-                {
-                    return false;
-                }
+                pDerived = derivedNub.GetAts();
             }
 
             if (!(pDerived is AggregateType atsDer))

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -39,11 +39,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (type is NullableType nub)
             {
-                CType typeT = nub.GetAts(checker.ErrorContext);
-                if (typeT != null)
-                    type = typeT;
-                else
-                    type = type.GetNakedType(true);
+                type = nub.GetAts();
             }
 
             if (!(type is AggregateType ats))
@@ -358,9 +354,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
 
                 case TypeKind.TK_NullableType:
-                    typeBnd = ((NullableType)typeBnd).GetAts(checker.ErrorContext);
-                    if (null == typeBnd)
-                        return true;
+                    typeBnd = ((NullableType)typeBnd).GetAts();
                     break;
 
                 case TypeKind.TK_AggregateType:
@@ -377,9 +371,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case TypeKind.TK_PointerType:
                     return false;
                 case TypeKind.TK_NullableType:
-                    arg = ((NullableType)arg).GetAts(checker.ErrorContext);
-                    if (null == arg)
-                        return true;
+                    arg = ((NullableType)arg).GetAts();
                     // Fall through.
                     goto case TypeKind.TK_TypeParameterType;
                 case TypeKind.TK_TypeParameterType:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullableType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullableType.cs
@@ -20,21 +20,17 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public BSYMMGR symmgr;
         public TypeManager typeManager;
 
-        public AggregateType GetAts(ErrorHandling errorContext)
+        public AggregateType GetAts()
         {
-            AggregateSymbol aggNullable = typeManager.GetNullable();
-            if (aggNullable == null)
-            {
-                throw Error.InternalCompilerError();
-            }
-
             if (ats == null)
             {
+                AggregateSymbol aggNullable = typeManager.GetNullable();
                 CType typePar = GetUnderlyingType();
-                CType[] typeParArray = new CType[] { typePar };
+                CType[] typeParArray = { typePar };
                 TypeArray ta = symmgr.AllocParams(1, typeParArray);
                 ats = typeManager.GetAggregate(aggNullable, ta);
             }
+
             return ats;
         }
         public CType GetUnderlyingType() { return UnderlyingType; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             }
             if (type is NullableType nub)
             {
-                type = nub.GetAts(_semanticChecker.SymbolLoader.GetErrorContext());
+                type = nub.GetAts();
             }
 
             if (!mem.Lookup(


### PR DESCRIPTION
* Remove paths for `Nullable<T>` not having `Value` property or ctor

Will only fail if `Nullable<T>` is so broken that we can't run anyway.

* Fix `NullableType.GetAts` calls

Remove unused parameter, move all implementation into check for memoised result, and remove paths for it returning null, which can't happen.

* Remove unnecessary looping to cast `T??`