### PR TITLE
Fix KnownColor issues

### DIFF
--- a/src/Common/src/System/Drawing/ColorTable.cs
+++ b/src/Common/src/System/Drawing/ColorTable.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace System.Drawing
@@ -23,17 +24,13 @@ namespace System.Drawing
         private static void FillConstants(Dictionary<string, Color> colors, Type enumType)
         {
             const MethodAttributes attrs = MethodAttributes.Public | MethodAttributes.Static;
-            PropertyInfo[] props = enumType.GetProperties();
-
-            foreach (PropertyInfo prop in props)
+            foreach (PropertyInfo prop in enumType.GetProperties())
             {
                 if (prop.PropertyType == typeof(Color))
                 {
-                    MethodInfo method = prop.GetGetMethod();
-                    if (method != null && (method.Attributes & attrs) == attrs)
-                    {
-                        colors[prop.Name] = (Color)prop.GetValue(null, null);
-                    }
+                    Debug.Assert(prop.GetGetMethod() != null);
+                    Debug.Assert((prop.GetGetMethod().Attributes & attrs) == attrs);
+                    colors[prop.Name] = (Color)prop.GetValue(null, null);
                 }
             }
         }

--- a/src/Common/src/System/Drawing/KnownColorTable.cs
+++ b/src/Common/src/System/Drawing/KnownColorTable.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System.Drawing
 {
 #if FEATURE_SYSTEM_EVENTS
@@ -403,28 +405,16 @@ namespace System.Drawing
 
         public static int KnownColorToArgb(KnownColor color)
         {
+            Debug.Assert(color > 0 && color <= KnownColor.MenuHighlight);
             EnsureColorTable();
-            if (color <= KnownColor.MenuHighlight)
-            {
-                return s_colorTable[unchecked((int)color)];
-            }
-            else
-            {
-                return 0;
-            }
+            return s_colorTable[unchecked((int)color)];
         }
 
         public static string KnownColorToName(KnownColor color)
         {
+            Debug.Assert(color > 0 && color <= KnownColor.MenuHighlight);
             EnsureColorNameTable();
-            if (color <= KnownColor.MenuHighlight)
-            {
-                return s_colorNameTable[unchecked((int)color)];
-            }
-            else
-            {
-                return null;
-            }
+            return s_colorNameTable[unchecked((int)color)];
         }
 
 #if FEATURE_WINDOWS_SYSTEM_COLORS

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -498,7 +498,7 @@ namespace System.Drawing
 
             float max, min;
             float delta;
-            float hue = 0.0f;
+            float hue;
 
             max = r; min = r;
 
@@ -518,8 +518,9 @@ namespace System.Drawing
             {
                 hue = 2 + (b - r) / delta;
             }
-            else if (b == max)
+            else
             {
+                Debug.Assert(b == max);
                 hue = 4 + (r - g) / delta;
             }
             hue *= 60;

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -455,7 +455,7 @@ namespace System.Drawing
         public static Color FromKnownColor(KnownColor color)
         {
             var value = (int)color;
-            if (value < (int)KnownColor.FirstColor || value > (int)KnownColor.LastColor)
+            if (value <= 0 || value > (int)KnownColor.LastColor)
             {
                 return FromName(color.ToString());
             }

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -477,11 +477,23 @@ namespace System.Drawing
 
             max = r; min = r;
 
-            if (g > max) max = g;
-            if (b > max) max = b;
+            if (g > max)
+            {
+                max = g;
+            }
+            else if (g < min)
+            {
+                min = g;
+            }
 
-            if (g < min) min = g;
-            if (b < min) min = b;
+            if (b > max)
+            {
+                max = b;
+            }
+            else if (b < min)
+            {
+                min = b;
+            }
 
             return (max + min) / 2;
         }
@@ -502,11 +514,23 @@ namespace System.Drawing
 
             max = r; min = r;
 
-            if (g > max) max = g;
-            if (b > max) max = b;
+            if (g > max)
+            {
+                max = g;
+            }
+            else if (g < min)
+            {
+                min = g;
+            }
 
-            if (g < min) min = g;
-            if (b < min) min = b;
+            if (b > max)
+            {
+                max = b;
+            }
+            else if (b < min)
+            {
+                min = b;
+            }
 
             delta = max - min;
 
@@ -543,11 +567,23 @@ namespace System.Drawing
             float max = r;
             float min = r;
 
-            if (g > max) max = g;
-            if (b > max) max = b;
+            if (g > max)
+            {
+                max = g;
+            }
+            else if (g < min)
+            {
+                min = g;
+            }
 
-            if (g < min) min = g;
-            if (b < min) min = b;
+            if (b > max)
+            {
+                max = b;
+            }
+            else if (b < min)
+            {
+                min = b;
+            }
 
             // if max == min, then there is no color and
             // the saturation is zero.

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -452,16 +452,8 @@ namespace System.Drawing
 
         public static Color FromArgb(int red, int green, int blue) => FromArgb(255, red, green, blue);
 
-        public static Color FromKnownColor(KnownColor color)
-        {
-            var value = (int)color;
-            if (value <= 0 || value > (int)KnownColor.LastColor)
-            {
-                return FromName(color.ToString());
-            }
-
-            return new Color(color);
-        }
+        public static Color FromKnownColor(KnownColor color) =>
+            color <= 0 || color > KnownColor.MenuHighlight ? FromName(color.ToString()) : new Color(color);
 
         public static Color FromName(string name)
         {

--- a/src/System.Drawing.Primitives/src/System/Drawing/KnownColor.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/KnownColor.cs
@@ -15,9 +15,7 @@ namespace System.Drawing
         // Do not modify this enum without updating KnownColorTable.
         //
 
-
         // 0 - reserved for "not a known color"
-        FirstColor = 0,
         // "System" colors
         /// <include file='doc\KnownColor.uex' path='docs/doc[@for="KnownColor.ActiveBorder"]/*' />
         /// <devdoc>
@@ -893,7 +891,6 @@ namespace System.Drawing
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        MenuHighlight,
-        LastColor = MenuHighlight,
+        MenuHighlight
     }
 }

