### PR TITLE
Sockets: ensure InnerReleaseHandle is called exactly once

### DIFF
--- a/src/Common/src/System/Net/SafeCloseSocket.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.cs
@@ -141,15 +141,17 @@ namespace System.Net.Sockets
 
             _released = true;
             InnerSafeCloseSocket innerSocket = _innerSocket == null ? null : Interlocked.Exchange<InnerSafeCloseSocket>(ref _innerSocket, null);
-
+            if (innerSocket != null)
+            {
 #if DEBUG
-            // On AppDomain unload we may still have pending Overlapped operations.
-            // ThreadPoolBoundHandle should handle this scenario by canceling them.
-            innerSocket?.LogRemainingOperations();
+                // On AppDomain unload we may still have pending Overlapped operations.
+                // ThreadPoolBoundHandle should handle this scenario by canceling them.
+                innerSocket.LogRemainingOperations();
 #endif
 
-            InnerReleaseHandle();
-            innerSocket?.DangerousRelease();
+                InnerReleaseHandle();
+                innerSocket.DangerousRelease();
+            }
 
             return true;
         }
@@ -175,11 +177,12 @@ namespace System.Net.Sockets
                         sw.SpinOnce();
                     }
 
+                    InnerReleaseHandle();
+
                     // Now free it with blocking.
                     innerSocket.BlockingRelease();
                 }
 
-                InnerReleaseHandle();
 #if DEBUG
             }
             catch (Exception exception) when (!ExceptionCheck.IsFatal(exception))


### PR DESCRIPTION
In SafeCloseSocket, InnerReleaseHandle often gets called twice today -- once by CloseAsIs, once by ReleaseHandle.  This can in rare occasions lead to deadlocks in the SocketAsyncContext code, deadlocked on the queuelock by multiple threads calling InnerReleaseHandle.

Ensure that InnerReleaseHandle is called exactly once, and is consistently called before the innerSocket is released.

@stephentoub @wfurt @Priya91 @davidsh @CIPop 