### PR TITLE
Add RandomNumberGenerator.GetBytes(Span) overload

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.csproj
@@ -17,6 +17,7 @@
     <Compile Include="System.Security.Cryptography.Algorithms.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
+    <Compile Include="System.Security.Cryptography.Algorithms.netcoreapp.cs" />
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj" />
     <ProjectReference Include="..\..\System.IO\ref\System.IO.csproj" />

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
@@ -11,5 +11,6 @@ namespace System.Security.Cryptography
     public abstract partial class RandomNumberGenerator : System.IDisposable
     {
         public virtual void GetBytes(Span<byte> data) { }
+        public virtual void GetNonZeroBytes(Span<byte> data) { }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+
+namespace System.Security.Cryptography
+{
+    public abstract partial class RandomNumberGenerator : System.IDisposable
+    {
+        public virtual void GetBytes(Span<byte> data) { }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-
 namespace System.Security.Cryptography
 {
     internal sealed partial class RandomNumberGeneratorImplementation : RandomNumberGenerator
@@ -11,14 +9,13 @@ namespace System.Security.Cryptography
         public override void GetBytes(byte[] data)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
-
-            GetBytesInternal(data, 0, data.Length);
+            GetBytes(new Span<byte>(data));
         }
 
         public override void GetBytes(byte[] data, int offset, int count)
         {
             VerifyGetBytes(data, offset, count);
-            GetBytesInternal(data, offset, count);
+            GetBytes(new Span<byte>(data, offset, count));
         }
 
         public override unsafe void GetBytes(Span<byte> data)
@@ -35,16 +32,19 @@ namespace System.Security.Cryptography
         public override void GetNonZeroBytes(byte[] data)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
+            GetNonZeroBytes(new Span<byte>(data));
+        }
 
-            int offset = 0;
-            while (offset < data.Length)
+        public override void GetNonZeroBytes(Span<byte> data)
+        {
+            while (data.Length > 0)
             {
-                // Fill the remaining portion of the array with random bytes.
-                GetBytesInternal(data, offset, data.Length - offset);
+                // Fill the remaining portion of the span with random bytes.
+                GetBytes(data);
 
                 // Find the first zero in the remaining portion.
                 int indexOfFirst0Byte = data.Length;
-                for (int i = offset; i < data.Length; i++)
+                for (int i = 0; i < data.Length; i++)
                 {
                     if (data[i] == 0)
                     {
@@ -64,26 +64,7 @@ namespace System.Security.Cryptography
 
                 // Request new random bytes if necessary; dont re-use
                 // existing bytes since they were shifted down.
-                offset = indexOfFirst0Byte;
-            }
-        }
-
-        private void GetBytesInternal(byte[] data, int offset, int count)
-        {
-            Debug.Assert(data != null);
-            Debug.Assert(offset >= 0);
-            Debug.Assert(count >= 0);
-            Debug.Assert(count <= data.Length - offset);
-
-            if (count > 0)
-            {
-                unsafe
-                {
-                    fixed (byte* pb = &data[offset])
-                    {
-                        GetBytes(pb, count);
-                    }
-                }
+                data = data.Slice(indexOfFirst0Byte);
             }
         }
     }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.cs
@@ -21,6 +21,17 @@ namespace System.Security.Cryptography
             GetBytesInternal(data, offset, count);
         }
 
+        public override unsafe void GetBytes(Span<byte> data)
+        {
+            if (data.Length > 0)
+            {
+                fixed (byte* ptr = &data.DangerousGetPinnableReference())
+                {
+                    GetBytes(ptr, data.Length);
+                }
+            }
+        }
+
         public override void GetNonZeroBytes(byte[] data)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -480,6 +480,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RandomNumberGenerator.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RandomNumberGenerator.cs
@@ -61,6 +61,7 @@ namespace System.Security.Cryptography
             }
             finally
             {
+                Array.Clear(array, 0, data.Length);
                 ArrayPool<byte>.Shared.Return(array);
             }
         }
@@ -70,6 +71,24 @@ namespace System.Security.Cryptography
             // For compatibility we cannot have it be abstract. Since this technically is an abstract method
             // with no implementation, we'll just throw NotImplementedException.
             throw new NotImplementedException();
+        }
+
+        public virtual void GetNonZeroBytes(Span<byte> data)
+        {
+            byte[] array = ArrayPool<byte>.Shared.Rent(data.Length);
+            try
+            {
+                // NOTE: There is no GetNonZeroBytes(byte[], int, int) overload, so this call
+                // may end up retrieving more data than was intended, if the array pool
+                // gives back a larger array than was actually needed.
+                GetNonZeroBytes(array);
+                new ReadOnlySpan<byte>(array, 0, data.Length).CopyTo(data);
+            }
+            finally
+            {
+                Array.Clear(array, 0, data.Length);
+                ArrayPool<byte>.Shared.Return(array);
+            }
         }
 
         internal void VerifyGetBytes(byte[] data, int offset, int count)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RandomNumberGenerator.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RandomNumberGenerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
+
 namespace System.Security.Cryptography
 {
     public abstract class RandomNumberGenerator : IDisposable
@@ -46,6 +48,20 @@ namespace System.Security.Cryptography
                     GetBytes(tempData);
                     Buffer.BlockCopy(tempData, 0, data, offset, count);
                 }
+            }
+        }
+
+        public virtual void GetBytes(Span<byte> data)
+        {
+            byte[] array = ArrayPool<byte>.Shared.Rent(data.Length);
+            try
+            {
+                GetBytes(array, 0, data.Length);
+                new ReadOnlySpan<byte>(array, 0, data.Length).CopyTo(data);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(array);
             }
         }
 

