### PR TITLE
Disable two collections tests on desktop

### DIFF
--- a/src/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
@@ -13,6 +13,7 @@ namespace System.Collections.Generic.Tests
 {
     public abstract partial class ComparersGenericTests<T>
     {
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Missing https://github.com/dotnet/coreclr/pull/4340")]
         [Fact]
         public void Comparer_ComparerDefault()
         {

--- a/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Tests.cs
@@ -9,6 +9,7 @@ namespace System.Collections.Generic.Tests
 {
     public abstract partial class ComparersGenericTests<T>
     {
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Missing https://github.com/dotnet/coreclr/pull/4340")]
         [Fact]
         public void EqualityComparer_EqualityComparerDefault()
         {


### PR DESCRIPTION
These tests are verifying that `{Equality}Comparer<T>.Default` is idempotent.  But whereas on core they are now initialized with beforefieldinit, on desktop they're lazily initialized with optimistic concurrency in a manner that can result in two threads each seeing their own distinct instance.  That invalidates these tests, which spordically fail in CI.

cc: @danmosemsft, @ianhays 