### PR TITLE
Prevent serial port test failures of aborting the run

### DIFF
--- a/src/System.IO.Ports/tests/SerialPort/BreakState.cs
+++ b/src/System.IO.Ports/tests/SerialPort/BreakState.cs
@@ -51,7 +51,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [ConditionalFact(nameof(HasNullModem), nameof(HasReliableBreak))]
+        [ConditionalFact(nameof(HasNullModem))]
         public void BreakState_true()
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
@@ -73,7 +73,7 @@ namespace System.IO.Ports.Tests
         }
 
  
-        [ConditionalFact(nameof(HasNullModem), nameof(HasReliableBreak))]
+        [ConditionalFact(nameof(HasNullModem))]
         public void BreakState_false()
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
@@ -97,7 +97,7 @@ namespace System.IO.Ports.Tests
         }
 
 
-        [ConditionalFact(nameof(HasNullModem), nameof(HasReliableBreak))]
+        [ConditionalFact(nameof(HasNullModem))]
         public void BreakState_true_false()
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
@@ -125,7 +125,7 @@ namespace System.IO.Ports.Tests
         }
 
 
-        [ConditionalFact(nameof(HasNullModem), nameof(HasReliableBreak))]
+        [ConditionalFact(nameof(HasNullModem))]
         public void BreakState_true_false_true()
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))

--- a/src/System.IO.Ports/tests/SerialPort/BreakState.cs
+++ b/src/System.IO.Ports/tests/SerialPort/BreakState.cs
@@ -51,8 +51,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-
-        [ConditionalFact(nameof(HasNullModem))]
+        [ConditionalFact(nameof(HasNullModem), nameof(HasReliableBreak))]
         public void BreakState_true()
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
@@ -73,8 +72,8 @@ namespace System.IO.Ports.Tests
             }
         }
 
-
-        [ConditionalFact(nameof(HasNullModem))]
+ 
+        [ConditionalFact(nameof(HasNullModem), nameof(HasReliableBreak))]
         public void BreakState_false()
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
@@ -98,7 +97,7 @@ namespace System.IO.Ports.Tests
         }
 
 
-        [ConditionalFact(nameof(HasNullModem))]
+        [ConditionalFact(nameof(HasNullModem), nameof(HasReliableBreak))]
         public void BreakState_true_false()
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
@@ -126,7 +125,7 @@ namespace System.IO.Ports.Tests
         }
 
 
-        [ConditionalFact(nameof(HasNullModem))]
+        [ConditionalFact(nameof(HasNullModem), nameof(HasReliableBreak))]
         public void BreakState_true_false_true()
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))

--- a/src/System.IO.Ports/tests/SerialPort/ErrorEvent.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ErrorEvent.cs
@@ -187,8 +187,6 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 ErrorEventHandler errEventHandler = new ErrorEventHandler(com1);
-                byte[] frameErrorBytes = new byte[1];
-                Random rndGen = new Random();
 
                 Debug.WriteLine("Verifying Frame event");
                 com1.DataBits = 7;
@@ -199,16 +197,10 @@ namespace System.IO.Ports.Tests
 
                 com1.ErrorReceived += errEventHandler.HandleEvent;
 
-                for (int i = 0; i < frameErrorBytes.Length; i++)
-                {
-                    frameErrorBytes[i] = (byte)rndGen.Next(0, 256);
-                }
-
                 //This should cause a frame error since the 8th bit is not set 
                 //and com1 is set to 7 data bits ao the 8th bit will +12v where
                 //com1 expects the stop bit at the 8th bit to be -12v
-                frameErrorBytes[0] = 0x01;
-
+                var frameErrorBytes = new byte[] { 0x01 };
                 for (int i = 0; i < NUM_TRYS; i++)
                 {
                     Debug.WriteLine("Verifying Frame event try: {0}", i);
@@ -221,7 +213,7 @@ namespace System.IO.Ports.Tests
                         errEventHandler.Validate(SerialError.Frame, -1);
                     }
                 }
-
+                
                 lock (com1)
                 {
                     if (com1.IsOpen)

--- a/src/System.IO.Ports/tests/SerialPort/Event_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Event_Generic.cs
@@ -27,18 +27,18 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-                PinChangedEventHandler pinChangedEventHandler = new PinChangedEventHandler(com1, false, true);
+                PinChangedEventHandler pinChangedEventHandler = new PinChangedEventHandler(com1, false, true, "EventHandlers_CalledSerially");
                 ReceivedEventHandler receivedEventHandler = new ReceivedEventHandler(com1, false, true);
                 ErrorEventHandler errorEventHandler = new ErrorEventHandler(com1, false, true);
                 int numPinChangedEvents = 0, numErrorEvents = 0, numReceivedEvents = 0;
                 int iterationWaitTime = 100;
 
                 /***************************************************************
-            Scenario Description: All of the event handlers should be called sequentially never
-            at the same time on multiple thread. Basically we will block each event handler caller thread and verify 
-            that no other thread is in another event handler
+                Scenario Description: All of the event handlers should be called sequentially never
+                at the same time on multiple thread. Basically we will block each event handler caller thread and verify 
+                that no other thread is in another event handler
 
-            ***************************************************************/
+                ***************************************************************/
 
                 Debug.WriteLine("Verifying that event handlers are called serially");
 
@@ -46,175 +46,178 @@ namespace System.IO.Ports.Tests
                 com2.WriteTimeout = 5000;
 
                 com1.Open();
-                com2.Open();
-
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-                com1.PinChanged += pinChangedEventHandler.HandleEvent;
-                com1.DataReceived += receivedEventHandler.HandleEvent;
-                com1.ErrorReceived += errorEventHandler.HandleEvent;
-
-                //This should cause ErrorEvent to be fired with a parity error since the 
-                //8th bit on com1 is the parity bit, com1 one expest this bit to be 1(Mark), 
-                //and com2 is writing 0 for this bit
-                com1.DataBits = 7;
-                com1.Parity = Parity.Mark;
-                com2.BaseStream.Write(new byte[1], 0, 1);
-                Debug.Print("ERROREvent Triggered");
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                //This should cause PinChangedEvent to be fired with SerialPinChanges.DsrChanged
-                //since we are setting DtrEnable to true
-                com2.DtrEnable = true;
-                Debug.WriteLine("PinChange Triggered");
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                //This should cause ReceivedEvent to be fired with ReceivedChars
-                //since we are writing some bytes
-                com1.DataBits = 8;
-                com1.Parity = Parity.None;
-                com2.BaseStream.Write(new byte[] { 40 }, 0, 1);
-                Debug.WriteLine("RxEvent Triggered");
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                //This should cause a frame error since the 8th bit is not set,
-                //and com1 is set to 7 data bits so the 8th bit will +12v where
-                //com1 expects the stop bit at the 8th bit to be -12v
-                com1.DataBits = 7;
-                com1.Parity = Parity.None;
-                com2.BaseStream.Write(new byte[] { 0x01 }, 0, 1);
-                Debug.WriteLine("FrameError Triggered");
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                //This should cause PinChangedEvent to be fired with SerialPinChanges.CtsChanged
-                //since we are setting RtsEnable to true
-                com2.RtsEnable = true;
-                Debug.WriteLine("PinChange Triggered");
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                //This should cause ReceivedEvent to be fired with EofReceived 
-                //since we are writing the EOF char		
-                com1.DataBits = 8;
-                com1.Parity = Parity.None;
-                com2.BaseStream.Write(new byte[] { 26 }, 0, 1);
-                Debug.WriteLine("RxEOF Triggered");
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                //This should cause PinChangedEvent to be fired with SerialPinChanges.Break
-                //since we are setting BreakState to true
-                com2.BreakState = true;
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                bool threadFound = true;
-                Stopwatch sw = Stopwatch.StartNew();
-                while (threadFound && sw.ElapsedMilliseconds < MAX_TIME_WAIT)
+                try
                 {
-                    threadFound = false;
+                    com2.Open();
 
-                    for (int i = 0; i < MAX_TIME_WAIT / iterationWaitTime; ++i)
+                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+                    com1.PinChanged += pinChangedEventHandler.HandleEvent;
+                    com1.DataReceived += receivedEventHandler.HandleEvent;
+                    com1.ErrorReceived += errorEventHandler.HandleEvent;
+
+                    //This should cause ErrorEvent to be fired with a parity error since the 
+                    //8th bit on com1 is the parity bit, com1 one expest this bit to be 1(Mark), 
+                    //and com2 is writing 0 for this bit
+                    com1.DataBits = 7;
+                    com1.Parity = Parity.Mark;
+                    com2.BaseStream.Write(new byte[4], 0, 4);
+                    Debug.Print("ERROREvent Triggered");
+                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                    //This should cause PinChangedEvent to be fired with SerialPinChanges.DsrChanged
+                    //since we are setting DtrEnable to true
+                    com2.DtrEnable = true;
+                    Debug.WriteLine("PinChange Triggered");
+                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                    //This should cause ReceivedEvent to be fired with ReceivedChars
+                    //since we are writing some bytes
+                    com1.DataBits = 8;
+                    com1.Parity = Parity.None;
+                    com2.BaseStream.Write(new byte[] { 40 }, 0, 1);
+                    Debug.WriteLine("RxEvent Triggered");
+                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                    //This should cause a frame error since the 8th bit is not set,
+                    //and com1 is set to 7 data bits so the 8th bit will +12v where
+                    //com1 expects the stop bit at the 8th bit to be -12v
+                    com1.DataBits = 7;
+                    com1.Parity = Parity.None;
+                    com2.BaseStream.Write(new byte[] { 0x01 }, 0, 1);
+                    Debug.WriteLine("FrameError Triggered");
+                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                    //This should cause PinChangedEvent to be fired with SerialPinChanges.CtsChanged
+                    //since we are setting RtsEnable to true
+                    com2.RtsEnable = true;
+                    Debug.WriteLine("PinChange Triggered");
+                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                    //This should cause ReceivedEvent to be fired with EofReceived 
+                    //since we are writing the EOF char		
+                    com1.DataBits = 8;
+                    com1.Parity = Parity.None;
+                    com2.BaseStream.Write(new byte[] { 26 }, 0, 1);
+                    Debug.WriteLine("RxEOF Triggered");
+                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                    //This should cause PinChangedEvent to be fired with SerialPinChanges.Break
+                    //since we are setting BreakState to true
+                    ////com2.BreakState = true;
+                    ////Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                    bool threadFound = true;
+                    Stopwatch sw = Stopwatch.StartNew();
+                    while (threadFound && sw.ElapsedMilliseconds < MAX_TIME_WAIT)
                     {
-                        Debug.WriteLine("Event counts: PinChange {0}, Rx {1}, error {2}", numPinChangedEvents, numReceivedEvents, numErrorEvents);
+                        threadFound = false;
 
-                        Debug.WriteLine("Waiting for pinchange event {0}ms", iterationWaitTime);
-
-                        if (pinChangedEventHandler.WaitForEvent(iterationWaitTime, numPinChangedEvents + 1))
+                        for (int i = 0; i < MAX_TIME_WAIT / iterationWaitTime; ++i)
                         {
-                            // A thread is in PinChangedEvent: verify that it is not in any other handler at the same time
-                            if (receivedEventHandler.NumEventsHandled != numReceivedEvents)
+                            Debug.WriteLine("Event counts: PinChange {0}, Rx {1}, error {2}", numPinChangedEvents, numReceivedEvents, numErrorEvents);
+
+                            Debug.WriteLine("Waiting for pinchange event {0}ms", iterationWaitTime);
+
+                            if (pinChangedEventHandler.WaitForEvent(iterationWaitTime, numPinChangedEvents + 1))
                             {
-                                Fail("Err_191818ahied A thread is in PinChangedEvent and ReceivedEvent");
+                                // A thread is in PinChangedEvent: verify that it is not in any other handler at the same time
+                                if (receivedEventHandler.NumEventsHandled != numReceivedEvents)
+                                {
+                                    Fail("Err_191818ahied A thread is in PinChangedEvent and ReceivedEvent");
+                                }
+
+                                if (errorEventHandler.NumEventsHandled != numErrorEvents)
+                                {
+                                    Fail("Err_198119hjaheid A thread is in PinChangedEvent and ErrorEvent");
+                                }
+
+                                ++numPinChangedEvents;
+                                pinChangedEventHandler.ResumeHandleEvent();
+                                threadFound = true;
+                                break;
                             }
 
-                            if (errorEventHandler.NumEventsHandled != numErrorEvents)
+                            Debug.WriteLine("Waiting for rx event {0}ms", iterationWaitTime);
+
+                            if (receivedEventHandler.WaitForEvent(iterationWaitTime, numReceivedEvents + 1))
                             {
-                                Fail("Err_198119hjaheid A thread is in PinChangedEvent and ErrorEvent");
+                                // A thread is in ReceivedEvent: verify that it is not in any other handler at the same time
+                                if (pinChangedEventHandler.NumEventsHandled != numPinChangedEvents)
+                                {
+                                    Fail("Err_2288ajed A thread is in ReceivedEvent and PinChangedEvent");
+                                }
+
+                                if (errorEventHandler.NumEventsHandled != numErrorEvents)
+                                {
+                                    Fail("Err_25158ajeiod A thread is in ReceivedEvent and ErrorEvent");
+                                }
+
+                                ++numReceivedEvents;
+                                receivedEventHandler.ResumeHandleEvent();
+                                threadFound = true;
+                                break;
                             }
 
-                            ++numPinChangedEvents;
-                            pinChangedEventHandler.ResumeHandleEvent();
-                            threadFound = true;
-                            break;
-                        }
+                            Debug.WriteLine("Waiting for error event {0}ms", iterationWaitTime);
 
-                        Debug.WriteLine("Waiting for rx event {0}ms", iterationWaitTime);
-
-                        if (receivedEventHandler.WaitForEvent(iterationWaitTime, numReceivedEvents + 1))
-                        {
-                            // A thread is in ReceivedEvent: verify that it is not in any other handler at the same time
-                            if (pinChangedEventHandler.NumEventsHandled != numPinChangedEvents)
+                            if (errorEventHandler.WaitForEvent(iterationWaitTime, numErrorEvents + 1))
                             {
-                                Fail("Err_2288ajed A thread is in ReceivedEvent and PinChangedEvent");
+                                // A thread is in ErrorEvent: verify that it is not in any other handler at the same time
+                                if (pinChangedEventHandler.NumEventsHandled != numPinChangedEvents)
+                                {
+                                    Fail("Err_01208akiehd A thread is in ErrorEvent and PinChangedEvent");
+                                }
+
+                                if (receivedEventHandler.NumEventsHandled != numReceivedEvents)
+                                {
+                                    Fail("Err_1254847ajied A thread is in ErrorEvent and ReceivedEvent");
+                                }
+
+                                ++numErrorEvents;
+                                errorEventHandler.ResumeHandleEvent();
+                                threadFound = true;
+                                break;
                             }
-
-                            if (errorEventHandler.NumEventsHandled != numErrorEvents)
-                            {
-                                Fail("Err_25158ajeiod A thread is in ReceivedEvent and ErrorEvent");
-                            }
-
-                            ++numReceivedEvents;
-                            receivedEventHandler.ResumeHandleEvent();
-                            threadFound = true;
-                            break;
-                        }
-
-                        Debug.WriteLine("Waiting for error event {0}ms", iterationWaitTime);
-
-                        if (errorEventHandler.WaitForEvent(iterationWaitTime, numErrorEvents + 1))
-                        {
-                            // A thread is in ErrorEvent: verify that it is not in any other handler at the same time
-                            if (pinChangedEventHandler.NumEventsHandled != numPinChangedEvents)
-                            {
-                                Fail("Err_01208akiehd A thread is in ErrorEvent and PinChangedEvent");
-                            }
-
-                            if (receivedEventHandler.NumEventsHandled != numReceivedEvents)
-                            {
-                                Fail("Err_1254847ajied A thread is in ErrorEvent and ReceivedEvent");
-                            }
-
-                            ++numErrorEvents;
-                            errorEventHandler.ResumeHandleEvent();
-                            threadFound = true;
-                            break;
                         }
                     }
-                }
 
-                if (!pinChangedEventHandler.WaitForEvent(MAX_TIME_WAIT, 3))
+                    if (!pinChangedEventHandler.WaitForEvent(MAX_TIME_WAIT, 3))
+                    {
+                        Fail("Err_2288ajied Expected 3 PinChangedEvents to be fired and only {0} occurred",
+                            pinChangedEventHandler.NumEventsHandled);
+                    }
+
+                    if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
+                    {
+                        Fail("Err_122808aoeid Expected 2 ReceivedEvents  to be fired and only {0} occurred",
+                            receivedEventHandler.NumEventsHandled);
+                    }
+
+                    if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
+                    {
+                        Fail("Err_215887ajeid Expected 3 ErrorEvents to be fired and only {0} occurred",
+                            errorEventHandler.NumEventsHandled);
+                    }
+
+                    //[] Verify all PinChangedEvents should have occurred
+                    pinChangedEventHandler.Validate(SerialPinChange.DsrChanged, 0);
+                    pinChangedEventHandler.Validate(SerialPinChange.CtsChanged, 0);
+
+                    //[] Verify all ReceivedEvent should have occurred
+                    receivedEventHandler.Validate(SerialData.Chars, 0);
+                    receivedEventHandler.Validate(SerialData.Eof, 0);
+
+                    //[] Verify all ErrorEvents should have occurred
+                    errorEventHandler.Validate(SerialError.RXParity, 0);
+                }
+                finally
                 {
-                    Fail("Err_2288ajied Expected 3 PinChangedEvents to be fired and only {0} occurred",
-                        pinChangedEventHandler.NumEventsHandled);
+                    // It's important that we close com1 BEFORE com2 (the using() block would do this the other way around normally)
+                    // This is because we have our special blocking event handlers hooked onto com1, and closing com2 is likely to 
+                    // cause a pin-change event which then hangs and prevents com1 from closing.
+                    // An alternative approach would be to unhook all the event-handlers before leaving the using() block.
+                    com1.Close();
                 }
