### PR TITLE
Remove ILCBuildType=chk from System.Security.Cryptography.X509Certificates.Tests (#22693)

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{A28B0064-EFB2-4B77-B97C-DECF5DAB074E}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
-    <ILCBuildType Condition="'$(TargetGroup)' == 'uap'">chk</ILCBuildType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Release|AnyCPU'" />


### PR DESCRIPTION
Related Issue: https://github.com/dotnet/corefx/issues/22475

The fix was ported to ProjectNRel branch so this can be safely removed. I tested locally and the tests now pass. 