### PR TITLE
Use expression-bodied members throughout ImmutableList

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList.cs
@@ -18,10 +18,7 @@ namespace System.Collections.Immutable
         /// <typeparam name="T">The type of items stored by the collection.</typeparam>
         /// <returns>The immutable collection.</returns>
         [Pure]
-        public static ImmutableList<T> Create<T>()
-        {
-            return ImmutableList<T>.Empty;
-        }
+        public static ImmutableList<T> Create<T>() => ImmutableList<T>.Empty;
 
         /// <summary>
         /// Creates a new immutable collection prefilled with the specified item.
@@ -30,10 +27,7 @@ namespace System.Collections.Immutable
         /// <param name="item">The item to prepopulate.</param>
         /// <returns>The new immutable collection.</returns>
         [Pure]
-        public static ImmutableList<T> Create<T>(T item)
-        {
-            return ImmutableList<T>.Empty.Add(item);
-        }
+        public static ImmutableList<T> Create<T>(T item) => ImmutableList<T>.Empty.Add(item);
 
         /// <summary>
         /// Creates a new immutable collection prefilled with the specified items.
@@ -42,10 +36,7 @@ namespace System.Collections.Immutable
         /// <param name="items">The items to prepopulate.</param>
         /// <returns>The new immutable collection.</returns>
         [Pure]
-        public static ImmutableList<T> CreateRange<T>(IEnumerable<T> items)
-        {
-            return ImmutableList<T>.Empty.AddRange(items);
-        }
+        public static ImmutableList<T> CreateRange<T>(IEnumerable<T> items) => ImmutableList<T>.Empty.AddRange(items);
 
         /// <summary>
         /// Creates a new immutable collection prefilled with the specified items.
@@ -54,10 +45,7 @@ namespace System.Collections.Immutable
         /// <param name="items">The items to prepopulate.</param>
         /// <returns>The new immutable collection.</returns>
         [Pure]
-        public static ImmutableList<T> Create<T>(params T[] items)
-        {
-            return ImmutableList<T>.Empty.AddRange(items);
-        }
+        public static ImmutableList<T> Create<T>(params T[] items) => ImmutableList<T>.Empty.AddRange(items);
 
         /// <summary>
         /// Creates a new immutable list builder.
@@ -65,10 +53,7 @@ namespace System.Collections.Immutable
         /// <typeparam name="T">The type of items stored by the collection.</typeparam>
         /// <returns>The immutable collection builder.</returns>
         [Pure]
-        public static ImmutableList<T>.Builder CreateBuilder<T>()
-        {
-            return Create<T>().ToBuilder();
-        }
+        public static ImmutableList<T>.Builder CreateBuilder<T>() => Create<T>().ToBuilder();
 
         /// <summary>
         /// Enumerates a sequence exactly once and produces an immutable list of its contents.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Enumerator.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Enumerator.cs
@@ -120,10 +120,7 @@ namespace System.Collections.Immutable
             }
 
             /// <inheritdoc/>
-            int ISecurePooledObjectUser.PoolUserId
-            {
-                get { return _poolUserId; }
-            }
+            int ISecurePooledObjectUser.PoolUserId => _poolUserId;
 
             /// <summary>
             /// The current element.
@@ -145,10 +142,7 @@ namespace System.Collections.Immutable
             /// <summary>
             /// The current element.
             /// </summary>
-            object System.Collections.IEnumerator.Current
-            {
-                get { return this.Current; }
-            }
+            object System.Collections.IEnumerator.Current => this.Current;
 
             /// <summary>
             /// Disposes of this enumerator and returns the stack reference to the resource pool.
@@ -239,18 +233,12 @@ namespace System.Collections.Immutable
             /// <summary>
             /// Obtains the right branch of the given node (or the left, if walking in reverse).
             /// </summary>
-            private Node NextBranch(Node node)
-            {
-                return _reversed ? node.Left : node.Right;
-            }
+            private Node NextBranch(Node node) => _reversed ? node.Left : node.Right;
 
             /// <summary>
             /// Obtains the left branch of the given node (or the right, if walking in reverse).
             /// </summary>
-            private Node PreviousBranch(Node node)
-            {
-                return _reversed ? node.Right : node.Left;
-            }
+            private Node PreviousBranch(Node node) => _reversed ? node.Right : node.Left;
 
             /// <summary>
             /// Throws an <see cref="ObjectDisposedException"/> if this enumerator has been disposed.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
