### PR TITLE
Replace Elevated Tests

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -22,7 +22,6 @@ namespace System.Diagnostics
         /// <summary>The name of the test console app.</summary>
         protected static readonly string TestConsoleApp = "RemoteExecutorConsoleApp.exe";
 
-
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
         /// <param name="options">Options to use for the invocation.</param>

--- a/src/CoreFx.Private.TestUtilities/src/System/IO/FileCleanupTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/IO/FileCleanupTestBase.cs
@@ -11,6 +11,10 @@ namespace System.IO
     /// <summary>Base class for test classes the use temporary files that need to be cleaned up.</summary>
     public abstract class FileCleanupTestBase : IDisposable
     {
+        private static readonly Lazy<bool> s_isElevated = new Lazy<bool>(() => AdminHelpers.IsProcessElevated());
+
+        protected static bool IsProcessElevated => s_isElevated.Value;
+
         /// <summary>Initialize the test class base.  This creates the associated test directory.</summary>
         protected FileCleanupTestBase()
         {

--- a/src/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
@@ -18,15 +18,14 @@ namespace System.ServiceProcess.Tests
     {
         private readonly TestServiceProvider _testService;
 
+        private static readonly Lazy<bool> s_isElevated = new Lazy<bool>(() => AdminHelpers.IsProcessElevated());
+        protected static bool IsProcessElevated => s_isElevated.Value;
+
         public ServiceBaseTests()
         {
             _testService = new TestServiceProvider();
         }
 
-        private static bool RunningWithElevatedPrivileges
-        {
-            get { return TestServiceProvider.RunningWithElevatedPrivileges; }
-        }
         private void AssertExpectedProperties(ServiceController testServiceController)
         {
             var comparer = PlatformDetection.IsFullFramework ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal; // Full framework upper cases the name
@@ -70,7 +69,7 @@ namespace System.ServiceProcess.Tests
             }
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void TestOnStartThenStop()
         {
             var controller = new ServiceController(_testService.TestServiceName);
@@ -84,7 +83,7 @@ OnStop
             Assert.Equal(expected, _testService.GetServiceOutput());
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void TestOnStartWithArgsThenStop()
         {
             var controller = new ServiceController(_testService.TestServiceName);
@@ -103,7 +102,7 @@ OnStop
             Assert.Equal(expected, _testService.GetServiceOutput());
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void TestOnPauseThenStop()
         {
             var controller = new ServiceController(_testService.TestServiceName);
@@ -120,7 +119,7 @@ OnStop
             Assert.Equal(expected, _testService.GetServiceOutput());
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void TestOnPauseAndContinueThenStop()
         {
             var controller = new ServiceController(_testService.TestServiceName);
@@ -140,7 +139,7 @@ OnStop
             Assert.Equal(expected, _testService.GetServiceOutput());
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void TestOnExecuteCustomCommand()
         {
             var controller = new ServiceController(_testService.TestServiceName);
@@ -157,7 +156,7 @@ OnStop
             Assert.Equal(expected, _testService.GetServiceOutput());
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void TestOnContinueBeforePause()
         {
             var controller = new ServiceController(_testService.TestServiceName);

--- a/src/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
@@ -14,15 +14,17 @@ namespace System.ServiceProcess.Tests
     public class ServiceControllerTests : IDisposable
     {
         private readonly TestServiceProvider _testService;
+        private static readonly Lazy<bool> s_isElevated = new Lazy<bool>(() => AdminHelpers.IsProcessElevated());
+
+        protected static bool IsProcessElevated => s_isElevated.Value;
+
+        private const int ExpectedDependentServiceCount = 3;
+
+        private readonly ServiceProvider _testService;
 
         public ServiceControllerTests()
         {
             _testService = new TestServiceProvider();
-        }
-
-        private static bool RunningWithElevatedPrivileges
-        {
-            get { return TestServiceProvider.RunningWithElevatedPrivileges; }
         }
 
         private void AssertExpectedProperties(ServiceController testServiceController)
@@ -34,28 +36,28 @@ namespace System.ServiceProcess.Tests
             Assert.Equal(ServiceType.Win32OwnProcess, testServiceController.ServiceType);
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void ConstructWithServiceName()
         {
             var controller = new ServiceController(_testService.TestServiceName);
             AssertExpectedProperties(controller);
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void ConstructWithServiceName_ToUpper()
         {
             var controller = new ServiceController(_testService.TestServiceName.ToUpperInvariant());
             AssertExpectedProperties(controller);
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void ConstructWithDisplayName()
         {
             var controller = new ServiceController(_testService.TestServiceDisplayName);
             AssertExpectedProperties(controller);
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void ConstructWithMachineName()
         {
             var controller = new ServiceController(_testService.TestServiceName, _testService.TestMachineName);
@@ -64,7 +66,7 @@ namespace System.ServiceProcess.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => { var c = new ServiceController(_testService.TestServiceName, ""); });
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void ControlCapabilities()
         {
             var controller = new ServiceController(_testService.TestServiceName);
@@ -75,7 +77,7 @@ namespace System.ServiceProcess.Tests
             Assert.True(controller.CanShutdown);
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void StartWithArguments()
         {
             var controller = new ServiceController(_testService.TestServiceName);
@@ -96,14 +98,14 @@ namespace System.ServiceProcess.Tests
             Assert.Equal(argsInput, argsOutput);
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void Start_NullArg_ThrowsArgumentNullException()
         {
             var controller = new ServiceController(_testService.TestServiceName);
             Assert.Throws<ArgumentNullException>(() => controller.Start(new string[] { null } ));
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void StopAndStart()
         {
             var controller = new ServiceController(_testService.TestServiceName);
@@ -122,7 +124,7 @@ namespace System.ServiceProcess.Tests
             }
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void PauseAndContinue()
         {
             var controller = new ServiceController(_testService.TestServiceName);
@@ -141,7 +143,7 @@ namespace System.ServiceProcess.Tests
             }
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void GetServices_FindSelf()
         {
             bool foundTestService = false;
@@ -158,7 +160,7 @@ namespace System.ServiceProcess.Tests
             Assert.True(foundTestService, "Test service was not enumerated with all services");
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void Dependencies()
         {
             // The test service creates a number of dependent services, each of which is depended on
@@ -175,7 +177,7 @@ namespace System.ServiceProcess.Tests
             Assert.Equal(dependentController.DependentServices[0].ServiceName, controller.ServiceName);
         }
 
-        [ConditionalFact(nameof(RunningWithElevatedPrivileges))]
+        [ConditionalFact(nameof(IsProcessElevated))]
         public void ServicesStartMode()
         {
             var controller = new ServiceController(_testService.TestServiceName);

--- a/src/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
@@ -14,13 +14,11 @@ namespace System.ServiceProcess.Tests
     public class ServiceControllerTests : IDisposable
     {
         private readonly TestServiceProvider _testService;
-        private static readonly Lazy<bool> s_isElevated = new Lazy<bool>(() => AdminHelpers.IsProcessElevated());
 
+        private static readonly Lazy<bool> s_isElevated = new Lazy<bool>(() => AdminHelpers.IsProcessElevated());
         protected static bool IsProcessElevated => s_isElevated.Value;
 
         private const int ExpectedDependentServiceCount = 3;
-
-        private readonly ServiceProvider _testService;
 
         public ServiceControllerTests()
         {


### PR DESCRIPTION
Uses helper method to condition existing tests that require elevation for Windows and Unix.