### PR TITLE
Make ManagedTests.DynamicCSharp…regclass029 test assert finalization

### DIFF
--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.indexer.regclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.indexer.regclass.cs
@@ -2238,8 +2238,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.indexer.regclas
 
                 memberClassStatus = MemberClass.t_status;
             }
-
-            Assert.Equal(0, Verify());
         }
 
         private static int Verify()
@@ -2276,8 +2274,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.indexer.regclas
             RequireLifetimesEnded();
             GC.Collect();
             GC.WaitForPendingFinalizers();
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
+            Assert.Equal(0, Verify());
         }
     }
     //</Code>


### PR DESCRIPTION
#5677 fixed a race in this test that was causing it to sometimes fail by finalizing too soon, but also moved the assertion of finalization into the finalizer, so it would only assert that the finalizer had run if the finalizer had run.

Move the assertion back to the point where the finalizer **should** be know to have run, but not in the finalizer itself. (That PR still fixed the actual race that stopped success being detected).