@@ -195,10 +195,7 @@ namespace System.Collections.Immutable
             /// <returns>
             /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.
             /// </returns>
-            public Enumerator GetEnumerator()
-            {
-                return new Enumerator(this);
-            }
+            public Enumerator GetEnumerator() => new Enumerator(this);
 
             /// <summary>
             /// Returns an enumerator that iterates through the collection.
@@ -207,10 +204,7 @@ namespace System.Collections.Immutable
             /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.
             /// </returns>
             [ExcludeFromCodeCoverage] // internal, never called, but here for interface implementation
-            IEnumerator<T> IEnumerable<T>.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
+            IEnumerator<T> IEnumerable<T>.GetEnumerator() => this.GetEnumerator();
 
             /// <summary>
             /// Returns an enumerator that iterates through the collection.
@@ -219,10 +213,7 @@ namespace System.Collections.Immutable
             /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.
             /// </returns>
             [ExcludeFromCodeCoverage] // internal, never called, but here for interface implementation
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
+            IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 
             #endregion
 
@@ -233,10 +224,7 @@ namespace System.Collections.Immutable
             /// <returns>
             /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.
             /// </returns>
-            internal Enumerator GetEnumerator(Builder builder)
-            {
-                return new Enumerator(this, builder);
-            }
+            internal Enumerator GetEnumerator(Builder builder) => new Enumerator(this, builder);
 
             /// <summary>
             /// Creates a node tree that contains the contents of a list.
@@ -493,11 +481,7 @@ namespace System.Collections.Immutable
             /// Reverses the order of the elements in the entire <see cref="ImmutableList{T}"/>.
             /// </summary>
             /// <returns>The reversed list.</returns>
-            internal Node Reverse()
-            {
-                Contract.Ensures(Contract.Result<Node>() != null);
-                return this.Reverse(0, this.Count);
-            }
+            internal Node Reverse() => this.Reverse(0, this.Count);
 
             /// <summary>
             /// Reverses the order of the elements in the specified range.
@@ -532,11 +516,7 @@ namespace System.Collections.Immutable
             /// Sorts the elements in the entire <see cref="ImmutableList{T}"/> using
             /// the default comparer.
             /// </summary>
-            internal Node Sort()
-            {
-                Contract.Ensures(Contract.Result<Node>() != null);
-                return this.Sort(Comparer<T>.Default);
-            }
+            internal Node Sort() => this.Sort(Comparer<T>.Default);
 
             /// <summary>
             /// Sorts the elements in the entire <see cref="ImmutableList{T}"/> using
@@ -567,11 +547,7 @@ namespace System.Collections.Immutable
             /// elements, or null to use the default comparer <see cref="Comparer{T}.Default"/>.
             /// </param>
             /// <returns>The sorted list.</returns>
-            internal Node Sort(IComparer<T> comparer)
-            {
-                Contract.Ensures(Contract.Result<Node>() != null);
-                return this.Sort(0, this.Count, comparer);
-            }
+            internal Node Sort(IComparer<T> comparer) => this.Sort(0, this.Count, comparer);
 
             /// <summary>
             /// Sorts the elements in a range of elements in <see cref="ImmutableList{T}"/>
@@ -698,10 +674,7 @@ namespace System.Collections.Immutable
             /// <see cref="ImmutableList{T}"/>, if found; otherwise, -1.
             /// </returns>
             [Pure]
-            internal int IndexOf(T item, IEqualityComparer<T> equalityComparer)
-            {
-                return this.IndexOf(item, 0, this.Count, equalityComparer);
-            }
+            internal int IndexOf(T item, IEqualityComparer<T> equalityComparer) => this.IndexOf(item, 0, this.Count, equalityComparer);
 
             /// <summary>
             /// Searches for the specified object and returns the zero-based index of the

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -152,8 +152,10 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="ICollection"/> interface.
         /// </summary>
+        /// <devremarks>
+        /// This type is immutable, so it is always thread-safe.
+        /// </devremarks>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        // This is immutable, so it is always thread-safe.
         bool ICollection.IsSynchronized => true;
 
         #endregion

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -31,10 +31,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableList{T}"/> class.
         /// </summary>
