### PR TITLE
Move argument validation for some ImmutableList functions to ImmutableList.Node

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Builder.cs
@@ -282,12 +282,7 @@ namespace System.Collections.Immutable
             /// copied from ImmutableList&lt;T&gt;. The System.Array must have
             /// zero-based indexing.
             /// </param>
-            public void CopyTo(T[] array)
-            {
-                Requires.NotNull(array, nameof(array));
-                Requires.Range(array.Length >= this.Count, nameof(array));
-                _root.CopyTo(array);
-            }
+            public void CopyTo(T[] array) => _root.CopyTo(array);
 
             /// <summary>
             /// Copies the entire ImmutableList&lt;T&gt; to a compatible one-dimensional
@@ -301,12 +296,7 @@ namespace System.Collections.Immutable
             /// <param name="arrayIndex">
             /// The zero-based index in array at which copying begins.
             /// </param>
-            public void CopyTo(T[] array, int arrayIndex)
-            {
-                Requires.NotNull(array, nameof(array));
-                Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
-                _root.CopyTo(array, arrayIndex);
-            }
+            public void CopyTo(T[] array, int arrayIndex) => _root.CopyTo(array, arrayIndex);
 
             /// <summary>
             /// Copies a range of elements from the ImmutableList&lt;T&gt; to
@@ -324,10 +314,7 @@ namespace System.Collections.Immutable
             /// </param>
             /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
             /// <param name="count">The number of elements to copy.</param>
-            public void CopyTo(int index, T[] array, int arrayIndex, int count)
-            {
-                _root.CopyTo(index, array, arrayIndex, count);
-            }
+            public void CopyTo(int index, T[] array, int arrayIndex, int count) => _root.CopyTo(index, array, arrayIndex, count);
 
             /// <summary>
             /// Creates a shallow copy of a range of elements in the source ImmutableList&lt;T&gt;.
@@ -384,11 +371,7 @@ namespace System.Collections.Immutable
             /// that match the conditions defined by the specified predicate; otherwise,
             /// false.
             /// </returns>
-            public bool Exists(Predicate<T> match)
-            {
-                Requires.NotNull(match, nameof(match));
-                return _root.Exists(match);
-            }
+            public bool Exists(Predicate<T> match) => _root.Exists(match);
 
             /// <summary>
             /// Searches for an element that matches the conditions defined by the specified
@@ -402,11 +385,7 @@ namespace System.Collections.Immutable
             /// The first element that matches the conditions defined by the specified predicate,
             /// if found; otherwise, the default value for type T.
             /// </returns>
-            public T Find(Predicate<T> match)
-            {
-                Requires.NotNull(match, nameof(match));
-                return _root.Find(match);
-            }
+            public T Find(Predicate<T> match) => _root.Find(match);
 
             /// <summary>
             /// Retrieves all the elements that match the conditions defined by the specified
@@ -421,11 +400,7 @@ namespace System.Collections.Immutable
             /// the conditions defined by the specified predicate, if found; otherwise, an
             /// empty ImmutableList&lt;T&gt;.
             /// </returns>
-            public ImmutableList<T> FindAll(Predicate<T> match)
-            {
-                Requires.NotNull(match, nameof(match));
-                return _root.FindAll(match);
-            }
+            public ImmutableList<T> FindAll(Predicate<T> match) => _root.FindAll(match);
 
             /// <summary>
             /// Searches for an element that matches the conditions defined by the specified
@@ -440,11 +415,7 @@ namespace System.Collections.Immutable
             /// The zero-based index of the first occurrence of an element that matches the
             /// conditions defined by match, if found; otherwise, -1.
             /// </returns>
-            public int FindIndex(Predicate<T> match)
-            {
-                Requires.NotNull(match, nameof(match));
-                return _root.FindIndex(match);
-            }
+            public int FindIndex(Predicate<T> match) => _root.FindIndex(match);
 
             /// <summary>
             /// Searches for an element that matches the conditions defined by the specified
@@ -458,13 +429,7 @@ namespace System.Collections.Immutable
             /// The zero-based index of the first occurrence of an element that matches the
             /// conditions defined by match, if found; otherwise, -1.
             /// </returns>
