### PR TITLE
Disable some Graphics tests which may seg-fault on Unix.

### DIFF
--- a/src/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.cs
@@ -2435,6 +2435,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void DrawArc_NullPen_ThrowsArgumentNullException()
         {
@@ -2448,6 +2449,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void DrawArc_DisposedPen_ThrowsArgumentException()
         {
@@ -2517,6 +2519,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void DrawArc_Disposed_ThrowsArgumentException()
         {
@@ -2582,6 +2585,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void DrawBezier_Disposed_ThrowsArgumentException()
         {


### PR DESCRIPTION
I investigated one of the recent System.Drawing.Common crash dumps from CI, and found that they were causing a seg fault in the cairo_DrawArc function in libgdiplus. I wasn't able to determine which test case was actually calling through to that function (many SOS features were not working), but I do know that cairo_DrawArc is only called in `Graphics.DrawArc`, so I have disabled all of the tests which call that method on Unix.

@stephentoub 