### PR TITLE
[release/1.1] Add newer shim package reference for Algorithms tests

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/tests/project.json
+++ b/src/System.Security.Cryptography.Algorithms/tests/project.json
@@ -17,6 +17,7 @@
       "target": "project",
       "exclude": "compile"
     },
+    "runtime.native.System.Security.Cryptography.Apple": "4.3.1-servicing-25603-01",
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-01005-01",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-01005-01"
   },


### PR DESCRIPTION
The Helix tests aren't seeing fixes made for macOS 10.13 because they
are still using the 4.3.0 (RTM) native assets.

This indicates that the servicing build is required.