### PR TITLE
Enable full duplex communication with ManagedHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingWriteStream.cs
@@ -13,22 +13,25 @@ namespace System.Net.Http
         {
             private static readonly byte[] s_finalChunkBytes = { (byte)'0', (byte)'\r', (byte)'\n', (byte)'\r', (byte)'\n' };
 
-            public ChunkedEncodingWriteStream(HttpConnection connection)
-                : base(connection)
+            public ChunkedEncodingWriteStream(HttpConnection connection, CancellationToken cancellationToken) :
+                base(connection, cancellationToken)
             {
             }
 
-            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ignored)
             {
                 ValidateBufferArgs(buffer, offset, count);
 
-                // Don't write if nothing was given
-                // Especially since we don't want to accidentally send a 0 chunk, which would indicate end of body
-                if (count == 0)
-                {
-                    return;
-                }
+                // Don't write if nothing was given, especially since we don't want to accidentally send a 0 chunk,
+                // which would indicate end of body.  We also avoid sending if the response has already completed,
+                // in which case there's no point sending further data (this might happen, for example, on a redirect.)
+                return count != 0 && _connection._currentRequest != null ?
+                    WriteAsyncCore(buffer, offset, count) :
+                    Task.CompletedTask;
+            }
 
+            private async Task WriteAsyncCore(byte[] buffer, int offset, int count)
+            {
                 // Write chunk length -- hex representation of count
                 bool digitWritten = false;
                 for (int i = 7; i >= 0; i--)
@@ -38,27 +41,34 @@ namespace System.Net.Http
                     int digit = (count & mask) >> shift;
                     if (digitWritten || digit != 0)
                     {
-                        await _connection.WriteByteAsync((byte)(digit < 10 ? '0' + digit : 'A' + digit - 10), cancellationToken).ConfigureAwait(false);
+                        await _connection.WriteByteAsync((byte)(digit < 10 ? '0' + digit : 'A' + digit - 10), _cancellationToken).ConfigureAwait(false);
                         digitWritten = true;
                     }
                 }
 
-                await _connection.WriteTwoBytesAsync((byte)'\r', (byte)'\n', cancellationToken).ConfigureAwait(false);
+                // End chunk length
+                await _connection.WriteTwoBytesAsync((byte)'\r', (byte)'\n', _cancellationToken).ConfigureAwait(false);
 
                 // Write chunk contents
-                await _connection.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
-                await _connection.WriteTwoBytesAsync((byte)'\r', (byte)'\n', cancellationToken).ConfigureAwait(false);
+                await _connection.WriteAsync(buffer, offset, count, _cancellationToken).ConfigureAwait(false);
+                await _connection.WriteTwoBytesAsync((byte)'\r', (byte)'\n', _cancellationToken).ConfigureAwait(false);
+
+                // Flush the chunk.  This is reasonable from the standpoint of having just written a standalone piece
+                // of data, but is also necessary to support duplex communication, where a CopyToAsync is taking the
+                // data from content and writing it here; if there was no flush, we might not send the data until the
+                // source was empty, and it might be kept open to enable subsequent communication.
+                await _connection.FlushAsync(_cancellationToken);
             }
 
-            public override Task FlushAsync(CancellationToken cancellationToken)
+            public override Task FlushAsync(CancellationToken ignored)
             {
-                return _connection.FlushAsync(cancellationToken);
+                return _connection.FlushAsync(_cancellationToken);
             }
             
