### PR TITLE
Drastically reduce the number of performance tests for System.Double.ToString

### DIFF
--- a/src/System.Runtime/tests/Performance/Perf.Double.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Double.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.Xunit.Performance;
 using Xunit;
@@ -12,466 +14,121 @@ namespace System.Tests
     public class Perf_Double
     {
         public static readonly double dValue = 1.23456789E+5;
-        private const int iterCount = 20000;
+        private string _string;
 
-        [Benchmark(InnerIterationCount = iterCount)]
-        [InlineData(104234.343)]
-        [InlineData(double.MinValue / 2)]
-        [InlineData(Math.PI)]
-        [InlineData(Math.E)]
-        [InlineData(double.MaxValue)]
-        [InlineData(double.MinValue)]
-        [InlineData(double.NaN)]
-        [InlineData(double.PositiveInfinity)]
-        [InlineData(double.NegativeInfinity)]
-        [InlineData(2.2250738585072009E-308)]
-        [InlineData(-2.2250738585072009E-308)]
-        [InlineData(1.1125369292536E-308)]
-        [InlineData(-0.0)]
-        [InlineData(0.0)]
-        public void DefaultToString(double number)
+        [Benchmark]
+        [InlineData(104234.343, 1_000_000)]
+        [InlineData(double.MaxValue, 100_000)]
+        [InlineData(double.MinValue, 100_000)]
+        [InlineData(double.NaN, 10_000_000)]
+        [InlineData(double.PositiveInfinity, 10_000_000)]
+        public void DefaultToString(double number, int innerIterations)
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    for (int i = 0; i < innerIterations; i++)
                     {
-                        number.ToString();
-                    }
-                }
-            }
-        }
-
-        [Benchmark(InnerIterationCount = iterCount)]
-        [InlineData("zh", 104234.343)]
-        [InlineData("zh", double.MinValue / 2)]
-        [InlineData("zh", Math.PI)]
-        [InlineData("zh", Math.E)]
-        [InlineData("zh", double.MaxValue)]
-        [InlineData("zh", double.MinValue)]
-        [InlineData("zh", double.NaN)]
-        [InlineData("zh", double.PositiveInfinity)]
-        [InlineData("zh", double.NegativeInfinity)]
-        [InlineData("zh", 2.2250738585072009E-308)]
-        [InlineData("zh", -2.2250738585072009E-308)]
-        [InlineData("zh", 1.1125369292536E-308)]
-        [InlineData("zh", -0.0)]
-        [InlineData("zh", 0.0)]
-        public void ToStringWithCultureInfo(string cultureName, double number)
-        {
-            CultureInfo cultureInfo = new CultureInfo(cultureName);
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                    {
-                        number.ToString(cultureInfo);
-                    }
-                }
-            }
-        }
-
-        [Benchmark(InnerIterationCount = iterCount)]
-        [InlineData("R", 104234.343)]
-        [InlineData("R", double.MinValue / 2)]
-        [InlineData("R", Math.PI)]
-        [InlineData("R", Math.E)]
-        [InlineData("R", double.MaxValue)]
-        [InlineData("R", double.MinValue)]
-        [InlineData("R", double.NaN)]
-        [InlineData("R", double.PositiveInfinity)]
-        [InlineData("R", double.NegativeInfinity)]
-        [InlineData("R", 2.2250738585072009E-308)]
-        [InlineData("R", -2.2250738585072009E-308)]
-        [InlineData("R", 1.1125369292536E-308)]
-        [InlineData("R", 0)]
-        [InlineData("G", 104234.343)]
-        [InlineData("G", double.MinValue / 2)]
-        [InlineData("G", Math.PI)]
-        [InlineData("G", Math.E)]
-        [InlineData("G", double.MaxValue)]
-        [InlineData("G", double.MinValue)]
-        [InlineData("G", double.NaN)]
-        [InlineData("G", double.PositiveInfinity)]
-        [InlineData("G", double.NegativeInfinity)]
-        [InlineData("G", 2.2250738585072009E-308)]
-        [InlineData("G", -2.2250738585072009E-308)]
-        [InlineData("G", 1.1125369292536E-308)]
-        [InlineData("G", -0.0)]
-        [InlineData("G", 0.0)]
-        [InlineData("G17", 104234.343)]
-        [InlineData("G17", double.MinValue / 2)]
-        [InlineData("G17", Math.PI)]
-        [InlineData("G17", Math.E)]
-        [InlineData("G17", double.MaxValue)]
-        [InlineData("G17", double.MinValue)]
-        [InlineData("G17", double.NaN)]
-        [InlineData("G17", double.PositiveInfinity)]
-        [InlineData("G17", double.NegativeInfinity)]
-        [InlineData("G17", 2.2250738585072009E-308)]
-        [InlineData("G17", -2.2250738585072009E-308)]
-        [InlineData("G17", 1.1125369292536E-308)]
-        [InlineData("G17", -0.0)]
-        [InlineData("G17", 0.0)]
-        [InlineData("G16", 104234.343)]
-        [InlineData("G16", double.MinValue / 2)]
-        [InlineData("G16", Math.PI)]
-        [InlineData("G16", Math.E)]
-        [InlineData("G16", double.MaxValue)]
-        [InlineData("G16", double.MinValue)]
-        [InlineData("G16", double.NaN)]
-        [InlineData("G16", double.PositiveInfinity)]
-        [InlineData("G16", double.NegativeInfinity)]
-        [InlineData("G16", 2.2250738585072009E-308)]
-        [InlineData("G16", -2.2250738585072009E-308)]
-        [InlineData("G16", 1.1125369292536E-308)]
-        [InlineData("G16", -0.0)]
-        [InlineData("G16", 0.0)]
-        [InlineData("G15", 104234.343)]
-        [InlineData("G15", double.MinValue / 2)]
-        [InlineData("G15", Math.PI)]
-        [InlineData("G15", Math.E)]
-        [InlineData("G15", double.MaxValue)]
-        [InlineData("G15", double.MinValue)]
-        [InlineData("G15", double.NaN)]
-        [InlineData("G15", double.PositiveInfinity)]
-        [InlineData("G15", double.NegativeInfinity)]
-        [InlineData("G15", 2.2250738585072009E-308)]
-        [InlineData("G15", -2.2250738585072009E-308)]
-        [InlineData("G15", 1.1125369292536E-308)]
-        [InlineData("G15", -0.0)]
-        [InlineData("G15", 0.0)]
-        [InlineData("G14", 104234.343)]
-        [InlineData("G14", double.MinValue / 2)]
-        [InlineData("G14", Math.PI)]
-        [InlineData("G14", Math.E)]
-        [InlineData("G14", double.MaxValue)]
-        [InlineData("G14", double.MinValue)]
-        [InlineData("G14", double.NaN)]
-        [InlineData("G14", double.PositiveInfinity)]
-        [InlineData("G14", double.NegativeInfinity)]
-        [InlineData("G14", 2.2250738585072009E-308)]
-        [InlineData("G14", -2.2250738585072009E-308)]
-        [InlineData("G14", 1.1125369292536E-308)]
-        [InlineData("G14", -0.0)]
-        [InlineData("G14", 0.0)]
-        [InlineData("G13", 104234.343)]
-        [InlineData("G13", double.MinValue / 2)]
-        [InlineData("G13", Math.PI)]
-        [InlineData("G13", Math.E)]
-        [InlineData("G13", double.MaxValue)]
-        [InlineData("G13", double.MinValue)]
-        [InlineData("G13", double.NaN)]
-        [InlineData("G13", double.PositiveInfinity)]
-        [InlineData("G13", double.NegativeInfinity)]
-        [InlineData("G13", 2.2250738585072009E-308)]
-        [InlineData("G13", -2.2250738585072009E-308)]
-        [InlineData("G13", 1.1125369292536E-308)]
-        [InlineData("G13", -0.0)]
-        [InlineData("G13", 0.0)]
-        [InlineData("G12", 104234.343)]
-        [InlineData("G12", double.MinValue / 2)]
-        [InlineData("G12", Math.PI)]
-        [InlineData("G12", Math.E)]
-        [InlineData("G12", double.MaxValue)]
-        [InlineData("G12", double.MinValue)]
-        [InlineData("G12", double.NaN)]
-        [InlineData("G12", double.PositiveInfinity)]
-        [InlineData("G12", double.NegativeInfinity)]
-        [InlineData("G12", 2.2250738585072009E-308)]
-        [InlineData("G12", -2.2250738585072009E-308)]
-        [InlineData("G12", 1.1125369292536E-308)]
-        [InlineData("G12", -0.0)]
-        [InlineData("G12", 0.0)]
-        [InlineData("G11", 104234.343)]
-        [InlineData("G11", double.MinValue / 2)]
-        [InlineData("G11", Math.PI)]
-        [InlineData("G11", Math.E)]
-        [InlineData("G11", double.MaxValue)]
-        [InlineData("G11", double.MinValue)]
-        [InlineData("G11", double.NaN)]
-        [InlineData("G11", double.PositiveInfinity)]
-        [InlineData("G11", double.NegativeInfinity)]
-        [InlineData("G11", 2.2250738585072009E-308)]
-        [InlineData("G11", -2.2250738585072009E-308)]
-        [InlineData("G11", 1.1125369292536E-308)]
-        [InlineData("G11", -0.0)]
-        [InlineData("G11", 0.0)]
-        [InlineData("G10", 104234.343)]
-        [InlineData("G10", double.MinValue / 2)]
-        [InlineData("G10", Math.PI)]
-        [InlineData("G10", Math.E)]
-        [InlineData("G10", double.MaxValue)]
-        [InlineData("G10", double.MinValue)]
-        [InlineData("G10", double.NaN)]
-        [InlineData("G10", double.PositiveInfinity)]
-        [InlineData("G10", double.NegativeInfinity)]
-        [InlineData("G10", 2.2250738585072009E-308)]
-        [InlineData("G10", -2.2250738585072009E-308)]
-        [InlineData("G10", 1.1125369292536E-308)]
-        [InlineData("G10", -0.0)]
-        [InlineData("G10", 0.0)]
-        [InlineData("G9", 104234.343)]
-        [InlineData("G9", double.MinValue / 2)]
-        [InlineData("G9", Math.PI)]
-        [InlineData("G9", Math.E)]
-        [InlineData("G9", double.MaxValue)]
-        [InlineData("G9", double.MinValue)]
-        [InlineData("G9", double.NaN)]
-        [InlineData("G9", double.PositiveInfinity)]
-        [InlineData("G9", double.NegativeInfinity)]
-        [InlineData("G9", 2.2250738585072009E-308)]
-        [InlineData("G9", -2.2250738585072009E-308)]
-        [InlineData("G9", 1.1125369292536E-308)]
-        [InlineData("G9", -0.0)]
-        [InlineData("G9", 0.0)]
-        [InlineData("G8", 104234.343)]
-        [InlineData("G8", double.MinValue / 2)]
-        [InlineData("G8", Math.PI)]
-        [InlineData("G8", Math.E)]
-        [InlineData("G8", double.MaxValue)]
-        [InlineData("G8", double.MinValue)]
-        [InlineData("G8", double.NaN)]
-        [InlineData("G8", double.PositiveInfinity)]
-        [InlineData("G8", double.NegativeInfinity)]
-        [InlineData("G8", 2.2250738585072009E-308)]
-        [InlineData("G8", -2.2250738585072009E-308)]
-        [InlineData("G8", 1.1125369292536E-308)]
-        [InlineData("G8", -0.0)]
-        [InlineData("G8", 0.0)]
-        [InlineData("G7", 104234.343)]
-        [InlineData("G7", double.MinValue / 2)]
-        [InlineData("G7", Math.PI)]
-        [InlineData("G7", Math.E)]
-        [InlineData("G7", double.MaxValue)]
-        [InlineData("G7", double.MinValue)]
-        [InlineData("G7", double.NaN)]
-        [InlineData("G7", double.PositiveInfinity)]
-        [InlineData("G7", double.NegativeInfinity)]
-        [InlineData("G7", 2.2250738585072009E-308)]
-        [InlineData("G7", -2.2250738585072009E-308)]
-        [InlineData("G7", 1.1125369292536E-308)]
-        [InlineData("G7", -0.0)]
-        [InlineData("G7", 0.0)]
-        [InlineData("G6", 104234.343)]
-        [InlineData("G6", double.MinValue / 2)]
-        [InlineData("G6", Math.PI)]
-        [InlineData("G6", Math.E)]
-        [InlineData("G6", double.MaxValue)]
-        [InlineData("G6", double.MinValue)]
-        [InlineData("G6", double.NaN)]
-        [InlineData("G6", double.PositiveInfinity)]
-        [InlineData("G6", double.NegativeInfinity)]
-        [InlineData("G6", 2.2250738585072009E-308)]
-        [InlineData("G6", -2.2250738585072009E-308)]
-        [InlineData("G6", 1.1125369292536E-308)]
-        [InlineData("G6", -0.0)]
-        [InlineData("G6", 0.0)]
-        [InlineData("G5", 104234.343)]
-        [InlineData("G5", double.MinValue / 2)]
-        [InlineData("G5", Math.PI)]
-        [InlineData("G5", Math.E)]
-        [InlineData("G5", double.MaxValue)]
-        [InlineData("G5", double.MinValue)]
-        [InlineData("G5", double.NaN)]
-        [InlineData("G5", double.PositiveInfinity)]
-        [InlineData("G5", double.NegativeInfinity)]
-        [InlineData("G5", 2.2250738585072009E-308)]
-        [InlineData("G5", -2.2250738585072009E-308)]
-        [InlineData("G5", 1.1125369292536E-308)]
-        [InlineData("G5", -0.0)]
-        [InlineData("G5", 0.0)]
-        [InlineData("G4", 104234.343)]
-        [InlineData("G4", double.MinValue / 2)]
-        [InlineData("G4", Math.PI)]
-        [InlineData("G4", Math.E)]
-        [InlineData("G4", double.MaxValue)]
-        [InlineData("G4", double.MinValue)]
-        [InlineData("G4", double.NaN)]
-        [InlineData("G4", double.PositiveInfinity)]
-        [InlineData("G4", double.NegativeInfinity)]
-        [InlineData("G4", 2.2250738585072009E-308)]
-        [InlineData("G4", -2.2250738585072009E-308)]
-        [InlineData("G4", 1.1125369292536E-308)]
-        [InlineData("G4", -0.0)]
-        [InlineData("G4", 0.0)]
-        [InlineData("G3", 104234.343)]
-        [InlineData("G3", double.MinValue / 2)]
-        [InlineData("G3", Math.PI)]
-        [InlineData("G3", Math.E)]
-        [InlineData("G3", double.MaxValue)]
-        [InlineData("G3", double.MinValue)]
-        [InlineData("G3", double.NaN)]
-        [InlineData("G3", double.PositiveInfinity)]
-        [InlineData("G3", double.NegativeInfinity)]
-        [InlineData("G3", 2.2250738585072009E-308)]
-        [InlineData("G3", -2.2250738585072009E-308)]
-        [InlineData("G3", 1.1125369292536E-308)]
-        [InlineData("G3", -0.0)]
-        [InlineData("G3", 0.0)]
-        [InlineData("G2", 104234.343)]
-        [InlineData("G2", double.MinValue / 2)]
-        [InlineData("G2", Math.PI)]
-        [InlineData("G2", Math.E)]
-        [InlineData("G2", double.MaxValue)]
-        [InlineData("G2", double.MinValue)]
-        [InlineData("G2", double.NaN)]
-        [InlineData("G2", double.PositiveInfinity)]
-        [InlineData("G2", double.NegativeInfinity)]
-        [InlineData("G2", 2.2250738585072009E-308)]
-        [InlineData("G2", -2.2250738585072009E-308)]
-        [InlineData("G2", 1.1125369292536E-308)]
-        [InlineData("G2", -0.0)]
-        [InlineData("G2", 0.0)]
-        [InlineData("G1", 104234.343)]
-        [InlineData("G1", double.MinValue / 2)]
-        [InlineData("G1", Math.PI)]
-        [InlineData("G1", Math.E)]
-        [InlineData("G1", double.MaxValue)]
-        [InlineData("G1", double.MinValue)]
-        [InlineData("G1", double.NaN)]
-        [InlineData("G1", double.PositiveInfinity)]
-        [InlineData("G1", double.NegativeInfinity)]
-        [InlineData("G1", 2.2250738585072009E-308)]
-        [InlineData("G1", -2.2250738585072009E-308)]
-        [InlineData("G1", 1.1125369292536E-308)]
-        [InlineData("G1", -0.0)]
-        [InlineData("G1", 0.0)]
-        [InlineData("G0", 104234.343)]
-        [InlineData("G0", double.MinValue / 2)]
-        [InlineData("G0", Math.PI)]
-        [InlineData("G0", Math.E)]
-        [InlineData("G0", double.MaxValue)]
-        [InlineData("G0", double.MinValue)]
-        [InlineData("G0", double.NaN)]
-        [InlineData("G0", double.PositiveInfinity)]
-        [InlineData("G0", double.NegativeInfinity)]
-        [InlineData("G0", 2.2250738585072009E-308)]
-        [InlineData("G0", -2.2250738585072009E-308)]
-        [InlineData("G0", 1.1125369292536E-308)]
-        [InlineData("G0", -0.0)]
-        [InlineData("G0", 0.0)]
-        [InlineData("F", 104234.343)]
-        [InlineData("F", double.MinValue / 2)]
-        [InlineData("F", Math.PI)]
-        [InlineData("F", Math.E)]
-        [InlineData("F", double.MaxValue)]
-        [InlineData("F", double.MinValue)]
-        [InlineData("F", double.NaN)]
-        [InlineData("F", double.PositiveInfinity)]
-        [InlineData("F", double.NegativeInfinity)]
-        [InlineData("F", 2.2250738585072009E-308)]
-        [InlineData("F", -2.2250738585072009E-308)]
-        [InlineData("F", 1.1125369292536E-308)]
-        [InlineData("F", -0.0)]
-        [InlineData("F", 0.0)]
-        [InlineData("F7", 104234.343)]
-        [InlineData("F7", double.MinValue / 2)]
-        [InlineData("F7", Math.PI)]
-        [InlineData("F7", Math.E)]
-        [InlineData("F7", double.MaxValue)]
-        [InlineData("F7", double.MinValue)]
-        [InlineData("F7", double.NaN)]
-        [InlineData("F7", double.PositiveInfinity)]
-        [InlineData("F7", double.NegativeInfinity)]
-        [InlineData("F7", 2.2250738585072009E-308)]
-        [InlineData("F7", -2.2250738585072009E-308)]
-        [InlineData("F7", 1.1125369292536E-308)]
-        [InlineData("F7", -0.0)]
-        [InlineData("F7", 0.0)]
-        [InlineData("F9", 104234.343)]
-        [InlineData("F9", double.MinValue / 2)]
-        [InlineData("F9", Math.PI)]
-        [InlineData("F9", Math.E)]
-        [InlineData("F9", double.MaxValue)]
-        [InlineData("F9", double.MinValue)]
-        [InlineData("F9", double.NaN)]
-        [InlineData("F9", double.PositiveInfinity)]
-        [InlineData("F9", double.NegativeInfinity)]
-        [InlineData("F9", 2.2250738585072009E-308)]
-        [InlineData("F9", -2.2250738585072009E-308)]
-        [InlineData("F9", 1.1125369292536E-308)]
-        [InlineData("F9", -0.0)]
-        [InlineData("F9", 0.0)]
-        [InlineData("F15", 104234.343)]
-        [InlineData("F15", double.MinValue / 2)]
-        [InlineData("F15", Math.PI)]
-        [InlineData("F15", Math.E)]
-        [InlineData("F15", double.MaxValue)]
-        [InlineData("F15", double.MinValue)]
-        [InlineData("F15", double.NaN)]
-        [InlineData("F15", double.PositiveInfinity)]
-        [InlineData("F15", double.NegativeInfinity)]
-        [InlineData("F15", 2.2250738585072009E-308)]
-        [InlineData("F15", -2.2250738585072009E-308)]
-        [InlineData("F15", 1.1125369292536E-308)]
-        [InlineData("F15", -0.0)]
-        [InlineData("F15", 0.0)]
-        [InlineData("F17", 104234.343)]
-        [InlineData("F17", double.MinValue / 2)]
-        [InlineData("F17", Math.PI)]
-        [InlineData("F17", Math.E)]
-        [InlineData("F17", double.MaxValue)]
-        [InlineData("F17", double.MinValue)]
-        [InlineData("F17", double.NaN)]
-        [InlineData("F17", double.PositiveInfinity)]
-        [InlineData("F17", double.NegativeInfinity)]
-        [InlineData("F17", 2.2250738585072009E-308)]
-        [InlineData("F17", -2.2250738585072009E-308)]
-        [InlineData("F17", 1.1125369292536E-308)]
-        [InlineData("F17", -0.0)]
-        [InlineData("F17", 0.0)]
-        [InlineData("F50", 104234.343)]
-        [InlineData("F50", double.MinValue / 2)]
-        [InlineData("F50", Math.PI)]
-        [InlineData("F50", Math.E)]
-        [InlineData("F50", double.MaxValue)]
-        [InlineData("F50", double.MinValue)]
-        [InlineData("F50", double.NaN)]
-        [InlineData("F50", double.PositiveInfinity)]
-        [InlineData("F50", double.NegativeInfinity)]
-        [InlineData("F50", 2.2250738585072009E-308)]
-        [InlineData("F50", -2.2250738585072009E-308)]
-        [InlineData("F50", 1.1125369292536E-308)]
-        [InlineData("F50", -0.0)]
-        [InlineData("F50", 0.0)]
-        [InlineData("E", 104234.343)]
-        [InlineData("E", double.MinValue / 2)]
-        [InlineData("E", Math.PI)]
-        [InlineData("E", Math.E)]
-        [InlineData("E", double.MaxValue)]
-        [InlineData("E", double.MinValue)]
-        [InlineData("E", double.NaN)]
-        [InlineData("E", double.PositiveInfinity)]
-        [InlineData("E", double.NegativeInfinity)]
-        [InlineData("E", 2.2250738585072009E-308)]
-        [InlineData("E", -2.2250738585072009E-308)]
-        [InlineData("E", 1.1125369292536E-308)]
-        [InlineData("E", -0.0)]
-        [InlineData("E", 0.0)]
-        public void ToStringWithFormat(string format, double number)
-        {
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                    {
-                        number.ToString(format);
+                        _string = number.ToString();
                     }
                 }
             }
         }
 
         [Benchmark]
