### PR TITLE
ManagedHandler: Moved exception strings to .resx resources.

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -366,4 +366,25 @@
   <data name="net_http_feature_UWPClientCertSupportRequiresCertInPersonalCertificateStore" xml:space="preserve">
     <value>Client certificate was not found in the personal (\"MY\") certificate store. In UWP, client certificates are only supported if they have been added to that certificate store.</value>
   </data>
+  <data name="net_http_content_unexpected_end" xml:space="preserve">
+    <value>Encountered an unexpected end of the content stream.</value>
+  </data>
+  <data name="net_http_headers_missing_location" xml:space="preserve">
+    <value>The response code indicates a redirect, but the 'Location' header is missing.</value>
+  </data>
+  <data name="net_http_invalid_chunk_size" xml:space="preserve">
+    <value>The response stream contains an invalid chunk size.</value>
+  </data>
+  <data name="net_http_max_redirects" xml:space="preserve">
+    <value>The maximum number of redirects was exceeded.</value>
+  </data>
+  <data name="net_http_proxy_invalid_scheme" xml:space="preserve">
+    <value>Invalid scheme for proxy. Scheme: '{0}'.</value>
+  </data>
+  <data name="net_http_request_invalid_char_encoding" xml:space="preserve">
+    <value>Requests must not contain non-ASCII characters.</value>
+  </data>
+  <data name="net_http_ssl_connection_failed" xml:space="preserve">
+    <value>The SSL connection could not be established, see inner exception.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -366,23 +366,17 @@
   <data name="net_http_feature_UWPClientCertSupportRequiresCertInPersonalCertificateStore" xml:space="preserve">
     <value>Client certificate was not found in the personal (\"MY\") certificate store. In UWP, client certificates are only supported if they have been added to that certificate store.</value>
   </data>
-  <data name="net_http_content_unexpected_end" xml:space="preserve">
-    <value>Encountered an unexpected end of the content stream.</value>
-  </data>
   <data name="net_http_headers_missing_location" xml:space="preserve">
     <value>The response code indicates a redirect, but the 'Location' header is missing.</value>
-  </data>
-  <data name="net_http_invalid_chunk_size" xml:space="preserve">
-    <value>The response stream contains an invalid chunk size.</value>
   </data>
   <data name="net_http_max_redirects" xml:space="preserve">
     <value>The maximum number of redirects was exceeded.</value>
   </data>
-  <data name="net_http_proxy_invalid_scheme" xml:space="preserve">
-    <value>Invalid scheme for proxy. Scheme: '{0}'.</value>
+  <data name="net_http_invalid_proxy_scheme" xml:space="preserve">
+    <value>Only the 'http' scheme is allowed for proxies.</value>
   </data>
   <data name="net_http_request_invalid_char_encoding" xml:space="preserve">
-    <value>Requests must not contain non-ASCII characters.</value>
+    <value>Request headers must contain only ASCII characters.</value>
   </data>
   <data name="net_http_ssl_connection_failed" xml:space="preserve">
     <value>The SSL connection could not be established, see inner exception.</value>

--- a/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
@@ -62,7 +62,7 @@ namespace System.Net.Http
                 Uri location = response.Headers.Location;
                 if (location == null)
                 {
-                    throw new HttpRequestException("no Location header for redirect");
+                    throw new HttpRequestException(SR.net_http_headers_missing_location);
                 }
 
                 if (!location.IsAbsoluteUri)
@@ -82,7 +82,7 @@ namespace System.Net.Http
                 redirectCount++;
                 if (redirectCount > _maxAutomaticRedirections)
                 {
-                    throw new HttpRequestException("max redirects exceeded");
+                    throw new HttpRequestException(SR.net_http_max_redirects);
                 }
 
                 // Set up for the automatic redirect

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingReadStream.cs
@@ -67,13 +67,13 @@ namespace System.Net.Http
                             {
                                 break;
                             }
-                            throw new IOException(SR.net_http_invalid_chunk_size);
+                            throw new IOException(SR.net_http_invalid_response);
                         }
                     }
                 }
                 catch (OverflowException e)
                 {
-                    throw new IOException(SR.net_http_invalid_chunk_size, e);
+                    throw new IOException(SR.net_http_invalid_response, e);
                 }
                 return size;
             }
@@ -117,7 +117,7 @@ namespace System.Net.Http
                 if (bytesRead <= 0)
                 {
                     // Unexpected end of response stream
-                    throw new IOException(SR.net_http_content_unexpected_end);
+                    throw new IOException(SR.net_http_invalid_response);
                 }
 
                 await ConsumeChunkBytes((ulong)bytesRead, cancellationToken).ConfigureAwait(false);

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingReadStream.cs
@@ -67,13 +67,13 @@ namespace System.Net.Http
                             {
                                 break;
                             }
