### PR TITLE
Update TODOs in ManagedHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/AuthenticationHelper.Basic.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/AuthenticationHelper.Basic.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http
         {
             if (credential.UserName.IndexOf(':') != -1)
             {
-                // TODO #21452: What's the right way to handle this?
+                // TODO #23135: What's the right way to handle this?
                 throw new NotImplementedException($"Basic auth: can't handle ':' in username \"{credential.UserName}\"");
             }
 
@@ -36,7 +36,7 @@ namespace System.Net.Http
             {
                 if (credential.Domain.IndexOf(':') != -1)
                 {
-                    // TODO #21452: What's the right way to handle this?
+                    // TODO #23135: What's the right way to handle this?
                     throw new NotImplementedException($"Basic auth: can't handle ':' in domain \"{credential.Domain}\"");
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ConnectHelper.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http
             var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
             try
             {
-                // TODO #21452: No cancellationToken on ConnectAsync?
+                // TODO #23151: cancellation support?
                 await (IPAddress.TryParse(host, out IPAddress address) ?
                     socket.ConnectAsync(address, port) :
                     socket.ConnectAsync(host, port)).ConfigureAwait(false);
@@ -25,17 +25,7 @@ namespace System.Net.Http
                 throw new HttpRequestException(se.Message, se);
             }
 
-            return new NetworkStream(socket, ownsSocket: true)
-            {
-#if false
-                // TODO #21452: Timeouts?
-                // Default timeout should be something less than infinity (the Socket default)
-                // Timeouts probably need to be configurable
-                // However, timeouts are also a huge pain when debugging, so consider that too.
-                ReadTimeout = 5000,
-                WriteTimeout = 5000
-#endif
-            };
+            return new NetworkStream(socket, ownsSocket: true);
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -203,8 +203,8 @@ namespace System.Net.Http
 
                 if (request.Version.Major != 1 || request.Version.Minor != 1)
                 {
-                    // TODO #21452: Support 1.0
-                    // TODO #21452: Support 2.0
+                    // TODO #23132: Support 1.0
+                    // TODO #23134: Support 2.0
                     throw new PlatformNotSupportedException($"Only HTTP 1.1 supported -- request.Version was {request.Version}");
                 }
 
@@ -263,9 +263,9 @@ namespace System.Net.Http
                         (HttpContentWriteStream)new ChunkedEncodingWriteStream(this) :
                         (HttpContentWriteStream)new ContentLengthWriteStream(this));
 
-                    // TODO #21452: CopyToAsync doesn't take a CancellationToken, how do we deal with Cancellation here?
-                    // TODO #21452: We need to enable duplex communication, which means not waiting here until all data is sent.
-                    // TODO #21452: Support Expect: 100-continue
+                    // TODO #23146: CopyToAsync doesn't take a CancellationToken, how do we deal with Cancellation here?
+                    // TODO #23145: We need to enable duplex communication, which means not waiting here until all data is sent.
+                    // TODO #23144: Support Expect: 100-continue
                     await request.Content.CopyToAsync(stream, _transportContext).ConfigureAwait(false);
                     await stream.FinishAsync(cancellationToken).ConfigureAwait(false);
                 }
@@ -411,7 +411,7 @@ namespace System.Net.Http
 
         private void ParseHeaderNameValue(Span<byte> line, HttpResponseMessage response)
         {
-            // TODO: Use Span to get the header name and value rather than going through ValueStringBuilder
+            // TODO #23147: Use Span to get the header name and value rather than going through ValueStringBuilder
 
             _sb.Clear();
             int pos = 0;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Net.Http.Headers;
+using System.Net.Security;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -84,7 +85,23 @@ namespace System.Net.Http
             _connectionClose = false;
             _disposed = false;
 
-            if (NetEventSource.IsEnabled) Trace("Connection created.");
+            if (NetEventSource.IsEnabled)
+            {
+                if (_stream is SslStream sslStream)
+                {
+                    Trace(
+                        $"Secure connection created to {key.Host}:{key.Port}. " +
+                        $"SslProtocol:{sslStream.SslProtocol}, " +
+                        $"CipherAlgorithm:{sslStream.CipherAlgorithm}, CipherStrength:{sslStream.CipherStrength}, " +
+                        $"HashAlgorithm:{sslStream.HashAlgorithm}, HashStrength:{sslStream.HashStrength}, " +
+                        $"KeyExchangeAlgorithm:{sslStream.KeyExchangeAlgorithm}, KeyExchangeStrength:{sslStream.KeyExchangeStrength}, " +
+                        $"LocalCert:{sslStream.LocalCertificate}, RemoteCert:{sslStream.RemoteCertificate}");
+                }
+                else
+                {
+                    Trace($"Connection created to {key.Host}:{key.Port}.");
+                }
+            }
         }
 
         public void Dispose()

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
@@ -58,7 +58,7 @@ namespace System.Net.Http
 
             try
             {
-                // TODO #21452: No cancellationToken?
+                // TODO https://github.com/dotnet/corefx/issues/23077#issuecomment-321807131: No cancellationToken?
                 await sslStream.AuthenticateAsClientAsync(host, _settings._clientCertificates, _settings._sslProtocols, _settings._checkCertificateRevocationList).ConfigureAwait(false);
             }
             catch (Exception e)
@@ -66,7 +66,6 @@ namespace System.Net.Http
                 sslStream.Dispose();
                 if (e is AuthenticationException || e is IOException)
                 {
-                    // TODO #21452: Tests expect HttpRequestException here.  Is that correct behavior?
                     throw new HttpRequestException("could not establish SSL connection", e);
                 }
                 throw;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPools.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPools.cs
@@ -21,7 +21,7 @@ namespace System.Net.Http
         /// <summary>The pools, indexed by endpoint.</summary>
         private readonly ConcurrentDictionary<HttpConnectionKey, HttpConnectionPool> _pools;
         /// <summary>Timer used to initiate cleaning of the pools.</summary>
-        private readonly Timer _cleaningTimer; // TODO: Consider changing this to stop when _pools is empty.
+        private readonly Timer _cleaningTimer; // TODO #23149: Consider changing this to stop when _pools is empty.
         /// <summary>The maximum number of connections allowed per pool. <see cref="int.MaxValue"/> indicates unlimited.</summary>
         private readonly int _maxConnectionsPerServer;
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -42,7 +42,7 @@ namespace System.Net.Http
             catch (Exception)
             {
                 // Eat any exception from the IWebProxy and just treat it as no proxy.
-                // TODO #21452: This seems a bit questionable, but it's what the tests expect
+                // This matches the behavior of other handlers.
             }
 
             return proxyUri == null ?
@@ -60,7 +60,7 @@ namespace System.Net.Http
 
             if (request.RequestUri.Scheme == UriScheme.Https)
             {
-                // TODO #21452: Implement SSL tunneling through proxy
+                // TODO #23136: Implement SSL tunneling through proxy
                 throw new NotImplementedException("no support for SSL tunneling through proxy");
             }
 
@@ -166,7 +166,7 @@ namespace System.Net.Http
         private static readonly Lazy<Uri> s_proxyFromEnvironment = new Lazy<Uri>(() =>
         {
             // http_proxy is standard on Unix, used e.g. by libcurl.
-            // TODO #21452: We should support the full array of environment variables here,
+            // TODO #23150: We should support the full array of environment variables here,
             // including no_proxy, all_proxy, etc.
 
             string proxyString = Environment.GetEnvironmentVariable("http_proxy");

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -143,7 +143,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #21452: The managed handler is currently sending out client certificates when it shouldn't.
+                // TODO #23128: The managed handler is currently sending out client certificates when it shouldn't.
                 return;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -71,7 +71,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                return; // TODO #21452: SSL proxy tunneling not yet implemented in ManagedHandler
+                return; // TODO #23136: SSL proxy tunneling not yet implemented in ManagedHandler
             }
 
             int port;
@@ -312,7 +312,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.NotNull(chain);
                     if (!ManagedHandlerTestHelpers.IsEnabled)
                     {
-                        // TODO #21452: This test is failing with the managed handler on the exact value of the managed errors,
+                        // TODO #23137: This test is failing with the managed handler on the exact value of the managed errors,
                         // e.g. reporting "RemoteCertificateNameMismatch, RemoteCertificateChainErrors" when we only expect
                         // "RemoteCertificateChainErrors"
                         Assert.Equal(expectedErrors, errors);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -93,7 +93,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #21452: The managed handler is failing.
+                // TODO #23138: The managed handler is failing.
                 return;
             }
 
@@ -132,7 +132,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #21452: The managed handler is failing.
+                // TODO #23138: The managed handler is failing.
                 return;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -492,11 +492,11 @@ namespace System.Net.Http.Functional.Tests
                 handler.Credentials = new NetworkCredential("unused", "unused");
                 using (var client = new HttpClient(handler))
                 {
-                    Task<HttpResponseMessage> getResponse = client.GetAsync(url);
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
+                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server, responseHeaders);
 
-                    await LoopbackServer.ReadRequestAndSendResponseAsync(server, responseHeaders);
-
-                    using (HttpResponseMessage response = await getResponse)
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+                    using (HttpResponseMessage response = await getResponseTask)
                     {
                         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
                     }
@@ -544,21 +544,28 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (origServer, origUrl) =>
                 {
                     var request = new HttpRequestMessage(new HttpMethod(oldMethod), origUrl);
-                    Task<HttpResponseMessage> getResponse = client.SendAsync(request);
 
-                    await LoopbackServer.ReadRequestAndSendResponseAsync(origServer,
+                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
+
+                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(origServer,
                             $"HTTP/1.1 {statusCode} OK\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             $"Location: {origUrl}\r\n" +
                             "\r\n");
+                    await Task.WhenAny(getResponseTask, serverTask);
+                    Assert.False(getResponseTask.IsCompleted, $"{getResponseTask.Status}: {getResponseTask.Exception}");
+                    await serverTask;
 
-                    List<string> receivedRequest = await LoopbackServer.ReadRequestAndSendResponseAsync(origServer,
+                    serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(origServer,
                             $"HTTP/1.1 200 OK\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             "\r\n");
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    List <string> receivedRequest = await serverTask;
                     string[] statusLineParts = receivedRequest[0].Split(' ');
 
-                    using (HttpResponseMessage response = await getResponse)
+                    using (HttpResponseMessage response = await getResponseTask)
                     {
                         Assert.Equal(200, (int)response.StatusCode);
                         Assert.Equal(newMethod, statusLineParts[0]);
@@ -739,17 +746,19 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await LoopbackServer.CreateServerAsync(async (redirectServer, redirectUrl) =>
                     {
-                        Task<HttpResponseMessage> getResponse = client.GetAsync(origUrl);
+                        Task<HttpResponseMessage> getResponseTask = client.GetAsync(origUrl);
 
                         Task redirectTask = LoopbackServer.ReadRequestAndSendResponseAsync(redirectServer);
 
-                        await LoopbackServer.ReadRequestAndSendResponseAsync(origServer,
+                        await TestHelper.WhenAllCompletedOrAnyFailed(
+                            getResponseTask,
+                            LoopbackServer.ReadRequestAndSendResponseAsync(origServer,
                                 $"HTTP/1.1 {statusCode} OK\r\n" +
                                 $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                                 $"Location: {redirectUrl}\r\n" +
-                                "\r\n");
+                                "\r\n"));
 
-                        using (HttpResponseMessage response = await getResponse)
+                        using (HttpResponseMessage response = await getResponseTask)
                         {
                             Assert.Equal(statusCode, (int)response.StatusCode);
                             Assert.Equal(origUrl, response.RequestMessage.RequestUri);
@@ -811,7 +820,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #21452: The managed handler is currently getting Ok when it should be getting Unauthorized.
+                // TODO #23129: The managed handler is currently getting Ok when it should be getting Unauthorized.
                 return;
             }
 
@@ -1022,17 +1031,18 @@ namespace System.Net.Http.Functional.Tests
                 using (var handler = new HttpClientHandler())
                 using (var client = new HttpClient(handler))
                 {
-                    Task<HttpResponseMessage> getResponse = client.GetAsync(url);
-
-                    await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
+                    await TestHelper.WhenAllCompletedOrAnyFailed(
+                        getResponseTask,
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
                             $"HTTP/1.1 200 OK\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             $"Set-Cookie: {cookie1.Key}={cookie1.Value}; Path=/\r\n" +
                             $"Set-Cookie   : {cookie2.Key}={cookie2.Value}; Path=/\r\n" + // space before colon to verify header is trimmed and recognized
                             $"Set-Cookie: {cookie3.Key}={cookie3.Value}; Path=/\r\n" +
-                            "\r\n");
+                            "\r\n"));
 
-                    using (HttpResponseMessage response = await getResponse)
+                    using (HttpResponseMessage response = await getResponseTask)
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                         CookieCollection cookies = handler.CookieContainer.GetCookies(url);
@@ -1064,9 +1074,10 @@ namespace System.Net.Http.Functional.Tests
                 using (var handler = new HttpClientHandler())
                 using (var client = new HttpClient(handler))
                 {
-                    Task<HttpResponseMessage> getResponse = client.GetAsync(url);
-
-                    await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
+                    await TestHelper.WhenAllCompletedOrAnyFailed(
+                        getResponseTask,
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
                             "HTTP/1.1 200 OK\r\n" +
                             "Transfer-Encoding: chunked\r\n" +
                             (includeTrailerHeader ? "Trailer: MyCoolTrailerHeader\r\n" : "") +
@@ -1075,9 +1086,9 @@ namespace System.Net.Http.Functional.Tests
                             "data\r\n" +
                             "0\r\n" +
                             "MyCoolTrailerHeader: amazingtrailer\r\n" +
-                            "\r\n");
+                            "\r\n"));
 
-                    using (HttpResponseMessage response = await getResponse)
+                    using (HttpResponseMessage response = await getResponseTask)
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                         if (includeTrailerHeader)
@@ -1290,12 +1301,14 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (var client = new HttpClient())
                 {
-                    Task<HttpResponseMessage> getResponse = client.GetAsync(url);
-                    await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
+                    await TestHelper.WhenAllCompletedOrAnyFailed(
+                        getResponseTask,
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
                             $"HTTP/1.1 {statusCode}\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                            "\r\n");
-                    using (HttpResponseMessage response = await getResponse)
+                            "\r\n"));
+                    using (HttpResponseMessage response = await getResponseTask)
                     {
                         Assert.Equal(statusCode, (int)response.StatusCode);
                     }
@@ -1319,13 +1332,13 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (var client = new HttpClient())
                 {
-                    Task<HttpResponseMessage> getResponse = client.GetAsync(url);
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
                     await LoopbackServer.ReadRequestAndSendResponseAsync(server,
                             $"HTTP/1.1 {statusCode}\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             "\r\n");
 
-                    await Assert.ThrowsAsync<HttpRequestException>(() => getResponse);
+                    await Assert.ThrowsAsync<HttpRequestException>(() => getResponseTask);
                 }
             });
         }
@@ -1821,7 +1834,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #21452: The test is hanging with the managed handler.
+                // TODO #23132: ManagedHandler doesn't support 1.0 currently.
                 return;
             }
 
@@ -1844,7 +1857,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #21452: The test is hanging with the managed handler.
+                // TODO #23132: ManagedHandler requires 1.0 currently.
                 return;
             }
 
@@ -1952,9 +1965,10 @@ namespace System.Net.Http.Functional.Tests
                 using (var client = new HttpClient())
                 {
                     Task<HttpResponseMessage> getResponse = client.SendAsync(request);
+                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponse, serverTask);
 
-                    List<string> receivedRequest = await LoopbackServer.ReadRequestAndSendResponseAsync(server);
-
+                    List<string> receivedRequest = await serverTask;
                     using (HttpResponseMessage response = await getResponse)
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -2104,11 +2118,12 @@ namespace System.Net.Http.Functional.Tests
 
                 using (var client = new HttpClient())
                 {
-                    Task<HttpResponseMessage> getResponse = client.SendAsync(request);
+                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
+                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
 
-                    List<string> receivedRequest = await LoopbackServer.ReadRequestAndSendResponseAsync(server);
-
-                    using (HttpResponseMessage response = await getResponse)
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+                    List<string> receivedRequest = await serverTask;
+                    using (HttpResponseMessage response = await getResponseTask)
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                         Assert.True(receivedRequest[0].Contains(uri.PathAndQuery), $"statusLine should contain {uri.PathAndQuery}");

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1065,7 +1065,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #21452: The managed handler isn't correctly handling trailing headers.
+                // TODO #23130: The managed handler isn't correctly handling trailing headers.
                 return;
             }
 
@@ -1221,7 +1221,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #21452: The ManagedHandler isn't correctly handling disposal of the handler.
+                // TODO #23131: The ManagedHandler isn't correctly handling disposal of the handler.
                 // It should cause the outstanding requests to be canceled with OperationCanceledExceptions,
                 // whereas currently it's resulting in ObjectDisposedExceptions.
                 return;
@@ -1857,7 +1857,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #23132: ManagedHandler requires 1.0 currently.
+                // TODO #23132: ManagedHandler requires 1.1 currently.
                 return;
             }
 
@@ -1881,7 +1881,7 @@ namespace System.Net.Http.Functional.Tests
             }
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #21452: The managed handler doesn't yet support HTTP/2.
+                // TODO #23134: The managed handler doesn't yet support HTTP/2.
                 return;
             }
 
