### PR TITLE
Add RSA span-based methods

### DIFF
--- a/src/Common/src/Internal/Cryptography/AsymmetricAlgorithmHelpers.Hash.cs
+++ b/src/Common/src/Internal/Cryptography/AsymmetricAlgorithmHelpers.Hash.cs
@@ -40,38 +40,25 @@ namespace Internal.Cryptography
             }
         }
 
+        public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
+        {
+            // The classes that call us are sealed and their base class has checked this already.
+            Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
+
+            using (HashAlgorithm hasher = GetHashAlgorithm(hashAlgorithm))
+            {
+                return hasher.TryComputeHash(source, destination, out bytesWritten);
+            }
+        }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5351", Justification = "MD5 is used when the user asks for it.")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "SHA1 is used when the user asks for it.")]
-        private static HashAlgorithm GetHashAlgorithm(HashAlgorithmName hashAlgorithmName)
-        {
-            HashAlgorithm hasher;
-
-            if (hashAlgorithmName == HashAlgorithmName.MD5)
-            {
-                hasher = MD5.Create();
-            }
-            else if (hashAlgorithmName == HashAlgorithmName.SHA1)
-            {
-                hasher = SHA1.Create();
-            }
-            else if (hashAlgorithmName == HashAlgorithmName.SHA256)
-            {
-                hasher = SHA256.Create();
-            }
-            else if (hashAlgorithmName == HashAlgorithmName.SHA384)
-            {
-                hasher = SHA384.Create();
-            }
-            else if (hashAlgorithmName == HashAlgorithmName.SHA512)
-            {
-                hasher = SHA512.Create();
-            }
-            else
-            {
-                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmName.Name);
-            }
-
-            return hasher;
-        }
+        private static HashAlgorithm GetHashAlgorithm(HashAlgorithmName hashAlgorithmName) =>
+            hashAlgorithmName == HashAlgorithmName.MD5 ? MD5.Create() :
+            hashAlgorithmName == HashAlgorithmName.SHA1 ? SHA1.Create() :
+            hashAlgorithmName == HashAlgorithmName.SHA256 ? SHA256.Create() :
+            hashAlgorithmName == HashAlgorithmName.SHA384 ? SHA384.Create() :
+            hashAlgorithmName == HashAlgorithmName.SHA512 ? (HashAlgorithm)SHA512.Create() :
+            throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmName.Name);
     }
 }

--- a/src/Common/src/Internal/Cryptography/CngCommon.Hash.cs
+++ b/src/Common/src/Internal/Cryptography/CngCommon.Hash.cs
@@ -19,11 +19,27 @@ namespace Internal.Cryptography
             Debug.Assert(count >= 0 && count <= data.Length);
             Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
 
-            using (HashProviderCng hashProvider = new HashProviderCng(hashAlgorithm.Name, null))
+            using (var hashProvider = new HashProviderCng(hashAlgorithm.Name, null))
             {
                 hashProvider.AppendHashData(data, offset, count);
-                byte[] hash = hashProvider.FinalizeHashAndReset();
-                return hash;
+                return hashProvider.FinalizeHashAndReset();
+            }
+        }
+
+        public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
+
+            using (var hashProvider = new HashProviderCng(hashAlgorithm.Name, null))
+            {
+                if (destination.Length < hashProvider.HashSizeInBytes)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                hashProvider.AppendHashData(source);
+                return hashProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
             }
         }
 
@@ -33,7 +49,7 @@ namespace Internal.Cryptography
             Debug.Assert(data != null);
             Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
 
-            using (HashProviderCng hashProvider = new HashProviderCng(hashAlgorithm.Name, null))
+            using (var hashProvider = new HashProviderCng(hashAlgorithm.Name, null))
             {
                 // Default the buffer size to 4K.
                 byte[] buffer = new byte[4096];

--- a/src/Common/src/Internal/Cryptography/CngCommon.SignVerify.cs
+++ b/src/Common/src/Internal/Cryptography/CngCommon.SignVerify.cs
@@ -3,11 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
-using System.Security.Cryptography;
-
 using Microsoft.Win32.SafeHandles;
-
 using ErrorCode = Interop.NCrypt.ErrorCode;
 using AsymmetricPaddingMode = Interop.NCrypt.AsymmetricPaddingMode;
 
@@ -35,11 +31,28 @@ namespace Internal.Cryptography
             return signature;
         }
 
-        public static unsafe bool VerifyHash(this SafeNCryptKeyHandle keyHandle, byte[] hash, byte[] signature, AsymmetricPaddingMode paddingMode, void* pPaddingInfo)
+        public static unsafe bool TrySignHash(this SafeNCryptKeyHandle keyHandle, ReadOnlySpan<byte> hash, Span<byte> signature, AsymmetricPaddingMode paddingMode, void* pPaddingInfo, out int bytesWritten)
+        {
+            ErrorCode error = Interop.NCrypt.NCryptSignHash(keyHandle, pPaddingInfo, hash, hash.Length, signature, signature.Length, out int numBytesNeeded, paddingMode);
+            switch (error)
+            {
+                case ErrorCode.ERROR_SUCCESS:
+                    bytesWritten = numBytesNeeded;
+                    return true;
+
+                case ErrorCode.NTE_BUFFER_TOO_SMALL:
+                    bytesWritten = 0;
+                    return false;
+
+                default:
+                    throw error.ToCryptographicException();
+            }
+        }
+
+        public static unsafe bool VerifyHash(this SafeNCryptKeyHandle keyHandle, ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, AsymmetricPaddingMode paddingMode, void* pPaddingInfo)
         {
             ErrorCode errorCode = Interop.NCrypt.NCryptVerifySignature(keyHandle, pPaddingInfo, hash, hash.Length, signature, signature.Length, paddingMode);
-            bool verified = (errorCode == ErrorCode.ERROR_SUCCESS);  // For consistency with other AsymmetricAlgorithm-derived classes, return "false" for any error code rather than making the caller catch an exception.
-            return verified;
+            return errorCode == ErrorCode.ERROR_SUCCESS;  // For consistency with other AsymmetricAlgorithm-derived classes, return "false" for any error code rather than making the caller catch an exception.
         }
     }
 }

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
@@ -182,11 +182,15 @@ internal static partial class Interop
         {
             Debug.Assert(padding.Mode == RSAEncryptionPaddingMode.Pkcs1 || padding.Mode == RSAEncryptionPaddingMode.Oaep);
             return TryExecuteTransform(
-                source, destination, out bytesWritten,
-                (ReadOnlySpan<byte> innerSource, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle) =>
-                    padding.Mode == RSAEncryptionPaddingMode.Pkcs1 ?
+                source,
+                destination,
+                out bytesWritten,
+                delegate (ReadOnlySpan<byte> innerSource, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle)
+                {
+                    return padding.Mode == RSAEncryptionPaddingMode.Pkcs1 ?
                         RsaEncryptPkcs(publicKey, innerSource, innerSource.Length, out outputHandle, out errorHandle) :
-                        RsaEncryptOaep(publicKey, innerSource, innerSource.Length, PalAlgorithmFromAlgorithmName(padding.OaepHashAlgorithm), out outputHandle, out errorHandle));
+                        RsaEncryptOaep(publicKey, innerSource, innerSource.Length, PalAlgorithmFromAlgorithmName(padding.OaepHashAlgorithm), out outputHandle, out errorHandle);
+                });
         }
 
         internal static byte[] RsaDecrypt(
@@ -223,11 +227,15 @@ internal static partial class Interop
         {
             Debug.Assert(padding.Mode == RSAEncryptionPaddingMode.Pkcs1 || padding.Mode == RSAEncryptionPaddingMode.Oaep);
             return TryExecuteTransform(
-                source, destination, out bytesWritten,
-                (ReadOnlySpan<byte> innerSource, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle) =>
-                    padding.Mode == RSAEncryptionPaddingMode.Pkcs1 ?
+                source,
+                destination,
+                out bytesWritten,
+                delegate (ReadOnlySpan<byte> innerSource, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle)
+                {
+                    return padding.Mode == RSAEncryptionPaddingMode.Pkcs1 ?
                         RsaDecryptPkcs(privateKey, innerSource, innerSource.Length, out outputHandle, out errorHandle) :
-                        RsaDecryptOaep(privateKey, innerSource, innerSource.Length, PalAlgorithmFromAlgorithmName(padding.OaepHashAlgorithm), out outputHandle, out errorHandle));
+                        RsaDecryptOaep(privateKey, innerSource, innerSource.Length, PalAlgorithmFromAlgorithmName(padding.OaepHashAlgorithm), out outputHandle, out errorHandle);
+                });
         }
 
         private static PAL_HashAlgorithm PalAlgorithmFromAlgorithmName(HashAlgorithmName hashAlgorithmName) =>

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
@@ -21,36 +21,90 @@ internal static partial class Interop
             out SafeSecKeyRefHandle pPrivateKey,
             out int pOSStatus);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptOaep")]
-        private static extern int RsaEncryptOaep(
+        private static unsafe int RsaEncryptOaep(
             SafeSecKeyRefHandle publicKey,
-            byte[] pbData,
+            ReadOnlySpan<byte> pbData,
+            int cbData,
+            PAL_HashAlgorithm mgfAlgorithm,
+            out SafeCFDataHandle pEncryptedOut,
+            out SafeCFErrorHandle pErrorOut)
+        {
+            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
+            {
+                return RsaEncryptOaep(publicKey, pbDataPtr, cbData, mgfAlgorithm, out pEncryptedOut, out pErrorOut);
+            }
+        }
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptOaep")]
+        private static extern unsafe int RsaEncryptOaep(
+            SafeSecKeyRefHandle publicKey,
+            byte* pbData,
             int cbData,
             PAL_HashAlgorithm mgfAlgorithm,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);
+
+        private static unsafe int RsaEncryptPkcs(
+            SafeSecKeyRefHandle publicKey,
+            ReadOnlySpan<byte> pbData,
+            int cbData,
+            out SafeCFDataHandle pEncryptedOut,
+            out SafeCFErrorHandle pErrorOut)
+        {
+            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
+            {
+                return RsaEncryptPkcs(publicKey, pbDataPtr, cbData, out pEncryptedOut, out pErrorOut);
+            }
+        }
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptPkcs")]
-        private static extern int RsaEncryptPkcs(
+        private static extern unsafe int RsaEncryptPkcs(
             SafeSecKeyRefHandle publicKey,
-            byte[] pbData,
+            byte* pbData,
             int cbData,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptOaep")]
-        private static extern int RsaDecryptOaep(
+        private static unsafe int RsaDecryptOaep(
             SafeSecKeyRefHandle publicKey,
-            byte[] pbData,
+            ReadOnlySpan<byte> pbData,
+            int cbData,
+            PAL_HashAlgorithm mgfAlgorithm,
+            out SafeCFDataHandle pEncryptedOut,
+            out SafeCFErrorHandle pErrorOut)
+        {
+            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
+            {
+                return RsaDecryptOaep(publicKey, pbDataPtr, cbData, mgfAlgorithm, out pEncryptedOut, out pErrorOut);
+            }
+        }
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptOaep")]
+        private static extern unsafe int RsaDecryptOaep(
+            SafeSecKeyRefHandle publicKey,
+            byte* pbData,
             int cbData,
             PAL_HashAlgorithm mgfAlgorithm,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptPkcs")]
-        private static extern int RsaDecryptPkcs(
+        private static unsafe int RsaDecryptPkcs(
             SafeSecKeyRefHandle publicKey,
-            byte[] pbData,
+            ReadOnlySpan<byte> pbData,
+            int cbData,
+            out SafeCFDataHandle pEncryptedOut,
+            out SafeCFErrorHandle pErrorOut)
+        {
+            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
+            {
+                return RsaDecryptPkcs(publicKey, pbDataPtr, cbData, out pEncryptedOut, out pErrorOut);
+            }
+        }
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptPkcs")]
+        private static extern unsafe int RsaDecryptPkcs(
+            SafeSecKeyRefHandle publicKey,
+            byte* pbData,
             int cbData,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);
@@ -117,7 +171,22 @@ internal static partial class Interop
                         out encrypted,
                         out error);
                 });
+        }
 
+        internal static bool TryRsaEncrypt(
+            SafeSecKeyRefHandle publicKey,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            RSAEncryptionPadding padding,
+            out int bytesWritten)
+        {
+            Debug.Assert(padding.Mode == RSAEncryptionPaddingMode.Pkcs1 || padding.Mode == RSAEncryptionPaddingMode.Oaep);
+            return TryExecuteTransform(
+                source, destination, out bytesWritten,
+                (ReadOnlySpan<byte> innerSource, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle) =>
+                    padding.Mode == RSAEncryptionPaddingMode.Pkcs1 ?
+                        RsaEncryptPkcs(publicKey, innerSource, innerSource.Length, out outputHandle, out errorHandle) :
+                        RsaEncryptOaep(publicKey, innerSource, innerSource.Length, PalAlgorithmFromAlgorithmName(padding.OaepHashAlgorithm), out outputHandle, out errorHandle));
         }
 
         internal static byte[] RsaDecrypt(
@@ -145,31 +214,28 @@ internal static partial class Interop
                 });
         }
 
-        private static Interop.AppleCrypto.PAL_HashAlgorithm PalAlgorithmFromAlgorithmName(
-                HashAlgorithmName hashAlgorithmName)
+        internal static bool TryRsaDecrypt(
+            SafeSecKeyRefHandle privateKey,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            RSAEncryptionPadding padding,
+            out int bytesWritten)
         {
-            if (hashAlgorithmName == HashAlgorithmName.MD5)
-            {
-                return Interop.AppleCrypto.PAL_HashAlgorithm.Md5;
-            }
-            else if (hashAlgorithmName == HashAlgorithmName.SHA1)
-            {
-                return Interop.AppleCrypto.PAL_HashAlgorithm.Sha1;
-            }
-            else if (hashAlgorithmName == HashAlgorithmName.SHA256)
-            {
-                return Interop.AppleCrypto.PAL_HashAlgorithm.Sha256;
-            }
-            else if (hashAlgorithmName == HashAlgorithmName.SHA384)
-            {
-                return Interop.AppleCrypto.PAL_HashAlgorithm.Sha384;
-            }
-            else if (hashAlgorithmName == HashAlgorithmName.SHA512)
-            {
-                return Interop.AppleCrypto.PAL_HashAlgorithm.Sha512;
-            }
-
-            throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmName.Name);
+            Debug.Assert(padding.Mode == RSAEncryptionPaddingMode.Pkcs1 || padding.Mode == RSAEncryptionPaddingMode.Oaep);
+            return TryExecuteTransform(
+                source, destination, out bytesWritten,
+                (ReadOnlySpan<byte> innerSource, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle) =>
+                    padding.Mode == RSAEncryptionPaddingMode.Pkcs1 ?
+                        RsaDecryptPkcs(privateKey, innerSource, innerSource.Length, out outputHandle, out errorHandle) :
+                        RsaDecryptOaep(privateKey, innerSource, innerSource.Length, PalAlgorithmFromAlgorithmName(padding.OaepHashAlgorithm), out outputHandle, out errorHandle));
         }