-        internal ImmutableList()
-        {
-            _root = Node.EmptyNode;
-        }
+        internal ImmutableList() => _root = Node.EmptyNode;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableList{T}"/> class.
@@ -51,12 +48,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
-        public ImmutableList<T> Clear()
-        {
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableList<T>>().IsEmpty);
-            return Empty;
-        }
+        public ImmutableList<T> Clear() => Empty;
 
         /// <summary>
         /// Searches the entire sorted <see cref="ImmutableList{T}"/> for an element
@@ -74,10 +66,7 @@ namespace System.Collections.Immutable
         /// find an implementation of the <see cref="IComparable{T}"/> generic interface or
         /// the <see cref="IComparable"/> interface for type <typeparamref name="T"/>.
         /// </exception>
-        public int BinarySearch(T item)
-        {
-            return this.BinarySearch(item, null);
-        }
+        public int BinarySearch(T item) => this.BinarySearch(item, null);
 
         /// <summary>
         ///  Searches the entire sorted <see cref="ImmutableList{T}"/> for an element
@@ -99,10 +88,7 @@ namespace System.Collections.Immutable
         /// cannot find an implementation of the <see cref="IComparable{T}"/> generic interface
         /// or the <see cref="IComparable"/> interface for type <typeparamref name="T"/>.
         /// </exception>
-        public int BinarySearch(T item, IComparer<T> comparer)
-        {
-            return this.BinarySearch(0, this.Count, item, comparer);
-        }
+        public int BinarySearch(T item, IComparer<T> comparer) => this.BinarySearch(0, this.Count, item, comparer);
 
         /// <summary>
         /// Searches a range of elements in the sorted <see cref="ImmutableList{T}"/>
@@ -133,10 +119,7 @@ namespace System.Collections.Immutable
         /// cannot find an implementation of the <see cref="IComparable{T}"/> generic interface
         /// or the <see cref="IComparable"/> interface for type <typeparamref name="T"/>.
         /// </exception>
-        public int BinarySearch(int index, int count, T item, IComparer<T> comparer)
-        {
-            return _root.BinarySearch(index, count, item, comparer);
-        }
+        public int BinarySearch(int index, int count, T item, IComparer<T> comparer) => _root.BinarySearch(index, count, item, comparer);
 
         #region IImmutableList<T> Properties
 
@@ -144,35 +127,17 @@ namespace System.Collections.Immutable
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        public bool IsEmpty
-        {
-            get
-            {
-                Contract.Ensures(Contract.Result<bool>() == (this.Count == 0));
-                return _root.IsEmpty;
-            }
-        }
+        public bool IsEmpty => _root.IsEmpty;
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
-        IImmutableList<T> IImmutableList<T>.Clear()
-        {
-            return this.Clear();
-        }
+        IImmutableList<T> IImmutableList<T>.Clear() => this.Clear();
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                Contract.Ensures(Contract.Result<int>() >= 0);
-                Contract.Ensures((Contract.Result<int>() == 0) == this.IsEmpty);
-                return _root.Count;
-            }
-        }
+        public int Count => _root.Count;
 
         #endregion
 
@@ -182,23 +147,14 @@ namespace System.Collections.Immutable
         /// See <see cref="ICollection"/>.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        object ICollection.SyncRoot
-        {
-            get { return this; }
-        }
+        object ICollection.SyncRoot => this;
 
         /// <summary>
         /// See the <see cref="ICollection"/> interface.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        bool ICollection.IsSynchronized
-        {
-            get
-            {
-                // This is immutable, so it is always thread-safe.
-                return true;
-            }
-        }
+        // This is immutable, so it is always thread-safe.
+        bool ICollection.IsSynchronized => true;
 
         #endregion
 
@@ -210,13 +166,7 @@ namespace System.Collections.Immutable
         /// <param name="index">The 0-based index of the element in the set to return.</param>
         /// <returns>The element at the given position.</returns>
         /// <exception cref="IndexOutOfRangeException">Thrown from getter when <paramref name="index"/> is negative or not less than <see cref="Count"/>.</exception>
-        public T this[int index]
-        {
-            get
-            {
-                return _root[index];
-            }
-        }
+        public T this[int index] => _root[index];
 
         #endregion
 
@@ -225,13 +175,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Gets the element in the collection at a given index.
         /// </summary>
-        T IOrderedCollection<T>.this[int index]
-        {
-            get
-            {
-                return this[index];
-            }
-        }
+        T IOrderedCollection<T>.this[int index] => this[index];
 
         #endregion
 
@@ -319,10 +263,7 @@ namespace System.Collections.Immutable
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
         [Pure]
