### PR TITLE
Expose and Add Tests for BitConverter APIs in Corefx

### DIFF
--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -125,37 +125,63 @@ namespace System
         public static readonly bool IsLittleEndian;
         public static long DoubleToInt64Bits(double value) { throw null; }
         public static byte[] GetBytes(bool value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, bool value) { throw null; }
         public static byte[] GetBytes(char value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, char value) { throw null; }
         public static byte[] GetBytes(double value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, double value) { throw null; }
         public static byte[] GetBytes(short value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, short value) { throw null; }
         public static byte[] GetBytes(int value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, int value) { throw null; }
         public static byte[] GetBytes(long value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, long value) { throw null; }
         public static byte[] GetBytes(float value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, float value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static byte[] GetBytes(ushort value) { throw null; }
         [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteBytes(Span<byte> destination, ushort value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
         public static byte[] GetBytes(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteBytes(Span<byte> destination, uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
         public static byte[] GetBytes(ulong value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteBytes(Span<byte> destination, ulong value) { throw null; }
         public static float Int32BitsToSingle(int value) { throw null; }
         public static double Int64BitsToDouble(long value) { throw null; }
         public static int SingleToInt32Bits(float value) { throw null; }
         public static bool ToBoolean(byte[] value, int startIndex) { throw null; }
+        public static bool ToBoolean(ReadOnlySpan<byte> value) { throw null; }
         public static char ToChar(byte[] value, int startIndex) { throw null; }
+        public static char ToChar(ReadOnlySpan<byte> value) { throw null; }
         public static double ToDouble(byte[] value, int startIndex) { throw null; }
+        public static double ToDouble(ReadOnlySpan<byte> value) { throw null; }
         public static short ToInt16(byte[] value, int startIndex) { throw null; }
+        public static short ToInt16(ReadOnlySpan<byte> value) { throw null; }
         public static int ToInt32(byte[] value, int startIndex) { throw null; }
+        public static int ToInt32(ReadOnlySpan<byte> value) { throw null; }
         public static long ToInt64(byte[] value, int startIndex) { throw null; }
+        public static long ToInt64(ReadOnlySpan<byte> value) { throw null; }
         public static float ToSingle(byte[] value, int startIndex) { throw null; }
+        public static float ToSingle(ReadOnlySpan<byte> value) { throw null; }
         public static string ToString(byte[] value) { throw null; }
         public static string ToString(byte[] value, int startIndex) { throw null; }
         public static string ToString(byte[] value, int startIndex, int length) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static ushort ToUInt16(byte[] value, int startIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
+        public static ushort ToUInt16(ReadOnlySpan<byte> value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
         public static uint ToUInt32(byte[] value, int startIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
+        public static uint ToUInt32(ReadOnlySpan<byte> value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
         public static ulong ToUInt64(byte[] value, int startIndex) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static ulong ToUInt64(ReadOnlySpan<byte> value) { throw null; }
     }
     public static partial class Convert
     {

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -125,31 +125,18 @@ namespace System
         public static readonly bool IsLittleEndian;
         public static long DoubleToInt64Bits(double value) { throw null; }
         public static byte[] GetBytes(bool value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, bool value) { throw null; }
         public static byte[] GetBytes(char value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, char value) { throw null; }
         public static byte[] GetBytes(double value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, double value) { throw null; }
         public static byte[] GetBytes(short value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, short value) { throw null; }
         public static byte[] GetBytes(int value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, int value) { throw null; }
         public static byte[] GetBytes(long value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, long value) { throw null; }
         public static byte[] GetBytes(float value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, float value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static byte[] GetBytes(ushort value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryWriteBytes(Span<byte> destination, ushort value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
         public static byte[] GetBytes(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryWriteBytes(Span<byte> destination, uint value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
         public static byte[] GetBytes(ulong value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static bool TryWriteBytes(Span<byte> destination, ulong value) { throw null; }
         public static float Int32BitsToSingle(int value) { throw null; }
         public static double Int64BitsToDouble(long value) { throw null; }
         public static int SingleToInt32Bits(float value) { throw null; }
@@ -182,6 +169,19 @@ namespace System
         public static ulong ToUInt64(byte[] value, int startIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static ulong ToUInt64(ReadOnlySpan<byte> value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, bool value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, char value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, double value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, short value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, int value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, long value) { throw null; }
+        public static bool TryWriteBytes(Span<byte> destination, float value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteBytes(Span<byte> destination, ushort value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteBytes(Span<byte> destination, uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteBytes(Span<byte> destination, ulong value) { throw null; }
     }
     public static partial class Convert
     {

--- a/src/System.Runtime.Extensions/tests/Configurations.props
+++ b/src/System.Runtime.Extensions/tests/Configurations.props
@@ -6,6 +6,7 @@
       netcoreapp-Unix;
       netstandard-Windows_NT;
       netstandard-Unix;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -17,7 +17,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard' or '$(TargetGroup)'=='netcoreapp'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
+  <ItemGroup>
     <Compile Include="System\ApplicationIdTests.cs" />
     <Compile Include="System\Convert.cs" />
     <Compile Include="System\EnvironmentTests.cs" />
@@ -30,9 +32,9 @@
     <Compile Include="System\Reflection\AssemblyNameProxyTests.cs" />
     <Compile Include="System\MarshalByRefObjectTest.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'!='netfx'">
-    <Compile Include="System\BitConverter.netcoreapp.cs" />
+  <ItemGroup Condition="'$(TargetGroup)'!='netstandard'">
     <Compile Include="System\BitConverterSpan.cs" />
+    <Compile Include="System\BitConverter.netcoreapp.cs" />
     <Compile Include="System\IO\Path.GetRelativePath.cs" />
     <Compile Include="System\MathTests.netcoreapp.cs" />
     <Compile Include="System\MathF.netcoreapp.cs" />

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -30,7 +30,8 @@
     <Compile Include="System\Reflection\AssemblyNameProxyTests.cs" />
     <Compile Include="System\MarshalByRefObjectTest.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
+  <ItemGroup Condition="'$(TargetGroup)'!='netfx'">
+    <Compile Include="System\BitConverter.netcoreapp.cs" />
     <Compile Include="System\BitConverterSpan.cs" />
     <Compile Include="System\IO\Path.GetRelativePath.cs" />
     <Compile Include="System\MathTests.netcoreapp.cs" />
@@ -40,7 +41,6 @@
     <Compile Include="System\IO\Path.IsPathFullyQualified.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="System\BitConverter.netcoreapp.cs" />
     <Compile Include="System\BitConverterArray.cs" />
     <Compile Include="System\BitConverterBase.cs" />
     <Compile Include="System\Environment.UserDomainName.cs" />

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -31,7 +31,7 @@
     <Compile Include="System\MarshalByRefObjectTest.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
-    <Compile Include="System\BitConverter.netcoreapp.cs" />
+    <Compile Include="System\BitConverterSpan.cs" />
     <Compile Include="System\IO\Path.GetRelativePath.cs" />
     <Compile Include="System\MathTests.netcoreapp.cs" />
     <Compile Include="System\MathF.netcoreapp.cs" />
@@ -40,6 +40,9 @@
     <Compile Include="System\IO\Path.IsPathFullyQualified.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="System\BitConverter.netcoreapp.cs" />
+    <Compile Include="System\BitConverterArray.cs" />
+    <Compile Include="System\BitConverterBase.cs" />
     <Compile Include="System\Environment.UserDomainName.cs" />
     <Compile Include="System\Environment.UserName.cs" />
     <Compile Include="System\Diagnostics\Stopwatch.cs" />

--- a/src/System.Runtime.Extensions/tests/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverter.cs
@@ -108,17 +108,17 @@ namespace System.Tests
         [Fact]
         public static void DoubleToInt64Bits()
         {
-            Double input = 123456.3234;
-            Int64 result = BitConverter.DoubleToInt64Bits(input);
+            double input = 123456.3234;
+            long result = BitConverter.DoubleToInt64Bits(input);
             Assert.Equal(4683220267154373240L, result);
-            Double roundtripped = BitConverter.Int64BitsToDouble(result);
+            double roundtripped = BitConverter.Int64BitsToDouble(result);
             Assert.Equal(input, roundtripped);
         }
 
         [Fact]
         public static void RoundtripBoolean()
         {
-            Byte[] bytes = BitConverter.GetBytes(true);
+            byte[] bytes = BitConverter.GetBytes(true);
             Assert.Equal(1, bytes.Length);
             Assert.Equal(1, bytes[0]);
             Assert.True(BitConverter.ToBoolean(bytes, 0));
@@ -132,79 +132,79 @@ namespace System.Tests
         [Fact]
         public static void RoundtripChar()
         {
-            Char input = 'A';
-            Byte[] expected = { 0x41, 0 };
+            char input = 'A';
+            byte[] expected = { 0x41, 0 };
             VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToChar, input, expected);
         }
 
         [Fact]
         public static void RoundtripDouble()
         {
-            Double input = 123456.3234;
-            Byte[] expected = { 0x78, 0x7a, 0xa5, 0x2c, 0x05, 0x24, 0xfe, 0x40 };
+            double input = 123456.3234;
+            byte[] expected = { 0x78, 0x7a, 0xa5, 0x2c, 0x05, 0x24, 0xfe, 0x40 };
             VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToDouble, input, expected);
         }
 
         [Fact]
         public static void RoundtripSingle()
         {
-            Single input = 8392.34f;
-            Byte[] expected = { 0x5c, 0x21, 0x03, 0x46 };
+            float input = 8392.34f;
+            byte[] expected = { 0x5c, 0x21, 0x03, 0x46 };
             VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToSingle, input, expected);
         }
 
         [Fact]
         public static void RoundtripInt16()
         {
-            Int16 input = 0x1234;
-            Byte[] expected = { 0x34, 0x12 };
+            short input = 0x1234;
+            byte[] expected = { 0x34, 0x12 };
             VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt16, input, expected);
         }
 
         [Fact]
         public static void RoundtripInt32()
         {
-            Int32 input = 0x12345678;
-            Byte[] expected = { 0x78, 0x56, 0x34, 0x12 };
+            int input = 0x12345678;
+            byte[] expected = { 0x78, 0x56, 0x34, 0x12 };
             VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt32, input, expected);
         }
 
         [Fact]
         public static void RoundtripInt64()
         {
-            Int64 input = 0x0123456789abcdef;
-            Byte[] expected = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
+            long input = 0x0123456789abcdef;
+            byte[] expected = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
             VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt64, input, expected);
         }
 
         [Fact]
         public static void RoundtripUInt16()
         {
-            UInt16 input = 0x1234;
-            Byte[] expected = { 0x34, 0x12 };
+            ushort input = 0x1234;
+            byte[] expected = { 0x34, 0x12 };
             VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt16, input, expected);
         }
 
         [Fact]
         public static void RoundtripUInt32()
         {
-            UInt32 input = 0x12345678;
-            Byte[] expected = { 0x78, 0x56, 0x34, 0x12 };
+            uint input = 0x12345678;
+            byte[] expected = { 0x78, 0x56, 0x34, 0x12 };
             VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt32, input, expected);
         }
 
         [Fact]
         public static void RoundtripUInt64()
         {
-            UInt64 input = 0x0123456789abcdef;
-            Byte[] expected = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
+            ulong input = 0x0123456789abcdef;
+            byte[] expected = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
             VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt64, input, expected);
         }
 
         [Fact]
         public static void RoundtripString()
         {
-            Byte[] bytes = { 0x12, 0x34, 0x56, 0x78, 0x9a };
+            byte[] bytes = { 0x12, 0x34, 0x56, 0x78, 0x9a };
 
             Assert.Equal("12-34-56-78-9A", BitConverter.ToString(bytes));
             Assert.Equal("56-78-9A", BitConverter.ToString(bytes, 2));
@@ -245,7 +245,7 @@ namespace System.Tests
 
         private static void VerifyRoundtrip<TInput>(Func<TInput, Byte[]> getBytes, Func<Byte[], int, TInput> convertBack, TInput input, Byte[] expectedBytes)
         {
-            Byte[] bytes = getBytes(input);
+            byte[] bytes = getBytes(input);
             Assert.Equal(expectedBytes.Length, bytes.Length);
 
             if (!BitConverter.IsLittleEndian)

--- a/src/System.Runtime.Extensions/tests/System/BitConverter.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverter.netcoreapp.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,10 +11,10 @@ namespace System.Tests
         [Fact]
         public static void SingleToInt32Bits()
         {
-            Single input = 12345.63f;
-            Int32 result = BitConverter.SingleToInt32Bits(input);
+            float input = 12345.63f;
+            int result = BitConverter.SingleToInt32Bits(input);
             Assert.Equal(1178658437, result);
-            Single roundtripped = BitConverter.Int32BitsToSingle(result);
+            float roundtripped = BitConverter.Int32BitsToSingle(result);
             Assert.Equal(input, roundtripped);
         }
     }

--- a/src/System.Runtime.Extensions/tests/System/BitConverterArray.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverterArray.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Tests
+{
+    public class BitConverterArray : BitConverterBase
+    {
+        public override void ConvertFromBool(bool boolean, int expected)
+        {
+            Assert.Equal(expected, BitConverter.GetBytes(boolean)[0]);
+        }
+
+        public override void ConvertFromShort(short num, byte[] byteArr)
+        {
+            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+        }
+
+        public override void ConvertFromChar(char character, byte[] byteArr)
+        {
+            Assert.Equal(byteArr, BitConverter.GetBytes(character));
+        }
+
+        public override void ConvertFromInt(int num, byte[] byteArr)
+        {
+            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+        }
+
+        public override void ConvertFromLong(long num, byte[] byteArr)
+        {
+            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+        }
+
+        public override void ConvertFromUShort(ushort num, byte[] byteArr)
+        {
+            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+        }
+
+        public override void ConvertFromUInt(uint num, byte[] byteArr)
+        {
+            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+        }
+
+        public override void ConvertFromULong(ulong num, byte[] byteArr)
+        {
+            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+        }
+
+        public override void ConvertFromFloat(float num, byte[] byteArr)
+        {
+            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+        }
+
+        public override void ConvertFromDouble(double num, byte[] byteArr)
+        {
+            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+        }
+
+        public override void ToChar(int index, char character)
+        {
+            byte[] byteArray = { 32, 0, 0, 42, 0, 65, 0, 125, 0, 197, 0, 168, 3, 41, 4, 172, 32 };
+            Assert.Equal(character, BitConverter.ToChar(byteArray, index));
+        }
+
+        public override void ToInt16(int index, short expected)
+        {
+            byte[] byteArray = { 15, 0, 0, 128, 16, 39, 240, 216, 241, 255, 127 };
+            Assert.Equal(expected, BitConverter.ToInt16(byteArray, index));
+        }
+
+        public override void ToInt32(int expected, byte[] byteArray)
+        {
+            Assert.Equal(expected, BitConverter.ToInt32(byteArray));
+        }
+
+        public override void ToInt64(int index, long expected)
+        {
+            byte[] byteArray =
+                { 0x00, 0x36, 0x65, 0xC4, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0xCA, 0x9A,
+            0x3B, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0x56, 0x55, 0x55, 0x55, 0x55, 0x55, 0xFF, 0xFF, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x00,
+            0x00, 0x64, 0xA7, 0xB3, 0xB6, 0xE0, 0x0D, 0x00, 0x00, 0x9C, 0x58, 0x4C, 0x49, 0x1F, 0xF2 };
+            Assert.Equal(expected, BitConverter.ToInt32(byteArray, index));
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/tests/System/BitConverterArray.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverterArray.cs
@@ -8,64 +8,64 @@ namespace System.Tests
 {
     public class BitConverterArray : BitConverterBase
     {
-        public override void ConvertFromBool(bool boolean, int expected)
+        public override void ConvertFromBool(bool boolean, byte[] expected)
         {
-            Assert.Equal(expected, BitConverter.GetBytes(boolean)[0]);
+            Assert.Equal(expected, BitConverter.GetBytes(boolean));
         }
 
-        public override void ConvertFromShort(short num, byte[] byteArr)
+        public override void ConvertFromShort(short num, byte[] expected)
         {
-            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+            Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
-        public override void ConvertFromChar(char character, byte[] byteArr)
+        public override void ConvertFromChar(char character, byte[] expected)
         {
-            Assert.Equal(byteArr, BitConverter.GetBytes(character));
+            Assert.Equal(expected, BitConverter.GetBytes(character));
         }
 
-        public override void ConvertFromInt(int num, byte[] byteArr)
+        public override void ConvertFromInt(int num, byte[] expected)
         {
-            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+            Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
-        public override void ConvertFromLong(long num, byte[] byteArr)
+        public override void ConvertFromLong(long num, byte[] expected)
         {
-            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+            Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
-        public override void ConvertFromUShort(ushort num, byte[] byteArr)
+        public override void ConvertFromUShort(ushort num, byte[] expected)
         {
-            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+            Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
-        public override void ConvertFromUInt(uint num, byte[] byteArr)
+        public override void ConvertFromUInt(uint num, byte[] expected)
         {
-            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+            Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
-        public override void ConvertFromULong(ulong num, byte[] byteArr)
+        public override void ConvertFromULong(ulong num, byte[] expected)
         {
-            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+            Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
-        public override void ConvertFromFloat(float num, byte[] byteArr)
+        public override void ConvertFromFloat(float num, byte[] expected)
         {
-            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+            Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
-        public override void ConvertFromDouble(double num, byte[] byteArr)
+        public override void ConvertFromDouble(double num, byte[] expected)
         {
-            Assert.Equal(byteArr, BitConverter.GetBytes(num));
+            Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
-        public override void ToChar(int index, char expected)
+        public override void ToChar(int index, char expected, byte[] byteArray)
         {
-            Assert.Equal(expected, BitConverter.ToChar(s_toCharByteArray, index));
+            Assert.Equal(expected, BitConverter.ToChar(byteArray, index));
         }
 
-        public override void ToInt16(int index, short expected)
+        public override void ToInt16(int index, short expected, byte[] byteArray)
         {
-            Assert.Equal(expected, BitConverter.ToInt16(s_toInt16ByteArray, index));
+            Assert.Equal(expected, BitConverter.ToInt16(byteArray, index));
         }
 
         public override void ToInt32(int expected, byte[] byteArray)
@@ -73,39 +73,39 @@ namespace System.Tests
             Assert.Equal(expected, BitConverter.ToInt32(byteArray, 0));
         }
 
-        public override void ToInt64(int index, long expected)
+        public override void ToInt64(int index, long expected, byte[] byteArray)
         {
-            Assert.Equal(expected, BitConverter.ToInt64(s_toInt64ByteArray, index));
+            Assert.Equal(expected, BitConverter.ToInt64(byteArray, index));
         }
 
-        public override void ToUInt16(int index, ushort expected)
+        public override void ToUInt16(int index, ushort expected, byte[] byteArray)
         {
-            Assert.Equal(expected, BitConverter.ToUInt16(s_toUInt16ByteArray, index));
+            Assert.Equal(expected, BitConverter.ToUInt16(byteArray, index));
         }
 
-        public override void ToUInt32(int index, uint expected)
+        public override void ToUInt32(int index, uint expected, byte[] byteArray)
         {
-            Assert.Equal(expected, BitConverter.ToUInt32(s_toUInt32ByteArray, index));
+            Assert.Equal(expected, BitConverter.ToUInt32(byteArray, index));
         }
 
-        public override void ToUInt64(int index, ulong expected)
+        public override void ToUInt64(int index, ulong expected, byte[] byteArray)
         {
-            Assert.Equal(expected, BitConverter.ToUInt64(s_toUInt64ByteArray, index));
+            Assert.Equal(expected, BitConverter.ToUInt64(byteArray, index));
         }
 
-        public override void ToSingle(int index, float expected)
+        public override void ToSingle(int index, float expected, byte[] byteArray)
         {
-            Assert.Equal(expected, BitConverter.ToSingle(s_toSingleByteArray, index));
+            Assert.Equal(expected, BitConverter.ToSingle(byteArray, index));
         }
 
-        public override void ToDouble(int index, double expected)
+        public override void ToDouble(int index, double expected, byte[] byteArray)
         {
-            Assert.Equal(expected, BitConverter.ToDouble(s_toDoubleByteArray, index));
+            Assert.Equal(expected, BitConverter.ToDouble(byteArray, index));
         }
 
-        public override void ToBoolean(int index, bool expected)
+        public override void ToBoolean(int index, bool expected, byte[] byteArray)
         {
-            Assert.Equal(expected, BitConverter.ToBoolean(s_toBooleanByteArray, index));
+            Assert.Equal(expected, BitConverter.ToBoolean(byteArray, index));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/BitConverterArray.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverterArray.cs
@@ -58,31 +58,54 @@ namespace System.Tests
             Assert.Equal(byteArr, BitConverter.GetBytes(num));
         }
 
-        public override void ToChar(int index, char character)
+        public override void ToChar(int index, char expected)
         {
-            byte[] byteArray = { 32, 0, 0, 42, 0, 65, 0, 125, 0, 197, 0, 168, 3, 41, 4, 172, 32 };
-            Assert.Equal(character, BitConverter.ToChar(byteArray, index));
+            Assert.Equal(expected, BitConverter.ToChar(s_toCharByteArray, index));
         }
 
         public override void ToInt16(int index, short expected)
         {
-            byte[] byteArray = { 15, 0, 0, 128, 16, 39, 240, 216, 241, 255, 127 };
-            Assert.Equal(expected, BitConverter.ToInt16(byteArray, index));
+            Assert.Equal(expected, BitConverter.ToInt16(s_toInt16ByteArray, index));
         }
 
         public override void ToInt32(int expected, byte[] byteArray)
         {
-            Assert.Equal(expected, BitConverter.ToInt32(byteArray));
+            Assert.Equal(expected, BitConverter.ToInt32(byteArray, 0));
         }
 
         public override void ToInt64(int index, long expected)
         {
-            byte[] byteArray =
-                { 0x00, 0x36, 0x65, 0xC4, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0xCA, 0x9A,
-            0x3B, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0x56, 0x55, 0x55, 0x55, 0x55, 0x55, 0xFF, 0xFF, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x00,
-            0x00, 0x64, 0xA7, 0xB3, 0xB6, 0xE0, 0x0D, 0x00, 0x00, 0x9C, 0x58, 0x4C, 0x49, 0x1F, 0xF2 };
-            Assert.Equal(expected, BitConverter.ToInt32(byteArray, index));
+            Assert.Equal(expected, BitConverter.ToInt64(s_toInt64ByteArray, index));
+        }
+
+        public override void ToUInt16(int index, ushort expected)
+        {
+            Assert.Equal(expected, BitConverter.ToUInt16(s_toUInt16ByteArray, index));
+        }
+
+        public override void ToUInt32(int index, uint expected)
+        {
+            Assert.Equal(expected, BitConverter.ToUInt32(s_toUInt32ByteArray, index));
+        }
+
+        public override void ToUInt64(int index, ulong expected)
+        {
+            Assert.Equal(expected, BitConverter.ToUInt64(s_toUInt64ByteArray, index));
+        }
+
+        public override void ToSingle(int index, float expected)
+        {
+            Assert.Equal(expected, BitConverter.ToSingle(s_toSingleByteArray, index));
+        }
+
+        public override void ToDouble(int index, double expected)
+        {
+            Assert.Equal(expected, BitConverter.ToDouble(s_toDoubleByteArray, index));
+        }
+
+        public override void ToBoolean(int index, bool expected)
+        {
+            Assert.Equal(expected, BitConverter.ToBoolean(s_toBooleanByteArray, index));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/BitConverterBase.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverterBase.cs
@@ -33,7 +33,7 @@ namespace System.Tests
         [InlineData('{', new byte[] { 0x7B, 0x00 })]
         [InlineData('\0', new byte[] { 0x00, 0x00 })]
         [InlineData(' ', new byte[] { 0x20, 0x00 })]
-        [InlineData('\u263a', new byte[] { 0x3A, 0x26 })]
+        [InlineData('\u263a', new byte[] { 0x3A, 0x26 })] // Smiley Face (☺)
         public abstract void ConvertFromChar(char character, byte[] byteArr);
 
         [Theory]
@@ -135,6 +135,8 @@ namespace System.Tests
         [InlineData(double.PositiveInfinity, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F })]
         public abstract void ConvertFromDouble(double num, byte[] byteArr);
 
+        public static byte[] s_toCharByteArray = { 32, 0, 0, 42, 0, 65, 0, 125, 0, 197, 0, 168, 3, 41, 4, 172, 32, 0x3A, 0x26 };
+
         [Theory]
         [InlineData(0, ' ')]
         [InlineData(1, '\0')]
@@ -145,7 +147,10 @@ namespace System.Tests
         [InlineData(11, '\u03A8')] // Greek capital letter Psi (Ψ)
         [InlineData(13, '\u0429')] // Cyrillic capital letter Shcha (Щ)
         [InlineData(15, '\u20AC')] // Euro sign (€)
-        public abstract void ToChar(int index, char character);
+        [InlineData(17, '\u263A')] // Smiley Face (☺)
+        public abstract void ToChar(int index, char expected);
+
+        public static byte[] s_toInt16ByteArray = { 15, 0, 0, 128, 16, 39, 240, 216, 241, 255, 127 };
 
         [Theory]
         [InlineData(1, (short)0)]
@@ -163,31 +168,136 @@ namespace System.Tests
         [InlineData(0x1000, new byte[] { 0x00, 0x10, 0x00, 0x00 })]
         public abstract void ToInt32(int expected, byte[] byteArray);
 
+        public static byte[] s_toInt64ByteArray = 
+            { 0x00, 0x36, 0x65, 0xC4, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0xCA, 0x9A,
+            0x3B, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0x56, 0x55, 0x55, 0x55, 0x55, 0x55, 0xFF, 0xFF, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x00,
+            0x00, 0x64, 0xA7, 0xB3, 0xB6, 0xE0, 0x0D, 0x00, 0x00, 0x9C, 0x58, 0x4C, 0x49, 0x1F, 0xF2 };
+
         [Theory]
         [InlineData(8, (long)0)]
         [InlineData(5, (long)16777215)]
         [InlineData(34, (long)-16777215)]
         [InlineData(17, (long)1000000000)]
         [InlineData(0, (long)-1000000000)]
-        //[InlineData(21, 4294967296)]
-        //[InlineData(26, -4294967296)]
-        //[InlineData(53, 187649984473770)]
-        //[InlineData(45, -187649984473770)]
-        //[InlineData(59, 1000000000000000000)]
-        //[InlineData(67, -1000000000000000000)]
-        //[InlineData(37, 9223372036854775807)]
-        //[InlineData(9, -9223372036854775808)]
+        [InlineData(21, 4294967296)]
+        [InlineData(26, -4294967296)]
+        [InlineData(53, 187649984473770)]
+        [InlineData(45, -187649984473770)]
+        [InlineData(59, 1000000000000000000)]
+        [InlineData(67, -1000000000000000000)]
+        [InlineData(37, 9223372036854775807)]
+        [InlineData(9, -9223372036854775808)]
         public abstract void ToInt64(int index, long expected);
 
-        /* TODO:
-         * ToUInt16
-         * ToUInt32
-         * ToUInt64
-         * ToSingle
-         * ToDouble
-         * ToBoolean
-         * FIX: ToInt64 (overflow?)
-         * ADD: Chars over unicode +255 to ToChar
-         */
+        public static byte[] s_toUInt16ByteArray = { 15, 0, 0, 255, 3, 16, 39, 255, 255, 127 };
+
+        [Theory]
+        [InlineData(1, (ushort)0)]
+        [InlineData(0, (ushort)15)]
+        [InlineData(3, (ushort)1023)]
+        [InlineData(5, (ushort)10000)]
+        [InlineData(8, (ushort)32767)]
+        [InlineData(7, (ushort)65535)]
+        public abstract void ToUInt16(int index, ushort expected);
+
+        public static byte[] s_toUInt32ByteArray = { 15, 0, 0, 0, 0, 16, 0, 255, 3, 0, 0, 202, 154, 59, 255, 255, 255, 255, 127 };
+
+        [Theory]
+        [InlineData(1, (uint)0)]
+        [InlineData(0, (uint)15)]
+        [InlineData(7, (uint)1023)]
+        [InlineData(3, (uint)1048576)]
+        [InlineData(10, (uint)1000000000)]
+        [InlineData(15, (uint)2147483647)]
+        [InlineData(14, 4294967295)]
+        public abstract void ToUInt32(int index, uint expected);
+
+        public static byte[] s_toUInt64ByteArray =
+            { 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x64, 0xa7, 0xb3, 0xb6, 0xe0,
+            0x0d, 0x00, 0xca, 0x9a, 0x3b, 0x00, 0x00, 0x00, 0x00, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x00, 0x00, 0xe8, 0x89, 0x04,
+            0x23, 0xc7, 0x8a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f };
+
+        [Theory]
+        [InlineData(3, (ulong)0)]
+        [InlineData(0, (ulong)16777215)]
+        [InlineData(21, (ulong)1000000000)]
+        [InlineData(7, (ulong)4294967296)]
+        [InlineData(29, (ulong)187649984473770)]
+        [InlineData(13, (ulong)1000000000000000000)]
+        [InlineData(35, 10000000000000000000)]
+        [InlineData(44, (ulong)9223372036854775807)]
+        [InlineData(43, 18446744073709551615)]
+        public abstract void ToUInt64(int index, ulong expected);
+
+        public static byte[] s_toSingleByteArray =
+            { 0x00, 0x00, 0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x70, 0x41, 0x00, 0xFF, 0x7F, 0x47, 0x00, 0x00, 0x80, 0x3B, 0x00, 0x00,
+            0x80, 0x2F, 0x49, 0x46, 0x83, 0x05, 0x4B, 0x06, 0x9E, 0x3F, 0x4D, 0x06, 0x9E, 0x3F, 0x50, 0x06, 0x9E, 0x3F, 0x1E, 0x37,
+            0xBE, 0x79, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0x7F, 0x7F, 0x01, 0x00, 0x00, 0x00, 0xC0, 0xFF, 0x00, 0x00, 0x80, 0xFF, 0x00,
+            0x00, 0x80, 0x7F };
+
+        [Theory]
+        [InlineData(0, 0.0000000E+000)]
+        [InlineData(2, 1.0000000E+000)]
+        [InlineData(6, 1.5000000E+001)]
+        [InlineData(10, 6.5535000E+004)]
+        [InlineData(14, 3.9062500E-003)]
+        [InlineData(18, 2.3283064E-010)]
+        [InlineData(22, 1.2345000E-035)]
+        [InlineData(26, 1.2345671E+000)]
+        [InlineData(30, 1.2345673E+000)]
+        [InlineData(34, 1.2345676E+000)]
+        [InlineData(38, 1.2345679E+035)]
+        [InlineData(42, -3.4028235E+038)]
+        [InlineData(45, 3.4028235E+038)]
+        [InlineData(49, 1.4012985E-045)]
+        [InlineData(51, float.NaN)]
+        [InlineData(55, float.NegativeInfinity)]
+        [InlineData(59, float.PositiveInfinity)]
+        public abstract void ToSingle(int index, float expected);
+
+        public static byte[] s_toDoubleByteArray =
+            { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F, 0x00, 0x00, 0x00, 0x00, 0x00, 0xE0, 0x6F, 0x40, 0x00, 0x00,
+            0xE0, 0xFF, 0xFF, 0xFF, 0xEF, 0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x70, 0x3F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0xF0, 0x3D, 0xDF, 0x88, 0x1E, 0x1C, 0xFE, 0x74, 0xAA, 0x01, 0xFA, 0x59, 0x8C, 0x42, 0xCA, 0xC0, 0xF3, 0x3F, 0xFB, 0x59,
+            0x8C, 0x42, 0xCA, 0xC0, 0xF3, 0x3F, 0xFC, 0x59, 0x8C, 0x42, 0xCA, 0xC0, 0xF3, 0x3F, 0x52, 0xD3, 0xBB, 0xBC, 0xE8, 0x7E,
+            0x3D, 0x7E, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xEF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xEF, 0x7F, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0xF0, 0x7F };
+
+        [Theory]
+        [InlineData(0, 0.0000000000000000E+000)]
+        [InlineData(2, 1.0000000000000000E+000)]
+        [InlineData(10, 2.5500000000000000E+002)]
+        [InlineData(18, 4.2949672950000000E+009)]
+        [InlineData(26, 3.9062500000000000E-003)]
+        [InlineData(34, 2.3283064365386963E-010)]
+        [InlineData(42, 1.2345678901234500E-300)]
+        [InlineData(50, 1.2345678901234565E+000)]
+        [InlineData(58, 1.2345678901234567E+000)]
+        [InlineData(66, 1.2345678901234569E+000)]
+        [InlineData(74, 1.2345678901234569E+300)]
+        [InlineData(82, -1.7976931348623157E+308)]
+        [InlineData(89, 1.7976931348623157E+308)]
+        [InlineData(97, 4.9406564584124654E-324)]
+        [InlineData(99, double.NaN)]
+        [InlineData(107, double.NegativeInfinity)]
+        [InlineData(115, double.PositiveInfinity)]
+        public abstract void ToDouble(int index, double expected);
+
+        public static byte[] s_toBooleanByteArray = { 0, 1, 2, 4, 8, 16, 32, 64, 128, 255 };
+
+        [Theory]
+        [InlineData(0, false)]
+        [InlineData(1, true)]
+        [InlineData(2, true)]
+        [InlineData(3, true)]
+        [InlineData(4, true)]
+        [InlineData(5, true)]
+        [InlineData(6, true)]
+        [InlineData(7, true)]
+        [InlineData(8, true)]
+        [InlineData(9, true)]
+        public abstract void ToBoolean(int index, bool expected);
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/BitConverterBase.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverterBase.cs
@@ -1,0 +1,193 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Tests
+{
+    public abstract class BitConverterBase
+    {
+
+        [Theory]
+        [InlineData(true, 1)]
+        [InlineData(false, 0)]
+        public abstract void ConvertFromBool(bool boolean, int expected);
+
+        [Theory]
+        [InlineData((short)0, new byte[] { 0x00, 0x00 })]
+        [InlineData((short)-15, new byte[] { 0xF1, 0xFF })]
+        [InlineData((short)15, new byte[] { 0x0F, 0x00 })]
+        [InlineData((short)10000, new byte[] { 0x10, 0x27 })]
+        [InlineData((short)-10000, new byte[] { 0xF0, 0xD8 })]
+        [InlineData(short.MinValue, new byte[] { 0x00, 0x80 })]
+        [InlineData(short.MaxValue, new byte[] { 0xFF, 0x7F })]
+        public abstract void ConvertFromShort(short num, byte[] byteArr);
+
+        [Theory]
+        [InlineData('A', new byte[] { 0x41, 0x00 })]
+        [InlineData('*', new byte[] { 0x2A, 0x00 })]
+        [InlineData('3', new byte[] { 0x33, 0x00 })]
+        [InlineData('[', new byte[] { 0x5B, 0x00 })]
+        [InlineData('a', new byte[] { 0x61, 0x00 })]
+        [InlineData('{', new byte[] { 0x7B, 0x00 })]
+        [InlineData('\0', new byte[] { 0x00, 0x00 })]
+        [InlineData(' ', new byte[] { 0x20, 0x00 })]
+        [InlineData('\u263a', new byte[] { 0x3A, 0x26 })]
+        public abstract void ConvertFromChar(char character, byte[] byteArr);
+
+        [Theory]
+        [InlineData(0, new byte[] { 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData(15, new byte[] { 0x0F, 0x00, 0x00, 0x00 })]
+        [InlineData(-15, new byte[] { 0xF1, 0xFF, 0xFF, 0xFF })]
+        [InlineData(1048576, new byte[] { 0x00, 0x00, 0x10, 0x00 })]
+        [InlineData(-1048576, new byte[] { 0x00, 0x00, 0xF0, 0xFF })]
+        [InlineData(1000000000, new byte[] { 0x00, 0xCA, 0x9A, 0x3B })]
+        [InlineData(-1000000000, new byte[] { 0x00, 0x36, 0x65, 0xC4 })]
+        [InlineData(int.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0x7F })]
+        [InlineData(int.MinValue, new byte[] { 0x00, 0x00, 0x00, 0x80 })]
+        public abstract void ConvertFromInt(int num, byte[] byteArr);
+
+        [Theory]
+        [InlineData(0, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData(16777215, new byte[] { 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData(-16777215, new byte[] { 0x01, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF })]
+        [InlineData(1000000000, new byte[] { 0x00, 0xCA, 0x9A, 0x3B, 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData(-1000000000, new byte[] { 0x00, 0x36, 0x65, 0xC4, 0xFF, 0xFF, 0xFF, 0xFF })]
+        [InlineData(4294967296, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00 })]
+        [InlineData(-4294967296, new byte[] { 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF })]
+        [InlineData(187649984473770, new byte[] { 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x00, 0x00 })]
+        [InlineData(-187649984473770, new byte[] { 0x56, 0x55, 0x55, 0x55, 0x55, 0x55, 0xFF, 0xFF })]
+        [InlineData(1000000000000000000, new byte[] { 0x00, 0x00, 0x64, 0xA7, 0xB3, 0xB6, 0xE0, 0x0D })]
+        [InlineData(-1000000000000000000, new byte[] { 0x00, 0x00, 0x9C, 0x58, 0x4C, 0x49, 0x1F, 0xF2 })]
+        [InlineData(long.MinValue, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 })]
+        [InlineData(long.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F })]
+        public abstract void ConvertFromLong(long num, byte[] byteArr);
+
+        [Theory]
+        [InlineData((ushort)0, new byte[] { 0x00, 0x00 })]
+        [InlineData((ushort)15, new byte[] { 0x0F, 0x00 })]
+        [InlineData((ushort)1023, new byte[] { 0xFF, 0x03 })]
+        [InlineData((ushort)10000, new byte[] { 0x10, 0x27 })]
+        [InlineData((ushort)short.MaxValue, new byte[] { 0xFF, 0x7F })]
+        [InlineData(ushort.MaxValue, new byte[] { 0xFF, 0xFF })]
+        public abstract void ConvertFromUShort(ushort num, byte[] byteArr);
+
+        [Theory]
+        [InlineData((uint)0, new byte[] { 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData((uint)15, new byte[] { 0x0F, 0x00, 0x00, 0x00 })]
+        [InlineData((uint)1023, new byte[] { 0xFF, 0x03, 0x00, 0x00 })]
+        [InlineData((uint)1048576, new byte[] { 0x00, 0x00, 0x10, 0x00 })]
+        [InlineData((uint)1000000000, new byte[] { 0x00, 0xCA, 0x9A, 0x3B })]
+        [InlineData(int.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0x7F })]
+        [InlineData(uint.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF })]
+        public abstract void ConvertFromUInt(uint num, byte[] byteArr);
+
+        [Theory]
+        [InlineData((ulong)0xFFFFFF, new byte[] { 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData((ulong)1000000000, new byte[] { 0x00, 0xCA, 0x9A, 0x3B, 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData((ulong)0x100000000, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00 })]
+        [InlineData((ulong)0xAAAAAAAAAAAA, new byte[] { 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x00, 0x00 })]
+        [InlineData((ulong)1000000000000000000, new byte[] { 0x00, 0x00, 0x64, 0xA7, 0xB3, 0xB6, 0xE0, 0x0D })]
+        [InlineData(10000000000000000000, new byte[] { 0x00, 0x00, 0xE8, 0x89, 0x04, 0x23, 0xC7, 0x8A })]
+        [InlineData((ulong)0, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData(long.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F })]
+        [InlineData(ulong.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF })]
+        public abstract void ConvertFromULong(ulong num, byte[] byteArr);
+
+        [Theory]
+        [InlineData(0.0F, new byte[] { 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData(1.0F, new byte[] { 0x00, 0x00, 0x80, 0x3F })]
+        [InlineData(15.0F, new byte[] { 0x00, 0x00, 0x70, 0x41 })]
+        [InlineData(65535.0F, new byte[] { 0x00, 0xFF, 0x7F, 0x47 })]
+        [InlineData(0.00390625F, new byte[] { 0x00, 0x00, 0x80, 0x3B })]
+        [InlineData(0.00000000023283064365386962890625F, new byte[] { 0x00, 0x00, 0x80, 0x2F })]
+        [InlineData(1.2345E-35F, new byte[] { 0x49, 0x46, 0x83, 0x05 })]
+        [InlineData(1.2345671F, new byte[] { 0x4B, 0x06, 0x9E, 0x3F })]
+        [InlineData(1.2345673F, new byte[] { 0x4D, 0x06, 0x9E, 0x3F })]
+        [InlineData(1.2345677F, new byte[] { 0x50, 0x06, 0x9E, 0x3F })]
+        [InlineData(1.23456789E+35F, new byte[] { 0x1E, 0x37, 0xBE, 0x79 })]
+        [InlineData(float.MinValue, new byte[] { 0xFF, 0xFF, 0x7F, 0xFF })]
+        [InlineData(float.MaxValue, new byte[] { 0xFF, 0xFF, 0x7F, 0x7F })]
+        [InlineData(float.Epsilon, new byte[] { 0x01, 0x00, 0x00, 0x00 })]
+        [InlineData(float.NaN, new byte[] { 0x00, 0x00, 0xC0, 0xFF })]
+        [InlineData(float.NegativeInfinity, new byte[] { 0x00, 0x00, 0x80, 0xFF })]
+        [InlineData(float.PositiveInfinity, new byte[] { 0x00, 0x00, 0x80, 0x7F })]
+        public abstract void ConvertFromFloat(float num, byte[] byteArr);
+
+        [Theory]
+        [InlineData(0.0, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData(1.0, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F })]
+        [InlineData(255.0, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0xE0, 0x6F, 0x40 })]
+        [InlineData(4294967295.0, new byte[] { 0x00, 0x00, 0xE0, 0xFF, 0xFF, 0xFF, 0xEF, 0x41 })]
+        [InlineData(0.00390625, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x70, 0x3F })]
+        [InlineData(0.00000000023283064365386962890625, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3D })]
+        [InlineData(1.23456789012345E-300, new byte[] { 0xDF, 0x88, 0x1E, 0x1C, 0xFE, 0x74, 0xAA, 0x01 })]
+        [InlineData(1.2345678901234565, new byte[] { 0xFA, 0x59, 0x8C, 0x42, 0xCA, 0xC0, 0xF3, 0x3F })]
+        [InlineData(1.2345678901234567, new byte[] { 0xFB, 0x59, 0x8C, 0x42, 0xCA, 0xC0, 0xF3, 0x3F })]
+        [InlineData(1.2345678901234569, new byte[] { 0xFC, 0x59, 0x8C, 0x42, 0xCA, 0xC0, 0xF3, 0x3F })]
+        [InlineData(1.23456789012345678E+300, new byte[] { 0x52, 0xD3, 0xBB, 0xBC, 0xE8, 0x7E, 0x3D, 0x7E })]
+        [InlineData(double.MinValue, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xEF, 0xFF })]
+        [InlineData(double.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xEF, 0x7F })]
+        [InlineData(double.Epsilon, new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData(double.NaN, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0xFF })]
+        [InlineData(double.NegativeInfinity, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xFF })]
+        [InlineData(double.PositiveInfinity, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F })]
+        public abstract void ConvertFromDouble(double num, byte[] byteArr);
+
+        [Theory]
+        [InlineData(0, ' ')]
+        [InlineData(1, '\0')]
+        [InlineData(3, '*')]
+        [InlineData(5, 'A')]
+        [InlineData(7, '}')]
+        [InlineData(9, '\u00C5')] // Latin capital letter A with ring above (Å)
+        [InlineData(11, '\u03A8')] // Greek capital letter Psi (Ψ)
+        [InlineData(13, '\u0429')] // Cyrillic capital letter Shcha (Щ)
+        [InlineData(15, '\u20AC')] // Euro sign (€)
+        public abstract void ToChar(int index, char character);
+
+        [Theory]
+        [InlineData(1, (short)0)]
+        [InlineData(0, (short)15)]
+        [InlineData(8, (short)-15)]
+        [InlineData(4, (short)10000)]
+        [InlineData(6, (short)-10000)]
+        [InlineData(9, (short)32767)]
+        [InlineData(2, (short)-32768)]
+        public abstract void ToInt16(int index, short expected);
+
+        [Theory]
+        [InlineData(0x00EC, new byte[] { 0xEC, 0x00, 0x00, 0x00 })]
+        [InlineData(0x3FFFFFFF, new byte[] { 0xFF, 0xFF, 0xFF, 0x3F })]
+        [InlineData(0x1000, new byte[] { 0x00, 0x10, 0x00, 0x00 })]
+        public abstract void ToInt32(int expected, byte[] byteArray);
+
+        [Theory]
+        [InlineData(8, (long)0)]
+        [InlineData(5, (long)16777215)]
+        [InlineData(34, (long)-16777215)]
+        [InlineData(17, (long)1000000000)]
+        [InlineData(0, (long)-1000000000)]
+        //[InlineData(21, 4294967296)]
+        //[InlineData(26, -4294967296)]
+        //[InlineData(53, 187649984473770)]
+        //[InlineData(45, -187649984473770)]
+        //[InlineData(59, 1000000000000000000)]
+        //[InlineData(67, -1000000000000000000)]
+        //[InlineData(37, 9223372036854775807)]
+        //[InlineData(9, -9223372036854775808)]
+        public abstract void ToInt64(int index, long expected);
+
+        /* TODO:
+         * ToUInt16
+         * ToUInt32
+         * ToUInt64
+         * ToSingle
+         * ToDouble
+         * ToBoolean
+         * FIX: ToInt64 (overflow?)
+         * ADD: Chars over unicode +255 to ToChar
+         */
+    }
+}

--- a/src/System.Runtime.Extensions/tests/System/BitConverterBase.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverterBase.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using System.Collections.Generic;
 
 namespace System.Tests
 {
@@ -10,9 +11,9 @@ namespace System.Tests
     {
 
         [Theory]
-        [InlineData(true, 1)]
-        [InlineData(false, 0)]
-        public abstract void ConvertFromBool(bool boolean, int expected);
+        [InlineData(true, new byte[] { 0x01 })]
+        [InlineData(false, new byte[] { 0x00 })]
+        public abstract void ConvertFromBool(bool boolean, byte[] expected);
 
         [Theory]
         [InlineData((short)0, new byte[] { 0x00, 0x00 })]
@@ -22,7 +23,7 @@ namespace System.Tests
         [InlineData((short)-10000, new byte[] { 0xF0, 0xD8 })]
         [InlineData(short.MinValue, new byte[] { 0x00, 0x80 })]
         [InlineData(short.MaxValue, new byte[] { 0xFF, 0x7F })]
-        public abstract void ConvertFromShort(short num, byte[] byteArr);
+        public abstract void ConvertFromShort(short num, byte[] expected);
 
         [Theory]
         [InlineData('A', new byte[] { 0x41, 0x00 })]
@@ -34,7 +35,7 @@ namespace System.Tests
         [InlineData('\0', new byte[] { 0x00, 0x00 })]
         [InlineData(' ', new byte[] { 0x20, 0x00 })]
         [InlineData('\u263a', new byte[] { 0x3A, 0x26 })] // Smiley Face (☺)
-        public abstract void ConvertFromChar(char character, byte[] byteArr);
+        public abstract void ConvertFromChar(char character, byte[] expected);
 
         [Theory]
         [InlineData(0, new byte[] { 0x00, 0x00, 0x00, 0x00 })]
@@ -46,7 +47,7 @@ namespace System.Tests
         [InlineData(-1000000000, new byte[] { 0x00, 0x36, 0x65, 0xC4 })]
         [InlineData(int.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0x7F })]
         [InlineData(int.MinValue, new byte[] { 0x00, 0x00, 0x00, 0x80 })]
-        public abstract void ConvertFromInt(int num, byte[] byteArr);
+        public abstract void ConvertFromInt(int num, byte[] expected);
 
         [Theory]
         [InlineData(0, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]
@@ -62,7 +63,7 @@ namespace System.Tests
         [InlineData(-1000000000000000000, new byte[] { 0x00, 0x00, 0x9C, 0x58, 0x4C, 0x49, 0x1F, 0xF2 })]
         [InlineData(long.MinValue, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 })]
         [InlineData(long.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F })]
-        public abstract void ConvertFromLong(long num, byte[] byteArr);
+        public abstract void ConvertFromLong(long num, byte[] expected);
 
         [Theory]
         [InlineData((ushort)0, new byte[] { 0x00, 0x00 })]
@@ -71,7 +72,7 @@ namespace System.Tests
         [InlineData((ushort)10000, new byte[] { 0x10, 0x27 })]
         [InlineData((ushort)short.MaxValue, new byte[] { 0xFF, 0x7F })]
         [InlineData(ushort.MaxValue, new byte[] { 0xFF, 0xFF })]
-        public abstract void ConvertFromUShort(ushort num, byte[] byteArr);
+        public abstract void ConvertFromUShort(ushort num, byte[] expected);
 
         [Theory]
         [InlineData((uint)0, new byte[] { 0x00, 0x00, 0x00, 0x00 })]
@@ -81,7 +82,7 @@ namespace System.Tests
         [InlineData((uint)1000000000, new byte[] { 0x00, 0xCA, 0x9A, 0x3B })]
         [InlineData(int.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0x7F })]
         [InlineData(uint.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF })]
-        public abstract void ConvertFromUInt(uint num, byte[] byteArr);
+        public abstract void ConvertFromUInt(uint num, byte[] expected);
 
         [Theory]
         [InlineData((ulong)0xFFFFFF, new byte[] { 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00 })]
@@ -93,7 +94,7 @@ namespace System.Tests
         [InlineData((ulong)0, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]
         [InlineData(long.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F })]
         [InlineData(ulong.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF })]
-        public abstract void ConvertFromULong(ulong num, byte[] byteArr);
+        public abstract void ConvertFromULong(ulong num, byte[] expected);
 
         [Theory]
         [InlineData(0.0F, new byte[] { 0x00, 0x00, 0x00, 0x00 })]
@@ -113,7 +114,7 @@ namespace System.Tests
         [InlineData(float.NaN, new byte[] { 0x00, 0x00, 0xC0, 0xFF })]
         [InlineData(float.NegativeInfinity, new byte[] { 0x00, 0x00, 0x80, 0xFF })]
         [InlineData(float.PositiveInfinity, new byte[] { 0x00, 0x00, 0x80, 0x7F })]
-        public abstract void ConvertFromFloat(float num, byte[] byteArr);
+        public abstract void ConvertFromFloat(float num, byte[] expected);
 
         [Theory]
         [InlineData(0.0, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]
@@ -133,34 +134,44 @@ namespace System.Tests
         [InlineData(double.NaN, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0xFF })]
         [InlineData(double.NegativeInfinity, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xFF })]
         [InlineData(double.PositiveInfinity, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F })]
-        public abstract void ConvertFromDouble(double num, byte[] byteArr);
+        public abstract void ConvertFromDouble(double num, byte[] expected);
 
-        public static byte[] s_toCharByteArray = { 32, 0, 0, 42, 0, 65, 0, 125, 0, 197, 0, 168, 3, 41, 4, 172, 32, 0x3A, 0x26 };
+        private static byte[] s_toCharByteArray = { 32, 0, 0, 42, 0, 65, 0, 125, 0, 197, 0, 168, 3, 41, 4, 172, 32, 0x3A, 0x26 };
+
+        private static IEnumerable<object[]> ToCharTestData()
+        {
+            yield return new object[] { 0, ' ', s_toCharByteArray};
+            yield return new object[] { 1, '\0', s_toCharByteArray };
+            yield return new object[] { 3, '*', s_toCharByteArray };
+            yield return new object[] { 5, 'A', s_toCharByteArray };
+            yield return new object[] { 7, '}', s_toCharByteArray };
+            yield return new object[] { 9, '\u00C5', s_toCharByteArray }; // Latin capital letter A with ring above (Å)
+            yield return new object[] { 11, '\u03A8', s_toCharByteArray }; // Greek capital letter Psi (Ψ)
+            yield return new object[] { 13, '\u0429', s_toCharByteArray }; // Cyrillic capital letter Shcha (Щ)
+            yield return new object[] { 15, '\u20AC', s_toCharByteArray }; // Euro sign (€)
+            yield return new object[] { 17, '\u263A', s_toCharByteArray }; // Smiley Face (☺)
+        }
 
         [Theory]
-        [InlineData(0, ' ')]
-        [InlineData(1, '\0')]
-        [InlineData(3, '*')]
-        [InlineData(5, 'A')]
-        [InlineData(7, '}')]
-        [InlineData(9, '\u00C5')] // Latin capital letter A with ring above (Å)
-        [InlineData(11, '\u03A8')] // Greek capital letter Psi (Ψ)
-        [InlineData(13, '\u0429')] // Cyrillic capital letter Shcha (Щ)
-        [InlineData(15, '\u20AC')] // Euro sign (€)
-        [InlineData(17, '\u263A')] // Smiley Face (☺)
-        public abstract void ToChar(int index, char expected);
+        [MemberData(nameof(ToCharTestData))]
+        public abstract void ToChar(int index, char expected, byte[] byteArray);
 
-        public static byte[] s_toInt16ByteArray = { 15, 0, 0, 128, 16, 39, 240, 216, 241, 255, 127 };
+        private static byte[] s_toInt16ByteArray = { 15, 0, 0, 128, 16, 39, 240, 216, 241, 255, 127 };
+
+        private static IEnumerable<object[]> ToInt16TestData()
+        {
+            yield return new object[] { 1, (short)0, s_toInt16ByteArray };
+            yield return new object[] { 0, (short)15, s_toInt16ByteArray };
+            yield return new object[] { 8, (short)-15, s_toInt16ByteArray };
+            yield return new object[] { 4, (short)10000, s_toInt16ByteArray };
+            yield return new object[] { 6, (short)-10000, s_toInt16ByteArray };
+            yield return new object[] { 9, (short)32767, s_toInt16ByteArray };
+            yield return new object[] { 2, (short)-32768, s_toInt16ByteArray };
+        }
 
         [Theory]
-        [InlineData(1, (short)0)]
-        [InlineData(0, (short)15)]
-        [InlineData(8, (short)-15)]
-        [InlineData(4, (short)10000)]
-        [InlineData(6, (short)-10000)]
-        [InlineData(9, (short)32767)]
-        [InlineData(2, (short)-32768)]
-        public abstract void ToInt16(int index, short expected);
+        [MemberData(nameof(ToInt16TestData))]
+        public abstract void ToInt16(int index, short expected, byte[] byteArray);
 
         [Theory]
         [InlineData(0x00EC, new byte[] { 0xEC, 0x00, 0x00, 0x00 })]
@@ -168,95 +179,120 @@ namespace System.Tests
         [InlineData(0x1000, new byte[] { 0x00, 0x10, 0x00, 0x00 })]
         public abstract void ToInt32(int expected, byte[] byteArray);
 
-        public static byte[] s_toInt64ByteArray = 
+        private static byte[] s_toInt64ByteArray = 
             { 0x00, 0x36, 0x65, 0xC4, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0xCA, 0x9A,
             0x3B, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0xFF,
             0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0x56, 0x55, 0x55, 0x55, 0x55, 0x55, 0xFF, 0xFF, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x00,
             0x00, 0x64, 0xA7, 0xB3, 0xB6, 0xE0, 0x0D, 0x00, 0x00, 0x9C, 0x58, 0x4C, 0x49, 0x1F, 0xF2 };
 
-        [Theory]
-        [InlineData(8, (long)0)]
-        [InlineData(5, (long)16777215)]
-        [InlineData(34, (long)-16777215)]
-        [InlineData(17, (long)1000000000)]
-        [InlineData(0, (long)-1000000000)]
-        [InlineData(21, 4294967296)]
-        [InlineData(26, -4294967296)]
-        [InlineData(53, 187649984473770)]
-        [InlineData(45, -187649984473770)]
-        [InlineData(59, 1000000000000000000)]
-        [InlineData(67, -1000000000000000000)]
-        [InlineData(37, 9223372036854775807)]
-        [InlineData(9, -9223372036854775808)]
-        public abstract void ToInt64(int index, long expected);
-
-        public static byte[] s_toUInt16ByteArray = { 15, 0, 0, 255, 3, 16, 39, 255, 255, 127 };
-
-        [Theory]
-        [InlineData(1, (ushort)0)]
-        [InlineData(0, (ushort)15)]
-        [InlineData(3, (ushort)1023)]
-        [InlineData(5, (ushort)10000)]
-        [InlineData(8, (ushort)32767)]
-        [InlineData(7, (ushort)65535)]
-        public abstract void ToUInt16(int index, ushort expected);
-
-        public static byte[] s_toUInt32ByteArray = { 15, 0, 0, 0, 0, 16, 0, 255, 3, 0, 0, 202, 154, 59, 255, 255, 255, 255, 127 };
+        private static IEnumerable<object[]> ToInt64TestData()
+        {
+            yield return new object[] { 8, (long)0, s_toInt64ByteArray };
+            yield return new object[] { 5, (long)16777215, s_toInt64ByteArray };
+            yield return new object[] { 34, (long)-16777215, s_toInt64ByteArray };
+            yield return new object[] { 17, (long)1000000000, s_toInt64ByteArray };
+            yield return new object[] { 0, (long)-1000000000, s_toInt64ByteArray };
+            yield return new object[] { 21, 4294967296, s_toInt64ByteArray };
+            yield return new object[] { 26, -4294967296, s_toInt64ByteArray };
+            yield return new object[] { 53, 187649984473770, s_toInt64ByteArray };
+            yield return new object[] { 45, -187649984473770, s_toInt64ByteArray };
+            yield return new object[] { 59, 1000000000000000000, s_toInt64ByteArray };
+            yield return new object[] { 67, -1000000000000000000, s_toInt64ByteArray };
+            yield return new object[] { 37, 9223372036854775807, s_toInt64ByteArray };
+            yield return new object[] { 9, -9223372036854775808, s_toInt64ByteArray };
+        }
 
         [Theory]
-        [InlineData(1, (uint)0)]
-        [InlineData(0, (uint)15)]
-        [InlineData(7, (uint)1023)]
-        [InlineData(3, (uint)1048576)]
-        [InlineData(10, (uint)1000000000)]
-        [InlineData(15, (uint)2147483647)]
-        [InlineData(14, 4294967295)]
-        public abstract void ToUInt32(int index, uint expected);
+        [MemberData(nameof(ToInt64TestData))]
+        public abstract void ToInt64(int index, long expected, byte[] byteArray);
 
-        public static byte[] s_toUInt64ByteArray =
+        private static byte[] s_toUInt16ByteArray = { 15, 0, 0, 255, 3, 16, 39, 255, 255, 127 };
+
+        private static IEnumerable<object[]> ToUInt16TestData()
+        {
+            yield return new object[] { 1, (ushort)0, s_toUInt16ByteArray };
+            yield return new object[] { 0, (ushort)15, s_toUInt16ByteArray };
+            yield return new object[] { 3, (ushort)1023, s_toUInt16ByteArray };
+            yield return new object[] { 5, (ushort)10000, s_toUInt16ByteArray };
+            yield return new object[] { 8, (ushort)32767, s_toUInt16ByteArray };
+            yield return new object[] { 7, (ushort)65535, s_toUInt16ByteArray };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToUInt16TestData))]
+        public abstract void ToUInt16(int index, ushort expected, byte[] byteArray);
+
+        private static byte[] s_toUInt32ByteArray = { 15, 0, 0, 0, 0, 16, 0, 255, 3, 0, 0, 202, 154, 59, 255, 255, 255, 255, 127 };
+
+        private static IEnumerable<object[]> ToUInt32TestData()
+        {
+            yield return new object[] { 1, (uint)0, s_toUInt32ByteArray };
+            yield return new object[] { 0, (uint)15, s_toUInt32ByteArray };
+            yield return new object[] { 7, (uint)1023, s_toUInt32ByteArray };
+            yield return new object[] { 3, (uint)1048576, s_toUInt32ByteArray };
+            yield return new object[] { 10, (uint)1000000000, s_toUInt32ByteArray };
+            yield return new object[] { 15, (uint)2147483647, s_toUInt32ByteArray };
+            yield return new object[] { 14, 4294967295, s_toUInt32ByteArray };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToUInt32TestData))]
+        public abstract void ToUInt32(int index, uint expected, byte[] byteArray);
+
+        private static byte[] s_toUInt64ByteArray =
             { 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x64, 0xa7, 0xb3, 0xb6, 0xe0,
             0x0d, 0x00, 0xca, 0x9a, 0x3b, 0x00, 0x00, 0x00, 0x00, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x00, 0x00, 0xe8, 0x89, 0x04,
             0x23, 0xc7, 0x8a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f };
 
-        [Theory]
-        [InlineData(3, (ulong)0)]
-        [InlineData(0, (ulong)16777215)]
-        [InlineData(21, (ulong)1000000000)]
-        [InlineData(7, (ulong)4294967296)]
-        [InlineData(29, (ulong)187649984473770)]
-        [InlineData(13, (ulong)1000000000000000000)]
-        [InlineData(35, 10000000000000000000)]
-        [InlineData(44, (ulong)9223372036854775807)]
-        [InlineData(43, 18446744073709551615)]
-        public abstract void ToUInt64(int index, ulong expected);
+        private static IEnumerable<object[]> ToUInt64TestData()
+        {
+            yield return new object[] { 3, (ulong)0, s_toUInt64ByteArray };
+            yield return new object[] { 0, (ulong)16777215, s_toUInt64ByteArray };
+            yield return new object[] { 21, (ulong)1000000000, s_toUInt64ByteArray };
+            yield return new object[] { 7, (ulong)4294967296, s_toUInt64ByteArray };
+            yield return new object[] { 29, (ulong)187649984473770, s_toUInt64ByteArray };
+            yield return new object[] { 13, (ulong)1000000000000000000, s_toUInt64ByteArray };
+            yield return new object[] { 35, 10000000000000000000, s_toUInt64ByteArray };
+            yield return new object[] { 44, (ulong)9223372036854775807, s_toUInt64ByteArray };
+            yield return new object[] { 43, 18446744073709551615, s_toUInt64ByteArray };
+        }
 
-        public static byte[] s_toSingleByteArray =
+        [Theory]
+        [MemberData(nameof(ToUInt64TestData))]
+        public abstract void ToUInt64(int index, ulong expected, byte[] byteArray);
+
+        private static byte[] s_toSingleByteArray =
             { 0x00, 0x00, 0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x70, 0x41, 0x00, 0xFF, 0x7F, 0x47, 0x00, 0x00, 0x80, 0x3B, 0x00, 0x00,
             0x80, 0x2F, 0x49, 0x46, 0x83, 0x05, 0x4B, 0x06, 0x9E, 0x3F, 0x4D, 0x06, 0x9E, 0x3F, 0x50, 0x06, 0x9E, 0x3F, 0x1E, 0x37,
             0xBE, 0x79, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0x7F, 0x7F, 0x01, 0x00, 0x00, 0x00, 0xC0, 0xFF, 0x00, 0x00, 0x80, 0xFF, 0x00,
             0x00, 0x80, 0x7F };
 
-        [Theory]
-        [InlineData(0, 0.0000000E+000)]
-        [InlineData(2, 1.0000000E+000)]
-        [InlineData(6, 1.5000000E+001)]
-        [InlineData(10, 6.5535000E+004)]
-        [InlineData(14, 3.9062500E-003)]
-        [InlineData(18, 2.3283064E-010)]
-        [InlineData(22, 1.2345000E-035)]
-        [InlineData(26, 1.2345671E+000)]
-        [InlineData(30, 1.2345673E+000)]
-        [InlineData(34, 1.2345676E+000)]
-        [InlineData(38, 1.2345679E+035)]
-        [InlineData(42, -3.4028235E+038)]
-        [InlineData(45, 3.4028235E+038)]
-        [InlineData(49, 1.4012985E-045)]
-        [InlineData(51, float.NaN)]
-        [InlineData(55, float.NegativeInfinity)]
-        [InlineData(59, float.PositiveInfinity)]
-        public abstract void ToSingle(int index, float expected);
+        private static IEnumerable<object[]> ToSingleTestData()
+        {
+            yield return new object[] { 0, 0.0000000E+000, s_toSingleByteArray };
+            yield return new object[] { 2, 1.0000000E+000, s_toSingleByteArray };
+            yield return new object[] { 6, 1.5000000E+001, s_toSingleByteArray };
+            yield return new object[] { 10, 6.5535000E+004, s_toSingleByteArray };
+            yield return new object[] { 14, 3.9062500E-003, s_toSingleByteArray };
+            yield return new object[] { 18, 2.3283064E-010, s_toSingleByteArray };
+            yield return new object[] { 22, 1.2345000E-035, s_toSingleByteArray };
+            yield return new object[] { 26, 1.2345671E+000, s_toSingleByteArray };
+            yield return new object[] { 30, 1.2345673E+000, s_toSingleByteArray };
+            yield return new object[] { 34, 1.2345676E+000, s_toSingleByteArray };
+            yield return new object[] { 38, 1.2345679E+035, s_toSingleByteArray };
+            yield return new object[] { 42, -3.4028235E+038, s_toSingleByteArray };
+            yield return new object[] { 45, 3.4028235E+038, s_toSingleByteArray };
+            yield return new object[] { 49, 1.4012985E-045, s_toSingleByteArray };
+            yield return new object[] { 51, float.NaN, s_toSingleByteArray };
+            yield return new object[] { 55, float.NegativeInfinity, s_toSingleByteArray };
+            yield return new object[] { 59, float.PositiveInfinity, s_toSingleByteArray };
+        }
 
-        public static byte[] s_toDoubleByteArray =
+        [Theory]
+        [MemberData(nameof(ToSingleTestData))]
+        public abstract void ToSingle(int index, float expected, byte[] byteArray);
+
+        private static byte[] s_toDoubleByteArray =
             { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F, 0x00, 0x00, 0x00, 0x00, 0x00, 0xE0, 0x6F, 0x40, 0x00, 0x00,
             0xE0, 0xFF, 0xFF, 0xFF, 0xEF, 0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x70, 0x3F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xF0, 0x3D, 0xDF, 0x88, 0x1E, 0x1C, 0xFE, 0x74, 0xAA, 0x01, 0xFA, 0x59, 0x8C, 0x42, 0xCA, 0xC0, 0xF3, 0x3F, 0xFB, 0x59,
@@ -265,39 +301,49 @@ namespace System.Tests
             0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0xF0, 0x7F };
 
-        [Theory]
-        [InlineData(0, 0.0000000000000000E+000)]
-        [InlineData(2, 1.0000000000000000E+000)]
-        [InlineData(10, 2.5500000000000000E+002)]
-        [InlineData(18, 4.2949672950000000E+009)]
-        [InlineData(26, 3.9062500000000000E-003)]
-        [InlineData(34, 2.3283064365386963E-010)]
-        [InlineData(42, 1.2345678901234500E-300)]
-        [InlineData(50, 1.2345678901234565E+000)]
-        [InlineData(58, 1.2345678901234567E+000)]
-        [InlineData(66, 1.2345678901234569E+000)]
-        [InlineData(74, 1.2345678901234569E+300)]
-        [InlineData(82, -1.7976931348623157E+308)]
-        [InlineData(89, 1.7976931348623157E+308)]
-        [InlineData(97, 4.9406564584124654E-324)]
-        [InlineData(99, double.NaN)]
-        [InlineData(107, double.NegativeInfinity)]
-        [InlineData(115, double.PositiveInfinity)]
-        public abstract void ToDouble(int index, double expected);
+        private static IEnumerable<object[]> ToDoubleTestData()
+        {
+            yield return new object[] { 0, 0.0000000000000000E+000, s_toDoubleByteArray };
+            yield return new object[] { 2, 1.0000000000000000E+000, s_toDoubleByteArray };
+            yield return new object[] { 10, 2.5500000000000000E+002, s_toDoubleByteArray };
+            yield return new object[] { 18, 4.2949672950000000E+009, s_toDoubleByteArray };
+            yield return new object[] { 26, 3.9062500000000000E-003, s_toDoubleByteArray };
+            yield return new object[] { 34, 2.3283064365386963E-010, s_toDoubleByteArray };
+            yield return new object[] { 42, 1.2345678901234500E-300, s_toDoubleByteArray };
+            yield return new object[] { 50, 1.2345678901234565E+000, s_toDoubleByteArray };
+            yield return new object[] { 58, 1.2345678901234567E+000, s_toDoubleByteArray };
+            yield return new object[] { 66, 1.2345678901234569E+000, s_toDoubleByteArray };
+            yield return new object[] { 74, 1.2345678901234569E+300, s_toDoubleByteArray };
+            yield return new object[] { 82, -1.7976931348623157E+308, s_toDoubleByteArray };
+            yield return new object[] { 89, 1.7976931348623157E+308, s_toDoubleByteArray };
+            yield return new object[] { 97, 4.9406564584124654E-324, s_toDoubleByteArray };
+            yield return new object[] { 99, double.NaN, s_toDoubleByteArray };
+            yield return new object[] { 107, double.NegativeInfinity, s_toDoubleByteArray };
+            yield return new object[] { 115, double.PositiveInfinity, s_toDoubleByteArray };
+        }
 
-        public static byte[] s_toBooleanByteArray = { 0, 1, 2, 4, 8, 16, 32, 64, 128, 255 };
+        [Theory]
+        [MemberData(nameof(ToDoubleTestData))]
+        public abstract void ToDouble(int index, double expected, byte[] byteArray);
+
+        private static byte[] s_toBooleanByteArray = { 0, 1, 2, 4, 8, 16, 32, 64, 128, 255 };
+
+        private static IEnumerable<object[]> ToBooleanTestData()
+        {
+            yield return new object[] { 0, false, s_toBooleanByteArray };
+            yield return new object[] { 1, true, s_toBooleanByteArray };
+            yield return new object[] { 2, true, s_toBooleanByteArray };
+            yield return new object[] { 3, true, s_toBooleanByteArray };
+            yield return new object[] { 4, true, s_toBooleanByteArray };
+            yield return new object[] { 5, true, s_toBooleanByteArray };
+            yield return new object[] { 6, true, s_toBooleanByteArray };
+            yield return new object[] { 7, true, s_toBooleanByteArray };
+            yield return new object[] { 8, true, s_toBooleanByteArray };
+            yield return new object[] { 9, true, s_toBooleanByteArray };
+        }
 
         [Theory]
-        [InlineData(0, false)]
-        [InlineData(1, true)]
-        [InlineData(2, true)]
-        [InlineData(3, true)]
-        [InlineData(4, true)]
-        [InlineData(5, true)]
-        [InlineData(6, true)]
-        [InlineData(7, true)]
-        [InlineData(8, true)]
-        [InlineData(9, true)]
-        public abstract void ToBoolean(int index, bool expected);
+        [MemberData(nameof(ToBooleanTestData))]
+        public abstract void ToBoolean(int index, bool expected, byte[] byteArray);
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/BitConverterSpan.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverterSpan.cs
@@ -38,86 +38,86 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToBoolean(Span<byte>.Empty); });
         }
 
-        public override void ConvertFromBool(bool boolean, int expected)
+        public override void ConvertFromBool(bool boolean, byte[] expected)
         {
             Span<byte> span = new Span<byte>(new byte[1]);
             Assert.True(BitConverter.TryWriteBytes(span, boolean));
-            Assert.Equal(expected, span[0]);
+            Assert.Equal(expected, span.ToArray());
         }
 
-        public override void ConvertFromShort(short num, byte[] byteArr)
+        public override void ConvertFromShort(short num, byte[] expected)
         {
             Span<byte> span = new Span<byte>(new byte[2]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
-            Assert.Equal(byteArr, span.ToArray());
+            Assert.Equal(expected, span.ToArray());
         }
 
-        public override void ConvertFromChar(char character, byte[] byteArr)
+        public override void ConvertFromChar(char character, byte[] expected)
         {
             Span<byte> span = new Span<byte>(new byte[2]);
             Assert.True(BitConverter.TryWriteBytes(span, character));
-            Assert.Equal(byteArr, span.ToArray());
+            Assert.Equal(expected, span.ToArray());
         }
 
-        public override void ConvertFromInt(int num, byte[] byteArr)
+        public override void ConvertFromInt(int num, byte[] expected)
         {
             Span<byte> span = new Span<byte>(new byte[4]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
-            Assert.Equal(byteArr, span.ToArray());
+            Assert.Equal(expected, span.ToArray());
         }
 
-        public override void ConvertFromLong(long num, byte[] byteArr)
+        public override void ConvertFromLong(long num, byte[] expected)
         {
             Span<byte> span = new Span<byte>(new byte[8]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
-            Assert.Equal(byteArr, span.ToArray());
+            Assert.Equal(expected, span.ToArray());
         }
 
-        public override void ConvertFromUShort(ushort num, byte[] byteArr)
+        public override void ConvertFromUShort(ushort num, byte[] expected)
         {
             Span<byte> span = new Span<byte>(new byte[2]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
-            Assert.Equal(byteArr, span.ToArray());
+            Assert.Equal(expected, span.ToArray());
         }
 
-        public override void ConvertFromUInt(uint num, byte[] byteArr)
+        public override void ConvertFromUInt(uint num, byte[] expected)
         {
             Span<byte> span = new Span<byte>(new byte[4]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
-            Assert.Equal(byteArr, span.ToArray());
+            Assert.Equal(expected, span.ToArray());
         }
 
-        public override void ConvertFromULong(ulong num, byte[] byteArr)
+        public override void ConvertFromULong(ulong num, byte[] expected)
         {
             Span<byte> span = new Span<byte>(new byte[8]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
-            Assert.Equal(byteArr, span.ToArray());
+            Assert.Equal(expected, span.ToArray());
         }
 
-        public override void ConvertFromFloat(float num, byte[] byteArr)
+        public override void ConvertFromFloat(float num, byte[] expected)
         {
             Span<byte> span = new Span<byte>(new byte[4]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
-            Assert.Equal(byteArr, span.ToArray());
+            Assert.Equal(expected, span.ToArray());
         }
 
-        public override void ConvertFromDouble(double num, byte[] byteArr)
+        public override void ConvertFromDouble(double num, byte[] expected)
         {
             Span<byte> span = new Span<byte>(new byte[8]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
-            Assert.Equal(byteArr, span.ToArray());
+            Assert.Equal(expected, span.ToArray());
         }
 
-        public override void ToChar(int index, char expected)
+        public override void ToChar(int index, char expected, byte[] byteArray)
         {
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toCharByteArray);
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             BitConverter.ToChar(span);
             Assert.Equal(expected, BitConverter.ToChar(span.Slice(index)));
         }
 
-        public override void ToInt16(int index, short expected)
+        public override void ToInt16(int index, short expected, byte[] byteArray)
         {
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toInt16ByteArray);
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToInt16(span.Slice(index)));
         }
 
@@ -127,45 +127,45 @@ namespace System.Tests
             Assert.Equal(expected, BitConverter.ToInt32(byteArray));
         }
 
-        public override void ToInt64(int index, long expected)
+        public override void ToInt64(int index, long expected, byte[] byteArray)
         {
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toInt64ByteArray);
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToInt64(span.Slice(index)));
         }
 
-        public override void ToUInt16(int index, ushort expected)
+        public override void ToUInt16(int index, ushort expected, byte[] byteArray)
         {
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toUInt16ByteArray);
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToUInt16(span.Slice(index)));
         }
 
-        public override void ToUInt32(int index, uint expected)
+        public override void ToUInt32(int index, uint expected, byte[] byteArray)
         {
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toUInt32ByteArray);
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToUInt32(span.Slice(index)));
         }
 
-        public override void ToUInt64(int index, ulong expected)
+        public override void ToUInt64(int index, ulong expected, byte[] byteArray)
         {
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toUInt64ByteArray);
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToUInt64(span.Slice(index)));
         }
 
-        public override void ToSingle(int index, float expected)
+        public override void ToSingle(int index, float expected, byte[] byteArray)
         {
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toSingleByteArray);
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToSingle(span.Slice(index)));
         }
 
-        public override void ToDouble(int index, double expected)
+        public override void ToDouble(int index, double expected, byte[] byteArray)
         {
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toDoubleByteArray);
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToDouble(span.Slice(index)));
         }
 
-        public override void ToBoolean(int index, bool expected)
+        public override void ToBoolean(int index, bool expected, byte[] byteArray)
         {
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toBooleanByteArray);
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToBoolean(span.Slice(index)));
         }
     }

--- a/src/System.Runtime.Extensions/tests/System/BitConverterSpan.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverterSpan.cs
@@ -108,18 +108,16 @@ namespace System.Tests
             Assert.Equal(byteArr, span.ToArray());
         }
 
-        public override void ToChar(int index, char character)
+        public override void ToChar(int index, char expected)
         {
-            byte[] byteArray = { 0x20, 0x00, 0x00, 0x2A, 0x00, 0x41, 0x00, 0x7D, 0x00, 0xC5, 0x00, 0xA8, 0x03, 0x29, 0x04, 0xAC, 0x20 };
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toCharByteArray);
             BitConverter.ToChar(span);
-            Assert.Equal(character, BitConverter.ToChar(span.Slice(index)));
+            Assert.Equal(expected, BitConverter.ToChar(span.Slice(index)));
         }
 
         public override void ToInt16(int index, short expected)
         {
-            byte[] byteArray = { 15, 0, 0, 128, 16, 39, 240, 216, 241, 255, 127 };
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toInt16ByteArray);
             Assert.Equal(expected, BitConverter.ToInt16(span.Slice(index)));
         }
 
