### PR TITLE
Add Span-based overloads to HashAlgorithm and IncrementalHash

### DIFF
--- a/src/Common/src/Internal/Cryptography/HashProvider.cs
+++ b/src/Common/src/Internal/Cryptography/HashProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
 
 namespace Internal.Cryptography
 {
@@ -29,15 +28,15 @@ namespace Internal.Cryptography
             if (data.Length - offset < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
-            AppendHashDataCore(data, offset, count);
+            AppendHashData(new ReadOnlySpan<byte>(data, offset, count));
         }
 
-        // Adds new data to be hashed. This can be called repeatedly in order to hash data from noncontiguous sources.
-        // Argument validation is handled by AppendHashData.
-        public abstract void AppendHashDataCore(byte[] data, int offset, int count);
-
+        public abstract void AppendHashData(ReadOnlySpan<byte> data);
+        
         // Compute the hash based on the appended data and resets the HashProvider for more hashing.
         public abstract byte[] FinalizeHashAndReset();
+
+        public abstract bool TryFinalizeHashAndReset(Span<byte> destination, out int bytesWritten);
 
         // Returns the length of the byte array returned by FinalizeHashAndReset.
         public abstract int HashSizeInBytes { get; }
@@ -53,4 +52,3 @@ namespace Internal.Cryptography
         public abstract void Dispose(bool disposing);
     }
 }
-

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
@@ -16,11 +16,27 @@ internal static partial class Interop
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestCreate")]
         internal static extern SafeDigestCtxHandle DigestCreate(PAL_HashAlgorithm algorithm, out int cbDigest);
 
+        internal static unsafe int DigestUpdate(SafeDigestCtxHandle ctx, ReadOnlySpan<byte> pbData, int cbData)
+        {
+            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
+            {
+                return DigestUpdate(ctx, pbDataPtr, cbData);
+            }
+        }
+
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestUpdate")]
-        internal static extern unsafe int DigestUpdate(SafeDigestCtxHandle ctx, byte* pbData, int cbData);
+        private static extern unsafe int DigestUpdate(SafeDigestCtxHandle ctx, byte* pbData, int cbData);
+
+        internal static unsafe int DigestFinal(SafeDigestCtxHandle ctx, Span<byte> pbOutput, int cbOutput)
+        {
+            fixed (byte* pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
+            {
+                return DigestFinal(ctx, pbOutputPtr, cbOutput);
+            }
+        }
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestFinal")]
-        internal static extern unsafe int DigestFinal(SafeDigestCtxHandle ctx, byte* pbOutput, int cbOutput);
+        private static extern unsafe int DigestFinal(SafeDigestCtxHandle ctx, byte* pbOutput, int cbOutput);
     }
 }
 

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
@@ -17,13 +17,29 @@ internal static partial class Interop
         internal static extern SafeHmacHandle HmacCreate(PAL_HashAlgorithm algorithm, ref int cbDigest);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacInit")]
-        internal static extern unsafe int HmacInit(SafeHmacHandle ctx, byte* pbKey, int cbKey);
+        internal static extern unsafe int HmacInit(SafeHmacHandle ctx, [In] byte[] pbKey, int cbKey);
+
+        internal static unsafe int HmacUpdate(SafeHmacHandle ctx, ReadOnlySpan<byte> pbData, int cbData)
+        {
+            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
+            {
+                return HmacUpdate(ctx, pbDataPtr, cbData);
+            }
+        }
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacUpdate")]
-        internal static extern unsafe int HmacUpdate(SafeHmacHandle ctx, byte* pbData, int cbData);
+        private static extern unsafe int HmacUpdate(SafeHmacHandle ctx, byte* pbData, int cbData);
+
+        internal static unsafe int HmacFinal(SafeHmacHandle ctx, ReadOnlySpan<byte> pbOutput, int cbOutput)
+        {
+            fixed (byte* pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
+            {
+                return HmacFinal(ctx, pbOutputPtr, cbOutput);
+            }
+        }
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacFinal")]
-        internal static extern unsafe int HmacFinal(SafeHmacHandle ctx, byte* pbOutput, int cbOutput);
+        private static extern unsafe int HmacFinal(SafeHmacHandle ctx, byte* pbOutput, int cbOutput);
     }
 }
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
@@ -19,8 +19,16 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestReset")]
         internal extern static int EvpDigestReset(SafeEvpMdCtxHandle ctx, IntPtr type);
 
+        internal static unsafe int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ReadOnlySpan<byte> d, int cnt)
+        {
+            fixed (byte* dPtr = &d.DangerousGetPinnableReference())
+            {
+                return EvpDigestUpdate(ctx, dPtr, cnt);
+            }
+        }
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestUpdate")]
-        internal extern static unsafe int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, byte* d, int cnt);
+        private extern static unsafe int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, byte* d, int cnt);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestFinalEx")]
         internal extern static unsafe int EvpDigestFinalEx(SafeEvpMdCtxHandle ctx, byte* md, ref uint s);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
@@ -19,8 +19,16 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacReset")]
         internal extern static int HmacReset(SafeHmacCtxHandle ctx);
 
+        internal static unsafe int HmacUpdate(SafeHmacCtxHandle ctx, ReadOnlySpan<byte> data, int len)
+        {
+            fixed (byte* dataPtr = &data.DangerousGetPinnableReference())
+            {
+                return HmacUpdate(ctx, dataPtr, len);
+            }
+        }
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacUpdate")]
-        internal extern static unsafe int HmacUpdate(SafeHmacCtxHandle ctx, byte* data, int len);
+        private extern static unsafe int HmacUpdate(SafeHmacCtxHandle ctx, byte* data, int len);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacFinal")]
         internal extern static unsafe int HmacFinal(SafeHmacCtxHandle ctx, byte* data, ref int len);

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptFinishHash.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptFinishHash.cs
@@ -2,18 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
-
 using Microsoft.Win32.SafeHandles;
 
 internal partial class Interop
 {
     internal partial class BCrypt
     {
+        internal static unsafe NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, byte[] pbOutput, int cbOutput, int dwFlags)
+        {
+            fixed (byte* ptr = pbOutput)
+            {
+                return BCryptFinishHash(hHash, ptr, cbOutput, dwFlags);
+            }
+        }
+
         [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        internal static extern NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, [Out] byte[] pbOutput, int cbOutput, int dwFlags);
+        internal static unsafe extern NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, byte* pbOutput, int cbOutput, int dwFlags);
     }
 }
 

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptFinishHash.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptFinishHash.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -9,16 +10,15 @@ internal partial class Interop
 {
     internal partial class BCrypt
     {
-        internal static unsafe NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, byte[] pbOutput, int cbOutput, int dwFlags)
+        internal static unsafe NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, Span<byte> pbOutput, int cbOutput, int dwFlags)
         {
-            fixed (byte* ptr = pbOutput)
+            fixed (byte* pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
             {
-                return BCryptFinishHash(hHash, ptr, cbOutput, dwFlags);
+                return BCryptFinishHash(hHash, pbOutputPtr, cbOutput, dwFlags);
             }
         }
 
         [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        internal static unsafe extern NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, byte* pbOutput, int cbOutput, int dwFlags);
+        private static unsafe extern NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, byte* pbOutput, int cbOutput, int dwFlags);
     }
 }
