### PR TITLE
Roll back ILC version change to fix uapaot tests

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -13,8 +13,8 @@
     <CoreClrCurrentRef>7ce24ccbcd1224ae1e4bbfed40305db25885f1bc</CoreClrCurrentRef>
     <CoreSetupCurrentRef>7ce24ccbcd1224ae1e4bbfed40305db25885f1bc</CoreSetupCurrentRef>
     <ExternalCurrentRef>5a0606fccb09fce4b47545ae9896139acca547f5</ExternalCurrentRef>
-    <ProjectNTfsCurrentRef>7ce24ccbcd1224ae1e4bbfed40305db25885f1bc</ProjectNTfsCurrentRef>
-    <ProjectNTfsTestILCCurrentRef>7ce24ccbcd1224ae1e4bbfed40305db25885f1bc</ProjectNTfsTestILCCurrentRef>
+    <ProjectNTfsCurrentRef>61a476c71370f594ffa8063c6aca090200364b07</ProjectNTfsCurrentRef>
+    <ProjectNTfsTestILCCurrentRef>61a476c71370f594ffa8063c6aca090200364b07</ProjectNTfsTestILCCurrentRef>
     <SniCurrentRef>8bd1ec5fac9f0eec34ff6b34b1d878b4359e02dd</SniCurrentRef>
     <StandardCurrentRef>7ce24ccbcd1224ae1e4bbfed40305db25885f1bc</StandardCurrentRef>
   </PropertyGroup>
@@ -25,9 +25,9 @@
     <CoreFxExpectedPrerelease>preview2-25608-01</CoreFxExpectedPrerelease>
     <CoreClrPackageVersion>2.1.0-preview2-25608-01</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25322-00</ExternalExpectedPrerelease>
-    <ProjectNTfsExpectedPrerelease>beta-25608-00</ProjectNTfsExpectedPrerelease>
-    <ProjectNTfsTestILCExpectedPrerelease>beta-25608-00</ProjectNTfsTestILCExpectedPrerelease>
-    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25608-00</ProjectNTfsTestILCPackageVersion>
+    <ProjectNTfsExpectedPrerelease>beta-25604-00</ProjectNTfsExpectedPrerelease>
+    <ProjectNTfsTestILCExpectedPrerelease>beta-25604-00</ProjectNTfsTestILCExpectedPrerelease>
+    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25604-00</ProjectNTfsTestILCPackageVersion>
     <NETStandardPackageVersion>2.1.0-preview1-25607-02</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview2-25607-02</MicrosoftNETCoreAppPackageVersion>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,9 +3,9 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "TestILC.amd64ret": "1.0.0-beta-25608-00",
-        "TestILC.armret": "1.0.0-beta-25608-00",
-        "TestILC.x86ret": "1.0.0-beta-25608-00"
+        "TestILC.amd64ret": "1.0.0-beta-25604-00",
+        "TestILC.armret": "1.0.0-beta-25604-00",
+        "TestILC.x86ret": "1.0.0-beta-25604-00"
       }
     }
   }


### PR DESCRIPTION
All our corefx uapaot tests are failing to ILC in master so rolling back the version to fix it.

@tijoytom when do we expect this fix to go in? If it is going to take a while I would rather just disable updates on ILC until you are done.