### PR TITLE
Fixing binary serialization EndOfStream exception

### DIFF
--- a/src/System.Security.Claims/src/System/Security/Claims/Claim.cs
+++ b/src/System.Security.Claims/src/System/Security/Claims/Claim.cs
@@ -125,11 +125,11 @@ namespace System.Security.Claims
             if ((mask & SerializationMask.HasProperties) == SerializationMask.HasProperties)
             {
                 int numProperties = reader.ReadInt32();
+                numPropertiesRead++;
                 for (int i = 0; i < numProperties; i++)
                 {
                     Properties.Add(reader.ReadString(), reader.ReadString());
                 }
-                numPropertiesRead++;
             }
 
             if ((mask & SerializationMask.UserData) == SerializationMask.UserData)

--- a/src/System.Security.Claims/src/System/Security/Claims/Claim.cs
+++ b/src/System.Security.Claims/src/System/Security/Claims/Claim.cs
@@ -129,6 +129,7 @@ namespace System.Security.Claims
                 {
                     Properties.Add(reader.ReadString(), reader.ReadString());
                 }
+                numPropertiesRead++;
             }
 
             if ((mask & SerializationMask.UserData) == SerializationMask.UserData)

--- a/src/System.Security.Claims/tests/ClaimTests.cs
+++ b/src/System.Security.Claims/tests/ClaimTests.cs
@@ -19,6 +19,7 @@ namespace System.Security.Claims
         }
 
         [Fact]
+        [ActiveIssue(22858, framework: TargetFrameworkMonikers.NetFramework)] // Roundtripping claim fails in full framework with EndOfStream exception
         public void BinaryWriteReadTest_Success()
         {
             var claim = new Claim(ClaimTypes.Actor, "value", ClaimValueTypes.String, "issuer", "originalIssuer");

--- a/src/System.Security.Claims/tests/ClaimTests.cs
+++ b/src/System.Security.Claims/tests/ClaimTests.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization.Formatters.Tests;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace System.Security.Claims
@@ -13,6 +16,39 @@ namespace System.Security.Claims
         public void Ctor_ArgumentValidation()
         {
             Assert.Throws<ArgumentNullException>(() => new Claim(null));
+        }
+
+        [Fact]
+        public void BinaryWriteReadTest_Success()
+        {
+            var claim = new Claim(ClaimTypes.Actor, "value", ClaimValueTypes.String, "issuer", "originalIssuer");
+            claim.Properties.Add("key1", "val1");
+            claim.Properties.Add("key2", "val2");
+
+            Claim clonedClaim = null;
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var binaryWriter = new BinaryWriter(memoryStream, Encoding.Default, true))
+                {
+                    claim.WriteTo(binaryWriter);
+                    binaryWriter.Flush();
+                }
+
+                memoryStream.Position = 0;
+                using (var binaryReader = new BinaryReader(memoryStream))
+                {
+                    clonedClaim = new Claim(binaryReader);
+                }
+            }
+
+            Assert.Equal(claim.Type, clonedClaim.Type);
+            Assert.Equal(claim.Value, clonedClaim.Value);
+            Assert.Equal(claim.ValueType, clonedClaim.ValueType);
+            Assert.Equal(claim.Issuer, clonedClaim.Issuer);
+            Assert.Equal(claim.OriginalIssuer, clonedClaim.OriginalIssuer);
+            Assert.Equal(claim.Properties.Count, clonedClaim.Properties.Count);
+            Assert.Equal(claim.Properties.ElementAt(0), clonedClaim.Properties.ElementAt(0));
+            Assert.Equal(claim.Properties.ElementAt(1), clonedClaim.Properties.ElementAt(1));
         }
     }
 }


### PR DESCRIPTION
Instantiating a Claim object with a BinaryReader as argument failed because it tried to read over the length of the Stream.

Fixing https://github.com/dotnet/corefx/issues/22818 and adding test
The bug also exists in .NET Framework 4.7: https://referencesource.microsoft.com/#mscorlib/system/security/claims/Claim.cs,477

How to transport the fix into the next version (or a servicing release) of .NET Framework? 

@Petermarcu Should this be integrated into the first servicing release of .NET Core 2.0 or into the final .NET Core 2.0 bits?

cc @karelz @danmosemsft