### PR TITLE
Add HttpListenerWebSocketContext.WebSocket.Receive/Close throw ObjectDisposedException after disposal in managed implementation

### DIFF
--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -279,7 +279,8 @@ namespace System.Net.WebSockets
 
             try
             {
-               WebSocketValidate.ThrowIfInvalidState(_state, _disposed, s_validSendStates);
+                ThrowIfDisposed();
+                WebSocketValidate.ThrowIfInvalidState(_state, _disposed, s_validSendStates);
                 ThrowIfOperationInProgress(_lastSendAsync);
             }
             catch (Exception exc)
@@ -304,6 +305,7 @@ namespace System.Net.WebSockets
 
             try
             {
+                ThrowIfDisposed();
                 WebSocketValidate.ThrowIfInvalidState(_state, _disposed, s_validReceiveStates);
 
                 Debug.Assert(!Monitor.IsEntered(StateUpdateLock), $"{nameof(StateUpdateLock)} must never be held when acquiring {nameof(ReceiveAsyncLock)}");
@@ -327,6 +329,7 @@ namespace System.Net.WebSockets
 
             try
             {
+                ThrowIfDisposed();
                 WebSocketValidate.ThrowIfInvalidState(_state, _disposed, s_validCloseStates);
             }
             catch (Exception exc)
@@ -343,6 +346,7 @@ namespace System.Net.WebSockets
 
             try
             {
+                ThrowIfDisposed();
                 WebSocketValidate.ThrowIfInvalidState(_state, _disposed, s_validCloseOutputStates);
             }
             catch (Exception exc)
@@ -1277,6 +1281,14 @@ namespace System.Net.WebSockets
             {
                 Abort();
                 throw new InvalidOperationException(SR.Format(SR.net_Websockets_AlreadyOneOutstandingOperation, methodName));
+            }
+        }
+        
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(GetType().FullName);
             }
         }
 

--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1288,7 +1288,7 @@ namespace System.Net.WebSockets
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(GetType().FullName);
+                throw new ObjectDisposedException(GetType().ToString());
             }
         }
 

--- a/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
@@ -1210,7 +1210,7 @@ namespace System.Net.WebSockets
             if (State == WebSocketState.Closed || State == WebSocketState.Aborted)
             {
                 throw new WebSocketException(WebSocketError.InvalidState,
-                    SR.Format(SR.net_WebSockets_InvalidState_ClosedOrAborted, GetType().FullName, State));
+                    SR.Format(SR.net_WebSockets_InvalidState_ClosedOrAborted, GetType().ToString(), State));
             }
         }
 
@@ -1219,7 +1219,7 @@ namespace System.Net.WebSockets
             if (aborted)
             {
                 throw new WebSocketException(WebSocketError.InvalidState,
-                    SR.Format(SR.net_WebSockets_InvalidState_ClosedOrAborted, GetType().FullName, WebSocketState.Aborted),
+                    SR.Format(SR.net_WebSockets_InvalidState_ClosedOrAborted, GetType().ToString(), WebSocketState.Aborted),
                     innerException);
             }
         }
@@ -1409,7 +1409,7 @@ namespace System.Net.WebSockets
         {
             if (_isDisposed)
             {
-                throw new ObjectDisposedException(GetType().FullName);
+                throw new ObjectDisposedException(GetType().ToString());
             }
         }
 
@@ -2406,7 +2406,7 @@ namespace System.Net.WebSockets
             {
                 if (_isDisposed)
                 {
-                    throw new ObjectDisposedException(GetType().FullName);
+                    throw new ObjectDisposedException(GetType().ToString());
                 }
             }
         }

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
@@ -35,7 +35,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue(18784, TargetFrameworkMonikers.Netcoreapp)]
         public async Task AddHeader_LongName_ThrowsArgumentOutOfRangeException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -73,7 +73,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue(18784, TargetFrameworkMonikers.Netcoreapp)]
         public async Task AppendHeader_LongName_ThrowsArgumentOutOfRangeException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -833,7 +833,7 @@ namespace System.Net.Tests
 
         [Theory]
         [InlineData("Transfer-Encoding")]
-        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue(18784, TargetFrameworkMonikers.Netcoreapp)]
         public async Task Headers_SetRestricted_ThrowsArgumentException(string name)
         {
             HttpListenerResponse response = await GetResponse();
@@ -854,7 +854,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue(18784, TargetFrameworkMonikers.Netcoreapp)]
         public async Task Headers_SetLongName_ThrowsArgumentOutOfRangeException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -866,7 +866,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue(18784, TargetFrameworkMonikers.Netcoreapp)]
         public async Task Headers_SetRequestHeader_ThrowsInvalidOperationException()
         {
             HttpListenerResponse response = await GetResponse();

--- a/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
@@ -77,7 +77,7 @@ namespace System.Net.Tests
             await AssertExtensions.ThrowsAsync<ArgumentException>("messageType", () => context.WebSocket.SendAsync(new ArraySegment<byte>(), messageType, false, new CancellationToken()));
         }
 
