### PR TITLE
[release/1.1] Simplify X509Chain building with OpenSSL

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -356,7 +356,7 @@
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.fedora.23-x64.runtime.native.System": {
       "StableVersions": [
@@ -392,7 +392,7 @@
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.native.System": {
       "StableVersions": [
@@ -435,7 +435,7 @@
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.opensuse.13.2-x64.runtime.native.System": {
       "StableVersions": [
@@ -471,7 +471,7 @@
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.osx.10.10-x64.runtime.native.System": {
       "StableVersions": [
@@ -507,7 +507,7 @@
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.rhel.7-x64.runtime.native.System": {
       "StableVersions": [
@@ -543,7 +543,7 @@
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.ubuntu.14.04-x64.runtime.native.System": {
       "StableVersions": [
@@ -579,7 +579,7 @@
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.ubuntu.16.04-x64.runtime.native.System": {
       "StableVersions": [
@@ -615,7 +615,7 @@
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.unix.Microsoft.Win32.Primitives": {
       "StableVersions": [
@@ -2098,7 +2098,8 @@
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.1.0",
         "4.1.0.0": "4.1.0",
-        "4.1.1.0": "4.3.0"
+        "4.1.1.0": "4.3.0",
+        "4.1.1.1": "4.3.1"
       }
     },
     "System.Security.Principal": {
@@ -2529,28 +2530,28 @@
       "StableVersions": [
         "4.3.0"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.1"
     },
     "runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.fedora.24-x64.runtime.native.System.IO.Compression": {
       "StableVersions": [
@@ -2581,21 +2582,21 @@
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": {
       "StableVersions": [
@@ -2626,48 +2627,48 @@
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": {
       "StableVersions": [
         "4.3.0"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.1"
     },
     "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": {
       "StableVersions": [
@@ -2698,14 +2699,14 @@
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
       "StableVersions": [
         "4.3.0",
         "4.3.1"
       ],
-      "BaselineVersion": "4.3.0"
+      "BaselineVersion": "4.3.2"
     },
     "runtime.win10-arm64.runtime.native.System.Data.SqlClient.sni": {
       "BaselineVersion": "4.3.0"

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -127,9 +127,13 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool X509StoreSetRevocationFlag(SafeX509StoreHandle ctx, X509RevocationFlag revocationFlag);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxInit")]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxInit2")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool X509StoreCtxInit(SafeX509StoreCtxHandle ctx, SafeX509StoreHandle store, SafeX509Handle x509);
+        internal static extern bool X509StoreCtxInit(
+            SafeX509StoreCtxHandle ctx,
+            SafeX509StoreHandle store,
+            SafeX509Handle x509,
+            SafeX509StackHandle extraCerts);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509VerifyCert")]
         internal static extern int X509VerifyCert(SafeX509StoreCtxHandle ctx);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.cpp
@@ -212,6 +212,11 @@ extern "C" int32_t CryptoNative_X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE
     return X509_STORE_CTX_init(ctx, store, x509, nullptr);
 }
 
+extern "C" int32_t CryptoNative_X509StoreCtxInit2(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509, X509Stack* extraStore)
+{
+    return X509_STORE_CTX_init(ctx, store, x509, extraStore);
+}
+
 extern "C" int32_t CryptoNative_X509VerifyCert(X509_STORE_CTX* ctx)
 {
     return X509_verify_cert(ctx);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -223,6 +223,11 @@ Shims the X509_STORE_CTX_init method.
 extern "C" int32_t CryptoNative_X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509);
 
 /*
+Shims the X509_STORE_CTX_init method.
+*/
+extern "C" int32_t CryptoNative_X509StoreCtxInit2(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509, X509Stack* extraStore);
+
+/*
 Shims the X509_verify_cert method.
 */
 extern "C" int32_t CryptoNative_X509VerifyCert(X509_STORE_CTX* ctx);

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/dir.props
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/dir.props
@@ -2,6 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
 
   <PropertyGroup>
-    <PackageVersion>4.3.1</PackageVersion>
+    <PackageVersion>4.3.2</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/dir.props
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/dir.props
@@ -2,6 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
 
   <PropertyGroup>
-    <PackageVersion>4.3.1</PackageVersion>
+    <PackageVersion>4.3.2</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.X509Certificates/dir.props
+++ b/src/System.Security.Cryptography.X509Certificates/dir.props
@@ -1,7 +1,8 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.1</AssemblyVersion>
+    <PackageVersion>4.3.1</PackageVersion>
   </PropertyGroup>
 </Project>
 

--- a/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
+++ b/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipGenerationCheck>true</SkipGenerationCheck>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\4.0\System.Security.Cryptography.X509Certificates.csproj">
       <SupportedFramework>net46</SupportedFramework>

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -61,7 +61,6 @@ namespace Internal.Cryptography.Pal
                 IChainPal chain = OpenSslX509ChainProcessor.BuildChain(
                     leaf,
                     candidates,
-                    downloaded,
                     systemTrusted,
                     applicationPolicy,
                     certificatePolicy,

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -101,7 +101,6 @@ namespace Internal.Cryptography.Pal
         public static IChainPal BuildChain(
             X509Certificate2 leaf,
             HashSet<X509Certificate2> candidates,
-            HashSet<X509Certificate2> downloaded,
             HashSet<X509Certificate2> systemTrusted,
             OidCollection applicationPolicy,
             OidCollection certificatePolicy,
@@ -121,9 +120,11 @@ namespace Internal.Cryptography.Pal
             // (If you need to think of it as an X509Store, it's a volatile memory store)
             using (SafeX509StoreHandle store = Interop.Crypto.X509StoreCreate())
             using (SafeX509StoreCtxHandle storeCtx = Interop.Crypto.X509StoreCtxCreate())
+            using (SafeX509StackHandle extraCerts = Interop.Crypto.NewX509Stack())
             {
                 Interop.Crypto.CheckValidOpenSslHandle(store);
                 Interop.Crypto.CheckValidOpenSslHandle(storeCtx);
+                Interop.Crypto.CheckValidOpenSslHandle(extraCerts);
 
                 bool lookupCrl = revocationMode != X509RevocationMode.NoCheck;
 
@@ -131,9 +132,15 @@ namespace Internal.Cryptography.Pal
                 {
                     OpenSslX509CertificateReader pal = (OpenSslX509CertificateReader)cert.Pal;
 
-                    if (!Interop.Crypto.X509StoreAddCert(store, pal.SafeHandle))
+                    using (SafeX509Handle handle = Interop.Crypto.X509UpRef(pal.SafeHandle))
                     {
-                        throw Interop.Crypto.CreateOpenSslCryptographicException();
+                        if (!Interop.Crypto.PushX509StackField(extraCerts, handle))
+                        {
+                            throw Interop.Crypto.CreateOpenSslCryptographicException();
+                        }
+
+                        // Ownership was transferred to the cert stack.
+                        handle.SetHandleAsInvalid();
                     }
 
                     if (lookupCrl)
@@ -159,9 +166,19 @@ namespace Internal.Cryptography.Pal
                     }
                 }
 
+                foreach (X509Certificate2 trustedCert in systemTrusted)
+                {
+                    OpenSslX509CertificateReader pal = (OpenSslX509CertificateReader)trustedCert.Pal;
+
+                    if (!Interop.Crypto.X509StoreAddCert(store, pal.SafeHandle))
+                    {
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
+                    }
+                }
+
                 SafeX509Handle leafHandle = ((OpenSslX509CertificateReader)leaf.Pal).SafeHandle;
 
-                if (!Interop.Crypto.X509StoreCtxInit(storeCtx, store, leafHandle))
+                if (!Interop.Crypto.X509StoreCtxInit(storeCtx, store, leafHandle, extraCerts))
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
@@ -208,22 +225,6 @@ namespace Internal.Cryptography.Pal
 
                         // Duplicate the certificate handle
                         X509Certificate2 elementCert = new X509Certificate2(elementCertPtr);
-
-                        // If the last cert is self signed then it's the root cert, do any extra checks.
-                        if (i == maybeRootDepth && IsSelfSigned(elementCert))
-                        {
-                            // If the root certificate was downloaded or the system
-                            // doesn't trust it, it's untrusted.
-                            if (downloaded.Contains(elementCert) ||
-                                !systemTrusted.Contains(elementCert))
-                            {
-                                AddElementStatus(
-                                    Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_CERT_UNTRUSTED,
-                                    status,
-                                    overallStatus);
-                            }
-                        }
-
                         elements[i] = new X509ChainElement(elementCert, status.ToArray(), "");
                     }
                 }
@@ -737,7 +738,7 @@ namespace Internal.Cryptography.Pal
 
             internal int VerifyCallback(int ok, IntPtr ctx)
             {
-                if (ok < 0)
+                if (ok != 0)
                 {
                     return ok;
                 }

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -29,6 +29,9 @@
     <Project Include="..\pkg\Microsoft.NETCore.Targets\Microsoft.NETCore.Targets.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="System.Security.Cryptography.X509Certificates\pkg\System.Security.Cryptography.X509Certificates.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >   
@@ -36,7 +39,15 @@
     <Project Include=".\Native\pkg\runtime.native.System.IO.Compression\runtime.native.System.IO.Compression.builds">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true;SkipUnix=true</AdditionalProperties>
     </Project>
+    <Project Include=".\Native\pkg\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
+    </Project>
     <Project Include=".\Native\pkg\runtime.native.System.Security.Cryptography.Apple\runtime.native.System.Security.Cryptography.Apple.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
+    </Project>
+    <Project Include=".\Native\pkg\runtime.native.System.Security.Cryptography.OpenSsl\runtime.native.System.Security.Cryptography.OpenSsl.builds">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
       <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
     </Project>


### PR DESCRIPTION
Backport #19017 (and #23026) to release/1.1 so our X509Chain processing model is the same across all released versions.

The change for 2.0 changed the signature of the shim function since it's a side-by-side model. For 1.1 a new shim function was added and the P/Invoke target changed as a defensive measure.

This also includes the packaging changes necessary to service the X509Certificates library (which should pull up the native shim change through the package closure).

Addresses #23023 for 1.1