--- a/src/System.Drawing.Primitives/tests/ColorTests.cs
+++ b/src/System.Drawing.Primitives/tests/ColorTests.cs
@@ -162,62 +162,6 @@ namespace System.Drawing.Primitives.Tests
                 .Select(p => new object[] { p.Name })
                 .ToArray();
 
-        public static readonly IEnumerable<object[]> AllKnownColors = Enum.GetValues(typeof(KnownColor)).Cast<KnownColor>()
-            .Where(kc => kc != 0)
-            .Select(kc => new object[] {kc})
-            .ToArray();
-
-        public static readonly IEnumerable<object[]> SystemColors =
-            new[]
-            {
-                KnownColor.ActiveBorder, KnownColor.ActiveCaption, KnownColor.ActiveCaptionText,
-                KnownColor.AppWorkspace, KnownColor.Control, KnownColor.ControlDark, KnownColor.ControlDarkDark,
-                KnownColor.ControlLight, KnownColor.ControlLightLight, KnownColor.ControlText, KnownColor.Desktop,
-                KnownColor.GrayText, KnownColor.Highlight, KnownColor.HighlightText, KnownColor.HotTrack,
-                KnownColor.InactiveBorder, KnownColor.InactiveCaption, KnownColor.InactiveCaptionText, KnownColor.Info,
-                KnownColor.InfoText, KnownColor.Menu, KnownColor.MenuText, KnownColor.ScrollBar, KnownColor.Window,
-                KnownColor.WindowFrame, KnownColor.WindowText, KnownColor.ButtonFace, KnownColor.ButtonHighlight,
-                KnownColor.ButtonShadow, KnownColor.GradientActiveCaption, KnownColor.GradientInactiveCaption,
-                KnownColor.MenuBar, KnownColor.MenuHighlight
-            }.Select(kc => new object[] {kc}).ToArray();
-
-        public static readonly IEnumerable<object[]> NonSystemColors =
-            new[]
-            {
-                KnownColor.Transparent, KnownColor.AliceBlue, KnownColor.AntiqueWhite, KnownColor.Aqua,
-                KnownColor.Aquamarine, KnownColor.Azure, KnownColor.Beige, KnownColor.Bisque, KnownColor.Black,
-                KnownColor.BlanchedAlmond, KnownColor.Blue, KnownColor.BlueViolet, KnownColor.Brown,
-                KnownColor.BurlyWood, KnownColor.CadetBlue, KnownColor.Chartreuse, KnownColor.Chocolate,
-                KnownColor.Coral, KnownColor.CornflowerBlue, KnownColor.Cornsilk, KnownColor.Crimson, KnownColor.Cyan,
-                KnownColor.DarkBlue, KnownColor.DarkCyan, KnownColor.DarkGoldenrod, KnownColor.DarkGray,
-                KnownColor.DarkGreen, KnownColor.DarkKhaki, KnownColor.DarkMagenta, KnownColor.DarkOliveGreen,
-                KnownColor.DarkOrange, KnownColor.DarkOrchid, KnownColor.DarkRed, KnownColor.DarkSalmon,
-                KnownColor.DarkSeaGreen, KnownColor.DarkSlateBlue, KnownColor.DarkSlateGray, KnownColor.DarkTurquoise,
-                KnownColor.DarkViolet, KnownColor.DeepPink, KnownColor.DeepSkyBlue, KnownColor.DimGray,
-                KnownColor.DodgerBlue, KnownColor.Firebrick, KnownColor.FloralWhite, KnownColor.ForestGreen,
-                KnownColor.Fuchsia, KnownColor.Gainsboro, KnownColor.GhostWhite, KnownColor.Gold, KnownColor.Goldenrod,
-                KnownColor.Gray, KnownColor.Green, KnownColor.GreenYellow, KnownColor.Honeydew, KnownColor.HotPink,
-                KnownColor.IndianRed, KnownColor.Indigo, KnownColor.Ivory, KnownColor.Khaki, KnownColor.Lavender,
-                KnownColor.LavenderBlush, KnownColor.LawnGreen, KnownColor.LemonChiffon, KnownColor.LightBlue,
-                KnownColor.LightCoral, KnownColor.LightCyan, KnownColor.LightGoldenrodYellow, KnownColor.LightGray,
-                KnownColor.LightGreen, KnownColor.LightPink, KnownColor.LightSalmon, KnownColor.LightSeaGreen,
-                KnownColor.LightSkyBlue, KnownColor.LightSlateGray, KnownColor.LightSteelBlue, KnownColor.LightYellow,
-                KnownColor.Lime, KnownColor.LimeGreen, KnownColor.Linen, KnownColor.Magenta, KnownColor.Maroon,
-                KnownColor.MediumAquamarine, KnownColor.MediumBlue, KnownColor.MediumOrchid, KnownColor.MediumPurple,
-                KnownColor.MediumSeaGreen, KnownColor.MediumSlateBlue, KnownColor.MediumSpringGreen,
-                KnownColor.MediumTurquoise, KnownColor.MediumVioletRed, KnownColor.MidnightBlue, KnownColor.MintCream,
-                KnownColor.MistyRose, KnownColor.Moccasin, KnownColor.NavajoWhite, KnownColor.Navy, KnownColor.OldLace,
-                KnownColor.Olive, KnownColor.OliveDrab, KnownColor.Orange, KnownColor.OrangeRed, KnownColor.Orchid,
-                KnownColor.PaleGoldenrod, KnownColor.PaleGreen, KnownColor.PaleTurquoise, KnownColor.PaleVioletRed,
-                KnownColor.PapayaWhip, KnownColor.PeachPuff, KnownColor.Peru, KnownColor.Pink, KnownColor.Plum,
-                KnownColor.PowderBlue, KnownColor.Purple, KnownColor.Red, KnownColor.RosyBrown, KnownColor.RoyalBlue,
-                KnownColor.SaddleBrown, KnownColor.Salmon, KnownColor.SandyBrown, KnownColor.SeaGreen,
-                KnownColor.SeaShell, KnownColor.Sienna, KnownColor.Silver, KnownColor.SkyBlue, KnownColor.SlateBlue,
-                KnownColor.SlateGray, KnownColor.Snow, KnownColor.SpringGreen, KnownColor.SteelBlue, KnownColor.Tan,
-                KnownColor.Teal, KnownColor.Thistle, KnownColor.Tomato, KnownColor.Turquoise, KnownColor.Violet,
-                KnownColor.Wheat, KnownColor.White, KnownColor.WhiteSmoke, KnownColor.Yellow, KnownColor.YellowGreen
-            }.Select(kc => new object[] {kc}).ToArray();
-
         private Color? GetColorByProperty(string name)
         {
             return (Color?)typeof(Color).GetProperty(name)?.GetValue(null);
@@ -303,7 +247,6 @@ namespace System.Drawing.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(ColorNamePairs))]
-        [InlineData("SomeUnknownColorName", "AnotherUnknownColorName")]
         public void GetHashCode(string name1, string name2)
         {
             Assert.NotEqual(name1, name2);
@@ -489,116 +432,6 @@ namespace System.Drawing.Primitives.Tests
         public void GetSaturation(int r, int g, int b, float expected)
         {
             Assert.Equal(expected, Color.FromArgb(r, g, b).GetSaturation());
-        }
-
-        [Theory, MemberData(nameof(NamedArgbValues))]
-        public void FromKnownColor(string name, int alpha, int red, int green, int blue)
-        {
-            Color color = Color.FromKnownColor(Enum.Parse<KnownColor>(name));
-            Assert.Equal(alpha, color.A);
-            Assert.Equal(red, color.R);
-            Assert.Equal(green, color.G);
-            Assert.Equal(blue, color.B);
-        }
-
-        [Fact]
-        public void FromOutOfRangeKnownColor()
-        {
-            Color color = Color.FromKnownColor((KnownColor)(-1));
-            Assert.Equal(0, color.A);
-            Assert.Equal(0, color.R);
-            Assert.Equal(0, color.G);
-            Assert.Equal(0, color.B);
-
-            color = Color.FromKnownColor(0);
-            Assert.Equal(0, color.A);
-            Assert.Equal(0, color.R);
-            Assert.Equal(0, color.G);
-            Assert.Equal(0, color.B);
-
-            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
-            Assert.Equal(0, color.A);
-            Assert.Equal(0, color.R);
-            Assert.Equal(0, color.G);
-            Assert.Equal(0, color.B);
-        }
-
-        [Theory, MemberData(nameof(AllKnownColors))]
-        public void ToKnownColor(KnownColor known) => Assert.Equal(known, Color.FromKnownColor(known).ToKnownColor());
-
-        [Theory, MemberData(nameof(AllKnownColors))]
-        public void ToKnownColorMatchesButIsNotKnown(KnownColor known)
-        {
-            Color color = Color.FromKnownColor(known);
-            Color match = Color.FromArgb(color.A, color.R, color.G, color.B);
-            Assert.Equal((KnownColor)0, match.ToKnownColor());
-        }
-
-        [Fact]
-        public void FromOutOfRangeKnownColorToKnownColor()
-        {
-            Color color = Color.FromKnownColor((KnownColor)(-1));
-            Assert.Equal((KnownColor)0, color.ToKnownColor());
-
-            color = Color.FromKnownColor(0);
-            Assert.Equal((KnownColor)0, color.ToKnownColor());
-
-            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
-            Assert.Equal((KnownColor)0, color.ToKnownColor());
-        }
-
-        [Theory, MemberData(nameof(SystemColors))]
-        public void IsSystemColorTrue(KnownColor known) => Assert.True(Color.FromKnownColor(known).IsSystemColor);
-
-        [Theory, MemberData(nameof(NonSystemColors))]
-        public void IsSystemColorFalse(KnownColor known) => Assert.False(Color.FromKnownColor(known).IsSystemColor);
-
-        [Theory, MemberData(nameof(SystemColors))]
-        public void IsSystemColorFalseOnMatching(KnownColor known)
-        {
-            Color color = Color.FromKnownColor(known);
-            Color match = Color.FromArgb(color.A, color.R, color.G, color.B);
-            Assert.False(match.IsSystemColor);
-        }
-
-        [Fact]
-        public void IsSystemColorOutOfRangeKnown()
-        {
-            Color color = Color.FromKnownColor((KnownColor)(-1));
-            Assert.False(color.IsSystemColor);
-
-            color = Color.FromKnownColor(0);
-            Assert.False(color.IsSystemColor);
-
-            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
-            Assert.False(color.IsSystemColor);
-        }
-
-        [Theory, MemberData(nameof(AllKnownColors))]
-        public void IsKnownColorTrue(KnownColor known)
-        {
-            Assert.True(Color.FromKnownColor(known).IsKnownColor);
-        }
-
-        [Theory, MemberData(nameof(AllKnownColors))]
-        public void IsKnownColorMatchFalse(KnownColor known)
-        {
-            Color color = Color.FromKnownColor(known);
-            Color match = Color.FromArgb(color.A, color.R, color.G, color.B);
-            Assert.False(match.IsKnownColor);
-        }
-
-        [Fact]
-        public void IsKnownColorOutOfRangeKnown()
-        {
-            Color color = Color.FromKnownColor((KnownColor)(-1));
-            Assert.False(color.IsKnownColor);
-
-            color = Color.FromKnownColor(0);
-            Assert.False(color.IsKnownColor);
-
-            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
-            Assert.False(color.IsKnownColor);
         }
 
         public static IEnumerable<object[]> Equality_MemberData()

--- a/src/System.Drawing.Primitives/tests/ColorTests.cs
+++ b/src/System.Drawing.Primitives/tests/ColorTests.cs
@@ -162,6 +162,62 @@ namespace System.Drawing.Primitives.Tests
                 .Select(p => new object[] { p.Name })
                 .ToArray();
 
+        public static readonly IEnumerable<object[]> AllKnownColors = Enum.GetValues(typeof(KnownColor)).Cast<KnownColor>()
+            .Where(kc => kc != 0)
+            .Select(kc => new object[] {kc})
+            .ToArray();
+
+        public static readonly IEnumerable<object[]> SystemColors =
+            new[]
+            {
+                KnownColor.ActiveBorder, KnownColor.ActiveCaption, KnownColor.ActiveCaptionText,
+                KnownColor.AppWorkspace, KnownColor.Control, KnownColor.ControlDark, KnownColor.ControlDarkDark,
+                KnownColor.ControlLight, KnownColor.ControlLightLight, KnownColor.ControlText, KnownColor.Desktop,
+                KnownColor.GrayText, KnownColor.Highlight, KnownColor.HighlightText, KnownColor.HotTrack,
+                KnownColor.InactiveBorder, KnownColor.InactiveCaption, KnownColor.InactiveCaptionText, KnownColor.Info,
+                KnownColor.InfoText, KnownColor.Menu, KnownColor.MenuText, KnownColor.ScrollBar, KnownColor.Window,
+                KnownColor.WindowFrame, KnownColor.WindowText, KnownColor.ButtonFace, KnownColor.ButtonHighlight,
+                KnownColor.ButtonShadow, KnownColor.GradientActiveCaption, KnownColor.GradientInactiveCaption,
+                KnownColor.MenuBar, KnownColor.MenuHighlight
+            }.Select(kc => new object[] {kc}).ToArray();
+
+        public static readonly IEnumerable<object[]> NonSystemColors =
+            new[]
+            {
+                KnownColor.Transparent, KnownColor.AliceBlue, KnownColor.AntiqueWhite, KnownColor.Aqua,
+                KnownColor.Aquamarine, KnownColor.Azure, KnownColor.Beige, KnownColor.Bisque, KnownColor.Black,
+                KnownColor.BlanchedAlmond, KnownColor.Blue, KnownColor.BlueViolet, KnownColor.Brown,
+                KnownColor.BurlyWood, KnownColor.CadetBlue, KnownColor.Chartreuse, KnownColor.Chocolate,
+                KnownColor.Coral, KnownColor.CornflowerBlue, KnownColor.Cornsilk, KnownColor.Crimson, KnownColor.Cyan,
+                KnownColor.DarkBlue, KnownColor.DarkCyan, KnownColor.DarkGoldenrod, KnownColor.DarkGray,
+                KnownColor.DarkGreen, KnownColor.DarkKhaki, KnownColor.DarkMagenta, KnownColor.DarkOliveGreen,
+                KnownColor.DarkOrange, KnownColor.DarkOrchid, KnownColor.DarkRed, KnownColor.DarkSalmon,
+                KnownColor.DarkSeaGreen, KnownColor.DarkSlateBlue, KnownColor.DarkSlateGray, KnownColor.DarkTurquoise,
+                KnownColor.DarkViolet, KnownColor.DeepPink, KnownColor.DeepSkyBlue, KnownColor.DimGray,
+                KnownColor.DodgerBlue, KnownColor.Firebrick, KnownColor.FloralWhite, KnownColor.ForestGreen,
+                KnownColor.Fuchsia, KnownColor.Gainsboro, KnownColor.GhostWhite, KnownColor.Gold, KnownColor.Goldenrod,
+                KnownColor.Gray, KnownColor.Green, KnownColor.GreenYellow, KnownColor.Honeydew, KnownColor.HotPink,
+                KnownColor.IndianRed, KnownColor.Indigo, KnownColor.Ivory, KnownColor.Khaki, KnownColor.Lavender,
+                KnownColor.LavenderBlush, KnownColor.LawnGreen, KnownColor.LemonChiffon, KnownColor.LightBlue,
+                KnownColor.LightCoral, KnownColor.LightCyan, KnownColor.LightGoldenrodYellow, KnownColor.LightGray,
+                KnownColor.LightGreen, KnownColor.LightPink, KnownColor.LightSalmon, KnownColor.LightSeaGreen,
+                KnownColor.LightSkyBlue, KnownColor.LightSlateGray, KnownColor.LightSteelBlue, KnownColor.LightYellow,
+                KnownColor.Lime, KnownColor.LimeGreen, KnownColor.Linen, KnownColor.Magenta, KnownColor.Maroon,
+                KnownColor.MediumAquamarine, KnownColor.MediumBlue, KnownColor.MediumOrchid, KnownColor.MediumPurple,
+                KnownColor.MediumSeaGreen, KnownColor.MediumSlateBlue, KnownColor.MediumSpringGreen,
+                KnownColor.MediumTurquoise, KnownColor.MediumVioletRed, KnownColor.MidnightBlue, KnownColor.MintCream,
+                KnownColor.MistyRose, KnownColor.Moccasin, KnownColor.NavajoWhite, KnownColor.Navy, KnownColor.OldLace,
+                KnownColor.Olive, KnownColor.OliveDrab, KnownColor.Orange, KnownColor.OrangeRed, KnownColor.Orchid,
+                KnownColor.PaleGoldenrod, KnownColor.PaleGreen, KnownColor.PaleTurquoise, KnownColor.PaleVioletRed,
+                KnownColor.PapayaWhip, KnownColor.PeachPuff, KnownColor.Peru, KnownColor.Pink, KnownColor.Plum,
+                KnownColor.PowderBlue, KnownColor.Purple, KnownColor.Red, KnownColor.RosyBrown, KnownColor.RoyalBlue,
+                KnownColor.SaddleBrown, KnownColor.Salmon, KnownColor.SandyBrown, KnownColor.SeaGreen,
+                KnownColor.SeaShell, KnownColor.Sienna, KnownColor.Silver, KnownColor.SkyBlue, KnownColor.SlateBlue,
+                KnownColor.SlateGray, KnownColor.Snow, KnownColor.SpringGreen, KnownColor.SteelBlue, KnownColor.Tan,
+                KnownColor.Teal, KnownColor.Thistle, KnownColor.Tomato, KnownColor.Turquoise, KnownColor.Violet,
+                KnownColor.Wheat, KnownColor.White, KnownColor.WhiteSmoke, KnownColor.Yellow, KnownColor.YellowGreen
+            }.Select(kc => new object[] {kc}).ToArray();
+
         private Color? GetColorByProperty(string name)
         {
             return (Color?)typeof(Color).GetProperty(name)?.GetValue(null);
@@ -247,6 +303,7 @@ namespace System.Drawing.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(ColorNamePairs))]
+        [InlineData("SomeUnknownColorName", "AnotherUnknownColorName")]
         public void GetHashCode(string name1, string name2)
         {
             Assert.NotEqual(name1, name2);
@@ -432,6 +489,116 @@ namespace System.Drawing.Primitives.Tests
         public void GetSaturation(int r, int g, int b, float expected)
         {
             Assert.Equal(expected, Color.FromArgb(r, g, b).GetSaturation());
+        }
+
+        [Theory, MemberData(nameof(NamedArgbValues))]
+        public void FromKnownColor(string name, int alpha, int red, int green, int blue)
+        {
+            Color color = Color.FromKnownColor(Enum.Parse<KnownColor>(name));
+            Assert.Equal(alpha, color.A);
+            Assert.Equal(red, color.R);
+            Assert.Equal(green, color.G);
+            Assert.Equal(blue, color.B);
+        }
+
+        [Fact]
+        public void FromOutOfRangeKnownColor()
+        {
+            Color color = Color.FromKnownColor((KnownColor)(-1));
+            Assert.Equal(0, color.A);
+            Assert.Equal(0, color.R);
+            Assert.Equal(0, color.G);
+            Assert.Equal(0, color.B);
+
+            color = Color.FromKnownColor(0);
+            Assert.Equal(0, color.A);
+            Assert.Equal(0, color.R);
+            Assert.Equal(0, color.G);
+            Assert.Equal(0, color.B);
+
+            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Assert.Equal(0, color.A);
+            Assert.Equal(0, color.R);
+            Assert.Equal(0, color.G);
+            Assert.Equal(0, color.B);
+        }
+
+        [Theory, MemberData(nameof(AllKnownColors))]
+        public void ToKnownColor(KnownColor known) => Assert.Equal(known, Color.FromKnownColor(known).ToKnownColor());
+
+        [Theory, MemberData(nameof(AllKnownColors))]
+        public void ToKnownColorMatchesButIsNotKnown(KnownColor known)
+        {
+            Color color = Color.FromKnownColor(known);
+            Color match = Color.FromArgb(color.A, color.R, color.G, color.B);
+            Assert.Equal((KnownColor)0, match.ToKnownColor());
+        }
+
+        [Fact]
+        public void FromOutOfRangeKnownColorToKnownColor()
+        {
+            Color color = Color.FromKnownColor((KnownColor)(-1));
+            Assert.Equal((KnownColor)0, color.ToKnownColor());
+
+            color = Color.FromKnownColor(0);
+            Assert.Equal((KnownColor)0, color.ToKnownColor());
+
+            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Assert.Equal((KnownColor)0, color.ToKnownColor());
+        }
+
+        [Theory, MemberData(nameof(SystemColors))]
+        public void IsSystemColorTrue(KnownColor known) => Assert.True(Color.FromKnownColor(known).IsSystemColor);
+
+        [Theory, MemberData(nameof(NonSystemColors))]
+        public void IsSystemColorFalse(KnownColor known) => Assert.False(Color.FromKnownColor(known).IsSystemColor);
+
+        [Theory, MemberData(nameof(SystemColors))]
+        public void IsSystemColorFalseOnMatching(KnownColor known)
+        {
+            Color color = Color.FromKnownColor(known);
+            Color match = Color.FromArgb(color.A, color.R, color.G, color.B);
+            Assert.False(match.IsSystemColor);
+        }
+
+        [Fact]
+        public void IsSystemColorOutOfRangeKnown()
+        {
+            Color color = Color.FromKnownColor((KnownColor)(-1));
+            Assert.False(color.IsSystemColor);
+
+            color = Color.FromKnownColor(0);
+            Assert.False(color.IsSystemColor);
+
+            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Assert.False(color.IsSystemColor);
+        }
+
+        [Theory, MemberData(nameof(AllKnownColors))]
+        public void IsKnownColorTrue(KnownColor known)
+        {
+            Assert.True(Color.FromKnownColor(known).IsKnownColor);
+        }
+
+        [Theory, MemberData(nameof(AllKnownColors))]
+        public void IsKnownColorMatchFalse(KnownColor known)
+        {
+            Color color = Color.FromKnownColor(known);
+            Color match = Color.FromArgb(color.A, color.R, color.G, color.B);
+            Assert.False(match.IsKnownColor);
+        }
+
+        [Fact]
+        public void IsKnownColorOutOfRangeKnown()
+        {
+            Color color = Color.FromKnownColor((KnownColor)(-1));
+            Assert.False(color.IsKnownColor);
+
+            color = Color.FromKnownColor(0);
+            Assert.False(color.IsKnownColor);
+
+            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Assert.False(color.IsKnownColor);
         }
 
         public static IEnumerable<object[]> Equality_MemberData()

--- a/src/System.Drawing.Primitives/tests/ColorTests.netcoreapp.cs
+++ b/src/System.Drawing.Primitives/tests/ColorTests.netcoreapp.cs
@@ -1,0 +1,190 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+
+namespace System.Drawing.Primitives.Tests
+{
+    public partial class ColorTests
+    {
+        public static readonly IEnumerable<object[]> AllKnownColors = Enum.GetValues(typeof(KnownColor)).Cast<KnownColor>()
+            .Where(kc => kc != 0)
+            .Select(kc => new object[] { kc })
+            .ToArray();
+
+        public static readonly IEnumerable<object[]> SystemColors =
+            new[]
+            {
+                KnownColor.ActiveBorder, KnownColor.ActiveCaption, KnownColor.ActiveCaptionText,
+                KnownColor.AppWorkspace, KnownColor.Control, KnownColor.ControlDark, KnownColor.ControlDarkDark,
+                KnownColor.ControlLight, KnownColor.ControlLightLight, KnownColor.ControlText, KnownColor.Desktop,
+                KnownColor.GrayText, KnownColor.Highlight, KnownColor.HighlightText, KnownColor.HotTrack,
+                KnownColor.InactiveBorder, KnownColor.InactiveCaption, KnownColor.InactiveCaptionText, KnownColor.Info,
+                KnownColor.InfoText, KnownColor.Menu, KnownColor.MenuText, KnownColor.ScrollBar, KnownColor.Window,
+                KnownColor.WindowFrame, KnownColor.WindowText, KnownColor.ButtonFace, KnownColor.ButtonHighlight,
+                KnownColor.ButtonShadow, KnownColor.GradientActiveCaption, KnownColor.GradientInactiveCaption,
+                KnownColor.MenuBar, KnownColor.MenuHighlight
+            }.Select(kc => new object[] { kc }).ToArray();
+
+        public static readonly IEnumerable<object[]> NonSystemColors =
+            new[]
+            {
+                KnownColor.Transparent, KnownColor.AliceBlue, KnownColor.AntiqueWhite, KnownColor.Aqua,
+                KnownColor.Aquamarine, KnownColor.Azure, KnownColor.Beige, KnownColor.Bisque, KnownColor.Black,
+                KnownColor.BlanchedAlmond, KnownColor.Blue, KnownColor.BlueViolet, KnownColor.Brown,
+                KnownColor.BurlyWood, KnownColor.CadetBlue, KnownColor.Chartreuse, KnownColor.Chocolate,
+                KnownColor.Coral, KnownColor.CornflowerBlue, KnownColor.Cornsilk, KnownColor.Crimson, KnownColor.Cyan,
+                KnownColor.DarkBlue, KnownColor.DarkCyan, KnownColor.DarkGoldenrod, KnownColor.DarkGray,
+                KnownColor.DarkGreen, KnownColor.DarkKhaki, KnownColor.DarkMagenta, KnownColor.DarkOliveGreen,
+                KnownColor.DarkOrange, KnownColor.DarkOrchid, KnownColor.DarkRed, KnownColor.DarkSalmon,
+                KnownColor.DarkSeaGreen, KnownColor.DarkSlateBlue, KnownColor.DarkSlateGray, KnownColor.DarkTurquoise,
+                KnownColor.DarkViolet, KnownColor.DeepPink, KnownColor.DeepSkyBlue, KnownColor.DimGray,
+                KnownColor.DodgerBlue, KnownColor.Firebrick, KnownColor.FloralWhite, KnownColor.ForestGreen,
+                KnownColor.Fuchsia, KnownColor.Gainsboro, KnownColor.GhostWhite, KnownColor.Gold, KnownColor.Goldenrod,
+                KnownColor.Gray, KnownColor.Green, KnownColor.GreenYellow, KnownColor.Honeydew, KnownColor.HotPink,
+                KnownColor.IndianRed, KnownColor.Indigo, KnownColor.Ivory, KnownColor.Khaki, KnownColor.Lavender,
+                KnownColor.LavenderBlush, KnownColor.LawnGreen, KnownColor.LemonChiffon, KnownColor.LightBlue,
+                KnownColor.LightCoral, KnownColor.LightCyan, KnownColor.LightGoldenrodYellow, KnownColor.LightGray,
+                KnownColor.LightGreen, KnownColor.LightPink, KnownColor.LightSalmon, KnownColor.LightSeaGreen,
+                KnownColor.LightSkyBlue, KnownColor.LightSlateGray, KnownColor.LightSteelBlue, KnownColor.LightYellow,
+                KnownColor.Lime, KnownColor.LimeGreen, KnownColor.Linen, KnownColor.Magenta, KnownColor.Maroon,
+                KnownColor.MediumAquamarine, KnownColor.MediumBlue, KnownColor.MediumOrchid, KnownColor.MediumPurple,
+                KnownColor.MediumSeaGreen, KnownColor.MediumSlateBlue, KnownColor.MediumSpringGreen,
+                KnownColor.MediumTurquoise, KnownColor.MediumVioletRed, KnownColor.MidnightBlue, KnownColor.MintCream,
+                KnownColor.MistyRose, KnownColor.Moccasin, KnownColor.NavajoWhite, KnownColor.Navy, KnownColor.OldLace,
+                KnownColor.Olive, KnownColor.OliveDrab, KnownColor.Orange, KnownColor.OrangeRed, KnownColor.Orchid,
+                KnownColor.PaleGoldenrod, KnownColor.PaleGreen, KnownColor.PaleTurquoise, KnownColor.PaleVioletRed,
+                KnownColor.PapayaWhip, KnownColor.PeachPuff, KnownColor.Peru, KnownColor.Pink, KnownColor.Plum,
+                KnownColor.PowderBlue, KnownColor.Purple, KnownColor.Red, KnownColor.RosyBrown, KnownColor.RoyalBlue,
+                KnownColor.SaddleBrown, KnownColor.Salmon, KnownColor.SandyBrown, KnownColor.SeaGreen,
+                KnownColor.SeaShell, KnownColor.Sienna, KnownColor.Silver, KnownColor.SkyBlue, KnownColor.SlateBlue,
+                KnownColor.SlateGray, KnownColor.Snow, KnownColor.SpringGreen, KnownColor.SteelBlue, KnownColor.Tan,
+                KnownColor.Teal, KnownColor.Thistle, KnownColor.Tomato, KnownColor.Turquoise, KnownColor.Violet,
+                KnownColor.Wheat, KnownColor.White, KnownColor.WhiteSmoke, KnownColor.Yellow, KnownColor.YellowGreen
+            }.Select(kc => new object[] { kc }).ToArray();
+
+        [Theory, MemberData(nameof(NamedArgbValues))]
+        public void FromKnownColor(string name, int alpha, int red, int green, int blue)
+        {
+            Color color = Color.FromKnownColor(Enum.Parse<KnownColor>(name));
+            Assert.Equal(alpha, color.A);
+            Assert.Equal(red, color.R);
+            Assert.Equal(green, color.G);
+            Assert.Equal(blue, color.B);
+        }
+
+        [Fact]
+        public void FromOutOfRangeKnownColor()
+        {
+            Color color = Color.FromKnownColor((KnownColor)(-1));
+            Assert.Equal(0, color.A);
+            Assert.Equal(0, color.R);
+            Assert.Equal(0, color.G);
+            Assert.Equal(0, color.B);
+
+            color = Color.FromKnownColor(0);
+            Assert.Equal(0, color.A);
+            Assert.Equal(0, color.R);
+            Assert.Equal(0, color.G);
+            Assert.Equal(0, color.B);
+
+            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Assert.Equal(0, color.A);
+            Assert.Equal(0, color.R);
+            Assert.Equal(0, color.G);
+            Assert.Equal(0, color.B);
+        }
+
+        [Theory, MemberData(nameof(AllKnownColors))]
+        public void ToKnownColor(KnownColor known) => Assert.Equal(known, Color.FromKnownColor(known).ToKnownColor());
+
+        [Theory, MemberData(nameof(AllKnownColors))]
+        public void ToKnownColorMatchesButIsNotKnown(KnownColor known)
+        {
+            Color color = Color.FromKnownColor(known);
+            Color match = Color.FromArgb(color.A, color.R, color.G, color.B);
+            Assert.Equal((KnownColor)0, match.ToKnownColor());
+        }
+
+        [Fact]
+        public void FromOutOfRangeKnownColorToKnownColor()
+        {
+            Color color = Color.FromKnownColor((KnownColor)(-1));
+            Assert.Equal((KnownColor)0, color.ToKnownColor());
+
+            color = Color.FromKnownColor(0);
+            Assert.Equal((KnownColor)0, color.ToKnownColor());
+
+            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Assert.Equal((KnownColor)0, color.ToKnownColor());
+        }
+
+        [Theory, MemberData(nameof(SystemColors))]
+        public void IsSystemColorTrue(KnownColor known) => Assert.True(Color.FromKnownColor(known).IsSystemColor);
+
+        [Theory, MemberData(nameof(NonSystemColors))]
+        public void IsSystemColorFalse(KnownColor known) => Assert.False(Color.FromKnownColor(known).IsSystemColor);
+
+        [Theory, MemberData(nameof(SystemColors))]
+        public void IsSystemColorFalseOnMatching(KnownColor known)
+        {
+            Color color = Color.FromKnownColor(known);
+            Color match = Color.FromArgb(color.A, color.R, color.G, color.B);
+            Assert.False(match.IsSystemColor);
+        }
+
+        [Fact]
+        public void IsSystemColorOutOfRangeKnown()
+        {
+            Color color = Color.FromKnownColor((KnownColor)(-1));
+            Assert.False(color.IsSystemColor);
+
+            color = Color.FromKnownColor(0);
+            Assert.False(color.IsSystemColor);
+
+            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Assert.False(color.IsSystemColor);
+        }
+
+        [Theory, MemberData(nameof(AllKnownColors))]
+        public void IsKnownColorTrue(KnownColor known)
+        {
+            Assert.True(Color.FromKnownColor(known).IsKnownColor);
+        }
+
+        [Theory, MemberData(nameof(AllKnownColors))]
+        public void IsKnownColorMatchFalse(KnownColor known)
+        {
+            Color color = Color.FromKnownColor(known);
+            Color match = Color.FromArgb(color.A, color.R, color.G, color.B);
+            Assert.False(match.IsKnownColor);
+        }
+
+        [Fact]
+        public void IsKnownColorOutOfRangeKnown()
+        {
+            Color color = Color.FromKnownColor((KnownColor)(-1));
+            Assert.False(color.IsKnownColor);
+
+            color = Color.FromKnownColor(0);
+            Assert.False(color.IsKnownColor);
+
+            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Assert.False(color.IsKnownColor);
+        }
+
+        [Fact]
+        public void GetHashCodeForUnknownNamed()
+        {
+            // NetFX gives all such colors the same hash code. CoreFX makes more effort with them.
+            Color c1 = Color.FromName("SomeUnknownColorName");
+            Color c2 = Color.FromName("AnotherUnknownColorName");
+            Assert.NotEqual(c2.GetHashCode(), c1.GetHashCode());
+            Assert.Equal(c1.GetHashCode(), c1.GetHashCode());
+        }
+    }
+}

--- a/src/System.Drawing.Primitives/tests/ColorTests.netcoreapp.cs
+++ b/src/System.Drawing.Primitives/tests/ColorTests.netcoreapp.cs
@@ -77,22 +77,13 @@ namespace System.Drawing.Primitives.Tests
             Assert.Equal(blue, color.B);
         }
 