-            public int FindIndex(int startIndex, Predicate<T> match)
-            {
-                Requires.NotNull(match, nameof(match));
-                Requires.Range(startIndex >= 0, nameof(startIndex));
-                Requires.Range(startIndex <= this.Count, nameof(startIndex));
-                return _root.FindIndex(startIndex, match);
-            }
+            public int FindIndex(int startIndex, Predicate<T> match) => _root.FindIndex(startIndex, match);
 
             /// <summary>
             /// Searches for an element that matches the conditions defined by the specified
@@ -479,15 +444,7 @@ namespace System.Collections.Immutable
             /// The zero-based index of the first occurrence of an element that matches the
             /// conditions defined by match, if found; otherwise, -1.
             /// </returns>
-            public int FindIndex(int startIndex, int count, Predicate<T> match)
-            {
-                Requires.NotNull(match, nameof(match));
-                Requires.Range(startIndex >= 0, nameof(startIndex));
-                Requires.Range(count >= 0, nameof(count));
-                Requires.Range(startIndex + count <= this.Count, nameof(count));
-
-                return _root.FindIndex(startIndex, count, match);
-            }
+            public int FindIndex(int startIndex, int count, Predicate<T> match) => _root.FindIndex(startIndex, count, match);
 
             /// <summary>
             /// Searches for an element that matches the conditions defined by the specified
@@ -501,11 +458,7 @@ namespace System.Collections.Immutable
             /// The last element that matches the conditions defined by the specified predicate,
             /// if found; otherwise, the default value for type T.
             /// </returns>
-            public T FindLast(Predicate<T> match)
-            {
-                Requires.NotNull(match, nameof(match));
-                return _root.FindLast(match);
-            }
+            public T FindLast(Predicate<T> match) => _root.FindLast(match);
 
             /// <summary>
             /// Searches for an element that matches the conditions defined by the specified
@@ -520,11 +473,7 @@ namespace System.Collections.Immutable
             /// The zero-based index of the last occurrence of an element that matches the
             /// conditions defined by match, if found; otherwise, -1.
             /// </returns>
-            public int FindLastIndex(Predicate<T> match)
-            {
-                Requires.NotNull(match, nameof(match));
-                return _root.FindLastIndex(match);
-            }
+            public int FindLastIndex(Predicate<T> match) => _root.FindLastIndex(match);
 
             /// <summary>
             /// Searches for an element that matches the conditions defined by the specified
@@ -539,13 +488,7 @@ namespace System.Collections.Immutable
             /// The zero-based index of the last occurrence of an element that matches the
             /// conditions defined by match, if found; otherwise, -1.
             /// </returns>
-            public int FindLastIndex(int startIndex, Predicate<T> match)
-            {
-                Requires.NotNull(match, nameof(match));
-                Requires.Range(startIndex >= 0, nameof(startIndex));
-                Requires.Range(startIndex == 0 || startIndex < this.Count, nameof(startIndex));
-                return _root.FindLastIndex(startIndex, match);
-            }
+            public int FindLastIndex(int startIndex, Predicate<T> match) => _root.FindLastIndex(startIndex, match);
 
             /// <summary>
             /// Searches for an element that matches the conditions defined by the specified
@@ -563,15 +506,7 @@ namespace System.Collections.Immutable
             /// The zero-based index of the last occurrence of an element that matches the
             /// conditions defined by match, if found; otherwise, -1.
             /// </returns>
-            public int FindLastIndex(int startIndex, int count, Predicate<T> match)
-            {
-                Requires.NotNull(match, nameof(match));
-                Requires.Range(startIndex >= 0, nameof(startIndex));
-                Requires.Range(count <= this.Count, nameof(count));
-                Requires.Range(startIndex - count + 1 >= 0, nameof(startIndex));
-
-                return _root.FindLastIndex(startIndex, count, match);
-            }
+            public int FindLastIndex(int startIndex, int count, Predicate<T> match) => _root.FindLastIndex(startIndex, count, match);
 
             /// <summary>
             /// Searches for the specified object and returns the zero-based index of the