-        public ImmutableList<T> Remove(T value)
-        {
-            return this.Remove(value, EqualityComparer<T>.Default);
-        }
+        public ImmutableList<T> Remove(T value) => this.Remove(value, EqualityComparer<T>.Default);
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
@@ -366,10 +307,7 @@ namespace System.Collections.Immutable
         /// A new list with the elements removed.
         /// </returns>
         [Pure]
-        public ImmutableList<T> RemoveRange(IEnumerable<T> items)
-        {
-            return this.RemoveRange(items, EqualityComparer<T>.Default);
-        }
+        public ImmutableList<T> RemoveRange(IEnumerable<T> items) => this.RemoveRange(items, EqualityComparer<T>.Default);
 
         /// <summary>
         /// Removes the specified values from this list.
@@ -447,19 +385,13 @@ namespace System.Collections.Immutable
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
         [Pure]
-        public ImmutableList<T> SetItem(int index, T value)
-        {
-            return this.Wrap(_root.ReplaceAt(index, value));
-        }
+        public ImmutableList<T> SetItem(int index, T value) => this.Wrap(_root.ReplaceAt(index, value));
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
         [Pure]
-        public ImmutableList<T> Replace(T oldValue, T newValue)
-        {
-            return this.Replace(oldValue, newValue, EqualityComparer<T>.Default);
-        }
+        public ImmutableList<T> Replace(T oldValue, T newValue) => this.Replace(oldValue, newValue, EqualityComparer<T>.Default);
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
@@ -484,11 +416,7 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <returns>The reversed list.</returns>
         [Pure]
-        public ImmutableList<T> Reverse()
-        {
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
-            return this.Wrap(_root.Reverse());
-        }
+        public ImmutableList<T> Reverse() => this.Wrap(_root.Reverse());
 
         /// <summary>
         /// Reverses the order of the elements in the specified range.
@@ -497,21 +425,14 @@ namespace System.Collections.Immutable
         /// <param name="count">The number of elements in the range to reverse.</param> 
         /// <returns>The reversed list.</returns>
         [Pure]
-        public ImmutableList<T> Reverse(int index, int count)
-        {
-            return this.Wrap(_root.Reverse(index, count));
-        }
+        public ImmutableList<T> Reverse(int index, int count) => this.Wrap(_root.Reverse(index, count));
 
         /// <summary>
         /// Sorts the elements in the entire <see cref="ImmutableList{T}"/> using
         /// the default comparer.
         /// </summary>
         [Pure]
-        public ImmutableList<T> Sort()
-        {
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
-            return this.Wrap(_root.Sort());
-        }
+        public ImmutableList<T> Sort() => this.Wrap(_root.Sort());
 
         /// <summary>
         /// Sorts the elements in the entire <see cref="ImmutableList{T}"/> using
@@ -540,11 +461,7 @@ namespace System.Collections.Immutable
         /// </param>
         /// <returns>The sorted list.</returns>
         [Pure]
-        public ImmutableList<T> Sort(IComparer<T> comparer)
-        {
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
-            return this.Wrap(_root.Sort(comparer));
-        }
+        public ImmutableList<T> Sort(IComparer<T> comparer) => this.Wrap(_root.Sort(comparer));
 
         /// <summary>
         /// Sorts the elements in a range of elements in <see cref="ImmutableList{T}"/>
@@ -642,10 +559,7 @@ namespace System.Collections.Immutable
         /// </param>
         /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         /// <param name="count">The number of elements to copy.</param>
-        public void CopyTo(int index, T[] array, int arrayIndex, int count)
-        {
-            _root.CopyTo(index, array, arrayIndex, count);
-        }
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) => _root.CopyTo(index, array, arrayIndex, count);
 
         /// <summary>
         /// Creates a shallow copy of a range of elements in the source <see cref="ImmutableList{T}"/>.
@@ -916,10 +830,7 @@ namespace System.Collections.Immutable
         /// contains <paramref name="count"/> number of elements, if found; otherwise, -1.
         /// </returns>
         [Pure]
-        public int IndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
-        {
-            return _root.IndexOf(item, index, count, equalityComparer);
-        }
+        public int IndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer) => _root.IndexOf(item, index, count, equalityComparer);
 
         /// <summary>
         /// Searches for the specified object and returns the zero-based index of the
