### PR TITLE
Some Microsoft.CSharp.RuntimeBinder.SymbolTable refactoring

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1735,81 +1735,84 @@ namespace Microsoft.CSharp.RuntimeBinder
                 {
                     object defValue = parameters[i].DefaultValue;
 #endif
-                    Type defType = defValue.GetType();
+                    switch (Type.GetTypeCode(defValue.GetType()))
+                    {
 
-                    if (defType == typeof(byte))
-                    {
-                        cv = ConstVal.Get((byte)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_BYTE);
+                        case TypeCode.Byte:
+                            cv = ConstVal.Get((byte)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_BYTE);
+                            break;
+
+                        case TypeCode.Int16:
+                            cv = ConstVal.Get((short)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_SHORT);
+                            break;
+
+                        case TypeCode.Int32:
+                            cv = ConstVal.Get((int)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_INT);
+                            break;
+
+                        case TypeCode.Int64:
+                            cv = ConstVal.Get((long)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_LONG);
+                            break;
+
+                        case TypeCode.Single:
+                            cv = ConstVal.Get((float)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_FLOAT);
+                            break;
+
+                        case TypeCode.Double:
+                            cv = ConstVal.Get((double)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_DOUBLE);
+                            break;
+
+                        case TypeCode.Decimal:
+                            cv = ConstVal.Get((decimal)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_DECIMAL);
+                            break;
+
+                        case TypeCode.Char:
+                            cv = ConstVal.Get((char)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_CHAR);
+                            break;
+
+                        case TypeCode.Boolean:
+                            cv = ConstVal.Get((bool)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_BOOL);
+                            break;
+
+                        case TypeCode.SByte:
+                            cv = ConstVal.Get((sbyte)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_SBYTE);
+                            break;
+
+                        case TypeCode.UInt16:
+                            cv = ConstVal.Get((ushort)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_USHORT);
+                            break;
+
+                        case TypeCode.UInt32:
+                            cv = ConstVal.Get((uint)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_UINT);
+                            break;
+
+                        case TypeCode.UInt64:
+                            cv = ConstVal.Get((ulong)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_ULONG);
+                            break;
+
+                        case TypeCode.String:
+                            cv = ConstVal.Get((string)defValue);
+                            cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_STRING);
+                            break;
                     }
-                    else if (defType == typeof(short))
-                    {
-                        cv = ConstVal.Get((short)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_SHORT);
-                    }
-                    else if (defType == typeof(int))
-                    {
-                        cv = ConstVal.Get((int)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_INT);
-                    }
-                    else if (defType == typeof(long))
-                    {
-                        cv = ConstVal.Get((long)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_LONG);
-                    }
-                    else if (defType == typeof(float))
-                    {
-                        cv = ConstVal.Get((float)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_FLOAT);
-                    }
-                    else if (defType == typeof(double))
-                    {
-                        cv = ConstVal.Get((double)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_DOUBLE);
-                    }
-                    else if (defType == typeof(decimal))
-                    {
-                        cv = ConstVal.Get((decimal)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_DECIMAL);
-                    }
-                    else if (defType == typeof(char))
-                    {
-                        cv = ConstVal.Get((char)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_CHAR);
-                    }
-                    else if (defType == typeof(bool))
-                    {
-                        cv = ConstVal.Get((bool)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_BOOL);
-                    }
-                    else if (defType == typeof(sbyte))
-                    {
-                        cv = ConstVal.Get((sbyte)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_SBYTE);
-                    }
-                    else if (defType == typeof(ushort))
-                    {
-                        cv = ConstVal.Get((ushort)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_USHORT);
-                    }
-                    else if (defType == typeof(uint))
-                    {
-                        cv = ConstVal.Get((uint)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_UINT);
-                    }
-                    else if (defType == typeof(ulong))
-                    {
-                        cv = ConstVal.Get((ulong)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_ULONG);
-                    }
-                    else if (defType == typeof(string))
-                    {
-                        cv = ConstVal.Get((string)defValue);
-                        cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_STRING);
-                    }
-                    // if we fall off the end of this cascading if, we get Object/null
+
+                    // if we hit no case in the switch, we get object/null
                     // because that's how we initialized the constval.
                 }
