### PR TITLE
Prevent unnecessary AIA fetches of trusted roots

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -418,6 +418,8 @@ namespace Internal.Cryptography.Pal
                     extraStore,
                     userIntermediateCerts,
                     systemIntermediateCerts,
+                    userRootCerts,
+                    systemRootCerts,
                 };
 
                 while (toProcess.Count > 0)


### PR DESCRIPTION
The "Simplify X509Chain" change no longer used userRootCerts or
systemRootCerts in FindCandidates. Since the eventual chain build would get
them from the trusted path there's not a functional difference, but
FindCandidates was doing an AIA fetch for the root certificates so it could
complete it locally.

This means that a lot of cert chain attempts use the network when they don't need to.

So just keep those certs in the scan list to revert the network use regression.