### PR TITLE
Clean up path validation related issues in System.Drawing.Common

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageAttributes.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageAttributes.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Diagnostics;
 using System.Drawing.Drawing2D;
 using System.Globalization;
+using System.IO;
 
 namespace System.Drawing.Imaging
 {
@@ -405,6 +406,9 @@ namespace System.Drawing.Imaging
         public void SetOutputChannelColorProfile(String colorProfileFilename,
                                                  ColorAdjustType type)
         {
+            // Called in order to emulate exception behavior from netfx related to invalid file paths.
+            Path.GetFullPath(colorProfileFilename);
+
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesOutputChannelColorProfile(
                                         new HandleRef(this, nativeImageAttributes),
                                         type,

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
@@ -243,6 +243,9 @@ namespace System.Drawing.Imaging
         /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, EmfType type, String description)
         {
+            // Called in order to emulate exception behavior from netfx related to invalid file paths.
+            Path.GetFullPath(fileName);
+
             IntPtr metafile = IntPtr.Zero;
 
             int status = SafeNativeMethods.Gdip.GdipRecordMetafileFileName(fileName, new HandleRef(null, referenceHdc),
@@ -558,6 +561,9 @@ namespace System.Drawing.Imaging
         /// </summary>
         public static MetafileHeader GetMetafileHeader(string fileName)
         {
+            // Called in order to emulate exception behavior from netfx related to invalid file paths.
+            Path.GetFullPath(fileName);
+
             MetafileHeader header = new MetafileHeader();
 
             IntPtr memory = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(MetafileHeaderEmf)));

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
@@ -59,6 +59,9 @@ namespace System.Drawing.Imaging
         /// </summary>
         public Metafile(string filename)
         {
+            // Called in order to emulate exception behavior from netfx related to invalid file paths.
+            Path.GetFullPath(filename);
+
             IntPtr metafile = IntPtr.Zero;
 
             int status = SafeNativeMethods.Gdip.GdipCreateMetafileFromFile(filename, out metafile);

--- a/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
@@ -1191,7 +1191,6 @@ namespace System.Drawing.Imaging.Tests
                 imageAttr.SetOutputChannelColorProfile(Helpers.GetTestColorProfilePath("RSWOP.icm"), ColorAdjustType.Default));
         }
 
-        [ActiveIssue(22367)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetOutputChannelColorProfile_Null_ThrowsArgumentNullException()
         {
@@ -1220,18 +1219,6 @@ namespace System.Drawing.Imaging.Tests
             {
                 Assert.Throws<OutOfMemoryException>(() => imageAttr.SetOutputChannelColorProfile("invalidPath"));
                 Assert.Throws<OutOfMemoryException>(() => imageAttr.SetOutputChannelColorProfile("invalidPath", ColorAdjustType.Default));
-            }
-        }
-
-        [ActiveIssue(22309)]
-        [ConditionalFact(Helpers.GdiplusIsAvailable)]
-        public void SetOutputChannelColorProfile_InvalidPath_ThrowsPathTooLongException()
-        {
-            string fileNameTooLong = new string('a', 261);
-            using (var imageAttr = new ImageAttributes())
-            {
-                Assert.Throws<PathTooLongException>(() => imageAttr.SetOutputChannelColorProfile(fileNameTooLong));
-                Assert.Throws<PathTooLongException>(() => imageAttr.SetOutputChannelColorProfile(fileNameTooLong, ColorAdjustType.Default));
             }
         }
 

--- a/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
@@ -1222,6 +1222,18 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetOutputChannelColorProfile_InvalidPath_ThrowsPathTooLongException()
+        {
+            string fileNameTooLong = new string('a', short.MaxValue);
+            using (var imageAttr = new ImageAttributes())
+            {
+                Assert.Throws<PathTooLongException>(() => imageAttr.SetOutputChannelColorProfile(fileNameTooLong));
+                Assert.Throws<PathTooLongException>(() => imageAttr.SetOutputChannelColorProfile(fileNameTooLong, ColorAdjustType.Default));
+            }
+        }
+
+
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void SetOutputChannelColorProfile_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)

--- a/src/System.Drawing.Common/tests/Imaging/MetafileTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/MetafileTests.cs
@@ -412,7 +412,7 @@ namespace System.Drawing.Imaging.Tests
 
             File.Delete(fileName);
         }
-        
+
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(Description_TestData))]
@@ -481,6 +481,21 @@ namespace System.Drawing.Imaging.Tests
                 AssertExtensions.Throws<ArgumentException>("path", null, () => new Metafile(fileName, referenceHdc));
                 AssertExtensions.Throws<ArgumentException>("path", null, () => new Metafile(fileName, referenceHdc, EmfType.EmfOnly));
                 AssertExtensions.Throws<ArgumentException>("path", null, () => new Metafile(fileName, referenceHdc, EmfType.EmfOnly, "description"));
