### PR TITLE
Fix ManagedHandler environment proxy setting handling

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -23,7 +23,7 @@ namespace System.Net.Http
             Debug.Assert(innerHandler != null);
 
             _innerHandler = innerHandler;
-            _proxy = settings._useProxy ? settings._proxy : new PassthroughWebProxy(s_proxyFromEnvironment.Value);
+            _proxy = (settings._useProxy && settings._proxy != null) ? settings._proxy : new PassthroughWebProxy(s_proxyFromEnvironment.Value);
             _defaultCredentials = settings._defaultProxyCredentials;
             _connectionPools = new HttpConnectionPools(settings._maxConnectionsPerServer);
         }

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -65,16 +65,15 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    // TODO #21452: Tests started hanging with updated connection pooling.  Needs to be investigated.
-    //public sealed class ManagedHandler_HttpClientHandler_DefaultProxyCredentials_Test : HttpClientHandler_DefaultProxyCredentials_Test, IDisposable
-    //{
-    //    public ManagedHandler_HttpClientHandler_DefaultProxyCredentials_Test() => ManagedHandlerTestHelpers.SetEnvVar();
-    //    public new void Dispose()
-    //    {
-    //        ManagedHandlerTestHelpers.RemoveEnvVar();
-    //        base.Dispose();
-    //    }
-    //}
+    public sealed class ManagedHandler_HttpClientHandler_DefaultProxyCredentials_Test : HttpClientHandler_DefaultProxyCredentials_Test, IDisposable
+    {
+        public ManagedHandler_HttpClientHandler_DefaultProxyCredentials_Test() => ManagedHandlerTestHelpers.SetEnvVar();
+        public new void Dispose()
+        {
+            ManagedHandlerTestHelpers.RemoveEnvVar();
+            base.Dispose();
+        }
+    }
 
     public sealed class ManagedHandler_HttpClientHandler_MaxConnectionsPerServer_Test : HttpClientHandler_MaxConnectionsPerServer_Test, IDisposable
     {


### PR DESCRIPTION
Missing a clause resulting in test failures.
cc: @geoffkizer 