### PR TITLE
Remove ILCBuildType=chk from SqlClient.Tests (#22835)

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -2,8 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <!-- [ActiveIssue(https://github.com/dotnet/corefx/issues/22416, TargetFrameworkMonikers.UapAot)] Crashes on UapAot -->
-    <ILCBuildType Condition="'$(ConfigurationGroup)|$(ArchGroup)' == 'Release|x86'">chk</ILCBuildType>
     <ProjectGuid>{F3E72F35-0351-4D67-9388-725BCAD807BA}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Debug|AnyCPU'" />


### PR DESCRIPTION
Related to issue: https://github.com/dotnet/corefx/issues/22416

There was a bug in nutc causing the tests to crash. This was fixed and ported to ProjectNRel. I verified locally that they don't crash anymore. 