@@ -973,37 +884,24 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
-        public bool Contains(T value)
-        {
-            Contract.Ensures(!this.IsEmpty || !Contract.Result<bool>());
-            return this.IndexOf(value) >= 0;
-        }
+        public bool Contains(T value) => this.IndexOf(value) >= 0;
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
-        public int IndexOf(T value)
-        {
-            return this.IndexOf(value, EqualityComparer<T>.Default);
-        }
+        public int IndexOf(T value) => this.IndexOf(value, EqualityComparer<T>.Default);
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        IImmutableList<T> IImmutableList<T>.Add(T value)
-        {
-            return this.Add(value);
-        }
+        IImmutableList<T> IImmutableList<T>.Add(T value) => this.Add(value);
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        IImmutableList<T> IImmutableList<T>.AddRange(IEnumerable<T> items)
-        {
-            return this.AddRange(items);
-        }
+        IImmutableList<T> IImmutableList<T>.AddRange(IEnumerable<T> items) => this.AddRange(items);
 
         /// <summary>
         /// Inserts the specified value at the specified index.
@@ -1012,10 +910,7 @@ namespace System.Collections.Immutable
         /// <param name="item">The element to add.</param>
         /// <returns>The new immutable list.</returns>
         [ExcludeFromCodeCoverage]
-        IImmutableList<T> IImmutableList<T>.Insert(int index, T item)
-        {
-            return this.Insert(index, item);
-        }
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T item) => this.Insert(index, item);
 
         /// <summary>
         /// Inserts the specified value at the specified index.
@@ -1033,37 +928,25 @@ namespace System.Collections.Immutable
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        IImmutableList<T> IImmutableList<T>.Remove(T value, IEqualityComparer<T> equalityComparer)
-        {
-            return this.Remove(value, equalityComparer);
-        }
+        IImmutableList<T> IImmutableList<T>.Remove(T value, IEqualityComparer<T> equalityComparer) => this.Remove(value, equalityComparer);
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match)
-        {
-            return this.RemoveAll(match);
-        }
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) => this.RemoveAll(match);
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        IImmutableList<T> IImmutableList<T>.RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer)
-        {
-            return this.RemoveRange(items, equalityComparer);
-        }
+        IImmutableList<T> IImmutableList<T>.RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer) => this.RemoveRange(items, equalityComparer);
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count)
-        {
-            return this.RemoveRange(index, count);
-        }
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) => this.RemoveRange(index, count);
 
         /// <summary>
         /// Removes the element at the specified index.
@@ -1071,10 +954,7 @@ namespace System.Collections.Immutable
         /// <param name="index">The index.</param>
         /// <returns>A new list with the elements removed.</returns>
         [ExcludeFromCodeCoverage]
-        IImmutableList<T> IImmutableList<T>.RemoveAt(int index)
-        {
-            return this.RemoveAt(index);
-        }
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) => this.RemoveAt(index);
 
         /// <summary>
         /// Replaces an element in the list at a given position with the specified element.
@@ -1083,10 +963,7 @@ namespace System.Collections.Immutable
         /// <param name="value">The element to replace the old element with.</param>
         /// <returns>The new list.</returns>
         [ExcludeFromCodeCoverage]
-        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value)
-        {
-            return this.SetItem(index, value);
-        }
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) => this.SetItem(index, value);
 
         /// <summary>
         /// Replaces an element in the list with the specified element.
@@ -1099,10 +976,7 @@ namespace System.Collections.Immutable
         /// </param>
         /// <returns>The new list.</returns>
         /// <exception cref="ArgumentException">Thrown when the old value does not exist in the list.</exception>
-        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer)
-        {
-            return this.Replace(oldValue, newValue, equalityComparer);
-        }
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer) => this.Replace(oldValue, newValue, equalityComparer);
 
         #endregion
 
@@ -1114,10 +988,7 @@ namespace System.Collections.Immutable
         /// <returns>
         /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.
         /// </returns>
-        IEnumerator<T> IEnumerable<T>.GetEnumerator()
-        {
-            return this.GetEnumerator();
-        }
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => this.GetEnumerator();
 
         #endregion
 
@@ -1129,10 +1000,7 @@ namespace System.Collections.Immutable
         /// <returns>
         /// An <see cref="IEnumerator"/> object that can be used to iterate through the collection.
         /// </returns>
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
-        }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
 
         #endregion
 
