### PR TITLE
Add StringBuilder Span-based APIs

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -7054,6 +7054,7 @@ namespace System.Text
         public System.Text.StringBuilder Append(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public System.Text.StringBuilder Append(ulong value) { throw null; }
+        public System.Text.StringBuilder Append(ReadOnlySpan<char> value) { throw null; }
         public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0) { throw null; }
         public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0, object arg1) { throw null; }
         public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0, object arg1, object arg2) { throw null; }
@@ -7072,6 +7073,7 @@ namespace System.Text
         public StringBuilder AppendJoin(char separator, params string[] values) { throw null; }
         public System.Text.StringBuilder Clear() { throw null; }
         public void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count) { }
+        public void CopyTo(int sourceIndex, Span<char> destination, int count) { }
         public int EnsureCapacity(int capacity) { throw null; }
         public bool Equals(System.Text.StringBuilder sb) { throw null; }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
@@ -7080,6 +7082,7 @@ namespace System.Text
         public System.Text.StringBuilder Insert(int index, char value) { throw null; }
         public System.Text.StringBuilder Insert(int index, char[] value) { throw null; }
         public System.Text.StringBuilder Insert(int index, char[] value, int startIndex, int charCount) { throw null; }
+        public System.Text.StringBuilder Insert(int index, ReadOnlySpan<char> value) { throw null; }
         public System.Text.StringBuilder Insert(int index, decimal value) { throw null; }
         public System.Text.StringBuilder Insert(int index, double value) { throw null; }
         public System.Text.StringBuilder Insert(int index, short value) { throw null; }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -7054,7 +7054,7 @@ namespace System.Text
         public System.Text.StringBuilder Append(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public System.Text.StringBuilder Append(ulong value) { throw null; }
-        public System.Text.StringBuilder Append(ReadOnlySpan<char> value) { throw null; }
+        public System.Text.StringBuilder Append(System.ReadOnlySpan<char> value) { throw null; }
         public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0) { throw null; }
         public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0, object arg1) { throw null; }
         public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0, object arg1, object arg2) { throw null; }
@@ -7073,7 +7073,7 @@ namespace System.Text
         public StringBuilder AppendJoin(char separator, params string[] values) { throw null; }
         public System.Text.StringBuilder Clear() { throw null; }
         public void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count) { }
-        public void CopyTo(int sourceIndex, Span<char> destination, int count) { }
+        public void CopyTo(int sourceIndex, System.Span<char> destination, int count) { }
         public int EnsureCapacity(int capacity) { throw null; }
         public bool Equals(System.Text.StringBuilder sb) { throw null; }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
@@ -7082,7 +7082,7 @@ namespace System.Text
         public System.Text.StringBuilder Insert(int index, char value) { throw null; }
         public System.Text.StringBuilder Insert(int index, char[] value) { throw null; }
         public System.Text.StringBuilder Insert(int index, char[] value, int startIndex, int charCount) { throw null; }
-        public System.Text.StringBuilder Insert(int index, ReadOnlySpan<char> value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, System.ReadOnlySpan<char> value) { throw null; }
         public System.Text.StringBuilder Insert(int index, decimal value) { throw null; }
         public System.Text.StringBuilder Insert(int index, double value) { throw null; }
         public System.Text.StringBuilder Insert(int index, short value) { throw null; }

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -735,13 +735,13 @@ namespace System.Text.Tests
         [Theory]
         [InlineData("Hello", new char[] { 'a' }, "Helloa")]
         [InlineData("Hello", new char[] { 'b', 'c', 'd' }, "Hellobcd")]
+        [InlineData("Hello", new char[] { 'b', '\0', 'd' }, "Hellob\0d")]
         [InlineData("", new char[] { 'e', 'f', 'g' }, "efg")]
         [InlineData("Hello", new char[0], "Hello")]
         public static void Append_CharSpan(string original, char[] value, string expected)
         {
             var builder = new StringBuilder(original);
             builder.Append(new ReadOnlySpan<char>(value));
-            Assert.Equal(expected, builder.ToString());
             Assert.Equal(expected, builder.ToString());
         }
 

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -732,19 +732,6 @@ namespace System.Text.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("requiredLength", () => builder.Append(new char[] { 'a' }, 0, 1));
         }
 
