### PR TITLE
[release/1.0] Prevent crash when Openssl's PKCS12_parse function fails.

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -16,7 +16,7 @@
     <XmlDocFileRoot>$(PackagesDir)Microsoft.Private.Intellisense/1.0.0-rc4-24206-00/xmldocs</XmlDocFileRoot>
     <!-- We're currently not building a "live" baseline, instead we're using .NETCore 1.0 RTM stable versions as the baseline -->
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
-    <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.0.3</LineupPackageVersion>  
+    <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.0.4</LineupPackageVersion>  
     <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.0.2</PlatformPackageVersion>  
   </PropertyGroup>
 

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs12.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs12.cpp
@@ -55,6 +55,16 @@ extern "C" int32_t CryptoNative_Pkcs12Parse(PKCS12* p12, const char* pass, EVP_P
         // error queue.  If we're returning success, clear the error queue.
         ERR_clear_error();
     }
+    else
+    {
+        // If PKCS12_parse encounters an error it will free the handles it 
+        // created, but it does not clear the output parameters they were 
+        // placed in.
+        // If those handles make it back into managed code they will crash 
+        // the coreclr when Disposed.
+        *pkey = nullptr;
+        *cert = nullptr;
+    }
 
     return ret;
 }

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageTargetRuntime>debian.8-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageTargetRuntime>rhel.7-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -27,10 +27,17 @@
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
+    <Project Include="..\pkg\Microsoft.NETCore.Targets\Microsoft.NETCore.Targets.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >
     <!-- add specific native builds / pkgproj's here to include in servicing builds -->
+    <Project Include="Native\pkg\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
+    </Project>
   </ItemGroup>
 
   <UsingTask TaskName="GenerateNetStandardSupportTable" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll" />


### PR DESCRIPTION
Backport #11147 to release/1.0.

Packaging changes based off of #18365.

Fixes #23022.