-        [Fact]
-        public void FromOutOfRangeKnownColor()
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(KnownColor.MenuHighlight + 1)]
+        public void FromOutOfRangeKnownColor(KnownColor known)
         {
-            Color color = Color.FromKnownColor((KnownColor)(-1));
-            Assert.Equal(0, color.A);
-            Assert.Equal(0, color.R);
-            Assert.Equal(0, color.G);
-            Assert.Equal(0, color.B);
-
-            color = Color.FromKnownColor(0);
-            Assert.Equal(0, color.A);
-            Assert.Equal(0, color.R);
-            Assert.Equal(0, color.G);
-            Assert.Equal(0, color.B);
-
-            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Color color = Color.FromKnownColor(known);
             Assert.Equal(0, color.A);
             Assert.Equal(0, color.R);
             Assert.Equal(0, color.G);
@@ -110,16 +101,13 @@ namespace System.Drawing.Primitives.Tests
             Assert.Equal((KnownColor)0, match.ToKnownColor());
         }
 
-        [Fact]
-        public void FromOutOfRangeKnownColorToKnownColor()
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(KnownColor.MenuHighlight + 1)]
+        public void FromOutOfRangeKnownColorToKnownColor(KnownColor known)
         {
-            Color color = Color.FromKnownColor((KnownColor)(-1));
-            Assert.Equal((KnownColor)0, color.ToKnownColor());
-
-            color = Color.FromKnownColor(0);
-            Assert.Equal((KnownColor)0, color.ToKnownColor());
-
-            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Color color = Color.FromKnownColor(known);
             Assert.Equal((KnownColor)0, color.ToKnownColor());
         }
 
