### PR TITLE
Fix SqlClient UapAot test failures caused by blocked reflection of internal types (#22618)

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -27,6 +27,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteScalarTest()
         {
             RemoteInvoke(() =>
@@ -49,6 +50,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteScalarErrorTest()
         {
             RemoteInvoke(() =>
@@ -73,6 +75,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteNonQueryTest()
         {
             RemoteInvoke(() =>
@@ -95,6 +98,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteNonQueryErrorTest()
         {
             RemoteInvoke(() =>
@@ -133,6 +137,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteReaderTest()
         {
             RemoteInvoke(() =>
@@ -156,6 +161,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteReaderErrorTest()
         {
             RemoteInvoke(() =>
@@ -182,6 +188,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteReaderWithCommandBehaviorTest()
         {
             RemoteInvoke(() =>
@@ -204,6 +211,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [ConditionalFact(nameof(IsConnectionStringConfigured))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteXmlReaderTest()
         {
             RemoteInvoke(cs =>
@@ -227,6 +235,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteXmlReaderErrorTest()
         {
             RemoteInvoke(() =>
@@ -253,6 +262,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteScalarAsyncTest()
         {
             RemoteInvoke(() =>
@@ -275,6 +285,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteScalarAsyncErrorTest()
         {
             RemoteInvoke(() =>
@@ -299,6 +310,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteNonQueryAsyncTest()
         {
             RemoteInvoke(() =>
@@ -321,6 +333,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteNonQueryAsyncErrorTest()
         {
             RemoteInvoke(() =>
@@ -344,6 +357,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteReaderAsyncTest()
         {
             RemoteInvoke(() =>
@@ -367,6 +381,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteReaderAsyncErrorTest()
         {
             RemoteInvoke(() =>
@@ -392,6 +407,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [ConditionalFact(nameof(IsConnectionStringConfigured))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteXmlReaderAsyncTest()
         {
             RemoteInvoke(cs =>
@@ -414,6 +430,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [ConditionalFact(nameof(IsConnectionStringConfigured))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteXmlReaderAsyncErrorTest()
         {
             RemoteInvoke(cs =>
@@ -440,6 +457,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ConnectionOpenTest()
         {
             RemoteInvoke(() =>
@@ -461,6 +479,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ConnectionOpenErrorTest()
         {
             RemoteInvoke(() =>
@@ -478,6 +497,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ConnectionOpenAsyncTest()
         {
             RemoteInvoke(() =>
@@ -495,6 +515,7 @@ namespace System.Data.SqlClient.Tests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ConnectionOpenAsyncErrorTest()
         {
             RemoteInvoke(() =>

--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/AssemblyResourceManager.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/AssemblyResourceManager.cs
@@ -55,19 +55,27 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 
         private bool TryGetResourceValue(string resourceName, object[] args, out object result)
         {
-            var type = _resourceAssembly.GetType("System.SR");
-            var info = type.GetProperty(resourceName, BindingFlags.NonPublic | BindingFlags.Static);
-
-            result = null;
-            if (info != null)
+            if (PlatformDetection.IsNetNative)
             {
-                result = info.GetValue(null);
-                if (args != null)
-                {
-                    result = string.Format((string)result, args);
-                }
+                result = string.Empty;
+                return true;
             }
-            return result != null;
+            else
+            {
+                var type = _resourceAssembly.GetType("System.SR");
+                var info = type.GetProperty(resourceName, BindingFlags.NonPublic | BindingFlags.Static);
+
+                result = null;
+                if (info != null)
+                {
+                    result = info.GetValue(null);
+                    if (args != null)
+                    {
+                        result = string.Format((string)result, args);
+                    }
+                }
+                return result != null;
+            }
         }
     }
 }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionTest.cs
@@ -232,14 +232,13 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     string executeCommandWithoutTransactionMessage = SystemDataResourceManager.Instance.ADP_TransactionRequired("ExecuteNonQuery");
                     string transactionConflictErrorMessage = SystemDataResourceManager.Instance.ADP_TransactionConnectionMismatch;
                     string parallelTransactionErrorMessage = SystemDataResourceManager.Instance.ADP_ParallelTransactionsNotSupported("SqlConnection");
-
-                    AssertException<InvalidOperationException>(() =>
+                    DataTestUtility.AssertThrowsWrapper<InvalidOperationException>(() =>
                     {
                         SqlCommand command = new SqlCommand("sql", connection);
                         command.ExecuteNonQuery();
                     }, executeCommandWithoutTransactionMessage);
 
-                    AssertException<InvalidOperationException>(() =>
+                    DataTestUtility.AssertThrowsWrapper<InvalidOperationException>(() =>
                     {
                         SqlConnection con1 = new SqlConnection(_connectionString);
                         con1.Open();
@@ -249,42 +248,36 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                         command.ExecuteNonQuery();
                     }, transactionConflictErrorMessage);
 
-                    AssertException<InvalidOperationException>(() =>
+                    DataTestUtility.AssertThrowsWrapper<InvalidOperationException>(() =>
                     {
                         connection.BeginTransaction(null);
                     }, parallelTransactionErrorMessage);
 
-                    AssertException<InvalidOperationException>(() =>
+                    DataTestUtility.AssertThrowsWrapper<InvalidOperationException>(() =>
                     {
                         connection.BeginTransaction("");
                     }, parallelTransactionErrorMessage);
 
-                    AssertException<ArgumentException>(() =>
+                    DataTestUtility.AssertThrowsWrapper<ArgumentException>(() =>
                     {
                         tx.Rollback(null);
                     }, invalidSaveStateMessage);
 
-                    AssertException<ArgumentException>(() =>
+                    DataTestUtility.AssertThrowsWrapper<ArgumentException>(() =>
                     {
                         tx.Rollback("");
                     }, invalidSaveStateMessage);
 
-                    AssertException<ArgumentException>(() =>
+                    DataTestUtility.AssertThrowsWrapper<ArgumentException>(() =>
                     {
                         tx.Save(null);
                     }, invalidSaveStateMessage);
 
-                    AssertException<ArgumentException>(() =>
+                    DataTestUtility.AssertThrowsWrapper<ArgumentException>(() =>
                     {
                         tx.Save("");
                     }, invalidSaveStateMessage);
                 }
-            }
-
-            public static void AssertException<T>(Action action, string expectedErrorMessage) where T : Exception
-            {
-                var exception = Assert.Throws<T>(action);
-                Assert.Equal(exception.Message, expectedErrorMessage);
             }
 
             private void ReadUncommitedIsolationLevel_ShouldReturnUncommitedData()
@@ -350,7 +343,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                         SqlTransaction tx2 = connection2.BeginTransaction(IsolationLevel.ReadCommitted);
                         command2.Transaction = tx2;
 
-                        AssertException<SqlException>(() => command2.ExecuteReader(), SystemDataResourceManager.Instance.SQL_Timeout as string);
+                        DataTestUtility.AssertThrowsWrapper<SqlException>(() => command2.ExecuteReader(), SystemDataResourceManager.Instance.SQL_Timeout as string);
 
                         tx2.Rollback();
                         connection2.Close();

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -112,6 +112,9 @@
     <Compile Include="SQL\WeakRefTest\WeakRefTest.cs" />
     <Compile Include="SQL\WeakRefTestYukonSpecific\WeakRefTestYukonSpecific.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Content Include="DDBasics\DDDataTypesTest\data.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>data.xml</Link>


### PR DESCRIPTION
Porting test fix to release/uwp6.0