-
-                if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
-                {
-                    Fail("Err_122808aoeid Expected 2 ReceivedEvents  to be fired and only {0} occurred",
-                        receivedEventHandler.NumEventsHandled);
-                }
-
-                if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
-                {
-                    Fail("Err_215887ajeid Expected 3 ErrorEvents to be fired and only {0} occurred",
-                        errorEventHandler.NumEventsHandled);
-                }
-
-                //[] Verify all PinChangedEvents should have occurred
-                pinChangedEventHandler.Validate(SerialPinChange.DsrChanged, 0);
-                pinChangedEventHandler.Validate(SerialPinChange.CtsChanged, 0);
-                pinChangedEventHandler.Validate(SerialPinChange.Break, 0);
-
-                //[] Verify all ReceivedEvent should have occurred
-                receivedEventHandler.Validate(SerialData.Chars, 0);
-                receivedEventHandler.Validate(SerialData.Eof, 0);
-
-                //[] Verify all ErrorEvents should have occurred
-                errorEventHandler.Validate(SerialError.RXParity, 0);
-                errorEventHandler.Validate(SerialError.Frame, 0);
-
-                // It's important that we close com1 BEFORE com2 (the using() block would do this the other way around normally)
-                // This is because we have our special blocking event handlers hooked onto com1, and closing com2 is likely to 
-                // cause a pin-change event which then hangs and prevents com1 from closing.
-                // An alternative approach would be to unhook all the event-handlers before leaving the using() block.
-                com1.Close();
             }
         }
 
@@ -224,33 +227,33 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-                PinChangedEventHandler pinChangedEventHandler = new PinChangedEventHandler(com1, false, true);
+                PinChangedEventHandler pinChangedEventHandler = new PinChangedEventHandler(com1, false, false, "Thread_In_PinChangedEvent");
 
                 Debug.WriteLine(
                     "Verifying that if a thread is blocked in a PinChangedEvent handler the port can still be closed");
 
                 com1.Open();
-                com2.Open();
-
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-                com1.PinChanged += pinChangedEventHandler.HandleEvent;
-
-                //This should cause PinChangedEvent to be fired with SerialPinChanges.DsrChanged
-                //since we are setting DtrEnable to true
-                com2.DtrEnable = true;
-
-                if (!pinChangedEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
+                try
                 {
-                    Fail("Err_32688ajoid Expected 1 PinChangedEvents to be fired and only {0} occurred",
-                        pinChangedEventHandler.NumEventsHandled);
+                    com2.Open();
+
+                    com1.PinChanged += pinChangedEventHandler.HandleEvent;
+
+                    //This should cause PinChangedEvent to be fired with SerialPinChanges.DsrChanged
+                    //since we are setting DtrEnable to true
+                    com2.DtrEnable = true;
+
+                    if (!pinChangedEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
+                    {
+                        Fail("Err_32688ajoid Expected 1 PinChangedEvents to be fired and only {0} occurred",
+                            pinChangedEventHandler.NumEventsHandled);
+                    }
                 }
-
-                Task task = Task.Run(() => com1.Close());
-                Thread.Sleep(5000);
-
-                pinChangedEventHandler.ResumeHandleEvent();
-
-                TCSupport.WaitForTaskCompletion(task);
+                finally
+                {
+                    Task task = Task.Run(() => com1.Close());
+                    TCSupport.WaitForTaskCompletion(task);
+                }
             }
         }
 
@@ -260,36 +263,36 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-                ReceivedEventHandler receivedEventHandler = new ReceivedEventHandler(com1, false, true);
+                ReceivedEventHandler receivedEventHandler = new ReceivedEventHandler(com1, false, false);
 
                 Debug.WriteLine(
                     "Verifying that if a thread is blocked in a RecevedEvent handler the port can still be closed");
 
                 com1.Open();
-                com2.Open();
-
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-                com1.DataReceived += receivedEventHandler.HandleEvent;
-
-                //This should cause ReceivedEvent to be fired with ReceivedChars
-                //since we are writing some bytes
-                com1.DataBits = 8;
-                com1.Parity = Parity.None;
-                com2.BaseStream.Write(new byte[] { 40 }, 0, 1);
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
+                try
                 {
-                    Fail("Err_122808aoeid Expected 1 ReceivedEvents  to be fired and only {0} occurred",
-                        receivedEventHandler.NumEventsHandled);
+                    com2.Open();
+
+                    com1.DataReceived += receivedEventHandler.HandleEvent;
+
+                    //This should cause ReceivedEvent to be fired with ReceivedChars
+                    //since we are writing some bytes
+                    com1.DataBits = 8;
+                    com1.Parity = Parity.None;
+                    com2.BaseStream.Write(new byte[] { 40 }, 0, 1);
+                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                    if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
+                    {
+                        Fail("Err_122808aoeid Expected 1 ReceivedEvents  to be fired and only {0} occurred",
+                            receivedEventHandler.NumEventsHandled);
+                    }
                 }
-
-                Task task = Task.Run(() => com1.Close());
-                Thread.Sleep(5000);
-
-                receivedEventHandler.ResumeHandleEvent();
-
-                TCSupport.WaitForTaskCompletion(task);
+                finally
+                {
+                    Task task = Task.Run(() => com1.Close());
+                    TCSupport.WaitForTaskCompletion(task);
+                }
             }
         }
 
@@ -299,34 +302,34 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-                ErrorEventHandler errorEventHandler = new ErrorEventHandler(com1, false, true);
+                ErrorEventHandler errorEventHandler = new ErrorEventHandler(com1, false, false);
 
                 Debug.WriteLine("Verifying that if a thread is blocked in a ErrorEvent handler the port can still be closed");
 
                 com1.Open();
