### PR TITLE
API checker: remove special case of CheckTokenMembershipEx in UWP

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01822-01
+2.0.0-prerelease-01901-01

--- a/src/System.Security.Principal.Windows/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
+++ b/src/System.Security.Principal.Windows/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
@@ -1,1 +1,0 @@
-kernel32.dll!CheckTokenMembershipEx


### PR DESCRIPTION
Fixes #22128 