@@ -1144,20 +1012,14 @@ namespace System.Collections.Immutable
         /// <param name="index">The index.</param>
         /// <param name="item">The item.</param>
         /// <exception cref="NotSupportedException">Always thrown.</exception>
-        void IList<T>.Insert(int index, T item)
-        {
-            throw new NotSupportedException();
-        }
+        void IList<T>.Insert(int index, T item) => throw new NotSupportedException();
 
         /// <summary>
         /// Removes the value at the specified index.
         /// </summary>
         /// <param name="index">The index.</param>
         /// <exception cref="NotSupportedException">Always thrown.</exception>
-        void IList<T>.RemoveAt(int index)
-        {
-            throw new NotSupportedException();
-        }
+        void IList<T>.RemoveAt(int index) => throw new NotSupportedException();
 
         /// <summary>
         /// Gets or sets the value at the specified index.
@@ -1166,8 +1028,8 @@ namespace System.Collections.Immutable
         /// <exception cref="NotSupportedException">Always thrown from the setter.</exception>
         T IList<T>.this[int index]
         {
-            get { return this[index]; }
-            set { throw new NotSupportedException(); }
+            get => this[index];
+            set => throw new NotSupportedException();
         }
 
         #endregion
@@ -1179,29 +1041,20 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="item">The item.</param>
         /// <exception cref="NotSupportedException">Always thrown.</exception>
-        void ICollection<T>.Add(T item)
-        {
-            throw new NotSupportedException();
-        }
+        void ICollection<T>.Add(T item) => throw new NotSupportedException();
 
         /// <summary>
         /// Clears this instance.
         /// </summary>
         /// <exception cref="NotSupportedException">Always thrown.</exception>
-        void ICollection<T>.Clear()
-        {
-            throw new NotSupportedException();
-        }
+        void ICollection<T>.Clear() => throw new NotSupportedException();
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="ICollection{T}"/> is read-only.
         /// </summary>
         /// <returns>true if the <see cref="ICollection{T}"/> is read-only; otherwise, false.
         ///   </returns>
-        bool ICollection<T>.IsReadOnly
-        {
-            get { return true; }
-        }
+        bool ICollection<T>.IsReadOnly => true;
 
         /// <summary>
         /// Removes the specified item.
@@ -1209,10 +1062,7 @@ namespace System.Collections.Immutable
         /// <param name="item">The item.</param>
         /// <returns>Nothing. An exception is always thrown.</returns>
         /// <exception cref="NotSupportedException">Always thrown.</exception>
-        bool ICollection<T>.Remove(T item)
-        {
-            throw new NotSupportedException();
-        }
+        bool ICollection<T>.Remove(T item) => throw new NotSupportedException();
 
         #endregion
 
@@ -1221,10 +1071,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="ICollection"/> interface.
         /// </summary>
-        void System.Collections.ICollection.CopyTo(Array array, int arrayIndex)
-        {
-            _root.CopyTo(array, arrayIndex);
-        }
+        void System.Collections.ICollection.CopyTo(Array array, int arrayIndex) => _root.CopyTo(array, arrayIndex);
 
         #endregion
 
@@ -1238,29 +1085,20 @@ namespace System.Collections.Immutable
         /// Nothing. An exception is always thrown.
         /// </returns>
         /// <exception cref="NotSupportedException">Always thrown.</exception>
-        int IList.Add(object value)
-        {
-            throw new NotSupportedException();
-        }
+        int IList.Add(object value) => throw new NotSupportedException();
 
         /// <summary>
         /// Removes the <see cref="IList"/> item at the specified index.
         /// </summary>
         /// <param name="index">The zero-based index of the item to remove.</param>
         /// <exception cref="NotSupportedException">Always thrown.</exception>
-        void IList.RemoveAt(int index)
-        {
-            throw new NotSupportedException();
-        }
+        void IList.RemoveAt(int index) => throw new NotSupportedException();
 
         /// <summary>
         /// Clears this instance.
         /// </summary>
         /// <exception cref="NotSupportedException">Always thrown.</exception>
-        void IList.Clear()
-        {
-            throw new NotSupportedException();
-        }
+        void IList.Clear() => throw new NotSupportedException();
 
         /// <summary>
         /// Determines whether the <see cref="IList"/> contains a specific value.
@@ -1269,15 +1107,7 @@ namespace System.Collections.Immutable
         /// <returns>
         /// true if the <see cref="object"/> is found in the <see cref="IList"/>; otherwise, false.
         /// </returns>
