### PR TITLE
ManagedHandler: Only run connection pool cleanup timer when needed

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPools.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPools.cs
@@ -40,7 +40,6 @@ namespace System.Net.Http
             _pools = new ConcurrentDictionary<HttpConnectionKey, HttpConnectionPool>();
             // Start out with the timer not running, since we have no pools.
             _cleaningTimer = new Timer(s => ((HttpConnectionPools)s).RemoveStalePools(), this, Timeout.Infinite, Timeout.Infinite);
-            _timerIsRunning = false;
         }
 
         /// <summary>Gets a pool for the specified endpoint, adding one if none existed.</summary>


### PR DESCRIPTION
Fixes #23149 

cc: @stephentoub 