-                com2.Open();
-
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-                com1.ErrorReceived += errorEventHandler.HandleEvent;
-
-                //This should cause ErrorEvent to be fired with a parity error since the 
-                //8th bit on com1 is the parity bit, com1 one expest this bit to be 1(Mark), 
-                //and com2 is writing 0 for this bit
-                com1.DataBits = 7;
-                com1.Parity = Parity.Mark;
-                com2.BaseStream.Write(new byte[1], 0, 1);
-                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
+                try
                 {
-                    Fail("Err_215887ajeid Expected 1 ErrorEvents to be fired and only {0} occurred", errorEventHandler.NumEventsHandled);
+                    com2.Open();
+
+                    com1.ErrorReceived += errorEventHandler.HandleEvent;
+
+                    //This should cause ErrorEvent to be fired with a parity error since the 
+                    //8th bit on com1 is the parity bit, com1 one expest this bit to be 1(Mark), 
+                    //and com2 is writing 0 for this bit
+                    com1.DataBits = 7;
+                    com1.Parity = Parity.Mark;
+                    com2.BaseStream.Write(new byte[4], 0, 4);
+
+                    if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
+                    {
+                        Fail("Err_215887ajeid Expected 1 ErrorEvents to be fired and only {0} occurred", errorEventHandler.NumEventsHandled);
+                    }
                 }
-
-                Task task = Task.Run(() => com1.Close());
-                Thread.Sleep(5000);
-
-                errorEventHandler.ResumeHandleEvent();
-                TCSupport.WaitForTaskCompletion(task);
+                finally
+                {
+                    Task task = Task.Run(() => com1.Close());
+                    TCSupport.WaitForTaskCompletion(task);
+                }
             }
         }
         #endregion
@@ -335,7 +338,7 @@ namespace System.IO.Ports.Tests
 
         private class PinChangedEventHandler : TestEventHandler<SerialPinChange>
         {
-            public PinChangedEventHandler(SerialPort com, bool shouldThrow, bool shouldWait) : base(com, shouldThrow, shouldWait)
+            public PinChangedEventHandler(SerialPort com, bool shouldThrow, bool shouldWait, string testName) : base(com, shouldThrow, shouldWait, testName)
             {
             }
 

--- a/src/System.IO.Ports/tests/SerialPort/Event_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Event_Generic.cs
@@ -27,18 +27,18 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-                PinChangedEventHandler pinChangedEventHandler = new PinChangedEventHandler(com1, false, true, "EventHandlers_CalledSerially");
+                PinChangedEventHandler pinChangedEventHandler = new PinChangedEventHandler(com1, false, true);
                 ReceivedEventHandler receivedEventHandler = new ReceivedEventHandler(com1, false, true);
                 ErrorEventHandler errorEventHandler = new ErrorEventHandler(com1, false, true);
                 int numPinChangedEvents = 0, numErrorEvents = 0, numReceivedEvents = 0;
                 int iterationWaitTime = 100;
 
                 /***************************************************************
-                Scenario Description: All of the event handlers should be called sequentially never
-                at the same time on multiple thread. Basically we will block each event handler caller thread and verify 
-                that no other thread is in another event handler
+            Scenario Description: All of the event handlers should be called sequentially never
+            at the same time on multiple thread. Basically we will block each event handler caller thread and verify 
+            that no other thread is in another event handler
 
-                ***************************************************************/
+            ***************************************************************/
 
                 Debug.WriteLine("Verifying that event handlers are called serially");
 
@@ -46,178 +46,179 @@ namespace System.IO.Ports.Tests
                 com2.WriteTimeout = 5000;
 
                 com1.Open();
-                try
+                com2.Open();
+
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+                com1.PinChanged += pinChangedEventHandler.HandleEvent;
+                com1.DataReceived += receivedEventHandler.HandleEvent;
+                com1.ErrorReceived += errorEventHandler.HandleEvent;
+
+                //This should cause ErrorEvent to be fired with a parity error since the 
+                //8th bit on com1 is the parity bit, com1 one expest this bit to be 1(Mark), 
+                //and com2 is writing 0 for this bit
+                com1.DataBits = 7;
+                com1.Parity = Parity.Mark;
+                com2.BaseStream.Write(new byte[1], 0, 1);
+                Debug.Print("ERROREvent Triggered");
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                //This should cause PinChangedEvent to be fired with SerialPinChanges.DsrChanged
+                //since we are setting DtrEnable to true
+                com2.DtrEnable = true;
+                Debug.WriteLine("PinChange Triggered");
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                //This should cause ReceivedEvent to be fired with ReceivedChars
+                //since we are writing some bytes
+                com1.DataBits = 8;
+                com1.Parity = Parity.None;
+                com2.BaseStream.Write(new byte[] { 40 }, 0, 1);
+                Debug.WriteLine("RxEvent Triggered");
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                //This should cause a frame error since the 8th bit is not set,
+                //and com1 is set to 7 data bits so the 8th bit will +12v where
+                //com1 expects the stop bit at the 8th bit to be -12v
+                com1.DataBits = 7;
+                com1.Parity = Parity.None;
+                com2.BaseStream.Write(new byte[] { 0x01 }, 0, 1);
+                Debug.WriteLine("FrameError Triggered");
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                //This should cause PinChangedEvent to be fired with SerialPinChanges.CtsChanged
+                //since we are setting RtsEnable to true
+                com2.RtsEnable = true;
+                Debug.WriteLine("PinChange Triggered");
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                //This should cause ReceivedEvent to be fired with EofReceived 
+                //since we are writing the EOF char		
+                com1.DataBits = 8;
+                com1.Parity = Parity.None;
+                com2.BaseStream.Write(new byte[] { 26 }, 0, 1);
+                Debug.WriteLine("RxEOF Triggered");
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                //This should cause PinChangedEvent to be fired with SerialPinChanges.Break
+                //since we are setting BreakState to true
+                com2.BreakState = true;
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                bool threadFound = true;
+                Stopwatch sw = Stopwatch.StartNew();
+                while (threadFound && sw.ElapsedMilliseconds < MAX_TIME_WAIT)
                 {
-                    com2.Open();
+                    threadFound = false;
 
-                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-                    com1.PinChanged += pinChangedEventHandler.HandleEvent;
-                    com1.DataReceived += receivedEventHandler.HandleEvent;
-                    com1.ErrorReceived += errorEventHandler.HandleEvent;
-
-                    //This should cause ErrorEvent to be fired with a parity error since the 
-                    //8th bit on com1 is the parity bit, com1 one expest this bit to be 1(Mark), 
-                    //and com2 is writing 0 for this bit
-                    com1.DataBits = 7;
-                    com1.Parity = Parity.Mark;
-                    com2.BaseStream.Write(new byte[4], 0, 4);
-                    Debug.Print("ERROREvent Triggered");
-                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                    //This should cause PinChangedEvent to be fired with SerialPinChanges.DsrChanged
-                    //since we are setting DtrEnable to true
-                    com2.DtrEnable = true;
-                    Debug.WriteLine("PinChange Triggered");
-                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                    //This should cause ReceivedEvent to be fired with ReceivedChars
-                    //since we are writing some bytes
-                    com1.DataBits = 8;
-                    com1.Parity = Parity.None;
-                    com2.BaseStream.Write(new byte[] { 40 }, 0, 1);
-                    Debug.WriteLine("RxEvent Triggered");
-                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                    //This should cause a frame error since the 8th bit is not set,
-                    //and com1 is set to 7 data bits so the 8th bit will +12v where
-                    //com1 expects the stop bit at the 8th bit to be -12v
-                    com1.DataBits = 7;
-                    com1.Parity = Parity.None;
-                    com2.BaseStream.Write(new byte[] { 0x01 }, 0, 1);
-                    Debug.WriteLine("FrameError Triggered");
-                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                    //This should cause PinChangedEvent to be fired with SerialPinChanges.CtsChanged
-                    //since we are setting RtsEnable to true
-                    com2.RtsEnable = true;
-                    Debug.WriteLine("PinChange Triggered");
-                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                    //This should cause ReceivedEvent to be fired with EofReceived 
-                    //since we are writing the EOF char		
-                    com1.DataBits = 8;
-                    com1.Parity = Parity.None;
-                    com2.BaseStream.Write(new byte[] { 26 }, 0, 1);
-                    Debug.WriteLine("RxEOF Triggered");
-                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                    //This should cause PinChangedEvent to be fired with SerialPinChanges.Break
-                    //since we are setting BreakState to true
-                    ////com2.BreakState = true;
-                    ////Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                    bool threadFound = true;
-                    Stopwatch sw = Stopwatch.StartNew();
-                    while (threadFound && sw.ElapsedMilliseconds < MAX_TIME_WAIT)
+                    for (int i = 0; i < MAX_TIME_WAIT / iterationWaitTime; ++i)
                     {
-                        threadFound = false;
+                        Debug.WriteLine("Event counts: PinChange {0}, Rx {1}, error {2}", numPinChangedEvents, numReceivedEvents, numErrorEvents);
 
-                        for (int i = 0; i < MAX_TIME_WAIT / iterationWaitTime; ++i)
+                        Debug.WriteLine("Waiting for pinchange event {0}ms", iterationWaitTime);
+
+                        if (pinChangedEventHandler.WaitForEvent(iterationWaitTime, numPinChangedEvents + 1))
                         {
-                            Debug.WriteLine("Event counts: PinChange {0}, Rx {1}, error {2}", numPinChangedEvents, numReceivedEvents, numErrorEvents);
-
-                            Debug.WriteLine("Waiting for pinchange event {0}ms", iterationWaitTime);
-
-                            if (pinChangedEventHandler.WaitForEvent(iterationWaitTime, numPinChangedEvents + 1))
+                            // A thread is in PinChangedEvent: verify that it is not in any other handler at the same time
+                            if (receivedEventHandler.NumEventsHandled != numReceivedEvents)
                             {
-                                // A thread is in PinChangedEvent: verify that it is not in any other handler at the same time
-                                if (receivedEventHandler.NumEventsHandled != numReceivedEvents)
-                                {
-                                    Fail("Err_191818ahied A thread is in PinChangedEvent and ReceivedEvent");
-                                }
-
-                                if (errorEventHandler.NumEventsHandled != numErrorEvents)
-                                {
-                                    Fail("Err_198119hjaheid A thread is in PinChangedEvent and ErrorEvent");
-                                }
-
-                                ++numPinChangedEvents;
-                                pinChangedEventHandler.ResumeHandleEvent();
-                                threadFound = true;
-                                break;
+                                Fail("Err_191818ahied A thread is in PinChangedEvent and ReceivedEvent");
                             }
 
-                            Debug.WriteLine("Waiting for rx event {0}ms", iterationWaitTime);
-
-                            if (receivedEventHandler.WaitForEvent(iterationWaitTime, numReceivedEvents + 1))
+                            if (errorEventHandler.NumEventsHandled != numErrorEvents)
                             {
-                                // A thread is in ReceivedEvent: verify that it is not in any other handler at the same time
-                                if (pinChangedEventHandler.NumEventsHandled != numPinChangedEvents)
-                                {
-                                    Fail("Err_2288ajed A thread is in ReceivedEvent and PinChangedEvent");
-                                }
-
-                                if (errorEventHandler.NumEventsHandled != numErrorEvents)
-                                {
-                                    Fail("Err_25158ajeiod A thread is in ReceivedEvent and ErrorEvent");
-                                }
-
-                                ++numReceivedEvents;
-                                receivedEventHandler.ResumeHandleEvent();
-                                threadFound = true;
-                                break;
+                                Fail("Err_198119hjaheid A thread is in PinChangedEvent and ErrorEvent");
                             }
 
-                            Debug.WriteLine("Waiting for error event {0}ms", iterationWaitTime);
+                            ++numPinChangedEvents;
+                            pinChangedEventHandler.ResumeHandleEvent();
+                            threadFound = true;
+                            break;
+                        }
 
-                            if (errorEventHandler.WaitForEvent(iterationWaitTime, numErrorEvents + 1))
+                        Debug.WriteLine("Waiting for rx event {0}ms", iterationWaitTime);
+
+                        if (receivedEventHandler.WaitForEvent(iterationWaitTime, numReceivedEvents + 1))
+                        {
+                            // A thread is in ReceivedEvent: verify that it is not in any other handler at the same time
+                            if (pinChangedEventHandler.NumEventsHandled != numPinChangedEvents)
                             {
-                                // A thread is in ErrorEvent: verify that it is not in any other handler at the same time
-                                if (pinChangedEventHandler.NumEventsHandled != numPinChangedEvents)
-                                {
-                                    Fail("Err_01208akiehd A thread is in ErrorEvent and PinChangedEvent");
-                                }
-
-                                if (receivedEventHandler.NumEventsHandled != numReceivedEvents)
-                                {
-                                    Fail("Err_1254847ajied A thread is in ErrorEvent and ReceivedEvent");
-                                }
-
-                                ++numErrorEvents;
-                                errorEventHandler.ResumeHandleEvent();
-                                threadFound = true;
-                                break;
+                                Fail("Err_2288ajed A thread is in ReceivedEvent and PinChangedEvent");
                             }
+
+                            if (errorEventHandler.NumEventsHandled != numErrorEvents)
+                            {
+                                Fail("Err_25158ajeiod A thread is in ReceivedEvent and ErrorEvent");
+                            }
+
+                            ++numReceivedEvents;
+                            receivedEventHandler.ResumeHandleEvent();
+                            threadFound = true;
+                            break;
+                        }
+
+                        Debug.WriteLine("Waiting for error event {0}ms", iterationWaitTime);
+
+                        if (errorEventHandler.WaitForEvent(iterationWaitTime, numErrorEvents + 1))
+                        {
+                            // A thread is in ErrorEvent: verify that it is not in any other handler at the same time
+                            if (pinChangedEventHandler.NumEventsHandled != numPinChangedEvents)
+                            {
+                                Fail("Err_01208akiehd A thread is in ErrorEvent and PinChangedEvent");
+                            }
+
+                            if (receivedEventHandler.NumEventsHandled != numReceivedEvents)
+                            {
+                                Fail("Err_1254847ajied A thread is in ErrorEvent and ReceivedEvent");
+                            }
+
+                            ++numErrorEvents;
+                            errorEventHandler.ResumeHandleEvent();
+                            threadFound = true;
+                            break;
                         }
                     }
-
-                    if (!pinChangedEventHandler.WaitForEvent(MAX_TIME_WAIT, 3))
-                    {
-                        Fail("Err_2288ajied Expected 3 PinChangedEvents to be fired and only {0} occurred",
-                            pinChangedEventHandler.NumEventsHandled);
-                    }
-
-                    if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
-                    {
-                        Fail("Err_122808aoeid Expected 2 ReceivedEvents  to be fired and only {0} occurred",
-                            receivedEventHandler.NumEventsHandled);
-                    }
-
-                    if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
-                    {
-                        Fail("Err_215887ajeid Expected 3 ErrorEvents to be fired and only {0} occurred",
-                            errorEventHandler.NumEventsHandled);
-                    }
-
-                    //[] Verify all PinChangedEvents should have occurred
-                    pinChangedEventHandler.Validate(SerialPinChange.DsrChanged, 0);
-                    pinChangedEventHandler.Validate(SerialPinChange.CtsChanged, 0);
-
-                    //[] Verify all ReceivedEvent should have occurred
-                    receivedEventHandler.Validate(SerialData.Chars, 0);
-                    receivedEventHandler.Validate(SerialData.Eof, 0);
-
-                    //[] Verify all ErrorEvents should have occurred
-                    errorEventHandler.Validate(SerialError.RXParity, 0);
                 }
-                finally
+
+                Assert.True(pinChangedEventHandler.SuccessfulWait, "pinChangedEventHandler did not receive resume handle event");
+                Assert.True(receivedEventHandler.SuccessfulWait, "receivedEventHandler did not receive resume handle event");
+                Assert.True(errorEventHandler.SuccessfulWait, "errorEventHandler did not receive resume handle event");
+
+                if (!pinChangedEventHandler.WaitForEvent(MAX_TIME_WAIT, 3))
                 {
-                    // It's important that we close com1 BEFORE com2 (the using() block would do this the other way around normally)
-                    // This is because we have our special blocking event handlers hooked onto com1, and closing com2 is likely to 
-                    // cause a pin-change event which then hangs and prevents com1 from closing.
-                    // An alternative approach would be to unhook all the event-handlers before leaving the using() block.
-                    com1.Close();
+                    Fail("Err_2288ajied Expected 3 PinChangedEvents to be fired and only {0} occurred",
+                        pinChangedEventHandler.NumEventsHandled);
                 }
+
+                if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
+                {
+                    Fail("Err_122808aoeid Expected 2 ReceivedEvents  to be fired and only {0} occurred",
+                        receivedEventHandler.NumEventsHandled);
+                }
+
+                if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
+                {
+                    Fail("Err_215887ajeid Expected 3 ErrorEvents to be fired and only {0} occurred",
+                        errorEventHandler.NumEventsHandled);
+                }
+
+                //[] Verify all PinChangedEvents should have occurred
+                pinChangedEventHandler.Validate(SerialPinChange.DsrChanged, 0);
+                pinChangedEventHandler.Validate(SerialPinChange.CtsChanged, 0);
+                pinChangedEventHandler.Validate(SerialPinChange.Break, 0);
+
+                //[] Verify all ReceivedEvent should have occurred
+                receivedEventHandler.Validate(SerialData.Chars, 0);
+                receivedEventHandler.Validate(SerialData.Eof, 0);
+
+                //[] Verify all ErrorEvents should have occurred
+                errorEventHandler.Validate(SerialError.RXParity, 0);
+                errorEventHandler.Validate(SerialError.Frame, 0);
+
+                // It's important that we close com1 BEFORE com2 (the using() block would do this the other way around normally)
+                // This is because we have our special blocking event handlers hooked onto com1, and closing com2 is likely to 
+                // cause a pin-change event which then hangs and prevents com1 from closing.
+                // An alternative approach would be to unhook all the event-handlers before leaving the using() block.
+                com1.Close();
             }
         }
 