@@ -131,13 +129,44 @@ namespace System.Tests
 
         public override void ToInt64(int index, long expected)
         {
-            byte[] byteArray =
-                { 0x00, 0x36, 0x65, 0xC4, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0xCA, 0x9A,
-            0x3B, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0x56, 0x55, 0x55, 0x55, 0x55, 0x55, 0xFF, 0xFF, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x00,
-            0x00, 0x64, 0xA7, 0xB3, 0xB6, 0xE0, 0x0D, 0x00, 0x00, 0x9C, 0x58, 0x4C, 0x49, 0x1F, 0xF2 };
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
-            Assert.Equal(expected, BitConverter.ToInt32(span.Slice(index)));
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toInt64ByteArray);
+            Assert.Equal(expected, BitConverter.ToInt64(span.Slice(index)));
+        }
+
+        public override void ToUInt16(int index, ushort expected)
+        {
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toUInt16ByteArray);
+            Assert.Equal(expected, BitConverter.ToUInt16(span.Slice(index)));
+        }
+
+        public override void ToUInt32(int index, uint expected)
+        {
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toUInt32ByteArray);
+            Assert.Equal(expected, BitConverter.ToUInt32(span.Slice(index)));
+        }
+
+        public override void ToUInt64(int index, ulong expected)
+        {
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toUInt64ByteArray);
+            Assert.Equal(expected, BitConverter.ToUInt64(span.Slice(index)));
+        }
+
+        public override void ToSingle(int index, float expected)
+        {
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toSingleByteArray);
+            Assert.Equal(expected, BitConverter.ToSingle(span.Slice(index)));
+        }
+
+        public override void ToDouble(int index, double expected)
+        {
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toDoubleByteArray);
+            Assert.Equal(expected, BitConverter.ToDouble(span.Slice(index)));
+        }
+
+        public override void ToBoolean(int index, bool expected)
+        {
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(s_toBooleanByteArray);
+            Assert.Equal(expected, BitConverter.ToBoolean(span.Slice(index)));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/BitConverterSpan.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverterSpan.cs
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Tests
+{
+    public class BitConverterSpan : BitConverterBase
+    {
+        [Fact]
+        public void TryWriteBytes_DestinationSpanNotLargeEnough()
+        {
+            Assert.False(BitConverter.TryWriteBytes(Span<byte>.Empty, false));
+            Assert.False(BitConverter.TryWriteBytes(Span<byte>.Empty, 'a'));
+            Assert.False(BitConverter.TryWriteBytes(Span<byte>.Empty, (short)2));
+            Assert.False(BitConverter.TryWriteBytes(Span<byte>.Empty, 2));
+            Assert.False(BitConverter.TryWriteBytes(Span<byte>.Empty, (long)2));
+            Assert.False(BitConverter.TryWriteBytes(Span<byte>.Empty, (ushort)2));
+            Assert.False(BitConverter.TryWriteBytes(Span<byte>.Empty, (uint)2));
+            Assert.False(BitConverter.TryWriteBytes(Span<byte>.Empty, (ulong)2));
+            Assert.False(BitConverter.TryWriteBytes(Span<byte>.Empty, (float)2));
+            Assert.False(BitConverter.TryWriteBytes(Span<byte>.Empty, 2.0));
+        }
+
+        [Fact]
+        public void ToMethods_DestinationSpanNotLargeEnough()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToChar(Span<byte>.Empty); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToInt16(Span<byte>.Empty); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToInt32(Span<byte>.Empty); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToInt64(Span<byte>.Empty); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToUInt16(Span<byte>.Empty); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToUInt32(Span<byte>.Empty); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToUInt64(Span<byte>.Empty); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToSingle(Span<byte>.Empty); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToDouble(Span<byte>.Empty); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToBoolean(Span<byte>.Empty); });
+        }
+
+        public override void ConvertFromBool(bool boolean, int expected)
+        {
+            Span<byte> span = new Span<byte>(new byte[1]);
+            Assert.True(BitConverter.TryWriteBytes(span, boolean));
+            Assert.Equal(expected, span[0]);
+        }
+
+        public override void ConvertFromShort(short num, byte[] byteArr)
+        {
+            Span<byte> span = new Span<byte>(new byte[2]);
+            Assert.True(BitConverter.TryWriteBytes(span, num));
+            Assert.Equal(byteArr, span.ToArray());
+        }
+
+        public override void ConvertFromChar(char character, byte[] byteArr)
+        {
+            Span<byte> span = new Span<byte>(new byte[2]);
+            Assert.True(BitConverter.TryWriteBytes(span, character));
+            Assert.Equal(byteArr, span.ToArray());
+        }
+
+        public override void ConvertFromInt(int num, byte[] byteArr)
+        {
+            Span<byte> span = new Span<byte>(new byte[4]);
+            Assert.True(BitConverter.TryWriteBytes(span, num));
+            Assert.Equal(byteArr, span.ToArray());
+        }
+
+        public override void ConvertFromLong(long num, byte[] byteArr)
+        {
+            Span<byte> span = new Span<byte>(new byte[8]);
+            Assert.True(BitConverter.TryWriteBytes(span, num));
+            Assert.Equal(byteArr, span.ToArray());
+        }
+
+        public override void ConvertFromUShort(ushort num, byte[] byteArr)
+        {
+            Span<byte> span = new Span<byte>(new byte[2]);
+            Assert.True(BitConverter.TryWriteBytes(span, num));
+            Assert.Equal(byteArr, span.ToArray());
+        }
+
+        public override void ConvertFromUInt(uint num, byte[] byteArr)
+        {
+            Span<byte> span = new Span<byte>(new byte[4]);
+            Assert.True(BitConverter.TryWriteBytes(span, num));
+            Assert.Equal(byteArr, span.ToArray());
+        }
+
+        public override void ConvertFromULong(ulong num, byte[] byteArr)
+        {
+            Span<byte> span = new Span<byte>(new byte[8]);
+            Assert.True(BitConverter.TryWriteBytes(span, num));
+            Assert.Equal(byteArr, span.ToArray());
+        }
+
+        public override void ConvertFromFloat(float num, byte[] byteArr)
+        {
+            Span<byte> span = new Span<byte>(new byte[4]);
+            Assert.True(BitConverter.TryWriteBytes(span, num));
+            Assert.Equal(byteArr, span.ToArray());
+        }
+
+        public override void ConvertFromDouble(double num, byte[] byteArr)
+        {
+            Span<byte> span = new Span<byte>(new byte[8]);
+            Assert.True(BitConverter.TryWriteBytes(span, num));
+            Assert.Equal(byteArr, span.ToArray());
+        }
+
+        public override void ToChar(int index, char character)
+        {
+            byte[] byteArray = { 0x20, 0x00, 0x00, 0x2A, 0x00, 0x41, 0x00, 0x7D, 0x00, 0xC5, 0x00, 0xA8, 0x03, 0x29, 0x04, 0xAC, 0x20 };
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
+            BitConverter.ToChar(span);
+            Assert.Equal(character, BitConverter.ToChar(span.Slice(index)));
+        }
+
+        public override void ToInt16(int index, short expected)
+        {
+            byte[] byteArray = { 15, 0, 0, 128, 16, 39, 240, 216, 241, 255, 127 };
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
+            Assert.Equal(expected, BitConverter.ToInt16(span.Slice(index)));
+        }
+
+        public override void ToInt32(int expected, byte[] byteArray)
+        {
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
+            Assert.Equal(expected, BitConverter.ToInt32(byteArray));
+        }
+
+        public override void ToInt64(int index, long expected)
+        {
+            byte[] byteArray =
+                { 0x00, 0x36, 0x65, 0xC4, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0xCA, 0x9A,
+            0x3B, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0x56, 0x55, 0x55, 0x55, 0x55, 0x55, 0xFF, 0xFF, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x00,
+            0x00, 0x64, 0xA7, 0xB3, 0xB6, 0xE0, 0x0D, 0x00, 0x00, 0x9C, 0x58, 0x4C, 0x49, 0x1F, 0xF2 };
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
+            Assert.Equal(expected, BitConverter.ToInt32(span.Slice(index)));
+        }
+    }
+}


### PR DESCRIPTION
Expose in System.Runtime.Extensions contract in corefx.
Second part of issue #22355 

Adding tests to verify correct implementation and exposure
(https://msdn.microsoft.com/en-us/library/system.bitconverter_methods(v=vs.110).aspx)
