### PR TITLE
Reverting version of TestILC + fixes on Globalization tests

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -13,8 +13,8 @@
     <CoreClrCurrentRef>26e8a70b4a0fbd66d95b940677e9b06470419e6d</CoreClrCurrentRef>
     <CoreSetupCurrentRef>26e8a70b4a0fbd66d95b940677e9b06470419e6d</CoreSetupCurrentRef>
     <ExternalCurrentRef>5a0606fccb09fce4b47545ae9896139acca547f5</ExternalCurrentRef>
-    <ProjectNTfsCurrentRef>26e8a70b4a0fbd66d95b940677e9b06470419e6d</ProjectNTfsCurrentRef>
-    <ProjectNTfsTestILCCurrentRef>26e8a70b4a0fbd66d95b940677e9b06470419e6d</ProjectNTfsTestILCCurrentRef>
+    <ProjectNTfsCurrentRef>61a476c71370f594ffa8063c6aca090200364b07</ProjectNTfsCurrentRef>
+    <ProjectNTfsTestILCCurrentRef>61a476c71370f594ffa8063c6aca090200364b07</ProjectNTfsTestILCCurrentRef>
     <SniCurrentRef>8bd1ec5fac9f0eec34ff6b34b1d878b4359e02dd</SniCurrentRef>
     <StandardCurrentRef>1ea842248842022f38c35f099222234e39445129</StandardCurrentRef>
   </PropertyGroup>
@@ -25,9 +25,9 @@
     <CoreFxExpectedPrerelease>preview2-25607-01</CoreFxExpectedPrerelease>
     <CoreClrPackageVersion>2.1.0-preview2-25607-01</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25322-00</ExternalExpectedPrerelease>
-    <ProjectNTfsExpectedPrerelease>beta-25607-00</ProjectNTfsExpectedPrerelease>
-    <ProjectNTfsTestILCExpectedPrerelease>beta-25607-00</ProjectNTfsTestILCExpectedPrerelease>
-    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25607-00</ProjectNTfsTestILCPackageVersion>
+    <ProjectNTfsExpectedPrerelease>beta-25604-00</ProjectNTfsExpectedPrerelease>
+    <ProjectNTfsTestILCExpectedPrerelease>beta-25604-00</ProjectNTfsTestILCExpectedPrerelease>
+    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25604-00</ProjectNTfsTestILCPackageVersion>
     <NETStandardPackageVersion>2.1.0-preview1-25605-03</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview2-25606-02</MicrosoftNETCoreAppPackageVersion>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,9 +3,9 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "TestILC.amd64ret": "1.0.0-beta-25607-00",
-        "TestILC.armret": "1.0.0-beta-25607-00",
-        "TestILC.x86ret": "1.0.0-beta-25607-00"
+        "TestILC.amd64ret": "1.0.0-beta-25604-00",
+        "TestILC.armret": "1.0.0-beta-25604-00",
+        "TestILC.x86ret": "1.0.0-beta-25604-00"
       }
     }
   }

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
@@ -35,9 +35,6 @@ namespace System.Globalization.Tests
         [Fact]
         public void TestSettingThreadCultures()
         {
-            if (PlatformDetection.IsNetNative && !PlatformDetection.IsWinRT) // Tide us over until .Net Native ILC tests run are run inside an appcontainer.
-                return;
-
             RemoteInvoke(() =>
             {
                 CultureInfo culture = new CultureInfo("ja-JP");

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
@@ -21,9 +21,6 @@ namespace System.Globalization.Tests
         [MemberData(nameof(CurrentInfo_CustomCulture_TestData))]
         public void CurrentInfo_CustomCulture(CultureInfo newCurrentCulture)
         {
-            if (PlatformDetection.IsNetNative && !PlatformDetection.IsWinRT) // Tide us over until .Net Native ILC tests run are run inside an appcontainer.
-                return;
-
             RemoteInvoke((cultureName) =>
             {
                 CultureInfo newCulture = new CultureInfo(cultureName);
@@ -36,9 +33,6 @@ namespace System.Globalization.Tests
         [Fact]
         public void CurrentInfo_Subclass_OverridesGetFormat()
         {
-            if (PlatformDetection.IsNetNative && !PlatformDetection.IsWinRT) // Tide us over until .Net Native ILC tests run are run inside an appcontainer.
-                return;
-
             RemoteInvoke(() =>
             {
                 CultureInfo.CurrentCulture = new CultureInfoSubclassOverridesGetFormat("en-US");
@@ -50,9 +44,6 @@ namespace System.Globalization.Tests
         [Fact]
         public void CurrentInfo_Subclass_OverridesNumberFormat()
         {
-            if (PlatformDetection.IsNetNative && !PlatformDetection.IsWinRT) // Tide us over until .Net Native ILC tests run are run inside an appcontainer.
-                return;
-
             RemoteInvoke(() =>
             {
                 CultureInfo.CurrentCulture = new CultureInfoSubclassOverridesNumberFormat("en-US");

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -140,7 +140,7 @@
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
       <Link>Common\System\RandomDataGenerator.cs</Link>
     </Compile>
-    <ProjectReference Condition="'$(TargetGroup)' != 'uap'" Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>


### PR DESCRIPTION
Fixes #23006

cc: @tarekgh @tijoytom 

Fixing some Globalization tests on uapaot and reverting the version change on PN dependencies since there was Build break in PN so we shouldn't have ingested a new dependencies.