### PR TITLE
Fixing abort race condition in ClientWebSocket for UWP.

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -131,7 +131,7 @@ namespace System.Net.WebSockets
                 X509Certificate2 dotNetClientCert = CertificateHelper.GetEligibleClientCertificate(options.ClientCertificates);
                 if (dotNetClientCert != null)
                 {
-                    RTCertificate winRtClientCert = await CertificateHelper.ConvertDotNetClientCertToWinRtClientCertAsync(dotNetClientCert);
+                    RTCertificate winRtClientCert = await CertificateHelper.ConvertDotNetClientCertToWinRtClientCertAsync(dotNetClientCert).ConfigureAwait(false);
                     if (winRtClientCert == null)
                     {
                         throw new PlatformNotSupportedException(string.Format(
@@ -159,7 +159,7 @@ namespace System.Net.WebSockets
                 _closeWebSocketReceiveResultTcs = new TaskCompletionSource<WebSocketReceiveResult>();
                 _messageWebSocket.MessageReceived += OnMessageReceived;
                 _messageWebSocket.Closed += OnCloseReceived;
-                await _messageWebSocket.ConnectAsync(uri).AsTask(cancellationToken);
+                await _messageWebSocket.ConnectAsync(uri).AsTask(cancellationToken).ConfigureAwait(false);
                 _subProtocol = _messageWebSocket.Information.Protocol;
                 _messageWriter = new DataWriter(_messageWebSocket.OutputStream);
             }
@@ -265,7 +265,7 @@ namespace System.Net.WebSockets
                     _messageWebSocket.Close((ushort) closeStatus, statusDescription ?? String.Empty);
                 }
 
-                var result = await _closeWebSocketReceiveResultTcs.Task;
+                var result = await _closeWebSocketReceiveResultTcs.Task.ConfigureAwait(false);
                 _closeStatus = result.CloseStatus;
                 _closeStatusDescription = result.CloseStatusDescription;
                 InterlockedCheckAndUpdateCloseState(WebSocketState.CloseReceived, s_validCloseStates);
@@ -313,7 +313,6 @@ namespace System.Net.WebSockets
         }
 
         private static readonly WebSocketState[] s_validReceiveStates = { WebSocketState.Open, WebSocketState.CloseSent };
-        private static readonly WebSocketState[] s_validAfterReceiveStates = { WebSocketState.Open, WebSocketState.CloseSent, WebSocketState.CloseReceived, WebSocketState.Closed };
         public override async Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer,
             CancellationToken cancellationToken)
         {
@@ -326,7 +325,8 @@ namespace System.Net.WebSockets
 
                 Task<WebSocketReceiveResult> completedTask = await Task.WhenAny(
                     _webSocketReceiveResultTcs.Task,
-                    _closeWebSocketReceiveResultTcs.Task);
+                    _closeWebSocketReceiveResultTcs.Task).ConfigureAwait(false);
+
                 WebSocketReceiveResult result = await completedTask;
 
                 if (result.MessageType == WebSocketMessageType.Close)
@@ -340,7 +340,6 @@ namespace System.Net.WebSockets
                     _webSocketReceiveResultTcs = new TaskCompletionSource<WebSocketReceiveResult>();
                 }
 
-                InterlockedCheckValidStates(s_validAfterReceiveStates);
                 return result;
             }
         }
@@ -446,7 +445,7 @@ namespace System.Net.WebSockets
                     _messageWebSocket.Control.MessageType = messageType == WebSocketMessageType.Binary
                         ? SocketMessageType.Binary
                         : SocketMessageType.Utf8;
-                    await _messageWriter.StoreAsync().AsTask(cancellationToken);
+                    await _messageWriter.StoreAsync().AsTask(cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception)


### PR DESCRIPTION
I was able to force a repro by queuing a ReadAsync task while, on another thread, scheduling two SendAsync operations that would Abort the WebSocket.
Exceptions are now handled through `AbortInternal` instead of checking the state of the socket after the ReadAsync operation.

I've also added `ConfigureAwait` statements to `await`s.

Fixes #22746