-

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptHashData.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptHashData.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 using Microsoft.Win32.SafeHandles;
@@ -12,8 +11,16 @@ internal partial class Interop
 {
     internal partial class BCrypt
     {
+        internal static unsafe NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, ReadOnlySpan<byte> pbInput, int cbInput, int dwFlags)
+        {
+            fixed (byte* pbInputPtr = &pbInput.DangerousGetPinnableReference())
+            {
+                return BCryptHashData(hHash, pbInputPtr, cbInput, dwFlags);
+            }
+        }
+
         [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        internal static extern unsafe NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, byte* pbInput, int cbInput, int dwFlags);
+        private static extern unsafe NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, byte* pbInput, int cbInput, int dwFlags);
     }
 }
 

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
@@ -8,6 +8,12 @@
 
 namespace System.Security.Cryptography
 {
+    public sealed partial class IncrementalHash : System.IDisposable
+    {
+        public void AppendData(ReadOnlySpan<byte> data) { }
+        public bool TryGetHashAndReset(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
     public abstract partial class RandomNumberGenerator : System.IDisposable
     {
         public virtual void GetBytes(Span<byte> data) { }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACMD5.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACMD5.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Security.Cryptography;
-
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -46,21 +42,22 @@ namespace System.Security.Cryptography
             }
         }
 
-        protected override void HashCore(byte[] rgb, int ib, int cb)
-        {
+        protected override void HashCore(byte[] rgb, int ib, int cb) =>
             _hMacCommon.AppendHashData(rgb, ib, cb);
-        }
 
-        protected override byte[] HashFinal()
-        {
-            return _hMacCommon.FinalizeHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _hMacCommon.AppendHashData(source);
+
+        protected override byte[] HashFinal() =>
+            _hMacCommon.FinalizeHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _hMacCommon.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public override void Initialize()
         {
             // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-            return;
         }
 
         protected override void Dispose(bool disposing)
@@ -68,9 +65,11 @@ namespace System.Security.Cryptography
             if (disposing)
             {
                 HMACCommon hMacCommon = _hMacCommon;
-                _hMacCommon = null;
                 if (hMacCommon != null)
+                {
+                    _hMacCommon = null;
                     hMacCommon.Dispose(disposing);
+                }
             }
             base.Dispose(disposing);
         }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
@@ -49,21 +49,22 @@ namespace System.Security.Cryptography
             }
         }
 
-        protected override void HashCore(byte[] rgb, int ib, int cb)
-        {
+        protected override void HashCore(byte[] rgb, int ib, int cb) =>
             _hMacCommon.AppendHashData(rgb, ib, cb);
-        }
 
-        protected override byte[] HashFinal()
-        {
-            return _hMacCommon.FinalizeHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _hMacCommon.AppendHashData(source);
+
+        protected override byte[] HashFinal() =>
+            _hMacCommon.FinalizeHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _hMacCommon.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public override void Initialize()
         {
             // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-            return;
         }
 
         protected override void Dispose(bool disposing)
@@ -71,9 +72,11 @@ namespace System.Security.Cryptography
             if (disposing)
             {
                 HMACCommon hMacCommon = _hMacCommon;
-                _hMacCommon = null;
                 if (hMacCommon != null)
+                {
+                    _hMacCommon = null;
                     hMacCommon.Dispose(disposing);
+                }
             }
             base.Dispose(disposing);
         }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA256.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA256.cs
@@ -46,21 +46,22 @@ namespace System.Security.Cryptography
             }
         }
 
-        protected override void HashCore(byte[] rgb, int ib, int cb)
-        {
+        protected override void HashCore(byte[] rgb, int ib, int cb) =>
             _hMacCommon.AppendHashData(rgb, ib, cb);
-        }
 
-        protected override byte[] HashFinal()
-        {
-            return _hMacCommon.FinalizeHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _hMacCommon.AppendHashData(source);
+
+        protected override byte[] HashFinal() =>
+            _hMacCommon.FinalizeHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _hMacCommon.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public override void Initialize()
         {
             // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-            return;
         }
 
         protected override void Dispose(bool disposing)
@@ -68,9 +69,11 @@ namespace System.Security.Cryptography
             if (disposing)
             {
                 HMACCommon hMacCommon = _hMacCommon;
-                _hMacCommon = null;
                 if (hMacCommon != null)
+                {
+                    _hMacCommon = null;
                     hMacCommon.Dispose(disposing);
+                }
             }
             base.Dispose(disposing);
         }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA384.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA384.cs
@@ -62,21 +62,22 @@ namespace System.Security.Cryptography
             }
         }
 
-        protected override void HashCore(byte[] rgb, int ib, int cb)
-        {
+        protected override void HashCore(byte[] rgb, int ib, int cb) =>
             _hMacCommon.AppendHashData(rgb, ib, cb);
-        }
 
-        protected override byte[] HashFinal()
-        {
-            return _hMacCommon.FinalizeHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _hMacCommon.AppendHashData(source);
+
+        protected override byte[] HashFinal() =>
+            _hMacCommon.FinalizeHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _hMacCommon.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public override void Initialize()
         {
             // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-            return;
         }
 
         protected override void Dispose(bool disposing)
@@ -84,9 +85,11 @@ namespace System.Security.Cryptography
             if (disposing)
             {
                 HMACCommon hMacCommon = _hMacCommon;
-                _hMacCommon = null;
                 if (hMacCommon != null)
+                {
+                    _hMacCommon = null;
                     hMacCommon.Dispose(disposing);
+                }
             }
             base.Dispose(disposing);
         }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA512.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA512.cs
@@ -60,21 +60,22 @@ namespace System.Security.Cryptography
             }
         }
 
-        protected override void HashCore(byte[] rgb, int ib, int cb)
-        {
+        protected override void HashCore(byte[] rgb, int ib, int cb) =>
             _hMacCommon.AppendHashData(rgb, ib, cb);
-        }
 
-        protected override byte[] HashFinal()
-        {
-            return _hMacCommon.FinalizeHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _hMacCommon.AppendHashData(source);
+
+        protected override byte[] HashFinal() =>
+            _hMacCommon.FinalizeHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _hMacCommon.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public override void Initialize()
         {
             // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-            return;
         }
 
         protected override void Dispose(bool disposing)
@@ -82,9 +83,11 @@ namespace System.Security.Cryptography
             if (disposing)
             {
                 HMACCommon hMacCommon = _hMacCommon;
-                _hMacCommon = null;
                 if (hMacCommon != null)
+                {
+                    _hMacCommon = null;
                     hMacCommon.Dispose(disposing);
+                }
             }
             base.Dispose(disposing);
         }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.cs
@@ -40,10 +40,7 @@ namespace System.Security.Cryptography
         /// <summary>
         /// Get the name of the algorithm being performed.
         /// </summary>
-        public HashAlgorithmName AlgorithmName
-        {
-            get { return _algorithmName; }
-        }
+        public HashAlgorithmName AlgorithmName => _algorithmName;
 
         /// <summary>
         /// Append the entire contents of <paramref name="data"/> to the data already processed in the hash or HMAC.
