### PR TITLE
Update the SortVersion Test

### DIFF
--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
@@ -410,8 +410,9 @@ namespace System.Globalization.Tests
         {
             SortVersion sv1 = CultureInfo.GetCultureInfo("en-US").CompareInfo.Version;
             SortVersion sv2 = CultureInfo.GetCultureInfo("ja-JP").CompareInfo.Version;
+            SortVersion sv3 = CultureInfo.GetCultureInfo("en").CompareInfo.Version;
             
-            Assert.Equal(sv1.FullVersion, sv2.FullVersion);
+            Assert.Equal(sv1.FullVersion, sv3.FullVersion);
             Assert.NotEqual(sv1.SortId, sv2.SortId);
         } 
     }


### PR DESCRIPTION
Although this test is not failing, we are updating it because it is not guaranteed to have the same sort version for all languages. Also on Linux, we return the hard coded version we get from ICU during the compilation. As we can compile with a specific version and run on other versions we’ll change this part to get the version at runtime which can give a different value for a different language. We’ll have a PR in coreclr side for that but would be nice to update the test even before getting updated coreclr