### PR TITLE
Remove CancellationToken field from StreamContent

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -15,7 +15,6 @@ namespace System.Net.Http
 
         private Stream _content;
         private int _bufferSize;
-        private CancellationToken _cancellationToken;
         private bool _contentConsumed;
         private long _start;
 
@@ -25,16 +24,6 @@ namespace System.Net.Http
         }
 
         public StreamContent(Stream content, int bufferSize)
-            : this(content, bufferSize, CancellationToken.None)
-        {
-        }
-
-        internal StreamContent(Stream content, CancellationToken cancellationToken)
-            : this(content, DefaultBufferSize, cancellationToken)
-        {
-        }
-
-        private StreamContent(Stream content, int bufferSize, CancellationToken cancellationToken)
         {
             if (content == null)
             {
@@ -47,7 +36,6 @@ namespace System.Net.Http
 
             _content = content;
             _bufferSize = bufferSize;
-            _cancellationToken = cancellationToken;
             if (content.CanSeek)
             {
                 _start = content.Position;
@@ -61,7 +49,7 @@ namespace System.Net.Http
 
             PrepareContent();
             // If the stream can't be re-read, make sure that it gets disposed once it is consumed.
-            return StreamToStreamCopy.CopyAsync(_content, stream, _bufferSize, !_content.CanSeek, _cancellationToken);
+            return StreamToStreamCopy.CopyAsync(_content, stream, _bufferSize, !_content.CanSeek);
         }
 
         protected internal override bool TryComputeLength(out long length)
@@ -117,7 +105,7 @@ namespace System.Net.Http
             _contentConsumed = true;
         }
 
-        private class ReadOnlyStream : DelegatingStream
+        private sealed class ReadOnlyStream : DelegatingStream
         {
             public override bool CanWrite
             {


### PR DESCRIPTION
This is a holdover from a previous design, isn't used, but is still taking up space in the StreamContent.  Remove it.

cc: @davidsh, @geoffkizer 