@@ -227,33 +228,33 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-                PinChangedEventHandler pinChangedEventHandler = new PinChangedEventHandler(com1, false, false, "Thread_In_PinChangedEvent");
+                PinChangedEventHandler pinChangedEventHandler = new PinChangedEventHandler(com1, false, true);
 
                 Debug.WriteLine(
                     "Verifying that if a thread is blocked in a PinChangedEvent handler the port can still be closed");
 
                 com1.Open();
-                try
+                com2.Open();
+
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+                com1.PinChanged += pinChangedEventHandler.HandleEvent;
+
+                //This should cause PinChangedEvent to be fired with SerialPinChanges.DsrChanged
+                //since we are setting DtrEnable to true
+                com2.DtrEnable = true;
+
+                if (!pinChangedEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
                 {
-                    com2.Open();
-
-                    com1.PinChanged += pinChangedEventHandler.HandleEvent;
-
-                    //This should cause PinChangedEvent to be fired with SerialPinChanges.DsrChanged
-                    //since we are setting DtrEnable to true
-                    com2.DtrEnable = true;
-
-                    if (!pinChangedEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
-                    {
-                        Fail("Err_32688ajoid Expected 1 PinChangedEvents to be fired and only {0} occurred",
-                            pinChangedEventHandler.NumEventsHandled);
-                    }
+                    Fail("Err_32688ajoid Expected 1 PinChangedEvents to be fired and only {0} occurred",
+                        pinChangedEventHandler.NumEventsHandled);
                 }
-                finally
-                {
-                    Task task = Task.Run(() => com1.Close());
-                    TCSupport.WaitForTaskCompletion(task);
-                }
+
+                Task task = Task.Run(() => com1.Close());
+                Thread.Sleep(5000);
+
+                pinChangedEventHandler.ResumeHandleEvent();
+                TCSupport.WaitForTaskCompletion(task);
+                Assert.True(pinChangedEventHandler.SuccessfulWait, "pinChangedEventHandler did not receive resume handle event");
             }
         }
 
@@ -263,36 +264,36 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-                ReceivedEventHandler receivedEventHandler = new ReceivedEventHandler(com1, false, false);
+                ReceivedEventHandler receivedEventHandler = new ReceivedEventHandler(com1, false, true);
 
                 Debug.WriteLine(
                     "Verifying that if a thread is blocked in a RecevedEvent handler the port can still be closed");
 
                 com1.Open();
-                try
+                com2.Open();
+
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+                com1.DataReceived += receivedEventHandler.HandleEvent;
+
+                //This should cause ReceivedEvent to be fired with ReceivedChars
+                //since we are writing some bytes
+                com1.DataBits = 8;
+                com1.Parity = Parity.None;
+                com2.BaseStream.Write(new byte[] { 40 }, 0, 1);
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
                 {
-                    com2.Open();
-
-                    com1.DataReceived += receivedEventHandler.HandleEvent;
-
-                    //This should cause ReceivedEvent to be fired with ReceivedChars
-                    //since we are writing some bytes
-                    com1.DataBits = 8;
-                    com1.Parity = Parity.None;
-                    com2.BaseStream.Write(new byte[] { 40 }, 0, 1);
-                    Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-                    if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
-                    {
-                        Fail("Err_122808aoeid Expected 1 ReceivedEvents  to be fired and only {0} occurred",
-                            receivedEventHandler.NumEventsHandled);
-                    }
+                    Fail("Err_122808aoeid Expected 1 ReceivedEvents  to be fired and only {0} occurred",
+                        receivedEventHandler.NumEventsHandled);
                 }
-                finally
-                {
-                    Task task = Task.Run(() => com1.Close());
-                    TCSupport.WaitForTaskCompletion(task);
-                }
+
+                Task task = Task.Run(() => com1.Close());
+                Thread.Sleep(5000);
+
+                receivedEventHandler.ResumeHandleEvent();
+                TCSupport.WaitForTaskCompletion(task);
+                Assert.True(receivedEventHandler.SuccessfulWait, "receivedEventHandler did not receive resume handle event");
             }
         }
 
@@ -302,34 +303,35 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-                ErrorEventHandler errorEventHandler = new ErrorEventHandler(com1, false, false);
+                ErrorEventHandler errorEventHandler = new ErrorEventHandler(com1, false, true);
 
                 Debug.WriteLine("Verifying that if a thread is blocked in a ErrorEvent handler the port can still be closed");
 
                 com1.Open();
-                try
+                com2.Open();
+
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+                com1.ErrorReceived += errorEventHandler.HandleEvent;
+
+                //This should cause ErrorEvent to be fired with a parity error since the 
+                //8th bit on com1 is the parity bit, com1 one expest this bit to be 1(Mark), 
+                //and com2 is writing 0 for this bit
+                com1.DataBits = 7;
+                com1.Parity = Parity.Mark;
+                com2.BaseStream.Write(new byte[1], 0, 1);
+                Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
+
+                if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
                 {
-                    com2.Open();
-
-                    com1.ErrorReceived += errorEventHandler.HandleEvent;
-
-                    //This should cause ErrorEvent to be fired with a parity error since the 
-                    //8th bit on com1 is the parity bit, com1 one expest this bit to be 1(Mark), 
-                    //and com2 is writing 0 for this bit
-                    com1.DataBits = 7;
-                    com1.Parity = Parity.Mark;
-                    com2.BaseStream.Write(new byte[4], 0, 4);
-
-                    if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
-                    {
-                        Fail("Err_215887ajeid Expected 1 ErrorEvents to be fired and only {0} occurred", errorEventHandler.NumEventsHandled);
-                    }
+                    Fail("Err_215887ajeid Expected 1 ErrorEvents to be fired and only {0} occurred", errorEventHandler.NumEventsHandled);
                 }
