### PR TITLE
System.Net.CookieParser to Support Cookie String with Trailing Semicolon

### DIFF
--- a/src/Common/src/System/Net/CookieParser.cs
+++ b/src/Common/src/System/Net/CookieParser.cs
@@ -282,7 +282,8 @@ namespace System.Net
                     }
                     ++_index;
                 }
-                else
+                
+                if (Eof)
                 {
                     _cookieLength = _index - _cookieStartIndex;
                 }

--- a/src/System.Net.Http/src/uap/System/Net/cookie.cs
+++ b/src/System.Net.Http/src/uap/System/Net/cookie.cs
@@ -1280,7 +1280,8 @@ namespace System.Net
                     }
                     ++m_index;
                 }
-                else
+                
+                if (Eof)
                 {
                     m_cookieLength = m_index - m_cookieStartIndex;
                 }

--- a/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
@@ -42,63 +42,25 @@ namespace NetPrimitivesUnitTests
             Assert.False(cookies[CookieName].DomainImplicit);
         }
 
-        [Fact]
-        public void CookieParser_GetString()
+        [Theory]
+        [InlineData("cookie_token=cookie_value")]
+        [InlineData("cookie_token=cookie_value;")]
+        [InlineData("cookie_token1=cookie_value1;cookie_token2=cookie_value2")]
+        [InlineData("cookie_token1=cookie_value1;cookie_token2=cookie_value2;")]
+        public void CookieParserGetString_SetCookieHeaderValue_Success(string cookieString)
         {
-            string cookieString = "cookie_token=cookie_value";
             var parser = new CookieParser(cookieString);
             string actual = parser.GetString();
             Assert.Equal(cookieString, actual);
         }
 
-        [Fact]
-        public void CookieParser_GetString_TwoTokens()
+        [Theory]
+        [InlineData("cookie_name", "cookie_value", "cookie_name=cookie_value")]
+        [InlineData("cookie_name", "cookie_value", "cookie_name=cookie_value;")]
+        public void CookieParserGet_SetCookieHeaderValue_Success(string name, string value, string cookieString)
         {
-            string cookieString = "cookie_token1=cookie_value1;cookie_token2=cookie_value2";
-            var parser = new CookieParser(cookieString);
-            string actual = parser.GetString();
-            Assert.Equal(cookieString, actual);
-        }
-
-        [Fact]
-        public void CookieParser_GetString_WithTrailingSemicolon()
-        {
-            string cookieString = "cookie_token=cookie_value;";
-            var parser = new CookieParser(cookieString);
-            string actual = parser.GetString();
-            Assert.Equal(cookieString, actual);
-        }
-
-        [Fact]
-        public void CookieParser_GetString_TwoTokens_WithTrailingSemicolon()
-        {
-            string cookieString = "cookie_token1=cookie_value1;cookie_token2=cookie_value2;";
-            var parser = new CookieParser(cookieString);
-            string actual = parser.GetString();
-            Assert.Equal(cookieString, actual);
-        }
-
-        [Fact]
-        public void CookieParser_Get()
-        {
-            string name = "cookie_token";
-            string value = "cookie_value";
-            string cookieString = $"{name}={value}";
             var parser = new CookieParser(cookieString);
             Cookie cookie= parser.Get();
-            Assert.NotNull(cookie);
-            Assert.Equal(name, cookie.Name);
-            Assert.Equal(value, cookie.Value);
-        }
-
-        [Fact]
-        public void CookieParser_Get_WithTrailingSemicolon()
-        {
-            string name = "cookie_token";
-            string value = "cookie_value";
-            string cookieString = $"{name}={value};"; // There's a semicolon at the end of the string
-            var parser = new CookieParser(cookieString);
-            Cookie cookie = parser.Get();
             Assert.NotNull(cookie);
             Assert.Equal(name, cookie.Name);
             Assert.Equal(value, cookie.Value);

--- a/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
@@ -41,5 +41,74 @@ namespace NetPrimitivesUnitTests
             Assert.Equal(1, cookies.Count);
             Assert.False(cookies[CookieName].DomainImplicit);
         }