+        [InlineData("zh", 104234.343, 1_000_000)]
+        [InlineData("zh", double.MaxValue, 100_000)]
+        [InlineData("zh", double.MinValue, 100_000)]
+        [InlineData("zh", double.NaN, 20_000_000)]
+        [InlineData("zh", double.PositiveInfinity, 20_000_000)]
+        [InlineData("zh", 0.0, 4_000_000)]
+        public void ToStringWithCultureInfo(string cultureName, double number, int innerIterations)
+        {
+            CultureInfo cultureInfo = new CultureInfo(cultureName);
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        _string = number.ToString(cultureInfo);
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> ToStringWithFormat_TestData()
+        {
+            string[] formats =
+            {
+                "R",
+                "G",
+                "G17",
+                "E",
+                "F"
+            };
+
+            double[] normalTestValues =
+            {
+                0.0,
+                250.0,
+            };
+
+            double[] edgeTestValues =
+            {
+                double.MaxValue,
+                double.MinValue,
+                double.Epsilon,
+            };
+
+            foreach (string format in formats)
+            {
+                foreach (double testValue in normalTestValues)
+                {
+                    yield return new object[] { format, testValue, 2_000_000 };
+                }
+
+                foreach (double testValue in edgeTestValues)
+                {
+                    yield return new object[] { format, testValue, 100_000 };
+                }
+            }
+
+            yield return new object[] { "G", double.PositiveInfinity, 20_000_000 };
+            yield return new object[] { "G", double.NaN, 20_000_000 };
+        }
+
+        [Benchmark]
+        [MemberData(nameof(ToStringWithFormat_TestData))]
+        public void ToStringWithFormat(string format, double number, int innerIterations)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        _string = number.ToString(format);
+                    }
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = 4_000_000)]
         public static void Decimal_ToString()
         {
             decimal decimalNum = new decimal(dValue);
             foreach (var iteration in Benchmark.Iterations)
+            {
                 using (iteration.StartMeasurement())
-                    decimalNum.ToString();
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        decimalNum.ToString();
+                    }
+                }
+            }
         }
     }
 }

