### PR TITLE
Turn on setting GIT URL in File Version

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01911-02
+2.0.0-prerelease-01914-02

--- a/dir.props
+++ b/dir.props
@@ -28,6 +28,9 @@
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
     <SourceDir>$(ProjectDir)src\</SourceDir>
 
+    <!-- This name is used to create a GIT reposiitory URL https://github.com/dotnet/$(GitHubRepositoryName) used to find source code for debugging -->
+    <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">corefx</GitHubRepositoryName>
+
     <!-- Output directories -->
     <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)bin/</BinDir>
 


### PR DESCRIPTION
This turns on tagging each CoreFX DLL built GitHub URL
of the source code that was used to build it.

You now get something that looks like the folloiwng when you do a filever -v

ProductVersion  4.6.25612.0 @BuiltBy: vancem-VANCEM4 @SrcCode: https://github.com/dotnet/corefx/tree/a329e252594f375348a8f06a3675606f5c03ce3f

Note that most of the work for this is in the buildtools, this simlpy sets the GitHubRepositoryName variable that turns it on.

@dagood 