@@ -92,14 +89,24 @@ namespace System.Security.Cryptography
             if (_disposed)
                 throw new ObjectDisposedException(typeof(IncrementalHash).Name);
 
+            AppendData(new ReadOnlySpan<byte>(data, offset, count));
+        }
+
+        public void AppendData(ReadOnlySpan<byte> data)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(typeof(IncrementalHash).Name);
+            }
+
+            Debug.Assert((_hash != null) ^ (_hmac != null));
             if (_hash != null)
             {
-                _hash.AppendHashDataCore(data, offset, count);
+                _hash.AppendHashData(data);
             }
             else
             {
-                Debug.Assert(_hmac != null, "Both _hash and _hmac were null");
-                _hmac.AppendHashData(data, offset, count);
+                _hmac.AppendHashData(data);
             }
         }
 
@@ -113,21 +120,27 @@ namespace System.Security.Cryptography
         public byte[] GetHashAndReset()
         {
             if (_disposed)
+            {
                 throw new ObjectDisposedException(typeof(IncrementalHash).Name);
-
-            byte[] hashValue;
-
-            if (_hash != null)
-            {
-                hashValue = _hash.FinalizeHashAndReset();
-            }
-            else
-            {
-                Debug.Assert(_hmac != null, "Both _hash and _hmac were null");
-                hashValue = _hmac.FinalizeHashAndReset();
             }
 
-            return hashValue;
+            Debug.Assert((_hash != null) ^ (_hmac != null));
+            return _hash != null ?
+                _hash.FinalizeHashAndReset() :
+                _hmac.FinalizeHashAndReset();
+        }
+
+        public bool TryGetHashAndReset(Span<byte> destination, out int bytesWritten)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(typeof(IncrementalHash).Name);
+            }
+
+            Debug.Assert((_hash != null) ^ (_hmac != null));
+            return _hash != null ?
+                _hash.TryFinalizeHashAndReset(destination, out bytesWritten) :
+                _hmac.TryFinalizeHashAndReset(destination, out bytesWritten);
         }
 
         /// <summary>

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
@@ -33,13 +33,13 @@ namespace System.Security.Cryptography
             protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
                 _hashProvider.AppendHashData(array, ibStart, cbSize);
 
-            protected override void HashCore(ReadOnlySpan<byte> source) =>
+            protected sealed override void HashCore(ReadOnlySpan<byte> source) =>
                 _hashProvider.AppendHashData(source);
 
             protected sealed override byte[] HashFinal() =>
                 _hashProvider.FinalizeHashAndReset();
 
-            protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            protected sealed override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
                 _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
             public sealed override void Initialize()

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
@@ -16,15 +16,9 @@ namespace System.Security.Cryptography
     {
         protected MD5() { }
 
-        public static new MD5 Create()
-        {
-            return new Implementation();
-        }
+        public static new MD5 Create() => new Implementation();
 
-        public static new MD5 Create(String algName)
-        {
-            return (MD5)CryptoConfig.CreateFromName(algName);
-        }
+        public static new MD5 Create(String algName) => (MD5)CryptoConfig.CreateFromName(algName);
 
         private sealed class Implementation : MD5
         {
@@ -36,21 +30,22 @@ namespace System.Security.Cryptography
                 HashSizeValue = _hashProvider.HashSizeInBytes * 8;
             }
 
-            protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)
-            {
+            protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
                 _hashProvider.AppendHashData(array, ibStart, cbSize);
-            }
 
-            protected sealed override byte[] HashFinal()
-            {
-                return _hashProvider.FinalizeHashAndReset();
-            }
+            protected override void HashCore(ReadOnlySpan<byte> source) =>
+                _hashProvider.AppendHashData(source);
+
+            protected sealed override byte[] HashFinal() =>
+                _hashProvider.FinalizeHashAndReset();
+
+            protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+                _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
             public sealed override void Initialize()
             {
                 // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
                 // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-                return;
             }
 
             protected sealed override void Dispose(bool disposing)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1.cs
@@ -17,15 +17,9 @@ namespace System.Security.Cryptography
         protected SHA1() { }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "This is the implementaton of SHA1")]
-        public static new SHA1 Create()
-        {
-            return new Implementation();
-        }
+        public static new SHA1 Create() => new Implementation();
 
-        public static new SHA1 Create(string hashName)
-        {
-            return (SHA1)CryptoConfig.CreateFromName(hashName);
-        }
+        public static new SHA1 Create(string hashName) => (SHA1)CryptoConfig.CreateFromName(hashName);
 
         private sealed class Implementation : SHA1
         {
@@ -37,21 +31,22 @@ namespace System.Security.Cryptography
                 HashSizeValue = _hashProvider.HashSizeInBytes * 8;
             }
 
-            protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)
-            {
+            protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
                 _hashProvider.AppendHashData(array, ibStart, cbSize);
-            }
 
-            protected sealed override byte[] HashFinal()
-            {
-                return _hashProvider.FinalizeHashAndReset();
-            }
+            protected override void HashCore(ReadOnlySpan<byte> source) =>
+                _hashProvider.AppendHashData(source);
+
+            protected sealed override byte[] HashFinal() =>
+                _hashProvider.FinalizeHashAndReset();
+
+            protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+                _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
             public sealed override void Initialize()
             {
                 // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
                 // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-                return;
             }
 
             protected sealed override void Dispose(bool disposing)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1.cs
@@ -34,13 +34,13 @@ namespace System.Security.Cryptography
             protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
                 _hashProvider.AppendHashData(array, ibStart, cbSize);
 
-            protected override void HashCore(ReadOnlySpan<byte> source) =>
+            protected sealed override void HashCore(ReadOnlySpan<byte> source) =>
                 _hashProvider.AppendHashData(source);
 
             protected sealed override byte[] HashFinal() =>
                 _hashProvider.FinalizeHashAndReset();
 
-            protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            protected sealed override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
                 _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
             public sealed override void Initialize()

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1Managed.cs
@@ -22,13 +22,13 @@ namespace System.Security.Cryptography
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _hashProvider.AppendHashData(array, ibStart, cbSize);
 
-        protected override void HashCore(ReadOnlySpan<byte> source) =>
+        protected sealed override void HashCore(ReadOnlySpan<byte> source) =>
             _hashProvider.AppendHashData(source);
 
         protected sealed override byte[] HashFinal() =>
             _hashProvider.FinalizeHashAndReset();
 
-        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+        protected sealed override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
             _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public sealed override void Initialize()

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1Managed.cs
@@ -19,21 +19,22 @@ namespace System.Security.Cryptography
             HashSizeValue = _hashProvider.HashSizeInBytes * 8;
         }
 
-        protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
+        protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _hashProvider.AppendHashData(array, ibStart, cbSize);
-        }
 
