### PR TITLE
Add DSA span-based methods

### DIFF
--- a/src/Common/src/Internal/Cryptography/AsymmetricAlgorithmHelpers.Der.cs
+++ b/src/Common/src/Internal/Cryptography/AsymmetricAlgorithmHelpers.Der.cs
@@ -19,7 +19,6 @@ namespace Internal.Cryptography
         /// </summary>
         public static byte[] ConvertIeee1363ToDer(ReadOnlySpan<byte> input)
         {
-            Debug.Assert(input != null);
             Debug.Assert(input.Length % 2 == 0);
             Debug.Assert(input.Length > 1);
 

--- a/src/Common/src/Internal/Cryptography/AsymmetricAlgorithmHelpers.Der.cs
+++ b/src/Common/src/Internal/Cryptography/AsymmetricAlgorithmHelpers.Der.cs
@@ -17,7 +17,7 @@ namespace Internal.Cryptography
         /// <summary>
         /// Convert Ieee1363 format of (r, s) to Der format
         /// </summary>
-        public static byte[] ConvertIeee1363ToDer(byte[] input)
+        public static byte[] ConvertIeee1363ToDer(ReadOnlySpan<byte> input)
         {
             Debug.Assert(input != null);
             Debug.Assert(input.Length % 2 == 0);
@@ -27,8 +27,8 @@ namespace Internal.Cryptography
             // Output is the DER encoded value of CONSTRUCTEDSEQUENCE(INTEGER(r), INTEGER(s)). 
             int halfLength = input.Length / 2;
 
-            byte[][] rEncoded = DerEncoder.SegmentedEncodeUnsignedInteger(input, 0, halfLength);
-            byte[][] sEncoded = DerEncoder.SegmentedEncodeUnsignedInteger(input, halfLength, halfLength);
+            byte[][] rEncoded = DerEncoder.SegmentedEncodeUnsignedInteger(input.Slice(0, halfLength));
+            byte[][] sEncoded = DerEncoder.SegmentedEncodeUnsignedInteger(input.Slice(halfLength, halfLength));
 
             return DerEncoder.ConstructSequence(rEncoded, sEncoded);
         }

--- a/src/Common/src/Internal/Cryptography/CngCommon.SignVerify.cs
+++ b/src/Common/src/Internal/Cryptography/CngCommon.SignVerify.cs
@@ -11,7 +11,7 @@ namespace Internal.Cryptography
 {
     internal static partial class CngCommon
     {
-        public static unsafe byte[] SignHash(this SafeNCryptKeyHandle keyHandle, byte[] hash, AsymmetricPaddingMode paddingMode, void* pPaddingInfo, int estimatedSize)
+        public static unsafe byte[] SignHash(this SafeNCryptKeyHandle keyHandle, ReadOnlySpan<byte> hash, AsymmetricPaddingMode paddingMode, void* pPaddingInfo, int estimatedSize)
         {
 #if DEBUG
             estimatedSize = 2;  // Make sure the NTE_BUFFER_TOO_SMALL scenario gets exercised.

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Dsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Dsa.cs
@@ -66,13 +66,31 @@ internal static partial class Interop
             return keySize;
         }
 
+        internal static unsafe bool DsaSign(SafeDsaHandle dsa, ReadOnlySpan<byte> hash, int hashLength, ReadOnlySpan<byte> refSignature, out int outSignatureLength)
+        {
+            fixed (byte* hashPtr = &hash.DangerousGetPinnableReference())
+            fixed (byte* refSignaturePtr = &refSignature.DangerousGetPinnableReference())
+            {
+                return DsaSign(dsa, hashPtr, hashLength, refSignaturePtr, out outSignatureLength);
+            }
+        }
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaSign")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool DsaSign(SafeDsaHandle dsa, byte[] hash, int hashLength, byte[] refSignature, out int outSignatureLength);
+        private static extern unsafe bool DsaSign(SafeDsaHandle dsa, byte* hash, int hashLength, byte* refSignature, out int outSignatureLength);
+
+        internal static unsafe bool DsaVerify(SafeDsaHandle dsa, ReadOnlySpan<byte> hash, int hashLength, ReadOnlySpan<byte> signature, int signatureLength)
+        {
+            fixed (byte* hashPtr = &hash.DangerousGetPinnableReference())
+            fixed (byte* signaturePtr = &signature.DangerousGetPinnableReference())
+            {
+                return DsaVerify(dsa, hashPtr, hashLength, signaturePtr, signatureLength);
+            }
+        }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaVerify")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool DsaVerify(SafeDsaHandle dsa, byte[] hash, int hashLength, byte[] signature, int signatureLength);
+        private static extern unsafe bool DsaVerify(SafeDsaHandle dsa, byte* hash, int hashLength, byte* signature, int signatureLength);
 
         internal static DSAParameters ExportDsaParameters(SafeDsaHandle key, bool includePrivateParameters)
         {

--- a/src/Common/src/System/Security/Cryptography/DSACng.SignVerify.cs
+++ b/src/Common/src/System/Security/Cryptography/DSACng.SignVerify.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using Internal.Cryptography;
 using Microsoft.Win32.SafeHandles;
-using System.Diagnostics;
 using static Interop.BCrypt;
 using static Interop.NCrypt;
 
@@ -19,15 +19,48 @@ namespace System.Security.Cryptography
             public override byte[] CreateSignature(byte[] rgbHash)
             {
                 if (rgbHash == null)
-                    throw new ArgumentNullException(nameof(rgbHash));
-
-                rgbHash = AdjustHashSizeIfNecessary(rgbHash);
-                using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
                 {
-                    unsafe
+                    throw new ArgumentNullException(nameof(rgbHash));
+                }
+
+                ReadOnlySpan<byte> source = rgbHash;
+                byte[] arrayToReturnToArrayPool = AdjustHashSizeIfNecessaryWithArrayPool(ref source);
+                try
+                {
+                    using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
                     {
-                        byte[] signature = CngCommon.SignHash(keyHandle, rgbHash, AsymmetricPaddingMode.None, null, rgbHash.Length * 2);
-                        return signature;
+                        unsafe
+                        {
+                            return CngCommon.SignHash(keyHandle, source, AsymmetricPaddingMode.None, null, source.Length * 2);
+                        }
+                    }
+                }
+                finally
+                {
+                    if (arrayToReturnToArrayPool != null)
+                    {
+                        Array.Clear(arrayToReturnToArrayPool, 0, source.Length);
+                        ArrayPool<byte>.Shared.Return(arrayToReturnToArrayPool);
+                    }
+                }
+            }
+
+            public override unsafe bool TryCreateSignature(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+            {
+                byte[] arrayToReturnToArrayPool = AdjustHashSizeIfNecessaryWithArrayPool(ref source);
+                try
+                {
+                    using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
+                    {
+                        return CngCommon.TrySignHash(keyHandle, source, destination, AsymmetricPaddingMode.None, null, out bytesWritten);
+                    }
+                }
+                finally
+                {
+                    if (arrayToReturnToArrayPool != null)
+                    {
+                        Array.Clear(arrayToReturnToArrayPool, 0, source.Length);
+                        ArrayPool<byte>.Shared.Return(arrayToReturnToArrayPool);
                     }
                 }
             }
@@ -35,29 +68,42 @@ namespace System.Security.Cryptography
             public override bool VerifySignature(byte[] rgbHash, byte[] rgbSignature)
             {
                 if (rgbHash == null)
-                    throw new ArgumentNullException(nameof(rgbHash));
-
-                if (rgbSignature == null)
-                    throw new ArgumentNullException(nameof(rgbSignature));
-
-                rgbHash = AdjustHashSizeIfNecessary(rgbHash);
-
-                using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
                 {
-                    unsafe
+                    throw new ArgumentNullException(nameof(rgbHash));
+                }
+                if (rgbSignature == null)
+                {
+                    throw new ArgumentNullException(nameof(rgbSignature));
+                }
+
+                return VerifySignature((ReadOnlySpan<byte>)rgbHash, (ReadOnlySpan<byte>)rgbSignature);
+            }
+
+            public override bool VerifySignature(ReadOnlySpan<byte> rgbHash, ReadOnlySpan<byte> rgbSignature)
+            {
+                byte[] arrayToReturnToArrayPool = AdjustHashSizeIfNecessaryWithArrayPool(ref rgbHash);
+                try
+                {
+                    using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
                     {
-                        bool verified = CngCommon.VerifyHash(keyHandle, rgbHash, rgbSignature, AsymmetricPaddingMode.None, null);
-                        return verified;
+                        unsafe
+                        {
+                            return CngCommon.VerifyHash(keyHandle, rgbHash, rgbSignature, AsymmetricPaddingMode.None, null);
+                        }
+                    }
+                }
+                finally
+                {
+                    if (arrayToReturnToArrayPool != null)
+                    {
+                        Array.Clear(arrayToReturnToArrayPool, 0, rgbHash.Length);
+                        ArrayPool<byte>.Shared.Return(arrayToReturnToArrayPool);
                     }
                 }
             }
 
-            private byte[] AdjustHashSizeIfNecessary(byte[] hash)
+            private byte[] AdjustHashSizeIfNecessaryWithArrayPool(ref ReadOnlySpan<byte> hash)
             {
-                Debug.Assert(hash != null);
-
-                int qLength = ComputeQLength();
-
                 // Windows CNG requires that the hash output and q match sizes, but we can better
                 // interoperate with other FIPS 186-3 implementations if we perform truncation
                 // here, before sending it to CNG. Since this is a scenario presented in the
@@ -67,20 +113,24 @@ namespace System.Security.Cryptography
                 // (since it gets treated as a big-endian number). Since this is also a scenario
                 // presented in the CAVP reference test suite, we can confirm our implementation.
 
+                int qLength = ComputeQLength();
+
                 if (qLength == hash.Length)
                 {
-                    return hash;
+                    return null;
                 }
-
-                if (qLength < hash.Length)
+                else if (qLength < hash.Length)
                 {
-                    Array.Resize(ref hash, qLength);
-                    return hash;
+                    hash = hash.Slice(0, qLength);
+                    return null;
                 }
-
-                byte[] paddedHash = new byte[qLength];
-                Buffer.BlockCopy(hash, 0, paddedHash, qLength - hash.Length, hash.Length);
-                return paddedHash;
+                else
+                {
+                    byte[] arrayPoolPaddedHash = ArrayPool<byte>.Shared.Rent(qLength);
+                    hash.CopyTo(new Span<byte>(arrayPoolPaddedHash, qLength - hash.Length, hash.Length));
+                    hash = new ReadOnlySpan<byte>(arrayPoolPaddedHash, 0, qLength);
+                    return arrayPoolPaddedHash;
+                }
             }
 
             private int ComputeQLength()

--- a/src/Common/src/System/Security/Cryptography/DSACng.cs
+++ b/src/Common/src/System/Security/Cryptography/DSACng.cs
@@ -48,15 +48,14 @@ namespace System.Security.Cryptography
             public override string KeyExchangeAlgorithm  => null;
 
             // Need to override since base methods throw a "override me" exception: makes SignData/VerifyData function.
-            protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
-            {
-                return CngCommon.HashData(data, offset, count, hashAlgorithm);
-            }
+            protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
+                CngCommon.HashData(data, offset, count, hashAlgorithm);
 
-            protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
-            {
-                return CngCommon.HashData(data, hashAlgorithm);
-            }
+            protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
+                CngCommon.HashData(data, hashAlgorithm);
+
+            protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+                CngCommon.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
 
             private void ForceSetKeySize(int newKeySize)
             {

--- a/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
@@ -208,6 +208,11 @@ namespace System.Security.Cryptography
                     if (signature == null)
                         throw new ArgumentNullException(nameof(signature));
 
+                    return VerifySignature((ReadOnlySpan<byte>)hash, (ReadOnlySpan<byte>)signature);
+                }
+
+                public override bool VerifySignature(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature)
+                {
                     byte[] derFormatSignature = AsymmetricAlgorithmHelpers.ConvertIeee1363ToDer(signature);
 
                     return Interop.AppleCrypto.VerifySignature(
@@ -227,10 +232,11 @@ namespace System.Security.Cryptography
                     return AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
                 }
 
-                protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
-                {
-                    return AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
-                }
+                protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
+                    AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
+
+                protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+                    AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
 
                 protected override void Dispose(bool disposing)
                 {

--- a/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
@@ -176,10 +176,10 @@ namespace System.Security.Cryptography
                     return Interop.AppleCrypto.ImportEphemeralKey(blob, hasPrivateKey);
                 }
 
-                public override byte[] CreateSignature(byte[] hash)
+                public override byte[] CreateSignature(byte[] rgbHash)
                 {
-                    if (hash == null)
-                        throw new ArgumentNullException(nameof(hash));
+                    if (rgbHash == null)
+                        throw new ArgumentNullException(nameof(rgbHash));
 
                     SecKeyPair keys = GetKeys();
 
@@ -188,7 +188,7 @@ namespace System.Security.Cryptography
                         throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
                     }
 
-                    byte[] derFormatSignature = Interop.AppleCrypto.GenerateSignature(keys.PrivateKey, hash);
+                    byte[] derFormatSignature = Interop.AppleCrypto.GenerateSignature(keys.PrivateKey, rgbHash);
 
                     // Since the AppleCrypto implementation is limited to FIPS 186-2, signature field sizes
                     // are always 160 bits / 20 bytes (the size of SHA-1, and the only legal length for Q).

--- a/src/Common/src/System/Security/Cryptography/DerEncoder.cs
+++ b/src/Common/src/System/Security/Cryptography/DerEncoder.cs
@@ -137,6 +137,8 @@ namespace System.Security.Cryptography
         /// <returns>The encoded segments { tag, length, value }</returns>
         internal static byte[][] SegmentedEncodeUnsignedInteger(ReadOnlySpan<byte> bigEndianBytes)
         {
+            Debug.Assert(!bigEndianBytes.IsEmpty, "The span must not be empty.");
+
             int start = 0;
             int end = start + bigEndianBytes.Length;
 
@@ -153,22 +155,11 @@ namespace System.Security.Cryptography
                 Debug.Assert(start >= 0);
             }
 
-            int length = end - start;
-            byte[] dataBytes;
-            int writeStart = 0;
-
             // If the first byte is bigger than 0x7F it will look like a negative number, since
             // we're unsigned, insert a zero-padding byte.
-            if (bigEndianBytes[start] > 0x7F)
-            {
-                dataBytes = new byte[length + 1];
-                writeStart = 1;
-            }
-            else
-            {
-                dataBytes = new byte[length];
-            }
-
+            int length = end - start;
+            int writeStart = bigEndianBytes[start] > 0x7F ? 1 : 0;
+            var dataBytes = new byte[length + writeStart];
             bigEndianBytes.Slice(start, length).CopyTo(new Span<byte>(dataBytes, writeStart));
 
             return new[]

--- a/src/Common/src/System/Security/Cryptography/DerEncoder.cs
+++ b/src/Common/src/System/Security/Cryptography/DerEncoder.cs
@@ -135,30 +135,10 @@ namespace System.Security.Cryptography
         /// </summary>
         /// <param name="bigEndianBytes">The value to encode, in big integer representation.</param>
         /// <returns>The encoded segments { tag, length, value }</returns>
-        internal static byte[][] SegmentedEncodeUnsignedInteger(byte[] bigEndianBytes)
+        internal static byte[][] SegmentedEncodeUnsignedInteger(ReadOnlySpan<byte> bigEndianBytes)
         {
-            Debug.Assert(bigEndianBytes != null);
-
-            return SegmentedEncodeUnsignedInteger(bigEndianBytes, 0, bigEndianBytes.Length);
-        }
-
-        /// <summary>
-        /// Encode the segments { tag, length, value } of an unsigned integer represented within a bounded array.
-        /// </summary>
-        /// <param name="bigEndianBytes">The value to encode, in big integer representation.</param>
-        /// <param name="offset">The offset into bigEndianBytes to read</param>
-        /// <param name="count">The count of bytes to read, must be greater than 0</param>
-        /// <returns>The encoded segments { tag, length, value }</returns>
-        internal static byte[][] SegmentedEncodeUnsignedInteger(byte[] bigEndianBytes, int offset, int count)
-        {
-            Debug.Assert(bigEndianBytes != null);
-            Debug.Assert(offset >= 0);
-            Debug.Assert(count > 0);
-            Debug.Assert(bigEndianBytes.Length > 0);
-            Debug.Assert(bigEndianBytes.Length >= count - offset);
-
-            int start = offset;
-            int end = start + count;
+            int start = 0;
+            int end = start + bigEndianBytes.Length;
 
             // Remove any leading zeroes.
             while (start < end && bigEndianBytes[start] == 0)
@@ -170,7 +150,7 @@ namespace System.Security.Cryptography
             if (start == end)
             {
                 start--;
-                Debug.Assert(start >= offset);
+                Debug.Assert(start >= 0);
             }
 
             int length = end - start;
@@ -189,7 +169,7 @@ namespace System.Security.Cryptography
                 dataBytes = new byte[length];
             }
 
-            Buffer.BlockCopy(bigEndianBytes, start, dataBytes, writeStart, length);
+            bigEndianBytes.Slice(start, length).CopyTo(new Span<byte>(dataBytes, writeStart));
 
             return new[]
             {

--- a/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -233,10 +233,7 @@ namespace System.Security.Cryptography
                 // with the already loaded key.
                 ForceSetKeySize(Interop.Crypto.EcKeyGetSize(newKey));
 
-                _key = new Lazy<SafeEcKeyHandle>(() => newKey, isThreadSafe: true);
-
-                // Have Lazy<T> consider the key to be loaded
-                var dummy = _key.Value;
+                _key = new Lazy<SafeEcKeyHandle>(newKey);
             }
         }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -262,7 +262,7 @@ namespace System.Security.Cryptography
             }
 
             FreeKey();
-            _key = new Lazy<SafeRsaHandle>(() => key, isThreadSafe:true);
+            _key = new Lazy<SafeRsaHandle>(key);
 
             // Use ForceSet instead of the property setter to ensure that LegalKeySizes doesn't interfere
             // with the already loaded key.

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.NistValidation.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.NistValidation.cs
@@ -7,10 +7,10 @@ using Xunit;
 
 namespace System.Security.Cryptography.Dsa.Tests
 {
-    public partial class DSASignVerify
+    public abstract partial class DSASignVerify
     {
         [Fact]
-        public static void Fips186_2_1()
+        public void Fips186_2_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-2dsatestvectors.zip
             // SigGen.txt, first case
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L1024_N160_SHA256_1()
+        public void Fips186_3_L1024_N160_SHA256_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L1024_N160_SHA384_1()
+        public void Fips186_3_L1024_N160_SHA384_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -129,7 +129,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L1024_N160_SHA384_4()
+        public void Fips186_3_L1024_N160_SHA384_4()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -169,7 +169,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L1024_N160_SHA512_1()
+        public void Fips186_3_L1024_N160_SHA512_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -209,7 +209,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L1024_N160_SHA512_4()
+        public void Fips186_3_L1024_N160_SHA512_4()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -249,7 +249,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L2048_N256_SHA256_1()
+        public void Fips186_3_L2048_N256_SHA256_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -306,7 +306,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L2048_N256_SHA384_1()
+        public void Fips186_3_L2048_N256_SHA384_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -363,7 +363,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L2048_N256_SHA1_1()
+        public void Fips186_3_L2048_N256_SHA1_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -420,7 +420,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L2048_N256_SHA384_3()
+        public void Fips186_3_L2048_N256_SHA384_3()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -477,7 +477,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L3072_N256_SHA256_1()
+        public void Fips186_3_L3072_N256_SHA256_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -546,7 +546,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L3072_N256_SHA384_1()
+        public void Fips186_3_L3072_N256_SHA384_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -615,7 +615,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L3072_N256_SHA512_1()
+        public void Fips186_3_L3072_N256_SHA512_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -684,7 +684,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Fips186_3_L3072_N256_SHA512_12()
+        public void Fips186_3_L3072_N256_SHA512_12()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
             // SigGen.txt
@@ -752,7 +752,7 @@ namespace System.Security.Cryptography.Dsa.Tests
             Validate(p, q, g, x, y, msg, r, s, HashAlgorithmName.SHA512);
         }
 
-        private static void Validate(
+        private void Validate(
             string p,
             string q,
             string g,
@@ -779,10 +779,10 @@ namespace System.Security.Cryptography.Dsa.Tests
                 byte[] message = msg.HexToByteArray();
                 byte[] signature = (r + s).HexToByteArray();
 
-                Assert.True(dsa.VerifyData(message, signature, hashAlgorithm), "Public+Private Valid Signature");
+                Assert.True(VerifyData(dsa, message, signature, hashAlgorithm), "Public+Private Valid Signature");
 
                 signature[0] ^= 0xFF;
-                Assert.False(dsa.VerifyData(message, signature, hashAlgorithm), "Public+Private Tampered Signature");
+                Assert.False(VerifyData(dsa, message, signature, hashAlgorithm), "Public+Private Tampered Signature");
             }
 
             // Public only
@@ -801,10 +801,10 @@ namespace System.Security.Cryptography.Dsa.Tests
                 byte[] message = msg.HexToByteArray();
                 byte[] signature = (r + s).HexToByteArray();
 
-                Assert.True(dsa.VerifyData(message, signature, hashAlgorithm), "Public-Only Valid Signature");
+                Assert.True(VerifyData(dsa, message, signature, hashAlgorithm), "Public-Only Valid Signature");
 
                 signature[0] ^= 0xFF;
-                Assert.False(dsa.VerifyData(message, signature, hashAlgorithm), "Public-Only Tampered Signature");
+                Assert.False(VerifyData(dsa, message, signature, hashAlgorithm), "Public-Only Tampered Signature");
             }
         }
     }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -2,40 +2,124 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using Test.Cryptography;
 using Xunit;
 
 namespace System.Security.Cryptography.Dsa.Tests
 {
-    public partial class DSASignVerify
+    public sealed class DSASignVerify_Array : DSASignVerify
     {
+        public override byte[] SignData(DSA dsa, byte[] data, HashAlgorithmName hashAlgorithm) =>
+            dsa.SignData(data, hashAlgorithm);
+        public override bool VerifyData(DSA dsa, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm) =>
+            dsa.VerifyData(data, signature, hashAlgorithm);
+
+        [Fact]
+        public void InvalidStreamArrayArguments_Throws()
+        {
+            using (DSA dsa = DSAFactory.Create(1024))
+            {
+                AssertExtensions.Throws<ArgumentNullException>("rgbHash", () => dsa.CreateSignature(null));
+
+                AssertExtensions.Throws<ArgumentNullException>("data", () => dsa.SignData((byte[])null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentNullException>("data", () => dsa.SignData(null, 0, 0, HashAlgorithmName.SHA1));
+
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => dsa.SignData(new byte[1], -1, 0, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => dsa.SignData(new byte[1], 2, 0, HashAlgorithmName.SHA1));
+
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => dsa.SignData(new byte[1], 0, -1, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => dsa.SignData(new byte[1], 0, 2, HashAlgorithmName.SHA1));
+
+                AssertExtensions.Throws<ArgumentNullException>("data", () => dsa.VerifyData((byte[])null, null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentNullException>("data", () => dsa.VerifyData(null, 0, 0, null, HashAlgorithmName.SHA1));
+
+                AssertExtensions.Throws<ArgumentNullException>("signature", () => dsa.VerifyData(new byte[1], null, HashAlgorithmName.SHA1));
+
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => dsa.VerifyData(new byte[1], -1, 0, new byte[1], HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => dsa.VerifyData(new byte[1], 2, 0, new byte[1], HashAlgorithmName.SHA1));
+
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => dsa.VerifyData(new byte[1], 0, -1, new byte[1], HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => dsa.VerifyData(new byte[1], 0, 2, new byte[1], HashAlgorithmName.SHA1));
+            }
+        }
+    }
+
+    public sealed class DSASignVerify_Stream : DSASignVerify
+    {
+        public override byte[] SignData(DSA dsa, byte[] data, HashAlgorithmName hashAlgorithm) =>
+            dsa.SignData(new MemoryStream(data), hashAlgorithm);
+        public override bool VerifyData(DSA dsa, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm) =>
+            dsa.VerifyData(new MemoryStream(data), signature, hashAlgorithm);
+
+        [Fact]
+        public void InvalidArrayArguments_Throws()
+        {
+            using (DSA dsa = DSAFactory.Create(1024))
+            {
+                AssertExtensions.Throws<ArgumentNullException>("data", () => dsa.SignData((Stream)null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentNullException>("data", () => dsa.VerifyData((Stream)null, null, HashAlgorithmName.SHA1));
+
+                AssertExtensions.Throws<ArgumentNullException>("signature", () => dsa.VerifyData(new MemoryStream(), null, HashAlgorithmName.SHA1));
+            }
+        }
+    }
+
+    public sealed class DSASignVerify_Span : DSASignVerify
+    {
+        public override byte[] SignData(DSA dsa, byte[] data, HashAlgorithmName hashAlgorithm) =>
+            TryWithOutputArray(dest => dsa.TrySignData(data, dest, hashAlgorithm, out int bytesWritten) ? (true, bytesWritten) : (false, 0));
+
+        public override bool VerifyData(DSA dsa, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm) =>
+            dsa.VerifyData((ReadOnlySpan<byte>)data, (ReadOnlySpan<byte>)signature, hashAlgorithm);
+
+        private static byte[] TryWithOutputArray(Func<byte[], (bool, int)> func)
+        {
+            for (int length = 256; ; length = checked(length * 2))
+            {
+                var result = new byte[length];
+                var (success, bytesWritten) = func(result);
+                if (success)
+                {
+                    Array.Resize(ref result, bytesWritten);
+                    return result;
+                }
+            }
+        }
+    }
+
+    public abstract partial class DSASignVerify
+    {
+        public abstract byte[] SignData(DSA dsa, byte[] data, HashAlgorithmName hashAlgorithm);
+        public abstract bool VerifyData(DSA dsa, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm);
+
         [ConditionalFact(nameof(SupportsKeyGeneration))]
-        public static void InvalidKeySize_DoesNotInvalidateKey()
+        public void InvalidKeySize_DoesNotInvalidateKey()
         {
             using (DSA dsa = DSAFactory.Create())
             {
-                byte[] signature = dsa.SignData(DSATestData.HelloBytes, HashAlgorithmName.SHA1);
+                byte[] signature = SignData(dsa, DSATestData.HelloBytes, HashAlgorithmName.SHA1);
 
                 // A 2049-bit key is hard to describe, none of the providers support it.
                 Assert.ThrowsAny<CryptographicException>(() => dsa.KeySize = 2049);
 
-                Assert.True(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA1));
+                Assert.True(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA1));
             }
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
-        public static void SignAndVerifyDataNew1024()
+        public void SignAndVerifyDataNew1024()
         {
             using (DSA dsa = DSAFactory.Create(1024))
             {
-                byte[] signature = dsa.SignData(DSATestData.HelloBytes, new HashAlgorithmName("SHA1"));
-                bool signatureMatched = dsa.VerifyData(DSATestData.HelloBytes, signature, new HashAlgorithmName("SHA1"));
+                byte[] signature = SignData(dsa, DSATestData.HelloBytes, new HashAlgorithmName("SHA1"));
+                bool signatureMatched = VerifyData(dsa, DSATestData.HelloBytes, signature, new HashAlgorithmName("SHA1"));
                 Assert.True(signatureMatched);
             }
         }
 
         [Fact]
-        public static void VerifyKnown_512()
+        public void VerifyKnown_512()
         {
             byte[] signature = (
                 // r:
@@ -46,12 +130,12 @@ namespace System.Security.Cryptography.Dsa.Tests
             using (DSA dsa = DSAFactory.Create())
             {
                 dsa.ImportParameters(DSATestData.Dsa512Parameters);
-                Assert.True(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA1));
+                Assert.True(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA1));
             }
         }
 
         [Fact]
-        public static void VerifyKnown_576()
+        public void VerifyKnown_576()
         {
             byte[] signature = (
                 // r:
@@ -62,12 +146,12 @@ namespace System.Security.Cryptography.Dsa.Tests
             using (DSA dsa = DSAFactory.Create())
             {
                 dsa.ImportParameters(DSATestData.Dsa576Parameters);
-                Assert.True(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA1));
+                Assert.True(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA1));
             }
         }
 
         [Fact]
-        public static void PublicKey_CannotSign()
+        public void PublicKey_CannotSign()
         {
             DSAParameters keyParameters = DSATestData.GetDSA1024Params();
             keyParameters.X = null;
@@ -77,24 +161,24 @@ namespace System.Security.Cryptography.Dsa.Tests
                 dsa.ImportParameters(keyParameters);
 
                 Assert.ThrowsAny<CryptographicException>(
-                    () => dsa.SignData(DSATestData.HelloBytes, HashAlgorithmName.SHA1));
+                    () => SignData(dsa, DSATestData.HelloBytes, HashAlgorithmName.SHA1));
             }
         }
 
         [Fact]
-        public static void SignAndVerifyDataExplicit1024()
+        public void SignAndVerifyDataExplicit1024()
         {
             SignAndVerify(DSATestData.HelloBytes, "SHA1", DSATestData.GetDSA1024Params(), 40);
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void SignAndVerifyDataExplicit2048()
+        public void SignAndVerifyDataExplicit2048()
         {
             SignAndVerify(DSATestData.HelloBytes, "SHA256", DSATestData.GetDSA2048Params(), 64);
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void VerifyKnown_2048_SHA256()
+        public void VerifyKnown_2048_SHA256()
         {
             byte[] signature =
             {
@@ -111,14 +195,14 @@ namespace System.Security.Cryptography.Dsa.Tests
             using (DSA dsa = DSAFactory.Create())
             {
                 dsa.ImportParameters(DSATestData.GetDSA2048Params());
-                Assert.True(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA256));
-                Assert.False(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA384));
-                Assert.False(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA512));
+                Assert.True(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA256));
+                Assert.False(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA384));
+                Assert.False(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA512));
             }
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void VerifyKnown_2048_SHA384()
+        public void VerifyKnown_2048_SHA384()
         {
             byte[] signature =
             {
@@ -135,14 +219,14 @@ namespace System.Security.Cryptography.Dsa.Tests
             using (DSA dsa = DSAFactory.Create())
             {
                 dsa.ImportParameters(DSATestData.GetDSA2048Params());
-                Assert.True(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA384));
-                Assert.False(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA256));
-                Assert.False(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA512));
+                Assert.True(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA384));
+                Assert.False(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA256));
+                Assert.False(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA512));
             }
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void VerifyKnown_2048_SHA512()
+        public void VerifyKnown_2048_SHA512()
         {
             byte[] signature =
             {
@@ -159,14 +243,14 @@ namespace System.Security.Cryptography.Dsa.Tests
             using (DSA dsa = DSAFactory.Create())
             {
                 dsa.ImportParameters(DSATestData.GetDSA2048Params());
-                Assert.True(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA512));
-                Assert.False(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA256));
-                Assert.False(dsa.VerifyData(DSATestData.HelloBytes, signature, HashAlgorithmName.SHA384));
+                Assert.True(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA512));
+                Assert.False(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA256));
+                Assert.False(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA384));
             }
         }
 
         [Fact]
