### PR TITLE
More thoroughly test RegularExpression collection debugger views

### DIFF
--- a/src/System.Text.RegularExpressions/tests/CaptureCollectionTests.netcoreapp.cs
+++ b/src/System.Text.RegularExpressions/tests/CaptureCollectionTests.netcoreapp.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
@@ -165,8 +166,19 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public static void DebuggerAttributeTests()
         {
-            DebuggerAttributes.ValidateDebuggerDisplayReferences(CreateCollection());
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(CreateCollection());
+            CaptureCollection col = CreateCollection();
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(col);
+            DebuggerAttributeInfo info = DebuggerAttributes.ValidateDebuggerTypeProxyProperties(col);
+            PropertyInfo itemProperty = info.Properties.Single(pr => pr.GetCustomAttribute<DebuggerBrowsableAttribute>().State == DebuggerBrowsableState.RootHidden);
+            Capture[] items = itemProperty.GetValue(info.Instance) as Capture[];
+            Assert.Equal(col, items);
+        }
+
+        [Fact]
+        public static void DebuggerAttributeTests_Null()
+        {
+            TargetInvocationException ex = Assert.Throws<TargetInvocationException>(() => DebuggerAttributes.ValidateDebuggerTypeProxyProperties(typeof(CaptureCollection), null));
+            Assert.IsType<ArgumentNullException>(ex.InnerException);
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/GroupCollectionTests.netcoreapp.cs
+++ b/src/System.Text.RegularExpressions/tests/GroupCollectionTests.netcoreapp.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
@@ -162,8 +163,19 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public static void DebuggerAttributeTests()
         {
-            DebuggerAttributes.ValidateDebuggerDisplayReferences(CreateCollection());
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(CreateCollection());
+            GroupCollection col = CreateCollection();
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(col);
+            DebuggerAttributeInfo info = DebuggerAttributes.ValidateDebuggerTypeProxyProperties(col);
+            PropertyInfo itemProperty = info.Properties.Single(pr => pr.GetCustomAttribute<DebuggerBrowsableAttribute>().State == DebuggerBrowsableState.RootHidden);
+            Group[] items = itemProperty.GetValue(info.Instance) as Group[];
+            Assert.Equal(col, items);
+        }
+
+        [Fact]
+        public static void DebuggerAttributeTests_Null()
+        {
+            TargetInvocationException ex = Assert.Throws<TargetInvocationException>(() => DebuggerAttributes.ValidateDebuggerTypeProxyProperties(typeof(GroupCollection), null));
+            Assert.IsType<ArgumentNullException>(ex.InnerException);
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/MatchCollectionTests.netcoreapp.cs
+++ b/src/System.Text.RegularExpressions/tests/MatchCollectionTests.netcoreapp.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
@@ -159,8 +160,19 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public static void DebuggerAttributeTests()
         {
-            DebuggerAttributes.ValidateDebuggerDisplayReferences(CreateCollection());
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(CreateCollection());
+            MatchCollection col = CreateCollection();
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(col);
+            DebuggerAttributeInfo info = DebuggerAttributes.ValidateDebuggerTypeProxyProperties(col);
+            PropertyInfo itemProperty = info.Properties.Single(pr => pr.GetCustomAttribute<DebuggerBrowsableAttribute>().State == DebuggerBrowsableState.RootHidden);
+            Match[] items = itemProperty.GetValue(info.Instance) as Match[];
+            Assert.Equal(col, items);
+        }
+
+        [Fact]
+        public static void DebuggerAttributeTests_Null()
+        {
+            TargetInvocationException ex = Assert.Throws<TargetInvocationException>(() => DebuggerAttributes.ValidateDebuggerTypeProxyProperties(typeof(MatchCollection), null));
+            Assert.IsType<ArgumentNullException>(ex.InnerException);
         }
     }
 }


### PR DESCRIPTION
Verify items are displayed for debugger correctly.

Verify exception on null passed to ctor.