-        protected sealed override byte[] HashFinal()
-        {
-            return _hashProvider.FinalizeHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _hashProvider.AppendHashData(source);
+
+        protected sealed override byte[] HashFinal() =>
+            _hashProvider.FinalizeHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public sealed override void Initialize()
         {
             // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-            return;
         }
 
         protected sealed override void Dispose(bool disposing)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256.cs
@@ -33,13 +33,13 @@ namespace System.Security.Cryptography
             protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
                 _hashProvider.AppendHashData(array, ibStart, cbSize);
 
-            protected override void HashCore(ReadOnlySpan<byte> source) =>
+            protected sealed override void HashCore(ReadOnlySpan<byte> source) =>
                 _hashProvider.AppendHashData(source);
 
             protected sealed override byte[] HashFinal() =>
                 _hashProvider.FinalizeHashAndReset();
 
-            protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            protected sealed override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
                 _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
             public sealed override void Initialize()

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256.cs
@@ -16,15 +16,9 @@ namespace System.Security.Cryptography
     {
         protected SHA256() { }
 
-        public static new SHA256 Create()
-        {
-            return new Implementation();
-        }
+        public static new SHA256 Create() => new Implementation();
 
-        public static new SHA256 Create(string hashName)
-        {
-            return (SHA256)CryptoConfig.CreateFromName(hashName);
-        }
+        public static new SHA256 Create(string hashName) => (SHA256)CryptoConfig.CreateFromName(hashName);
 
         private sealed class Implementation : SHA256
         {
@@ -36,21 +30,22 @@ namespace System.Security.Cryptography
                 HashSizeValue = _hashProvider.HashSizeInBytes * 8;
             }
 
-            protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)
-            {
+            protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
                 _hashProvider.AppendHashData(array, ibStart, cbSize);
-            }
 
-            protected sealed override byte[] HashFinal()
-            {
-                return _hashProvider.FinalizeHashAndReset();
-            }
+            protected override void HashCore(ReadOnlySpan<byte> source) =>
+                _hashProvider.AppendHashData(source);
+
+            protected sealed override byte[] HashFinal() =>
+                _hashProvider.FinalizeHashAndReset();
+
+            protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+                _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
             public sealed override void Initialize()
             {
                 // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
                 // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-                return;
             }
 
             protected sealed override void Dispose(bool disposing)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256Managed.cs
@@ -22,13 +22,13 @@ namespace System.Security.Cryptography
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _hashProvider.AppendHashData(array, ibStart, cbSize);
 
-        protected override void HashCore(ReadOnlySpan<byte> source) =>
+        protected sealed override void HashCore(ReadOnlySpan<byte> source) =>
             _hashProvider.AppendHashData(source);
 
         protected sealed override byte[] HashFinal() =>
             _hashProvider.FinalizeHashAndReset();
 
-        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+        protected sealed override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
             _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public sealed override void Initialize()

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256Managed.cs
@@ -19,21 +19,22 @@ namespace System.Security.Cryptography
             HashSizeValue = _hashProvider.HashSizeInBytes * 8;
         }
 
-        protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
+        protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _hashProvider.AppendHashData(array, ibStart, cbSize);
-        }
 
-        protected sealed override byte[] HashFinal()
-        {
-            return _hashProvider.FinalizeHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _hashProvider.AppendHashData(source);
+
+        protected sealed override byte[] HashFinal() =>
+            _hashProvider.FinalizeHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public sealed override void Initialize()
         {
             // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-            return;
         }
 
         protected sealed override void Dispose(bool disposing)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384.cs
@@ -33,13 +33,13 @@ namespace System.Security.Cryptography
             protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
                 _hashProvider.AppendHashData(array, ibStart, cbSize);
 
-            protected override void HashCore(ReadOnlySpan<byte> source) =>
+            protected sealed override void HashCore(ReadOnlySpan<byte> source) =>
                 _hashProvider.AppendHashData(source);
 
             protected sealed override byte[] HashFinal() =>
                 _hashProvider.FinalizeHashAndReset();
 
-            protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            protected sealed override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
                 _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
             public sealed override void Initialize()

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384.cs
@@ -16,15 +16,9 @@ namespace System.Security.Cryptography
     {
         protected SHA384() { }
 
-        public static new SHA384 Create()
-        {
-            return new Implementation();
-        }
+        public static new SHA384 Create() => new Implementation();
 
-        public static new SHA384 Create(string hashName)
-        {
-            return (SHA384)CryptoConfig.CreateFromName(hashName);
-        }
+        public static new SHA384 Create(string hashName) => (SHA384)CryptoConfig.CreateFromName(hashName);
 
         private sealed class Implementation : SHA384
         {
@@ -36,21 +30,22 @@ namespace System.Security.Cryptography
                 HashSizeValue = _hashProvider.HashSizeInBytes * 8;
             }
 
-            protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)
-            {
+            protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
                 _hashProvider.AppendHashData(array, ibStart, cbSize);
-            }
 
-            protected sealed override byte[] HashFinal()
-            {
-                return _hashProvider.FinalizeHashAndReset();
-            }
+            protected override void HashCore(ReadOnlySpan<byte> source) =>
+                _hashProvider.AppendHashData(source);
+
+            protected sealed override byte[] HashFinal() =>
+                _hashProvider.FinalizeHashAndReset();
+
+            protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+                _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
             public sealed override void Initialize()
             {
                 // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
                 // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-                return;
             }
 
             protected sealed override void Dispose(bool disposing)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384Managed.cs
@@ -22,13 +22,13 @@ namespace System.Security.Cryptography
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _hashProvider.AppendHashData(array, ibStart, cbSize);
 
-        protected override void HashCore(ReadOnlySpan<byte> source) =>
+        protected sealed override void HashCore(ReadOnlySpan<byte> source) =>
             _hashProvider.AppendHashData(source);
 
         protected sealed override byte[] HashFinal() =>
             _hashProvider.FinalizeHashAndReset();
 
-        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+        protected sealed override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
             _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public sealed override void Initialize()

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384Managed.cs
@@ -19,21 +19,22 @@ namespace System.Security.Cryptography
             HashSizeValue = _hashProvider.HashSizeInBytes * 8;
         }
 
-        protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
+        protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _hashProvider.AppendHashData(array, ibStart, cbSize);
-        }
 