--- a/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
@@ -10,44 +10,8 @@ using Xunit;
 
 namespace System.Security.Cryptography.RNG.Tests
 {
-    public class RandomNumberGeneratorTests
+    public partial class RandomNumberGeneratorTests
     {
-        [Fact]
-        public static void DifferentSequential_10()
-        {
-            DifferentSequential(10);
-        }
-
-        [Fact]
-        public static void DifferentSequential_256()
-        {
-            DifferentSequential(256);
-        }
-
-        [Fact]
-        public static void DifferentSequential_65536()
-        {
-            DifferentSequential(65536);
-        }
-
-        [Fact]
-        public static void DifferentParallel_10()
-        {
-            DifferentParallel(10);
-        }
-
-        [Fact]
-        public static void DifferentParallel_256()
-        {
-            DifferentParallel(256);
-        }
-
-        [Fact]
-        public static void DifferentParallel_65536()
-        {
-            DifferentParallel(65536);
-        }
-
         [Fact]
         public static void RandomDistribution()
         {
@@ -172,7 +136,7 @@ namespace System.Security.Cryptography.RNG.Tests
         }
 
         [Fact]
-        public static void GetBytes_Offset_ZeroCount()
+        public static void GetBytes_Array_Offset_ZeroCount()
         {
             using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
             {
@@ -192,7 +156,11 @@ namespace System.Security.Cryptography.RNG.Tests
             }
         }
 
-        private static void DifferentSequential(int arraySize)
+        [Theory]
+        [InlineData(10)]
+        [InlineData(256)]
+        [InlineData(65536)]
+        public static void DifferentSequential_Array(int arraySize)
         {
             // Ensure that the RNG doesn't produce a stable set of data.
             byte[] first = new byte[arraySize];
@@ -214,7 +182,11 @@ namespace System.Security.Cryptography.RNG.Tests
             Assert.NotEqual(first, second);
         }
 
-        private static void DifferentParallel(int arraySize)
+        [Theory]
+        [InlineData(10)]
+        [InlineData(256)]
+        [InlineData(65536)]
+        public static void DifferentParallel(int arraySize)
         {
             // Ensure that two RNGs don't produce the same data series (such as being implemented via new Random(1)).
             byte[] first = new byte[arraySize];

--- a/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
@@ -100,7 +100,7 @@ namespace System.Security.Cryptography.RNG.Tests
         }
 
         [Fact]
-        public static void GetNonZeroBytes()
+        public static void GetNonZeroBytes_Array()
         {
             using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
             {

--- a/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.netcoreapp.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.RNG.Tests
+{
+    public partial class RandomNumberGeneratorTests
+    {
+        [Theory]
+        [InlineData(10)]
+        [InlineData(256)]
+        [InlineData(65536)]
+        public static void DifferentSequential_Span(int arraySize)
+        {
+            // Ensure that the RNG doesn't produce a stable set of data.
+            var first = new byte[arraySize];
+            var second = new byte[arraySize];
+
+            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes((Span<byte>)first);
+                rng.GetBytes((Span<byte>)second);
+            }
+
+            // Random being random, there is a chance that it could produce the same sequence.
+            // The smallest test case that we have is 10 bytes.
+            // The probability that they are the same, given a Truly Random Number Generator is:
+            // Pmatch(byte0) * Pmatch(byte1) * Pmatch(byte2) * ... * Pmatch(byte9)
+            // = 1/256 * 1/256 * ... * 1/256
+            // = 1/(256^10)
+            // = 1/1,208,925,819,614,629,174,706,176
+            Assert.NotEqual(first, second);
+        }
+
+        [Fact]
+        public static void GetBytes_Span_ZeroCount()
+        {
+            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
+            {
+                var rand = new byte[1] { 1 };
+                rng.GetBytes(new Span<byte>(rand, 0, 0));
+                Assert.Equal(1, rand[0]);
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.netcoreapp.cs
@@ -44,5 +44,16 @@ namespace System.Security.Cryptography.RNG.Tests
                 Assert.Equal(1, rand[0]);
             }
         }
+
+        [Fact]
+        public static void GetNonZeroBytes_Span()
+        {
+            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
+            {
+                var rand = new byte[65536];
+                rng.GetNonZeroBytes(new Span<byte>(rand));
+                Assert.Equal(-1, Array.IndexOf<byte>(rand, 0));
+            }
+        }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -137,7 +137,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Folder Include="Common\Interop\Unix\" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
     <Compile Include="AesManagedTests.cs" />
@@ -152,6 +151,7 @@
     <Compile Include="ECDiffieHellmanPublicKeyTests.cs" />
     <Compile Include="PaddingModeTests.cs" />
     <Compile Include="PKCS1MaskGenerationMethodTest.cs" />
+    <Compile Include="RandomNumberGeneratorTests.netcoreapp.cs" />
     <Compile Include="RC2Provider.cs" />
     <Compile Include="RC2Tests.cs" />
     <Compile Include="RijndaelTests.cs" />

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RNGCryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RNGCryptoServiceProvider.cs
@@ -26,7 +26,9 @@ namespace System.Security.Cryptography
 
         public override void GetBytes(byte[] data) => _impl.GetBytes(data);
         public override void GetBytes(byte[] data, int offset, int count) => _impl.GetBytes(data, offset, count);
+        public override void GetBytes(Span<byte> data) => _impl.GetBytes(data);
         public override void GetNonZeroBytes(byte[] data) => _impl.GetNonZeroBytes(data);
+        public override void GetNonZeroBytes(Span<byte> data) => _impl.GetNonZeroBytes(data);
 
         protected override void Dispose(bool disposing)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/22690
cc: @bartonjs 