+
+        private static PAL_HashAlgorithm PalAlgorithmFromAlgorithmName(HashAlgorithmName hashAlgorithmName) =>
+            hashAlgorithmName == HashAlgorithmName.MD5 ? PAL_HashAlgorithm.Md5 :
+            hashAlgorithmName == HashAlgorithmName.SHA1 ? PAL_HashAlgorithm.Sha1 :
+            hashAlgorithmName == HashAlgorithmName.SHA256 ? PAL_HashAlgorithm.Sha256 :
+            hashAlgorithmName == HashAlgorithmName.SHA384 ? PAL_HashAlgorithm.Sha384 :
+            hashAlgorithmName == HashAlgorithmName.SHA512 ? PAL_HashAlgorithm.Sha512 :
+            throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmName.Name);
     }
 }

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -28,30 +29,74 @@ internal static partial class Interop
             out SafeCFDataHandle pSignatureOut,
             out SafeCFErrorHandle pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
+        private static unsafe int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
             SafeSecKeyRefHandle privateKey,
-            byte[] pbDataHash,
+            ReadOnlySpan<byte> pbDataHash,
+            int cbDataHash,
+            PAL_HashAlgorithm hashAlgorithm,
+            out SafeCFDataHandle pSignatureOut,
+            out SafeCFErrorHandle pErrorOut)
+        {
+            fixed (byte* pbDataHashPtr = &pbDataHash.DangerousGetPinnableReference())
+            {
+                return AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
+                    privateKey, pbDataHashPtr, cbDataHash, hashAlgorithm, out pSignatureOut, out pErrorOut);
+            }
+        }
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern unsafe int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
+            SafeSecKeyRefHandle privateKey,
+            byte* pbDataHash,
             int cbDataHash,
             PAL_HashAlgorithm hashAlgorithm,
             out SafeCFDataHandle pSignatureOut,
             out SafeCFErrorHandle pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_VerifySignature(
+        private static unsafe int AppleCryptoNative_VerifySignature(
             SafeSecKeyRefHandle publicKey,
-            byte[] pbDataHash,
+            ReadOnlySpan<byte> pbDataHash,
             int cbDataHash,
-            byte[] pbSignature,
+            ReadOnlySpan<byte> pbSignature,
+            int cbSignature,
+            out SafeCFErrorHandle pErrorOut)
+        {
+            fixed (byte* pbDataHashPtr = &pbDataHash.DangerousGetPinnableReference(), pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
+            {
+                return AppleCryptoNative_VerifySignature(publicKey, pbDataHashPtr, cbDataHash, pbSignaturePtr, cbSignature, out pErrorOut);
+            }
+        }
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern unsafe int AppleCryptoNative_VerifySignature(
+            SafeSecKeyRefHandle publicKey,
+            byte* pbDataHash,
+            int cbDataHash,
+            byte* pbSignature,
             int cbSignature,
             out SafeCFErrorHandle pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_VerifySignatureWithHashAlgorithm(
+        private static unsafe int AppleCryptoNative_VerifySignatureWithHashAlgorithm(
             SafeSecKeyRefHandle publicKey,
-            byte[] pbDataHash,
+            ReadOnlySpan<byte> pbDataHash,
             int cbDataHash,
-            byte[] pbSignature,
+            ReadOnlySpan<byte> pbSignature,
+            int cbSignature,
+            PAL_HashAlgorithm hashAlgorithm,
+            out SafeCFErrorHandle pErrorOut)
+        {
+            fixed (byte* pbDataHashPtr = &pbDataHash.DangerousGetPinnableReference(), pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
+            {
+                return AppleCryptoNative_VerifySignatureWithHashAlgorithm(publicKey, pbDataHashPtr, cbDataHash, pbSignaturePtr, cbSignature, hashAlgorithm, out pErrorOut);
+            }
+        }
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern unsafe int AppleCryptoNative_VerifySignatureWithHashAlgorithm(
+            SafeSecKeyRefHandle publicKey,
+            byte* pbDataHash,
+            int cbDataHash,
+            byte* pbSignature,
             int cbSignature,
             PAL_HashAlgorithm hashAlgorithm,
             out SafeCFErrorHandle pErrorOut);
@@ -60,6 +105,7 @@ internal static partial class Interop
         private static extern ulong AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(SafeSecKeyRefHandle publicKey);
 
         private delegate int SecKeyTransform(out SafeCFDataHandle data, out SafeCFErrorHandle error);
+        private delegate int SecKeySpanTransform(ReadOnlySpan<byte> source, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle);
 
         private static byte[] ExecuteTransform(SecKeyTransform transform)
         {
@@ -89,6 +135,35 @@ internal static partial class Interop
             }
         }
 
+        private static bool TryExecuteTransform(
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            out int bytesWritten,
+            SecKeySpanTransform transform)
+        {
+            SafeCFDataHandle outputHandle;
+            SafeCFErrorHandle errorHandle;
+
+            int ret = transform(source, out outputHandle, out errorHandle);
+
+            using (errorHandle)
+            using (outputHandle)
+            {
+                const int Success = 1;
+                const int kErrorSeeError = -2;
+                switch (ret)
+                {
+                    case Success:
+                        return CoreFoundation.TryCFWriteData(outputHandle, destination, out bytesWritten);
+                    case kErrorSeeError:
+                        throw CreateExceptionForCFError(errorHandle);
+                    default:
+                        Debug.Fail($"transform returned {ret}");
+                        throw new CryptographicException();
+                }
+            }
+        }
+        
         internal static int GetSimpleKeySizeInBits(SafeSecKeyRefHandle publicKey)
         {
             ulong keySizeInBytes = AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(publicKey);
@@ -162,14 +237,29 @@ internal static partial class Interop
                         out error));
         }
 
+        internal static bool TryGenerateSignature(
+            SafeSecKeyRefHandle privateKey,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            PAL_HashAlgorithm hashAlgorithm,
+            out int bytesWritten)
+        {
+            Debug.Assert(privateKey != null, "privateKey != null");
+            Debug.Assert(hashAlgorithm != PAL_HashAlgorithm.Unknown, "hashAlgorithm != PAL_HashAlgorithm.Unknown");
+
+            return TryExecuteTransform(
+                source, destination, out bytesWritten,
+                (ReadOnlySpan<byte> innerSource, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle) =>
+                    AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
+                        privateKey, innerSource, innerSource.Length, hashAlgorithm, out outputHandle, out errorHandle));
+        }
+
         internal static bool VerifySignature(
             SafeSecKeyRefHandle publicKey,
-            byte[] dataHash,
-            byte[] signature)
+            ReadOnlySpan<byte> dataHash,
+            ReadOnlySpan<byte> signature)
         {
             Debug.Assert(publicKey != null, "publicKey != null");
-            Debug.Assert(dataHash != null, "dataHash != null");
-            Debug.Assert(signature != null, "signature != null");
 
             SafeCFErrorHandle error;
 
@@ -204,13 +294,11 @@ internal static partial class Interop
 
         internal static bool VerifySignature(
             SafeSecKeyRefHandle publicKey,
-            byte[] dataHash,
-            byte[] signature,
+            ReadOnlySpan<byte> dataHash,
+            ReadOnlySpan<byte> signature,
             PAL_HashAlgorithm hashAlgorithm)
         {
             Debug.Assert(publicKey != null, "publicKey != null");
-            Debug.Assert(dataHash != null, "dataHash != null");
-            Debug.Assert(signature != null, "signature != null");
             Debug.Assert(hashAlgorithm != PAL_HashAlgorithm.Unknown);
 
             SafeCFErrorHandle error;

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.cs
@@ -61,7 +61,8 @@ internal static partial class Interop
             int cbSignature,
             out SafeCFErrorHandle pErrorOut)
         {
-            fixed (byte* pbDataHashPtr = &pbDataHash.DangerousGetPinnableReference(), pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
+            fixed (byte* pbDataHashPtr = &pbDataHash.DangerousGetPinnableReference())
+            fixed (byte* pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
             {
                 return AppleCryptoNative_VerifySignature(publicKey, pbDataHashPtr, cbDataHash, pbSignaturePtr, cbSignature, out pErrorOut);
             }
@@ -85,7 +86,8 @@ internal static partial class Interop
             PAL_HashAlgorithm hashAlgorithm,
             out SafeCFErrorHandle pErrorOut)
         {
-            fixed (byte* pbDataHashPtr = &pbDataHash.DangerousGetPinnableReference(), pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
+            fixed (byte* pbDataHashPtr = &pbDataHash.DangerousGetPinnableReference())
+            fixed (byte* pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
             {
                 return AppleCryptoNative_VerifySignatureWithHashAlgorithm(publicKey, pbDataHashPtr, cbDataHash, pbSignaturePtr, cbSignature, hashAlgorithm, out pErrorOut);
             }
@@ -248,10 +250,14 @@ internal static partial class Interop
             Debug.Assert(hashAlgorithm != PAL_HashAlgorithm.Unknown, "hashAlgorithm != PAL_HashAlgorithm.Unknown");
 
             return TryExecuteTransform(
-                source, destination, out bytesWritten,
-                (ReadOnlySpan<byte> innerSource, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle) =>
-                    AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
-                        privateKey, innerSource, innerSource.Length, hashAlgorithm, out outputHandle, out errorHandle));
+                source,
+                destination,
+                out bytesWritten,
+                delegate (ReadOnlySpan<byte> innerSource, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle)
+                {
+                    return AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
+                        privateKey, innerSource, innerSource.Length, hashAlgorithm, out outputHandle, out errorHandle);
+                });
         }
 
         internal static bool VerifySignature(

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
@@ -25,19 +25,45 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeRsaPublicKey")]
         internal static extern SafeRsaHandle DecodeRsaPublicKey(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaPublicEncrypt")]
-        internal extern static int RsaPublicEncrypt(
+        internal static unsafe int RsaPublicEncrypt(
             int flen,
-            byte[] from,
-            byte[] to,
+            ReadOnlySpan<byte> from,
+            Span<byte> to,
+            SafeRsaHandle rsa,
+            RsaPadding padding)
+        {
+            fixed (byte* fromPtr = &from.DangerousGetPinnableReference(), toPtr = &to.DangerousGetPinnableReference())
+            {
+                return RsaPublicEncrypt(flen, fromPtr, toPtr, rsa, padding);
+            }
+        }
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaPublicEncrypt")]
+        private extern static unsafe int RsaPublicEncrypt(
+            int flen,
+            byte* from,
+            byte* to,
             SafeRsaHandle rsa,
             RsaPadding padding);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaPrivateDecrypt")]
-        internal extern static int RsaPrivateDecrypt(
+        internal static unsafe int RsaPrivateDecrypt(
             int flen,
-            byte[] from,
-            byte[] to,
+            ReadOnlySpan<byte> from,
+            Span<byte> to,
+            SafeRsaHandle rsa,
+            RsaPadding padding)
+        {
+            fixed (byte* fromPtr = &from.DangerousGetPinnableReference(), toPtr = &to.DangerousGetPinnableReference())
+            {
+                return RsaPrivateDecrypt(flen, fromPtr, toPtr, rsa, padding);
+            }
+        }
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaPrivateDecrypt")]
+        private extern static unsafe int RsaPrivateDecrypt(
+            int flen,
+            byte* from,
+            byte* to,
             SafeRsaHandle rsa,
             RsaPadding padding);
 
@@ -47,13 +73,29 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaGenerateKeyEx")]
         internal static extern int RsaGenerateKeyEx(SafeRsaHandle rsa, int bits, SafeBignumHandle e);
 
+        internal static unsafe bool RsaSign(int type, ReadOnlySpan<byte> m, int m_len, Span<byte> sigret, out int siglen, SafeRsaHandle rsa)
+        {
+            fixed (byte* mPtr = &m.DangerousGetPinnableReference(), sigretPtr = &sigret.DangerousGetPinnableReference())
+            {
+                return RsaSign(type, mPtr, m_len, sigretPtr, out siglen, rsa);
+            }
+        }
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaSign")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool RsaSign(int type, byte[] m, int m_len, byte[] sigret, out int siglen, SafeRsaHandle rsa);
+        private static extern unsafe bool RsaSign(int type, byte* m, int m_len, byte* sigret, out int siglen, SafeRsaHandle rsa);
+
+        internal static unsafe bool RsaVerify(int type, ReadOnlySpan<byte> m, int m_len, ReadOnlySpan<byte> sigbuf, int siglen, SafeRsaHandle rsa)
+        {
+            fixed (byte* mPtr = &m.DangerousGetPinnableReference(), sigbufPtr = &sigbuf.DangerousGetPinnableReference())
+            {
+                return RsaVerify(type, mPtr, m_len, sigbufPtr, siglen, rsa);
+            }
+        }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaVerify")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool RsaVerify(int type, byte[] m, int m_len, byte[] sigbuf, int siglen, SafeRsaHandle rsa);
+        private static extern unsafe bool RsaVerify(int type, byte* m, int m_len, byte* sigbuf, int siglen, SafeRsaHandle rsa);
 
         internal static RSAParameters ExportRsaParameters(SafeRsaHandle key, bool includePrivateParameters)
         {

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
@@ -32,7 +32,8 @@ internal static partial class Interop
             SafeRsaHandle rsa,
             RsaPadding padding)
         {
-            fixed (byte* fromPtr = &from.DangerousGetPinnableReference(), toPtr = &to.DangerousGetPinnableReference())
+            fixed (byte* fromPtr = &from.DangerousGetPinnableReference())
+            fixed (byte* toPtr = &to.DangerousGetPinnableReference())
             {
                 return RsaPublicEncrypt(flen, fromPtr, toPtr, rsa, padding);
             }
@@ -53,7 +54,8 @@ internal static partial class Interop
             SafeRsaHandle rsa,
             RsaPadding padding)
         {
-            fixed (byte* fromPtr = &from.DangerousGetPinnableReference(), toPtr = &to.DangerousGetPinnableReference())
+            fixed (byte* fromPtr = &from.DangerousGetPinnableReference())
+            fixed (byte* toPtr = &to.DangerousGetPinnableReference())
             {
                 return RsaPrivateDecrypt(flen, fromPtr, toPtr, rsa, padding);
             }
@@ -75,7 +77,8 @@ internal static partial class Interop
 
         internal static unsafe bool RsaSign(int type, ReadOnlySpan<byte> m, int m_len, Span<byte> sigret, out int siglen, SafeRsaHandle rsa)
         {
-            fixed (byte* mPtr = &m.DangerousGetPinnableReference(), sigretPtr = &sigret.DangerousGetPinnableReference())
+            fixed (byte* mPtr = &m.DangerousGetPinnableReference())
+            fixed (byte* sigretPtr = &sigret.DangerousGetPinnableReference())
             {
                 return RsaSign(type, mPtr, m_len, sigretPtr, out siglen, rsa);
             }
@@ -87,7 +90,8 @@ internal static partial class Interop
 
         internal static unsafe bool RsaVerify(int type, ReadOnlySpan<byte> m, int m_len, ReadOnlySpan<byte> sigbuf, int siglen, SafeRsaHandle rsa)
         {
-            fixed (byte* mPtr = &m.DangerousGetPinnableReference(), sigbufPtr = &sigbuf.DangerousGetPinnableReference())
+            fixed (byte* mPtr = &m.DangerousGetPinnableReference())
+            fixed (byte* sigbufPtr = &sigbuf.DangerousGetPinnableReference())
             {
                 return RsaVerify(type, mPtr, m_len, sigbufPtr, siglen, rsa);
             }

--- a/src/Common/src/Interop/Windows/NCrypt/Interop.EncryptDecrypt.cs
+++ b/src/Common/src/Interop/Windows/NCrypt/Interop.EncryptDecrypt.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -9,17 +10,26 @@ internal static partial class Interop
 {
     internal static partial class NCrypt
     {
+        internal static unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags)
+        {
+            fixed (byte* pbInputPtr = &pbInput.DangerousGetPinnableReference(), pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
+            {
+                return NCryptEncrypt(hKey, pbInputPtr, cbInput, pPaddingInfo, pbOutputPtr, cbOutput, out pcbResult, dwFlags);
+            }
+        }
 
         [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, [In] byte[] pbInput, int cbInput, void* pPaddingInfo, [Out] byte[] pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+        private static extern unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, byte* pbInput, int cbInput, void* pPaddingInfo, byte* pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+
+        internal static unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags)
+        {
+            fixed (byte* pbInputPtr = &pbInput.DangerousGetPinnableReference(), pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
+            {
+                return NCryptDecrypt(hKey, pbInputPtr, cbInput, pPaddingInfo, pbOutputPtr, cbOutput, out pcbResult, dwFlags);
+            }
+        }
 
         [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, byte* pbInput, int cbInput, void* pPaddingInfo, byte* pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
-
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, [In] byte[] pbInput, int cbInput, void* pPaddingInfo, [Out] byte[] pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
-
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, byte* pbInput, int cbInput, void* pPaddingInfo, byte* pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+        private static extern unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, byte* pbInput, int cbInput, void* pPaddingInfo, byte* pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
     }
 }

--- a/src/Common/src/Interop/Windows/NCrypt/Interop.EncryptDecrypt.cs
+++ b/src/Common/src/Interop/Windows/NCrypt/Interop.EncryptDecrypt.cs
@@ -12,7 +12,8 @@ internal static partial class Interop
     {
         internal static unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags)
         {
-            fixed (byte* pbInputPtr = &pbInput.DangerousGetPinnableReference(), pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
+            fixed (byte* pbInputPtr = &pbInput.DangerousGetPinnableReference())
+            fixed (byte* pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
             {
                 return NCryptEncrypt(hKey, pbInputPtr, cbInput, pPaddingInfo, pbOutputPtr, cbOutput, out pcbResult, dwFlags);
             }
@@ -23,7 +24,8 @@ internal static partial class Interop
 
         internal static unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags)
         {
-            fixed (byte* pbInputPtr = &pbInput.DangerousGetPinnableReference(), pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
+            fixed (byte* pbInputPtr = &pbInput.DangerousGetPinnableReference())
+            fixed (byte* pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
             {
                 return NCryptDecrypt(hKey, pbInputPtr, cbInput, pPaddingInfo, pbOutputPtr, cbOutput, out pcbResult, dwFlags);
             }

--- a/src/Common/src/Interop/Windows/NCrypt/Interop.SignVerify.cs
+++ b/src/Common/src/Interop/Windows/NCrypt/Interop.SignVerify.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -9,10 +10,26 @@ internal static partial class Interop
 {
     internal static partial class NCrypt
     {
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern unsafe ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, [In] byte[] pbHashValue, int cbHashValue, [Out] byte[] pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags);
+        internal static unsafe ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, Span<byte> pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags)
+        {
+            fixed (byte* pbHashValuePtr = &pbHashValue.DangerousGetPinnableReference(), pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
+            {
+                return NCryptSignHash(hKey, pPaddingInfo, pbHashValuePtr, cbHashValue, pbSignaturePtr, cbSignature, out pcbResult, dwFlags);
+            }
+        }
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern unsafe ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void *pPaddingInfo, [In] byte[] pbHashValue, int cbHashValue, [In] byte[] pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags);
+        [DllImport(Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        private static extern unsafe ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, byte* pbHashValue, int cbHashValue, byte* pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags);
+
+        internal static unsafe ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, ReadOnlySpan<byte> pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags)
+        {
+            fixed (byte* pbHashValuePtr = &pbHashValue.DangerousGetPinnableReference(), pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
+            {
+                return NCryptVerifySignature(hKey, pPaddingInfo, pbHashValuePtr, cbHashValue, pbSignaturePtr, cbSignature, dwFlags);
+            }
+        }
+
+        [DllImport(Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        private static extern unsafe ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, byte* pbHashValue, int cbHashValue, byte* pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags);
     }
 }

--- a/src/Common/src/Interop/Windows/NCrypt/Interop.SignVerify.cs
+++ b/src/Common/src/Interop/Windows/NCrypt/Interop.SignVerify.cs
@@ -12,7 +12,8 @@ internal static partial class Interop
     {
         internal static unsafe ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, Span<byte> pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags)
         {
-            fixed (byte* pbHashValuePtr = &pbHashValue.DangerousGetPinnableReference(), pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
+            fixed (byte* pbHashValuePtr = &pbHashValue.DangerousGetPinnableReference())
+            fixed (byte* pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
             {
                 return NCryptSignHash(hKey, pPaddingInfo, pbHashValuePtr, cbHashValue, pbSignaturePtr, cbSignature, out pcbResult, dwFlags);
             }
@@ -23,7 +24,8 @@ internal static partial class Interop
 
         internal static unsafe ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, ReadOnlySpan<byte> pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags)
         {
-            fixed (byte* pbHashValuePtr = &pbHashValue.DangerousGetPinnableReference(), pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
+            fixed (byte* pbHashValuePtr = &pbHashValue.DangerousGetPinnableReference())
+            fixed (byte* pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
             {
                 return NCryptVerifySignature(hKey, pPaddingInfo, pbHashValuePtr, cbHashValue, pbSignaturePtr, cbSignature, dwFlags);
             }

--- a/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -68,7 +68,10 @@ namespace System.Security.Cryptography
                             };
                             return EncryptOrDecrypt(keyHandle, data, AsymmetricPaddingMode.NCRYPT_PAD_OAEP_FLAG, &paddingInfo, encrypt);
                         }
-                        finally { Marshal.FreeHGlobal(namePtr); }
+                        finally
+                        {
+                            Marshal.FreeHGlobal(namePtr);
+                        }
 
                     default:
                         throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
@@ -104,7 +107,10 @@ namespace System.Security.Cryptography
                             };
                             return TryEncryptOrDecrypt(keyHandle, source, destination, AsymmetricPaddingMode.NCRYPT_PAD_OAEP_FLAG, &paddingInfo, encrypt, out bytesWritten);
                         }
-                        finally { Marshal.FreeHGlobal(namePtr); }
+                        finally
+                        {
+                            Marshal.FreeHGlobal(namePtr);
+                        }
 
                     default:
                         throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
@@ -144,9 +150,7 @@ namespace System.Security.Cryptography
         }
 
         // Now that the padding mode and information have been marshaled to their native counterparts, perform the encryption or decryption.
-        private unsafe bool TryEncryptOrDecrypt(
-            SafeNCryptKeyHandle key, ReadOnlySpan<byte> input, Span<byte> output,
-            AsymmetricPaddingMode paddingMode, void* paddingInfo, bool encrypt, out int bytesWritten)
+        private unsafe bool TryEncryptOrDecrypt(SafeNCryptKeyHandle key, ReadOnlySpan<byte> input, Span<byte> output, AsymmetricPaddingMode paddingMode, void* paddingInfo, bool encrypt, out int bytesWritten)
         {
             int numBytesNeeded;
             ErrorCode errorCode = encrypt ?

--- a/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
-
 using Internal.Cryptography;
 
 using ErrorCode = Interop.NCrypt.ErrorCode;
@@ -18,76 +18,102 @@ namespace System.Security.Cryptography
 #endif
     public sealed partial class RSACng : RSA
     {
-        /// <summary>
-        ///     Encrypts data using the public key.
-        /// </summary>
-        public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding)
-        {
-            unsafe
-            {
-                return EncryptOrDecrypt(data, padding, Interop.NCrypt.NCryptEncrypt);
-            }
-        }
+        /// <summary>Encrypts data using the public key.</summary>
+        public override unsafe byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) =>
+            EncryptOrDecrypt(data, padding, encrypt: true);
 
-        /// <summary>
-        ///     Decrypts data using the private key.
-        /// </summary>
-        public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
-        {
-            unsafe
-            {
-                return EncryptOrDecrypt(data, padding, Interop.NCrypt.NCryptDecrypt);
-            }
-        }
+        /// <summary>Decrypts data using the private key.</summary>
+        public override unsafe byte[] Decrypt(byte[] data, RSAEncryptionPadding padding) =>
+            EncryptOrDecrypt(data, padding, encrypt: false);
 
-        //
+        /// <summary>Encrypts data using the public key.</summary>
+        public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
+            TryEncryptOrDecrypt(source, destination, padding, encrypt: true, bytesWritten: out bytesWritten);
+
+        /// <summary>Decrypts data using the private key.</summary>
+        public override bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
+            TryEncryptOrDecrypt(source, destination, padding, encrypt: false, bytesWritten: out bytesWritten);
+
         // Conveniently, Encrypt() and Decrypt() are identical save for the actual P/Invoke call to CNG. Thus, both
-        // APIs invoke this common helper with the "transform" parameter determining whether encryption or decryption is done.
-        //
-        private byte[] EncryptOrDecrypt(byte[] data, RSAEncryptionPadding padding, EncryptOrDecryptAction encryptOrDecrypt)
+        // array-based APIs invoke this common helper with the "encrypt" parameter determining whether encryption or decryption is done.
+        private unsafe byte[] EncryptOrDecrypt(byte[] data, RSAEncryptionPadding padding, bool encrypt)
         {
             if (data == null)
-                throw new ArgumentNullException(nameof(data));
-
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
-
-            unsafe
             {
-                using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
+                throw new ArgumentNullException(nameof(data));
+            }
+            if (padding == null)
+            {
+                throw new ArgumentNullException(nameof(padding));
+            }
+
+            using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
+            {
+                switch (padding.Mode)
                 {
-                    switch (padding.Mode)
-                    {
-                        case RSAEncryptionPaddingMode.Pkcs1:
-                            return EncryptOrDecrypt(keyHandle, data, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, null, encryptOrDecrypt);
+                    case RSAEncryptionPaddingMode.Pkcs1:
+                        return EncryptOrDecrypt(keyHandle, data, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, null, encrypt);
 
-                        case RSAEncryptionPaddingMode.Oaep:
+                    case RSAEncryptionPaddingMode.Oaep:
+                        IntPtr namePtr = Marshal.StringToHGlobalUni(padding.OaepHashAlgorithm.Name);
+                        try
+                        {
+                            var paddingInfo = new BCRYPT_OAEP_PADDING_INFO()
                             {
-                                using (SafeUnicodeStringHandle safeHashAlgorithmName = new SafeUnicodeStringHandle(padding.OaepHashAlgorithm.Name))
-                                {
-                                    BCRYPT_OAEP_PADDING_INFO paddingInfo = new BCRYPT_OAEP_PADDING_INFO()
-                                    {
-                                        pszAlgId = safeHashAlgorithmName.DangerousGetHandle(),
+                                pszAlgId = namePtr,
 
-                                        // It would nice to put randomized data here but RSAEncryptionPadding does not at this point provide support for this.
-                                        pbLabel = IntPtr.Zero,
-                                        cbLabel = 0,
-                                    };
-                                    return EncryptOrDecrypt(keyHandle, data, AsymmetricPaddingMode.NCRYPT_PAD_OAEP_FLAG, &paddingInfo, encryptOrDecrypt);
-                                }
-                            }
+                                // It would nice to put randomized data here but RSAEncryptionPadding does not at this point provide support for this.
+                                pbLabel = IntPtr.Zero,
+                                cbLabel = 0,
+                            };
+                            return EncryptOrDecrypt(keyHandle, data, AsymmetricPaddingMode.NCRYPT_PAD_OAEP_FLAG, &paddingInfo, encrypt);
+                        }
+                        finally { Marshal.FreeHGlobal(namePtr); }
 
-                        default:
-                            throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
-                    }
+                    default:
+                        throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
                 }
             }
         }
 
-        //
+        // Conveniently, Encrypt() and Decrypt() are identical save for the actual P/Invoke call to CNG. Thus, both
+        // span-based APIs invoke this common helper with the "encrypt" parameter determining whether encryption or decryption is done.
+        private unsafe bool TryEncryptOrDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, bool encrypt, out int bytesWritten)
+        {
+            if (padding == null)
+            {
+                throw new ArgumentNullException(nameof(padding));
+            }
+
+            using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
+            {
+                switch (padding.Mode)
+                {
+                    case RSAEncryptionPaddingMode.Pkcs1:
+                        return TryEncryptOrDecrypt(keyHandle, source, destination, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, null, encrypt, out bytesWritten);
+
+                    case RSAEncryptionPaddingMode.Oaep:
+                        IntPtr namePtr = Marshal.StringToHGlobalUni(padding.OaepHashAlgorithm.Name);
+                        try
+                        {
+                            var paddingInfo = new BCRYPT_OAEP_PADDING_INFO()
+                            {
+                                pszAlgId = namePtr,
+                                pbLabel = IntPtr.Zero, // It would nice to put randomized data here but RSAEncryptionPadding does not at this point provide support for this.
+                                cbLabel = 0,
+                            };
+                            return TryEncryptOrDecrypt(keyHandle, source, destination, AsymmetricPaddingMode.NCRYPT_PAD_OAEP_FLAG, &paddingInfo, encrypt, out bytesWritten);
+                        }
+                        finally { Marshal.FreeHGlobal(namePtr); }
+
+                    default:
+                        throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
+                }
+            }
+        }
+
         // Now that the padding mode and information have been marshaled to their native counterparts, perform the encryption or decryption.
-        //
-        private unsafe byte[] EncryptOrDecrypt(SafeNCryptKeyHandle key, byte[] input, AsymmetricPaddingMode paddingMode, void* paddingInfo, EncryptOrDecryptAction encryptOrDecrypt)
+        private unsafe byte[] EncryptOrDecrypt(SafeNCryptKeyHandle key, byte[] input, AsymmetricPaddingMode paddingMode, void* paddingInfo, bool encrypt)
         {
             int estimatedSize = KeySize / 8;
 #if DEBUG
@@ -96,21 +122,49 @@ namespace System.Security.Cryptography
 
             byte[] output = new byte[estimatedSize];
             int numBytesNeeded;
-            ErrorCode errorCode = encryptOrDecrypt(key, input, input.Length, paddingInfo, output, output.Length, out numBytesNeeded, paddingMode);
+            ErrorCode errorCode = encrypt ?
+                Interop.NCrypt.NCryptEncrypt(key, input, input.Length, paddingInfo, output, output.Length, out numBytesNeeded, paddingMode) :
+                Interop.NCrypt.NCryptDecrypt(key, input, input.Length, paddingInfo, output, output.Length, out numBytesNeeded, paddingMode);
+
             if (errorCode == ErrorCode.NTE_BUFFER_TOO_SMALL)
             {
                 output = new byte[numBytesNeeded];
-                errorCode = encryptOrDecrypt(key, input, input.Length, paddingInfo, output, output.Length, out numBytesNeeded, paddingMode);
+                errorCode = encrypt ?
+                    Interop.NCrypt.NCryptEncrypt(key, input, input.Length, paddingInfo, output, output.Length, out numBytesNeeded, paddingMode) :
+                    Interop.NCrypt.NCryptDecrypt(key, input, input.Length, paddingInfo, output, output.Length, out numBytesNeeded, paddingMode);
+
             }
             if (errorCode != ErrorCode.ERROR_SUCCESS)
+            {
                 throw errorCode.ToCryptographicException();
+            }
 
             Array.Resize(ref output, numBytesNeeded);
             return output;
         }
 
-        // Delegate binds to either NCryptEncrypt() or NCryptDecrypt() depending on which api was called.
-        private unsafe delegate ErrorCode EncryptOrDecryptAction(SafeNCryptKeyHandle hKey, byte[] pbInput, int cbInput, void* pPaddingInfo, byte[] pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+        // Now that the padding mode and information have been marshaled to their native counterparts, perform the encryption or decryption.
+        private unsafe bool TryEncryptOrDecrypt(
+            SafeNCryptKeyHandle key, ReadOnlySpan<byte> input, Span<byte> output,
+            AsymmetricPaddingMode paddingMode, void* paddingInfo, bool encrypt, out int bytesWritten)
+        {
+            int numBytesNeeded;
+            ErrorCode errorCode = encrypt ?
+                Interop.NCrypt.NCryptEncrypt(key, input, input.Length, paddingInfo, output, output.Length, out numBytesNeeded, paddingMode) :
+                Interop.NCrypt.NCryptDecrypt(key, input, input.Length, paddingInfo, output, output.Length, out numBytesNeeded, paddingMode);
+
+            switch (errorCode)
+            {
+                case ErrorCode.ERROR_SUCCESS:
+                    bytesWritten = numBytesNeeded;
+                    return true;
+                case ErrorCode.NTE_BUFFER_TOO_SMALL:
+                    bytesWritten = 0;
+                    return false;
+                default:
+                    throw errorCode.ToCryptographicException();
+            }
+        }
     }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     }

--- a/src/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
@@ -2,14 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-
+using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
-
 using Internal.Cryptography;
 
-using ErrorCode = Interop.NCrypt.ErrorCode;
 using AsymmetricPaddingMode = Interop.NCrypt.AsymmetricPaddingMode;
 using BCRYPT_PKCS1_PADDING_INFO = Interop.BCrypt.BCRYPT_PKCS1_PADDING_INFO;
 using BCRYPT_PSS_PADDING_INFO = Interop.BCrypt.BCRYPT_PSS_PADDING_INFO;
@@ -28,22 +24,79 @@ namespace System.Security.Cryptography
         public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
             if (hash == null)
-                throw new ArgumentNullException(nameof(hash));
-
-            unsafe
             {
-                byte[] signature = null;
-                SignOrVerify(padding, hashAlgorithm, hash,
-                    delegate (AsymmetricPaddingMode paddingMode, void* pPaddingInfo)
+                throw new ArgumentNullException(nameof(hash));
+            }
+
+            string hashAlgorithmName = hashAlgorithm.Name;
+            if (string.IsNullOrEmpty(hashAlgorithmName))
+            {
+                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            }
+            if (padding == null)
+            {
+                throw new ArgumentNullException(nameof(padding));
+            }
+
+            using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
+            {
+                IntPtr namePtr = Marshal.StringToHGlobalUni(hashAlgorithmName);
+                try
+                {
+                    unsafe
                     {
                         int estimatedSize = KeySize / 8;
-                        using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
+                        switch (padding.Mode)
                         {
-                            signature = keyHandle.SignHash(hash, paddingMode, pPaddingInfo, estimatedSize);
+                            case RSASignaturePaddingMode.Pkcs1:
+                                var pkcsPaddingInfo = new BCRYPT_PKCS1_PADDING_INFO() { pszAlgId = namePtr };
+                                return keyHandle.SignHash(hash, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, &pkcsPaddingInfo, estimatedSize);
+
+                            case RSASignaturePaddingMode.Pss:
+                                var pssPaddingInfo = new BCRYPT_PSS_PADDING_INFO() { pszAlgId = namePtr, cbSalt = hash.Length };
+                                return keyHandle.SignHash(hash, AsymmetricPaddingMode.NCRYPT_PAD_PSS_FLAG, &pssPaddingInfo, estimatedSize);
+
+                            default:
+                                throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
                         }
                     }
-                );
-                return signature;
+                }
+                finally { Marshal.FreeHGlobal(namePtr); }
+            }
+        }
+
+        public override unsafe bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
+        {
+            string hashAlgorithmName = hashAlgorithm.Name;
+            if (string.IsNullOrEmpty(hashAlgorithmName))
+            {
+                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            }
+            if (padding == null)
+            {
+                throw new ArgumentNullException(nameof(padding));
+            }
+
+            using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
+            {
+                IntPtr namePtr = Marshal.StringToHGlobalUni(hashAlgorithmName);
+                try
+                {
+                    switch (padding.Mode)
+                    {
+                        case RSASignaturePaddingMode.Pkcs1:
+                            var pkcs1PaddingInfo = new BCRYPT_PKCS1_PADDING_INFO() { pszAlgId = namePtr };
+                            return keyHandle.TrySignHash(source, destination, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, &pkcs1PaddingInfo, out bytesWritten);
+
+                        case RSASignaturePaddingMode.Pss:
+                            var pssPaddingInfo = new BCRYPT_PSS_PADDING_INFO() { pszAlgId = namePtr, cbSalt = source.Length };
+                            return keyHandle.TrySignHash(source, destination, AsymmetricPaddingMode.NCRYPT_PAD_PSS_FLAG, &pssPaddingInfo, out bytesWritten);
+
+                        default:
+                            throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
+                    }
+                }
+                finally { Marshal.FreeHGlobal(namePtr); }
             }
         }
 
@@ -53,74 +106,51 @@ namespace System.Security.Cryptography
         public override bool VerifyHash(byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
             if (hash == null)
-                throw new ArgumentNullException(nameof(hash));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-
-            unsafe
             {
-                bool verified = false;
-                SignOrVerify(padding, hashAlgorithm, hash,
-                    delegate (AsymmetricPaddingMode paddingMode, void* pPaddingInfo)
-                    {
-                        using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
-                        {
-                            verified = keyHandle.VerifyHash(hash, signature, paddingMode, pPaddingInfo);
-                        }
-                    }
-                );
-                return verified;
+                throw new ArgumentNullException(nameof(hash));
             }
+            if (signature == null)
+            {
+                throw new ArgumentNullException(nameof(signature));
+            }
+
+            return VerifyHash((ReadOnlySpan<byte>)hash, (ReadOnlySpan<byte>)signature, hashAlgorithm, padding);
         }
 
-        //
-        // Common helper for SignHash() and VerifyHash(). Creates the necessary PADDING_INFO structure based on the chosen padding mode and then passes it
-        // to "signOrVerify" which performs the actual signing or verification.
-        //
-        private static unsafe void SignOrVerify(RSASignaturePadding padding, HashAlgorithmName hashAlgorithm, byte[] hash, SignOrVerifyAction signOrVerify)
+        public override unsafe bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
             string hashAlgorithmName = hashAlgorithm.Name;
             if (string.IsNullOrEmpty(hashAlgorithmName))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
-
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
-
-            switch (padding.Mode)
             {
-                case RSASignaturePaddingMode.Pkcs1:
-                    {
-                        using (SafeUnicodeStringHandle safeHashAlgorithmName = new SafeUnicodeStringHandle(hashAlgorithmName))
-                        {
-                            BCRYPT_PKCS1_PADDING_INFO paddingInfo = new BCRYPT_PKCS1_PADDING_INFO()
-                            {
-                                pszAlgId = safeHashAlgorithmName.DangerousGetHandle(),
-                            };
-                            signOrVerify(AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, &paddingInfo);
-                        }
-                        break;
-                    }
+                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            }
+            if (padding == null)
+            {
+                throw new ArgumentNullException(nameof(padding));
+            }
 
-                case RSASignaturePaddingMode.Pss:
+            using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
+            {
+                IntPtr namePtr = Marshal.StringToHGlobalUni(hashAlgorithmName);
+                try
+                {
+                    switch (padding.Mode)
                     {
-                        using (SafeUnicodeStringHandle safeHashAlgorithmName = new SafeUnicodeStringHandle(hashAlgorithmName))
-                        {
-                            BCRYPT_PSS_PADDING_INFO paddingInfo = new BCRYPT_PSS_PADDING_INFO()
-                            {
-                                pszAlgId = safeHashAlgorithmName.DangerousGetHandle(),
-                                cbSalt = hash.Length,
-                            };
-                            signOrVerify(AsymmetricPaddingMode.NCRYPT_PAD_PSS_FLAG, &paddingInfo);
-                        }
-                        break;
-                    }
+                        case RSASignaturePaddingMode.Pkcs1:
+                            var pkcs1PaddingInfo = new BCRYPT_PKCS1_PADDING_INFO() { pszAlgId = namePtr };
+                            return keyHandle.VerifyHash(hash, signature, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, &pkcs1PaddingInfo);
 
-                default:
-                    throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
+                        case RSASignaturePaddingMode.Pss:
+                            var pssPaddingInfo = new BCRYPT_PSS_PADDING_INFO() { pszAlgId = namePtr, cbSalt = hash.Length };
+                            return keyHandle.VerifyHash(hash, signature, AsymmetricPaddingMode.NCRYPT_PAD_PSS_FLAG, &pssPaddingInfo);
+
+                        default:
+                            throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
+                    }
+                }
+                finally { Marshal.FreeHGlobal(namePtr); }
             }
         }
-
-        private unsafe delegate void SignOrVerifyAction(AsymmetricPaddingMode paddingMode, void* pPaddingInfo);
     }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     }

--- a/src/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
@@ -61,7 +61,10 @@ namespace System.Security.Cryptography
                         }
                     }
                 }
-                finally { Marshal.FreeHGlobal(namePtr); }
+                finally
+                {
+                    Marshal.FreeHGlobal(namePtr);
+                }
             }
         }
 
@@ -96,7 +99,10 @@ namespace System.Security.Cryptography
                             throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
                     }
                 }
-                finally { Marshal.FreeHGlobal(namePtr); }
+                finally
+                {
+                    Marshal.FreeHGlobal(namePtr);
+                }
             }
         }
 