+            }
+        }
+
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Ctor_PathTooLong_ThrowsPathTooLongException()
+        {
+            string fileName = GetPath(new string('a', short.MaxValue));
+            using (var bufferGraphics = Graphics.FromHwndInternal(IntPtr.Zero))
+            {
+                IntPtr referenceHdc = bufferGraphics.GetHdc();
+                Assert.Throws<PathTooLongException>(() => new Metafile(fileName, referenceHdc));
+                Assert.Throws<PathTooLongException>(() => new Metafile(fileName, referenceHdc, EmfType.EmfOnly));
+                Assert.Throws<PathTooLongException>(() => new Metafile(fileName, referenceHdc, EmfType.EmfOnly, "description"));
+                DeleteFile(fileName);
             }
         }
 
@@ -1061,7 +1076,7 @@ namespace System.Drawing.Imaging.Tests
             GraphicsUnit graphicsUnit = (GraphicsUnit)int.MaxValue;
 
             AssertMetafileHeaderIsBlank(metafile.GetMetafileHeader());
-            Assert.Equal(new Rectangle(0, 0, 1, 1), metafile.GetBounds(ref graphicsUnit));           
+            Assert.Equal(new Rectangle(0, 0, 1, 1), metafile.GetBounds(ref graphicsUnit));
             Assert.Equal(GraphicsUnit.Pixel, graphicsUnit);
         }
 

--- a/src/System.Drawing.Common/tests/Imaging/MetafileTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/MetafileTests.cs
@@ -93,13 +93,13 @@ namespace System.Drawing.Imaging.Tests
             yield return new object[] { string.Empty };
         }
 
-        [ActiveIssue(22640)]
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
-        [MemberData(nameof(InvalidPath_TestData))]
+        [InlineData(@"fileNo*-//\\#@(found")]
+        [InlineData("")]
         public void Ctor_InvalidPath_ThrowsArgumentException(string path)
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new Metafile(path));
+            AssertExtensions.Throws<ArgumentException>("path", null, () => new Metafile(path));
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]

--- a/src/System.Drawing.Common/tests/Imaging/MetafileTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/MetafileTests.cs
@@ -113,12 +113,11 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(22741)]
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Ctor_NullStream_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new Metafile((Stream)null));
+            AssertExtensions.Throws<ArgumentNullException, ArgumentException>("stream", null, () => new Metafile((Stream)null));
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]

--- a/src/System.Drawing.Common/tests/Imaging/MetafileTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/MetafileTests.cs
@@ -71,7 +71,6 @@ namespace System.Drawing.Imaging.Tests
             Assert.Throws<ExternalException>(() => new Metafile(GetPath(BmpFile)));
         }
 
