### PR TITLE
Update UAP test regarding 'TRACE' method

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -123,6 +123,9 @@
   <data name="net_http_httpmethod_format_error" xml:space="preserve">
     <value>The format of the HTTP method is invalid.</value>
   </data>
+  <data name="net_http_httpmethod_notsupported_error" xml:space="preserve">
+    <value>The HTTP method '{0}' is not supported on this platform.</value>
+  </data>
   <data name="net_http_reasonphrase_format_error" xml:space="preserve">
     <value>The reason phrase must not contain new-line characters.</value>
   </data>

--- a/src/System.Net.Http/src/uap/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/uap/System/Net/HttpClientHandler.cs
@@ -591,6 +591,13 @@ namespace System.Net.Http
             HttpResponseMessage response;
             try
             {
+                if (string.Equals(request.Method.Method, HttpMethod.Trace.Method, StringComparison.OrdinalIgnoreCase))
+                {
+                    // https://github.com/dotnet/corefx/issues/22161
+                    throw new PlatformNotSupportedException(string.Format(CultureInfo.InvariantCulture,
+                        SR.net_http_httpmethod_notsupported_error, request.Method.Method));
+                }
+
                 await ConfigureRequest(request).ConfigureAwait(false);
 
                 Task<HttpResponseMessage> responseTask = DiagnosticsHandler.IsEnabled() ? 

--- a/src/System.Net.Http/src/uap/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/uap/System/Net/HttpClientHandler.cs
@@ -244,7 +244,7 @@ namespace System.Net.Http
             {
                 if (value <= 0)
                 {
-                    throw new ArgumentOutOfRangeException("value");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
                 CheckDisposedOrStarted();
             }

--- a/src/System.Net.Http/src/uap/System/Net/HttpHandlerToFilter.cs
+++ b/src/System.Net.Http/src/uap/System/Net/HttpHandlerToFilter.cs
@@ -87,23 +87,15 @@ namespace System.Net.Http
                 RTHttpResponseMessage rtResponse;
                 try
                 {
-                    if (redirects > 0)
-                    {
-                        rtResponse = await FilterWithNoCredentials.SendRequestAsync(rtRequest).AsTask(cancel).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        rtResponse = await _filter.SendRequestAsync(rtRequest).AsTask(cancel).ConfigureAwait(false);
-                    }
+                    rtResponse = await (redirects > 0 ? FilterWithNoCredentials : _filter).SendRequestAsync(rtRequest).AsTask(cancel).ConfigureAwait(false);
                 }
                 catch (TaskCanceledException)
                 {
                     throw;
                 }
-                catch (Exception)
+                catch
                 {
-                    object info;
-                    if (rtRequest.Properties.TryGetValue(SavedExceptionDispatchInfoLookupKey, out info))
+                    if (rtRequest.Properties.TryGetValue(SavedExceptionDispatchInfoLookupKey, out object info))
                     {
                         ((ExceptionDispatchInfo)info).Throw();
                     }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1632,13 +1632,19 @@ namespace System.Net.Http.Functional.Tests
 
         #region Various HTTP Method Tests
 
-        [ActiveIssue(22161, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(HttpMethods))]
         public async Task SendAsync_SendRequestUsingMethodToEchoServerWithNoContent_MethodCorrectlySent(
             string method,
             bool secureServer)
         {
+            if (PlatformDetection.IsUap && method == "TRACE")
+            {
+                // 'TRACE' method is not supported on Uap.
+                // See: https://github.com/dotnet/corefx/issues/22161
+                return;
+            }
+
             using (var client = new HttpClient())
             {
                 var request = new HttpRequestMessage(


### PR DESCRIPTION
Uap platform doesn't support the 'TRACE' verb.  After discussion with Wininet team, the method is explicitly not allowed. So, removing the activeissue and just skipping that part of the test.
 
Also made some nit fixes as part of delayed feedback from other PRs.

Fixes #22161