### PR TITLE
Enable RHEL6 and CentOS 6 RID detection in build

### DIFF
--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -23,14 +23,21 @@ usage()
 
 initHostDistroRid()
 {
+    __HostDistroRid=""
     if [ "$__HostOS" == "Linux" ]; then
-        if [ ! -e /etc/os-release ]; then
-            echo "WARNING: Can not determine runtime id for current distro."
-            __HostDistroRid=""
-        else
+        if [ -e /etc/os-release ]; then
             source /etc/os-release
             __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
+        elif [ -e /etc/redhat-release ]; then
+            local redhatRelease=$(</etc/redhat-release)
+            if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
+               __HostDistroRid="rhel.6-$__HostArch"
+            fi
         fi
+    fi
+
+    if [ "$__HostDistroRid" == "" ]; then
+        echo "WARNING: Can not determine runtime id for current distro."
     fi
 }
 


### PR DESCRIPTION
This change adds RHEL6 and CentOS 6 RID detection to src/Native/build-native.sh.
These distros don't have the /etc/os-release file and so we need to use another
source - the /etc/redhat-release file.
It is an exact copy of the same change merged in for CoreCLR.