@@ -592,10 +527,8 @@ namespace System.Collections.Immutable
             /// to the last element, if found; otherwise, -1.
             /// </returns>
             [Pure]
-            public int IndexOf(T item, int index)
-            {
-                return _root.IndexOf(item, index, this.Count - index, EqualityComparer<T>.Default);
-            }
+            public int IndexOf(T item, int index) =>
+                _root.IndexOf(item, index, this.Count - index, EqualityComparer<T>.Default);
 
             /// <summary>
             /// Searches for the specified object and returns the zero-based index of the
@@ -619,10 +552,8 @@ namespace System.Collections.Immutable
             /// contains count number of elements, if found; otherwise, -1.
             /// </returns>
             [Pure]
-            public int IndexOf(T item, int index, int count)
-            {
-                return _root.IndexOf(item, index, count, EqualityComparer<T>.Default);
-            }
+            public int IndexOf(T item, int index, int count) =>
+                _root.IndexOf(item, index, count, EqualityComparer<T>.Default);
 
             /// <summary>
             /// Searches for the specified object and returns the zero-based index of the
@@ -650,10 +581,8 @@ namespace System.Collections.Immutable
             /// contains count number of elements, if found; otherwise, -1.
             /// </returns>
             [Pure]
-            public int IndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
-            {
-                return _root.IndexOf(item, index, count, equalityComparer);
-            }
+            public int IndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer) =>
+                _root.IndexOf(item, index, count, equalityComparer);
 
             /// <summary>
             /// Searches for the specified object and returns the zero-based index of the
@@ -726,10 +655,8 @@ namespace System.Collections.Immutable
             /// and ends at index, if found; otherwise, -1.
             /// </returns>
             [Pure]
-            public int LastIndexOf(T item, int startIndex, int count)
-            {
-                return _root.LastIndexOf(item, startIndex, count, EqualityComparer<T>.Default);
-            }
+            public int LastIndexOf(T item, int startIndex, int count) =>
+                _root.LastIndexOf(item, startIndex, count, EqualityComparer<T>.Default);
 
             /// <summary>
             /// Searches for the specified object and returns the zero-based index of the
@@ -750,10 +677,8 @@ namespace System.Collections.Immutable
             /// and ends at index, if found; otherwise, -1.
             /// </returns>
             [Pure]
-            public int LastIndexOf(T item, int startIndex, int count, IEqualityComparer<T> equalityComparer)
-            {
-                return _root.LastIndexOf(item, startIndex, count, equalityComparer);
-            }
+            public int LastIndexOf(T item, int startIndex, int count, IEqualityComparer<T> equalityComparer) =>
+                _root.LastIndexOf(item, startIndex, count, equalityComparer);
 
             /// <summary>
             /// Determines whether every element in the ImmutableList&lt;T&gt;
@@ -768,11 +693,7 @@ namespace System.Collections.Immutable
             /// conditions defined by the specified predicate; otherwise, false. If the list
             /// has no elements, the return value is true.
             /// </returns>