@@ -148,7 +154,10 @@ namespace System.Security.Cryptography
                             throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
                     }
                 }
-                finally { Marshal.FreeHGlobal(namePtr); }
+                finally
+                {
+                    Marshal.FreeHGlobal(namePtr);
+                }
             }
         }
     }

--- a/src/Common/src/System/Security/Cryptography/RSACng.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.cs
@@ -47,15 +47,14 @@ namespace System.Security.Cryptography
             }
         }
 
-        protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
-        {
-            return CngCommon.HashData(data, offset, count, hashAlgorithm);
-        }
+        protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
+            CngCommon.HashData(data, offset, count, hashAlgorithm);
 
-        protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
-        {
-            return CngCommon.HashData(data, hashAlgorithm);
-        }
+        protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+            CngCommon.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
+
+        protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
+            CngCommon.HashData(data, hashAlgorithm);
 
         private void ForceSetKeySize(int newKeySize)
         {

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -13,10 +13,7 @@ namespace System.Security.Cryptography
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     public partial class RSA : AsymmetricAlgorithm
     {
-        public static new RSA Create()
-        {
-            return new RSAImplementation.RSAOpenSsl();
-        }
+        public static new RSA Create() => new RSAImplementation.RSAOpenSsl();
     }
 
     internal static partial class RSAImplementation
@@ -123,6 +120,35 @@ namespace System.Security.Cryptography
             return plainBytes;
         }
 
