### PR TITLE
Remove char[] allocation from Uri.HexEscape

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -1407,10 +1407,15 @@ namespace System
             {
                 throw new ArgumentOutOfRangeException(nameof(character));
             }
-            char[] chars = new char[3];
-            int pos = 0;
-            UriHelper.EscapeAsciiChar(character, chars, ref pos);
-            return new string(chars);
+
+            unsafe
+            {
+                char* chars = stackalloc char[3];
+                chars[0] = '%';
+                chars[1] = UriHelper.s_hexUpperChars[(character & 0xf0) >> 4];
+                chars[2] = UriHelper.s_hexUpperChars[character & 0xf];
+                return new string(chars, 0, 3);
+            }
         }
 
         //

--- a/src/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/System.Private.Uri/src/System/UriHelper.cs
@@ -9,7 +9,7 @@ namespace System
 {
     internal static class UriHelper
     {
-        private static readonly char[] s_hexUpperChars = {
+        internal static readonly char[] s_hexUpperChars = {
                                    '0', '1', '2', '3', '4', '5', '6', '7',
                                    '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 


### PR DESCRIPTION
cc: @cipop, @davidsh