### PR TITLE
Various fixes for Unix Pen and CustomLineCap.

### DIFF
--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -192,6 +192,7 @@
     <Compile Include="System\Drawing\ColorTranslator.cs" />
     <Compile Include="System\Drawing\ContentAlignment.cs" />
     <Compile Include="System\Drawing\CopyPixelOperation.cs" />
+    <Compile Include="System\Drawing\Drawing2D\CustomLineCap.Windows.cs" />
     <Compile Include="System\Drawing\Drawing2D\GraphicsContainer.cs" />
     <Compile Include="System\Drawing\Drawing2D\GraphicsPath.cs" />
     <Compile Include="System\Drawing\Drawing2D\LinearGradientBrush.cs" />
@@ -214,6 +215,7 @@
     <Compile Include="System\Drawing\Internal\GPStream.cs" />
     <Compile Include="System\Drawing\Internal\SystemColorTracker.cs" />
     <Compile Include="System\Drawing\LocalAppContextSwitches.cs" />
+    <Compile Include="System\Drawing\Pen.Windows.cs" />
     <Compile Include="System\Drawing\Printing\DefaultPrintController.cs" />
     <Compile Include="System\Drawing\Printing\ModeField.cs" />
     <Compile Include="System\Drawing\Printing\PageSettings.cs" />
@@ -300,6 +302,7 @@
     <Compile Include="Unix\System.Drawing\ImageAnimator.cs" />
     <Compile Include="Unix\System.Drawing\Image.cs" />
     <Compile Include="Unix\System.Drawing\KnownColors.cs" />
+    <Compile Include="System\Drawing\Pen.Unix.cs" />
     <Compile Include="Unix\System.Drawing\Region.cs" />
     <Compile Include="Unix\System.Drawing\SRDescriptionAttribute.cs" />
     <Compile Include="Unix\System.Drawing\StringFormat.cs" />
@@ -307,6 +310,8 @@
     <Compile Include="Unix\System.Drawing\SystemFonts.cs" />
     <Compile Include="Unix\System.Drawing\SystemIcons.cs" />
     <Compile Include="Unix\System.Drawing\ToolboxBitmapAttribute.cs" />
