### PR TITLE
Reenable passing System.Diagnostics.Process test

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -900,7 +900,6 @@ namespace System.Diagnostics.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Behavior differs on Windows and Unix
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/18212", TargetFrameworkMonikers.UapAot)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapNotUapAot, "Retrieving information about local processes is not supported on uap")]
         public void TestProcessOnRemoteMachineWindows()
         {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/18212

In fact this test doesn't crash anymore. @danmosemsft I don't know if I should port this to release/uwp6.0 since it is marked as future.