### PR TITLE
fix flaky socket test

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -351,7 +351,8 @@ namespace System.Net.Sockets.Tests
                     connectSaea.Completed += (s, e) => tcs.SetResult(e.SocketError);
                     connectSaea.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, ((IPEndPoint)listen.LocalEndPoint).Port);
 
-                    Assert.True(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, connectSaea), $"ConnectAsync completed synchronously with SocketError == {connectSaea.SocketError}");
+                    bool pending = Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, connectSaea);
+                    if (!pending) tcs.SetResult(connectSaea.SocketError);
                     if (tcs.Task.IsCompleted)
                     {
                         Assert.NotEqual(SocketError.Success, tcs.Task.Result);


### PR DESCRIPTION
The test is assuming ConnectAsync will never complete synchronously, but at least on Linux, it does sometimes.

Fix by handling the sync completion case properly.

@stephentoub @Priya91 @wfurt 

@dotnet-bot test Outerloop Linux x64 Debug Build
@dotnet-bot test Outerloop Windows x64 Debug Build
@dotnet-bot test Outerloop OSX x64 Debug Build