### PR TITLE
Remove unused properties from ErrorType

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -150,27 +150,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             ErrAppendParentCore(sym.parent, pctx);
         }
 
-        private void ErrAppendParentType(CType pType, SubstContext pctx)
-        {
-            if (pType is ErrorType err)
-            {
-                ErrAppendParentCore(err.GetNSParent(), pctx);
-            }
-            else if (pType is AggregateType agg)
-            {
-                ErrAppendParentCore(agg.GetOwningAggregate(), pctx);
-            }
-            else
-            {
-                var part = pType.GetBaseOrParameterOrElementType();
-                if (part != null)
-                {
-                    ErrAppendType(part, null);
-                    ErrAppendChar('.');
-                }
-            }
-        }
-
         private void ErrAppendParentCore(Symbol parent, SubstContext pctx)
         {
             if (null == parent)
@@ -528,7 +507,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     if (err.HasParent())
                     {
                         Debug.Assert(err.nameText != null && err.typeArgs != null);
-                        ErrAppendParentType(pType, pctx);
                         ErrAppendName(err.nameText);
                         ErrAppendTypeParameters(err.typeArgs, pctx, true);
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -154,15 +154,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         {
             if (pType is ErrorType err)
             {
-                if (err.HasTypeParent())
-                {
-                    ErrAppendType(err.GetTypeParent(), null);
-                    ErrAppendChar('.');
-                }
-                else
-                {
-                    ErrAppendParentCore(err.GetNSParent(), pctx);
-                }
+                ErrAppendParentCore(err.GetNSParent(), pctx);
             }
             else if (pType is AggregateType agg)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -504,7 +504,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
                 case TypeKind.TK_ErrorType:
                     ErrorType err = (ErrorType)pType;
-                    if (err.HasParent())
+                    if (err.HasParent)
                     {
                         Debug.Assert(err.nameText != null && err.typeArgs != null);
                         ErrAppendName(err.nameText);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 switch (_typeDest.GetTypeKind())
                 {
                     case TypeKind.TK_ErrorType:
-                        Debug.Assert(((ErrorType)_typeDest).HasParent());
+                        Debug.Assert(((ErrorType)_typeDest).HasParent);
                         if (_typeSrc != _typeDest)
                         {
                             return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -195,7 +195,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 _pFixedResults[iParam] = GetTypeManager().GetErrorType(
-                                        null,
                                         ((TypeParameterType)_pMethodTypeParameters[iParam]).GetName(),
                                         BSYMMGR.EmptyTypeArray());
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -195,7 +195,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 _pFixedResults[iParam] = GetTypeManager().GetErrorType(
-                                        null/*pParentType*/,
                                         null,
                                         ((TypeParameterType)_pMethodTypeParameters[iParam]).GetName(),
                                         BSYMMGR.EmptyTypeArray());

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
@@ -18,12 +18,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public Name nameText;
         public TypeArray typeArgs;
 
-        public bool HasParent() { return _pParentNS != null; }
-
-        public AssemblyQualifiedNamespaceSymbol GetNSParent() { return _pParentNS; }
-
-        public void SetNSParent(AssemblyQualifiedNamespaceSymbol pNS) { _pParentNS = pNS; }
-
-        private AssemblyQualifiedNamespaceSymbol _pParentNS;
+        public bool HasParent { get; set; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
@@ -18,6 +18,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public Name nameText;
         public TypeArray typeArgs;
 
+        // ErrorTypes are always either the per-TypeManager singleton ErrorType
+        // that has a null nameText and no namespace parent, or else have a
+        // non-null nameText and have the root namespace as the namespace parent,
+        // so checking that nameText isn't null is equivalent to checking if the
+        // type has a parent.
         public bool HasParent => nameText != null;
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
@@ -18,6 +18,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public Name nameText;
         public TypeArray typeArgs;
 
-        public bool HasParent { get; set; }
+        public bool HasParent => nameText != null;
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
@@ -18,17 +18,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public Name nameText;
         public TypeArray typeArgs;
 
-        public bool HasParent() { return _pParentType != null || _pParentNS != null; }
+        public bool HasParent() { return _pParentNS != null; }
 
-        public bool HasTypeParent() { return _pParentType != null; }
-        public CType GetTypeParent() { return _pParentType; }
-        public void SetTypeParent(CType pType) { _pParentType = pType; }
-
-        public bool HasNSParent() { return _pParentNS != null; }
         public AssemblyQualifiedNamespaceSymbol GetNSParent() { return _pParentNS; }
+
         public void SetNSParent(AssemblyQualifiedNamespaceSymbol pNS) { _pParentNS = pNS; }
 
-        private CType _pParentType;
         private AssemblyQualifiedNamespaceSymbol _pParentNS;
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -515,7 +515,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // be equivalent or convertible (like ANONMETHSYMs)
         public bool IsNeverSameType()
         {
-            return this is MethodGroupType || this is ErrorType err && !err.HasParent();
+            return this is MethodGroupType || this is ErrorType err && !err.HasParent;
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -179,7 +179,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public void InitFromParent()
         {
             Debug.Assert(!(this is AggregateType));
-            _fHasErrors = (this is ErrorType err ? err.GetTypeParent() : GetBaseOrParameterOrElementType()).HasErrors();
+            Debug.Assert(!(this is ErrorType));
+            _fHasErrors = GetBaseOrParameterOrElementType().HasErrors();
         }
 
         public bool HasErrors()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public ErrorType CreateError(
             Name name,
-            AssemblyQualifiedNamespaceSymbol pParentNS,
+            bool hasParent,
             Name nameText,
             TypeArray typeArgs)
         {
@@ -79,7 +79,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             e.SetName(name);
             e.nameText = nameText;
             e.typeArgs = typeArgs;
-            e.SetNSParent(pParentNS);
+            e.HasParent = hasParent;
 
             e.SetTypeKind(TypeKind.TK_ErrorType);
             return e;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
@@ -71,7 +71,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public ErrorType CreateError(
             Name name,
-            CType parent,
             AssemblyQualifiedNamespaceSymbol pParentNS,
             Name nameText,
             TypeArray typeArgs)
@@ -80,7 +79,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             e.SetName(name);
             e.nameText = nameText;
             e.typeArgs = typeArgs;
-            e.SetTypeParent(parent);
             e.SetNSParent(pParentNS);
 
             e.SetTypeKind(TypeKind.TK_ErrorType);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
@@ -71,7 +71,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public ErrorType CreateError(
             Name name,
-            bool hasParent,
             Name nameText,
             TypeArray typeArgs)
         {
@@ -79,7 +78,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             e.SetName(name);
             e.nameText = nameText;
             e.typeArgs = typeArgs;
-            e.HasParent = hasParent;
 
             e.SetTypeKind(TypeKind.TK_ErrorType);
             return e;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _typeTable = new TypeTable();
 
             // special types with their own symbol kind.
-            _errorType = _typeFactory.CreateError(null, false, null, null);
+            _errorType = _typeFactory.CreateError(null, null, null);
             _voidType = _typeFactory.CreateVoid();
             _nullType = _typeFactory.CreateNull();
             _typeMethGrp = _typeFactory.CreateMethodGroup();
@@ -331,7 +331,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (pError == null)
             {
                 // No existing error symbol. Create a new one.
-                pError = _typeFactory.CreateError(name, true, nameText, typeArgs);
+                pError = _typeFactory.CreateError(name, nameText, typeArgs);
                 pError.SetErrors(true);
                 _typeTable.InsertError(name, pError);
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -489,19 +489,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if (err.HasParent())
                     {
                         Debug.Assert(err.nameText != null && err.typeArgs != null);
-
-                        CType pParentType = null;
-                        if (err.HasTypeParent())
-                        {
-                            pParentType = SubstTypeCore(err.GetTypeParent(), pctx);
-                        }
-
                         TypeArray typeArgs = SubstTypeArray(err.typeArgs, pctx);
-                        if (typeArgs != err.typeArgs || (err.HasTypeParent() && pParentType != err.GetTypeParent()))
+                        if (typeArgs != err.typeArgs)
                         {
                             return GetErrorType(err.GetNSParent(), err.nameText, typeArgs);
                         }
                     }
+
                     return type;
 
                 case TypeKind.TK_TypeParameterType:
@@ -643,43 +637,25 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     ErrorType errSrc = (ErrorType)typeSrc;
                     if (!(typeDst is ErrorType errDst) || !errSrc.HasParent() || !errDst.HasParent())
                         return false;
+
+                {
+                    Debug.Assert(errSrc.nameText != null && errSrc.typeArgs != null);
+                    Debug.Assert(errDst.nameText != null && errDst.typeArgs != null);
+
+                    if (errSrc.nameText != errDst.nameText || errSrc.typeArgs.Count != errDst.typeArgs.Count
+                        || errSrc.GetNSParent() != errDst.GetNSParent())
                     {
-                        Debug.Assert(errSrc.nameText != null && errSrc.typeArgs != null);
-                        Debug.Assert(errDst.nameText != null && errDst.typeArgs != null);
-
-                        if (errSrc.nameText != errDst.nameText || errSrc.typeArgs.Count != errDst.typeArgs.Count)
-                            return false;
-
-                        if (errSrc.HasTypeParent() != errDst.HasTypeParent())
-                        {
-                            return false;
-                        }
-                        if (errSrc.HasTypeParent())
-                        {
-                            if (errSrc.GetTypeParent() != errDst.GetTypeParent())
-                            {
-                                return false;
-                            }
-                            if (!SubstEqualTypesCore(errDst.GetTypeParent(), errSrc.GetTypeParent(), pctx))
-                            {
-                                return false;
-                            }
-                        }
-                        else
-                        {
-                            if (errSrc.GetNSParent() != errDst.GetNSParent())
-                            {
-                                return false;
-                            }
-                        }
-
-                        // All the args must unify.
-                        for (int i = 0; i < errSrc.typeArgs.Count; i++)
-                        {
-                            if (!SubstEqualTypesCore(errDst.typeArgs[i], errSrc.typeArgs[i], pctx))
-                                return false;
-                        }
+                        return false;
                     }
+
+                    // All the args must unify.
+                    for (int i = 0; i < errSrc.typeArgs.Count; i++)
+                    {
+                        if (!SubstEqualTypesCore(errDst.typeArgs[i], errSrc.typeArgs[i], pctx))
+                            return false;
+                    }
+                }
+
                     return true;
 
                 case TypeKind.TK_TypeParameterType:
@@ -774,12 +750,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             if (TypeContainsType(err.typeArgs[i], typeFind))
                                 return true;
                         }
-                        if (err.HasTypeParent())
-                        {
-                            type = err.GetTypeParent();
-                            goto LRecurse;
-                        }
                     }
+
                     return false;
 
                 case TypeKind.TK_TypeParameterType:
@@ -835,12 +807,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                 return true;
                             }
                         }
-                        if (err.HasTypeParent())
-                        {
-                            type = err.GetTypeParent();
-                            goto LRecurse;
-                        }
                     }
+
                     return false;
 
                 case TypeKind.TK_TypeParameterType:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -333,14 +333,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(name != null);
 
             Debug.Assert(pParentNS != null);
-            ErrorType pError = _typeTable.LookupError(name, pParentNS);
+            ErrorType pError = _typeTable.LookupError(name);
 
             if (pError == null)
             {
                 // No existing error symbol. Create a new one.
                 pError = _typeFactory.CreateError(name, pParentNS, nameText, typeArgs);
                 pError.SetErrors(true);
-                _typeTable.InsertError(name, pParentNS, pError);
+                _typeTable.InsertError(name, pError);
             }
             else
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _typeTable = new TypeTable();
 
             // special types with their own symbol kind.
-            _errorType = _typeFactory.CreateError(null, null, null, null, null);
+            _errorType = _typeFactory.CreateError(null, null, null, null);
             _voidType = _typeFactory.CreateVoid();
             _nullType = _typeFactory.CreateNull();
             _typeMethGrp = _typeFactory.CreateMethodGroup();
@@ -314,14 +314,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         public ErrorType GetErrorType(
-                CType pParentType,
                 AssemblyQualifiedNamespaceSymbol pParentNS,
                 Name nameText,
                 TypeArray typeArgs)
         {
             Debug.Assert(nameText != null);
-            Debug.Assert(pParentType == null || pParentNS == null);
-            if (pParentType == null && pParentNS == null)
+            if (pParentNS == null)
             {
                 // Use the root namespace as the parent.
                 pParentNS = _BSymmgr.GetRootNsAid();
@@ -334,30 +332,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Name name = _BSymmgr.GetNameFromPtrs(nameText, typeArgs);
             Debug.Assert(name != null);
 
-            ErrorType pError = null;
-            if (pParentType != null)
-            {
-                pError = _typeTable.LookupError(name, pParentType);
-            }
-            else
-            {
-                Debug.Assert(pParentNS != null);
-                pError = _typeTable.LookupError(name, pParentNS);
-            }
+            Debug.Assert(pParentNS != null);
+            ErrorType pError = _typeTable.LookupError(name, pParentNS);
 
             if (pError == null)
             {
                 // No existing error symbol. Create a new one.
-                pError = _typeFactory.CreateError(name, pParentType, pParentNS, nameText, typeArgs);
+                pError = _typeFactory.CreateError(name, pParentNS, nameText, typeArgs);
                 pError.SetErrors(true);
-                if (pParentType != null)
-                {
-                    _typeTable.InsertError(name, pParentType, pError);
-                }
-                else
-                {
-                    _typeTable.InsertError(name, pParentNS, pError);
-                }
+                _typeTable.InsertError(name, pParentNS, pError);
             }
             else
             {
@@ -516,7 +499,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         TypeArray typeArgs = SubstTypeArray(err.typeArgs, pctx);
                         if (typeArgs != err.typeArgs || (err.HasTypeParent() && pParentType != err.GetTypeParent()))
                         {
-                            return GetErrorType(pParentType, err.GetNSParent(), err.nameText, typeArgs);
+                            return GetErrorType(err.GetNSParent(), err.nameText, typeArgs);
                         }
                     }
                     return type;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
@@ -48,11 +48,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     {
         // Two way hashes
         private readonly Dictionary<KeyPair<AggregateSymbol, Name>, AggregateType> _pAggregateTable;
-        private readonly Dictionary<KeyPair<AssemblyQualifiedNamespaceSymbol, Name>, ErrorType> _pErrorWithNamespaceParentTable;
         private readonly Dictionary<KeyPair<CType, Name>, ArrayType> _pArrayTable;
         private readonly Dictionary<KeyPair<CType, Name>, ParameterModifierType> _pParameterModifierTable;
 
         // One way hashes
+        private readonly Dictionary<Name, ErrorType> _pErrorWithNamespaceParentTable;
         private readonly Dictionary<CType, PointerType> _pPointerTable;
         private readonly Dictionary<CType, NullableType> _pNullableTable;
         private readonly Dictionary<TypeParameterSymbol, TypeParameterType> _pTypeParameterTable;
@@ -60,7 +60,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public TypeTable()
         {
             _pAggregateTable = new Dictionary<KeyPair<AggregateSymbol, Name>, AggregateType>();
-            _pErrorWithNamespaceParentTable = new Dictionary<KeyPair<AssemblyQualifiedNamespaceSymbol, Name>, ErrorType>();
+            _pErrorWithNamespaceParentTable = new Dictionary<Name, ErrorType>();
             _pArrayTable = new Dictionary<KeyPair<CType, Name>, ArrayType>();
             _pParameterModifierTable = new Dictionary<KeyPair<CType, Name>, ParameterModifierType>();
             _pPointerTable = new Dictionary<CType, PointerType>();
@@ -88,21 +88,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _pAggregateTable.Add(new KeyPair<AggregateSymbol, Name>(pAggregateSymbol, pName), pAggregate);
         }
 
-        public ErrorType LookupError(Name pName, AssemblyQualifiedNamespaceSymbol pParentNS)
-        {
-            var key = new KeyPair<AssemblyQualifiedNamespaceSymbol, Name>(pParentNS, pName);
-            ErrorType result;
-            if (_pErrorWithNamespaceParentTable.TryGetValue(key, out result))
-            {
-                return result;
-            }
-            return null;
-        }
+        public ErrorType LookupError(Name pName) =>
+            _pErrorWithNamespaceParentTable.TryGetValue(pName, out ErrorType result) ? result : null;
 
-        public void InsertError(Name pName, AssemblyQualifiedNamespaceSymbol pParentNS, ErrorType pError)
+        public void InsertError(Name pName, ErrorType pError)
         {
-            Debug.Assert(LookupError(pName, pParentNS) == null);
-            _pErrorWithNamespaceParentTable.Add(new KeyPair<AssemblyQualifiedNamespaceSymbol, Name>(pParentNS, pName), pError);
+            Debug.Assert(LookupError(pName) == null);
+            _pErrorWithNamespaceParentTable.Add(pName, pError);
         }
 
         public ArrayType LookupArray(Name pName, CType pElementType)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
@@ -48,7 +48,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     {
         // Two way hashes
         private readonly Dictionary<KeyPair<AggregateSymbol, Name>, AggregateType> _pAggregateTable;
-        private readonly Dictionary<KeyPair<CType, Name>, ErrorType> _pErrorWithTypeParentTable;
         private readonly Dictionary<KeyPair<AssemblyQualifiedNamespaceSymbol, Name>, ErrorType> _pErrorWithNamespaceParentTable;
         private readonly Dictionary<KeyPair<CType, Name>, ArrayType> _pArrayTable;
         private readonly Dictionary<KeyPair<CType, Name>, ParameterModifierType> _pParameterModifierTable;
@@ -62,7 +61,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             _pAggregateTable = new Dictionary<KeyPair<AggregateSymbol, Name>, AggregateType>();
             _pErrorWithNamespaceParentTable = new Dictionary<KeyPair<AssemblyQualifiedNamespaceSymbol, Name>, ErrorType>();
-            _pErrorWithTypeParentTable = new Dictionary<KeyPair<CType, Name>, ErrorType>();
             _pArrayTable = new Dictionary<KeyPair<CType, Name>, ArrayType>();
             _pParameterModifierTable = new Dictionary<KeyPair<CType, Name>, ParameterModifierType>();
             _pPointerTable = new Dictionary<CType, PointerType>();
@@ -90,17 +88,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _pAggregateTable.Add(new KeyPair<AggregateSymbol, Name>(pAggregateSymbol, pName), pAggregate);
         }
 
-        public ErrorType LookupError(Name pName, CType pParentType)
-        {
-            var key = new KeyPair<CType, Name>(pParentType, pName);
-            ErrorType result;
-            if (_pErrorWithTypeParentTable.TryGetValue(key, out result))
-            {
-                return result;
-            }
-            return null;
-        }
-
         public ErrorType LookupError(Name pName, AssemblyQualifiedNamespaceSymbol pParentNS)
         {
             var key = new KeyPair<AssemblyQualifiedNamespaceSymbol, Name>(pParentNS, pName);
@@ -110,12 +97,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return result;
             }
             return null;
-        }
-
-        public void InsertError(Name pName, CType pParentType, ErrorType pError)
-        {
-            Debug.Assert(LookupError(pName, pParentType) == null);
-            _pErrorWithTypeParentTable.Add(new KeyPair<CType, Name>(pParentType, pName), pError);
         }
 
         public void InsertError(Name pName, AssemblyQualifiedNamespaceSymbol pParentNS, ErrorType pError)


### PR DESCRIPTION
`ErrorType` never has `TypeParent` set to anything except null, and either both the `nameText` is not null and the namespace parent is the root namespace, or both are null, so the tests for it can become tests on `nameText`.