### PR TITLE
Remove finalizer race in four test cases.

### DIFF
--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.genmethod.regclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.genmethod.regclass.cs
@@ -921,10 +921,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
             }
         }
 
-        public void Foo()
-        {
-        }
-
         private static int Verify()
         {
             lock (Test.locker)
@@ -943,7 +939,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
         {
             Test t = new Test();
             Test.s_field = "Field";
-            t.Foo();
+            GC.KeepAlive(t);
         }
 
         [Fact]

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.regclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.regclass.cs
@@ -1755,10 +1755,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclas
             }
         }
 
-        public void Foo()
-        {
-        }
-
         private static int Verify()
         {
             lock (Test.locker)
@@ -1783,7 +1779,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclas
         {
             Test t = new Test();
             Test.s_field = null;
-            t.Foo();
+            GC.KeepAlive(t);
         }
 
         [Fact]
@@ -3437,10 +3433,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclas
             }
         }
 
-        public void Foo()
-        {
-        }
-
         private static int Verify()
         {
             lock (Test.locker)
@@ -3465,7 +3457,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclas
         {
             Test t = new Test();
             Test.s_field = null;
-            t.Foo();
+            GC.KeepAlive(t);
         }
 
         [Fact]

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.property.autoproperty.regclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.property.autoproperty.regclass.cs
@@ -498,10 +498,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.property.autopr
             }
         }
 
-        public void Foo()
-        {
-        }
-
         private static int Verify()
         {
             lock (Test.locker)
@@ -520,7 +516,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.property.autopr
         {
             Test t = new Test();
             Test.s_field = "Field";
-            t.Foo();
+            GC.KeepAlive(t);
         }
 
         [Fact]


### PR DESCRIPTION
Don't assume calling an instance no-op will prevent collection, use `GC.KeepAlive()` instead.

Fixes #7543