+        public override bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+        {
+            if (padding == null)
+            {
+                throw new ArgumentNullException(nameof(padding));
+            }
+
+            Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding);
+            SafeRsaHandle key = _key.Value;
+            CheckInvalidKey(key);
+
+            if (destination.Length < Interop.Crypto.RsaSize(key))
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            int returnValue = Interop.Crypto.RsaPrivateDecrypt(source.Length, source, destination, key, rsaPadding);
+            CheckReturn(returnValue);
+
+            // If the padding mode is RSA_NO_PADDING then the size of the decrypted block
+            // will be RSA_size. If any padding was used, then some amount (determined by the padding algorithm)
+            // will have been reduced, and only returnValue bytes were part of the decrypted
+            // body.  Either way, we can just use returnValue, but some additional bytes may have been overwritten
+            // in the destination span.
+            bytesWritten = returnValue;
+            return true;
+        }
+
         public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding)
         {
             if (data == null)
@@ -148,21 +174,34 @@ namespace System.Security.Cryptography
             return buf;
         }
 
-        private static Interop.Crypto.RsaPadding GetInteropPadding(RSAEncryptionPadding padding)
+        public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
         {
-            if (padding == RSAEncryptionPadding.Pkcs1)
+            if (padding == null)
             {
-                return Interop.Crypto.RsaPadding.Pkcs1;
+                throw new ArgumentNullException(nameof(padding));
             }
-            else if (padding == RSAEncryptionPadding.OaepSHA1)
+
+            Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding);
+            SafeRsaHandle key = _key.Value;
+            CheckInvalidKey(key);
+
+            if (destination.Length < Interop.Crypto.RsaSize(key))
             {
-                return Interop.Crypto.RsaPadding.OaepSHA1;
+                bytesWritten = 0;
+                return false;
             }