-        public static void VerifyKnownSignature()
+        public void VerifyKnownSignature()
         {
             using (DSA dsa = DSAFactory.Create())
             {
@@ -176,16 +260,16 @@ namespace System.Security.Cryptography.Dsa.Tests
                 DSATestData.GetDSA1024_186_2(out dsaParameters, out signature, out data);
 
                 dsa.ImportParameters(dsaParameters);
-                Assert.True(dsa.VerifyData(data, signature, HashAlgorithmName.SHA1));
+                Assert.True(VerifyData(dsa, data, signature, HashAlgorithmName.SHA1));
 
                 // Negative case
                 signature[signature.Length - 1] ^= 0xff;
-                Assert.False(dsa.VerifyData(data, signature, HashAlgorithmName.SHA1));
+                Assert.False(VerifyData(dsa, data, signature, HashAlgorithmName.SHA1));
             }
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Sign2048WithSha1()
+        public void Sign2048WithSha1()
         {
             byte[] data = { 1, 2, 3, 4 };
 
@@ -193,14 +277,14 @@ namespace System.Security.Cryptography.Dsa.Tests
             {
                 dsa.ImportParameters(DSATestData.GetDSA2048Params());
 
-                byte[] signature = dsa.SignData(data, HashAlgorithmName.SHA1);
+                byte[] signature = SignData(dsa, data, HashAlgorithmName.SHA1);
 
-                Assert.True(dsa.VerifyData(data, signature, HashAlgorithmName.SHA1));
+                Assert.True(VerifyData(dsa, data, signature, HashAlgorithmName.SHA1));
             }
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
-        public static void Verify2048WithSha1()
+        public void Verify2048WithSha1()
         {
             byte[] data = { 1, 2, 3, 4 };
 
@@ -212,25 +296,25 @@ namespace System.Security.Cryptography.Dsa.Tests
             {
                 dsa.ImportParameters(DSATestData.GetDSA2048Params());
 
-                Assert.True(dsa.VerifyData(data, signature, HashAlgorithmName.SHA1), "Untampered data verifies");
+                Assert.True(VerifyData(dsa, data, signature, HashAlgorithmName.SHA1), "Untampered data verifies");
 
                 data[0] ^= 0xFF;
-                Assert.False(dsa.VerifyData(data, signature, HashAlgorithmName.SHA1), "Tampered data verifies");
+                Assert.False(VerifyData(dsa, data, signature, HashAlgorithmName.SHA1), "Tampered data verifies");
 
                 data[0] ^= 0xFF;
                 signature[signature.Length - 1] ^= 0xFF;
-                Assert.False(dsa.VerifyData(data, signature, HashAlgorithmName.SHA1), "Tampered signature verifies");
+                Assert.False(VerifyData(dsa, data, signature, HashAlgorithmName.SHA1), "Tampered signature verifies");
             }
         }
 
-        private static void SignAndVerify(byte[] data, string hashAlgorithmName, DSAParameters dsaParameters, int expectedSignatureLength)
+        private void SignAndVerify(byte[] data, string hashAlgorithmName, DSAParameters dsaParameters, int expectedSignatureLength)
         {
             using (DSA dsa = DSAFactory.Create())
             {
                 dsa.ImportParameters(dsaParameters);
-                byte[] signature = dsa.SignData(data, new HashAlgorithmName(hashAlgorithmName));
+                byte[] signature = SignData(dsa, data, new HashAlgorithmName(hashAlgorithmName));
                 Assert.Equal(expectedSignatureLength, signature.Length);
-                bool signatureMatched = dsa.VerifyData(data, signature, new HashAlgorithmName(hashAlgorithmName));
+                bool signatureMatched = VerifyData(dsa, data, signature, new HashAlgorithmName(hashAlgorithmName));
                 Assert.True(signatureMatched);
             }
         }

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.netcoreapp.cs
@@ -8,6 +8,14 @@
 
 namespace System.Security.Cryptography
 {
+    public abstract partial class DSA : System.Security.Cryptography.AsymmetricAlgorithm
+    {
+        public virtual bool TryCreateSignature(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) { throw null; }
+        protected virtual bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
+        public virtual bool TrySignData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
+        public virtual bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm) { throw null; }
+        public virtual bool VerifySignature(ReadOnlySpan<byte> rgbHash, ReadOnlySpan<byte> rgbSignature) { throw null; }
+    }
     public sealed partial class IncrementalHash : System.IDisposable
     {
         public void AppendData(System.ReadOnlySpan<byte> data) { }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
@@ -132,7 +132,7 @@ namespace System.Security.Cryptography
         public virtual bool TryCreateSignature(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
             byte[] sig = CreateSignature(source.ToArray());
-            if (destination.Length >= sig.Length)
+            if (sig.Length <= destination.Length)
             {
                 new ReadOnlySpan<byte>(sig).CopyTo(destination);
                 bytesWritten = sig.Length;

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.IO;
 
 namespace System.Security.Cryptography
@@ -69,6 +70,10 @@ namespace System.Security.Cryptography
 
         public byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm)
         {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
             return SignData(data, 0, data.Length, hashAlgorithm);
         }
 
@@ -77,7 +82,7 @@ namespace System.Security.Cryptography
             if (data == null) { throw new ArgumentNullException(nameof(data)); }
             if (offset < 0 || offset > data.Length) { throw new ArgumentOutOfRangeException(nameof(offset)); }
             if (count < 0 || count > data.Length - offset) { throw new ArgumentOutOfRangeException(nameof(count)); }
-            if (String.IsNullOrEmpty(hashAlgorithm.Name)) { throw HashAlgorithmNameNullOrEmpty(); }
+            if (string.IsNullOrEmpty(hashAlgorithm.Name)) { throw HashAlgorithmNameNullOrEmpty(); }
 
             byte[] hash = HashData(data, offset, count, hashAlgorithm);
             return CreateSignature(hash);
@@ -86,7 +91,7 @@ namespace System.Security.Cryptography
         public virtual byte[] SignData(Stream data, HashAlgorithmName hashAlgorithm)
         {
             if (data == null) { throw new ArgumentNullException(nameof(data)); }
-            if (String.IsNullOrEmpty(hashAlgorithm.Name)) { throw HashAlgorithmNameNullOrEmpty(); }
+            if (string.IsNullOrEmpty(hashAlgorithm.Name)) { throw HashAlgorithmNameNullOrEmpty(); }
 
             byte[] hash = HashData(data, hashAlgorithm);
             return CreateSignature(hash);
@@ -94,6 +99,11 @@ namespace System.Security.Cryptography
 
         public bool VerifyData(byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm)
         {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
             return VerifyData(data, 0, data.Length, signature, hashAlgorithm);
         }
 
@@ -103,7 +113,7 @@ namespace System.Security.Cryptography
             if (offset < 0 || offset > data.Length) { throw new ArgumentOutOfRangeException(nameof(offset)); }
             if (count < 0 || count > data.Length - offset) { throw new ArgumentOutOfRangeException(nameof(count)); }
             if (signature == null) { throw new ArgumentNullException(nameof(signature)); }
-            if (String.IsNullOrEmpty(hashAlgorithm.Name)) { throw HashAlgorithmNameNullOrEmpty(); }
+            if (string.IsNullOrEmpty(hashAlgorithm.Name)) { throw HashAlgorithmNameNullOrEmpty(); }
 
             byte[] hash = HashData(data, offset, count, hashAlgorithm);
             return VerifySignature(hash, signature);
@@ -113,20 +123,104 @@ namespace System.Security.Cryptography
         {
             if (data == null) { throw new ArgumentNullException(nameof(data)); }
             if (signature == null) { throw new ArgumentNullException(nameof(signature)); }
-            if (String.IsNullOrEmpty(hashAlgorithm.Name)) { throw HashAlgorithmNameNullOrEmpty(); }
+            if (string.IsNullOrEmpty(hashAlgorithm.Name)) { throw HashAlgorithmNameNullOrEmpty(); }
 
             byte[] hash = HashData(data, hashAlgorithm);
             return VerifySignature(hash, signature);
         }
 
-        private static Exception DerivedClassMustOverride()
+        public virtual bool TryCreateSignature(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            return new NotImplementedException(SR.NotSupported_SubclassOverride);
+            byte[] sig = CreateSignature(source.ToArray());
+            if (destination.Length >= sig.Length)
+            {
+                new ReadOnlySpan<byte>(sig).CopyTo(destination);
+                bytesWritten = sig.Length;
+                return true;
+            }
+            else
+            {
+                bytesWritten = 0;
+                return false;
+            }
         }
 
-        internal static Exception HashAlgorithmNameNullOrEmpty()
+        protected virtual bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
         {
-            return new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
+            byte[] array = ArrayPool<byte>.Shared.Rent(source.Length);
+            try
+            {
+                source.CopyTo(array);
+                byte[] hash = HashData(array, 0, source.Length, hashAlgorithm);
+                if (destination.Length >= hash.Length)
+                {
+                    new ReadOnlySpan<byte>(hash).CopyTo(destination);
+                    bytesWritten = hash.Length;
+                    return true;
+                }
+                else
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+            }
+            finally
+            {
+                Array.Clear(array, 0, source.Length);
+                ArrayPool<byte>.Shared.Return(array);
+            }
         }
+
+        public virtual bool TrySignData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
+        {
+            if (string.IsNullOrEmpty(hashAlgorithm.Name))
+            {
+                throw HashAlgorithmNameNullOrEmpty();
+            }
+
+            if (TryHashData(source, destination, hashAlgorithm, out int hashLength) &&
+                TryCreateSignature(destination.Slice(0, hashLength), destination, out bytesWritten))
+            {
+                return true;
+            }
+
+            bytesWritten = 0;
+            return false;
+        }
+
+        public virtual bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm)
+        {
+            if (string.IsNullOrEmpty(hashAlgorithm.Name))
+            {
+                throw HashAlgorithmNameNullOrEmpty();
+            }
+
+            for (int i = 256; ; i = checked(i * 2))
+            {
+                int hashLength = 0;
+                byte[] hash = ArrayPool<byte>.Shared.Rent(i);
+                try
+                {
+                    if (TryHashData(data, hash, hashAlgorithm, out hashLength))
+                    {
+                        return VerifySignature(new ReadOnlySpan<byte>(hash, 0, hashLength), signature);
+                    }
+                }
+                finally
+                {
+                    Array.Clear(hash, 0, hashLength);
+                    ArrayPool<byte>.Shared.Return(hash);
+                }
+            }
+        }
+
+        public virtual bool VerifySignature(ReadOnlySpan<byte> rgbHash, ReadOnlySpan<byte> rgbSignature) =>
+            VerifySignature(rgbHash.ToArray(), rgbSignature.ToArray());
+
+        private static Exception DerivedClassMustOverride() =>
+            new NotImplementedException(SR.NotSupported_SubclassOverride);
+
+        internal static Exception HashAlgorithmNameNullOrEmpty() =>
+            new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/DSATests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DSATests.cs
@@ -4,12 +4,15 @@
 
 using System.IO;
 using System.Reflection;
+using System.Security.Cryptography.Dsa.Tests;
 using Xunit;
 
 namespace System.Security.Cryptography.Algorithms.Tests
 {
     public class DSATests
     {
+        public static bool SupportsKeyGeneration => DSAFactory.SupportsKeyGeneration;
+
         [Fact]
         public void BaseVirtualsNotImplementedException()
         {
@@ -18,7 +21,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
             Assert.Throws<NotImplementedException>(() => dsa.HashData(null, 0, 0, HashAlgorithmName.SHA1));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public void TryCreateSignature_UsesCreateSignature()
         {
             var input = new byte[1024];
@@ -59,7 +62,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public void TrySignData_UsesTryHashDataAndTryCreateSignature()
         {
             var input = new byte[1024];
@@ -84,7 +87,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public void VerifyData_Array_UsesHashDataAndVerifySignature()
         {
             var input = new byte[1024];
@@ -108,7 +111,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public void VerifyData_Stream_UsesHashDataAndVerifySignature()
         {
             var input = new byte[1024];
@@ -127,7 +130,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public void VerifyData_Span_UsesTryHashDataAndVerifySignature()
         {
             var input = new byte[1024];

--- a/src/System.Security.Cryptography.Algorithms/tests/DSATests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DSATests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Reflection;
 using Xunit;
 
 namespace System.Security.Cryptography.Algorithms.Tests
@@ -13,8 +14,134 @@ namespace System.Security.Cryptography.Algorithms.Tests
         public void BaseVirtualsNotImplementedException()
         {
             var dsa = new EmptyDSA();
-            Assert.Throws<NotImplementedException>(() => dsa.HashData(null, HashAlgorithmName.SHA256));
-            Assert.Throws<NotImplementedException>(() => dsa.HashData(null, 0, 0, HashAlgorithmName.SHA256));
+            Assert.Throws<NotImplementedException>(() => dsa.HashData(null, HashAlgorithmName.SHA1));
+            Assert.Throws<NotImplementedException>(() => dsa.HashData(null, 0, 0, HashAlgorithmName.SHA1));
+        }
+
+        [Fact]
+        public void TryCreateSignature_UsesCreateSignature()
+        {
+            var input = new byte[1024];
+            new Random(42).NextBytes(input);
+            int bytesWritten = 0;
+
+            using (var wrapperDsa = new OverrideAbstractDSA(DSA.Create(1024)))
+            {
+                byte[] initialSig = wrapperDsa.CreateSignature(input);
+                byte[] actualSig = new byte[initialSig.Length];
+
+                Assert.False(wrapperDsa.TryCreateSignature(input, new Span<byte>(actualSig, 0, actualSig.Length - 1), out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+                Assert.All(actualSig, b => Assert.Equal(0, b));
+
+                Assert.True(wrapperDsa.TryCreateSignature(input, actualSig, out bytesWritten));
+                Assert.Equal(initialSig.Length, bytesWritten);
+                Assert.Contains(actualSig, b => b != 0);
+            }
+        }
+
+        [Fact]
+        public void SignData_InvalidArguments_Throws()
+        {
+            using (var wrapperDsa = new OverrideAbstractDSA(DSA.Create(1024)))
+            {
+                AssertExtensions.Throws<ArgumentNullException>("data", () => wrapperDsa.SignData((byte[])null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentNullException>("data", () => wrapperDsa.SignData((Stream)null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentNullException>("data", () => wrapperDsa.SignData(null, 0, 0, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => wrapperDsa.SignData(new byte[1], -1, 0, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => wrapperDsa.SignData(new byte[1], 2, 0, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => wrapperDsa.SignData(new byte[1], 0, -1, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => wrapperDsa.SignData(new byte[1], 0, 2, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.SignData(new byte[1], new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.SignData(new byte[1], new HashAlgorithmName("")));
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.SignData(new MemoryStream(new byte[1]), new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.SignData(new MemoryStream(new byte[1]), new HashAlgorithmName("")));
+            }
+        }
+
+        [Fact]
+        public void TrySignData_UsesTryHashDataAndTryCreateSignature()
+        {
+            var input = new byte[1024];
+            new Random(42).NextBytes(input);
+            int bytesWritten = 0;
+
+            using (var wrapperDsa = new OverrideAbstractDSA(DSA.Create(1024)))
+            {
+                byte[] initialSig = wrapperDsa.SignData(input, HashAlgorithmName.SHA1);
+                byte[] actualSig = new byte[initialSig.Length];
+
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.TrySignData(new byte[1], new byte[1], new HashAlgorithmName(null), out int _));
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.TrySignData(new byte[1], new byte[1], new HashAlgorithmName(""), out int _));
+
+                Assert.False(wrapperDsa.TrySignData(input, new Span<byte>(actualSig, 0, 1), HashAlgorithmName.SHA1, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+                Assert.All(actualSig, b => Assert.Equal(0, b));
+
+                Assert.True(wrapperDsa.TrySignData(input, actualSig, HashAlgorithmName.SHA1, out bytesWritten));
+                Assert.Equal(initialSig.Length, bytesWritten);
+                Assert.Contains(actualSig, b => b != 0);
+            }
+        }
+
+        [Fact]
+        public void VerifyData_Array_UsesHashDataAndVerifySignature()
+        {
+            var input = new byte[1024];
+            new Random(42).NextBytes(input);
+
+            using (var wrapperDsa = new OverrideAbstractDSA(DSA.Create(1024)))
+            {
+                AssertExtensions.Throws<ArgumentNullException>("data", () => wrapperDsa.VerifyData((byte[])null, null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentNullException>("data", () => wrapperDsa.VerifyData(null, 0, 0, null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => wrapperDsa.VerifyData(new byte[1], -1, 0, null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => wrapperDsa.VerifyData(new byte[1], 2, 0, null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => wrapperDsa.VerifyData(new byte[1], 0, -1, null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => wrapperDsa.VerifyData(new byte[1], 0, 2, null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentNullException>("signature", () => wrapperDsa.VerifyData(new byte[1], 0, 1, null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData(new byte[1], new byte[1], new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData(new byte[1], new byte[1], new HashAlgorithmName("")));
+
+                byte[] signature = wrapperDsa.SignData(input, HashAlgorithmName.SHA1);
+                Assert.True(wrapperDsa.VerifyData(input.AsSpan(), signature, HashAlgorithmName.SHA1));
+                Assert.False(wrapperDsa.VerifyData(input.AsSpan(), signature.AsReadOnlySpan().Slice(0, signature.Length - 1), HashAlgorithmName.SHA1));
+            }
+        }
+
+        [Fact]
+        public void VerifyData_Stream_UsesHashDataAndVerifySignature()
+        {
+            var input = new byte[1024];
+            new Random(42).NextBytes(input);
+
+            using (var wrapperDsa = new OverrideAbstractDSA(DSA.Create(1024)))
+            {
+                AssertExtensions.Throws<ArgumentNullException>("data", () => wrapperDsa.VerifyData((Stream)null, null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentNullException>("signature", () => wrapperDsa.VerifyData(new MemoryStream(new byte[1]), null, HashAlgorithmName.SHA1));
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData(new MemoryStream(new byte[1]), new byte[1], new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData(new MemoryStream(new byte[1]), new byte[1], new HashAlgorithmName("")));
+
+                byte[] signature = wrapperDsa.SignData(new MemoryStream(input), HashAlgorithmName.SHA1);
+                Assert.True(wrapperDsa.VerifyData(new MemoryStream(input), signature, HashAlgorithmName.SHA1));
+                Assert.False(wrapperDsa.VerifyData(new MemoryStream(input), signature.AsReadOnlySpan().Slice(0, signature.Length - 1).ToArray(), HashAlgorithmName.SHA1));
+            }
+        }
+
+        [Fact]
+        public void VerifyData_Span_UsesTryHashDataAndVerifySignature()
+        {
+            var input = new byte[1024];
+            new Random(42).NextBytes(input);
+
+            using (var wrapperDsa = new OverrideAbstractDSA(DSA.Create(1024)))
+            {
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData((Span<byte>)new byte[1], new byte[1], new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData((Span<byte>)new byte[1], new byte[1], new HashAlgorithmName("")));
+
+                byte[] signature = wrapperDsa.SignData(input, HashAlgorithmName.SHA1);
+                Assert.True(wrapperDsa.VerifyData(input.AsSpan(), signature, HashAlgorithmName.SHA1));
+                Assert.False(wrapperDsa.VerifyData(input.AsSpan(), signature.AsReadOnlySpan().Slice(0, signature.Length - 1), HashAlgorithmName.SHA1));
+            }
         }
 
         private sealed class EmptyDSA : DSA
@@ -30,6 +157,35 @@ namespace System.Security.Cryptography.Algorithms.Tests
                 base.HashData(data, hashAlgorithm);
             public new bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
                 base.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
+        }
+
+        private sealed class OverrideAbstractDSA : DSA
+        {
+            private readonly DSA _dsa;
+
+            public OverrideAbstractDSA(DSA dsa) => _dsa = dsa;
+            protected override void Dispose(bool disposing) => _dsa.Dispose();
+
+            public override byte[] CreateSignature(byte[] rgbHash) => _dsa.CreateSignature(rgbHash);
+            public override DSAParameters ExportParameters(bool includePrivateParameters) => _dsa.ExportParameters(includePrivateParameters);
+            public override void ImportParameters(DSAParameters parameters) => _dsa.ImportParameters(parameters);
+            public override bool VerifySignature(byte[] rgbHash, byte[] rgbSignature) => _dsa.VerifySignature(rgbHash, rgbSignature);
+            protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
+                (byte[])_dsa.GetType().GetMethod(
+                    nameof(HashData),
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    null,
+                    new Type[] { typeof(Stream), typeof(HashAlgorithmName) },
+                    null)
+                .Invoke(_dsa, new object[] { data, hashAlgorithm });
+            protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
+                (byte[])_dsa.GetType().GetMethod(
+                    nameof(HashData),
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    null,
+                    new Type[] { typeof(byte[]), typeof(int), typeof(int), typeof(HashAlgorithmName) },
+                    null)
+                .Invoke(_dsa, new object[] { data, offset, count, hashAlgorithm });
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/DSATests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DSATests.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Xunit;
+
+namespace System.Security.Cryptography.Algorithms.Tests
+{
+    public class DSATests
+    {
+        [Fact]
+        public void BaseVirtualsNotImplementedException()
+        {
+            var dsa = new EmptyDSA();
+            Assert.Throws<NotImplementedException>(() => dsa.HashData(null, HashAlgorithmName.SHA256));
+            Assert.Throws<NotImplementedException>(() => dsa.HashData(null, 0, 0, HashAlgorithmName.SHA256));
+        }
+
+        private sealed class EmptyDSA : DSA
+        {
+            public override byte[] CreateSignature(byte[] rgbHash) => throw new NotImplementedException();
+            public override void ImportParameters(DSAParameters parameters) => throw new NotImplementedException();
+            public override DSAParameters ExportParameters(bool includePrivateParameters) => throw new NotImplementedException();
+            public override bool VerifySignature(byte[] rgbHash, byte[] rgbSignature) => throw new NotImplementedException();
+
+            public new byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
+                base.HashData(data, offset, count, hashAlgorithm);
+            public new byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
+                base.HashData(data, hashAlgorithm);
+            public new bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
+                base.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="DESTests.cs" />
     <Compile Include="DSACreateTests.cs" />
     <Compile Include="DSASignatureFormatterTests.cs" />
+    <Compile Include="DSATests.cs" />
     <Compile Include="ECDiffieHellmanPublicKeyTests.cs" />
     <Compile Include="HashAlgorithmTest.netcoreapp.cs" />
     <Compile Include="IncrementalHashTests.netcoreapp.cs" />

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -276,6 +276,7 @@
     <Reference Include="System.Runtime.Handles" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Resources.ResourceManager" />

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -86,6 +86,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
@@ -46,9 +46,12 @@ namespace System.Security.Cryptography
         {
             throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_CAPI_Required, nameof(CspParameters)));
         }
-
+        
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5351", Justification = "This is the implementation of DSACryptoServiceProvider")]
         public override byte[] CreateSignature(byte[] rgbHash) => _impl.CreateSignature(rgbHash);
+
+        public override bool TryCreateSignature(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) =>
+            _impl.TryCreateSignature(source, destination, out bytesWritten);
 
         public CspKeyContainerInfo CspKeyContainerInfo
         {
@@ -89,6 +92,14 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
 
             return AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
+        }
+
+        protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
+        {
+            if (hashAlgorithm != HashAlgorithmName.SHA1)
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
+
+            return AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
         }
 
         public void ImportCspBlob(byte[] keyBlob)
@@ -156,7 +167,7 @@ namespace System.Security.Cryptography
         public override byte[] SignData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
         {
             if (hashAlgorithm != HashAlgorithmName.SHA1)
-                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm);
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
 
             return _impl.SignData(data, offset, count, hashAlgorithm);
         }
@@ -164,9 +175,17 @@ namespace System.Security.Cryptography
         public override byte[] SignData(Stream data, HashAlgorithmName hashAlgorithm)
         {
             if (hashAlgorithm != HashAlgorithmName.SHA1)
-                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm);
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
 
             return _impl.SignData(data, hashAlgorithm);
+        }
+
+        public override bool TrySignData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten)
+        {
+            if (hashAlgorithm != HashAlgorithmName.SHA1)
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
+
+            return _impl.TrySignData(source, destination, hashAlgorithm, out bytesWritten);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5351", Justification = "This is the implementation of DSACryptoServiceProvider")]
@@ -181,7 +200,7 @@ namespace System.Security.Cryptography
 
             // Only SHA1 allowed; the default value is SHA1
             if (str != null && string.Compare(str, "SHA1", StringComparison.OrdinalIgnoreCase) != 0)
-                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm);
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, str);
 
             return CreateSignature(rgbHash);
         }
@@ -200,7 +219,7 @@ namespace System.Security.Cryptography
 
             // Only SHA1 allowed; the default value is SHA1
             if (str != null && string.Compare(str, "SHA1", StringComparison.OrdinalIgnoreCase) != 0)
-                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm);
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, str);
 
             return _impl.VerifySignature(rgbHash, rgbSignature);
         }
@@ -208,7 +227,7 @@ namespace System.Security.Cryptography
         public override bool VerifyData(byte[] data, int offset, int count, byte[] signature, HashAlgorithmName hashAlgorithm)
         {
             if (hashAlgorithm != HashAlgorithmName.SHA1)
-                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm);
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
 
             return _impl.VerifyData(data, offset, count, signature, hashAlgorithm);
         }
@@ -216,12 +235,23 @@ namespace System.Security.Cryptography
         public override bool VerifyData(Stream data, byte[] signature, HashAlgorithmName hashAlgorithm)
         {
             if (hashAlgorithm != HashAlgorithmName.SHA1)
-                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm);
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
+
+            return _impl.VerifyData(data, signature, hashAlgorithm);
+        }
+
+        public override bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm)
+        {
+            if (hashAlgorithm != HashAlgorithmName.SHA1)
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
 
             return _impl.VerifyData(data, signature, hashAlgorithm);
         }
 
         public override bool VerifySignature(byte[] rgbHash, byte[] rgbSignature) =>
+            _impl.VerifySignature(rgbHash, rgbSignature);
+
+        public override bool VerifySignature(ReadOnlySpan<byte> rgbHash, ReadOnlySpan<byte> rgbSignature) =>
             _impl.VerifySignature(rgbHash, rgbSignature);
 
         // UseMachineKeyStore has no effect in Unix

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
@@ -46,7 +46,7 @@ namespace System.Security.Cryptography
         {
             throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_CAPI_Required, nameof(CspParameters)));
         }
-        
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5351", Justification = "This is the implementation of DSACryptoServiceProvider")]
         public override byte[] CreateSignature(byte[] rgbHash) => _impl.CreateSignature(rgbHash);
 
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography
 
         public CspKeyContainerInfo CspKeyContainerInfo
         {
-            get {throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_CAPI_Required, nameof(CspKeyContainerInfo))); }
+            get { throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_CAPI_Required, nameof(CspKeyContainerInfo))); }
         }
 
         protected override void Dispose(bool disposing)

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -116,6 +116,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/ECDsaX509SignatureGenerator.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/ECDsaX509SignatureGenerator.cs
@@ -53,8 +53,8 @@ namespace System.Security.Cryptography.X509Certificates
             int segmentLength = ieeeFormat.Length / 2;
 
             return DerEncoder.ConstructSequence(
-                DerEncoder.SegmentedEncodeUnsignedInteger(ieeeFormat, 0, segmentLength),
-                DerEncoder.SegmentedEncodeUnsignedInteger(ieeeFormat, segmentLength, segmentLength));
+                DerEncoder.SegmentedEncodeUnsignedInteger(new ReadOnlySpan<byte>(ieeeFormat, 0, segmentLength)),
+                DerEncoder.SegmentedEncodeUnsignedInteger(new ReadOnlySpan<byte>(ieeeFormat, segmentLength, segmentLength)));
         }
 
         protected override PublicKey BuildPublicKey()


### PR DESCRIPTION
- Augmented DSA with new span-based methods
- Overrode relevant methods on DSACng and DSACryptoServiceProvider on Unix with full implementations
- Overrode relevant methods on DSAOpenSSL and DSASecurityTransforms with valid implementations that avoid some of the base implementation costs, but there's still a lot of allocation there to be avoided subsequently.
- Did not override implementations on DSACryptoServiceProvider on Windows, for the same reason I didn't do so in RSACryptoServiceProvider (it mutates the input).
- Added a bunch of tests.

Contributes to https://github.com/dotnet/corefx/issues/22615
cc: @bartonjs 