### PR TITLE
More thoroughly test collection debugger views

### DIFF
--- a/src/Common/tests/System/Collections/DebugView.Tests.cs
+++ b/src/Common/tests/System/Collections/DebugView.Tests.cs
@@ -75,7 +75,8 @@ namespace System.Collections.Tests
         public static void TestDebuggerAttributes_Null(object obj)
         {
             Type proxyType = DebuggerAttributes.GetProxyType(obj);
-            Assert.Throws<TargetInvocationException>(() => Activator.CreateInstance(proxyType, (object)null));
+            TargetInvocationException tie = Assert.Throws<TargetInvocationException>(() => Activator.CreateInstance(proxyType, (object)null));
+            Assert.IsType<ArgumentNullException>(tie.InnerException);
         }
     }
 }

--- a/src/Common/tests/System/Collections/DebugView.Tests.cs
+++ b/src/Common/tests/System/Collections/DebugView.Tests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using Xunit;
 
@@ -66,7 +67,10 @@ namespace System.Collections.Tests
         public static void TestDebuggerAttributes(object obj)
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(obj);
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(obj);
+            DebuggerAttributeInfo info = DebuggerAttributes.ValidateDebuggerTypeProxyProperties(obj);
+            PropertyInfo itemProperty = info.Properties.Single(pr => pr.GetCustomAttribute<DebuggerBrowsableAttribute>().State == DebuggerBrowsableState.RootHidden);
+            Array items = itemProperty.GetValue(info.Instance) as Array;
+            Assert.Equal((obj as IEnumerable).Cast<object>().ToArray(), items.Cast<object>());
         }
 
         [Theory]

--- a/src/Common/tests/System/Collections/DebugView.Tests.cs
+++ b/src/Common/tests/System/Collections/DebugView.Tests.cs
@@ -29,6 +29,35 @@ namespace System.Collections.Tests
             yield return new object[] { new SortedDictionary<long, Guid>().Values };
             yield return new object[] { new SortedList<string, int>().Keys };
             yield return new object[] { new SortedList<float, long>().Values };
+
+            yield return new object[] { new Dictionary<int, string>{{1, "One"}, {2, "Two"}} };
+            yield return new object[] { new HashSet<string>{"One", "Two"} };
+
+            LinkedList<object> linkedList = new LinkedList<object>();
+            linkedList.AddFirst(1);
+            linkedList.AddLast(2);
+            yield return new object[] { linkedList };
+            yield return new object[] { new List<int>{1, 2} };
+
+            Queue<double> queue = new Queue<double>();
+            queue.Enqueue(1);
+            queue.Enqueue(2);
+            yield return new object[] { queue };
+            yield return new object[] { new SortedDictionary<string, int>{{"One", 1}, {"Two", 2}} };
+            yield return new object[] { new SortedList<int, string>{{1, "One"}, {2, "Two"}} };
+            yield return new object[] { new SortedSet<int>{1, 2} };
+
+            var stack = new Stack<object>();
+            stack.Push(1);
+            stack.Push(2);
+            yield return new object[] { stack };
+
+            yield return new object[] { new Dictionary<double, float>{{1.0, 1.0f}, {2.0, 2.0f}}.Keys };
+            yield return new object[] { new Dictionary<float, double>{{1.0f, 1.0}, {2.0f, 2.0}}.Values };
+            yield return new object[] { new SortedDictionary<Guid, string>{{Guid.NewGuid(), "One"}, {Guid.NewGuid(), "Two"}}.Keys };
+            yield return new object[] { new SortedDictionary<long, Guid>{{1L, Guid.NewGuid()}, {2L, Guid.NewGuid()}}.Values };
+            yield return new object[] { new SortedList<string, int>{{"One", 1}, {"Two", 2}}.Keys };
+            yield return new object[] { new SortedList<float, long>{{1f, 1L}, {2f, 2L}}.Values };
         }
 
         [Theory]


### PR DESCRIPTION
Include collections with contents in objects tested.

Make `TestDebuggerAttributes_Null` confirm exception thrown was ANE

Verify items are displayed for debugger correctly.