### PR TITLE
Add two tests for Graphics.DrawString.

### DIFF
--- a/src/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.cs
@@ -3461,6 +3461,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void DrawString_DefaultFont_Succeeds()
         {
@@ -3472,6 +3473,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void DrawString_CompositingModeSourceCopy_ThrowsArgumentException()
         {

--- a/src/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.cs
@@ -8,6 +8,7 @@ using System.Drawing.Imaging;
 using System.Drawing.Text;
 using System.Linq;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.Drawing.Tests
 {
@@ -3460,6 +3461,30 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DrawString_DefaultFont_Succeeds()
+        {
+            using (var image = new Bitmap(50, 50))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                graphics.DrawString("Test text", SystemFonts.DefaultFont, Brushes.White, new Point());
+                VerifyBitmapNotBlank(image);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DrawString_CompositingModeSourceCopy_ThrowsArgumentException()
+        {
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                graphics.CompositingMode = CompositingMode.SourceCopy;
+                AssertExtensions.Throws<ArgumentException>(
+                    null,
+                    () => graphics.DrawString("Test text", SystemFonts.DefaultFont, Brushes.White, new Point()));
+            }
+        }
+
         private static void VerifyGraphics(Graphics graphics, RectangleF expectedVisibleClipBounds)
         {
             Assert.NotNull(graphics.Clip);
@@ -3480,6 +3505,24 @@ namespace System.Drawing.Tests
             Assert.Equal(TextRenderingHint.SystemDefault, graphics.TextRenderingHint);
             Assert.Equal(new Matrix(), graphics.Transform);
             Assert.Equal(expectedVisibleClipBounds, graphics.VisibleClipBounds);
+        }
+
+        private static void VerifyBitmapNotBlank(Bitmap bmp)
+        {
+            Color emptyColor = Color.FromArgb(0);
+            for (int y = 0; y < bmp.Height; y++)
+            {
+                for (int x = 0; x < bmp.Width; x++)
+                {
+                    Color pixel = bmp.GetPixel(x, y);
+                    if (!pixel.Equals(emptyColor))
+                    {
+                        return;
+                    }
+                }
+            }
+
+            throw new XunitException("The entire image was blank.");
         }
     }
 }

--- a/src/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.cs
@@ -3468,7 +3468,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             {
                 graphics.DrawString("Test text", SystemFonts.DefaultFont, Brushes.White, new Point());
-                VerifyBitmapNotBlank(image);
+                Helpers.VerifyBitmapNotBlank(image);
             }
         }
 
@@ -3505,24 +3505,6 @@ namespace System.Drawing.Tests
             Assert.Equal(TextRenderingHint.SystemDefault, graphics.TextRenderingHint);
             Assert.Equal(new Matrix(), graphics.Transform);
             Assert.Equal(expectedVisibleClipBounds, graphics.VisibleClipBounds);
-        }
-
-        private static void VerifyBitmapNotBlank(Bitmap bmp)
-        {
-            Color emptyColor = Color.FromArgb(0);
-            for (int y = 0; y < bmp.Height; y++)
-            {
-                for (int x = 0; x < bmp.Width; x++)
-                {
-                    Color pixel = bmp.GetPixel(x, y);
-                    if (!pixel.Equals(emptyColor))
-                    {
-                        return;
-                    }
-                }
-            }
-
-            throw new XunitException("The entire image was blank.");
         }
     }
 }

--- a/src/System.Drawing.Common/tests/Helpers.cs
+++ b/src/System.Drawing.Common/tests/Helpers.cs
@@ -174,5 +174,23 @@ namespace System.Drawing
             public int Right;
             public int Bottom;
         }
+
+        public static void VerifyBitmapNotBlank(Bitmap bmp)
+        {
+            Color emptyColor = Color.FromArgb(0);
+            for (int y = 0; y < bmp.Height; y++)
+            {
+                for (int x = 0; x < bmp.Width; x++)
+                {
+                    Color pixel = bmp.GetPixel(x, y);
+                    if (!pixel.Equals(emptyColor))
+                    {
+                        return;
+                    }
+                }
+            }
+
+            throw new XunitException("The entire image was blank.");
+        }
     }
 }


### PR DESCRIPTION
This adds two very simple tests for `Graphics.DrawString`.

@hughbe @KostaVlev 