-                            throw new IOException("Invalid chunk size in response stream");
+                            throw new IOException(SR.net_http_invalid_chunk_size);
                         }
                     }
                 }
                 catch (OverflowException e)
                 {
-                    throw new IOException("Invalid chunk size in response stream", e);
+                    throw new IOException(SR.net_http_invalid_chunk_size, e);
                 }
                 return size;
             }
@@ -117,7 +117,7 @@ namespace System.Net.Http
                 if (bytesRead <= 0)
                 {
                     // Unexpected end of response stream
-                    throw new IOException("Unexpected end of content stream while processing chunked response body");
+                    throw new IOException(SR.net_http_content_unexpected_end);
                 }
 
                 await ConsumeChunkBytes((ulong)bytesRead, cancellationToken).ConfigureAwait(false);

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ContentLengthReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ContentLengthReadStream.cs
@@ -52,7 +52,7 @@ namespace System.Net.Http
                 if (bytesRead <= 0)
                 {
                     // Unexpected end of response stream
-                    throw new IOException(SR.net_http_content_unexpected_end);
+                    throw new IOException(SR.net_http_invalid_response);
                 }
 
                 Debug.Assert((ulong)bytesRead <= _contentBytesRemaining);

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ContentLengthReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ContentLengthReadStream.cs
@@ -52,7 +52,7 @@ namespace System.Net.Http
                 if (bytesRead <= 0)
                 {
                     // Unexpected end of response stream
-                    throw new IOException("Unexpected end of content stream");
+                    throw new IOException(SR.net_http_content_unexpected_end);
                 }
 
                 Debug.Assert((ulong)bytesRead <= _contentBytesRemaining);

--- a/src/System.Net.Http/src/System/Net/Http/Managed/DecompressionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/DecompressionHandler.cs
@@ -131,7 +131,7 @@ namespace System.Net.Http
             {
                 if (_contentConsumed)
                 {
-                    throw new InvalidOperationException("content already consumed");
+                    throw new InvalidOperationException(SR.net_http_content_stream_already_read);
                 }
 
                 _contentConsumed = true;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -576,7 +576,7 @@ namespace System.Net.Http
                 {
                     if ((c & 0xFF80) != 0)
                     {
-                        throw new HttpRequestException("Non-ASCII characters found");
+                        throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
                     }
                     writeBuffer[offset++] = (byte)c;
                 }
@@ -616,7 +616,7 @@ namespace System.Net.Http
                 char c = s[i];
                 if ((c & 0xFF80) != 0)
                 {
-                    throw new HttpRequestException("Non-ASCII characters found");
+                    throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
                 }
                 await WriteByteAsync((byte)c, cancellationToken).ConfigureAwait(false);
             }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionContent.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http
             {
                 if (_stream == null)
                 {
-                    throw new InvalidOperationException("content already consumed");
+                    throw new InvalidOperationException(SR.net_http_content_stream_already_read);
                 }
 
                 HttpContentReadStream stream = _stream;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
@@ -66,7 +66,7 @@ namespace System.Net.Http
                 sslStream.Dispose();
                 if (e is AuthenticationException || e is IOException)
                 {
-                    throw new HttpRequestException("could not establish SSL connection", e);
+                    throw new HttpRequestException(SR.net_http_ssl_connection_failed, e);
                 }
                 throw;
             }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http
             UsingSSL = 
                 uri.Scheme == UriScheme.Http ? false :
                 uri.Scheme == UriScheme.Https ? true :
-                throw new ArgumentException("Invalid Uri scheme", nameof(uri));
+                throw new ArgumentException(SR.net_http_client_http_baseaddress_required, nameof(uri));
 
             Host = uri.Host;
             Port = uri.Port;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -55,7 +55,7 @@ namespace System.Net.Http
         {
             if (proxyUri.Scheme != UriScheme.Http)
             {
-                throw new InvalidOperationException(SR.Format(SR.net_http_proxy_invalid_scheme, proxyUri.Scheme));
+                throw new InvalidOperationException(SR.net_http_invalid_proxy_scheme);
             }
 
             if (request.RequestUri.Scheme == UriScheme.Https)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -55,7 +55,7 @@ namespace System.Net.Http
         {
             if (proxyUri.Scheme != UriScheme.Http)
             {
-                throw new InvalidOperationException($"invalid scheme {proxyUri.Scheme} for proxy");
+                throw new InvalidOperationException(SR.Format(SR.net_http_proxy_invalid_scheme, proxyUri.Scheme));
             }
 
             if (request.RequestUri.Scheme == UriScheme.Https)


### PR DESCRIPTION
Fixes #23148 

NOTE: I purposely ignored exceptions that had TODOs with active issues for functionality that is not implemented.

cc @stephentoub 