### PR TITLE
BufferBuilder: Avoid unnecessary char[] and byte[] allocations

### DIFF
--- a/src/System.Net.Mail/src/System/Net/BufferBuilder.cs
+++ b/src/System.Net.Mail/src/System/Net/BufferBuilder.cs
@@ -66,8 +66,10 @@ namespace System.Net.Mail
         {
             if (allowUnicode)
             {
-                byte[] bytes = Encoding.UTF8.GetBytes(value.ToCharArray(), offset, count);
-                Append(bytes);
+                int byteCount = Encoding.UTF8.GetByteCount(value, offset, count);
+                EnsureBuffer(byteCount);
+                Encoding.UTF8.GetBytes(value, offset, count, _buffer, _offset);
+                _offset += byteCount;
             }
             else
             {


### PR DESCRIPTION
Use `GetByteCount` and the overload of `GetBytes` that avoids the unnecessary `char[]` and `byte[]` allocations.