### PR TITLE
Remove Microsoft.CSharp.RuntimeBinder.Semantics.SymbolLoader.FCanLift

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -911,7 +911,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                     0,
                                     false));
                 }
-                else if (GetSymbolLoader().FCanLift() && typeParam.IsNonNubValType() &&
+                else if (typeParam.IsNonNubValType() &&
                          GetTypes().SubstType(methCur.RetType, atsCur).IsNonNubValType() &&
                          canConvert(arg, nubParam = GetTypes().GetNullable(typeParam)))
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -154,11 +154,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(rgbofs != null);
 
-            int ibos;
-            int ibosMinLift;
-
-            ibosMinLift = GetSymbolLoader().FCanLift() ? 0 : g_binopSignatures.Length;
-            for (ibos = 0; ibos < g_binopSignatures.Length; ibos++)
+            int ibosMinLift = 0;
+            for (int ibos = 0; ibos < g_binopSignatures.Length; ibos++)
             {
                 BinOpSig bos = g_binopSignatures[ibos];
                 if ((bos.mask & info.mask) == 0)
@@ -704,8 +701,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             else
             {
                 pgrflt = LiftFlags.None;
-                if (!GetSymbolLoader().FCanLift())
-                    return false;
                 typeDst = GetSymbolLoader().GetTypeManager().GetNullable(typeDst);
                 if (!canConvert(info.arg1, typeDst))
                     return false;
@@ -740,8 +735,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             else
             {
                 pgrflt = LiftFlags.None;
-                if (!GetSymbolLoader().FCanLift())
-                    return false;
                 typeDst = GetSymbolLoader().GetTypeManager().GetNullable(typeDst);
                 if (!canConvert(info.arg2, typeDst))
                     return false;
@@ -1490,7 +1483,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(pArgument != null);
             Debug.Assert(pArgument.Type != null);
 
-            long iuosMinLift = GetSymbolLoader().FCanLift() ? 0 : g_rguos.Length;
+            long iuosMinLift = 0;
 
             CType pArgumentType = pArgument.Type;
             CType pRawType = pArgumentType.StripNubs();
@@ -2630,8 +2623,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     false));
                 return true;
             }
-            if (fDontLift || !GetSymbolLoader().FCanLift() ||
-                !UserDefinedBinaryOperatorCanBeLifted(ek, method, ats, paramsCur))
+            if (fDontLift || !UserDefinedBinaryOperatorCanBeLifted(ek, method, ats, paramsCur))
             {
                 return false;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -719,11 +719,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return pSource is TypeParameterType srcParType && HasImplicitTypeParameterBaseConversion(srcParType, pDest);
         }
 
-        public bool FCanLift()
-        {
-            return null != GetPredefAgg(PredefinedType.PT_G_OPTIONAL);
-        }
-
         public bool IsBaseAggregate(AggregateSymbol derived, AggregateSymbol @base)
         {
             Debug.Assert(!derived.IsEnum() && !@base.IsEnum());


### PR DESCRIPTION
Always returns true (flag for static compiling where nullable and hence lifting is not available).

Remove, and paths for it being false.