@@ -137,16 +125,13 @@ namespace System.Drawing.Primitives.Tests
             Assert.False(match.IsSystemColor);
         }
 
-        [Fact]
-        public void IsSystemColorOutOfRangeKnown()
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(KnownColor.MenuHighlight + 1)]
+        public void IsSystemColorOutOfRangeKnown(KnownColor known)
         {
-            Color color = Color.FromKnownColor((KnownColor)(-1));
-            Assert.False(color.IsSystemColor);
-
-            color = Color.FromKnownColor(0);
-            Assert.False(color.IsSystemColor);
-
-            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Color color = Color.FromKnownColor(known);
             Assert.False(color.IsSystemColor);
         }
 
@@ -164,16 +149,13 @@ namespace System.Drawing.Primitives.Tests
             Assert.False(match.IsKnownColor);
         }
 
-        [Fact]
-        public void IsKnownColorOutOfRangeKnown()
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(KnownColor.MenuHighlight + 1)]
+        public void IsKnownColorOutOfRangeKnown(KnownColor known)
         {
-            Color color = Color.FromKnownColor((KnownColor)(-1));
-            Assert.False(color.IsKnownColor);
-
-            color = Color.FromKnownColor(0);
-            Assert.False(color.IsKnownColor);
-
-            color = Color.FromKnownColor(KnownColor.MenuHighlight + 1);
+            Color color = Color.FromKnownColor(known);
             Assert.False(color.IsKnownColor);
         }
 

--- a/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.csproj
+++ b/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.csproj
@@ -32,8 +32,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
     <Compile Include="SizeFTests.netcoreapp.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
+    <Compile Include="ColorTests.netcoreapp.cs" />
     <Compile Include="SizeTests.netcoreapp.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
* Don't consider 0 a valid `KnownColor`

Fixes #22819

* Remove `KnownColor.First` and `KnownColor.Last`

Fixes #22820

Also add tests and remove dead branches, bringing S.D.Primitives coverage up to 99.9% lines/100% branches (100%/100% excluding common file field unused in S.D.Primitives).