### PR TITLE
HttpMethod.ToString(): Remove unnecessary string.ToString() call

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
@@ -119,7 +119,7 @@ namespace System.Net.Http
 
         public override string ToString()
         {
-            return _method.ToString();
+            return _method;
         }
 
         public static bool operator ==(HttpMethod left, HttpMethod right)


### PR DESCRIPTION
Avoid making a virtual function call when the code already has a string.

I wasn't sure if I was supposed to propose this change on some other branch ('dev*') instead.  Let me know.