+    <Compile Include="System\Drawing\Drawing2D\AdjustableArrowCap.Unix.cs" />
+    <Compile Include="System\Drawing\Drawing2D\CustomLineCap.Unix.cs" />
     <Compile Include="Unix\System.Drawing.Drawing2D\GraphicsContainer.cs" />
     <Compile Include="Unix\System.Drawing.Drawing2D\GraphicsPath.cs" />
     <Compile Include="Unix\System.Drawing.Drawing2D\LinearGradientBrush.cs" />

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/AdjustableArrowCap.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/AdjustableArrowCap.Unix.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Drawing.Drawing2D
+{
+    public sealed partial class AdjustableArrowCap : CustomLineCap
+    {
+        public override object Clone()
+        {
+            IntPtr clonedCap;
+            int status = SafeNativeMethods.Gdip.GdipCloneCustomLineCap(new HandleRef(this, nativeCap), out clonedCap);
+
+            if (status != SafeNativeMethods.Gdip.Ok)
+                throw SafeNativeMethods.Gdip.StatusException(status);
+
+            return new AdjustableArrowCap(clonedCap);
+        }
+    }
+}

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/AdjustableArrowCap.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/AdjustableArrowCap.Unix.cs
@@ -12,9 +12,7 @@ namespace System.Drawing.Drawing2D
         {
             IntPtr clonedCap;
             int status = SafeNativeMethods.Gdip.GdipCloneCustomLineCap(new HandleRef(this, nativeCap), out clonedCap);
-
-            if (status != SafeNativeMethods.Gdip.Ok)
-                throw SafeNativeMethods.Gdip.StatusException(status);
+            SafeNativeMethods.Gdip.CheckStatus(status);
 
             return new AdjustableArrowCap(clonedCap);
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/AdjustableArrowCap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/AdjustableArrowCap.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Drawing.Drawing2D
 {
-    public sealed class AdjustableArrowCap : CustomLineCap
+    public sealed partial class AdjustableArrowCap : CustomLineCap
     {
         internal AdjustableArrowCap(IntPtr nativeCap) : base(nativeCap) { }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/CustomLineCap.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/CustomLineCap.Unix.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Drawing.Drawing2D
+{    
+    public partial class CustomLineCap
+    {
+        internal static CustomLineCap CreateCustomLineCapObject(IntPtr cap)
+        {
+            // libgdiplus does not implement GdipGetCustomLineCapType, so it will not correctly handle
+            // AdjustableArrowCap objects.
+            return new CustomLineCap(cap);
+        }
+    }
+}

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/CustomLineCap.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/CustomLineCap.Windows.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Drawing.Drawing2D
+{    
+    public partial class CustomLineCap
+    {
+        internal static CustomLineCap CreateCustomLineCapObject(IntPtr cap)
+        {
+            int status = SafeNativeMethods.Gdip.GdipGetCustomLineCapType(new HandleRef(null, cap), out CustomLineCapType capType);
+
+            if (status != SafeNativeMethods.Gdip.Ok)
+            {
+                SafeNativeMethods.Gdip.GdipDeleteCustomLineCap(new HandleRef(null, cap));
+                throw SafeNativeMethods.Gdip.StatusException(status);
+            }
+
+            switch (capType)
+            {
+                case CustomLineCapType.Default:
+                    return new CustomLineCap(cap);
+
+                case CustomLineCapType.AdjustableArrowCap:
+                    return new AdjustableArrowCap(cap);
+            }
+
+            SafeNativeMethods.Gdip.GdipDeleteCustomLineCap(new HandleRef(null, cap));
+            throw SafeNativeMethods.Gdip.StatusException(SafeNativeMethods.Gdip.NotImplemented);
+        }
+    }
+}

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/CustomLineCap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/CustomLineCap.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Drawing.Drawing2D
 {    
-    public class CustomLineCap : MarshalByRefObject, ICloneable, IDisposable
+    public partial class CustomLineCap : MarshalByRefObject, ICloneable, IDisposable
     {
 #if FINALIZATION_WATCH
         private string allocationSite = Graphics.GetAllocationStack();
@@ -74,7 +74,7 @@ namespace System.Drawing.Drawing2D
 
         ~CustomLineCap() => Dispose(false);
 
-        public object Clone()
+        public virtual object Clone()
         {
             IntPtr clonedCap;
             int status = SafeNativeMethods.Gdip.GdipCloneCustomLineCap(new HandleRef(this, nativeCap), out clonedCap);
@@ -83,29 +83,6 @@ namespace System.Drawing.Drawing2D
                 throw SafeNativeMethods.Gdip.StatusException(status);
 
             return CreateCustomLineCapObject(clonedCap);
-        }
-
-        internal static CustomLineCap CreateCustomLineCapObject(IntPtr cap)
-        {
-            int status = SafeNativeMethods.Gdip.GdipGetCustomLineCapType(new HandleRef(null, cap), out CustomLineCapType capType);
-
-            if (status != SafeNativeMethods.Gdip.Ok)
-            {
-                SafeNativeMethods.Gdip.GdipDeleteCustomLineCap(new HandleRef(null, cap));
-                throw SafeNativeMethods.Gdip.StatusException(status);
-            }
-
-            switch (capType)
-            {
-                case CustomLineCapType.Default:
-                    return new CustomLineCap(cap);
-
-                case CustomLineCapType.AdjustableArrowCap:
-                    return new AdjustableArrowCap(cap);
-            }
-
-            SafeNativeMethods.Gdip.GdipDeleteCustomLineCap(new HandleRef(null, cap));
-            throw SafeNativeMethods.Gdip.StatusException(SafeNativeMethods.Gdip.NotImplemented);
         }
 
         public void SetStrokeCaps(LineCap startCap, LineCap endCap)

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.Unix.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing.Drawing2D;
+using System.Runtime.InteropServices;
+
+namespace System.Drawing
+{
+    public partial class Pen
+    {
+        // libgdiplus does not implement GdipGetPenCustomEndCap, so we cache the last-known value here.
+        // Note that this value is not necessarily in sync with the true native value of this property,
+        // as it could have been set outside of the CustomEndCap property on this type.
+        private CustomLineCap _cachedEndCap;
+
+        /// <summary>
+        /// Gets or sets a custom cap style to use at the beginning of lines drawn with this <see cref='Pen'/>.
+        /// </summary>
+        public CustomLineCap CustomStartCap
+        {
+            get
+            {
+                IntPtr lineCap = IntPtr.Zero;
+                int status = SafeNativeMethods.Gdip.GdipGetPenCustomStartCap(new HandleRef(this, NativePen), out lineCap);
+                SafeNativeMethods.Gdip.CheckStatus(status);
+                if (lineCap == IntPtr.Zero)
+                {
+                    throw new ArgumentException(SR.Format(SR.GdiplusInvalidParameter));
+                }
+
+                return CustomLineCap.CreateCustomLineCapObject(lineCap);
+            }
+            set
+            {
+                if (_immutable)
+                {
+                    throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
+                }
+
+                int status = SafeNativeMethods.Gdip.GdipSetPenCustomStartCap(new HandleRef(this, NativePen),
+                                                              new HandleRef(value, (value == null) ? IntPtr.Zero : value.nativeCap));
+                SafeNativeMethods.Gdip.CheckStatus(status);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a custom cap style to use at the end of lines drawn with this <see cref='Pen'/>.
+        /// </summary>
+        public CustomLineCap CustomEndCap
+        {
+            get
+            {
+                // If the CustomEndCap has never been set, this accessor should throw.
+                if (_cachedEndCap == null)
+                {
+                    throw new ArgumentException(SR.Format(SR.GdiplusInvalidParameter));
+                }
+
+                return _cachedEndCap;
+            }
+            set
+            {
+                if (_immutable)
+                {
+                    throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
+                }
+
+                // Windows GDI+ clones the CustomLineCap before storing it in the Pen.
+                CustomLineCap clone = value == null ? null : (CustomLineCap)value.Clone();
+
+                int status = SafeNativeMethods.Gdip.GdipSetPenCustomEndCap(
+                    new HandleRef(this, NativePen),
+                    new HandleRef(clone, (clone == null) ? IntPtr.Zero : clone.nativeCap));
+                SafeNativeMethods.Gdip.CheckStatus(status);
+                _cachedEndCap = clone;
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.Windows.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing.Drawing2D;
+using System.Runtime.InteropServices;
+
+namespace System.Drawing
+{
+    public partial class Pen
+    {
+        /// <summary>
+        /// Gets or sets a custom cap style to use at the beginning of lines drawn with this <see cref='Pen'/>.
+        /// </summary>
+        public CustomLineCap CustomStartCap
+        {
+            get
+            {
+                IntPtr lineCap = IntPtr.Zero;
+                int status = SafeNativeMethods.Gdip.GdipGetPenCustomStartCap(new HandleRef(this, NativePen), out lineCap);
+                SafeNativeMethods.Gdip.CheckStatus(status);
+
+                return CustomLineCap.CreateCustomLineCapObject(lineCap);
+            }
+            set
+            {
+                if (_immutable)
+                {
+                    throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
+                }
+
+                int status = SafeNativeMethods.Gdip.GdipSetPenCustomStartCap(new HandleRef(this, NativePen),
+                                                              new HandleRef(value, (value == null) ? IntPtr.Zero : value.nativeCap));
+                SafeNativeMethods.Gdip.CheckStatus(status);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a custom cap style to use at the end of lines drawn with this <see cref='Pen'/>.
+        /// </summary>
+        public CustomLineCap CustomEndCap
+        {
+            get
+            {
+                IntPtr lineCap = IntPtr.Zero;
+                int status = SafeNativeMethods.Gdip.GdipGetPenCustomEndCap(new HandleRef(this, NativePen), out lineCap);
+                SafeNativeMethods.Gdip.CheckStatus(status);
+                return CustomLineCap.CreateCustomLineCapObject(lineCap);
+            }
+            set
+            {
+                if (_immutable)
+                {
+                    throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
+                }
+
+                int status = SafeNativeMethods.Gdip.GdipSetPenCustomEndCap(
+                    new HandleRef(this, NativePen),
+                    new HandleRef(value, (value == null) ? IntPtr.Zero : value.nativeCap));
+                SafeNativeMethods.Gdip.CheckStatus(status);
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -14,7 +14,7 @@ namespace System.Drawing
     /// <summary>
     /// Defines an object used to draw lines and curves.
     /// </summary>
-    public sealed class Pen : MarshalByRefObject, ICloneable, IDisposable
+    public sealed partial class Pen : MarshalByRefObject, ICloneable, IDisposable
 #if FEATURE_SYSTEM_EVENTS
         , ISystemColorTracker
 #endif
@@ -360,58 +360,6 @@ namespace System.Drawing
         }
 
         /// <summary>
-        /// Gets or sets a custom cap style to use at the beginning of lines drawn with this <see cref='Pen'/>.
-        /// </summary>
-        public CustomLineCap CustomStartCap
-        {
-            get
-            {
-                IntPtr lineCap = IntPtr.Zero;
-                int status = SafeNativeMethods.Gdip.GdipGetPenCustomStartCap(new HandleRef(this, NativePen), out lineCap);
-                SafeNativeMethods.Gdip.CheckStatus(status);
-
-                return CustomLineCap.CreateCustomLineCapObject(lineCap);
-            }
-            set
-            {
-                if (_immutable)
-                {
-                    throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
-                }
-
-                int status = SafeNativeMethods.Gdip.GdipSetPenCustomStartCap(new HandleRef(this, NativePen),
-                                                              new HandleRef(value, (value == null) ? IntPtr.Zero : value.nativeCap));
-                SafeNativeMethods.Gdip.CheckStatus(status);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a custom cap style to use at the end of lines drawn with this <see cref='Pen'/>.
-        /// </summary>
-        public CustomLineCap CustomEndCap
-        {
-            get
-            {
-                IntPtr lineCap = IntPtr.Zero;
-                int status = SafeNativeMethods.Gdip.GdipGetPenCustomEndCap(new HandleRef(this, NativePen), out lineCap);
-                SafeNativeMethods.Gdip.CheckStatus(status);
-
-                return CustomLineCap.CreateCustomLineCapObject(lineCap);
-            }
-            set
-            {
-                if (_immutable)
-                {
-                    throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
-                }
-
-                int status = SafeNativeMethods.Gdip.GdipSetPenCustomEndCap(new HandleRef(this, NativePen),
-                                                            new HandleRef(value, (value == null) ? IntPtr.Zero : value.nativeCap));
-                SafeNativeMethods.Gdip.CheckStatus(status);
-            }
-        }
-
-        /// <summary>
         /// Gets or sets the limit of the thickness of the join on a mitered corner.
         /// </summary>
         public float MiterLimit
@@ -516,6 +464,12 @@ namespace System.Drawing
         /// </summary>
         public void MultiplyTransform(Matrix matrix, MatrixOrder order)
         {
+            if (matrix.nativeMatrix == IntPtr.Zero)
+            {
+                // Disposed matrices should result in a no-op.
+                return;
+            }
+
             int status = SafeNativeMethods.Gdip.GdipMultiplyPenTransform(new HandleRef(this, NativePen),
                                                           new HandleRef(matrix, matrix.nativeMatrix),
                                                           order);

--- a/src/System.Drawing.Common/tests/Drawing2D/AdjustableArrowCapTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/AdjustableArrowCapTests.cs
@@ -114,7 +114,6 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Clone_Success()
         {

--- a/src/System.Drawing.Common/tests/PenTests.cs
+++ b/src/System.Drawing.Common/tests/PenTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing.Drawing2D;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Drawing.Tests
@@ -19,7 +20,6 @@ namespace System.Drawing.Tests
             yield return new object[] { new PathGradientBrush(new Point[] { new Point(1, 2), new Point(2, 3) }), PenType.PathGradient };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(Ctor_Brush_TestData))]
         public void Ctor_Brush<T>(T brush, PenType penType) where T : Brush
@@ -52,7 +52,6 @@ namespace System.Drawing.Tests
             yield return new object[] { new SolidBrush(Color.Red), float.MaxValue, PenType.SolidColor };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(Ctor_Brush_Width_TestData))]
         public void Ctor_Brush_Width<T>(T brush, float width, PenType expectedPenType) where T : Brush
@@ -99,7 +98,6 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Pen(brush, 10));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Ctor_Color()
         {
@@ -110,7 +108,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(-1)]
         [InlineData(0)]
@@ -144,7 +141,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(PenAlignment.Center - 1)]
         [InlineData(PenAlignment.Right + 1)]
@@ -170,7 +166,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(Ctor_Brush_TestData))]
         public void Brush_SetValid_GetReturnsExpected<T>(T brush, PenType penType) where  T : Brush
@@ -197,7 +192,6 @@ namespace System.Drawing.Tests
             public override object Clone() => this;
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Brush_SetNullBrush_ThrowsArgumentNullException()
         {
@@ -286,25 +280,35 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Color_HatchBrush_ThrowsArgumentException()
         {
             using (var brush = new HatchBrush(HatchStyle.BackwardDiagonal, Color.Red))
             using (var pen = new Pen(brush))
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Color);
+                ValidateInitialPenColorState(pen);
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Color_LinearGradientBrush_ThrowsArgumentException()
         {
             using (var brush = new LinearGradientBrush(Point.Empty, new Point(1, 2), Color.Blue, Color.Red))
             using (var pen = new Pen(brush))
             {
+                ValidateInitialPenColorState(pen);
+            }
+        }
+
+        private void ValidateInitialPenColorState(Pen pen)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
                 AssertExtensions.Throws<ArgumentException>(null, () => pen.Color);
+            }
+            else
+            {
+                Assert.Equal(Color.FromArgb(0), pen.Color);
             }
         }
 
@@ -329,7 +333,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Color_GetSetWhenDisposedWithoutBrush_Success()
         {
@@ -426,7 +429,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void CustomEndCap_SetValid_GetReturnsExpected()
         {
@@ -446,7 +448,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void CustomEndCap_SetNull_ThrowsArgumentException()
         {
@@ -472,7 +473,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void CustomEndCap_GetSetWhenDisposed_ThrowsArgumentException()
         {
@@ -489,7 +489,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void CustomStartCap_SetValid_GetReturnsExpected()
         {
@@ -509,7 +508,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void CustomStartCap_SetNull_ThrowsArgumentException()
         {
@@ -535,7 +533,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void CustomStartCap_GetSetWhenDisposed_ThrowsArgumentException()
         {
@@ -566,7 +563,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(DashCap.Flat - 1)]
         [InlineData(DashCap.Round - 1)]
@@ -643,7 +639,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void DashPattern_SetNullPattern_ThrowsArgumentException()
         {
@@ -691,7 +686,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(DashStyle.Dash, new float[] { 3, 1 })]
         [InlineData(DashStyle.DashDot, new float[] { 3, 1, 1, 1 })]
@@ -732,7 +726,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(DashStyle.Solid - 1)]
         [InlineData(DashStyle.Custom + 1)]
@@ -794,7 +787,6 @@ namespace System.Drawing.Tests
             yield return new object[] { LineCap.Custom + 1 };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(LineCap_Invalid_TestData))]
         public void EndCap_SetInvalid_ThrowsInvalidEnumArgumentException(LineCap lineCap)
@@ -834,7 +826,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(LineJoin.Miter - 1)]
         [InlineData(LineJoin.MiterClipped + 1)]
@@ -952,7 +943,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void MultiplyTransform_DisposedMatrix_Nop()
         {
@@ -1216,7 +1206,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(LineCap_Invalid_TestData))]
         public void StartCap_SetInvalid_ThrowsInvalidEnumArgumentException(LineCap lineCap)
@@ -1258,7 +1247,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Transform_SetNull_ThrowsArgumentNullException()
         {

--- a/src/System.Drawing.Common/tests/SystemPensTest.cs
+++ b/src/System.Drawing.Common/tests/SystemPensTest.cs
@@ -49,7 +49,6 @@ namespace System.Drawing.Tests
 
         public static object[] Pen(Func<Pen> getPen, Color expectedColor) => new object[] { getPen, expectedColor };
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(SystemPens_TestData))]
         public void SystemPens_Get_ReturnsExpected(Func<Pen> getPen, Color expectedColor)


### PR DESCRIPTION
Pen changes
* Fix behavior of Pen.CustomEndCap/StartCap on Unix.
  * Use a cached value for CustomEndCap, because a get accessor is not available via libgdiplus.
  * Try to match the exception behavior of Windows for these two properties.
  * Correctly clone CustomLineCap objects before storing them in set_CustomEndCap / set_CustomStartCap.
  * MultiplyTransform now explicitly checks for a disposed matrix before using it. libgdiplus does not ignored null matrix handles -- it throws an exception.
  * Re-enable all Pen tests on all platforms.

CustomLineCap changes
* Stop using unavailable GdipGetCustomLineCapType function on Unix
* Allow AdjustableArrowCap objects to be successfully cloned despite the above