### PR TITLE
Send secure cookies with WSS upgrade request.

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -734,7 +734,7 @@ namespace System.Net
                 return null;
             }
 
-            bool isSecure = (uri.Scheme == UriScheme.Https);
+            bool isSecure = (uri.Scheme == UriScheme.Https || uri.Scheme == UriScheme.Wss);
             int port = uri.Port;
             CookieCollection cookies = null;
 

--- a/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -137,8 +137,15 @@ namespace System.Net.WebSockets.Client.Tests
             {
                 Assert.Null(cws.Options.Cookies);
                 cws.Options.Cookies = new CookieContainer();
-                cws.Options.Cookies.Add(server, new Cookie("Cookies", "Are Yummy"));
-                cws.Options.Cookies.Add(server, new Cookie("Especially", "Chocolate Chip"));
+
+                Cookie cookie1 = new Cookie("Cookies", "Are Yummy");
+                Cookie cookie2 = new Cookie("Especially", "Chocolate Chip");
+                Cookie secureCookie = new Cookie("Occasionally", "Raisin");
+                secureCookie.Secure = true;
+
+                cws.Options.Cookies.Add(server, cookie1);
+                cws.Options.Cookies.Add(server, cookie2);
+                cws.Options.Cookies.Add(server, secureCookie);
 
                 using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
                 {
@@ -163,8 +170,10 @@ namespace System.Net.WebSockets.Client.Tests
 
                 Assert.Equal(WebSocketMessageType.Text, recvResult.MessageType);
                 string headers = WebSocketData.GetTextFromBuffer(segment);
+
                 Assert.True(headers.Contains("Cookies=Are Yummy"));
                 Assert.True(headers.Contains("Especially=Chocolate Chip"));
+                Assert.Equal(server.Scheme == "wss", headers.Contains("Occasionally=Raisin"));
 
                 await cws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
             }


### PR DESCRIPTION
Fixes: #22551 
Adds WSS to the secure protocol check of CookieContainer so that cookies are sent along with the initial HTTP upgrade request used in the handshake of a secure WebSocket connection. Also modifies the current Websocket ConnectAsync_CookieHeaders_Success test to check that secure cookies are sent when they should be. 