### PR TITLE
Added BinaryWriter Span-based APIs

### DIFF
--- a/src/System.IO/tests/BinaryWriter/BinaryWriter.WriteByteCharTests.cs
+++ b/src/System.IO/tests/BinaryWriter/BinaryWriter.WriteByteCharTests.cs
@@ -569,7 +569,7 @@ namespace System.IO.Tests
 
             using (Stream memoryStream = CreateStream())
             {
-                using (BinaryWriter binaryWriter = new BinaryWriter(memoryStream))
+                using (BinaryWriter binaryWriter = new BinaryWriter(memoryStream, Encoding.Unicode))
                 {
                     binaryWriter.Write(byteSpan);
                     binaryWriter.Write(charSpan);

--- a/src/System.IO/tests/BinaryWriter/BinaryWriter.WriteByteCharTests.cs
+++ b/src/System.IO/tests/BinaryWriter/BinaryWriter.WriteByteCharTests.cs
@@ -558,5 +558,40 @@ namespace System.IO.Tests
             mstr.Dispose();
             dw2.Dispose();
         }
+
+        [Fact]
+        public void BinaryWriter_WriteSpan()
+        {
+            byte[] bytes = new byte[] { 4, 2, 7, 0xFF };
+            char[] chars = new char[] { 'a', '7', Char.MaxValue };
+            Span<byte> byteSpan = new Span<byte>(bytes);
+            Span<char> charSpan = new Span<char>(chars);
+
+            using (Stream memoryStream = CreateStream())
+            {
+                using (BinaryWriter binaryWriter = new BinaryWriter(memoryStream))
+                {
+                    binaryWriter.Write(byteSpan);
+                    binaryWriter.Write(charSpan);
+
+                    Stream baseStream = binaryWriter.BaseStream;
+                    baseStream.Position = 2;
+
+                    Assert.Equal(7, baseStream.ReadByte());
+                    Assert.Equal(0xFF, baseStream.ReadByte());
+
+                    char testChar;
+
+                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
+                    Assert.Equal('a', testChar);
+
+                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
+                    Assert.Equal('7', testChar);
+
+                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
+                    Assert.Equal(Char.MaxValue, testChar);
+                }
+            }
+        }
     }
 }

--- a/src/System.IO/tests/BinaryWriter/BinaryWriter.WriteByteCharTests.cs
+++ b/src/System.IO/tests/BinaryWriter/BinaryWriter.WriteByteCharTests.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace System.IO.Tests
 {
-    public class BinaryWriter_WriteByteCharTests
+    public partial class BinaryWriter_WriteByteCharTests
     {
         protected virtual Stream CreateStream()
         {
@@ -557,41 +557,6 @@ namespace System.IO.Tests
 
             mstr.Dispose();
             dw2.Dispose();
-        }
-
-        [Fact]
-        public void BinaryWriter_WriteSpan()
-        {
-            byte[] bytes = new byte[] { 4, 2, 7, 0xFF };
-            char[] chars = new char[] { 'a', '7', Char.MaxValue };
-            Span<byte> byteSpan = new Span<byte>(bytes);
-            Span<char> charSpan = new Span<char>(chars);
-
-            using (Stream memoryStream = CreateStream())
-            {
-                using (BinaryWriter binaryWriter = new BinaryWriter(memoryStream, Encoding.Unicode))
-                {
-                    binaryWriter.Write(byteSpan);
-                    binaryWriter.Write(charSpan);
-
-                    Stream baseStream = binaryWriter.BaseStream;
-                    baseStream.Position = 2;
-
-                    Assert.Equal(7, baseStream.ReadByte());
-                    Assert.Equal(0xFF, baseStream.ReadByte());
-
-                    char testChar;
-
-                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
-                    Assert.Equal('a', testChar);
-
-                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
-                    Assert.Equal('7', testChar);
-
-                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
-                    Assert.Equal(Char.MaxValue, testChar);
-                }
-            }
         }
     }
 }

--- a/src/System.IO/tests/BinaryWriter/BinaryWriter.WriteByteCharTests.netcoreapp.cs
+++ b/src/System.IO/tests/BinaryWriter/BinaryWriter.WriteByteCharTests.netcoreapp.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System;
+using System.IO;
+using System.Text;
+
+namespace System.IO.Tests
+{
+    public partial class BinaryWriter_WriteByteCharTests
+    {
+        [Fact]
+        public void BinaryWriter_WriteSpan()
+        {
+            byte[] bytes = new byte[] { 4, 2, 7, 0xFF };
+            char[] chars = new char[] { 'a', '7', Char.MaxValue };
+            Span<byte> byteSpan = new Span<byte>(bytes);
+            Span<char> charSpan = new Span<char>(chars);
+
+            using (Stream memoryStream = CreateStream())
+            {
+                using (BinaryWriter binaryWriter = new BinaryWriter(memoryStream, Encoding.Unicode))
+                {
+                    binaryWriter.Write(byteSpan);
+                    binaryWriter.Write(charSpan);
+
+                    Stream baseStream = binaryWriter.BaseStream;
+                    baseStream.Position = 2;
+
+                    Assert.Equal(7, baseStream.ReadByte());
+                    Assert.Equal(0xFF, baseStream.ReadByte());
+
+                    char testChar;
+
+                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
+                    Assert.Equal('a', testChar);
+
+                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
+                    Assert.Equal('7', testChar);
+
+                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
+                    Assert.Equal(Char.MaxValue, testChar);
+                }
+            }
+        }
+    }
+}

