### PR TITLE
[release/2.0] Re-enable test disabled on High Sierra since the bug is fixed

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -13,7 +13,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class ChainTests
     {
         internal static bool CanModifyStores { get; } = TestEnvironmentConfiguration.CanModifyStores;
-        internal static bool CanBuildSelfSignedChainReliably { get; } = !PlatformDetection.IsMacOsHighSierra;
 
         private static bool TrustsMicrosoftDotComRoot
         {
@@ -164,7 +163,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal(IntPtr.Zero, chain.ChainContext);
         }
 
-        [ConditionalFact(nameof(CanBuildSelfSignedChainReliably))]
+        [Fact]
         public static void TestResetMethod()
         {
             using (var sampleCert = new X509Certificate2(TestData.DssCer))


### PR DESCRIPTION
The latest beta release of High Sierra seems to have fixed the issue where
doing a revocation check on a self-signed certificate caused the SecTrustRef to
go into an invalid state, so re-enable the test we disabled due to that problem.