@@ -1934,7 +1934,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #21452: The managed handler doesn't yet support HTTP/2.
+                // TODO #23134: The managed handler doesn't yet support HTTP/2.
                 return;
             }
 
@@ -2000,11 +2000,11 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(CredentialsForProxy))]
-        public void Proxy_BypassFalse_GetRequestGoesThroughCustomProxy(ICredentials creds, bool wrapCredsInCache)
+        public async Task Proxy_BypassFalse_GetRequestGoesThroughCustomProxy(ICredentials creds, bool wrapCredsInCache)
         {
             if (ManagedHandlerTestHelpers.IsEnabled)
             {
-                // TODO #21452: The test is hanging with the managed handler for some of the theory inputs.
+                // TODO #23135: ManagedHandler currently gets error "System.NotImplementedException : Basic auth: can't handle ':' in domain "dom:\ain""
                 return;
             }
 
@@ -2029,7 +2029,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 Task<HttpResponseMessage> responseTask = client.GetAsync(Configuration.Http.RemoteEchoServer);
                 Task<string> responseStringTask = responseTask.ContinueWith(t => t.Result.Content.ReadAsStringAsync(), TaskScheduler.Default).Unwrap();
-                Task.WaitAll(proxyTask, responseTask, responseStringTask);
+                await TestHelper.WhenAllCompletedOrAnyFailed(proxyTask, responseTask, responseStringTask);
 
                 using (responseTask.Result)
                 {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -128,20 +128,22 @@ namespace System.Net.Http.Functional.Tests
             {
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
-                    Task<string> t = client.GetStringAsync(url);
-                    await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                    Task<string> getTask = client.GetStringAsync(url);
+                    Task serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server,
                         $"HTTP/1.1 200 OK\r\n" +
                         $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                         $"Content-Length: {contentLength}\r\n" +
                         "\r\n" +
                         new string('s', contentLength));
+                    Task bothTasks = TestHelper.WhenAllCompletedOrAnyFailed(getTask, serverTask);
+
                     if (exceptionExpected)
                     {
-                        await Assert.ThrowsAsync<HttpRequestException>(() => t);
+                        await Assert.ThrowsAsync<HttpRequestException>(() => bothTasks);
                     }
                     else
                     {
-                        await t;
+                        await bothTasks;
                     }
                 });
             }

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -42,13 +42,13 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    // TODO #21452: Tests on this class fail when the associated condition is enabled.
+    // TODO #23139: Tests on this class fail when the associated condition is enabled.
     //public sealed class ManagedHandler_HttpClientEKUTest : HttpClientEKUTest, IDisposable
     //{
     //    public ManagedHandler_HttpClientEKUTest() => ManagedHandlerTestHelpers.SetEnvVar();
     //    public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
     //}