-                finally
-                {
-                    Task task = Task.Run(() => com1.Close());
-                    TCSupport.WaitForTaskCompletion(task);
-                }
+
+                Task task = Task.Run(() => com1.Close());
+                Thread.Sleep(5000);
+
+                errorEventHandler.ResumeHandleEvent();
+                TCSupport.WaitForTaskCompletion(task);
+                Assert.True(errorEventHandler.SuccessfulWait, "errorEventHandler did not receive resume handle event");
             }
         }
         #endregion
@@ -338,7 +340,7 @@ namespace System.IO.Ports.Tests
 
         private class PinChangedEventHandler : TestEventHandler<SerialPinChange>
         {
-            public PinChangedEventHandler(SerialPort com, bool shouldThrow, bool shouldWait, string testName) : base(com, shouldThrow, shouldWait, testName)
+            public PinChangedEventHandler(SerialPort com, bool shouldThrow, bool shouldWait) : base(com, shouldThrow, shouldWait)
             {
             }
 

--- a/src/System.IO.Ports/tests/SerialPort/PinChangedEvent.cs
+++ b/src/System.IO.Ports/tests/SerialPort/PinChangedEvent.cs
@@ -90,7 +90,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [ConditionalFact(nameof(HasNullModem))]
+        [ConditionalFact(nameof(HasNullModem), nameof(HasReliableBreak))]
         public void PinChangedEvent_Break()
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
@@ -144,20 +144,16 @@ namespace System.IO.Ports.Tests
                 com1.Open();
                 com2.Open();
 
-                com2.BreakState = true;
-                Thread.Sleep(100);
                 com2.DtrEnable = true;
                 Thread.Sleep(100);
                 com2.RtsEnable = true;
 
-                eventHandler.WaitForEvent(MAX_TIME_WAIT, 3);
+                eventHandler.WaitForEvent(MAX_TIME_WAIT, 2);
 
-                eventHandler.Validate(SerialPinChange.Break, 0);
                 eventHandler.Validate(SerialPinChange.DsrChanged, 0);
                 eventHandler.Validate(SerialPinChange.CtsChanged, 0);
 
                 com1.PinChanged -= pinchangedEventHandler;
-                com2.BreakState = false;
                 com2.DtrEnable = false;
                 com2.RtsEnable = false;
             }

--- a/src/System.IO.Ports/tests/SerialPort/PinChangedEvent.cs
+++ b/src/System.IO.Ports/tests/SerialPort/PinChangedEvent.cs
@@ -90,7 +90,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [ConditionalFact(nameof(HasNullModem), nameof(HasReliableBreak))]
+        [ConditionalFact(nameof(HasNullModem))]
         public void PinChangedEvent_Break()
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
@@ -144,16 +144,20 @@ namespace System.IO.Ports.Tests
                 com1.Open();
                 com2.Open();
 
+                com2.BreakState = true;
+                Thread.Sleep(100);
                 com2.DtrEnable = true;
                 Thread.Sleep(100);
                 com2.RtsEnable = true;
 
-                eventHandler.WaitForEvent(MAX_TIME_WAIT, 2);
+                eventHandler.WaitForEvent(MAX_TIME_WAIT, 3);
 
+                eventHandler.Validate(SerialPinChange.Break, 0);
                 eventHandler.Validate(SerialPinChange.DsrChanged, 0);
                 eventHandler.Validate(SerialPinChange.CtsChanged, 0);
 
                 com1.PinChanged -= pinchangedEventHandler;
+                com2.BreakState = false;
                 com2.DtrEnable = false;
                 com2.RtsEnable = false;
             }

--- a/src/System.IO.Ports/tests/SerialPort/ReadByte.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadByte.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 
@@ -73,7 +74,7 @@ namespace System.IO.Ports.Tests
                 byte[] byteXmitBuffer = TCSupport.GetRandomBytes(512);
                 byte[] byteRcvBuffer = new byte[byteXmitBuffer.Length];
                 ASyncRead asyncRead = new ASyncRead(com1);
-                Thread asyncReadThread = new Thread(asyncRead.Read);
+                var asyncReadTask = new Task(asyncRead.Read);
 
                 Debug.WriteLine(
                     "Verifying that ReadByte() will read bytes that have been received after the call to Read was made");
@@ -87,7 +88,7 @@ namespace System.IO.Ports.Tests
                 if (!com2.IsOpen) //This is necessary since com1 and com2 might be the same port if we are using a loopback
                     com2.Open();
 
-                asyncReadThread.Start();
+                asyncReadTask.Start();
                 asyncRead.ReadStartedEvent.WaitOne();
                 //This only tells us that the thread has started to execute code in the method
                 Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
@@ -127,6 +128,8 @@ namespace System.IO.Ports.Tests
                         }
                     }
                 }
+
+                TCSupport.WaitForTaskCompletion(asyncReadTask);
             }
         }
         #endregion

--- a/src/System.IO.Ports/tests/SerialPort/ReadByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadByte_Generic.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
@@ -113,7 +114,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-                Thread t = new Thread(WriteToCom1);
+                var t = new Task(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Encoding = new UTF8Encoding();
@@ -132,9 +133,7 @@ namespace System.IO.Ports.Tests
                 {
                 }
 
-                //Wait for the thread to finish
-                while (t.IsAlive)
-                    Thread.Sleep(50);
+                TCSupport.WaitForTaskCompletion(t);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();

--- a/src/System.IO.Ports/tests/SerialPort/ReadChar.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadChar.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 
@@ -292,8 +293,7 @@ namespace System.IO.Ports.Tests
                 char[] charXmitBuffer = TCSupport.GetRandomChars(512, TCSupport.CharacterOptions.None);
                 char[] charRcvBuffer = new char[charXmitBuffer.Length];
                 ASyncRead asyncRead = new ASyncRead(com1);
-                Thread asyncReadThread =
-                    new Thread(asyncRead.Read);
+                var asyncReadTask = new Task(asyncRead.Read);
 
 
                 Debug.WriteLine(
@@ -308,7 +308,7 @@ namespace System.IO.Ports.Tests
                 if (!com2.IsOpen) //This is necessary since com1 and com2 might be the same port if we are using a loopback
                     com2.Open();
 
-                asyncReadThread.Start();
+                asyncReadTask.Start();
                 asyncRead.ReadStartedEvent.WaitOne();
                 //This only tells us that the thread has started to execute code in the method
                 Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
@@ -335,6 +335,8 @@ namespace System.IO.Ports.Tests
                     Assert.Equal(receivedLength, charXmitBuffer.Length);
                     Assert.Equal(charXmitBuffer, charRcvBuffer);
                 }
+
+                TCSupport.WaitForTaskCompletion(asyncReadTask);
             }
         }
 

