### PR TITLE
Fix MonoTests.System.Data.DataRowExtensionsTest on ILC

### DIFF
--- a/src/System.Data.DataSetExtensions/src/System/Data/DataRowExtensions.cs
+++ b/src/System.Data.DataSetExtensions/src/System/Data/DataRowExtensions.cs
@@ -143,22 +143,17 @@ namespace System.Data
 
         private static class UnboxT<T>
         {
-            internal static readonly Converter<object, T> s_unbox = Create(typeof(T));
+            internal static readonly Converter<object, T> s_unbox = Create();
 
-            private static Converter<object, T> Create(Type type)
+            private static Converter<object, T> Create()
             {
-                if (type.IsValueType)
-                {
-                    if (type.IsConstructedGenericType && (typeof(Nullable<>) == type.GetGenericTypeDefinition()))
-                    {
-                        return NullableField;
-                    }
+                if (default(T) == null)
+                    return ReferenceOrNullableField;
+                else
                     return ValueField;
-                }
-                return ReferenceField;
             }
 
-            private static T ReferenceField(object value)
+            private static T ReferenceOrNullableField(object value)
             {
                 return ((DBNull.Value == value) ? default(T) : (T)value);
             }
@@ -168,15 +163,6 @@ namespace System.Data
                 if (DBNull.Value == value)
                 {
                     throw DataSetUtil.InvalidCast(string.Format(SR.DataSetLinq_NonNullableCast, typeof(T).ToString()));
-                }
-                return (T)value;
-            }
-
-            private static T NullableField(object value)
-            {
-                if (DBNull.Value == value)
-                {
-                    return default(T);
                 }
                 return (T)value;
             }

--- a/src/System.Data.DataSetExtensions/src/System/Data/DataRowExtensions.cs
+++ b/src/System.Data.DataSetExtensions/src/System/Data/DataRowExtensions.cs
@@ -149,13 +149,9 @@ namespace System.Data
             {
                 if (type.IsValueType)
                 {
-                    if (type.IsGenericType && !type.IsGenericTypeDefinition && (typeof(Nullable<>) == type.GetGenericTypeDefinition()))
+                    if (type.IsConstructedGenericType && (typeof(Nullable<>) == type.GetGenericTypeDefinition()))
                     {
-                        return (Converter<object, T>)Delegate.CreateDelegate(
-                            typeof(Converter<object, T>),
-                                typeof(UnboxT<T>)
-                                    .GetMethod("NullableField", Reflection.BindingFlags.Static | Reflection.BindingFlags.NonPublic)
-                                    .MakeGenericMethod(type.GetGenericArguments()[0]));
+                        return NullableField;
                     }
                     return ValueField;
                 }
@@ -176,13 +172,13 @@ namespace System.Data
                 return (T)value;
             }
 
-            private static TElem? NullableField<TElem>(object value) where TElem : struct
+            private static T NullableField(object value)
             {
                 if (DBNull.Value == value)
                 {
-                    return default(TElem?);
+                    return default(T);
                 }
-                return new TElem?((TElem)value);
+                return (T)value;
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/23096

Unbox utility used Reflection on private members
to unbox a Nullable.

It's really a lot simpler just to... unbox it.