-            public bool TrueForAll(Predicate<T> match)
-            {
-                Requires.NotNull(match, nameof(match));
-                return _root.TrueForAll(match);
-            }
+            public bool TrueForAll(Predicate<T> match) => _root.TrueForAll(match);
 
             #endregion
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
@@ -780,7 +780,7 @@ namespace System.Collections.Immutable
             internal void CopyTo(T[] array)
             {
                 Requires.NotNull(array, nameof(array));
-                Requires.Argument(array.Length >= this.Count);
+                Requires.Range(array.Length >= this.Count, nameof(array));
 
                 int index = 0;
                 foreach (var element in this)
@@ -805,8 +805,7 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNull(array, nameof(array));
                 Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
-                Requires.Range(arrayIndex <= array.Length, nameof(arrayIndex));
-                Requires.Argument(arrayIndex + this.Count <= array.Length);
+                Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
                 foreach (var element in this)
                 {
@@ -906,6 +905,8 @@ namespace System.Collections.Immutable
             /// </returns>
             internal bool TrueForAll(Predicate<T> match)
             {
+                Requires.NotNull(match, nameof(match));
+
                 foreach (var item in this)
                 {
                     if (!match(item))
@@ -1049,9 +1050,8 @@ namespace System.Collections.Immutable
             /// </returns>
             internal int FindIndex(int startIndex, Predicate<T> match)
             {
-                Requires.Range(startIndex >= 0, nameof(startIndex));
-                Requires.Range(startIndex <= this.Count, nameof(startIndex));
                 Requires.NotNull(match, nameof(match));
+                Requires.Range(startIndex >= 0 && startIndex <= this.Count, nameof(startIndex));
 
                 return this.FindIndex(startIndex, this.Count - startIndex, match);
             }
@@ -1071,10 +1071,10 @@ namespace System.Collections.Immutable
             /// </returns>
             internal int FindIndex(int startIndex, int count, Predicate<T> match)
             {
+                Requires.NotNull(match, nameof(match));
                 Requires.Range(startIndex >= 0, nameof(startIndex));
                 Requires.Range(count >= 0, nameof(count));
-                Requires.Argument(startIndex + count <= this.Count);
-                Requires.NotNull(match, nameof(match));
+                Requires.Range(startIndex + count <= this.Count, nameof(count));
 
                 using (var enumerator = new Enumerator(this, startIndex: startIndex, count: count))
                 {
@@ -1141,12 +1141,7 @@ namespace System.Collections.Immutable
                 Requires.NotNull(match, nameof(match));
                 Contract.Ensures(Contract.Result<int>() >= -1);
 
-                if (this.IsEmpty)
-                {
-                    return -1;
-                }
-
-                return this.FindLastIndex(this.Count - 1, this.Count, match);
+                return this.IsEmpty ? -1 : this.FindLastIndex(this.Count - 1, this.Count, match);
             }
 
             /// <summary>
@@ -1168,12 +1163,7 @@ namespace System.Collections.Immutable
                 Requires.Range(startIndex >= 0, nameof(startIndex));
                 Requires.Range(startIndex == 0 || startIndex < this.Count, nameof(startIndex));
 
-                if (this.IsEmpty)
-                {
-                    return -1;
-                }
-
-                return this.FindLastIndex(startIndex, startIndex + 1, match);
+                return this.IsEmpty ? -1 : this.FindLastIndex(startIndex, startIndex + 1, match);
             }
 
             /// <summary>
@@ -1197,7 +1187,7 @@ namespace System.Collections.Immutable
                 Requires.NotNull(match, nameof(match));
                 Requires.Range(startIndex >= 0, nameof(startIndex));
                 Requires.Range(count <= this.Count, nameof(count));
-                Requires.Argument(startIndex - count + 1 >= 0);
+                Requires.Range(startIndex - count + 1 >= 0, nameof(startIndex));
 
                 using (var enumerator = new Enumerator(this, startIndex: startIndex, count: count, reversed: true))
                 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -518,12 +518,7 @@ namespace System.Collections.Immutable
         /// copied from <see cref="ImmutableList{T}"/>. The <see cref="Array"/> must have
         /// zero-based indexing.
         /// </param>
-        public void CopyTo(T[] array)
-        {
-            Requires.NotNull(array, nameof(array));
-            Requires.Range(array.Length >= this.Count, nameof(array));
-            _root.CopyTo(array);
-        }
+        public void CopyTo(T[] array) => _root.CopyTo(array);
 
         /// <summary>
         /// Copies the entire <see cref="ImmutableList{T}"/> to a compatible one-dimensional
@@ -537,13 +532,7 @@ namespace System.Collections.Immutable
         /// <param name="arrayIndex">
         /// The zero-based index in array at which copying begins.
         /// </param>
-        public void CopyTo(T[] array, int arrayIndex)
-        {
-            Requires.NotNull(array, nameof(array));
-            Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
-            Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
-            _root.CopyTo(array, arrayIndex);
-        }
+        public void CopyTo(T[] array, int arrayIndex) => _root.CopyTo(array, arrayIndex);
 
         /// <summary>
         /// Copies a range of elements from the <see cref="ImmutableList{T}"/> to
@@ -618,11 +607,7 @@ namespace System.Collections.Immutable
         /// that match the conditions defined by the specified predicate; otherwise,
         /// false.
         /// </returns>
-        public bool Exists(Predicate<T> match)
-        {
-            Requires.NotNull(match, nameof(match));
-            return _root.Exists(match);
-        }
+        public bool Exists(Predicate<T> match) => _root.Exists(match);
 
         /// <summary>
         /// Searches for an element that matches the conditions defined by the specified
@@ -636,11 +621,7 @@ namespace System.Collections.Immutable
         /// The first element that matches the conditions defined by the specified predicate,
         /// if found; otherwise, the default value for type <typeparamref name="T"/>.
         /// </returns>
-        public T Find(Predicate<T> match)
-        {
-            Requires.NotNull(match, nameof(match));
-            return _root.Find(match);
-        }
+        public T Find(Predicate<T> match) => _root.Find(match);
 
         /// <summary>
         /// Retrieves all the elements that match the conditions defined by the specified
@@ -655,11 +636,7 @@ namespace System.Collections.Immutable
         /// the conditions defined by the specified predicate, if found; otherwise, an
         /// empty <see cref="ImmutableList{T}"/>.
         /// </returns>
-        public ImmutableList<T> FindAll(Predicate<T> match)
-        {
-            Requires.NotNull(match, nameof(match));
-            return _root.FindAll(match);
-        }
+        public ImmutableList<T> FindAll(Predicate<T> match) => _root.FindAll(match);
 
         /// <summary>
         /// Searches for an element that matches the conditions defined by the specified
@@ -674,11 +651,7 @@ namespace System.Collections.Immutable
         /// The zero-based index of the first occurrence of an element that matches the
         /// conditions defined by <paramref name="match"/>, if found; otherwise, -1.
         /// </returns>
-        public int FindIndex(Predicate<T> match)
-        {
-            Requires.NotNull(match, nameof(match));
-            return _root.FindIndex(match);
-        }
+        public int FindIndex(Predicate<T> match) => _root.FindIndex(match);
 
         /// <summary>
         /// Searches for an element that matches the conditions defined by the specified
@@ -692,13 +665,7 @@ namespace System.Collections.Immutable
         /// The zero-based index of the first occurrence of an element that matches the
         /// conditions defined by <paramref name="match"/>, if found; otherwise, -1.
         /// </returns>
-        public int FindIndex(int startIndex, Predicate<T> match)
-        {
-            Requires.NotNull(match, nameof(match));
-            Requires.Range(startIndex >= 0, nameof(startIndex));
-            Requires.Range(startIndex <= this.Count, nameof(startIndex));
-            return _root.FindIndex(startIndex, match);
-        }
+        public int FindIndex(int startIndex, Predicate<T> match) => _root.FindIndex(startIndex, match);
 
         /// <summary>
         /// Searches for an element that matches the conditions defined by the specified
@@ -713,15 +680,7 @@ namespace System.Collections.Immutable
         /// The zero-based index of the first occurrence of an element that matches the
         /// conditions defined by <paramref name="match"/>, if found; otherwise, -1.
         /// </returns>
-        public int FindIndex(int startIndex, int count, Predicate<T> match)
-        {
-            Requires.NotNull(match, nameof(match));
-            Requires.Range(startIndex >= 0, nameof(startIndex));
-            Requires.Range(count >= 0, nameof(count));
-            Requires.Range(startIndex + count <= this.Count, nameof(count));
-
-            return _root.FindIndex(startIndex, count, match);
-        }
+        public int FindIndex(int startIndex, int count, Predicate<T> match) => _root.FindIndex(startIndex, count, match);
 
         /// <summary>
         /// Searches for an element that matches the conditions defined by the specified
@@ -735,11 +694,7 @@ namespace System.Collections.Immutable
         /// The last element that matches the conditions defined by the specified predicate,
         /// if found; otherwise, the default value for type <typeparamref name="T"/>.
         /// </returns>
-        public T FindLast(Predicate<T> match)
-        {
-            Requires.NotNull(match, nameof(match));
-            return _root.FindLast(match);
-        }
+        public T FindLast(Predicate<T> match) => _root.FindLast(match);
 
         /// <summary>
         /// Searches for an element that matches the conditions defined by the specified
@@ -754,11 +709,7 @@ namespace System.Collections.Immutable
         /// The zero-based index of the last occurrence of an element that matches the
         /// conditions defined by <paramref name="match"/>, if found; otherwise, -1.
         /// </returns>
-        public int FindLastIndex(Predicate<T> match)
-        {
-            Requires.NotNull(match, nameof(match));
-            return _root.FindLastIndex(match);
-        }
+        public int FindLastIndex(Predicate<T> match) => _root.FindLastIndex(match);
 
         /// <summary>
         /// Searches for an element that matches the conditions defined by the specified
@@ -773,13 +724,7 @@ namespace System.Collections.Immutable
         /// The zero-based index of the last occurrence of an element that matches the
         /// conditions defined by <paramref name="match"/>, if found; otherwise, -1.
         /// </returns>
-        public int FindLastIndex(int startIndex, Predicate<T> match)
-        {
-            Requires.NotNull(match, nameof(match));
-            Requires.Range(startIndex >= 0, nameof(startIndex));
-            Requires.Range(startIndex == 0 || startIndex < this.Count, nameof(startIndex));
-            return _root.FindLastIndex(startIndex, match);
-        }
+        public int FindLastIndex(int startIndex, Predicate<T> match) => _root.FindLastIndex(startIndex, match);
 
         /// <summary>
         /// Searches for an element that matches the conditions defined by the specified
@@ -797,15 +742,7 @@ namespace System.Collections.Immutable
         /// The zero-based index of the last occurrence of an element that matches the
         /// conditions defined by <paramref name="match"/>, if found; otherwise, -1.
         /// </returns>
-        public int FindLastIndex(int startIndex, int count, Predicate<T> match)
-        {
-            Requires.NotNull(match, nameof(match));
-            Requires.Range(startIndex >= 0, nameof(startIndex));
-            Requires.Range(count <= this.Count, nameof(count));
-            Requires.Range(startIndex - count + 1 >= 0, nameof(startIndex));
-
-            return _root.FindLastIndex(startIndex, count, match);
-        }
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) => _root.FindLastIndex(startIndex, count, match);
 
         /// <summary>
         /// Searches for the specified object and returns the zero-based index of the
@@ -855,10 +792,7 @@ namespace System.Collections.Immutable
         /// and ends at <paramref name="index"/>, if found; otherwise, -1.
         /// </returns>
         [Pure]
-        public int LastIndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
-        {
-            return _root.LastIndexOf(item, index, count, equalityComparer);
-        }
+        public int LastIndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer) => _root.LastIndexOf(item, index, count, equalityComparer);
 
         /// <summary>
         /// Determines whether every element in the <see cref="ImmutableList{T}"/>
@@ -873,11 +807,7 @@ namespace System.Collections.Immutable
         /// conditions defined by the specified predicate; otherwise, false. If the list
         /// has no elements, the return value is true.
         /// </returns>
-        public bool TrueForAll(Predicate<T> match)
-        {
-            Requires.NotNull(match, nameof(match));
-            return _root.TrueForAll(match);
-        }
+        public bool TrueForAll(Predicate<T> match) => _root.TrueForAll(match);
 
         #endregion
 


### PR DESCRIPTION
I am still breaking up parts of https://github.com/dotnet/corefx/pull/15382 into different PRs to make reviewing easier. In this PR, I've removed argument validation for a couple of `ImmutableList` functions. I did this since I noticed many functions validated their arguments twice, once in `ImmutableList` and once in `ImmutableList.Node`. It's simpler if we just omit validation for the former and let the `Node` class take care of it.

There were a few places where `ImmutableList` and `Node` validated arguments differently. For those cases, I copied and pasted the `ImmutableList` validation into the `Node` method to preserve exception behavior.

/cc @safern, @ianhays, @AArnott 