-        protected sealed override byte[] HashFinal()
-        {
-            return _hashProvider.FinalizeHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _hashProvider.AppendHashData(source);
+
+        protected sealed override byte[] HashFinal() =>
+            _hashProvider.FinalizeHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public sealed override void Initialize()
         {
             // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-            return;
         }
 
         protected sealed override void Dispose(bool disposing)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512.cs
@@ -33,13 +33,13 @@ namespace System.Security.Cryptography
             protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
                 _hashProvider.AppendHashData(array, ibStart, cbSize);
 
-            protected override void HashCore(ReadOnlySpan<byte> source) =>
+            protected sealed override void HashCore(ReadOnlySpan<byte> source) =>
                 _hashProvider.AppendHashData(source);
 
             protected sealed override byte[] HashFinal() =>
                 _hashProvider.FinalizeHashAndReset();
 
-            protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            protected sealed override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
                 _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
             public sealed override void Initialize()

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512.cs
@@ -16,15 +16,9 @@ namespace System.Security.Cryptography
     {
         protected SHA512() { }
 
-        public static new SHA512 Create()
-        {
-            return new Implementation();
-        }
+        public static new SHA512 Create() => new Implementation();
 
-        public static new SHA512 Create(string hashName)
-        {
-            return (SHA512)CryptoConfig.CreateFromName(hashName);
-        }
+        public static new SHA512 Create(string hashName) => (SHA512)CryptoConfig.CreateFromName(hashName);
 
         private sealed class Implementation : SHA512
         {
@@ -36,21 +30,22 @@ namespace System.Security.Cryptography
                 HashSizeValue = _hashProvider.HashSizeInBytes * 8;
             }
 
-            protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)
-            {
+            protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
                 _hashProvider.AppendHashData(array, ibStart, cbSize);
-            }
 
-            protected sealed override byte[] HashFinal()
-            {
-                return _hashProvider.FinalizeHashAndReset();
-            }
+            protected override void HashCore(ReadOnlySpan<byte> source) =>
+                _hashProvider.AppendHashData(source);
+
+            protected sealed override byte[] HashFinal() =>
+                _hashProvider.FinalizeHashAndReset();
+
+            protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+                _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
             public sealed override void Initialize()
             {
                 // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
                 // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-                return;
             }
 
             protected sealed override void Dispose(bool disposing)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512Managed.cs
@@ -22,13 +22,13 @@ namespace System.Security.Cryptography
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _hashProvider.AppendHashData(array, ibStart, cbSize);
 
-        protected override void HashCore(ReadOnlySpan<byte> source) =>
+        protected sealed override void HashCore(ReadOnlySpan<byte> source) =>
             _hashProvider.AppendHashData(source);
 
         protected sealed override byte[] HashFinal() =>
             _hashProvider.FinalizeHashAndReset();
 
-        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+        protected sealed override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
             _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public sealed override void Initialize()

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512Managed.cs
@@ -19,21 +19,22 @@ namespace System.Security.Cryptography
             HashSizeValue = _hashProvider.HashSizeInBytes * 8;
         }
 
-        protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
+        protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _hashProvider.AppendHashData(array, ibStart, cbSize);
-        }
 
-        protected sealed override byte[] HashFinal()
-        {
-            return _hashProvider.FinalizeHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _hashProvider.AppendHashData(source);
+
+        protected sealed override byte[] HashFinal() =>
+            _hashProvider.FinalizeHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
 
         public sealed override void Initialize()
         {
             // Nothing to do here. We expect HashAlgorithm to invoke HashFinal() and Initialize() as a pair. This reflects the 
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
-            return;
         }
 
         protected sealed override void Dispose(bool disposing)

--- a/src/System.Security.Cryptography.Algorithms/tests/HashAlgorithmTest.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HashAlgorithmTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 {
-    public abstract class HashAlgorithmTest
+    public abstract partial class HashAlgorithmTest
     {
         protected abstract HashAlgorithm Create();
 
@@ -208,6 +208,12 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 
         protected void Verify(byte[] input, string output)
         {
+            Verify_Array(input, output);
+            Verify_Span(input, output);
+        }
+
+        private void Verify_Array(byte[] input, string output)
+        {
             byte[] expected = ByteUtils.HexToByteArray(output);
             byte[] actual;
 
@@ -222,6 +228,8 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
                 Assert.Equal(expected, actual);
             }
         }
+
+        partial void Verify_Span(byte[] input, string output);
 
         protected void VerifyRepeating(string input, int repeatCount, string output)
         {

--- a/src/System.Security.Cryptography.Algorithms/tests/HashAlgorithmTest.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HashAlgorithmTest.netcoreapp.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Hashing.Algorithms.Tests
+{
+    public abstract partial class HashAlgorithmTest
+    {
+        partial void Verify_Span(byte[] input, string output)
+        {
+            byte[] expected = ByteUtils.HexToByteArray(output);
+            byte[] actual;
+            int bytesWritten;
+
+            using (HashAlgorithm hash = Create())
+            {
+                actual = new byte[expected.Length - 1];
+                Assert.False(hash.TryComputeHash(input, actual, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+
+                actual = new byte[expected.Length];
+                Assert.True(hash.TryComputeHash(input, actual, out bytesWritten));
+                Assert.Equal(expected.Length, bytesWritten);
+                Assert.Equal(expected, actual);
+                Assert.Throws<NullReferenceException>(() => hash.Hash); // byte[] not initialized
+            }
+        }
+
+        [Fact]
+        public void Dispose_TryComputeHash_ThrowsException()
+        {
+            HashAlgorithm hash = Create();
+            hash.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => hash.ComputeHash(new byte[1]));
+            Assert.Throws<ObjectDisposedException>(() => hash.TryComputeHash(new byte[1], new byte[1], out int bytesWritten));
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/HashAlgorithmTest.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HashAlgorithmTest.netcoreapp.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Test.Cryptography;
 using Xunit;
 
@@ -17,15 +18,43 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 
             using (HashAlgorithm hash = Create())
             {
+                // Too small
                 actual = new byte[expected.Length - 1];
                 Assert.False(hash.TryComputeHash(input, actual, out bytesWritten));
                 Assert.Equal(0, bytesWritten);
 
+                // Just right
                 actual = new byte[expected.Length];
                 Assert.True(hash.TryComputeHash(input, actual, out bytesWritten));
                 Assert.Equal(expected.Length, bytesWritten);
                 Assert.Equal(expected, actual);
-                Assert.Throws<NullReferenceException>(() => hash.Hash); // byte[] not initialized
+
+                // Bigger than needed
+                actual = new byte[expected.Length + 1];
+                actual[actual.Length - 1] = 42;
+                Assert.True(hash.TryComputeHash(input, actual, out bytesWritten));
+                Assert.Equal(expected.Length, bytesWritten);
+                Assert.Equal(expected, actual.AsSpan().Slice(0, expected.Length).ToArray());
+                Assert.Equal(42, actual[actual.Length - 1]);
+            }
+        }
+
+        [Fact]
+        public void ComputeHash_TryComputeHash_HashSetExplicitlyByBoth()
+        {
+            using (HashAlgorithm hash = Create())
+            {
+                byte[] input = Enumerable.Range(0, 100).Select(i => (byte)i).ToArray();
+
+                byte[] computeHashResult = hash.ComputeHash(input);
+                Assert.NotNull(computeHashResult);
+                Assert.NotNull(hash.Hash);
+                Assert.NotSame(computeHashResult, hash.Hash);
+                Assert.Equal(computeHashResult, hash.Hash);
+
+                Assert.True(hash.TryComputeHash(input, computeHashResult, out int bytesWritten));
+                Assert.Equal(computeHashResult.Length, bytesWritten);
+                Assert.Null(hash.Hash);
             }
         }
 

--- a/src/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.cs
@@ -112,8 +112,8 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
             while (position < s_inputBytes.Length - StepB)
             {
-                incrementalHash.AppendData(s_inputBytes, position, StepA);
-                position += StepA;
+                incrementalHash.AppendData(s_inputBytes, position, StepB);
+                position += StepB;
             }
 
             incrementalHash.AppendData(s_inputBytes, position, s_inputBytes.Length - position);

--- a/src/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Security.Cryptography.Algorithms.Tests
 {
-    public class IncrementalHashTests
+    public partial class IncrementalHashTests
     {
         // Some arbitrarily chosen OID segments
         private static readonly byte[] s_hmacKey = { 2, 5, 29, 54, 1, 2, 84, 113, 54, 91, 1, 1, 2, 5, 29, 10, };
@@ -38,6 +38,31 @@ namespace System.Security.Cryptography.Algorithms.Tests
             };
         }
 
+        [Fact]
+        public static void InvalidArguments_Throw()
+        {
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => IncrementalHash.CreateHash(new HashAlgorithmName(null)));
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => IncrementalHash.CreateHash(new HashAlgorithmName("")));
+
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => IncrementalHash.CreateHMAC(new HashAlgorithmName(null), new byte[1]));
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => IncrementalHash.CreateHMAC(new HashAlgorithmName(""), new byte[1]));
+
+            AssertExtensions.Throws<ArgumentNullException>("key", () => IncrementalHash.CreateHMAC(HashAlgorithmName.SHA512, null));
+
+            using (IncrementalHash incrementalHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA512))
+            {
+                AssertExtensions.Throws<ArgumentNullException>("data", () => incrementalHash.AppendData(null));
+                AssertExtensions.Throws<ArgumentNullException>("data", () => incrementalHash.AppendData(null, 0, 0));
+
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => incrementalHash.AppendData(new byte[1], -1, 1));
+
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => incrementalHash.AppendData(new byte[1], 0, -1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => incrementalHash.AppendData(new byte[1], 0, 2));
+
+                Assert.Throws<ArgumentException>(() => incrementalHash.AppendData(new byte[2], 1, 2));
+            }
+        }
+
         [Theory]
         [MemberData(nameof(GetHashAlgorithms))]
         public static void VerifyIncrementalHash(HashAlgorithm referenceAlgorithm, HashAlgorithmName hashAlgorithm)