--- a/src/System.IO.Ports/tests/SerialPort/ReadChar_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadChar_Generic.cs
@@ -7,6 +7,7 @@ using System.IO.PortsTests;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
@@ -114,7 +115,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-                Thread t = new Thread(WriteToCom1);
+                var t = new Task(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Encoding = new UTF8Encoding();
@@ -135,9 +136,7 @@ namespace System.IO.Ports.Tests
                 {
                 }
 
-                //Wait for the thread to finish
-                while (t.IsAlive)
-                    Thread.Sleep(50);
+                TCSupport.WaitForTaskCompletion(t);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();

--- a/src/System.IO.Ports/tests/SerialPort/ReadLine.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadLine.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 
@@ -353,7 +354,7 @@ namespace System.IO.Ports.Tests
             {
                 char[] charXmitBuffer = TCSupport.GetRandomChars(512, TCSupport.CharacterOptions.None);
                 var asyncRead = new ASyncRead(com1);
-                var asyncReadThread = new Thread(new ThreadStart(asyncRead.Read));
+                var asyncReadTask = new Task(asyncRead.Read);
 
                 char endLineChar = com1.NewLine[0];
                 char notEndLineChar = TCSupport.GetRandomOtherChar(endLineChar, TCSupport.CharacterOptions.None);
@@ -380,7 +381,7 @@ namespace System.IO.Ports.Tests
                 if (!com2.IsOpen) //This is necessary since com1 and com2 might be the same port if we are using a loopback
                     com2.Open();
 
-                asyncReadThread.Start();
+                asyncReadTask.Start();
                 asyncRead.ReadStartedEvent.WaitOne();
                 //This only tells us that the thread has started to execute code in the method
                 Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
@@ -462,7 +463,7 @@ namespace System.IO.Ports.Tests
 
                 var continueRunning = true;
                 var numberOfIterations = 0;
-                var writeToCom2Thread = new Thread(delegate ()
+                var writeToCom2Task = new Task(delegate ()
                 {
                     while (continueRunning)
                     {
@@ -498,12 +499,12 @@ namespace System.IO.Ports.Tests
                 if (!com2.IsOpen) //This is necessary since com1 and com2 might be the same port if we are using a loopback
                     com2.Open();
 
-                writeToCom2Thread.Start();
+                writeToCom2Task.Start();
 
                 Assert.Throws<TimeoutException>(() => com2.ReadLine());
 
                 continueRunning = false;
-                writeToCom2Thread.Join();
+                writeToCom2Task.Wait();
 
                 com1.Write(com1.NewLine);
 

--- a/src/System.IO.Ports/tests/SerialPort/ReadLine_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadLine_Generic.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
@@ -122,7 +123,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-                Thread t = new Thread(WriteToCom1);
+                var t = new Task(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Encoding = new UTF8Encoding();
@@ -141,9 +142,7 @@ namespace System.IO.Ports.Tests
                 {
                 }
 
-                //Wait for the thread to finish
-                while (t.IsAlive)
-                    Thread.Sleep(50);
+                TCSupport.WaitForTaskCompletion(t);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();

--- a/src/System.IO.Ports/tests/SerialPort/ReadTo.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadTo.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 
@@ -361,8 +362,7 @@ namespace System.IO.Ports.Tests
                 char[] charXmitBuffer = TCSupport.GetRandomChars(512, TCSupport.CharacterOptions.None);
                 string endString = "END";
                 ASyncRead asyncRead = new ASyncRead(com1, endString);
-                Thread asyncReadThread =
-                    new Thread(asyncRead.Read);
+                var asyncReadTask = new Task(asyncRead.Read);
 
                 char endChar = endString[0];
                 char notEndChar = TCSupport.GetRandomOtherChar(endChar, TCSupport.CharacterOptions.None);
@@ -389,7 +389,7 @@ namespace System.IO.Ports.Tests
                 if (!com2.IsOpen) //This is necessary since com1 and com2 might be the same port if we are using a loopback
                     com2.Open();
 
-                asyncReadThread.Start();
+                asyncReadTask.Start();
                 asyncRead.ReadStartedEvent.WaitOne();
                 //This only tells us that the thread has started to execute code in the method
                 Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
@@ -489,7 +489,7 @@ namespace System.IO.Ports.Tests
 
                 bool continueRunning = true;
                 int numberOfIterations = 0;
-                Thread writeToCom2Thread = new Thread(delegate ()
+                var writeToCom2Task = new Task(delegate ()
                 {
                     while (continueRunning)
                     {
@@ -524,12 +524,12 @@ namespace System.IO.Ports.Tests
                 if (!com2.IsOpen) //This is necessary since com1 and com2 might be the same port if we are using a loopback
                     com2.Open();
 
-                writeToCom2Thread.Start();
+                writeToCom2Task.Start();
 
                 Assert.Throws<TimeoutException>(() => com2.ReadTo(new string(endChar, 1)));
 
                 continueRunning = false;
-                writeToCom2Thread.Join();
+                writeToCom2Task.Wait();
 
                 com1.Write(new string(endChar, 1));
 

--- a/src/System.IO.Ports/tests/SerialPort/ReadTo_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadTo_Generic.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
@@ -122,7 +123,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-                Thread t = new Thread(WriteToCom1);
+                var t = new Task(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Encoding = new UTF8Encoding();
@@ -142,9 +143,7 @@ namespace System.IO.Ports.Tests
                 {
                 }
 
-                //Wait for the thread to finish
-                while (t.IsAlive)
-                    Thread.Sleep(50);
+                TCSupport.WaitForTaskCompletion(t);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();

--- a/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 
@@ -299,8 +300,7 @@ namespace System.IO.Ports.Tests
                 byte[] byteXmitBuffer = TCSupport.GetRandomBytes(512);
                 byte[] byteRcvBuffer = new byte[byteXmitBuffer.Length];
                 ASyncRead asyncRead = new ASyncRead(com1, byteRcvBuffer, 0, byteRcvBuffer.Length);
-                Thread asyncReadThread =
-                    new Thread(asyncRead.Read);
+                var asyncReadTask = new Task(asyncRead.Read);
 
 
                 Debug.WriteLine(
@@ -315,7 +315,7 @@ namespace System.IO.Ports.Tests
                 if (!com2.IsOpen) //This is necessary since com1 and com2 might be the same port if we are using a loopback
                     com2.Open();
 
-                asyncReadThread.Start();
+                asyncReadTask.Start();
                 asyncRead.ReadStartedEvent.WaitOne();
                 //This only tells us that the thread has started to execute code in the method
                 Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
@@ -354,6 +354,8 @@ namespace System.IO.Ports.Tests
                         }
                     }
                 }
+
+                TCSupport.WaitForTaskCompletion(asyncReadTask);
             }
         }
         #endregion

--- a/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int_Generic.cs
@@ -7,6 +7,7 @@ using System.IO.PortsTests;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
@@ -124,7 +125,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random();
-                Thread t = new Thread(WriteToCom1);
+                var t = new Task(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Encoding = new UTF8Encoding();
@@ -144,9 +145,7 @@ namespace System.IO.Ports.Tests
                 {
                 }
 
-                //Wait for the thread to finish
-                while (t.IsAlive)
-                    Thread.Sleep(50);
+                TCSupport.WaitForTaskCompletion(t);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();

--- a/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
@@ -7,6 +7,7 @@ using System.IO.PortsTests;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 
@@ -380,7 +381,7 @@ namespace System.IO.Ports.Tests
                 char[] charXmitBuffer = TCSupport.GetRandomChars(512, TCSupport.CharacterOptions.None);
                 char[] charRcvBuffer = new char[charXmitBuffer.Length];
                 ASyncRead asyncRead = new ASyncRead(com1, charRcvBuffer, 0, charRcvBuffer.Length);
-                Thread asyncReadThread = new Thread(asyncRead.Read);
+                var asyncReadTask = new Task(asyncRead.Read);
 
 
                 Debug.WriteLine(
@@ -395,7 +396,7 @@ namespace System.IO.Ports.Tests
                 if (!com2.IsOpen) //This is necessary since com1 and com2 might be the same port if we are using a loopback
                     com2.Open();
 
-                asyncReadThread.Start();
+                asyncReadTask.Start();
                 asyncRead.ReadStartedEvent.WaitOne();
                 // The WaitOne only tells us that the thread has started to execute code in the method
                 Thread.Sleep(2000); // We need to wait to guarantee that we are executing code in SerialPort
@@ -419,6 +420,8 @@ namespace System.IO.Ports.Tests
                     Assert.Equal(charXmitBuffer.Length, receivedLength);
                     Assert.Equal(charXmitBuffer, charRcvBuffer);
                 }
+
+                TCSupport.WaitForTaskCompletion(asyncReadTask);
             }
         }
 

--- a/src/System.IO.Ports/tests/SerialPort/Read_char_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_char_int_int_Generic.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
@@ -127,7 +128,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-                Thread t = new Thread(WriteToCom1);
+                var t = new Task(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Encoding = new UTF8Encoding();
@@ -147,9 +148,7 @@ namespace System.IO.Ports.Tests
                 {
                 }
 
-                //Wait for the thread to finish
-                while (t.IsAlive)
-                    Thread.Sleep(50);
+                TCSupport.WaitForTaskCompletion(t);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();

--- a/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int_Generic.cs
@@ -6,13 +6,14 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
-using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
 {
+    [Trait("Crash", "True")]
     public class Write_byte_int_int_generic : PortsTest
     {
         //Set bounds fore random timeout values.
@@ -141,9 +142,7 @@ namespace System.IO.Ports.Tests
             {
                 Random rndGen = new Random(-55);
                 AsyncEnableRts asyncEnableRts = new AsyncEnableRts();
-                Thread t = new Thread(asyncEnableRts.EnableRTS);
-
-                int waitTime;
+                var t = new Task(asyncEnableRts.EnableRTS);
 
                 com1.WriteTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Handshake = Handshake.RequestToSend;
@@ -155,14 +154,7 @@ namespace System.IO.Ports.Tests
                 //Call EnableRTS asynchronously this will enable RTS in the middle of the following write call allowing it to succeed 
                 //before the timeout is reached
                 t.Start();
-                waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
+                TCSupport.WaitForTaskToStart(t);
 
                 try
                 {
@@ -174,9 +166,7 @@ namespace System.IO.Ports.Tests
 
                 asyncEnableRts.Stop();
 
-                while (t.IsAlive)
-                    Thread.Sleep(100);
-
+                TCSupport.WaitForTaskCompletion(t);
                 VerifyTimeout(com1);
             }
         }
@@ -187,9 +177,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, BYTE_SIZE_BYTES_TO_WRITE);
-                Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
-
-                int waitTime;
+                var t = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 Debug.WriteLine("Verifying BytesToWrite with one call to Write");
 
@@ -199,19 +187,11 @@ namespace System.IO.Ports.Tests
 
                 //Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 t.Start();
-                waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                { //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForTaskToStart(t);
                 TCSupport.WaitForExactWriteBufferLoad(com, BYTE_SIZE_BYTES_TO_WRITE);
 
                 //Wait for write method to timeout
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
             }
         }
 
@@ -222,10 +202,8 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, BYTE_SIZE_BYTES_TO_WRITE);
-                Thread t1 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
-                Thread t2 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
-
-                int waitTime;
+                var t1 = new Task(asyncWriteRndByteArray.WriteRndByteArray);
+                var t2 = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 Debug.WriteLine("Verifying BytesToWrite with successive calls to Write");
                 com.Handshake = Handshake.RequestToSend;
@@ -234,30 +212,18 @@ namespace System.IO.Ports.Tests
 
                 //Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 t1.Start();
-                waitTime = 0;
-
-                while (t1.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                { //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForTaskToStart(t1);
                 TCSupport.WaitForExactWriteBufferLoad(com, BYTE_SIZE_BYTES_TO_WRITE);
 
                 //Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 t2.Start();
-                waitTime = 0;
-                while (t2.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                { //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForTaskToStart(t2);
                 TCSupport.WaitForExactWriteBufferLoad(com, BYTE_SIZE_BYTES_TO_WRITE * 2);
 
                 //Wait for both write methods to timeout
-                while (t1.IsAlive || t2.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t1);
+                var aggregatedException = Assert.Throws<AggregateException>(() => TCSupport.WaitForTaskCompletion(t2));
+                Assert.IsType<IOException>(aggregatedException.InnerException);
             }
         }
 
@@ -267,26 +233,14 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, BYTE_SIZE_HANDSHAKE);
-                Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
-
-                int waitTime;
+                var t = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 //Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 Debug.WriteLine("Verifying Handshake=None");
 
                 com.Open();
                 t.Start();
-                waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                { //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                //Wait for write method to timeout
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
 
                 if (0 != com.BytesToWrite)
                 {
@@ -435,11 +389,10 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, BYTE_SIZE_HANDSHAKE);
-                Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                var t = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 byte[] XOffBuffer = new byte[1];
                 byte[] XOnBuffer = new byte[1];
-                int waitTime;
 
                 XOffBuffer[0] = 19;
                 XOnBuffer[0] = 17;
@@ -464,16 +417,7 @@ namespace System.IO.Ports.Tests
 
                 //Write a random byte asynchronously so we can verify some things while the write call is blocking
                 t.Start();
-                waitTime = 0;
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                waitTime = 0;
-
+                TCSupport.WaitForTaskToStart(t);
                 TCSupport.WaitForExactWriteBufferLoad(com1, BYTE_SIZE_HANDSHAKE);
 
                 //Verify that CtsHolding is false if the RequestToSend or RequestToSendXOnXOff handshake method is used
@@ -493,10 +437,7 @@ namespace System.IO.Ports.Tests
                     com2.Write(XOnBuffer, 0, 1);
                 }
 
-                //Wait till write finishes
-                while (t.IsAlive)
-                    Thread.Sleep(100);
-
+                TCSupport.WaitForTaskCompletion(t);
                 Assert.Equal(0, com1.BytesToWrite);
 
                 //Verify that CtsHolding is true if the RequestToSend or RequestToSendXOnXOff handshake method is used

--- a/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int_Generic.cs
@@ -13,7 +13,6 @@ using Xunit.NetCore.Extensions;
 
 namespace System.IO.Ports.Tests
 {
-    [Trait("Crash", "True")]
     public class Write_byte_int_int_generic : PortsTest
     {
         //Set bounds fore random timeout values.

--- a/src/System.IO.Ports/tests/SerialPort/Write_str_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_str_Generic.cs
@@ -6,10 +6,10 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
-using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
 {
@@ -142,9 +142,7 @@ namespace System.IO.Ports.Tests
             {
                 Random rndGen = new Random(-55);
                 AsyncEnableRts asyncEnableRts = new AsyncEnableRts();
-                Thread t = new Thread(asyncEnableRts.EnableRTS);
-
-                int waitTime;
+                var t = new Task(asyncEnableRts.EnableRTS);
 
                 com1.WriteTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Handshake = Handshake.RequestToSend;
@@ -158,14 +156,7 @@ namespace System.IO.Ports.Tests
                 //Call EnableRTS asynchronously this will enable RTS in the middle of the following write call allowing it to succeed 
                 //before the timeout is reached
                 t.Start();
-                waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
+                TCSupport.WaitForTaskToStart(t);
 
                 try
                 {
@@ -177,8 +168,7 @@ namespace System.IO.Ports.Tests
 
                 asyncEnableRts.Stop();
 
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
 
                 VerifyTimeout(com1);
             }
@@ -190,9 +180,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndStr asyncWriteRndStr = new AsyncWriteRndStr(com, s_STRING_SIZE_BYTES_TO_WRITE);
-                Thread t = new Thread(asyncWriteRndStr.WriteRndStr);
-
-                int waitTime;
+                var t = new Task(asyncWriteRndStr.WriteRndStr);
 
                 Debug.WriteLine("Verifying BytesToWrite with one call to Write");
                 com.Handshake = Handshake.RequestToSend;
@@ -201,20 +189,9 @@ namespace System.IO.Ports.Tests
 
                 //Write a random string asynchronously so we can verify some things while the write call is blocking
                 t.Start();
-                waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForTaskToStart(t);
                 TCSupport.WaitForWriteBufferToLoad(com, s_STRING_SIZE_BYTES_TO_WRITE);
-
-                //Wait for write method to timeout
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
             }
         }
 
@@ -224,10 +201,8 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndStr asyncWriteRndStr = new AsyncWriteRndStr(com, s_STRING_SIZE_BYTES_TO_WRITE);
-                var t1 = new Thread(asyncWriteRndStr.WriteRndStr);
-                var t2 = new Thread(asyncWriteRndStr.WriteRndStr);
-
-                int waitTime;
+                var t1 = new Task(asyncWriteRndStr.WriteRndStr);
+                var t2 = new Task(asyncWriteRndStr.WriteRndStr);
 
                 Debug.WriteLine("Verifying BytesToWrite with successive calls to Write");
                 com.Handshake = Handshake.RequestToSend;
@@ -236,33 +211,18 @@ namespace System.IO.Ports.Tests
 
                 //Write a random string asynchronously so we can verify some things while the write call is blocking
                 t1.Start();
-                waitTime = 0;
-
-                while (t1.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForTaskToStart(t1);
                 TCSupport.WaitForWriteBufferToLoad(com, s_STRING_SIZE_BYTES_TO_WRITE);
 
                 //Write a random string asynchronously so we can verify some things while the write call is blocking
                 t2.Start();
-                waitTime = 0;
-
-                while (t2.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForTaskToStart(t2);
                 TCSupport.WaitForWriteBufferToLoad(com, s_STRING_SIZE_BYTES_TO_WRITE * 2);
 
                 //Wait for both write methods to timeout
-                while (t1.IsAlive || t2.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t1);
+                var aggregatedException = Assert.Throws<AggregateException>(() => TCSupport.WaitForTaskCompletion(t2));
+                Assert.IsType<IOException>(aggregatedException.InnerException);
             }
         }
 
@@ -272,27 +232,14 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndStr asyncWriteRndStr = new AsyncWriteRndStr(com, STRING_SIZE_HANDSHAKE);
-                Thread t = new Thread(asyncWriteRndStr.WriteRndStr);
-
-                int waitTime;
+                var t = new Task(asyncWriteRndStr.WriteRndStr);
 
                 //Write a random string asynchronously so we can verify some things while the write call is blocking
                 Debug.WriteLine("Verifying Handshake=None");
                 com.Open();
 
                 t.Start();
-                waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                { //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                //Wait for both write methods to timeout
-                while (t.IsAlive)
-                    Thread.Sleep(100);
-
+                TCSupport.WaitForTaskCompletion(t);
                 Assert.Equal(0, com.BytesToWrite);
             }
         }
@@ -438,11 +385,10 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 AsyncWriteRndStr asyncWriteRndStr = new AsyncWriteRndStr(com1, STRING_SIZE_HANDSHAKE);
-                Thread t = new Thread(asyncWriteRndStr.WriteRndStr);
+                var t = new Task(asyncWriteRndStr.WriteRndStr);
 
                 byte[] XOffBuffer = new byte[1];
                 byte[] XOnBuffer = new byte[1];
-                int waitTime;
 
                 XOffBuffer[0] = 19;
                 XOnBuffer[0] = 17;
@@ -467,15 +413,7 @@ namespace System.IO.Ports.Tests
 
                 //Write a random string asynchronously so we can verify some things while the write call is blocking
                 t.Start();
-                waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    //Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForTaskToStart(t);
                 TCSupport.WaitForExactWriteBufferLoad(com1, STRING_SIZE_HANDSHAKE);
 
                 //Verify that CtsHolding is false if the RequestToSend or RequestToSendXOnXOff handshake method is used
@@ -496,8 +434,7 @@ namespace System.IO.Ports.Tests
                 }
 
                 //Wait till write finishes
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
 
                 //Verify that the correct number of bytes are in the buffer
                 if (0 != com1.BytesToWrite)

--- a/src/System.IO.Ports/tests/SerialStream/BeginRead_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/BeginRead_Generic.cs
@@ -6,9 +6,9 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
-using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
 {
@@ -238,8 +238,7 @@ namespace System.IO.Ports.Tests
                 IAsyncResult readAsyncResult;
 
                 var asyncRead = new AsyncRead(com1);
-                var asyncEndRead = new Thread(asyncRead.EndRead);
-                int waitTime;
+                var asyncEndRead = new Task(asyncRead.EndRead);
                 var asyncCallbackCalled = false;
 
                 com1.Open();
@@ -260,24 +259,11 @@ namespace System.IO.Ports.Tests
                 }
 
                 asyncEndRead.Start();
-
-                waitTime = 0;
-                while (asyncEndRead.ThreadState == ThreadState.Unstarted && waitTime < MAX_WAIT_THREAD)
-                {
-                    // Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                if (MAX_WAIT_THREAD <= waitTime)
-                {
-                    Fail("Err_018158ajied!!!: Expected EndRead to have returned");
-                }
-
+                TCSupport.WaitForTaskToStart(asyncEndRead);
                 Thread.Sleep(100 < com1.ReadTimeout ? 2 * com1.ReadTimeout : 200);
                 // Sleep for 200ms or 2 times the ReadTimeout
 
-                if (!asyncEndRead.IsAlive)
+                if (!asyncEndRead.IsCompleted)
                 {
                     // Verify EndRead is blocking and is still alive
                     Fail("Err_4085858aiehe!!!: Expected read to not have completed");
@@ -290,19 +276,8 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(new byte[8], 0, 8);
 
-                waitTime = 0;
-                while (asyncEndRead.IsAlive && waitTime < MAX_WAIT_THREAD)
-                {
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                if (MAX_WAIT_THREAD <= waitTime)
-                {
-                    Fail("Err_018158ajied!!!: Expected EndRead to have returned");
-                }
-
-                waitTime = 0;
+                TCSupport.WaitForTaskCompletion(asyncEndRead);
+                var waitTime = 0;
                 while (!asyncCallbackCalled && waitTime < 5000)
                 {
                     Thread.Sleep(50);

--- a/src/System.IO.Ports/tests/SerialStream/BeginWrite_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/BeginWrite_Generic.cs
@@ -5,9 +5,9 @@
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
-using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
 {
@@ -268,8 +268,7 @@ namespace System.IO.Ports.Tests
             using (var com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 var asyncRead = new AsyncWrite(com1);
-                var asyncEndWrite = new Thread(asyncRead.EndWrite);
-                int waitTime;
+                var asyncEndWrite = new Task(asyncRead.EndWrite);
                 var asyncCallbackCalled = false;
 
                 com1.Open();
@@ -290,24 +289,11 @@ namespace System.IO.Ports.Tests
                 }
 
                 asyncEndWrite.Start();
-
-                waitTime = 0;
-                while (asyncEndWrite.ThreadState == ThreadState.Unstarted && waitTime < MAX_WAIT_THREAD)
-                {
-                    // Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                if (MAX_WAIT_THREAD <= waitTime)
-                {
-                    Fail("Err_018158ajied!!!: Expected EndRead to have returned");
-                }
-
+                TCSupport.WaitForTaskToStart(asyncEndWrite);
                 Thread.Sleep(100 < com1.WriteTimeout ? 2 * com1.WriteTimeout : 200);
                 // Sleep for 200ms or 2 times the WriteTimeout
 
-                if (!asyncEndWrite.IsAlive)
+                if (asyncEndWrite.IsCompleted)
                 {
                     // Verify EndRead is blocking and is still alive
                     Fail("Err_4085858aiehe!!!: Expected read to not have completed");
@@ -320,19 +306,8 @@ namespace System.IO.Ports.Tests
 
                 com2.RtsEnable = true;
 
-                waitTime = 0;
-                while (asyncEndWrite.IsAlive && waitTime < MAX_WAIT_THREAD)
-                {
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                if (MAX_WAIT_THREAD <= waitTime)
-                {
-                    Fail("Err_018158ajied!!!: Expected EndRead to have returned");
-                }
-
-                waitTime = 0;
+                TCSupport.WaitForTaskCompletion(asyncEndWrite);
+                var waitTime = 0;
                 while (!asyncCallbackCalled && waitTime < 5000)
                 {
                     Thread.Sleep(50);

--- a/src/System.IO.Ports/tests/SerialStream/Flush.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Flush.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 
@@ -133,7 +134,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, DEFAULT_BUFFER_SIZE);
-                Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                var t = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 Debug.WriteLine("Verifying Flush method after output buffer has been filled");
 
@@ -147,9 +148,7 @@ namespace System.IO.Ports.Tests
 
                 VerifyFlush(com1);
 
-                // Wait for write method to timeout
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
             }
         }
 
@@ -159,7 +158,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, DEFAULT_BUFFER_SIZE);
-                Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                var t = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 Debug.WriteLine("Verifying call Flush method several times after output buffer has been filled");
 
@@ -175,9 +174,7 @@ namespace System.IO.Ports.Tests
                 VerifyFlush(com1);
                 VerifyFlush(com1);
 
-                // Wait for write method to timeout
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
             }
         }
 
@@ -187,8 +184,8 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, DEFAULT_BUFFER_SIZE);
-                Thread t1 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
-                Thread t2 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                var t1 = new Task(asyncWriteRndByteArray.WriteRndByteArray);
+                var t2 = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 int elapsedTime;
 
@@ -210,9 +207,7 @@ namespace System.IO.Ports.Tests
 
                 VerifyFlush(com1);
 
-                // Wait for write method to timeout
-                while (t1.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t1);
 
                 t2.Start();
 
@@ -220,9 +215,7 @@ namespace System.IO.Ports.Tests
 
                 VerifyFlush(com1);
 
-                // Wait for write method to timeout
-                while (t2.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t2);
             }
         }
 
@@ -233,7 +226,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, DEFAULT_BUFFER_SIZE);
-                Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                var t = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 byte[] xmitBytes = new byte[DEFAULT_BUFFER_SIZE];
 
@@ -256,9 +249,7 @@ namespace System.IO.Ports.Tests
 
                 VerifyFlush(com1);
 
-                // Wait for write method to timeout
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
             }
         }
 
@@ -269,7 +260,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, DEFAULT_BUFFER_SIZE);
-                Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                var t = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 int elapsedTime = 0;
                 byte[] xmitBytes = new byte[DEFAULT_BUFFER_SIZE];
@@ -301,9 +292,7 @@ namespace System.IO.Ports.Tests
                 VerifyFlush(com1);
                 VerifyFlush(com1);
 
-                // Wait for write method to timeout
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
             }
         }
 
@@ -314,8 +303,8 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, DEFAULT_BUFFER_SIZE);
-                Thread t1 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
-                Thread t2 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                var t1 = new Task(asyncWriteRndByteArray.WriteRndByteArray);
+                var t2 = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 byte[] xmitBytes = new byte[DEFAULT_BUFFER_SIZE];
 
@@ -339,9 +328,7 @@ namespace System.IO.Ports.Tests
 
                 VerifyFlush(com1);
 
-                // Wait for write method to timeout
-                while (t1.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t1);
 
                 t2.Start();
 
@@ -353,9 +340,7 @@ namespace System.IO.Ports.Tests
 
                 VerifyFlush(com1);
 
-                // Wait for write method to timeout
-                while (t2.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t2);
             }
         }
 

