### PR TITLE
Turning off builds of packages that won't ship with UWP6.0

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -4,13 +4,29 @@
 
   <PropertyGroup>
     <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(BinDir)pkg/reports/</PackageReportDir>
+    <BuildAllPackages>false</BuildAllPackages>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Project Include="$(MSBuildThisFileDirectory)..\pkg\*\*.builds" Condition="'$(SkipManagedPackageBuild)' != 'true'">
+  <ItemGroup Condition="'$(BuildAllPackages)' == 'true'">
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\*\*.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <Project Include="*\pkg\**\*.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipManagedPackageBuild)' != 'true'">
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.Private.PackageBaseline\Microsoft.Private.PackageBaseline.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.NETCore.Targets\Microsoft.NETCore.Targets.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.Private.CoreFx.UAP\Microsoft.Private.CoreFx.UAP.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
   </ItemGroup>


### PR DESCRIPTION
cc: @weshaggard @ericstj 

Turning off builds of packages that won't ship with UWP6.0.
After these changes, the only packages that will be built out of this branch are:
- Microsoft.NETCore.Platforms
- Microsoft.NETCore.Targets
- Microsoft.Private.Corefx.UAP + RID specific packages of this one.

That means that none of our OOB packages, nor will `Microsoft.Private.CoreFx.NETCoreApp`, `Microsoft.Private.PackageBaseline`, and `NETStandard.Library.NETFramework` will build any longer.