@@ -45,6 +70,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
             using (referenceAlgorithm)
             using (IncrementalHash incrementalHash = IncrementalHash.CreateHash(hashAlgorithm))
             {
+                Assert.Equal(hashAlgorithm, incrementalHash.AlgorithmName);
                 VerifyIncrementalResult(referenceAlgorithm, incrementalHash);
             }
         }

--- a/src/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.netcoreapp.cs
@@ -65,8 +65,8 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
             while (position < s_inputBytes.Length - StepB)
             {
-                incrementalHash.AppendData(new ReadOnlySpan<byte>(s_inputBytes, position, StepA));
-                position += StepA;
+                incrementalHash.AppendData(new ReadOnlySpan<byte>(s_inputBytes, position, StepB));
+                position += StepB;
             }
 
             incrementalHash.AppendData(new ReadOnlySpan<byte>(s_inputBytes, position, s_inputBytes.Length - position));

--- a/src/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.netcoreapp.cs
@@ -1,0 +1,184 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Algorithms.Tests
+{
+    public partial class IncrementalHashTests
+    {
+        [Theory]
+        [MemberData(nameof(GetHashAlgorithms))]
+        public static void VerifyIncrementalHash_Span(HashAlgorithm referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            using (referenceAlgorithm)
+            using (IncrementalHash incrementalHash = IncrementalHash.CreateHash(hashAlgorithm))
+            {
+                VerifyIncrementalResult_Span(referenceAlgorithm, incrementalHash);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHMACs))]
+        public static void VerifyIncrementalHMAC_Span(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            using (referenceAlgorithm)
+            using (IncrementalHash incrementalHash = IncrementalHash.CreateHMAC(hashAlgorithm, s_hmacKey))
+            {
+                referenceAlgorithm.Key = s_hmacKey;
+                VerifyIncrementalResult_Span(referenceAlgorithm, incrementalHash);
+            }
+        }
+
+        private static void VerifyIncrementalResult_Span(HashAlgorithm referenceAlgorithm, IncrementalHash incrementalHash)
+        {
+            int referenceHashLength;
+            byte[] referenceHash = new byte[1];
+            while (!referenceAlgorithm.TryComputeHash(s_inputBytes, referenceHash, out referenceHashLength))
+            {
+                referenceHash = new byte[referenceHash.Length * 2];
+            }
+
+            const int StepA = 13;
+            const int StepB = 7;
+            int position = 0;
+
+            while (position < s_inputBytes.Length - StepA)
+            {
+                incrementalHash.AppendData(new ReadOnlySpan<byte>(s_inputBytes, position, StepA));
+                position += StepA;
+            }
+
+            incrementalHash.AppendData(new ReadOnlySpan<byte>(s_inputBytes, position, s_inputBytes.Length - position));
+
+            byte[] incrementalA = new byte[referenceHashLength];
+            int bytesWritten;
+            Assert.True(incrementalHash.TryGetHashAndReset(incrementalA, out bytesWritten));
+            Assert.Equal(referenceHashLength, bytesWritten);
+            Assert.Equal<byte>(new Span<byte>(referenceHash, 0, referenceHashLength).ToArray(), new Span<byte>(incrementalA).Slice(0, bytesWritten).ToArray());
+
+            // Now try again, verifying both immune to step size behaviors, and that GetHashAndReset resets.
+            position = 0;
+
+            while (position < s_inputBytes.Length - StepB)
+            {
+                incrementalHash.AppendData(new ReadOnlySpan<byte>(s_inputBytes, position, StepA));
+                position += StepA;
+            }
+
+            incrementalHash.AppendData(new ReadOnlySpan<byte>(s_inputBytes, position, s_inputBytes.Length - position));
+
+            byte[] incrementalB = new byte[referenceHashLength];
+            Assert.True(incrementalHash.TryGetHashAndReset(incrementalB, out bytesWritten));
+            Assert.Equal(referenceHashLength, bytesWritten);
+            Assert.Equal<byte>(new Span<byte>(referenceHash, 0, referenceHashLength).ToArray(), incrementalB);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHashAlgorithms))]
+        public static void VerifyEmptyHash_Span(HashAlgorithm referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            using (referenceAlgorithm)
+            using (IncrementalHash incrementalHash = IncrementalHash.CreateHash(hashAlgorithm))
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    incrementalHash.AppendData(ReadOnlySpan<byte>.Empty);
+                }
+
+                byte[] referenceHash = referenceAlgorithm.ComputeHash(Array.Empty<byte>());
+                byte[] incrementalResult = new byte[referenceHash.Length];
+                Assert.True(incrementalHash.TryGetHashAndReset(incrementalResult, out int bytesWritten));
+                Assert.Equal(referenceHash.Length, bytesWritten);
+                Assert.Equal(referenceHash, incrementalResult);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHMACs))]
+        public static void VerifyEmptyHMAC_Span(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            using (referenceAlgorithm)
+            using (IncrementalHash incrementalHash = IncrementalHash.CreateHMAC(hashAlgorithm, s_hmacKey))
+            {
+                referenceAlgorithm.Key = s_hmacKey;
+
+                for (int i = 0; i < 10; i++)
+                {
+                    incrementalHash.AppendData(ReadOnlySpan<byte>.Empty);
+                }
+
+                byte[] referenceHash = referenceAlgorithm.ComputeHash(Array.Empty<byte>());
+                byte[] incrementalResult = new byte[referenceHash.Length];
+                Assert.True(incrementalHash.TryGetHashAndReset(incrementalResult, out int bytesWritten));
+                Assert.Equal(referenceHash.Length, bytesWritten);
+                Assert.Equal(referenceHash, incrementalResult);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHashAlgorithms))]
+        public static void VerifyTrivialHash_Span(HashAlgorithm referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            using (referenceAlgorithm)
+            using (IncrementalHash incrementalHash = IncrementalHash.CreateHash(hashAlgorithm))
+            {
+                byte[] referenceHash = referenceAlgorithm.ComputeHash(Array.Empty<byte>());
+                byte[] incrementalResult = new byte[referenceHash.Length];
+                Assert.True(incrementalHash.TryGetHashAndReset(incrementalResult, out int bytesWritten));
+                Assert.Equal(referenceHash.Length, bytesWritten);
+                Assert.Equal(referenceHash, incrementalResult);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHMACs))]
+        public static void VerifyTrivialHMAC_Span(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            using (referenceAlgorithm)
+            using (IncrementalHash incrementalHash = IncrementalHash.CreateHMAC(hashAlgorithm, s_hmacKey))
+            {
+                referenceAlgorithm.Key = s_hmacKey;
+
+                byte[] referenceHash = referenceAlgorithm.ComputeHash(Array.Empty<byte>());
+                byte[] incrementalResult = new byte[referenceHash.Length];
+                Assert.True(incrementalHash.TryGetHashAndReset(incrementalResult, out int bytesWritten));
+                Assert.Equal(referenceHash.Length, bytesWritten);
+                Assert.Equal(referenceHash, incrementalResult);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHashAlgorithms))]
+        public static void Dispose_HashAlgorithm_ThrowsException(HashAlgorithm referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            referenceAlgorithm.Dispose();
+            var incrementalHash = IncrementalHash.CreateHash(hashAlgorithm);
+            incrementalHash.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(new byte[1]));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(new ReadOnlySpan<byte>(new byte[1])));
+
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.GetHashAndReset());
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.TryGetHashAndReset(new byte[1], out int _));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHMACs))]
+        public static void Dispose_HMAC_ThrowsException(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            referenceAlgorithm.Dispose();
+            var incrementalHash = IncrementalHash.CreateHMAC(hashAlgorithm, s_hmacKey);
+            incrementalHash.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(new byte[1]));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(new ReadOnlySpan<byte>(new byte[1])));
+
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.GetHashAndReset());
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.TryGetHashAndReset(new byte[1], out int _));
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -149,6 +149,8 @@
     <Compile Include="DSACreateTests.cs" />
     <Compile Include="DSASignatureFormatterTests.cs" />
     <Compile Include="ECDiffieHellmanPublicKeyTests.cs" />
