### PR TITLE
Add ExactSpelling = true to non WACK apis.

### DIFF
--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
@@ -10,7 +10,7 @@ internal partial class Interop
 {
     internal partial class NtDll
     {
-        [DllImport(Libraries.NtDll,ExactSpelling=true)]
+        [DllImport(Libraries.NtDll, ExactSpelling=true)]
         private static extern int RtlGetVersion(out RTL_OSVERSIONINFOEX lpVersionInformation);
 
         internal static string RtlGetVersion()

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
@@ -10,7 +10,7 @@ internal partial class Interop
 {
     internal partial class NtDll
     {
-        [DllImport(Libraries.NtDll)]
+        [DllImport(Libraries.NtDll,ExactSpelling=true)]
         private static extern int RtlGetVersion(out RTL_OSVERSIONINFOEX lpVersionInformation);
 
         internal static string RtlGetVersion()

--- a/src/Common/src/Interop/Windows/kernel32/Interop.CreateFile.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CreateFile.cs
@@ -14,7 +14,7 @@ internal partial class Interop
         /// <summary>
         /// WARNING: The private methods do not implicitly handle long paths. Use CreateFile.
         /// </summary>
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false,ExactSpelling = true)]
         private static extern SafeFileHandle CreateFilePrivate(
             string lpFileName,
             int dwDesiredAccess,

--- a/src/Common/src/Interop/Windows/kernel32/Interop.CreateFile.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CreateFile.cs
@@ -14,7 +14,7 @@ internal partial class Interop
         /// <summary>
         /// WARNING: The private methods do not implicitly handle long paths. Use CreateFile.
         /// </summary>
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false,ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
         private static extern SafeFileHandle CreateFilePrivate(
             string lpFileName,
             int dwDesiredAccess,


### PR DESCRIPTION
We are removing the UseDefaultPinvoke from
UAPAOT runs and tests using these APIs will
fail since these APIs are not in UWP profile.
RtlGetVersion is test only , CreateFileW is
a known issue and will be fixed.