### PR TITLE
Add DiaSymReader to list of included packages in test-runtime depproj.

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -85,6 +85,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageToInclude Include="Microsoft.DiaSymReader.Native"/>
     <PackageToInclude Include="xunit.abstractions"/>
     <PackageToInclude Include="xunit.assert"/>
     <PackageToInclude Include="xunit.extensibility.core"/>

--- a/src/shims/manual/System.csproj
+++ b/src/shims/manual/System.csproj
@@ -25,7 +25,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.forwards.cs" />
-    <ReferencePath Include="$(RuntimePath)System.*.dll;$(RuntimePath)Microsoft.*.dll" Exclude="$(RuntimePath)Microsoft.Diagnostics.Tracing.TraceEvent.dll" />
+    <ReferencePath
+      Include="$(RuntimePath)System.*.dll;$(RuntimePath)Microsoft.*.dll"
+      Exclude="$(RuntimePath)Microsoft.Diagnostics.Tracing.TraceEvent.dll;$(RuntimePath)Microsoft.DiaSymReader.Native.*.dll" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/shims/manual/mscorlib.csproj
+++ b/src/shims/manual/mscorlib.csproj
@@ -25,7 +25,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="mscorlib.forwards.cs" />
-    <ReferencePath Include="$(RuntimePath)System.*.dll;$(RuntimePath)Microsoft.*.dll" Exclude="$(RuntimePath)Microsoft.Diagnostics.Tracing.TraceEvent.dll" />
+    <ReferencePath
+      Include="$(RuntimePath)System.*.dll;$(RuntimePath)Microsoft.*.dll"
+      Exclude="$(RuntimePath)Microsoft.Diagnostics.Tracing.TraceEvent.dll;$(RuntimePath)Microsoft.DiaSymReader.Native.*.dll" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Depproj files do some filtering based on this ItemGroup. By adding this entry here, the native binary for DiaSymReader will be copied into the test shared framework, and we should get line numbers on all Windows runs.

@danmosemsft @ericstj 