-            public override async Task FinishAsync(CancellationToken cancellationToken)
+            public override async Task FinishAsync()
             {
                 // Send 0 byte chunk to indicate end, then final CrLf
-                await _connection.WriteBytesAsync(s_finalChunkBytes, cancellationToken).ConfigureAwait(false);
+                await _connection.WriteBytesAsync(s_finalChunkBytes, _cancellationToken).ConfigureAwait(false);
                 _connection = null;
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ContentLengthReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ContentLengthReadStream.cs
@@ -18,16 +18,8 @@ namespace System.Net.Http
             public ContentLengthReadStream(HttpConnection connection, ulong contentLength)
                 : base(connection)
             {
-                if (contentLength == 0)
-                {
-                    _connection = null;
-                    _contentBytesRemaining = 0;
-                    connection.ReturnConnectionToPool();
-                }
-                else
-                {
-                    _contentBytesRemaining = contentLength;
-                }
+                Debug.Assert(contentLength > 0, "Caller should have checked for 0.");
+                _contentBytesRemaining = contentLength;
             }
 
             public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -39,6 +39,7 @@ namespace System.Net.Http
         private ValueStringBuilder _sb; // mutable struct, do not make this readonly
 
         private HttpRequestMessage _currentRequest;
+        private Task _sendRequestContentTask;
         private readonly byte[] _writeBuffer;
         private int _writeOffset;
 
@@ -48,8 +49,7 @@ namespace System.Net.Http
         private int _readLength;
 
         private bool _connectionClose; // Connection: close was seen on last response
-
-        private bool _disposed;
+        private int _disposed; // 1 yes, 0 no
 
         public HttpConnection(
             HttpConnectionPool pool,
@@ -76,14 +76,7 @@ namespace System.Net.Http
             _sb = new ValueStringBuilder(DefaultCapacity);
 
             _writeBuffer = new byte[InitialWriteBufferSize];
-            _writeOffset = 0;
-
             _readBuffer = new byte[InitialReadBufferSize];
-            _readLength = 0;
-            _readOffset = 0;
-
-            _connectionClose = false;
-            _disposed = false;
 
             if (NetEventSource.IsEnabled)
             {
@@ -106,10 +99,11 @@ namespace System.Net.Http
 
         public void Dispose()
         {
-            if (!_disposed)
+            // Ensure we're only disposed once.  Dispose could be called concurrently, for example,
+            // if the request and the response were running concurrently and both incurred an exception.
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
             {
                 if (NetEventSource.IsEnabled) Trace("Connection closing.");
-                _disposed = true;
                 _pool.DecrementConnectionCount();
                 _stream.Dispose();
             }
@@ -256,22 +250,30 @@ namespace System.Net.Http
                 // CRLF for end of headers.
                 await WriteTwoBytesAsync((byte)'\r', (byte)'\n', cancellationToken).ConfigureAwait(false);
 
-                // Write body, if any
+                // Flush out anything buffered from the request headers to finish sending them.
+                await FlushAsync(cancellationToken).ConfigureAwait(false);
+
+                Debug.Assert(_sendRequestContentTask == null);
                 if (request.Content != null)
                 {
-                    HttpContentWriteStream stream = (request.HasHeaders && request.Headers.TransferEncodingChunked == true ?
-                        (HttpContentWriteStream)new ChunkedEncodingWriteStream(this) :
-                        (HttpContentWriteStream)new ContentLengthWriteStream(this));
-
-                    // TODO #23146: CopyToAsync doesn't take a CancellationToken, how do we deal with Cancellation here?
-                    // TODO #23145: We need to enable duplex communication, which means not waiting here until all data is sent.
                     // TODO #23144: Support Expect: 100-continue
-                    await request.Content.CopyToAsync(stream, _transportContext).ConfigureAwait(false);
-                    await stream.FinishAsync(cancellationToken).ConfigureAwait(false);
-                }
 
-                // Flush out anything buffered from the request to finish sending it.
-                await FlushAsync(cancellationToken).ConfigureAwait(false);
+                    // Asynchronously send the body if there is one.  This can run concurrently with receiving the response.
+                    bool transferEncodingChunked = request.HasHeaders && request.Headers.TransferEncodingChunked == true;
+                    HttpContentWriteStream stream = transferEncodingChunked ? (HttpContentWriteStream)
+                        new ChunkedEncodingWriteStream(this, cancellationToken) :
+                        new ContentLengthWriteStream(this, cancellationToken);
+
+                    // Start the copy from the request.  We do this here in case it synchronously throws
+                    // an exception, e.g. StreamContent throwing for non-rewindable content, and because if
+                    // we did it in SendRequestContentAsync, that exception would get trapped in the returned
+                    // task... at that point, we might get stuck waiting to receive a response from the server
+                    // that'll never come, as the server is still expecting us to send data.
+                    _sendRequestContentTask = SendRequestContentAsync(
+                        request.Content.CopyToAsync(stream, _transportContext),
+                        stream,
+                        cancellationToken);
+                }
 
                 // Parse the response status line and headers
                 var response = new HttpResponseMessage() { RequestMessage = request, Content = new HttpConnectionContent(CancellationToken.None) };
@@ -290,6 +292,17 @@ namespace System.Net.Http
                 if (response.Headers.ConnectionClose.GetValueOrDefault())
                 {
                     _connectionClose = true;
+                }
+
+                // Before creating the response stream, check to see if we're done sending any content,
+                // and propagate any exceptions that may have occurred.  The most common case is that
+                // the server won't send back response content until it's received the whole request,
+                // so the majority of the time this task will be complete.
+                Task sendRequestContentTask = _sendRequestContentTask;
+                if (sendRequestContentTask != null && sendRequestContentTask.IsCompleted)
+                {
+                    sendRequestContentTask.GetAwaiter().GetResult();
+                    _sendRequestContentTask = null;
                 }
 
                 // Create the response stream.
@@ -333,6 +346,27 @@ namespace System.Net.Http
                 {
                     throw new HttpRequestException(SR.net_http_client_execution_error, error);
                 }
+                throw;
+            }
+        }
+
+        private async Task SendRequestContentAsync(Task copyTask, HttpContentWriteStream stream, CancellationToken cancellationToken)
+        {
+            try
+            {
+                // Wait for all of the data to be copied to the server.
+                await copyTask.ConfigureAwait(false);
+
+                // Finish the content; with a chunked upload, this includes writing the terminating chunk.
+                await stream.FinishAsync().ConfigureAwait(false);
+
+                // Flush any content that might still be buffered.
+                await FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                Trace($"Error while sending request content: {e}");
+                Dispose();
                 throw;
             }
         }
@@ -905,14 +939,67 @@ namespace System.Net.Http
         {
             Debug.Assert(_writeOffset == 0, "Everything in write buffer should have been flushed.");
             Debug.Assert(_readAheadTask == null, "Expected a previous initial read to already be consumed.");
+            Debug.Assert(_currentRequest != null, "Expected the connection to be associated with a request.");
+
+            // Unassociated the connection from a request.  If there's an in-flight request content still
+            // being sent, it'll see this nulled out and stop sending.
+            _currentRequest = null;
+
+            // Check to see if we're still sending request content.
+            Task sendRequestContentTask = _sendRequestContentTask;
+            if (sendRequestContentTask != null)
+            {
+                if (!sendRequestContentTask.IsCompleted)
+                {
+                    // We're still transferring request content.  Only put the connection back into the
+                    // pool when we're done transferring.
+                    if (NetEventSource.IsEnabled) Trace("Still transferring request content. Delaying returning connection to pool.");
+                    sendRequestContentTask.ContinueWith((_, state) =>
+                    {
+                        var innerConnection = (HttpConnection)state;
+                        if (NetEventSource.IsEnabled) innerConnection.Trace("Request content send completed.");
+                        innerConnection.ReturnConnectionToPoolCore();
+                    }, this, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+                    return;
+                }
+
+                // We're done transferring request content.  Check whether we incurred an exception,
+                // and if we did, propagate it to our caller.
+                if (!sendRequestContentTask.IsCompletedSuccessfully)
+                {
+                    sendRequestContentTask.GetAwaiter().GetResult();
+                }
+            }
+
+            ReturnConnectionToPoolCore();
+        }
+
+        private void ReturnConnectionToPoolCore()
+        {
+            Debug.Assert(_sendRequestContentTask == null || _sendRequestContentTask.IsCompleted);
+
+            if (NetEventSource.IsEnabled)
+            {
+                if (_connectionClose)
+                {
+                    Trace("Server requested connection be closed.");
+                }
+                if (_sendRequestContentTask != null && _sendRequestContentTask.IsFaulted)
+                {
+                    Trace($"Sending request content incurred an exception: {_sendRequestContentTask.Exception.InnerException}");
+                }
+            }
 
             // If server told us it's closing the connection, don't put this back in the pool.
-            if (!_connectionClose)
+            // And if we incurred an error while transferring request content, also skip the pool.
+            if (!_connectionClose &&
+                (_sendRequestContentTask == null || _sendRequestContentTask.IsCompletedSuccessfully))
             {
                 try
                 {
                     // Null out the associated request before the connection is potentially reused by another.
                     _currentRequest = null;
+                    _sendRequestContentTask = null;
 
                     // When putting a connection back into the pool, we initiate a pre-emptive
                     // read on the stream.  When the connection is subsequently taken out of the

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
@@ -250,8 +250,8 @@ namespace System.Net.Http
                 }
 
                 // Pool the connection by adding it to the list.
-                if (NetEventSource.IsEnabled) connection.Trace("Returning connection to pool.");
                 list.Add(new CachedConnection(connection));
+                if (NetEventSource.IsEnabled) connection.Trace("Stored connection in pool.");
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentStream.cs
@@ -15,12 +15,12 @@ namespace System.Net.Http
                 throw new ArgumentNullException(nameof(buffer));
             }
 
-            if (offset < 0 || offset > buffer.Length)
+            if ((uint)offset > buffer.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(offset));
             }
 
-            if (count < 0 || count > buffer.Length - offset)
+            if ((uint)count > buffer.Length - offset)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
             }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentWriteStream.cs
@@ -13,10 +13,19 @@ namespace System.Net.Http
     {
         protected HttpConnection _connection;
 
-        public HttpContentWriteStream(HttpConnection connection)
+        /// <summary>Cancellation token associated with the send operation.</summary>
+        /// <remarks>
+        /// Because of how this write stream is used, the CancellationToken passed into the individual
+        /// stream operations will be the default non-cancelable token and can be ignored.  Instead,
+        /// this token is used.
+        /// </remarks>
+        protected readonly CancellationToken _cancellationToken;
+
+        public HttpContentWriteStream(HttpConnection connection, CancellationToken cancellationToken)
         {
             Debug.Assert(connection != null);
             _connection = connection;
+            _cancellationToken = cancellationToken;
         }
 
         public override bool CanRead => false;
@@ -42,7 +51,7 @@ namespace System.Net.Http
         public override void Write(byte[] buffer, int offset, int count) =>
             WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
 
-        public abstract Task FinishAsync(CancellationToken cancellationToken);
+        public abstract Task FinishAsync();
 
         protected override void Dispose(bool disposing)
         {

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -178,6 +178,8 @@ namespace System.Net.Http.Functional.Tests
                 var ep = (IPEndPoint)listener.LocalEndPoint;
 
                 var clientToServerStream = new ProducerConsumerStream();
+                clientToServerStream.WriteByte(0);
+
                 var reqMsg = new HttpRequestMessage
                 {
                     RequestUri = new Uri($"http://{ep.Address}:{ep.Port}/"),
@@ -214,7 +216,7 @@ namespace System.Net.Http.Functional.Tests
                     {
                         // Send a byte from the client to the server.  The server will receive
                         // the byte as a chunk.
-                        clientToServerStream.WriteByte(i);
+                        if (i > 0) clientToServerStream.WriteByte(i); // 0 was already seeded when the stream was created above
                         Assert.Equal('1', serverStream.ReadByte());
                         Assert.Equal('\r', serverStream.ReadByte());
                         Assert.Equal('\n', serverStream.ReadByte());

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
 using System.IO;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -159,6 +161,137 @@ namespace System.Net.Http.Functional.Tests
     //        base.Dispose();
     //    }
     //}
+
+    public sealed class ManagedHandler_HttpClientHandler_DuplexCommunication_Test : IDisposable
+    {
+        public ManagedHandler_HttpClientHandler_DuplexCommunication_Test() => ManagedHandlerTestHelpers.SetEnvVar();
+        public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
+
+        [Fact]
+        public async Task SendBytesBackAndForthBetweenClientAndServer_Success()
+        {
+            using (var client = new HttpClient())
+            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listener.Listen(1);
+                var ep = (IPEndPoint)listener.LocalEndPoint;
+
+                var clientToServerStream = new ProducerConsumerStream();
+                var reqMsg = new HttpRequestMessage
+                {
+                    RequestUri = new Uri($"http://{ep.Address}:{ep.Port}/"),
+                    Content = new StreamContent(clientToServerStream),
+                };
+                Task<HttpResponseMessage> req = client.SendAsync(reqMsg, HttpCompletionOption.ResponseHeadersRead);
+
+                using (Socket server = await listener.AcceptAsync())
+                using (var serverStream = new NetworkStream(server, ownsSocket: false))
+                {
+                    // Skip request headers.
+                    while (true)
+                    {
+                        if (serverStream.ReadByte() == '\r')
+                        {
+                            serverStream.ReadByte();
+                            break;
+                        }
+                        while (serverStream.ReadByte() != '\r') { }
+                        serverStream.ReadByte();
+                    }
+
+                    // Send response headers.
+                    await server.SendAsync(
+                        new ArraySegment<byte>(Encoding.ASCII.GetBytes($"HTTP/1.1 200 OK\r\nConnection: close\r\nDate: {DateTimeOffset.UtcNow:R}\r\n\r\n")),
+                        SocketFlags.None);
+
+                    HttpResponseMessage resp = await req;
+                    Stream serverToClientStream = await resp.Content.ReadAsStreamAsync();
+
+                    // Communication should now be open between the client and server.
+                    // Ping pong bytes back and forth.
+                    for (byte i = 0; i < 100; i++)
+                    {
+                        // Send a byte from the client to the server.  The server will receive
+                        // the byte as a chunk.
+                        clientToServerStream.WriteByte(i);
+                        Assert.Equal('1', serverStream.ReadByte());
+                        Assert.Equal('\r', serverStream.ReadByte());
+                        Assert.Equal('\n', serverStream.ReadByte());
+                        Assert.Equal(i, serverStream.ReadByte());
+                        Assert.Equal('\r', serverStream.ReadByte());
+                        Assert.Equal('\n', serverStream.ReadByte());
+
+                        // Send a byte from the server to the client.  The client will receive
+                        // the byte on its own, with HttpClient stripping away the chunk encoding.
+                        serverStream.WriteByte(i);
+                        Assert.Equal(i, serverToClientStream.ReadByte());
+                    }
+
+                    clientToServerStream.DoneWriting();
+                    server.Shutdown(SocketShutdown.Send);
+                    Assert.Equal(-1, clientToServerStream.ReadByte());
+                }
+            }
+        }
+
+        private sealed class ProducerConsumerStream : Stream
+        {
+            private readonly BlockingCollection<byte[]> _buffers = new BlockingCollection<byte[]>();
+            private ArraySegment<byte> _remaining;
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                if (count > 0)
+                {
+                    byte[] tmp = new byte[count];
+                    Buffer.BlockCopy(buffer, offset, tmp, 0, count);
+                    _buffers.Add(tmp);
+                }
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (count > 0)
+                {
+                    if (_remaining.Count == 0)
+                    {
+                        if (!_buffers.TryTake(out byte[] tmp, Timeout.Infinite))
+                        {
+                            return 0;
+                        }
+                        _remaining = new ArraySegment<byte>(tmp, 0, tmp.Length);
+                    }
+
+                    if (_remaining.Count <= count)
+                    {
+                        count = _remaining.Count;
+                        Buffer.BlockCopy(_remaining.Array, _remaining.Offset, buffer, offset, count);
+                        _remaining = default(ArraySegment<byte>);
+                    }
+                    else
+                    {
+                        Buffer.BlockCopy(_remaining.Array, _remaining.Offset, buffer, offset, count);
+                        _remaining = new ArraySegment<byte>(_remaining.Array, _remaining.Offset + count, _remaining.Count - count);
+                    }
+                }
+
+                return count;
+            }
+
+            public void DoneWriting() => _buffers.CompleteAdding();
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotImplementedException();
+            public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public override void Flush() { }
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+            public override void SetLength(long value) => throw new NotImplementedException();
+        }
+
+    }
 
     public sealed class ManagedHandler_HttpClientHandler_ConnectionPooling_Test : IDisposable
     {

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -20,6 +20,9 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\ConsoleEventListener.cs">
+      <Link>Common\System\Diagnostics\Tracing\ConsoleEventListener.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\IO\DelegateStream.cs">
       <Link>Common\System\IO\DelegateStream.cs</Link>
     </Compile>


### PR DESCRIPTION
ManagedHandler currently waits for all of the request content to be sent before it processes any response content.  While that matches with what many servers do (not sending any response content until all request content has been received), some sites and situations do benefit from or even require full duplex communication, such that the response can be processed even while the request content is being sent.  This change is also a necessary step towards enabling Expect: 100-continue, as we need to be able to receive the response header before having sent the content, and even without Expect: 100-continue, this allows us to stop sending a large request body if a server quickly sends back a status indicating the transfer isn't needed (e.g. a redirect).

This change also improves on the cancellation support for sending the request body.  The send cancellation token is now embedded in the request content stream and uses that token for all operations.

Fixes https://github.com/dotnet/corefx/issues/23145
Fixes https://github.com/dotnet/corefx/issues/23146
cc: @geoffkizer 