--- a/src/System.Runtime/tests/Performance/Perf.Double.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Double.cs
@@ -13,15 +13,16 @@ namespace System.Tests
 {
     public class Perf_Double
     {
-        public static readonly double dValue = 1.23456789E+5;
-        private string _string;
+        private volatile string _string;
 
         [Benchmark]
         [InlineData(104234.343, 1_000_000)]
         [InlineData(double.MaxValue, 100_000)]
         [InlineData(double.MinValue, 100_000)]
+        [InlineData(double.MinValue / 2, 100_000)]
         [InlineData(double.NaN, 10_000_000)]
         [InlineData(double.PositiveInfinity, 10_000_000)]
+        [InlineData(2.2250738585072009E-308, 100_000)]
         public void DefaultToString(double number, int innerIterations)
         {
             foreach (var iteration in Benchmark.Iterations)
@@ -66,7 +67,7 @@ namespace System.Tests
                 "G",
                 "G17",
                 "E",
-                "F"
+                "F50"
             };
 
             double[] normalTestValues =
@@ -118,7 +119,7 @@ namespace System.Tests
         [Benchmark(InnerIterationCount = 4_000_000)]
         public static void Decimal_ToString()
         {
-            decimal decimalNum = new decimal(dValue);
+            decimal decimalNum = new decimal(1.23456789E+5);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())


### PR DESCRIPTION
We recently added a large number of performance tests for `System.Double.ToString`. Realistically, we only need a much smaller subset of these tests in order to give us good performance coverage. I've reduced the total number of tests to 38, down from several hundred. Due to the nature of performance tests, even this small set may still take several minutes to complete.

I chose a subset that I thought still covered our bases, but I may have missed something important. I can add some additional test cases (or even trim out some of these) if we think that's the case.

Along with that, I also made some small functional changes to the tests. I've tweaked the inner iteration count so that each of the test iterations hovers around 500 ms of execution time. @jorive also recommended storing the ToString results into a field to discourage JIT optimizations from affecting the results.

@stephentoub @mazong1123 @jorive 