-    
+
     public sealed class ManagedHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test : HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test, IDisposable
     {
         public ManagedHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test() => ManagedHandlerTestHelpers.SetEnvVar();
@@ -121,7 +121,7 @@ namespace System.Net.Http.Functional.Tests
         public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
     }
 
-    // TODO #21452:
+    // TODO #23140:
     //public sealed class ManagedHandler_DefaultCredentialsTest : DefaultCredentialsTest, IDisposable
     //{
     //    public ManagedHandler_DefaultCredentialsTest(ITestOutputHelper output) : base(output) => ManagedHandlerTestHelpers.SetEnvVar();
@@ -138,7 +138,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    // TODO #21452: Socket's don't support canceling individual operations, so ReadStream on NetworkStream
+    // TODO #23141: Socket's don't support canceling individual operations, so ReadStream on NetworkStream
     // isn't cancelable once the operation has started.  We either need to wrap the operation with one that's
     // "cancelable", meaning that the underlying operation will still be running even though we've returned "canceled",
     // or we need to just recognize that cancellation in such situations can be left up to the caller to do the
@@ -149,7 +149,7 @@ namespace System.Net.Http.Functional.Tests
     //    public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
     //}
 
-    // TODO #21452: The managed handler doesn't currently track how much data was written for the response headers.
+    // TODO #23142: The managed handler doesn't currently track how much data was written for the response headers.
     //public sealed class ManagedHandler_HttpClientHandler_MaxResponseHeadersLength_Test : HttpClientHandler_MaxResponseHeadersLength_Test, IDisposable
     //{
     //    public ManagedHandler_HttpClientHandler_MaxResponseHeadersLength_Test() => ManagedHandlerTestHelpers.SetEnvVar();


### PR DESCRIPTION
I cleaned up the TODOs in ManagedHandler, opening individual issues for each aspect and updating the comments to link to the associated issue.

In the process of doing so, I found that some of the "hangs" reported were due to test issues, where the tests would hang if the HttpClient.GetAsync operation failed, so I fixed those such that we now see the actual reason for the failure rather than the test hanging.

And I added a bit more tracing to ManagedHandler, in particular to see details about the established SSL connection.

cc: @geoffkizer 