-            else
-            {
-                throw PaddingModeNotSupported();
-            }
+
+            int returnValue = Interop.Crypto.RsaPublicEncrypt(source.Length, source, destination, key, rsaPadding);
+            CheckReturn(returnValue);
+
+            bytesWritten = returnValue;
+            return true;
         }
+
+        private static Interop.Crypto.RsaPadding GetInteropPadding(RSAEncryptionPadding padding) =>
+            padding == RSAEncryptionPadding.Pkcs1 ? Interop.Crypto.RsaPadding.Pkcs1 :
+            padding == RSAEncryptionPadding.OaepSHA1 ? Interop.Crypto.RsaPadding.OaepSHA1 :
+            throw PaddingModeNotSupported();
 
         public override RSAParameters ExportParameters(bool includePrivateParameters)
         {
@@ -245,11 +284,7 @@ namespace System.Security.Cryptography
             if (_key != null && _key.IsValueCreated)
             {
                 SafeRsaHandle handle = _key.Value;
-
-                if (handle != null)
-                {
-                    handle.Dispose();
-                }
+                handle?.Dispose();
             }
         }
 
@@ -308,12 +343,10 @@ namespace System.Security.Cryptography
 
         private static void CheckBoolReturn(int returnValue)
         {
-            if (returnValue == 1)
+            if (returnValue != 1)
             {
-                return;
+               throw Interop.Crypto.CreateOpenSslCryptographicException();
             }
-
-            throw Interop.Crypto.CreateOpenSslCryptographicException();
         }
 
         private SafeRsaHandle GenerateKey()
@@ -350,15 +383,14 @@ namespace System.Security.Cryptography
             return key;
         }
 
-        protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
-        {
-            return AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
-        }
+        protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
+            AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
 
-        protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
-        {
-            return AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
-        }
+        protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
+            AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
+
+        protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+            AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
 
         public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
@@ -404,6 +436,42 @@ namespace System.Security.Cryptography
             return signature;
         }
 
+        public override bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
+        {
+            if (string.IsNullOrEmpty(hashAlgorithm.Name))
+            {
+                throw HashAlgorithmNameNullOrEmpty();
+            }
+            if (padding == null)
+            {
+                throw new ArgumentNullException(nameof(padding));
+            }
+            if (padding != RSASignaturePadding.Pkcs1)
+            {
+                throw PaddingModeNotSupported();
+            }
+
+            int algorithmNid = GetAlgorithmNid(hashAlgorithm);
+            SafeRsaHandle rsa = _key.Value;
+
+            int bytesRequired = Interop.Crypto.RsaSize(rsa);
+            if (destination.Length < bytesRequired)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            int signatureSize;
+            if (!Interop.Crypto.RsaSign(algorithmNid, source, source.Length, destination, out signatureSize, rsa))
+            {
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
+            }
+
+            Debug.Assert(signatureSize == bytesRequired, $"RSA_sign reported signatureSize was {signatureSize}, when {bytesRequired} was expected");
+            bytesWritten = signatureSize;
+            return true;
+        }
+
         public override bool VerifyHash(
             byte[] hash,
             byte[] signature,
@@ -411,29 +479,35 @@ namespace System.Security.Cryptography
             RSASignaturePadding padding)
         {
             if (hash == null)
+            {
                 throw new ArgumentNullException(nameof(hash));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
-            if (padding != RSASignaturePadding.Pkcs1)
-                throw PaddingModeNotSupported();
+            }
+            if (signature == null)
+            {
+                throw new ArgumentNullException(nameof(signature));
+            }
 
-            return VerifyHash(hash, signature, hashAlgorithm);
+            return VerifyHash(new ReadOnlySpan<byte>(hash), new ReadOnlySpan<byte>(signature), hashAlgorithm, padding);
         }
 
-        private bool VerifyHash(byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithmName)
+        public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
-            int algorithmNid = GetAlgorithmNid(hashAlgorithmName);
-            SafeRsaHandle rsa = _key.Value;
+            if (string.IsNullOrEmpty(hashAlgorithm.Name))
+            {
+                throw HashAlgorithmNameNullOrEmpty();
+            }
+            if (padding == null)
+            {
+                throw new ArgumentNullException(nameof(padding));
+            }
+            if (padding != RSASignaturePadding.Pkcs1)
+            {
+                throw PaddingModeNotSupported();
+            }
 
-            return Interop.Crypto.RsaVerify(
-                algorithmNid,
-                hash,
-                hash.Length,
-                signature,
-                signature.Length,
-                rsa);
+            int algorithmNid = GetAlgorithmNid(hashAlgorithm);
+            SafeRsaHandle rsa = _key.Value;
+            return Interop.Crypto.RsaVerify(algorithmNid, hash, hash.Length, signature, signature.Length, rsa);
         }
 
         private static int GetAlgorithmNid(HashAlgorithmName hashAlgorithmName)
@@ -452,15 +526,11 @@ namespace System.Security.Cryptography
             return nid;
         }
 
-        private static Exception PaddingModeNotSupported()
-        {
-            return new CryptographicException(SR.Cryptography_InvalidPaddingMode);
-        }
+        private static Exception PaddingModeNotSupported() =>
+            new CryptographicException(SR.Cryptography_InvalidPaddingMode);
 
-        private static Exception HashAlgorithmNameNullOrEmpty()
-        {
-            return new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
-        }
+        private static Exception HashAlgorithmNameNullOrEmpty() =>
+            new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
     }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     }

--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -189,6 +189,8 @@ namespace System.Security.Cryptography
             {
                 if (hash == null)
                     throw new ArgumentNullException(nameof(hash));
+                if (string.IsNullOrEmpty(hashAlgorithm.Name))
+                    throw HashAlgorithmNameNullOrEmpty();
                 if (padding == null)
                     throw new ArgumentNullException(nameof(padding));
                 if (padding != RSASignaturePadding.Pkcs1)
@@ -225,6 +227,10 @@ namespace System.Security.Cryptography
 
             public override bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
             {
+                if (string.IsNullOrEmpty(hashAlgorithm.Name))
+                {
+                    throw HashAlgorithmNameNullOrEmpty();
+                }
                 if (padding == null)
                 {
                     throw new ArgumentNullException(nameof(padding));
@@ -381,6 +387,9 @@ namespace System.Security.Cryptography
                 return Interop.AppleCrypto.ImportEphemeralKey(pkcs1Blob, isPrivateKey);
             }
         }
+
+        private static Exception HashAlgorithmNameNullOrEmpty() =>
+            new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
     }
 
     internal static class RsaKeyBlobHelpers

--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -155,10 +155,11 @@ namespace System.Security.Cryptography
                 }
             }
 
-            public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding)
-            {
-                return Interop.AppleCrypto.RsaEncrypt(GetKeys().PublicKey, data, padding);
-            }
+            public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) =>
+                Interop.AppleCrypto.RsaEncrypt(GetKeys().PublicKey, data, padding);
+
+            public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
+                Interop.AppleCrypto.TryRsaEncrypt(GetKeys().PublicKey, source, destination, padding, out bytesWritten);
 
             public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
             {
@@ -170,6 +171,18 @@ namespace System.Security.Cryptography
                 }
 
                 return Interop.AppleCrypto.RsaDecrypt(keys.PrivateKey, data, padding);
+            }
+
+            public override bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+            {
+                SecKeyPair keys = GetKeys();
+
+                if (keys.PrivateKey == null)
+                {
+                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                }
+
+                return Interop.AppleCrypto.TryRsaDecrypt(keys.PrivateKey, source, destination, padding, out bytesWritten);
             }
 
             public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
@@ -210,35 +223,77 @@ namespace System.Security.Cryptography
                     palAlgId);
             }
 
+            public override bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
+            {
+                if (padding == null)
+                {
+                    throw new ArgumentNullException(nameof(padding));
+                }
+                if (padding != RSASignaturePadding.Pkcs1)
+                {
+                    throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
+                }
+
+                SecKeyPair keys = GetKeys();
+
+                if (keys.PrivateKey == null)
+                {
+                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                }
+
+                Interop.AppleCrypto.PAL_HashAlgorithm palAlgId = PalAlgorithmFromAlgorithmName(hashAlgorithm, out int expectedSize);
+                if (source.Length != expectedSize)
+                {
+                    // Windows: NTE_BAD_DATA ("Bad Data.")
+                    // OpenSSL: RSA_R_INVALID_MESSAGE_LENGTH ("invalid message length")
+                    throw new CryptographicException(
+                        SR.Format(
+                            SR.Cryptography_BadHashSize_ForAlgorithm,
+                            source.Length,
+                            expectedSize,
+                            hashAlgorithm.Name));
+                }
+
+                return Interop.AppleCrypto.TryGenerateSignature(keys.PrivateKey, source, destination, palAlgId, out bytesWritten);
+            }
+
             public override bool VerifyHash(
                 byte[] hash,
                 byte[] signature,
                 HashAlgorithmName hashAlgorithm,
                 RSASignaturePadding padding)
             {
+                if (hash == null)
+                {
+                    throw new ArgumentNullException(nameof(hash));
+                }
+                if (signature == null)
+                {
+                    throw new ArgumentNullException(nameof(signature));
+                }
+
+                return VerifyHash((ReadOnlySpan<byte>)hash, (ReadOnlySpan<byte>)signature, hashAlgorithm, padding);
+            }
+
+            public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+            {
                 if (padding != RSASignaturePadding.Pkcs1)
+                {
                     throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
+                }
 
-                int expectedSize;
-                Interop.AppleCrypto.PAL_HashAlgorithm palAlgId =
-                    PalAlgorithmFromAlgorithmName(hashAlgorithm, out expectedSize);
-
-                return Interop.AppleCrypto.VerifySignature(
-                    GetKeys().PublicKey,
-                    hash,
-                    signature,
-                    palAlgId);
+                Interop.AppleCrypto.PAL_HashAlgorithm palAlgId = PalAlgorithmFromAlgorithmName(hashAlgorithm, out int expectedSize);
+                return Interop.AppleCrypto.VerifySignature(GetKeys().PublicKey, hash, signature, palAlgId);
             }
 
-            protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
-            {
-                return AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
-            }
+            protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
+                AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
 
-            protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
-            {
-                return AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
-            }
+            protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
+                AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
+
+            protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+                AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
 
             protected override void Dispose(bool disposing)
             {

--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -155,14 +155,41 @@ namespace System.Security.Cryptography
                 }
             }
 
