### PR TITLE
[release/uwp6.0] System.Net.CookieParser to Support Cookie String with Trailing Semicolon

### DIFF
--- a/src/Common/src/System/Net/CookieParser.cs
+++ b/src/Common/src/System/Net/CookieParser.cs
@@ -282,7 +282,8 @@ namespace System.Net
                     }
                     ++_index;
                 }
-                else
+                
+                if (Eof)
                 {
                     _cookieLength = _index - _cookieStartIndex;
                 }

--- a/src/System.Net.Http/src/uap/System/Net/cookie.cs
+++ b/src/System.Net.Http/src/uap/System/Net/cookie.cs
@@ -1280,7 +1280,8 @@ namespace System.Net
                     }
                     ++m_index;
                 }
-                else
+                
+                if (Eof)
                 {
                     m_cookieLength = m_index - m_cookieStartIndex;
                 }

--- a/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
@@ -41,5 +41,72 @@ namespace NetPrimitivesUnitTests
             Assert.Equal(1, cookies.Count);
             Assert.False(cookies[CookieName].DomainImplicit);
         }
+
+        [Theory]
+        [InlineData("cookie_name=cookie_value")]
+        [InlineData("cookie_name=cookie_value;")]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2")]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2;")]
+        public void CookieParserGetString_SetCookieHeaderValue_Success(string cookieString)
+        {
+            var parser = new CookieParser(cookieString);
+            string actual = parser.GetString();
+            Assert.Equal(cookieString, actual);
+        }
+
+        [Theory]
+        [InlineData("cookie_name=cookie_value", new[] { "cookie_name", "cookie_value" })]
+        [InlineData("cookie_name=cookie_value;", new[] { "cookie_name", "cookie_value" })]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2", new[] { "cookie_name1", "cookie_value1", "cookie_name2", "cookie_value2" })]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2;", new[] { "cookie_name1", "cookie_value1", "cookie_name2", "cookie_value2" })]
+        public void CookieParserGetServer_SetCookieHeaderValue_Success(string cookieString, string[] expectedStrings)
+        {
+            int index = 0;
+            int cookieCount = 0;
+            var parser = new CookieParser(cookieString);
+            while (true)
+            {
+                Cookie cookie = parser.GetServer();
+                if (cookie == null)
+                {
+                    break;
+                }
+
+                cookieCount++;
+                Assert.Equal(expectedStrings[index++], cookie.Name);
+                Assert.Equal(expectedStrings[index++], cookie.Value);
+            }
+
+            int expectedCookieCount = expectedStrings.Length >> 1;
+            Assert.Equal(expectedCookieCount, cookieCount);
+        }
+
+        [ActiveIssue(22925)]
+        [Theory]
+        [InlineData("cookie_name=cookie_value", new[] { "cookie_name", "cookie_value" })]
+        [InlineData("cookie_name=cookie_value;", new[] { "cookie_name", "cookie_value" })]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2", new[] { "cookie_name1", "cookie_value1", "cookie_name2", "cookie_value2" })]
+        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2;", new[] { "cookie_name1", "cookie_value1", "cookie_name2", "cookie_value2" })]
+        public void CookieParserGet_SetCookieHeaderValue_Success(string cookieString, string[] expectedStrings)
+        {
+            int index = 0;
+            int cookieCount = 0;
+            var parser = new CookieParser(cookieString);
+            while (true)
+            {
+                Cookie cookie = parser.Get();
+                if (cookie == null)
+                {
+                    break;
+                }
+
+                cookieCount++;
+                Assert.Equal(expectedStrings[index++], cookie.Name);
+                Assert.Equal(expectedStrings[index++], cookie.Value);
+            }
+
+            int expectedCookieCount = expectedStrings.Length >> 1;
+            Assert.Equal(expectedCookieCount, cookieCount);
+        }
     }
 }


### PR DESCRIPTION
The issue was that if a cookie string has trailing semicolon, System.Net.CookieParser.GetString() returns empty string. The issue was found on UAP/UAPAOT runs as System.Net.CookieParser.GetString() was used on those platforms.

Fix #22877