### PR TITLE
Have Microsoft.CSharp treat type name collisions better.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
@@ -80,5 +80,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         internal static Exception DynamicArgumentNeedsValue(string paramName) =>
             new ArgumentException(SR.DynamicArgumentNeedsValue, paramName);
+
+        internal static Exception BindingNameCollision() => new RuntimeBinderException(SR.BindingNameCollision);
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 // In order to make this work, we have to reset the symbol table and begin
                 // the second binding over again when we detect the collision. So this is
                 // something like a longjmp to the beginning of binding. For a single binding,
-                // if we have to do this more than once, we give an ICE--this would be a
+                // if we have to do this more than once, we give an RBE--this would be a
                 // scenario that needs to know about both N.T's simultaneously to work.
 
                 // See SymbolTable.LoadSymbolsFromType for more information.
@@ -136,8 +136,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     catch (ResetBindException)
                     {
                         Reset();
-                        Debug.Assert(false, "More than one symbol table name collision in a single binding");
-                        throw Error.InternalCompilerError();
+                        throw Error.BindingNameCollision();
                     }
                 }
             }

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -349,4 +349,7 @@
   <data name="DynamicArgumentNeedsValue" xml:space="preserve">
     <value>The runtime binder cannot bind a metaobject without a value</value>
   </data>
+  <data name="BindingNameCollision" xml:space="preserve">
+    <value>More than one type in the binding has the same full name.</value>
+  </data>
 </root>

--- a/src/System.Linq.Expressions/tests/Dynamic/BinaryOperationTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/BinaryOperationTests.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Linq.Expressions.Tests;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
@@ -744,6 +747,27 @@ namespace System.Dynamic.Tests
             Func<object> func = Expression.Lambda<Func<object>>(expression).Compile(useInterpreter);
             Assert.Equal("42", func().ToString());
         }
+
+#if FEATURE_COMPILE // We're not testing compilation, but we do need Reflection.Emit for the test
+        [Fact]
+        public void OperationOnTwoObjectsDifferentTypesOfSameName()
+        {
+            object objX = Activator.CreateInstance(
+                AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestAssembly"), AssemblyBuilderAccess.Run)
+                    .DefineDynamicModule("TestModule").DefineType("TestType", TypeAttributes.Public).CreateType());
+            object objY = Activator.CreateInstance(
+                AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestAssembly"), AssemblyBuilderAccess.Run)
+                    .DefineDynamicModule("TestModule").DefineType("TestType", TypeAttributes.Public).CreateType());
+
+            CallSiteBinder binder =
+                Microsoft.CSharp.RuntimeBinder.Binder.BinaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.Equal,
+                    GetType(), new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null), CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            var cs = CallSite<Func<CallSite, object, object, object>>.Create(binder);
+            var t = cs.Target;
+            Assert.Throws<RuntimeBinderException>(() => t(cs, objX, objY));
+        }
+#endif
 
         private class BinaryCallSiteBinder : BinaryOperationBinder
         {


### PR DESCRIPTION
Throw `RuntimeBinderException` with an explanatory message instead of `RuntimeBinderInternalCompilerException` and assertion failure.

Fixes #23020