### PR TITLE
Add retry to PDB conversion official build step

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01902-02
+2.0.0-prerelease-01903-01


### PR DESCRIPTION
This brings in https://github.com/dotnet/buildtools/pull/1623, which adds a retry to the official build step that converts Portable PDBs to Windows PDBs. This will fix an occasional build error in the "Symbol Publish" leg: https://github.com/dotnet/core-eng/issues/1273.