--- a/src/System.IO.Ports/tests/SerialStream/ReadByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/ReadByte_Generic.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
@@ -105,7 +106,7 @@ namespace System.IO.Ports.Tests
             using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 var rndGen = new Random(-55);
-                var t = new Thread(WriteToCom1);
+                var t = new Task(WriteToCom1);
 
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
@@ -128,9 +129,7 @@ namespace System.IO.Ports.Tests
                 {
                 }
 
-                // Wait for the thread to finish
-                while (t.IsAlive)
-                    Thread.Sleep(50);
+                TCSupport.WaitForTaskCompletion(t);
 
                 // Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();

--- a/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int_Generic.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
@@ -117,7 +118,7 @@ namespace System.IO.Ports.Tests
             using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 var rndGen = new Random(-55);
-                var t = new Thread(WriteToCom1);
+                var t = new Task(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Encoding = new UTF8Encoding();
@@ -138,9 +139,7 @@ namespace System.IO.Ports.Tests
                 {
                 }
 
-                // Wait for the thread to finish
-                while (t.IsAlive)
-                    Thread.Sleep(50);
+                TCSupport.WaitForTaskCompletion(t);
 
                 // Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();

--- a/src/System.IO.Ports/tests/SerialStream/WriteByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/WriteByte_Generic.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
-using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
 {
@@ -124,9 +123,7 @@ namespace System.IO.Ports.Tests
             {
                 var rndGen = new Random(-55);
                 var asyncEnableRts = new AsyncEnableRts();
-                var t = new Thread(asyncEnableRts.EnableRTS);
-
-                int waitTime;
+                var t = new Task(asyncEnableRts.EnableRTS);
 
                 com1.WriteTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Handshake = Handshake.RequestToSend;
@@ -140,15 +137,7 @@ namespace System.IO.Ports.Tests
                 // Call EnableRTS asynchronously this will enable RTS in the middle of the following write call allowing it to succeed 
                 // before the timeout is reached
                 t.Start();
-                waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    // Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForTaskToStart(t);
                 try
                 {
                     com1.BaseStream.WriteByte(DEFAULT_BYTE);
@@ -158,10 +147,7 @@ namespace System.IO.Ports.Tests
                 }
 
                 asyncEnableRts.Stop();
-
-                while (t.IsAlive)
-                    Thread.Sleep(100);
-
+                TCSupport.WaitForTaskCompletion(t);
                 VerifyTimeout(com1);
             }
         }

--- a/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int_Generic.cs
@@ -13,7 +13,6 @@ using Xunit.NetCore.Extensions;
 
 namespace System.IO.Ports.Tests
 {
-    [Trait("Crash", "True")]
     public class SerialStream_Write_byte_int_int_Generic : PortsTest
     {
         // Set bounds fore random timeout values.

--- a/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int_Generic.cs
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Configuration;
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 using Xunit.NetCore.Extensions;
-using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
 {
+    [Trait("Crash", "True")]
     public class SerialStream_Write_byte_int_int_Generic : PortsTest
     {
         // Set bounds fore random timeout values.
@@ -136,7 +136,7 @@ namespace System.IO.Ports.Tests
             {
                 var rndGen = new Random(-55);
                 var asyncEnableRts = new AsyncEnableRts();
-                var t = new Thread(asyncEnableRts.EnableRTS);
+                var t = new Task(asyncEnableRts.EnableRTS);
 
                 com1.WriteTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Handshake = Handshake.RequestToSend;
@@ -150,14 +150,7 @@ namespace System.IO.Ports.Tests
                 // Call EnableRTS asynchronously this will enable RTS in the middle of the following write call allowing it to succeed 
                 // before the timeout is reached
                 t.Start();
-                var waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    // Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
+                TCSupport.WaitForTaskToStart(t);
 
                 try
                 {
@@ -169,9 +162,7 @@ namespace System.IO.Ports.Tests
 
                 asyncEnableRts.Stop();
 
-                while (t.IsAlive)
-                    Thread.Sleep(100);
-
+                TCSupport.WaitForTaskCompletion(t);
                 VerifyTimeout(com1);
             }
         }
@@ -182,7 +173,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, s_BYTE_SIZE_BYTES_TO_WRITE);
-                var t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                var t = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 Debug.WriteLine("Verifying BytesToWrite with one call to Write");
 
@@ -192,20 +183,11 @@ namespace System.IO.Ports.Tests
 
                 // Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 t.Start();
-                var waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    // Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
+                TCSupport.WaitForTaskToStart(t);
 
                 TCSupport.WaitForWriteBufferToLoad(com, s_BYTE_SIZE_BYTES_TO_WRITE);
 
-                // Wait for write method to timeout
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
             }
         }
 
@@ -216,8 +198,8 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, s_BYTE_SIZE_BYTES_TO_WRITE);
-                var t1 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
-                var t2 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                var t1 = new Task(asyncWriteRndByteArray.WriteRndByteArray);
+                var t2 = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 Debug.WriteLine("Verifying BytesToWrite with successive calls to Write");
 
@@ -227,33 +209,17 @@ namespace System.IO.Ports.Tests
 
                 // Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 t1.Start();
-                var waitTime = 0;
-
-                while (t1.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    // Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForTaskToStart(t1);
                 TCSupport.WaitForExactWriteBufferLoad(com, s_BYTE_SIZE_BYTES_TO_WRITE);
 
                 // Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 t2.Start();
-                waitTime = 0;
-
-                while (t2.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    // Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForTaskToStart(t2);
                 TCSupport.WaitForExactWriteBufferLoad(com, s_BYTE_SIZE_BYTES_TO_WRITE * 2);
 
                 // Wait for both write methods to timeout
-                while (t1.IsAlive || t2.IsAlive)
-                    Thread.Sleep(100);
+                var aggregatedException = Assert.Throws<AggregateException>(() => TCSupport.WaitForTaskCompletion(t2));
+                Assert.IsType<IOException>(aggregatedException.InnerException);
             }
         }
 
@@ -263,25 +229,14 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, s_BYTE_SIZE_HANDSHAKE);
-                var t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                var t = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 // Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 Debug.WriteLine("Verifying Handshake=None");
 
                 com.Open();
                 t.Start();