+
+        [Fact]
+        public void CookieParser_GetString()
+        {
+            string cookieString = "cookie_token=cookie_value";
+            var parser = new CookieParser(cookieString);
+
+            string actual = parser.GetString();
+            Assert.Equal(cookieString, actual);
+        }
+
+        [Fact]
+        public void CookieParser_GetString_TwoTokens()
+        {
+            string cookieString = "cookie_token1=cookie_value1;cookie_token2=cookie_value2";
+            var parser = new CookieParser(cookieString);
+
+            string actual = parser.GetString();
+            Assert.Equal(cookieString, actual);
+        }
+
+        [Fact]
+        public void CookieParser_GetString_WithTrailingSemicolon()
+        {
+            string cookieString = "cookie_token=cookie_value";
+            string cookieStringWithSemicolon = $"{cookieString};";
+            var parser = new CookieParser(cookieStringWithSemicolon);
+
+            string actual = parser.GetString();
+            Assert.Equal(cookieStringWithSemicolon, actual);
+        }
+
+        [Fact]
+        public void CookieParser_GetString_TwoTokens_WithTrailingSemicolon()
+        {
+            string cookieString = "cookie_token1=cookie_value1;cookie_token2=cookie_value2;";
+            var parser = new CookieParser(cookieString);
+
+            string actual = parser.GetString();
+            Assert.Equal(cookieString, actual);
+        }
+
+        [Fact]
+        public void CookieParser_Get()
+        {
+            string name = "cookie_token";
+            string value = "cookie_value";
+            string cookieString = $"{name}={value}";
+            var parser = new CookieParser(cookieString);
+            Cookie cookie= parser.Get();
+
+            Assert.NotNull(cookie);
+            Assert.Equal(name, cookie.Name);
+            Assert.Equal(value, cookie.Value);
+        }
+
+        [Fact]
+        public void CookieParser_Get_WithTrailingSemicolon()
+        {
+            string name = "cookie_token";
+            string value = "cookie_value";
+            string cookieString = $"{name}={value};"; // There's a semicolon at the end of the string
+            var parser = new CookieParser(cookieString);
+            Cookie cookie = parser.Get();
+
+            Assert.NotNull(cookie);
+            Assert.Equal(name, cookie.Name);
+            Assert.Equal(value, cookie.Value);
+        }
     }
 }

--- a/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
@@ -47,7 +47,6 @@ namespace NetPrimitivesUnitTests
         {
             string cookieString = "cookie_token=cookie_value";
             var parser = new CookieParser(cookieString);
-
             string actual = parser.GetString();
             Assert.Equal(cookieString, actual);
         }
@@ -57,7 +56,6 @@ namespace NetPrimitivesUnitTests
         {
             string cookieString = "cookie_token1=cookie_value1;cookie_token2=cookie_value2";
             var parser = new CookieParser(cookieString);
-
             string actual = parser.GetString();
             Assert.Equal(cookieString, actual);
         }
@@ -65,12 +63,10 @@ namespace NetPrimitivesUnitTests
         [Fact]
         public void CookieParser_GetString_WithTrailingSemicolon()
         {
-            string cookieString = "cookie_token=cookie_value";
-            string cookieStringWithSemicolon = $"{cookieString};";
-            var parser = new CookieParser(cookieStringWithSemicolon);
-
+            string cookieString = "cookie_token=cookie_value;";
+            var parser = new CookieParser(cookieString);
             string actual = parser.GetString();
-            Assert.Equal(cookieStringWithSemicolon, actual);
+            Assert.Equal(cookieString, actual);
         }
 
         [Fact]
@@ -78,7 +74,6 @@ namespace NetPrimitivesUnitTests
         {
             string cookieString = "cookie_token1=cookie_value1;cookie_token2=cookie_value2;";
             var parser = new CookieParser(cookieString);
-
             string actual = parser.GetString();
             Assert.Equal(cookieString, actual);
         }
@@ -91,7 +86,6 @@ namespace NetPrimitivesUnitTests
             string cookieString = $"{name}={value}";
             var parser = new CookieParser(cookieString);
             Cookie cookie= parser.Get();
-
             Assert.NotNull(cookie);
             Assert.Equal(name, cookie.Name);
             Assert.Equal(value, cookie.Value);