-            public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) =>
-                Interop.AppleCrypto.RsaEncrypt(GetKeys().PublicKey, data, padding);
+            public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding)
+            {
+                if (data == null)
+                {
+                    throw new ArgumentNullException(nameof(data));
+                }
+                if (padding == null)
+                {
+                    throw new ArgumentNullException(nameof(padding));
+                }
 
-            public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
-                Interop.AppleCrypto.TryRsaEncrypt(GetKeys().PublicKey, source, destination, padding, out bytesWritten);
+                return Interop.AppleCrypto.RsaEncrypt(GetKeys().PublicKey, data, padding);
+            }
+
+            public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+            {
+                if (padding == null)
+                {
+                    throw new ArgumentNullException(nameof(padding));
+                }
+
+                return Interop.AppleCrypto.TryRsaEncrypt(GetKeys().PublicKey, source, destination, padding, out bytesWritten);
+            }
 
             public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
             {
+                if (data == null)
+                {
+                    throw new ArgumentNullException(nameof(data));
+                }
+                if (padding == null)
+                {
+                    throw new ArgumentNullException(nameof(padding));
+                }
+
                 SecKeyPair keys = GetKeys();
 
                 if (keys.PrivateKey == null)
@@ -175,6 +202,11 @@ namespace System.Security.Cryptography
 
             public override bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
             {
+                if (padding == null)
+                {
+                    throw new ArgumentNullException(nameof(padding));
+                }
+
                 SecKeyPair keys = GetKeys();
 
                 if (keys.PrivateKey == null)
@@ -283,6 +315,14 @@ namespace System.Security.Cryptography
 
             public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
             {
+                if (string.IsNullOrEmpty(hashAlgorithm.Name))
+                {
+                    throw HashAlgorithmNameNullOrEmpty();
+                }
+                if (padding == null)
+                {
+                    throw new ArgumentNullException(nameof(padding));
+                }
                 if (padding != RSASignaturePadding.Pkcs1)
                 {
                     throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -6,12 +6,43 @@ using Xunit;
 
 namespace System.Security.Cryptography.Rsa.Tests
 {
-    public class EncryptDecrypt
+    public sealed class EncryptDecrypt_Array : EncryptDecrypt
+    {
+        protected override byte[] Encrypt(RSA rsa, byte[] data, RSAEncryptionPadding padding) =>
+            rsa.Encrypt(data, padding);
+        protected override byte[] Decrypt(RSA rsa, byte[] data, RSAEncryptionPadding padding) =>
+            rsa.Decrypt(data, padding);
+
+        [Fact]
+        public void NullArray_Throws()
+        {
+            using (RSA rsa = RSAFactory.Create())
+            {
+                AssertExtensions.Throws<ArgumentNullException>("data", () => rsa.Encrypt(null, RSAEncryptionPadding.OaepSHA1));
+                AssertExtensions.Throws<ArgumentNullException>("data", () => rsa.Decrypt(null, RSAEncryptionPadding.OaepSHA1));
+            }
+        }
+    }
+
+    public abstract class EncryptDecrypt
     {
         private static bool EphemeralKeysAreExportable => !PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx462OrNewer();
 
+        protected abstract byte[] Encrypt(RSA rsa, byte[] data, RSAEncryptionPadding padding);
+        protected abstract byte[] Decrypt(RSA rsa, byte[] data, RSAEncryptionPadding padding);
+
         [Fact]
-        public static void DecryptSavedAnswer()
+        public void NullPadding_Throws()
+        {
+            using (RSA rsa = RSAFactory.Create())
+            {
+                AssertExtensions.Throws<ArgumentNullException>("padding", () => Encrypt(rsa, new byte[1], null));
+                AssertExtensions.Throws<ArgumentNullException>("padding", () => Decrypt(rsa, new byte[1], null));
+            }
+        }
+
+        [Fact]
+        public void DecryptSavedAnswer()
         {
             byte[] cipherBytes =
             {
@@ -38,14 +69,14 @@ namespace System.Security.Cryptography.Rsa.Tests
             using (RSA rsa = RSAFactory.Create())
             {
                 rsa.ImportParameters(TestData.RSA1024Params);
-                output = rsa.Decrypt(cipherBytes, RSAEncryptionPadding.OaepSHA1);
+                output = Decrypt(rsa, cipherBytes, RSAEncryptionPadding.OaepSHA1);
             }
 
             Assert.Equal(TestData.HelloBytes, output);
         }
 
         [Fact]
-        public static void DecryptWithPublicKey_Fails()
+        public void DecryptWithPublicKey_Fails()
         {
             byte[] cipherBytes =
             {
@@ -79,12 +110,12 @@ namespace System.Security.Cryptography.Rsa.Tests
                 rsa.ImportParameters(pubParameters);
 
                 Assert.ThrowsAny<CryptographicException>(
-                    () => rsa.Decrypt(cipherBytes, RSAEncryptionPadding.OaepSHA1));
+                    () => Decrypt(rsa, cipherBytes, RSAEncryptionPadding.OaepSHA1));
             }
         }
 
         [Fact]
-        public static void DecryptSavedAnswer_OaepSHA384()
+        public void DecryptSavedAnswer_OaepSHA384()
         {
             byte[] cipherBytes =
             {
@@ -130,12 +161,12 @@ namespace System.Security.Cryptography.Rsa.Tests
 
                 if (RSAFactory.SupportsSha2Oaep)
                 {
-                    output = rsa.Decrypt(cipherBytes, RSAEncryptionPadding.OaepSHA384);
+                    output = Decrypt(rsa, cipherBytes, RSAEncryptionPadding.OaepSHA384);
                 }
                 else
                 {
                     Assert.ThrowsAny<CryptographicException>(
-                        () => rsa.Decrypt(cipherBytes, RSAEncryptionPadding.OaepSHA384));
+                        () => Decrypt(rsa, cipherBytes, RSAEncryptionPadding.OaepSHA384));
 
                     return;
                 }
@@ -145,7 +176,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        public static void DecryptSavedAnswerUnusualExponent()
+        public void DecryptSavedAnswerUnusualExponent()
         {
             byte[] cipherBytes =
             {
@@ -172,22 +203,22 @@ namespace System.Security.Cryptography.Rsa.Tests
             using (RSA rsa = RSAFactory.Create())
             {
                 rsa.ImportParameters(TestData.UnusualExponentParameters);
-                output = rsa.Decrypt(cipherBytes, RSAEncryptionPadding.OaepSHA1);
+                output = Decrypt(rsa, cipherBytes, RSAEncryptionPadding.OaepSHA1);
             }
 
             Assert.Equal(TestData.HelloBytes, output);
         }
 
         [Fact]
-        public static void RsaCryptRoundtrip()
+        public void RsaCryptRoundtrip()
         {
             byte[] crypt;
             byte[] output;
 
             using (RSA rsa = RSAFactory.Create())
             {
-                crypt = rsa.Encrypt(TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
-                output = rsa.Decrypt(crypt, RSAEncryptionPadding.OaepSHA1);
+                crypt = Encrypt(rsa, TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
+                output = Decrypt(rsa, crypt, RSAEncryptionPadding.OaepSHA1);
             }
 
             Assert.NotEqual(crypt, output);
@@ -195,24 +226,24 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [ConditionalFact(nameof(EphemeralKeysAreExportable))]
-        public static void RsaDecryptAfterExport()
+        public void RsaDecryptAfterExport()
         {
             byte[] output;
 
             using (RSA rsa = RSAFactory.Create())
             {
-                byte[] crypt = rsa.Encrypt(TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
+                byte[] crypt = Encrypt(rsa, TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
 
                 // Export the key, this should not clear/destroy the key.
                 RSAParameters ignored = rsa.ExportParameters(true);
-                output = rsa.Decrypt(crypt, RSAEncryptionPadding.OaepSHA1);
+                output = Decrypt(rsa, crypt, RSAEncryptionPadding.OaepSHA1);
             }
 
             Assert.Equal(TestData.HelloBytes, output);
         }
 
         [Fact]
-        public static void LargeKeyCryptRoundtrip()
+        public void LargeKeyCryptRoundtrip()
         {
             byte[] output;
 
@@ -228,18 +259,18 @@ namespace System.Security.Cryptography.Rsa.Tests
                     return;
                 }
 
-                byte[] crypt = rsa.Encrypt(TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
+                byte[] crypt = Encrypt(rsa, TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
 
                 Assert.Equal(rsa.KeySize, crypt.Length * 8);
 
-                output = rsa.Decrypt(crypt, RSAEncryptionPadding.OaepSHA1);
+                output = Decrypt(rsa, crypt, RSAEncryptionPadding.OaepSHA1);
             }
 
             Assert.Equal(TestData.HelloBytes, output);
         }
 
         [Fact]
-        public static void UnusualExponentCryptRoundtrip()
+        public void UnusualExponentCryptRoundtrip()
         {
             byte[] crypt;
             byte[] output;
@@ -248,8 +279,8 @@ namespace System.Security.Cryptography.Rsa.Tests
             {
                 rsa.ImportParameters(TestData.UnusualExponentParameters);
 
-                crypt = rsa.Encrypt(TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
-                output = rsa.Decrypt(crypt, RSAEncryptionPadding.OaepSHA1);
+                crypt = Encrypt(rsa, TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
+                output = Decrypt(rsa, crypt, RSAEncryptionPadding.OaepSHA1);
             }
 
             Assert.NotEqual(crypt, output);
@@ -257,7 +288,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        public static void NotSupportedValueMethods()
+        public void NotSupportedValueMethods()
         {
             using (RSA rsa = RSAFactory.Create())
             {

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.netcoreapp.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.netcoreapp.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Security.Cryptography.Rsa.Tests
+{
+    public sealed class EncryptDecrypt_Span : EncryptDecrypt
+    {
+        protected override byte[] Encrypt(RSA rsa, byte[] data, RSAEncryptionPadding padding) =>
+            TryWithOutputArray(dest => rsa.TryEncrypt(data, dest, padding, out int bytesWritten) ? (true, bytesWritten) : (false, 0));
+
+        protected override byte[] Decrypt(RSA rsa, byte[] data, RSAEncryptionPadding padding) =>
+            TryWithOutputArray(dest => rsa.TryDecrypt(data, dest, padding, out int bytesWritten) ? (true, bytesWritten) : (false, 0));
+
+        private static byte[] TryWithOutputArray(Func<byte[], (bool, int)> func)
+        {
+            for (int length = 256; ; length = checked(length * 2))
+            {
+                var result = new byte[length];
+                var (success, bytesWritten) = func(result);
+                if (success)
+                {
+                    Array.Resize(ref result, bytesWritten);
+                    return result;
+                }
+            }
+        }
+
+        [Fact]
+        public void Decrypt_VariousSizeSpans_Success()
+        {
+            using (RSA rsa = RSAFactory.Create())
+            {
+                rsa.ImportParameters(TestData.RSA1024Params);
+                byte[] cipherBytes = Encrypt(rsa, TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
+                byte[] actual;
+                int bytesWritten;
+
+                // Too small
+                actual = new byte[TestData.HelloBytes.Length - 1];
+                Assert.False(rsa.TryDecrypt(cipherBytes, actual, RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    // Just right... but that may be insufficient on Unix, where with padding the output destination
+                    // may need to be larger than the actual decrypted content.
+                    actual = new byte[TestData.HelloBytes.Length];
+                    Assert.True(rsa.TryDecrypt(cipherBytes, actual, RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+                    Assert.Equal(TestData.HelloBytes.Length, bytesWritten);
+                    Assert.Equal<byte>(TestData.HelloBytes, actual);
+                }
+
+                // Bigger than needed
+                actual = new byte[TestData.HelloBytes.Length + 1000];
+                Assert.True(rsa.TryDecrypt(cipherBytes, actual, RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+                Assert.Equal(TestData.HelloBytes.Length, bytesWritten);
+                Assert.Equal<byte>(TestData.HelloBytes, actual.AsSpan().Slice(0, TestData.HelloBytes.Length).ToArray());
+            }
+        }
+
+        [Fact]
+        public void Encrypt_VariousSizeSpans_Success()
+        {
+            using (RSA rsa = RSAFactory.Create())
+            {
+                rsa.ImportParameters(TestData.RSA1024Params);
+                byte[] cipherBytes = Encrypt(rsa, TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
+                byte[] actual;
+                int bytesWritten;
+
+                // Too small
+                actual = new byte[cipherBytes.Length - 1];
+                Assert.False(rsa.TryEncrypt(TestData.HelloBytes, actual, RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+
+                // Just right
+                actual = new byte[cipherBytes.Length];
+                Assert.True(rsa.TryEncrypt(TestData.HelloBytes, actual, RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+                Assert.Equal(cipherBytes.Length, bytesWritten);
+
+                // Bigger than needed
+                actual = new byte[cipherBytes.Length + 1];
+                Assert.True(rsa.TryEncrypt(TestData.HelloBytes, actual, RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+                Assert.Equal(cipherBytes.Length, bytesWritten);
+            }
+        }
+    }
+}

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
@@ -10,6 +10,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         RSA Create(int keySize);
         bool Supports384PrivateKey { get; }
         bool SupportsSha2Oaep { get; }
+        bool SupportsDecryptingIntoExactSpaceRequired { get; }
     }
 
     public static partial class RSAFactory
@@ -27,5 +28,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         public static bool Supports384PrivateKey => s_provider.Supports384PrivateKey;
 
         public static bool SupportsSha2Oaep => s_provider.SupportsSha2Oaep;
+
+        public static bool SupportsDecryptingIntoExactSpaceRequired => s_provider.SupportsDecryptingIntoExactSpaceRequired;
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.netcoreapp.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.netcoreapp.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Rsa.Tests
+{
+    public sealed class SignVerify_Span : SignVerify
+    {
+        protected override byte[] SignData(RSA rsa, byte[] data, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            TryWithOutputArray(dest => rsa.TrySignData(data, dest, hashAlgorithm, padding, out int bytesWritten) ? (true, bytesWritten) : (false, 0));
+
+        protected override byte[] SignHash(RSA rsa, byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            TryWithOutputArray(dest => rsa.TrySignHash(hash, dest, hashAlgorithm, padding, out int bytesWritten) ? (true, bytesWritten) : (false, 0));
+
+        protected override bool VerifyData(RSA rsa, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            rsa.VerifyData((ReadOnlySpan<byte>)data, (ReadOnlySpan<byte>)signature, hashAlgorithm, padding);
+
+        protected override bool VerifyHash(RSA rsa, byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            rsa.VerifyHash((ReadOnlySpan<byte>)hash, (ReadOnlySpan<byte>)signature, hashAlgorithm, padding);
+
+        private static byte[] TryWithOutputArray(Func<byte[], (bool,int)> func)
+        {
+            for (int length = 256; ; length = checked(length * 2))
+            {
+                var result = new byte[length];
+                var (success, bytesWritten) = func(result);
+                if (success)
+                {
+                    Array.Resize(ref result, bytesWritten);
+                    return result;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
@@ -10,13 +10,22 @@ namespace System.Security.Cryptography
 {
     public sealed partial class IncrementalHash : System.IDisposable
     {
-        public void AppendData(ReadOnlySpan<byte> data) { }
-        public bool TryGetHashAndReset(Span<byte> destination, out int bytesWritten) { throw null; }
+        public void AppendData(System.ReadOnlySpan<byte> data) { }
+        public bool TryGetHashAndReset(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
-
     public abstract partial class RandomNumberGenerator : System.IDisposable
     {
-        public virtual void GetBytes(Span<byte> data) { }
-        public virtual void GetNonZeroBytes(Span<byte> data) { }
+        public virtual void GetBytes(System.Span<byte> data) { }
+        public virtual void GetNonZeroBytes(System.Span<byte> data) { }
+    }
+    public abstract partial class RSA : System.Security.Cryptography.AsymmetricAlgorithm
+    {
+        public virtual bool TryDecrypt(System.ReadOnlySpan<byte> source, System.Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) { throw null; }
+        public virtual bool TryEncrypt(System.ReadOnlySpan<byte> source, System.Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) { throw null; }
+        protected virtual bool TryHashData(System.ReadOnlySpan<byte> source, System.Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
+        public virtual bool TrySignData(System.ReadOnlySpan<byte> source, System.Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) { throw null; }
+        public virtual bool TrySignHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) { throw null; }
+        public virtual bool VerifyData(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) { throw null; }
+        public virtual bool VerifyHash(System.ReadOnlySpan<byte> hash, System.ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) { throw null; }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
@@ -2,15 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.IO;
-
-using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
     public abstract partial class RSA : AsymmetricAlgorithm
     {
-        public static new RSA Create(String algName)
+        public static new RSA Create(string algName)
         {
             return (RSA)CryptoConfig.CreateFromName(algName);
         }
@@ -49,28 +48,96 @@ namespace System.Security.Cryptography
 
         public abstract RSAParameters ExportParameters(bool includePrivateParameters);
         public abstract void ImportParameters(RSAParameters parameters);
-        public virtual byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) { throw DerivedClassMustOverride(); }
-        public virtual byte[] Decrypt(byte[] data, RSAEncryptionPadding padding) { throw DerivedClassMustOverride(); }
-        public virtual byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) { throw DerivedClassMustOverride(); }
-        public virtual bool VerifyHash(byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) { throw DerivedClassMustOverride(); }
+        public virtual byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) => throw DerivedClassMustOverride();
+        public virtual byte[] Decrypt(byte[] data, RSAEncryptionPadding padding) => throw DerivedClassMustOverride();
+        public virtual byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) => throw DerivedClassMustOverride();
+        public virtual bool VerifyHash(byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) => throw DerivedClassMustOverride();
 
-        protected virtual byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) { throw DerivedClassMustOverride(); }
-        protected virtual byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) { throw DerivedClassMustOverride(); }
+        protected virtual byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) => throw DerivedClassMustOverride();
+        protected virtual byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) => throw DerivedClassMustOverride();
 
-        private static Exception DerivedClassMustOverride()
+        public virtual bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
         {
-            return new NotImplementedException(SR.NotSupported_SubclassOverride);
+            byte[] result = Decrypt(source.ToArray(), padding);
+
+            if (destination.Length >= result.Length)
+            {
+                new ReadOnlySpan<byte>(result).CopyTo(destination);
+                bytesWritten = result.Length;
+                return true;
+            }
+
+            bytesWritten = 0;
+            return false;
         }
 
-        public virtual byte[] DecryptValue(byte[] rgb) 
+        public virtual bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
         {
+            byte[] result = Encrypt(source.ToArray(), padding);
+
+            if (destination.Length >= result.Length)
+            {
+                new ReadOnlySpan<byte>(result).CopyTo(destination);
+                bytesWritten = result.Length;
+                return true;
+            }
+
+            bytesWritten = 0;
+            return false;
+        }
+
+        protected virtual bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
+        {
+            byte[] result;
+            byte[] array = ArrayPool<byte>.Shared.Rent(source.Length);
+            try
+            {
+                source.CopyTo(array);
+                result = HashData(array, 0, source.Length, hashAlgorithm);
+            }
+            finally
+            {
+                Array.Clear(array, 0, source.Length);
+                ArrayPool<byte>.Shared.Return(array);
+            }
+
+            if (destination.Length >= result.Length)
+            {
+                new ReadOnlySpan<byte>(result).CopyTo(destination);
+                bytesWritten = result.Length;
+                return true;
+            }
+
+            bytesWritten = 0;
+            return false;
+        }
+
+        public virtual bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
+        {
+            byte[] result = SignHash(source.ToArray(), hashAlgorithm, padding);
+
+            if (destination.Length >= result.Length)
+            {
+                new ReadOnlySpan<byte>(result).CopyTo(destination);
+                bytesWritten = result.Length;
+                return true;
+            }
+
+            bytesWritten = 0;
+            return false;
+        }
+
+        public virtual bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            VerifyHash(hash.ToArray(), signature.ToArray(), hashAlgorithm, padding);
+
+        private static Exception DerivedClassMustOverride() =>
+            new NotImplementedException(SR.NotSupported_SubclassOverride);
+
+        public virtual byte[] DecryptValue(byte[] rgb) =>
             throw new NotSupportedException(SR.NotSupported_Method); // Same as Desktop
-        }
 
-        public virtual byte[] EncryptValue(byte[] rgb) 
-        {
+        public virtual byte[] EncryptValue(byte[] rgb) =>
             throw new NotSupportedException(SR.NotSupported_Method); // Same as Desktop
-        }
 
         public byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
@@ -115,6 +182,27 @@ namespace System.Security.Cryptography
 
             byte[] hash = HashData(data, hashAlgorithm);
             return SignHash(hash, hashAlgorithm, padding);
+        }
+
+        public virtual bool TrySignData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
+        {
+            if (string.IsNullOrEmpty(hashAlgorithm.Name))
+            {
+                throw HashAlgorithmNameNullOrEmpty();
+            }
+            if (padding == null)
+            {
+                throw new ArgumentNullException(nameof(padding));
+            }
+
+            if (TryHashData(source, destination, hashAlgorithm, out int hashLength) &&
+                TrySignHash(destination.Slice(0, hashLength), destination, hashAlgorithm, padding, out bytesWritten))
+            {
+                return true;
+            }
+
+            bytesWritten = 0;
+            return false;
         }
 
         public bool VerifyData(byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
@@ -165,12 +253,40 @@ namespace System.Security.Cryptography
             return VerifyHash(hash, signature, hashAlgorithm, padding);
         }
 
+        public virtual bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+        {
+            if (string.IsNullOrEmpty(hashAlgorithm.Name))
+            {
+                throw HashAlgorithmNameNullOrEmpty();
+            }
+            if (padding == null)
+            {
+                throw new ArgumentNullException(nameof(padding));
+            }
+
+            for (int i = 256; ; i = checked(i * 2))
+            {
+                int hashLength = 0;
+                byte[] hash = ArrayPool<byte>.Shared.Rent(i);
+                try
+                {
+                    if (TryHashData(data, hash, hashAlgorithm, out hashLength))
+                    {
+                        return VerifyHash(new ReadOnlySpan<byte>(hash, 0, hashLength), signature, hashAlgorithm, padding);
+                    }
+                }
+                finally
+                {
+                    Array.Clear(hash, 0, hashLength);
+                    ArrayPool<byte>.Shared.Return(hash);
+                }
+            }
+        }
+
         public override string KeyExchangeAlgorithm => "RSA";
         public override string SignatureAlgorithm => "RSA";
 
-        private static Exception HashAlgorithmNameNullOrEmpty()
-        {
-            return new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
-        }
+        private static Exception HashAlgorithmNameNullOrEmpty() =>
+            new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
@@ -10,10 +10,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     {
         private bool? _supports384PrivateKey;
 
-        public RSA Create()
-        {
-            return RSA.Create();
-        }
+        public RSA Create() => RSA.Create();
 
         public RSA Create(int keySize)
         {
@@ -53,6 +50,8 @@ namespace System.Security.Cryptography.Rsa.Tests
             // Currently only RSACng does, which is the default provider on Windows.
             get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !(Create() is RSACryptoServiceProvider); }
         }
+
+        public bool SupportsDecryptingIntoExactSpaceRequired => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.Algorithms/tests/RSATests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RSATests.cs
@@ -1,0 +1,237 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace System.Security.Cryptography.Algorithms.Tests
+{
+    public class RSATests
+    {
+        [Fact]
+        public void BaseVirtualsNotImplementedException()
+        {
+            var rsa = new EmptyRSA();
+            Assert.Throws<NotImplementedException>(() => rsa.Decrypt(null, null));
+            Assert.Throws<NotImplementedException>(() => rsa.Encrypt(null, null));
+            Assert.Throws<NotImplementedException>(() => rsa.SignHash(null, HashAlgorithmName.SHA256, null));
+            Assert.Throws<NotImplementedException>(() => rsa.VerifyHash(null, null, HashAlgorithmName.SHA256, null));
+            Assert.Throws<NotImplementedException>(() => rsa.HashData(null, 0, 0, HashAlgorithmName.SHA256));
+            Assert.Throws<NotImplementedException>(() => rsa.HashData(null, HashAlgorithmName.SHA256));
+        }
+
+        [Fact]
+        public void TryDecrypt_UsesDecrypt()
+        {
+            var rsa = new DelegateRSA { DecryptDelegate = (data, padding) => data };
+            int bytesWritten;
+            byte[] actual, expected;
+
+            Assert.False(rsa.TryDecrypt(new byte[3], new byte[2], RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+
+            expected = new byte[2] { 42, 43 };
+            actual = new byte[2];
+            Assert.True(rsa.TryDecrypt(expected, actual, RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(42, actual[0]);
+            Assert.Equal(43, actual[1]);
+
+            actual = new byte[3];
+            Assert.True(rsa.TryDecrypt(expected, actual, RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(42, actual[0]);
+            Assert.Equal(43, actual[1]);
+            Assert.Equal(0, actual[2]);
+        }
+
+        [Fact]
+        public void TryEncrypt_UsesEncrypt()
+        {
+            var rsa = new DelegateRSA { EncryptDelegate = (data, padding) => data };
+            int bytesWritten;
+            byte[] actual, expected;
+
+            Assert.False(rsa.TryEncrypt(new byte[3], new byte[2], RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+
+            expected = new byte[2] { 42, 43 };
+            actual = new byte[2];
+            Assert.True(rsa.TryEncrypt(expected, actual, RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(42, actual[0]);
+            Assert.Equal(43, actual[1]);
+
+            actual = new byte[3];
+            Assert.True(rsa.TryEncrypt(expected, actual, RSAEncryptionPadding.OaepSHA1, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(42, actual[0]);
+            Assert.Equal(43, actual[1]);
+            Assert.Equal(0, actual[2]);
+        }
+
+        [Fact]
+        public void TryHashData_UsesHashData()
+        {
+            var rsa = new DelegateRSA { HashDataArrayDelegate = (data, offset, count, name) => new Span<byte>(data, offset, count).ToArray() };
+            int bytesWritten;
+            byte[] actual, expected;
+
+            Assert.False(rsa.TryHashData(new byte[3], new byte[2], HashAlgorithmName.SHA256, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+
+            expected = new byte[2] { 42, 43 };
+            actual = new byte[2];
+            Assert.True(rsa.TryHashData(expected, actual, HashAlgorithmName.SHA256, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(42, actual[0]);
+            Assert.Equal(43, actual[1]);
+
+            actual = new byte[3];
+            Assert.True(rsa.TryHashData(expected, actual, HashAlgorithmName.SHA256, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(42, actual[0]);
+            Assert.Equal(43, actual[1]);
+            Assert.Equal(0, actual[2]);
+        }
+
+        [Fact]
+        public void TrySignHash_UsesSignHash()
+        {
+            var rsa = new DelegateRSA { SignHashDelegate = (data, name, padding) => data };
+            int bytesWritten;
+            byte[] actual, expected;
+
+            Assert.False(rsa.TrySignHash(new byte[3], new byte[2], HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+
+            expected = new byte[2] { 42, 43 };
+            actual = new byte[2];
+            Assert.True(rsa.TrySignHash(expected, actual, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(42, actual[0]);
+            Assert.Equal(43, actual[1]);
+
+            actual = new byte[3];
+            Assert.True(rsa.TrySignHash(expected, actual, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(42, actual[0]);
+            Assert.Equal(43, actual[1]);
+            Assert.Equal(0, actual[2]);
+        }
+
+        [Fact]
+        public void VerifyHashSpan_UsesVerifyHashArray()
+        {
+            bool invoked = false;
+            var rsa = new DelegateRSA { VerifyHashDelegate = delegate { invoked = true; return true; } };
+            Assert.True(rsa.VerifyHash(ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, HashAlgorithmName.SHA256, RSASignaturePadding.Pss));
+            Assert.True(invoked);
+        }
+
+        [Fact]
+        public void SignDataArray_UsesHashDataAndSignHash()
+        {
+            var rsa = new DelegateRSA();
+
+            AssertExtensions.Throws<ArgumentNullException>("data", () => rsa.SignData((byte[])null, HashAlgorithmName.SHA256, null));
+            AssertExtensions.Throws<ArgumentNullException>("data", () => rsa.SignData(null, 0, 0, HashAlgorithmName.SHA256, null));
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => rsa.SignData(new byte[1], -1, 0, HashAlgorithmName.SHA256, null));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => rsa.SignData(new byte[1], 2, 0, HashAlgorithmName.SHA256, null));
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => rsa.SignData(new byte[1], 0, -1, HashAlgorithmName.SHA256, null));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => rsa.SignData(new byte[1], 0, 2, HashAlgorithmName.SHA256, null));
+
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.SignData(new byte[1], 0, 1, new HashAlgorithmName(null), null));
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.SignData(new byte[1], 0, 1, new HashAlgorithmName(""), null));
+
+            AssertExtensions.Throws<ArgumentNullException>("padding", () => rsa.SignData(new byte[1], 0, 1, new HashAlgorithmName("abc"), null));
+
+            rsa.HashDataArrayDelegate = (data, offset, count, name) => new Span<byte>(data, offset, count).ToArray();
+            rsa.SignHashDelegate = (data, name, padding) => data.Select(b => (byte)(b * 2)).ToArray();
+            Assert.Equal<byte>(new byte[] { 6, 8, 10, 12, 14, 16 }, rsa.SignData(new byte[] { 3, 4, 5, 6, 7, 8 }, HashAlgorithmName.SHA256, RSASignaturePadding.Pss));
+            Assert.Equal<byte>(new byte[] { 10, 12, 14 }, rsa.SignData(new byte[] { 3, 4, 5, 6, 7, 8 }, 2, 3, HashAlgorithmName.SHA256, RSASignaturePadding.Pss));
+        }
+
+        [Fact]
+        public void SignDataStream_UsesHashDataAndSignHash()
+        {
+            var rsa = new DelegateRSA();
+
+            AssertExtensions.Throws<ArgumentNullException>("data", () => rsa.SignData((Stream)null, HashAlgorithmName.SHA256, null));
+
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.SignData(Stream.Null, new HashAlgorithmName(null), null));
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.SignData(Stream.Null, new HashAlgorithmName(""), null));
+
+            AssertExtensions.Throws<ArgumentNullException>("padding", () => rsa.SignData(Stream.Null, new HashAlgorithmName("abc"), null));
+
+            rsa.HashDataStreamDelegate = (stream, name) => ((MemoryStream)stream).ToArray();
+            rsa.SignHashDelegate = (data, name, padding) => data.Select(b => (byte)(b * 2)).ToArray();
+            Assert.Equal<byte>(new byte[] { 6, 8, 10, 12, 14, 16 }, rsa.SignData(new MemoryStream(new byte[] { 3, 4, 5, 6, 7, 8 }), HashAlgorithmName.SHA256, RSASignaturePadding.Pss));
+        }
+
+        [Fact]
+        public void VerifyDataStream_UsesHashDataAndVerifyHash()
+        {
+            var rsa = new DelegateRSA();
+
+            AssertExtensions.Throws<ArgumentNullException>("data", () => rsa.VerifyData((Stream)null, null, HashAlgorithmName.SHA256, null));
+            
+            AssertExtensions.Throws<ArgumentNullException>("signature", () => rsa.VerifyData(Stream.Null, null, HashAlgorithmName.SHA256, null));
+
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.VerifyData(Stream.Null, new byte[1], new HashAlgorithmName(null), null));
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.VerifyData(Stream.Null, new byte[1], new HashAlgorithmName(""), null));
+
+            AssertExtensions.Throws<ArgumentNullException>("padding", () => rsa.VerifyData(Stream.Null, new byte[1], new HashAlgorithmName("abc"), null));
+
+            rsa.HashDataStreamDelegate = (stream, name) => ((MemoryStream)stream).ToArray();
+            rsa.VerifyHashDelegate = (hash, signature, name, padding) => hash[0] == 42;
+            Assert.True(rsa.VerifyData(new MemoryStream(new byte[] { 42 }), new byte[1] { 24 }, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+        }
+
+        private sealed class EmptyRSA : RSA
+        {
+            public override RSAParameters ExportParameters(bool includePrivateParameters) => throw new NotImplementedException();
+            public override void ImportParameters(RSAParameters parameters) => throw new NotImplementedException();
+            public new byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) => base.HashData(data, offset, count, hashAlgorithm);
+            public new byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) => base.HashData(data, hashAlgorithm);
+        }
+
+        private sealed class DelegateRSA : RSA
+        {
+            public Func<byte[], RSAEncryptionPadding, byte[]> DecryptDelegate;
+            public Func<byte[], RSAEncryptionPadding, byte[]> EncryptDelegate;
+            public Func<byte[], HashAlgorithmName, RSASignaturePadding, byte[]> SignHashDelegate = null;
+            public Func<byte[], byte[], HashAlgorithmName, RSASignaturePadding, bool> VerifyHashDelegate = null;
+            public Func<byte[], int, int, HashAlgorithmName, byte[]> HashDataArrayDelegate = null;
+            public Func<Stream, HashAlgorithmName, byte[]> HashDataStreamDelegate = null;
+
+            public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) =>
+                EncryptDelegate(data, padding);
+
+            public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding) =>
+                DecryptDelegate(data, padding);
+
+            public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+                SignHashDelegate(hash, hashAlgorithm, padding);
+
+            public override bool VerifyHash(byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+                VerifyHashDelegate(hash, signature, hashAlgorithm, padding);
+
+            protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
+                HashDataArrayDelegate(data, offset, count, hashAlgorithm);
+
+            protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
+                HashDataStreamDelegate(data, hashAlgorithm);
+
+            public new bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+                base.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
+
+            public override RSAParameters ExportParameters(bool includePrivateParameters) => throw new NotImplementedException();
+            public override void ImportParameters(RSAParameters parameters) => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -213,6 +213,9 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs</Link>
     </Compile>
@@ -221,6 +224,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -157,6 +157,7 @@
     <Compile Include="RC2Provider.cs" />
     <Compile Include="RC2Tests.cs" />
     <Compile Include="RijndaelTests.cs" />
+    <Compile Include="RSATests.cs" />
     <Compile Include="RSACreateTests.cs" />
     <Compile Include="RSAKeyExchangeFormatterTests.cs" />
     <Compile Include="RSASignatureFormatterTests.cs" />

--- a/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
@@ -10,15 +10,9 @@ namespace System.Security.Cryptography.Rsa.Tests
     {
         private bool? _supports384PrivateKey;
 
-        public RSA Create()
-        {
-            return new RSACng();
-        }
+        public RSA Create() => new RSACng();
 
-        public RSA Create(int keySize)
-        {
-            return new RSACng(keySize);
-        }
+        public RSA Create(int keySize) => new RSACng(keySize);
 
         public bool Supports384PrivateKey
         {
@@ -27,7 +21,8 @@ namespace System.Security.Cryptography.Rsa.Tests
                 if (!_supports384PrivateKey.HasValue)
                 {
                     // For Windows 7 (Microsoft Windows 6.1) and Windows 8 (Microsoft Windows 6.2) this is false for RSACng.
-                    _supports384PrivateKey = !RuntimeInformation.OSDescription.Contains("Windows 6.1") &&
+                    _supports384PrivateKey =
+                        !RuntimeInformation.OSDescription.Contains("Windows 6.1") &&
                         !RuntimeInformation.OSDescription.Contains("Windows 6.2");
                 }
 
@@ -35,10 +30,9 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
-        public bool SupportsSha2Oaep
-        {
-            get { return true; }
-        }
+        public bool SupportsSha2Oaep => true;
+
+        public bool SupportsDecryptingIntoExactSpaceRequired => true;
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -133,6 +133,9 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs</Link>
     </Compile>
@@ -141,6 +144,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net462' OR '$(TargetGroup)' == 'net47' OR '$(TargetGroup)' == 'netcoreapp'">

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
@@ -61,11 +61,17 @@ namespace System.Security.Cryptography
                 throw PaddingModeNotSupported();
         }
 
-        public override bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
-            padding == null ? throw new ArgumentNullException(nameof(padding)) :
-            source.Length > (KeySize / 8) ? throw new CryptographicException(SR.Format(SR.Cryptography_Padding_DecDataTooBig, Convert.ToString(KeySize / 8))) :
-            padding == RSAEncryptionPadding.Pkcs1 || padding == RSAEncryptionPadding.OaepSHA1 ? _impl.TryDecrypt(source, destination, padding, out bytesWritten) :
-            throw PaddingModeNotSupported();
+        public override bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+        {
+            if (padding == null)
+                throw new ArgumentNullException(nameof(padding));
+            if (source.Length > (KeySize / 8))
+                throw new CryptographicException(SR.Format(SR.Cryptography_Padding_DecDataTooBig, Convert.ToString(KeySize / 8)));
+            if (padding != RSAEncryptionPadding.Pkcs1 && padding != RSAEncryptionPadding.OaepSHA1)
+                throw PaddingModeNotSupported();
+
+            return _impl.TryDecrypt(source, destination, padding, out bytesWritten);
+        }
 
         protected override void Dispose(bool disposing)
         {
@@ -79,9 +85,7 @@ namespace System.Security.Cryptography
         public byte[] Encrypt(byte[] rgb, bool fOAEP)
         {
             if (rgb == null)
-            {
                 throw new ArgumentNullException(nameof(rgb));
-            }
 
             return _impl.Encrypt(rgb, fOAEP ? RSAEncryptionPadding.OaepSHA1 : RSAEncryptionPadding.Pkcs1);
         }
@@ -99,10 +103,15 @@ namespace System.Security.Cryptography
                 throw PaddingModeNotSupported();
         }
 
-        public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
-            padding == null ? throw new ArgumentNullException(nameof(padding)) :
-            padding == RSAEncryptionPadding.Pkcs1 || padding == RSAEncryptionPadding.OaepSHA1 ? _impl.TryEncrypt(source, destination, padding, out bytesWritten) :
-            throw PaddingModeNotSupported();
+        public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten)
+        {
+            if (padding == null)
+                throw new ArgumentNullException(nameof(padding));
+            if (padding != RSAEncryptionPadding.Pkcs1 && padding != RSAEncryptionPadding.OaepSHA1)
+                throw PaddingModeNotSupported();
+
+            return _impl.TryEncrypt(source, destination, padding, out bytesWritten);
+        }
 
         public byte[] ExportCspBlob(bool includePrivateParameters)
         {

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
@@ -27,20 +27,14 @@ namespace System.Security.Cryptography
             _impl = RSA.Create(dwKeySize);
         }
 
-        public RSACryptoServiceProvider(int dwKeySize, CspParameters parameters)
-        {
+        public RSACryptoServiceProvider(int dwKeySize, CspParameters parameters) =>
             throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_CAPI_Required, nameof(CspParameters)));
-        }
 
-        public RSACryptoServiceProvider(CspParameters parameters)
-        {
+        public RSACryptoServiceProvider(CspParameters parameters) =>
             throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_CAPI_Required, nameof(CspParameters)));
-        }
 
-        public CspKeyContainerInfo CspKeyContainerInfo
-        {
-            get { throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_CAPI_Required, nameof(CspKeyContainerInfo))); }
-        }
+        public CspKeyContainerInfo CspKeyContainerInfo =>
+            throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_CAPI_Required, nameof(CspKeyContainerInfo)));
 
         public byte[] Decrypt(byte[] rgb, bool fOAEP)
         {
@@ -61,20 +55,17 @@ namespace System.Security.Cryptography
             if (padding == null)
                 throw new ArgumentNullException(nameof(padding));
 
-            if (padding == RSAEncryptionPadding.Pkcs1)
-            {
-                return Decrypt(data, fOAEP: false);
-            }
-            else if (padding == RSAEncryptionPadding.OaepSHA1)
-            {
-                // For compat, this prevents OaepSHA2 options as fOAEP==true will cause Decrypt to use OaepSHA1
-                return Decrypt(data, fOAEP: true);
-            }
-            else
-            {
+            return
+                padding == RSAEncryptionPadding.Pkcs1 ? Decrypt(data, fOAEP: false) :
+                padding == RSAEncryptionPadding.OaepSHA1 ? Decrypt(data, fOAEP: true) : // For compat, this prevents OaepSHA2 options as fOAEP==true will cause Decrypt to use OaepSHA1
                 throw PaddingModeNotSupported();
-            }
         }
+
+        public override bool TryDecrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
+            padding == null ? throw new ArgumentNullException(nameof(padding)) :
+            source.Length > (KeySize / 8) ? throw new CryptographicException(SR.Format(SR.Cryptography_Padding_DecDataTooBig, Convert.ToString(KeySize / 8))) :
+            padding == RSAEncryptionPadding.Pkcs1 || padding == RSAEncryptionPadding.OaepSHA1 ? _impl.TryDecrypt(source, destination, padding, out bytesWritten) :
+            throw PaddingModeNotSupported();
 
         protected override void Dispose(bool disposing)
         {
@@ -102,20 +93,16 @@ namespace System.Security.Cryptography
             if (padding == null)
                 throw new ArgumentNullException(nameof(padding));
 
-            if (padding == RSAEncryptionPadding.Pkcs1)
-            {
-                return Encrypt(data, fOAEP: false);
-            }
-            else if (padding == RSAEncryptionPadding.OaepSHA1)
-            {
-                // For compat, this prevents OaepSHA2 options as fOAEP==true will cause Decrypt to use OaepSHA1
-                return Encrypt(data, fOAEP: true);
-            }
-            else
-            {
+            return
+                padding == RSAEncryptionPadding.Pkcs1 ? Encrypt(data, fOAEP: false) :
+                padding == RSAEncryptionPadding.OaepSHA1 ?  Encrypt(data, fOAEP: true) : // For compat, this prevents OaepSHA2 options as fOAEP==true will cause Decrypt to use OaepSHA1
                 throw PaddingModeNotSupported();
-            }
         }
+
+        public override bool TryEncrypt(ReadOnlySpan<byte> source, Span<byte> destination, RSAEncryptionPadding padding, out int bytesWritten) =>
+            padding == null ? throw new ArgumentNullException(nameof(padding)) :
+            padding == RSAEncryptionPadding.Pkcs1 || padding == RSAEncryptionPadding.OaepSHA1 ? _impl.TryEncrypt(source, destination, padding, out bytesWritten) :
+            throw PaddingModeNotSupported();
 
         public byte[] ExportCspBlob(bool includePrivateParameters)
         {
@@ -128,6 +115,9 @@ namespace System.Security.Cryptography
 
         protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
             AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
+
+        protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+            AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
 
         protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
             AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
@@ -166,10 +156,7 @@ namespace System.Security.Cryptography
         // PersistKeyInCsp has no effect in Unix
         public bool PersistKeyInCsp { get; set; }
 
-        public bool PublicOnly
-        {
-            get { return _publicOnly; }
-        }
+        public bool PublicOnly => _publicOnly;
 
         public override string SignatureAlgorithm => "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
 
@@ -178,6 +165,9 @@ namespace System.Security.Cryptography
 
         public override byte[] SignData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
             _impl.SignData(data, offset, count, hashAlgorithm, padding);
+
+        public override bool TrySignData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) =>
+            _impl.TrySignData(source, destination, hashAlgorithm, padding, out bytesWritten);
 
         public byte[] SignData(byte[] buffer, int offset, int count, object halg) =>
             _impl.SignData(buffer, offset, count, HashAlgorithmNames.ObjToHashAlgorithmName(halg), RSASignaturePadding.Pkcs1);
@@ -190,6 +180,9 @@ namespace System.Security.Cryptography
 
         public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
             _impl.SignHash(hash, hashAlgorithm, padding);
+
+        public override bool TrySignHash(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten) =>
+            _impl.TrySignHash(source, destination, hashAlgorithm, padding, out bytesWritten);
 
         public byte[] SignHash(byte[] rgbHash, string str)
         {
@@ -210,29 +203,42 @@ namespace System.Security.Cryptography
         public override bool VerifyData(byte[] data, int offset, int count, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
             _impl.VerifyData(data, offset, count, signature, hashAlgorithm, padding);
 
+        public override bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            _impl.VerifyData(data, signature, hashAlgorithm, padding);
+
         public override bool VerifyHash(byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
+            if (hash == null)
+            {
+                throw new ArgumentNullException(nameof(hash));
+            }
             if (signature == null)
+            {
                 throw new ArgumentNullException(nameof(signature));
-            if (padding != RSASignaturePadding.Pkcs1)
-                throw PaddingModeNotSupported();
+            }
 
-            // _impl does remaining parameter validation
-
-            return _impl.VerifyHash(hash, signature, hashAlgorithm, padding);
+            return VerifyHash((ReadOnlySpan<byte>)hash, (ReadOnlySpan<byte>)signature, hashAlgorithm, padding);
         }
+
+        public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) =>
+            padding == null ? throw new ArgumentNullException(nameof(padding)) :
+            padding != RSASignaturePadding.Pkcs1 ? throw PaddingModeNotSupported() :
+            _impl.VerifyHash(hash, signature, hashAlgorithm, padding);
 
         public bool VerifyHash(byte[] rgbHash, string str, byte[] rgbSignature)
         {
             if (rgbHash == null)
+            {
                 throw new ArgumentNullException(nameof(rgbHash));
+            }
             if (rgbSignature == null)
+            {
                 throw new ArgumentNullException(nameof(rgbSignature));
+            }
 
-            // _impl does remaining parameter validation
-
-            HashAlgorithmName algName = HashAlgorithmNames.NameOrOidToHashAlgorithmName(str);
-            return _impl.VerifyHash(rgbHash, rgbSignature, algName, RSASignaturePadding.Pkcs1);
+            return VerifyHash(
+                (ReadOnlySpan<byte>)rgbHash, (ReadOnlySpan<byte>)rgbSignature,
+                HashAlgorithmNames.NameOrOidToHashAlgorithmName(str), RSASignaturePadding.Pkcs1);
         }
 
         // UseMachineKeyStore has no effect in Unix

--- a/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
+++ b/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
@@ -2,29 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Security.Cryptography.Rsa.Tests
 {
     public class RSACryptoServiceProviderProvider : IRSAProvider
     {
-        public RSA Create()
-        {
-            return new RSACryptoServiceProvider();
-        }
+        public RSA Create() => new RSACryptoServiceProvider();
 
-        public RSA Create(int keySize)
-        {
-            return new RSACryptoServiceProvider(keySize);
-        }
-        
-        public bool Supports384PrivateKey
-        {
-            get { return true; }
-        }
+        public RSA Create(int keySize) => new RSACryptoServiceProvider(keySize);
 
-        public bool SupportsSha2Oaep
-        {
-            get { return false; }
-        }
+        public bool Supports384PrivateKey => true;
+
+        public bool SupportsSha2Oaep => false;
+
+        public bool SupportsDecryptingIntoExactSpaceRequired => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -106,6 +106,9 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs</Link>
     </Compile>
@@ -114,6 +117,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs</Link>
     </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
@@ -6,25 +6,15 @@ namespace System.Security.Cryptography.Rsa.Tests
 {
     public class RSAOpenSslProvider : IRSAProvider
     {
-        public RSA Create()
-        {
-            return new RSAOpenSsl();
-        }
+        public RSA Create() => new RSAOpenSsl();
 
-        public RSA Create(int keySize)
-        {
-            return new RSAOpenSsl(keySize);
-        }
+        public RSA Create(int keySize) => new RSAOpenSsl(keySize);
 
-        public bool Supports384PrivateKey
-        {
-            get { return true; }
-        }
+        public bool Supports384PrivateKey => true;
 
-        public bool SupportsSha2Oaep
-        {
-            get { return false; }
-        }
+        public bool SupportsSha2Oaep => false;
+
+        public bool SupportsDecryptingIntoExactSpaceRequired => false;
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -108,5 +108,13 @@
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs</Link>
+    </Compile>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
- Add RSA.TryDecrypt/TryEncrypt/TryHashData/TrySignData/TrySignHash/VerifyData/VerifyHash, with default implementations on the base class
- Override the relevant methods on RSACng (Windows), RSAOpenSSL (Linux), RSASecurityTransforms (macOS), as well as on RSACryptoServiceProvider on Unix.
- I did not override the members on RSACryptoServiceProvider's Windows implementation, as it mutates the input, something we should stay away from when supplied a ReadOnlySpan; we can revisit subsequently if needed.
- Modified the existing tests to also test the span-based methods in addition to the array-based methods, and added some additional tests
- Some minor cleanup of code here and there as I was modifying nearby code

Contributes to https://github.com/dotnet/corefx/issues/22615
cc: @bartonjs 