-                var waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    // Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                // Wait for write method to timeout
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
 
                 Assert.Equal(0, com.BytesToWrite);
             }
@@ -438,11 +393,10 @@ namespace System.IO.Ports.Tests
             using (var com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, s_BYTE_SIZE_HANDSHAKE);
-                var t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                var t = new Task(asyncWriteRndByteArray.WriteRndByteArray);
 
                 var XOffBuffer = new byte[1];
                 var XOnBuffer = new byte[1];
-                int waitTime;
 
                 XOffBuffer[0] = 19;
                 XOnBuffer[0] = 17;
@@ -467,15 +421,7 @@ namespace System.IO.Ports.Tests
 
                 // Write a random byte asynchronously so we can verify some things while the write call is blocking
                 t.Start();
-                waitTime = 0;
-
-                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
-                {
-                    // Wait for the thread to start
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForTaskToStart(t);
                 TCSupport.WaitForWriteBufferToLoad(com1, s_BYTE_SIZE_HANDSHAKE);
 
                 // Verify that CtsHolding is false if the RequestToSend or RequestToSendXOnXOff handshake method is used
@@ -496,9 +442,7 @@ namespace System.IO.Ports.Tests
                     com2.BaseStream.Write(XOnBuffer, 0, 1);
                 }
 
-                // Wait till write finishes
-                while (t.IsAlive)
-                    Thread.Sleep(100);
+                TCSupport.WaitForTaskCompletion(t);
 
                 // Verify that the correct number of bytes are in the buffer
                 Assert.Equal(0, com1.BytesToWrite);

--- a/src/System.IO.Ports/tests/Support/PortsTest.cs
+++ b/src/System.IO.Ports/tests/Support/PortsTest.cs
@@ -20,8 +20,6 @@ namespace System.IO.PortsTests
 
         public static bool HasLoopbackOrNullModem => TCSupport.SufficientHardwareRequirements(TCSupport.SerialPortRequirements.LoopbackOrNullModem);
 
-        public static bool HasReliableBreak => false;
-
         /// <summary>
         /// Shows that we can retain a single byte in the transmit queue if flow control doesn't permit transmission
         /// This is true for traditional PC ports, but will be false if there is additional driver/hardware buffering in the system

--- a/src/System.IO.Ports/tests/Support/PortsTest.cs
+++ b/src/System.IO.Ports/tests/Support/PortsTest.cs
@@ -20,6 +20,8 @@ namespace System.IO.PortsTests
 
         public static bool HasLoopbackOrNullModem => TCSupport.SufficientHardwareRequirements(TCSupport.SerialPortRequirements.LoopbackOrNullModem);
 
+        public static bool HasReliableBreak => false;
+
         /// <summary>
         /// Shows that we can retain a single byte in the transmit queue if flow control doesn't permit transmission
         /// This is true for traditional PC ports, but will be false if there is additional driver/hardware buffering in the system

--- a/src/System.IO.Ports/tests/Support/TestEventHandler.cs
+++ b/src/System.IO.Ports/tests/Support/TestEventHandler.cs
@@ -27,6 +27,7 @@ namespace Legacy.Support
         private readonly bool _shouldWait;
         private readonly AutoResetEvent _eventHandlerWait = new AutoResetEvent(false);
         private readonly object _lock = new object();
+        private readonly string _testName;
 
         public int NumEventsHandled { get; private set; }
 
@@ -35,7 +36,7 @@ namespace Legacy.Support
         /// </summary>
         public Predicate<T> EventFilter { get; set; }
 
-        protected TestEventHandler(SerialPort com, bool shouldThrow, bool shouldWait)
+        protected TestEventHandler(SerialPort com, bool shouldThrow, bool shouldWait, string testName = "Not set")
         {
             if (shouldThrow && shouldWait)
             {
@@ -45,6 +46,7 @@ namespace Legacy.Support
             _com = com;
             _shouldThrow = shouldThrow;
             _shouldWait = shouldWait;
+            _testName = testName;
         }
 
         protected void HandleEvent(object source, T eventType)
@@ -78,7 +80,7 @@ namespace Legacy.Support
 
             if (_shouldWait)
             {
-                Assert.True(_eventHandlerWait.WaitOne(10000));
+                Assert.True(_eventHandlerWait.WaitOne(10000), $"Handler type: [{GetType()}] Test name: [{_testName}]");
             }
         }
 
@@ -144,7 +146,7 @@ namespace Legacy.Support
                     }
                 }
             }
-            Assert.True(false, $"Failed to validate event type {eventType}");
+            Assert.True(false, $"Failed to validate event type {eventType}. Received: {string.Join(", ", _eventTypes)}");
         }
 
         public int NumberOfOccurrencesOfType(T eventType)

--- a/src/System.IO.Ports/tests/Support/TestEventHandler.cs
+++ b/src/System.IO.Ports/tests/Support/TestEventHandler.cs
@@ -27,16 +27,17 @@ namespace Legacy.Support
         private readonly bool _shouldWait;
         private readonly AutoResetEvent _eventHandlerWait = new AutoResetEvent(false);
         private readonly object _lock = new object();
-        private readonly string _testName;
+        private bool _successfulWait;
 
         public int NumEventsHandled { get; private set; }
+        public bool SuccessfulWait => !_shouldWait || _successfulWait;
 
         /// <summary>
         /// If you set this filter, then it must return 'true' to record an event
         /// </summary>
         public Predicate<T> EventFilter { get; set; }
 
-        protected TestEventHandler(SerialPort com, bool shouldThrow, bool shouldWait, string testName = "Not set")
+        protected TestEventHandler(SerialPort com, bool shouldThrow, bool shouldWait)
         {
             if (shouldThrow && shouldWait)
             {
@@ -46,7 +47,6 @@ namespace Legacy.Support
             _com = com;
             _shouldThrow = shouldThrow;
             _shouldWait = shouldWait;
-            _testName = testName;
         }
 
         protected void HandleEvent(object source, T eventType)
@@ -80,7 +80,7 @@ namespace Legacy.Support
 
             if (_shouldWait)
             {
-                Assert.True(_eventHandlerWait.WaitOne(10000), $"Handler type: [{GetType()}] Test name: [{_testName}]");
+                _successfulWait = _eventHandlerWait.WaitOne(10000);
             }
         }
 


### PR DESCRIPTION
Not pretty but a way to get tests to run with the flaky driver/ports so runs with and without changes can be easily compared (i.e.: one could check if the set of failures is affected by the changes or not). Basically this change replaces `Thread` usage with `Task` and handle the failures on the test case directly. Notice that the default diff from GH is going to make this looks bigger than it is, I recommend ignoring whitespace diffs to better see this.

This fixes #23230 