@@ -105,7 +99,6 @@ namespace NetPrimitivesUnitTests
             string cookieString = $"{name}={value};"; // There's a semicolon at the end of the string
             var parser = new CookieParser(cookieString);
             Cookie cookie = parser.Get();
-
             Assert.NotNull(cookie);
             Assert.Equal(name, cookie.Name);
             Assert.Equal(value, cookie.Value);

--- a/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
@@ -43,10 +43,10 @@ namespace NetPrimitivesUnitTests
         }
 
         [Theory]
-        [InlineData("cookie_token=cookie_value")]
-        [InlineData("cookie_token=cookie_value;")]
-        [InlineData("cookie_token1=cookie_value1;cookie_token2=cookie_value2")]
-        [InlineData("cookie_token1=cookie_value1;cookie_token2=cookie_value2;")]
+        [InlineData("cookie_name=cookie_value")]
+        [InlineData("cookie_name=cookie_value;")]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2")]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2;")]
         public void CookieParserGetString_SetCookieHeaderValue_Success(string cookieString)
         {
             var parser = new CookieParser(cookieString);
@@ -55,15 +55,58 @@ namespace NetPrimitivesUnitTests
         }
 
         [Theory]
-        [InlineData("cookie_name", "cookie_value", "cookie_name=cookie_value")]
-        [InlineData("cookie_name", "cookie_value", "cookie_name=cookie_value;")]
-        public void CookieParserGet_SetCookieHeaderValue_Success(string name, string value, string cookieString)
+        [InlineData("cookie_name=cookie_value", new[] { "cookie_name", "cookie_value" })]
+        [InlineData("cookie_name=cookie_value;", new[] { "cookie_name", "cookie_value" })]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2", new[] { "cookie_name1", "cookie_value1", "cookie_name2", "cookie_value2" })]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2;", new[] { "cookie_name1", "cookie_value1", "cookie_name2", "cookie_value2" })]
+        public void CookieParserGetServer_SetCookieHeaderValue_Success(string cookieString, string[] expectedStrings)
         {
+            int index = 0;
+            int cookieCount = 0;
             var parser = new CookieParser(cookieString);
-            Cookie cookie= parser.Get();
-            Assert.NotNull(cookie);
-            Assert.Equal(name, cookie.Name);
-            Assert.Equal(value, cookie.Value);
+            while (true)
+            {
+                Cookie cookie = parser.GetServer();
+                if (cookie == null)
+                {
+                    break;
+                }
+
+                cookieCount++;
+                Assert.Equal(expectedStrings[index++], cookie.Name);
+                Assert.Equal(expectedStrings[index++], cookie.Value);
+            }
+
+            int expectedCookieCount = expectedStrings.Length >> 1;
+            Assert.Equal(expectedCookieCount, cookieCount);
+        }
+
+        [ActiveIssue(22925)]
+        [Theory]
+        [InlineData("cookie_name=cookie_value", new[] { "cookie_name", "cookie_value" })]
+        [InlineData("cookie_name=cookie_value;", new[] { "cookie_name", "cookie_value" })]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2", new[] { "cookie_name1", "cookie_value1", "cookie_name2", "cookie_value2" })]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2;", new[] { "cookie_name1", "cookie_value1", "cookie_name2", "cookie_value2" })]
+        public void CookieParserGet_SetCookieHeaderValue_Success(string cookieString, string[] expectedStrings)
+        {
+            int index = 0;
+            int cookieCount = 0;
+            var parser = new CookieParser(cookieString);
+            while (true)
+            {
+                Cookie cookie = parser.Get();
+                if (cookie == null)
+                {
+                    break;
+                }
+
+                cookieCount++;
+                Assert.Equal(expectedStrings[index++], cookie.Name);
+                Assert.Equal(expectedStrings[index++], cookie.Value);
+            }
+
+            int expectedCookieCount = expectedStrings.Length >> 1;
+            Assert.Equal(expectedCookieCount, cookieCount);
         }
     }
 }


### PR DESCRIPTION
The issue was that if a cookie string has trailing semicolon, `System.Net.CookieParser.GetString()` returns empty string. The issue was found on UAP/UAPAOT runs as `System.Net.CookieParser.GetString()` was used on those platforms.

We would also need to port the fix to UWP6.0 branch.

Fix #22877