+    <Compile Include="HashAlgorithmTest.netcoreapp.cs" />
+    <Compile Include="IncrementalHashTests.netcoreapp.cs" />
     <Compile Include="PaddingModeTests.cs" />
     <Compile Include="PKCS1MaskGenerationMethodTest.cs" />
     <Compile Include="RandomNumberGeneratorTests.netcoreapp.cs" />

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/MD5CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/MD5CryptoServiceProvider.cs
@@ -38,7 +38,7 @@ namespace System.Security.Cryptography
 
         // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 
-        protected sealed override void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/MD5CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/MD5CryptoServiceProvider.cs
@@ -24,15 +24,17 @@ namespace System.Security.Cryptography
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
         }
 
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
+        protected override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _incrementalHash.AppendData(array, ibStart, cbSize);
-        }
 
-        protected override byte[] HashFinal()
-        {
-            return _incrementalHash.GetHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _incrementalHash.AppendData(source);
+
+        protected override byte[] HashFinal() =>
+            _incrementalHash.GetHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _incrementalHash.TryGetHashAndReset(destination, out bytesWritten);
 
         // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA1CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA1CryptoServiceProvider.cs
@@ -27,15 +27,17 @@ namespace System.Security.Cryptography
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
         }
 
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
+        protected override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _incrementalHash.AppendData(array, ibStart, cbSize);
-        }
 
-        protected override byte[] HashFinal()
-        {
-            return _incrementalHash.GetHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _incrementalHash.AppendData(source);
+
+        protected override byte[] HashFinal() =>
+            _incrementalHash.GetHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _incrementalHash.TryGetHashAndReset(destination, out bytesWritten);
 
         // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA1CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA1CryptoServiceProvider.cs
@@ -41,7 +41,7 @@ namespace System.Security.Cryptography
 
         // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 
-        protected sealed override void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA256CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA256CryptoServiceProvider.cs
@@ -27,15 +27,17 @@ namespace System.Security.Cryptography
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
         }
 
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
+        protected override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _incrementalHash.AppendData(array, ibStart, cbSize);
-        }
 
-        protected override byte[] HashFinal()
-        {
-            return _incrementalHash.GetHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _incrementalHash.AppendData(source);
+
+        protected override byte[] HashFinal() =>
+            _incrementalHash.GetHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _incrementalHash.TryGetHashAndReset(destination, out bytesWritten);
 
         // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA256CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA256CryptoServiceProvider.cs
@@ -41,7 +41,7 @@ namespace System.Security.Cryptography
 
         // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 
-        protected sealed override void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA384CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA384CryptoServiceProvider.cs
@@ -27,15 +27,17 @@ namespace System.Security.Cryptography
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
         }
 
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
+        protected override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _incrementalHash.AppendData(array, ibStart, cbSize);
-        }
 
-        protected override byte[] HashFinal()
-        {
-            return _incrementalHash.GetHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _incrementalHash.AppendData(source);
+
+        protected override byte[] HashFinal() =>
+            _incrementalHash.GetHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _incrementalHash.TryGetHashAndReset(destination, out bytesWritten);
 
         // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA384CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA384CryptoServiceProvider.cs
@@ -41,7 +41,7 @@ namespace System.Security.Cryptography
 
         // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 
-        protected sealed override void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA512CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA512CryptoServiceProvider.cs
@@ -27,15 +27,17 @@ namespace System.Security.Cryptography
             // reality that our native crypto providers (e.g. CNG) expose hash finalization and object reinitialization as an atomic operation.
         }
 
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
+        protected override void HashCore(byte[] array, int ibStart, int cbSize) =>
             _incrementalHash.AppendData(array, ibStart, cbSize);
-        }
 
-        protected override byte[] HashFinal()
-        {
-            return _incrementalHash.GetHashAndReset();
-        }
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
+            _incrementalHash.AppendData(source);
+
+        protected override byte[] HashFinal() =>
+            _incrementalHash.GetHashAndReset();
+
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            _incrementalHash.TryGetHashAndReset(destination, out bytesWritten);
 
         // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA512CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA512CryptoServiceProvider.cs
@@ -41,7 +41,7 @@ namespace System.Security.Cryptography
 
         // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 
