### PR TITLE
Remove unnecessary GetTypeInfo from Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1155,7 +1155,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             {
                 type = type.GetGenericTypeDefinition();
             }
-            Type[] interfaces = type.GetTypeInfo().ImplementedInterfaces.ToArray();
+            Type[] interfaces = type.GetInterfaces();
 
             // We won't be able to find the difference between Ifaces and
             // IfacesAll anymore - at runtime, the class implements all of its


### PR DESCRIPTION
While `ImplementedInterfaces` can be more efficient than `GetInterfaces` on WinRT (see https://github.com/dotnet/corefx/issues/16305#issuecomment-280969609) the subsequent use of `ToArray` undoes that, and makes it an efficiency lose on other platforms, so replace with `GetInterfaces`.

This is the last legacy of the reduced `System.Type` API surface in the assembly, so closes #8577