### PR TITLE
Expand Deflate64 WindowSize

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -36,12 +36,12 @@ namespace System.IO.Compression
 
         // Extra bits for length code 257 - 285.
         private static readonly byte[] s_extraLengthBits =
-            { 0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,16,56,62 };
+            { 0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,16 };
 
         // The base length for length code 257 - 285.
         // The formula to get the real length for a length code is lengthBase[code - 257] + (value stored in extraBits)
         private static readonly int[] s_lengthBase =
-            { 3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,3,0,0 };
+            { 3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,3};
 
         // The base distance for distance code 0 - 31
         // The real distance for a distance code is  distanceBasePosition[code] + (value stored in extraBits)
@@ -401,9 +401,10 @@ namespace System.IO.Compression
             end_of_block_code_seen = false;
 
             int freeBytes = _output.FreeBytes;   // it is a little bit faster than frequently accessing the property
-            while (freeBytes > 258)
+            while (freeBytes > 65536)
             {
-                // 258 means we can safely do decoding since maximum repeat length is 258
+                // With Deflate64 we can have up to a 64kb length, so we ensure at least that much space is available
+                // in the OutputWindow to avoid overwriting previous unflushed output data.
 
                 int symbol;
                 switch (_state)
@@ -506,7 +507,7 @@ namespace System.IO.Compression
                         goto case InflaterState.HaveDistCode;
 
                     case InflaterState.HaveDistCode:
-                        // To avoid a table lookup we note that for distanceCode >= 2,
+                        // To avoid a table lookup we note that for distanceCode > 3,
                         // extra_bits = (distanceCode-2) >> 1
                         int offset;
                         if (_distanceCode > 3)
@@ -524,7 +525,6 @@ namespace System.IO.Compression
                             offset = _distanceCode + 1;
                         }
 
-                        Debug.Assert(freeBytes >= 258, "following operation is not safe!");
                         _output.WriteLengthDistance(_length, offset);
                         freeBytes -= _length;
                         _state = InflaterState.DecodeTop;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputWindow.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputWindow.cs
@@ -15,10 +15,13 @@ namespace System.IO.Compression
     /// </summary>
     internal sealed class OutputWindow
     {
-        private const int WindowSize = 65536;
-        private const int WindowMask = 65535;
+        // With Deflate64 we can have up to a 65536 length as well as up to a 65538 distance. This means we need a Window that is at
+        // least 131074 bytes long so we have space to retrieve up to a full 64kb in lookback and place it in our buffer without 
+        // overwriting existing data. OutputWindow requires that the WindowSize be a exponent of 2, so we round up to 2^18.
+        private const int WindowSize = 262144;
+        private const int WindowMask = 262143;
 
-        private readonly byte[] _window = new byte[WindowSize]; // The window is 2^15 bytes
+        private readonly byte[] _window = new byte[WindowSize]; // The window is 2^18 bytes
         private int _end;       // this is the position to where we should write next byte
         private int _bytesUsed; // The number of bytes in the output window which is not consumed.
 
@@ -34,14 +37,14 @@ namespace System.IO.Compression
         public void WriteLengthDistance(int length, int distance)
         {
             Debug.Assert((_bytesUsed + length) <= WindowSize, "No Enough space");
-
+            
             // move backwards distance bytes in the output stream,
             // and copy length bytes from this position to the output stream.
             _bytesUsed += length;
             int copyStart = (_end - distance) & WindowMask; // start position for coping.
 
             int border = WindowSize - length;
-            if (copyStart <= border && _end < border)
+            if (copyStart <= border && _end < border) 
             {
                 if (length <= distance)
                 {


### PR DESCRIPTION
The WindowSize being used in the old managed deflate implementation that I modified to decompress Deflate64 is too small. Deflate64 can have lengths up to 64kb as well as distances up to 64kb when doing lookback. In my initial implementation I disregarded the increased length, allowing potentially 64kb of data to be written to an outputwindow that only has as little as 258 bytes of open space. This causes the previously inflated yet-to-be-flushed data to be overwritten, causing invalid output.

The fix is simple: increase the WindowSize to fit the new length/distance maximums. Becuase of the way our managed Deflate implementation is written, it's not possible to simply flush the OutputWindow after already determining the lookback without a large rewrite, so I opted for the increased WindowSize solution instead.

Testing is unfortunately not simple because it's rare that a file will need such a high length/distance and we do not have a Deflate64 deflater so we have to rely on other programs for generating test input. I've got a file that allows reproduction of the failure, but it's 3gb and doesn't experience data loss until a little under the 1gb mark. Because of the large size of the test file, I've left it out.

I also took the chance to cleanup the s_extraLengthBits field. Currently, we attempt to read extra bits from input when given an invalid symbol for determining length. By shortening the arrays to only valid values, we instead throw an InvalidDataException early.

cc: @stephentoub 