### PR TITLE
More thoroughly test concurrent collection debugger views

### DIFF
--- a/src/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
+++ b/src/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
@@ -962,7 +962,10 @@ namespace System.Collections.Concurrent.Tests
         {
             IProducerConsumerCollection<int> c = CreateProducerConsumerCollection(count);
             DebuggerAttributes.ValidateDebuggerDisplayReferences(c);
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(c);
+            DebuggerAttributeInfo info = DebuggerAttributes.ValidateDebuggerTypeProxyProperties(c);
+            PropertyInfo itemProperty = info.Properties.Single(pr => pr.GetCustomAttribute<DebuggerBrowsableAttribute>().State == DebuggerBrowsableState.RootHidden);
+            Array items = itemProperty.GetValue(info.Instance) as Array;
+            Assert.Equal(c, items.Cast<int>());
         }
 
         [Fact]


### PR DESCRIPTION
Test null input to ctor throws `ArgumentNullException`.

Test contents are reflected in debugger view objects.