--- a/src/System.IO/tests/BinaryWriter/BinaryWriterTests.cs
+++ b/src/System.IO/tests/BinaryWriter/BinaryWriterTests.cs
@@ -351,41 +351,6 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
-        public void BinaryWriter_WriteSpan()
-        {
-            byte[] bytes = new byte[] { 4, 2, 7, 0xFF };
-            char[] chars = new char[] { 'a', '7', Char.MaxValue };
-            Span<byte> byteSpan = new Span<byte>(bytes);
-            Span<char> charSpan = new Span<char>(chars);
-
-            using (Stream memoryStream = CreateStream())
-            {
-                using (BinaryWriter binaryWriter = new BinaryWriter(memoryStream))
-                {
-                    binaryWriter.Write(byteSpan);
-                    binaryWriter.Write(charSpan);
-
-                    Stream baseStream = binaryWriter.BaseStream;
-                    baseStream.Position = 2;
-
-                    Assert.Equal(7, baseStream.ReadByte());
-                    Assert.Equal(0xFF, baseStream.ReadByte());
-
-                    char testChar;
-
-                    testChar = BitConverter.ToChar(new byte[] { baseStream.ReadByte(), baseStream.ReadByte() }, 0);
-                    Assert.Equal('a', testChar);
-
-                    testChar = BitConverter.ToChar(new byte[] { baseStream.ReadByte(), baseStream.ReadByte() }, 0);
-                    Assert.Equal('7', testChar);
-
-                    testChar = BitConverter.ToChar(new byte[] { baseStream.ReadByte(), baseStream.ReadByte() }, 0);
-                    Assert.Equal(Char.MaxValue, testChar);
-                }
-            }
-        }
-
         private void ValidateDisposedExceptions(BinaryWriter binaryWriter)
         {
             Assert.Throws<ObjectDisposedException>(() => binaryWriter.Seek(1, SeekOrigin.Begin));

--- a/src/System.IO/tests/BinaryWriter/BinaryWriterTests.cs
+++ b/src/System.IO/tests/BinaryWriter/BinaryWriterTests.cs
@@ -351,6 +351,41 @@ namespace System.IO.Tests
             }
         }
 
+        [Fact]
+        public void BinaryWriter_WriteSpan()
+        {
+            byte[] bytes = new byte[] { 4, 2, 7, 0xFF };
+            char[] chars = new char[] { 'a', '7', Char.MaxValue };
+            Span<byte> byteSpan = new Span<byte>(bytes);
+            Span<char> charSpan = new Span<char>(chars);
+
+            using (Stream memoryStream = CreateStream())
+            {
+                using (BinaryWriter binaryWriter = new BinaryWriter(memoryStream))
+                {
+                    binaryWriter.Write(byteSpan);
+                    binaryWriter.Write(charSpan);
+
+                    Stream baseStream = binaryWriter.BaseStream;
+                    baseStream.Position = 2;
+
+                    Assert.Equal(7, baseStream.ReadByte());
+                    Assert.Equal(0xFF, baseStream.ReadByte());
+
+                    char testChar;
+
+                    testChar = BitConverter.ToChar(new byte[] { baseStream.ReadByte(), baseStream.ReadByte() }, 0);
+                    Assert.Equal('a', testChar);
+
+                    testChar = BitConverter.ToChar(new byte[] { baseStream.ReadByte(), baseStream.ReadByte() }, 0);
+                    Assert.Equal('7', testChar);
+
+                    testChar = BitConverter.ToChar(new byte[] { baseStream.ReadByte(), baseStream.ReadByte() }, 0);
+                    Assert.Equal(Char.MaxValue, testChar);
+                }
+            }
+        }
+
         private void ValidateDisposedExceptions(BinaryWriter binaryWriter)
         {
             Assert.Throws<ObjectDisposedException>(() => binaryWriter.Seek(1, SeekOrigin.Begin));

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="StreamWriter\StreamWriter.StringCtorTests.cs" />
     <Compile Include="Stream\Stream.APMMethodsTests.cs" />
     <Compile Include="BinaryWriter\BinaryWriter.WriteByteCharTests.cs" />
+    <Compile Include="BinaryWriter\BinaryWriter.WriteByteCharTests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="BinaryWriter\BinaryWriter.WriteTests.cs" />
     <Compile Include="BinaryWriter\BinaryWriterTests.cs" />
     <Compile Include="BufferedStream\BufferedStream.FlushTests.cs" />

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1254,6 +1254,8 @@ namespace System.IO
         public virtual void Write(uint value) { }
         [System.CLSCompliantAttribute(false)]
         public virtual void Write(ulong value) { }
+        public virtual void Write(ReadOnlySpan<byte> span) { }
+        public virtual void Write(ReadOnlySpan<char> span) { }
         protected void Write7BitEncodedInt(int value) { }
     }
     public sealed partial class BufferedStream : System.IO.Stream


### PR DESCRIPTION
Added tests for BinaryWriter Span-based APIs and exposed them from System.IO contract.
Connected to https://github.com/dotnet/coreclr/pull/13378