-        [ActiveIssue(22598)]
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Ctor_NullString_ThrowsArgumentNullException()
@@ -457,7 +456,6 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(22723)]
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Ctor_NullPath_ThrowsArgumentNullException()
@@ -471,7 +469,6 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(22723)]
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(@"fileNo*-//\\#@(found")]
@@ -481,25 +478,9 @@ namespace System.Drawing.Imaging.Tests
             using (var bufferGraphics = Graphics.FromHwndInternal(IntPtr.Zero))
             {
                 IntPtr referenceHdc = bufferGraphics.GetHdc();
-                AssertExtensions.Throws<ArgumentException>(null, () => new Metafile(fileName, referenceHdc));
-                AssertExtensions.Throws<ArgumentException>(null, () => new Metafile(fileName, referenceHdc, EmfType.EmfOnly));
-                AssertExtensions.Throws<ArgumentException>(null, () => new Metafile(fileName, referenceHdc, EmfType.EmfOnly, "description"));
-            }
-        }
-
-        [ActiveIssue(22723)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
-        [ConditionalFact(Helpers.GdiplusIsAvailable)]
-        public void Ctor_PathTooLong_ThrowsPathTooLongException()
-        {
-            string fileName = GetPath(new string('a', 261));
-            using (var bufferGraphics = Graphics.FromHwndInternal(IntPtr.Zero))
-            {
-                IntPtr referenceHdc = bufferGraphics.GetHdc();
-                Assert.Throws<PathTooLongException>(() => new Metafile(fileName, referenceHdc));
-                Assert.Throws<PathTooLongException>(() => new Metafile(fileName, referenceHdc, EmfType.EmfOnly));
-                Assert.Throws<PathTooLongException>(() => new Metafile(fileName, referenceHdc, EmfType.EmfOnly, "description"));
-                DeleteFile(fileName);
+                AssertExtensions.Throws<ArgumentException>("path", null, () => new Metafile(fileName, referenceHdc));
+                AssertExtensions.Throws<ArgumentException>("path", null, () => new Metafile(fileName, referenceHdc, EmfType.EmfOnly));
+                AssertExtensions.Throws<ArgumentException>("path", null, () => new Metafile(fileName, referenceHdc, EmfType.EmfOnly, "description"));
             }
         }
 
@@ -954,18 +935,9 @@ namespace System.Drawing.Imaging.Tests
         [InlineData("")]
         public void Static_GetMetafileHeader_InvalidPath_ThrowsArgumentException(string fileName)
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => Metafile.GetMetafileHeader(fileName));
+            AssertExtensions.Throws<ArgumentException>("path", null, () => Metafile.GetMetafileHeader(fileName));
         }
 
-        [ActiveIssue(22747)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
-        [ConditionalFact(Helpers.GdiplusIsAvailable)]
-        public void Static_GetMetafileHeader_PathTooLong_ThrowsPathTooLongException()
-        {
-            Assert.Throws<PathTooLongException>(() => Metafile.GetMetafileHeader(GetPath(new string('a', 261))));
-        }
-
-        [ActiveIssue(22747)]
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Static_GetMetafileHeader_NullString_ThrowsArgumentNullException()


### PR DESCRIPTION
There were several places in the .NET Framework codebase for System.Drawing which called `IntSecurity.DemandReadFileIO(string);`. On first glance, this looks to be a CAS-related call, which isn't interesting in .NET Core. What isn't obvious is that this also ends up calling `Path.GetFullPath` on the string passed in, and that call may throw argument validation exceptions. If the path is `null`, for example, the security demand will result in an ArgumentNullException. These calls were omitted from the .NET Core version when I trimmed out all of the security demands.

I've added these back, and fixed up several test cases which validated the behavior, and were previously disabled. Path.GetFullPath in .NET Core now correctly sets the `ParamName` property on its ArgumentException, so the assertions have been augmented to expect that.

There were several tests which also expected some methods to result in a `PathTooLongException` being thrown from `Path.GetFullPath`. However, .NET Core no longer eagerly throws that exception from `Path.GetFullPath`. I have removed those test cases.

@hughbe @KostaVlev 