-        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20395, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(IsNotWindows7))]
         public async Task SendAsync_Disposed_ThrowsObjectDisposedException()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
@@ -121,7 +121,7 @@ namespace System.Net.Tests
             await AssertExtensions.ThrowsAsync<ArgumentNullException>("buffer.Array", () => context.WebSocket.ReceiveAsync(new ArraySegment<byte>(), new CancellationToken()));
         }
 
-        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20395, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(IsNotWindows7))]
         public async Task ReceiveAsync_Disposed_ThrowsObjectDisposedException()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();

--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -17,19 +17,16 @@ namespace System.Net.Tests
     {
         private HttpListenerFactory _factory;
         private HttpListener _listener;
-        private GetContextHelper _helper;
 
         public HttpRequestStreamTests()
         {
             _factory = new HttpListenerFactory();
             _listener = _factory.GetListener();
-            _helper = new GetContextHelper(_listener, _factory.ListeningUrl);
         }
 
         public void Dispose()
         {
             _factory.Dispose();
-            _helper.Dispose();
         }
 
         [Theory]

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <Compile Include="GetContextHelper.cs" />
     <Compile Include="HttpListenerFactory.cs" />
-    <!-- <Compile Include="HttpListenerAuthenticationTests.cs" />
+    <Compile Include="HttpListenerAuthenticationTests.cs" />
     <Compile Include="HttpListenerContextTests.cs" />
     <Compile Include="HttpListenerPrefixCollectionTests.cs" />
     <Compile Include="HttpListenerResponseTests.cs" />
@@ -23,13 +23,13 @@
     <Compile Include="HttpListenerResponseTests.Headers.cs" />
     <Compile Include="HttpListenerRequestTests.cs" />
     <Compile Include="HttpListenerTests.cs" />
-    <Compile Include="HttpListenerTimeoutManagerTests.cs" /> -->
+    <Compile Include="HttpListenerTimeoutManagerTests.cs" />
     <Compile Include="HttpListenerWebSocketTests.cs" />
-    <!-- <Compile Include="HttpRequestStreamTests.cs" />
+    <Compile Include="HttpRequestStreamTests.cs" />
     <Compile Include="HttpResponseStreamTests.cs" />
     <Compile Include="InvalidClientRequestTests.cs" />
     <Compile Include="SimpleHttpTests.cs" />
-    <Compile Include="WebSocketTests.cs" /> -->
+    <Compile Include="WebSocketTests.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\tests\System\PlatformDetection.cs</Link>

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <Compile Include="GetContextHelper.cs" />
     <Compile Include="HttpListenerFactory.cs" />
-    <Compile Include="HttpListenerAuthenticationTests.cs" />
+    <!-- <Compile Include="HttpListenerAuthenticationTests.cs" />
     <Compile Include="HttpListenerContextTests.cs" />
     <Compile Include="HttpListenerPrefixCollectionTests.cs" />
     <Compile Include="HttpListenerResponseTests.cs" />
@@ -23,13 +23,13 @@
     <Compile Include="HttpListenerResponseTests.Headers.cs" />
     <Compile Include="HttpListenerRequestTests.cs" />
     <Compile Include="HttpListenerTests.cs" />
-    <Compile Include="HttpListenerTimeoutManagerTests.cs" />
+    <Compile Include="HttpListenerTimeoutManagerTests.cs" /> -->
     <Compile Include="HttpListenerWebSocketTests.cs" />
-    <Compile Include="HttpRequestStreamTests.cs" />
+    <!-- <Compile Include="HttpRequestStreamTests.cs" />
     <Compile Include="HttpResponseStreamTests.cs" />
     <Compile Include="InvalidClientRequestTests.cs" />
     <Compile Include="SimpleHttpTests.cs" />
-    <Compile Include="WebSocketTests.cs" />
+    <Compile Include="WebSocketTests.cs" /> -->
     <Compile Include="XUnitAssemblyAttributes.cs" />
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\tests\System\PlatformDetection.cs</Link>


### PR DESCRIPTION
We should add a check `ThrowIfDisposed()` before checking for InvalidState in managed implementation.

Fix: #20395

Close: #22057

Removed unused ContextHelper in HttpRequestStreamTests test class.