### PR TITLE
Remove VSFAIL from Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 switch (_typeDest.GetTypeKind())
                 {
                     default:
-                        VSFAIL("Bad type kind");
+                        Debug.Fail($"Bad type kind: {_typeDest.GetTypeKind()}");
                         return false;
                     case TypeKind.TK_VoidType:
                         return false; // Can't convert to a method group or anon method.
@@ -203,7 +203,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         Debug.Assert(valueSrc.Type == _typeSrc.StripNubs());
                         if (!_binder.BindExplicitConversion(valueSrc, valueSrc.Type, _exprTypeDest, _pDestinationTypeForLambdaErrorReporting, _needsExprDest, out _exprDest, _flags | CONVERTTYPE.NOUDC))
                         {
-                            VSFAIL("BindExplicitConversion failed unexpectedly");
+                            Debug.Fail("BindExplicitConversion failed unexpectedly");
                             return false;
                         }
                         if (_exprDest is ExprUserDefinedConversion udc)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -263,11 +263,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public BindingContext GetContext() { return Context; }
         private CNullable m_nullable;
 
-        private static void VSFAIL(string s)
-        {
-            Debug.Assert(false, s);
-        }
-
         public ExpressionBinder(BindingContext context)
         {
             Context = context;
@@ -1087,17 +1082,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private static ErrorCode GetStandardLvalueError(CheckLvalueKind kind)
         {
+            Debug.Assert(kind >= CheckLvalueKind.Assignment && kind <= CheckLvalueKind.Increment);
             switch (kind)
             {
-                default:
-                    VSFAIL("bad kind");
-                    return ErrorCode.ERR_AssgLvalueExpected;
-                case CheckLvalueKind.Assignment:
-                    return ErrorCode.ERR_AssgLvalueExpected;
                 case CheckLvalueKind.OutParameter:
                     return ErrorCode.ERR_RefLvalueExpected;
                 case CheckLvalueKind.Increment:
                     return ErrorCode.ERR_IncrementLvalueExpected;
+                default:
+                    return ErrorCode.ERR_AssgLvalueExpected;
             }
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
                         return true;
                     case TypeKind.TK_MethodGroupType:
-                        VSFAIL("Something is wrong with Type.IsNeverSameType()");
+                        Debug.Fail("Something is wrong with Type.IsNeverSameType()");
                         return false;
                     case TypeKind.TK_ArgumentListType:
                         return _typeSrc == _typeDest;
@@ -168,7 +168,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 switch (_typeSrc.GetTypeKind())
                 {
                     default:
-                        VSFAIL("Bad type symbol kind");
+                        Debug.Fail($"Bad type symbol kind: {_typeSrc.GetTypeKind()}");
                         break;
                     case TypeKind.TK_MethodGroupType:
                         if (_exprSrc is ExprMemberGroup memGrp)
@@ -416,18 +416,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Expr arg1 = _binder.mustCast(_exprSrc, typeSrcBase);
                     ExprClass arg2 = GetExprFactory().CreateClass(typeDstBase);
 
-                    bool convertible;
-                    if (0 != (_flags & CONVERTTYPE.ISEXPLICIT))
-                    {
-                        convertible = _binder.BindExplicitConversion(arg1, arg1.Type, arg2, typeDstBase, out arg1, _flags | CONVERTTYPE.NOUDC);
-                    }
-                    else
-                    {
-                        convertible = _binder.BindImplicitConversion(arg1, arg1.Type, arg2, typeDstBase, out arg1, _flags | CONVERTTYPE.NOUDC);
-                    }
+                    bool convertible = (_flags & CONVERTTYPE.ISEXPLICIT) != 0
+                        ? _binder.BindExplicitConversion(
+                            arg1, arg1.Type, arg2, typeDstBase, out arg1, _flags | CONVERTTYPE.NOUDC)
+                        : _binder.BindImplicitConversion(
+                            arg1, arg1.Type, arg2, typeDstBase, out arg1, _flags | CONVERTTYPE.NOUDC);
+
                     if (!convertible)
                     {
-                        VSFAIL("bind(Im|Ex)plicitConversion failed unexpectedly");
+                        Debug.Fail("bind(Im|Ex)plicitConversion failed unexpectedly");
                         return false;
                     }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.CSharp.RuntimeBinder.Errors;
@@ -175,7 +176,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 switch (cv1)
                 {
                     default:
-                        VSFAIL("Shouldn't happen!");
+                        Debug.Fail("Shouldn't happen!");
                         continue;
 
                     case ConvKind.None:
@@ -258,7 +259,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 switch (cv2)
                 {
                     default:
-                        VSFAIL("Shouldn't happen!");
+                        Debug.Fail("Shouldn't happen!");
                         continue;
                     case ConvKind.None:
                         continue;
@@ -1109,35 +1110,31 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 bt2 = WhichTypeIsBetter(bofs1.Type2(), bofs2.Type2(), type2);
             }
 
-            int res = 0;
+            int res;
 
+            Debug.Assert(Enum.IsDefined(typeof(BetterType), bt1));
+            Debug.Assert(Enum.IsDefined(typeof(BetterType), bt2));
             switch (bt1)
             {
-                default:
-                    VSFAIL("Shouldn't happen");
-                    break;
-                case BetterType.Same:
-                case BetterType.Neither:
-                    break;
                 case BetterType.Left:
-                    res--;
+                    res = -1;
                     break;
+
                 case BetterType.Right:
-                    res++;
+                    res = 1;
+                    break;
+
+                default:
+                    res = 0;
                     break;
             }
 
             switch (bt2)
             {
-                default:
-                    VSFAIL("Shouldn't happen");
-                    break;
-                case BetterType.Same:
-                case BetterType.Neither:
-                    break;
                 case BetterType.Left:
                     res--;
                     break;
+
                 case BetterType.Right:
                     res++;
                     break;
@@ -1226,7 +1223,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
 
                 default:
-                    VSFAIL("Bad op");
+                    Debug.Fail($"Bad op: {op}");
                     return false;
             }
             return true;
@@ -1504,7 +1501,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 switch (cv)
                 {
                     default:
-                        VSFAIL("Shouldn't happen!");
+                        Debug.Fail("Shouldn't happen!");
                         continue;
 
                     case ConvKind.None:
@@ -1640,18 +1637,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 bt = WhichTypeIsBetter(uofs1.GetType(), uofs2.GetType(), typeArg);
             }
 
+            Debug.Assert(Enum.IsDefined(typeof(BetterType), bt));
             switch (bt)
             {
-                default:
-                    VSFAIL("Shouldn't happen");
-                    return 0;
-                case BetterType.Same:
-                case BetterType.Neither:
-                    return 0;
                 case BetterType.Left:
                     return -1;
                 case BetterType.Right:
                     return +1;
+                default:
+                    return 0;
             }
         }
 
@@ -1870,7 +1864,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             switch (ek)
             {
                 default:
-                    VSFAIL("Bad kind");
+                    Debug.Fail($"Bad kind: {ek}");
                     typeRet = null;
                     break;
                 case ExpressionKind.Add:
@@ -2326,7 +2320,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     pBinopKind = BinOpKind.Equal;
                     break;
                 default:
-                    VSFAIL("Bad ek");
+                    Debug.Fail($"Bad ek: {ek}");
                     pBinopKind = BinOpKind.Add;
                     return false;
             }


### PR DESCRIPTION
Just a wrapper on `Debug.Fail` that won't be completely removed from release (but still won't do anything in release).

Replace with `Debug.Fail` or, when possible, with a more explicit assertion.