+
                 methProp.SetDefaultParameterValue(i, cvType, cv);
             }
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1667,8 +1667,8 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private void SetParameterAttributes(MethodOrPropertySymbol methProp, ParameterInfo[] parameters, int i)
         {
-            if (((parameters[i].Attributes & ParameterAttributes.Optional) != 0) &&
-                !parameters[i].ParameterType.IsByRef)
+            ParameterInfo parameter = parameters[i];
+            if ((parameter.Attributes & ParameterAttributes.Optional) != 0 && !parameter.ParameterType.IsByRef)
             {
                 methProp.SetOptionalParameter(i);
                 PopulateSymbolTableWithName("Value", new Type[] { typeof(Missing) }, typeof(Missing)); // We might need this later
@@ -1677,9 +1677,9 @@ namespace Microsoft.CSharp.RuntimeBinder
             object[] attrs;
 
             // Get MarshalAsAttribute
-            if ((parameters[i].Attributes & ParameterAttributes.HasFieldMarshal) != 0)
+            if ((parameter.Attributes & ParameterAttributes.HasFieldMarshal) != 0)
             {
-                if ((attrs = parameters[i].GetCustomAttributes(typeof(MarshalAsAttribute), false).ToArray()) != null
+                if ((attrs = parameter.GetCustomAttributes(typeof(MarshalAsAttribute), false).ToArray()) != null
                     && attrs.Length > 0)
                 {
                     MarshalAsAttribute attr = (MarshalAsAttribute)attrs[0];
@@ -1688,7 +1688,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             }
 
             // Get the various kinds of default values
-            if ((attrs = parameters[i].GetCustomAttributes(typeof(DateTimeConstantAttribute), false).ToArray()) != null
+            if ((attrs = parameter.GetCustomAttributes(typeof(DateTimeConstantAttribute), false).ToArray()) != null
                 && attrs.Length > 0)
             {
                 // Get DateTimeConstant
@@ -1699,7 +1699,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 CType cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_DATETIME);
                 methProp.SetDefaultParameterValue(i, cvType, cv);
             }
-            else if ((attrs = parameters[i].GetCustomAttributes(typeof(DecimalConstantAttribute), false).ToArray()) != null
+            else if ((attrs = parameter.GetCustomAttributes(typeof(DecimalConstantAttribute), false).ToArray()) != null
                 && attrs.Length > 0)
             {
                 // Get DecimalConstant
@@ -1710,8 +1710,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 CType cvType = _semanticChecker.SymbolLoader.GetPredefindType(PredefinedType.PT_DECIMAL);
                 methProp.SetDefaultParameterValue(i, cvType, cv);
             }
-            else if (((parameters[i].Attributes & ParameterAttributes.HasDefault) != 0) &&
-                !parameters[i].ParameterType.IsByRef)
+            else if ((parameter.Attributes & ParameterAttributes.HasDefault) != 0 && !parameter.ParameterType.IsByRef)
             {
                 // Only set a default value if we have one, and the type that we're
                 // looking at isn't a by ref type or a type parameter.
@@ -1721,13 +1720,13 @@ namespace Microsoft.CSharp.RuntimeBinder
 
                 // We need to use RawDefaultValue, because DefaultValue is too clever.
 #if UNSUPPORTEDAPI
-                if (parameters[i].RawDefaultValue != null)
+                if (parameter.RawDefaultValue != null)
                 {
-                    object defValue = parameters[i].RawDefaultValue;
+                    object defValue = parameter.RawDefaultValue;
 #else
-                if (parameters[i].DefaultValue != null)
+                if (parameter.DefaultValue != null)
                 {
-                    object defValue = parameters[i].DefaultValue;
+                    object defValue = parameter.DefaultValue;
 #endif
                     switch (Type.GetTypeCode(defValue.GetType()))
                     {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -425,7 +425,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                         continue;
                     }
 
-                    CType ctype = null;
+                    CType ctype;
                     if (t.IsGenericParameter && t.DeclaringType == genericDefinition)
                     {
                         ctype = LoadClassTypeParameter(agg, t);
@@ -533,8 +533,6 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             if (t.DeclaringMethod != null)
             {
-                MethodBase parentMethod = t.DeclaringMethod;
-
                 if (parentType.GetGenericArguments() == null || pos >= parentType.GetGenericArguments().Length)
                 {
                     return t;
@@ -898,8 +896,6 @@ namespace Microsoft.CSharp.RuntimeBinder
                 if (t.IsGenericParameter && t.DeclaringMethod != null)
                 {
                     MethodBase methodBase = t.DeclaringMethod;
-                    ParameterInfo[] parameters = methodBase.GetParameters();
-
                     bool bAdded = false;
 #if UNSUPPORTEDAPI
                     foreach (MethodInfo methinfo in Enumerable.Where(t.DeclaringType.GetRuntimeMethods(), m => m.MetadataToken == methodBase.MetadataToken))
@@ -1121,8 +1117,6 @@ namespace Microsoft.CSharp.RuntimeBinder
             }
 
             agg.SetSealed(type.IsSealed);
-
-            AggregateType baseAggType = agg.getThisType();
             if (type.BaseType != null)
             {
                 // type.BaseType can be null for Object or for interface types.


### PR DESCRIPTION
* Define `AddMethodToSymbolTable` as taking `MethodBase`

`AddMethodToSymbolTable` is called with a `MemberInfo` that can be either a `MethodInfo` or a `ConstructorInfo`, and takes different paths for each.

Much of what these paths do is a duplication of calls that are available through those types common `MethodBase` base.

Change the parameter type to `MethodBase` and use it as much as possible.

* Replace if-else ladder on Type with switch on `TypeCode`

* Remove some unused locals and assignments