-        bool IList.Contains(object value)
-        {
-            if (IsCompatibleObject(value))
-            {
-                return this.Contains((T)value);
-            }
-
-            return false;
-        }
+        bool IList.Contains(object value) => IsCompatibleObject(value) && this.Contains((T)value);
 
         /// <summary>
         /// Determines the index of a specific item in the <see cref="IList"/>.
@@ -1286,15 +1116,7 @@ namespace System.Collections.Immutable
         /// <returns>
         /// The index of <paramref name="value"/> if found in the list; otherwise, -1.
         /// </returns>
-        int IList.IndexOf(object value)
-        {
-            if (IsCompatibleObject(value))
-            {
-                return this.IndexOf((T)value);
-            }
-
-            return -1;
-        }
+        int IList.IndexOf(object value) => IsCompatibleObject(value) ? this.IndexOf((T)value) : -1;
 
         /// <summary>
         /// Inserts an item to the <see cref="IList"/> at the specified index.
@@ -1302,39 +1124,27 @@ namespace System.Collections.Immutable
         /// <param name="index">The zero-based index at which <paramref name="value"/> should be inserted.</param>
         /// <param name="value">The object to insert into the <see cref="IList"/>.</param>
         /// <exception cref="NotSupportedException">Always thrown.</exception>
-        void IList.Insert(int index, object value)
-        {
-            throw new NotSupportedException();
-        }
+        void IList.Insert(int index, object value) => throw new NotSupportedException();
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="IList"/> has a fixed size.
         /// </summary>
         /// <returns>true if the <see cref="IList"/> has a fixed size; otherwise, false.</returns>
-        bool IList.IsFixedSize
-        {
-            get { return true; }
-        }
+        bool IList.IsFixedSize => true;
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="ICollection{T}"/> is read-only.
         /// </summary>
         /// <returns>true if the <see cref="ICollection{T}"/> is read-only; otherwise, false.
         ///   </returns>
-        bool IList.IsReadOnly
-        {
-            get { return true; }
-        }
+        bool IList.IsReadOnly => true;
 
         /// <summary>
         /// Removes the first occurrence of a specific object from the <see cref="IList"/>.
         /// </summary>
         /// <param name="value">The object to remove from the <see cref="IList"/>.</param>
         /// <exception cref="NotSupportedException">Always thrown.</exception>
-        void IList.Remove(object value)
-        {
-            throw new NotSupportedException();
-        }
+        void IList.Remove(object value) => throw new NotSupportedException();
 
         /// <summary>
         /// Gets or sets the <see cref="System.Object"/> at the specified index.
@@ -1348,8 +1158,8 @@ namespace System.Collections.Immutable
         /// <exception cref="NotSupportedException">Always thrown from the setter.</exception>
         object IList.this[int index]
         {
-            get { return this[index]; }
-            set { throw new NotSupportedException(); }
+            get => this[index];
+            set => throw new NotSupportedException();
         }
 
         #endregion
@@ -1367,21 +1177,12 @@ namespace System.Collections.Immutable
         /// that a stack that has already been returned to the resource pool may still be in use by one of the enumerator copies, leading to data
         /// corruption and/or exceptions.
         /// </remarks>
-        public Enumerator GetEnumerator()
-        {
-            return new Enumerator(_root);
-        }
+        public Enumerator GetEnumerator() => new Enumerator(_root);
 
         /// <summary>
         /// Returns the root <see cref="Node"/> of the list
         /// </summary>
-        internal Node Root
-        {
-            get
-            {
-                return _root;
-            }
-        }
+        internal Node Root => _root;
 
         /// <summary>
         /// Creates a new sorted set wrapper for a node tree.
@@ -1463,8 +1264,7 @@ namespace System.Collections.Immutable
         {
             // If the items being added actually come from an ImmutableList<T>
             // then there is no value in reconstructing it.
-            ImmutableList<T> other;
-            if (TryCastToImmutableList(items, out other))
+            if (TryCastToImmutableList(items, out ImmutableList<T> other))
             {
                 return other;
             }


### PR DESCRIPTION
This is still part of my old PR #15382 for `ImmutableList`; I am porting all of the style-only changes I made during that PR so there will be less noise while reviewing the actual changes. Most of the style changes I made were converting members to use expression-bodied form.

This is a follow-up to https://github.com/dotnet/corefx/pull/22842.

/cc @AArnott, @safern