-        protected sealed override void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -94,10 +94,13 @@ namespace System.Security.Cryptography
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         protected abstract void HashCore(byte[] array, int ibStart, int cbSize);
+        protected virtual void HashCore(ReadOnlySpan<byte> source) { throw null; }
         protected abstract byte[] HashFinal();
         public abstract void Initialize();
         public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) { throw null; }
         public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) { throw null; }
+        public bool TryComputeHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) { throw null; }
+        protected virtual bool TryHashFinal(Span<byte> destination, out int bytesWritten) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct HashAlgorithmName : System.IEquatable<System.Security.Cryptography.HashAlgorithmName>

--- a/src/System.Security.Cryptography.Primitives/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Primitives/src/Resources/Strings.resx
@@ -115,4 +115,7 @@
   <data name="CryptoConfigNotSupported" xml:space="preserve">
     <value>Accessing a hash algorithm by manipulating the HashName property is not supported on this platform. Instead, you must instantiate one of the supplied subtypes (such as HMACSHA1.)</value>
   </data>
+  <data name="InvalidOperation_IncorrectImplementation" xml:space="preserve">
+    <value>The algorithm's implementation is incorrect.</value>
+  </data>
 </root>

--- a/src/System.Security.Cryptography.Primitives/src/System.Security.Cryptography.Primitives.csproj
+++ b/src/System.Security.Cryptography.Primitives/src/System.Security.Cryptography.Primitives.csproj
@@ -33,6 +33,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Resources.ResourceManager" />

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HMAC.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HMAC.cs
@@ -6,43 +6,30 @@ namespace System.Security.Cryptography
 {
     public abstract class HMAC : KeyedHashAlgorithm
     {
+        private string _hashName;
         private int _blockSizeValue = 64;
 
         protected int BlockSizeValue
         {
-            get
-            {
-                return _blockSizeValue;
-            }
-            
-            set
-            {
-                _blockSizeValue = value;
-            }
+            get => _blockSizeValue;
+            set => _blockSizeValue = value;
         }
 
         protected HMAC() { }
 
-        public static new HMAC Create()
-        {
-            return Create("System.Security.Cryptography.HMAC");
-        }
+        public static new HMAC Create() => Create("System.Security.Cryptography.HMAC");
 
-        public static new HMAC Create(string algorithmName)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public static new HMAC Create(string algorithmName) => throw new PlatformNotSupportedException();
 
-        public String HashName
+        public string HashName
         {
-            get
-            {
-                return _hashName;
-            }
+            get => _hashName;
             set
             {
                 if (value == null)
+                {
                     throw new ArgumentNullException(nameof(HashName));
+                }
 
                 // On the desktop, setting the HashName selects (or switches over to) a new hashing algorithm via CryptoConfig.
                 // Our intended refactoring turns HMAC back into an abstract class with no algorithm-specific implementation.
@@ -52,7 +39,9 @@ namespace System.Security.Cryptography
                 // Since the set is public, ensure that hmac.HashName = hmac.HashName works without throwing.
 
                 if (_hashName != null && value != _hashName)
+                {
                     throw new PlatformNotSupportedException(SR.HashNameMultipleSetNotSupported);
+                }
 
                 _hashName = value;
             }
@@ -60,38 +49,26 @@ namespace System.Security.Cryptography
 
         public override byte[] Key
         {
-            get
-            {
-                return base.Key;
-            }
-
-            set
-            {
-                base.Key = value;
-            }
+            get => base.Key;
+            set => base.Key = value;
         }
 
-        protected override void Dispose(bool disposing)
-        {
+        protected override void Dispose(bool disposing) =>
             base.Dispose(disposing);
-        }
 
-        protected override void HashCore(byte[] rgb, int ib, int cb)
-        {
+        protected override void HashCore(byte[] rgb, int ib, int cb) =>
             throw new PlatformNotSupportedException(SR.CryptoConfigNotSupported);
-        }
 
-        protected override byte[] HashFinal()
-        {
+        protected override void HashCore(ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException(SR.CryptoConfigNotSupported);
-        }
 
-        public override void Initialize()
-        {
+        protected override byte[] HashFinal() =>
             throw new PlatformNotSupportedException(SR.CryptoConfigNotSupported);
-        }
 
-        private String _hashName;
+        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+            throw new PlatformNotSupportedException(SR.CryptoConfigNotSupported);
+
+        public override void Initialize() =>
+            throw new PlatformNotSupportedException(SR.CryptoConfigNotSupported);
     }
 }
-

--- a/src/System.Security.Cryptography.Primitives/tests/HashAlgorithmTest.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/HashAlgorithmTest.netcoreapp.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Xunit;
+
+namespace System.Security.Cryptography.Hashing.Tests
+{
+    public partial class HashAlgorithmTest
+    {
+        [Fact]
+        public void SpanMethodsUsed_NotOverridden_ArrayMethodsInvoked()
+        {
+            byte[] input = Enumerable.Range(0, 1024).Select(i => (byte)i).ToArray();
+            byte[] output;
+            int bytesWritten;
+
+            var testAlgorithm = new SummingTestHashAlgorithm();
+
+            output = new byte[sizeof(long) - 1];
+            Assert.False(testAlgorithm.TryComputeHash(input, output, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal<byte>(new byte[sizeof(long) - 1], output);
+
+            output = new byte[sizeof(long)];
+            Assert.True(testAlgorithm.TryComputeHash(input, output, out bytesWritten));
+            Assert.Equal(sizeof(long), bytesWritten);
+            Assert.Equal(input.Sum(b => (long)b), BitConverter.ToInt64(output, 0));
+        }
+
+        private sealed class SummingTestHashAlgorithm : HashAlgorithm
+        {
+            private long _sum;
+
+            public SummingTestHashAlgorithm() => HashSizeValue = sizeof(long)*8;
+
+            public override void Initialize() => _sum = 0;
+
+            protected override void HashCore(byte[] array, int ibStart, int cbSize)
+            {
+                for (int i = ibStart; i < ibStart + cbSize; i++) _sum += array[i];
+            }
+
+            protected override byte[] HashFinal() => BitConverter.GetBytes(_sum);
+            
+            // Do not override HashCore(ReadOnlySpan) and TryHashFinal.  Consuming
+            // test verifies that calling the base implementations invokes the array
+            // implementations by verifying the right value is produced.
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
+++ b/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
     <Compile Include="CryptoConfigTests.cs" />
+    <Compile Include="HashAlgorithmTest.netcoreapp.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
- Added IncrementalHash.AppendData/TryGetHashAndReset span-based methods
- Added HashAlgorithm.TryComputeHash/HashCore/TryHashFinal span-based methods
- Overrode methods on MD5, SHA1, SHA1Managed, SHA256, SHA256Managed, SHA384, SHA384Managed, SHA512, SHA512Managed, HMACMD5, HMACSHA1, HMACSHA256, HMACSHA384, HMACSHA512, MD5CryptoServiceProvider, SHA1CryptoServiceProvider, SHA256CryptoServiceProvider, SHA512CryptoServiceProvider
- Added tests
- Some minor formatting cleanup along the way to make things more consistent with the new code being added

Fixes https://github.com/dotnet/corefx/issues/22613
Fixes https://github.com/dotnet/corefx/issues/22614
cc: @bartonjs, @KrzysztofCwalina 