-        [Theory]
-        [InlineData("Hello", new char[] { 'a' }, "Helloa")]
-        [InlineData("Hello", new char[] { 'b', 'c', 'd' }, "Hellobcd")]
-        [InlineData("Hello", new char[] { 'b', '\0', 'd' }, "Hellob\0d")]
-        [InlineData("", new char[] { 'e', 'f', 'g' }, "efg")]
-        [InlineData("Hello", new char[0], "Hello")]
-        public static void Append_CharSpan(string original, char[] value, string expected)
-        {
-            var builder = new StringBuilder(original);
-            builder.Append(new ReadOnlySpan<char>(value));
-            Assert.Equal(expected, builder.ToString());
-        }
-
         public static IEnumerable<object[]> AppendFormat_TestData()
         {
             yield return new object[] { "", null, "", new object[0], "" };
@@ -1030,42 +1017,6 @@ namespace System.Text.Tests
 
             AssertExtensions.Throws<ArgumentException>(null, () => builder.CopyTo(0, new char[10], 10, 1)); // Destination index + count > destinationArray.Length
             AssertExtensions.Throws<ArgumentException>(null, () => builder.CopyTo(0, new char[10], 9, 2)); // Destination index + count > destinationArray.Length
-        }
-
-        [Theory]
-        [InlineData("Hello", 0, new char[] { '\0', '\0', '\0', '\0', '\0' }, 5, new char[] { 'H', 'e', 'l', 'l', 'o' })]
-        [InlineData("Hello", 0, new char[] { '\0', '\0', '\0', '\0' }, 4, new char[] { 'H', 'e', 'l', 'l' })]
-        [InlineData("Hello", 1, new char[] { '\0', '\0', '\0', '\0', '\0' }, 4, new char[] { 'e', 'l', 'l', 'o', '\0' })]
-        public static void CopyTo_CharSpan(string value, int sourceIndex, char[] destination, int count, char[] expected)
-        {
-            var builder = new StringBuilder(value);
-            builder.CopyTo(sourceIndex, new Span<char>(destination), count);
-            Assert.Equal(expected, destination);
-        }
-
-        [Fact]
-        public static void CopyTo_CharSpan_StringBuilderWithMultipleChunks()
-        {
-            StringBuilder builder = StringBuilderWithMultipleChunks();
-            char[] destination = new char[builder.Length];
-            builder.CopyTo(0, new Span<char>(destination), destination.Length);
-            Assert.Equal(s_chunkSplitSource.ToCharArray(), destination);
-        }
-
-        [Fact]
-        public static void CopyTo_CharSpan_Invalid()
-        {
-            var builder = new StringBuilder("Hello");
-
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("sourceIndex", () => builder.CopyTo(-1, new Span<char>(new char[10]), 0)); // Source index < 0
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("sourceIndex", () => builder.CopyTo(6, new Span<char>(new char[10]), 0)); // Source index > builder.Length
-
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => builder.CopyTo(0, new Span<char>(new char[10]), -1)); // Count < 0
-
-            AssertExtensions.Throws<ArgumentException>(null, () => builder.CopyTo(5, new Span<char>(new char[10]), 1)); // Source index + count > builder.Length
-            AssertExtensions.Throws<ArgumentException>(null, () => builder.CopyTo(4, new Span<char>(new char[10]), 2)); // Source index + count > builder.Length
-
-            AssertExtensions.Throws<ArgumentException>(null, () => builder.CopyTo(0, new Span<char>(new char[10]), 11)); // count > destinationArray.Length
         }
 
         [Fact]
@@ -1630,29 +1581,6 @@ namespace System.Text.Tests
             var builder = new StringBuilder(0, 5);
             builder.Append("Hello");
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => builder.Insert(0, new char[0], 0, -1)); // Char count < 0
-        }
-
-        [Theory]
-        [InlineData("Hello", 0, new char[] { '\0' }, "\0Hello")]
-        [InlineData("Hello", 3, new char[] { 'a', 'b', 'c' }, "Helabclo")]
-        [InlineData("Hello", 5, new char[] { 'd', 'e', 'f' }, "Hellodef")]
-        [InlineData("Hello", 0, new char[0], "Hello")]
-        public static void Insert_CharSpan(string original, int index, char[] value, string expected)
-        {
-            var builder = new StringBuilder(original);
-            builder.Insert(index, new ReadOnlySpan<char>(value));
-            Assert.Equal(expected, builder.ToString());
-        }
-
-        [Fact]
-        public static void Insert_CharSpan_Invalid()
-        {
-            var builder = new StringBuilder(0, 5);
-            builder.Append("Hello");
-
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => builder.Insert(-1, new ReadOnlySpan<char>(new char[0]))); // Index < 0
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => builder.Insert(builder.Length + 1, new ReadOnlySpan<char>(new char[0]))); // Index > builder.Length
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("requiredLength", () => builder.Insert(builder.Length, new ReadOnlySpan<char>(new char[1]))); // New length > builder.MaxCapacity
         }
 
         [Theory]


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/22430

Depends on https://github.com/dotnet/coreclr/pull/13163

- Add span-based Append/Insert/CopyTo methods to StringBuilder
- Add unit tests for the new methods