### PR TITLE
[release/1.0] Simplify X509Chain building with OpenSSL

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
@@ -421,7 +421,7 @@
       <Version>4.0.1</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="runtime.native.System.Security.Cryptography">
-      <Version>4.0.0</Version>
+      <Version>4.0.2</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Private.DataContractSerialization">
       <Version>4.1.2</Version>

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -107,9 +107,13 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool X509StoreSetRevocationFlag(SafeX509StoreHandle ctx, X509RevocationFlag revocationFlag);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxInit")]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxInit2")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool X509StoreCtxInit(SafeX509StoreCtxHandle ctx, SafeX509StoreHandle store, SafeX509Handle x509);
+        internal static extern bool X509StoreCtxInit(
+            SafeX509StoreCtxHandle ctx,
+            SafeX509StoreHandle store,
+            SafeX509Handle x509,
+            SafeX509StackHandle extraCerts);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509VerifyCert")]
         internal static extern int X509VerifyCert(SafeX509StoreCtxHandle ctx);

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
@@ -212,6 +212,11 @@ extern "C" int32_t CryptoNative_X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE
     return X509_STORE_CTX_init(ctx, store, x509, nullptr);
 }
 
+extern "C" int32_t CryptoNative_X509StoreCtxInit2(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509, X509Stack* extraStore)
+{
+    return X509_STORE_CTX_init(ctx, store, x509, extraStore);
+}
+
 extern "C" int32_t CryptoNative_X509VerifyCert(X509_STORE_CTX* ctx)
 {
     return X509_verify_cert(ctx);

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.h
@@ -223,6 +223,11 @@ Shims the X509_STORE_CTX_init method.
 extern "C" int32_t CryptoNative_X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509);
 
 /*
+Shims the X509_STORE_CTX_init method.
+*/
+extern "C" int32_t CryptoNative_X509StoreCtxInit2(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509, X509Stack* extraStore);
+
+/*
 Shims the X509_verify_cert method.
 */
 extern "C" int32_t CryptoNative_X509VerifyCert(X509_STORE_CTX* ctx);

--- a/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
+++ b/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.1.1</Version>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\4.0\System.Security.Cryptography.X509Certificates.csproj">
       <SupportedFramework>net46</SupportedFramework>

--- a/src/System.Security.Cryptography.X509Certificates/pkg/ValidationSuppression.txt
+++ b/src/System.Security.Cryptography.X509Certificates/pkg/ValidationSuppression.txt
@@ -1,0 +1,6 @@
+// The netfx facades have their versions locked, but we should
+// permit the netcoreapp implementations to use a higher runtime assembly
+// version than the ref assembly.
+// The refs shouldn't get bumped because that could push the 1.0 assembly to
+// a higher version than the 1.1 assembly.
+PermitHigherCompatibleImplementationVersion

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -58,7 +58,6 @@ namespace Internal.Cryptography.Pal
             IChainPal chain = OpenSslX509ChainProcessor.BuildChain(
                 leaf,
                 candidates,
-                downloaded,
                 systemTrusted,
                 applicationPolicy,
                 certificatePolicy,

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -10,8 +10,9 @@
     <ProjectGuid>{6F8576C2-6CD0-4DF3-8394-00B002D82E40}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.X509Certificates</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.1</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetGroup)'=='net46'">4.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='net461'">4.1.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.6</PackageTargetFramework>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -30,6 +30,9 @@
     <Project Include="..\pkg\Microsoft.NETCore.Targets\Microsoft.NETCore.Targets.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="System.Security.Cryptography.X509Certificates\pkg\System.Security.Cryptography.X509Certificates.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >


### PR DESCRIPTION
Backport #23218 to release/1.0 so our X509Chain processing model is the same across all released versions.

In the 1.1 version of this change the chain builder context used X509UpRef, which was added in 1.1 to reduce memory, since that isn't available in 1.0 this edition uses X509Duplicate.

This also includes the packaging changes necessary to service the X509Certificates library (which should pull up the native shim change through the package closure).

Addresses #23023 for 1.0.