### PR TITLE
Avoid manually pinning spans in crypto interop

### DIFF
--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
@@ -16,27 +16,17 @@ internal static partial class Interop
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestCreate")]
         internal static extern SafeDigestCtxHandle DigestCreate(PAL_HashAlgorithm algorithm, out int cbDigest);
 
-        internal static unsafe int DigestUpdate(SafeDigestCtxHandle ctx, ReadOnlySpan<byte> pbData, int cbData)
-        {
-            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
-            {
-                return DigestUpdate(ctx, pbDataPtr, cbData);
-            }
-        }
+        internal static int DigestUpdate(SafeDigestCtxHandle ctx, ReadOnlySpan<byte> pbData, int cbData) =>
+            DigestUpdate(ctx, ref pbData.DangerousGetPinnableReference(), cbData);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestUpdate")]
-        private static extern unsafe int DigestUpdate(SafeDigestCtxHandle ctx, byte* pbData, int cbData);
+        private static extern int DigestUpdate(SafeDigestCtxHandle ctx, ref byte pbData, int cbData);
 
-        internal static unsafe int DigestFinal(SafeDigestCtxHandle ctx, Span<byte> pbOutput, int cbOutput)
-        {
-            fixed (byte* pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
-            {
-                return DigestFinal(ctx, pbOutputPtr, cbOutput);
-            }
-        }
+        internal static int DigestFinal(SafeDigestCtxHandle ctx, Span<byte> pbOutput, int cbOutput) =>
+            DigestFinal(ctx, ref pbOutput.DangerousGetPinnableReference(), cbOutput);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestFinal")]
-        private static extern unsafe int DigestFinal(SafeDigestCtxHandle ctx, byte* pbOutput, int cbOutput);
+        private static extern int DigestFinal(SafeDigestCtxHandle ctx, ref byte pbOutput, int cbOutput);
     }
 }
 

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
@@ -19,27 +19,17 @@ internal static partial class Interop
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacInit")]
         internal static extern unsafe int HmacInit(SafeHmacHandle ctx, [In] byte[] pbKey, int cbKey);
 
-        internal static unsafe int HmacUpdate(SafeHmacHandle ctx, ReadOnlySpan<byte> pbData, int cbData)
-        {
-            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
-            {
-                return HmacUpdate(ctx, pbDataPtr, cbData);
-            }
-        }
+        internal static int HmacUpdate(SafeHmacHandle ctx, ReadOnlySpan<byte> pbData, int cbData) =>
+            HmacUpdate(ctx, ref pbData.DangerousGetPinnableReference(), cbData);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacUpdate")]
-        private static extern unsafe int HmacUpdate(SafeHmacHandle ctx, byte* pbData, int cbData);
+        private static extern int HmacUpdate(SafeHmacHandle ctx, ref byte pbData, int cbData);
 
-        internal static unsafe int HmacFinal(SafeHmacHandle ctx, ReadOnlySpan<byte> pbOutput, int cbOutput)
-        {
-            fixed (byte* pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
-            {
-                return HmacFinal(ctx, pbOutputPtr, cbOutput);
-            }
-        }
+        internal static int HmacFinal(SafeHmacHandle ctx, ReadOnlySpan<byte> pbOutput, int cbOutput) =>
+            HmacFinal(ctx, ref pbOutput.DangerousGetPinnableReference(), cbOutput);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacFinal")]
-        private static extern unsafe int HmacFinal(SafeHmacHandle ctx, byte* pbOutput, int cbOutput);
+        private static extern unsafe int HmacFinal(SafeHmacHandle ctx, ref byte pbOutput, int cbOutput);
     }
 }
 

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
@@ -21,90 +21,70 @@ internal static partial class Interop
             out SafeSecKeyRefHandle pPrivateKey,
             out int pOSStatus);
 
-        private static unsafe int RsaEncryptOaep(
+        private static int RsaEncryptOaep(
             SafeSecKeyRefHandle publicKey,
             ReadOnlySpan<byte> pbData,
             int cbData,
             PAL_HashAlgorithm mgfAlgorithm,
             out SafeCFDataHandle pEncryptedOut,
-            out SafeCFErrorHandle pErrorOut)
-        {
-            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
-            {
-                return RsaEncryptOaep(publicKey, pbDataPtr, cbData, mgfAlgorithm, out pEncryptedOut, out pErrorOut);
-            }
-        }
+            out SafeCFErrorHandle pErrorOut) =>
+            RsaEncryptOaep(publicKey, ref pbData.DangerousGetPinnableReference(), cbData, mgfAlgorithm, out pEncryptedOut, out pErrorOut);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptOaep")]
-        private static extern unsafe int RsaEncryptOaep(
+        private static extern int RsaEncryptOaep(
             SafeSecKeyRefHandle publicKey,
-            byte* pbData,
+            ref byte pbData,
             int cbData,
             PAL_HashAlgorithm mgfAlgorithm,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);
 
-        private static unsafe int RsaEncryptPkcs(
+        private static int RsaEncryptPkcs(
             SafeSecKeyRefHandle publicKey,
             ReadOnlySpan<byte> pbData,
             int cbData,
             out SafeCFDataHandle pEncryptedOut,
-            out SafeCFErrorHandle pErrorOut)
-        {
-            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
-            {
-                return RsaEncryptPkcs(publicKey, pbDataPtr, cbData, out pEncryptedOut, out pErrorOut);
-            }
-        }
+            out SafeCFErrorHandle pErrorOut) =>
+            RsaEncryptPkcs(publicKey, ref pbData.DangerousGetPinnableReference(), cbData, out pEncryptedOut, out pErrorOut);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptPkcs")]
-        private static extern unsafe int RsaEncryptPkcs(
+        private static extern int RsaEncryptPkcs(
             SafeSecKeyRefHandle publicKey,
-            byte* pbData,
+            ref byte pbData,
             int cbData,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);
 
-        private static unsafe int RsaDecryptOaep(
+        private static int RsaDecryptOaep(
             SafeSecKeyRefHandle publicKey,
             ReadOnlySpan<byte> pbData,
             int cbData,
             PAL_HashAlgorithm mgfAlgorithm,
             out SafeCFDataHandle pEncryptedOut,
-            out SafeCFErrorHandle pErrorOut)
-        {
-            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
-            {
-                return RsaDecryptOaep(publicKey, pbDataPtr, cbData, mgfAlgorithm, out pEncryptedOut, out pErrorOut);
-            }
-        }
+            out SafeCFErrorHandle pErrorOut) =>
+            RsaDecryptOaep(publicKey, ref pbData.DangerousGetPinnableReference(), cbData, mgfAlgorithm, out pEncryptedOut, out pErrorOut);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptOaep")]
-        private static extern unsafe int RsaDecryptOaep(
+        private static extern int RsaDecryptOaep(
             SafeSecKeyRefHandle publicKey,
-            byte* pbData,
+            ref byte pbData,
             int cbData,
             PAL_HashAlgorithm mgfAlgorithm,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);
 
-        private static unsafe int RsaDecryptPkcs(
+        private static int RsaDecryptPkcs(
             SafeSecKeyRefHandle publicKey,
             ReadOnlySpan<byte> pbData,
             int cbData,
             out SafeCFDataHandle pEncryptedOut,
-            out SafeCFErrorHandle pErrorOut)
-        {
-            fixed (byte* pbDataPtr = &pbData.DangerousGetPinnableReference())
-            {
-                return RsaDecryptPkcs(publicKey, pbDataPtr, cbData, out pEncryptedOut, out pErrorOut);
-            }
-        }
+            out SafeCFErrorHandle pErrorOut) =>
+            RsaDecryptPkcs(publicKey, ref pbData.DangerousGetPinnableReference(), cbData, out pEncryptedOut, out pErrorOut);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptPkcs")]
-        private static extern unsafe int RsaDecryptPkcs(
+        private static extern int RsaDecryptPkcs(
             SafeSecKeyRefHandle publicKey,
-            byte* pbData,
+            ref byte pbData,
             int cbData,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Random.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Random.cs
@@ -10,13 +10,12 @@ internal static partial class Interop
 {
     internal static partial class AppleCrypto
     {
-        internal static unsafe void GetRandomBytes(byte* pbBuffer, int count)
+        internal static void GetRandomBytes(ref byte pbBuffer, int count)
         {
-            Debug.Assert(pbBuffer != null);
             Debug.Assert(count >= 0);
 
             int errorCode;
-            int ret = AppleCryptoNative_GetRandomBytes(pbBuffer, count, out errorCode);
+            int ret = AppleCryptoNative_GetRandomBytes(ref pbBuffer, count, out errorCode);
 
             if (ret == 0)
             {
@@ -30,6 +29,6 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.AppleCryptoNative)]
-        private static extern unsafe int AppleCryptoNative_GetRandomBytes(byte* buf, int num, out int errorCode);
+        private static extern int AppleCryptoNative_GetRandomBytes(ref byte buf, int num, out int errorCode);
     }
 }

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.cs
@@ -21,98 +21,89 @@ internal static partial class Interop
             out SafeSecKeyRefHandle ppKeyOut,
             out int pOSStatus);
 
-        private static unsafe int AppleCryptoNative_GenerateSignature(
+        private static int AppleCryptoNative_GenerateSignature(
             SafeSecKeyRefHandle privateKey,
             ReadOnlySpan<byte> pbDataHash,
             int cbDataHash,
             out SafeCFDataHandle pSignatureOut,
-            out SafeCFErrorHandle pErrorOut)
-        {
-            fixed (byte* pbDataHashPtr = &pbDataHash.DangerousGetPinnableReference())
-            {
-                return AppleCryptoNative_GenerateSignature(
-                    privateKey, pbDataHashPtr, cbDataHash, out pSignatureOut, out pErrorOut);
-            }
-        }
+            out SafeCFErrorHandle pErrorOut) =>
+            AppleCryptoNative_GenerateSignature(
+                privateKey, ref pbDataHash.DangerousGetPinnableReference(), cbDataHash, out pSignatureOut, out pErrorOut);
 
         [DllImport(Libraries.AppleCryptoNative)]
-        private static extern unsafe int AppleCryptoNative_GenerateSignature(
+        private static extern int AppleCryptoNative_GenerateSignature(
             SafeSecKeyRefHandle privateKey,
-            byte* pbDataHash,
+            ref byte pbDataHash,
             int cbDataHash,
             out SafeCFDataHandle pSignatureOut,
             out SafeCFErrorHandle pErrorOut);
 
-        private static unsafe int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
+        private static int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
             SafeSecKeyRefHandle privateKey,
             ReadOnlySpan<byte> pbDataHash,
             int cbDataHash,
             PAL_HashAlgorithm hashAlgorithm,
             out SafeCFDataHandle pSignatureOut,
-            out SafeCFErrorHandle pErrorOut)
-        {
-            fixed (byte* pbDataHashPtr = &pbDataHash.DangerousGetPinnableReference())
-            {
-                return AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
-                    privateKey, pbDataHashPtr, cbDataHash, hashAlgorithm, out pSignatureOut, out pErrorOut);
-            }
-        }
+            out SafeCFErrorHandle pErrorOut) =>
+            AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
+                privateKey, ref pbDataHash.DangerousGetPinnableReference(), cbDataHash, hashAlgorithm, out pSignatureOut, out pErrorOut);
 
         [DllImport(Libraries.AppleCryptoNative)]
-        private static extern unsafe int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
+        private static extern int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
             SafeSecKeyRefHandle privateKey,
-            byte* pbDataHash,
+            ref byte pbDataHash,
             int cbDataHash,
             PAL_HashAlgorithm hashAlgorithm,
             out SafeCFDataHandle pSignatureOut,
             out SafeCFErrorHandle pErrorOut);
 
-        private static unsafe int AppleCryptoNative_VerifySignature(
+        private static int AppleCryptoNative_VerifySignature(
             SafeSecKeyRefHandle publicKey,
             ReadOnlySpan<byte> pbDataHash,
             int cbDataHash,
             ReadOnlySpan<byte> pbSignature,
             int cbSignature,
-            out SafeCFErrorHandle pErrorOut)
-        {
-            fixed (byte* pbDataHashPtr = &pbDataHash.DangerousGetPinnableReference())
-            fixed (byte* pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
-            {
-                return AppleCryptoNative_VerifySignature(publicKey, pbDataHashPtr, cbDataHash, pbSignaturePtr, cbSignature, out pErrorOut);
-            }
-        }
+            out SafeCFErrorHandle pErrorOut) =>
+            AppleCryptoNative_VerifySignature(
+                publicKey,
+                ref pbDataHash.DangerousGetPinnableReference(),
+                cbDataHash,
+                ref pbSignature.DangerousGetPinnableReference(),
+                cbSignature,
+                out pErrorOut);
 
         [DllImport(Libraries.AppleCryptoNative)]
-        private static extern unsafe int AppleCryptoNative_VerifySignature(
+        private static extern int AppleCryptoNative_VerifySignature(
             SafeSecKeyRefHandle publicKey,
-            byte* pbDataHash,
+            ref byte pbDataHash,
             int cbDataHash,
-            byte* pbSignature,
+            ref byte pbSignature,
             int cbSignature,
             out SafeCFErrorHandle pErrorOut);
 
-        private static unsafe int AppleCryptoNative_VerifySignatureWithHashAlgorithm(
+        private static int AppleCryptoNative_VerifySignatureWithHashAlgorithm(
             SafeSecKeyRefHandle publicKey,
             ReadOnlySpan<byte> pbDataHash,
             int cbDataHash,
             ReadOnlySpan<byte> pbSignature,
             int cbSignature,
             PAL_HashAlgorithm hashAlgorithm,
-            out SafeCFErrorHandle pErrorOut)
-        {
-            fixed (byte* pbDataHashPtr = &pbDataHash.DangerousGetPinnableReference())
-            fixed (byte* pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
-            {
-                return AppleCryptoNative_VerifySignatureWithHashAlgorithm(publicKey, pbDataHashPtr, cbDataHash, pbSignaturePtr, cbSignature, hashAlgorithm, out pErrorOut);
-            }
-        }
+            out SafeCFErrorHandle pErrorOut) =>
+            AppleCryptoNative_VerifySignatureWithHashAlgorithm(
+                publicKey,
+                ref pbDataHash.DangerousGetPinnableReference(),
+                cbDataHash,
+                ref pbSignature.DangerousGetPinnableReference(),
+                cbSignature,
+                hashAlgorithm,
+                out pErrorOut);
 
         [DllImport(Libraries.AppleCryptoNative)]
-        private static extern unsafe int AppleCryptoNative_VerifySignatureWithHashAlgorithm(
+        private static extern int AppleCryptoNative_VerifySignatureWithHashAlgorithm(
             SafeSecKeyRefHandle publicKey,
-            byte* pbDataHash,
+            ref byte pbDataHash,
             int cbDataHash,
-            byte* pbSignature,
+            ref byte pbSignature,
             int cbSignature,
             PAL_HashAlgorithm hashAlgorithm,
             out SafeCFErrorHandle pErrorOut);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Dsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Dsa.cs
@@ -66,31 +66,19 @@ internal static partial class Interop
             return keySize;
         }
 
-        internal static unsafe bool DsaSign(SafeDsaHandle dsa, ReadOnlySpan<byte> hash, int hashLength, ReadOnlySpan<byte> refSignature, out int outSignatureLength)
-        {
-            fixed (byte* hashPtr = &hash.DangerousGetPinnableReference())
-            fixed (byte* refSignaturePtr = &refSignature.DangerousGetPinnableReference())
-            {
-                return DsaSign(dsa, hashPtr, hashLength, refSignaturePtr, out outSignatureLength);
-            }
-        }
+        internal static bool DsaSign(SafeDsaHandle dsa, ReadOnlySpan<byte> hash, int hashLength, ReadOnlySpan<byte> refSignature, out int outSignatureLength) =>
+            DsaSign(dsa, ref hash.DangerousGetPinnableReference(), hashLength, ref refSignature.DangerousGetPinnableReference(), out outSignatureLength);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaSign")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern unsafe bool DsaSign(SafeDsaHandle dsa, byte* hash, int hashLength, byte* refSignature, out int outSignatureLength);
+        private static extern bool DsaSign(SafeDsaHandle dsa, ref byte hash, int hashLength, ref byte refSignature, out int outSignatureLength);
 
-        internal static unsafe bool DsaVerify(SafeDsaHandle dsa, ReadOnlySpan<byte> hash, int hashLength, ReadOnlySpan<byte> signature, int signatureLength)
-        {
-            fixed (byte* hashPtr = &hash.DangerousGetPinnableReference())
-            fixed (byte* signaturePtr = &signature.DangerousGetPinnableReference())
-            {
-                return DsaVerify(dsa, hashPtr, hashLength, signaturePtr, signatureLength);
-            }
-        }
+        internal static bool DsaVerify(SafeDsaHandle dsa, ReadOnlySpan<byte> hash, int hashLength, ReadOnlySpan<byte> signature, int signatureLength) =>
+            DsaVerify(dsa, ref hash.DangerousGetPinnableReference(), hashLength, ref signature.DangerousGetPinnableReference(), signatureLength);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaVerify")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern unsafe bool DsaVerify(SafeDsaHandle dsa, byte* hash, int hashLength, byte* signature, int signatureLength);
+        private static extern bool DsaVerify(SafeDsaHandle dsa, ref byte hash, int hashLength, ref byte signature, int signatureLength);
 
         internal static DSAParameters ExportDsaParameters(SafeDsaHandle key, bool includePrivateParameters)
         {

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
@@ -19,19 +19,14 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestReset")]
         internal extern static int EvpDigestReset(SafeEvpMdCtxHandle ctx, IntPtr type);
 
-        internal static unsafe int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ReadOnlySpan<byte> d, int cnt)
-        {
-            fixed (byte* dPtr = &d.DangerousGetPinnableReference())
-            {
-                return EvpDigestUpdate(ctx, dPtr, cnt);
-            }
-        }
+        internal static int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ReadOnlySpan<byte> d, int cnt) =>
+            EvpDigestUpdate(ctx, ref d.DangerousGetPinnableReference(), cnt);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestUpdate")]
-        private extern static unsafe int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, byte* d, int cnt);
+        private extern static int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ref byte d, int cnt);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestFinalEx")]
-        internal extern static unsafe int EvpDigestFinalEx(SafeEvpMdCtxHandle ctx, byte* md, ref uint s);
+        internal extern static int EvpDigestFinalEx(SafeEvpMdCtxHandle ctx, ref byte md, ref uint s);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpMdSize")]
         internal extern static int EvpMdSize(IntPtr md);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.cs
@@ -10,27 +10,15 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        internal static unsafe bool EcDsaSign(ReadOnlySpan<byte> dgst, int dlen, Span<byte> sig, [In, Out] ref int siglen, SafeEcKeyHandle ecKey)
-        {
-            fixed (byte* dgstPtr = &dgst.DangerousGetPinnableReference())
-            fixed (byte* sigPtr = &sig.DangerousGetPinnableReference())
-            {
-                return EcDsaSign(dgstPtr, dlen, sigPtr, ref siglen, ecKey);
-            }
-        }
+        internal static bool EcDsaSign(ReadOnlySpan<byte> dgst, int dlen, Span<byte> sig, [In, Out] ref int siglen, SafeEcKeyHandle ecKey) =>
+            EcDsaSign(ref dgst.DangerousGetPinnableReference(), dlen, ref sig.DangerousGetPinnableReference(), ref siglen, ecKey);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaSign")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern unsafe bool EcDsaSign([In] byte* dgst, int dlen, [Out] byte* sig, [In, Out] ref int siglen, SafeEcKeyHandle ecKey);
+        private static extern bool EcDsaSign(ref byte dgst, int dlen, ref byte sig, [In, Out] ref int siglen, SafeEcKeyHandle ecKey);
 
-        internal static unsafe int EcDsaVerify(ReadOnlySpan<byte> dgst, int dgst_len, ReadOnlySpan<byte> sigbuf, int sig_len, SafeEcKeyHandle ecKey)
-        {
-            fixed (byte* dgstPtr = &dgst.DangerousGetPinnableReference())
-            fixed (byte* sigbufPtr = &sigbuf.DangerousGetPinnableReference())
-            {
-                return EcDsaVerify(dgstPtr, dgst_len, sigbufPtr, sig_len, ecKey);
-            }
-        }
+        internal static unsafe int EcDsaVerify(ReadOnlySpan<byte> dgst, int dgst_len, ReadOnlySpan<byte> sigbuf, int sig_len, SafeEcKeyHandle ecKey) =>
+            EcDsaVerify(ref dgst.DangerousGetPinnableReference(), dgst_len, ref sigbuf.DangerousGetPinnableReference(), sig_len, ecKey);
 
         /*-
          * returns
@@ -39,7 +27,7 @@ internal static partial class Interop
          *     -1: error
          */
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaVerify")]
-        private static extern unsafe int EcDsaVerify(byte* dgst, int dgst_len, byte* sigbuf, int sig_len, SafeEcKeyHandle ecKey);
+        private static extern int EcDsaVerify(ref byte dgst, int dgst_len, ref byte sigbuf, int sig_len, SafeEcKeyHandle ecKey);
 
         // returns the maximum length of a DER encoded ECDSA signature created with this key.
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaSize")]

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     internal static partial class Crypto
     {
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacCreate")]
-        internal extern static unsafe SafeHmacCtxHandle HmacCreate(byte* key, int keyLen, IntPtr md);
+        internal extern static SafeHmacCtxHandle HmacCreate(ref byte key, int keyLen, IntPtr md);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacDestroy")]
         internal extern static void HmacDestroy(IntPtr ctx);
@@ -19,18 +19,13 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacReset")]
         internal extern static int HmacReset(SafeHmacCtxHandle ctx);
 
-        internal static unsafe int HmacUpdate(SafeHmacCtxHandle ctx, ReadOnlySpan<byte> data, int len)
-        {
-            fixed (byte* dataPtr = &data.DangerousGetPinnableReference())
-            {
-                return HmacUpdate(ctx, dataPtr, len);
-            }
-        }
+        internal static int HmacUpdate(SafeHmacCtxHandle ctx, ReadOnlySpan<byte> data, int len) =>
+            HmacUpdate(ctx, ref data.DangerousGetPinnableReference(), len);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacUpdate")]
-        private extern static unsafe int HmacUpdate(SafeHmacCtxHandle ctx, byte* data, int len);
+        private extern static int HmacUpdate(SafeHmacCtxHandle ctx, ref byte data, int len);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacFinal")]
-        internal extern static unsafe int HmacFinal(SafeHmacCtxHandle ctx, byte* data, ref int len);
+        internal extern static int HmacFinal(SafeHmacCtxHandle ctx, ref byte data, ref int len);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.RAND.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.RAND.cs
@@ -9,16 +9,15 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        internal static unsafe bool GetRandomBytes(byte* pbBuffer, int count)
+        internal static bool GetRandomBytes(ref byte pbBuffer, int count)
         {
-            Debug.Assert(pbBuffer != null);
             Debug.Assert(count >= 0);
 
-            return CryptoNative_GetRandomBytes(pbBuffer, count);
+            return CryptoNative_GetRandomBytes(ref pbBuffer, count);
         }
 
         [DllImport(Libraries.CryptoNative)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern unsafe bool CryptoNative_GetRandomBytes(byte* buf, int num);
+        private static extern bool CryptoNative_GetRandomBytes(ref byte buf, int num);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
@@ -25,47 +25,35 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeRsaPublicKey")]
         internal static extern SafeRsaHandle DecodeRsaPublicKey(byte[] buf, int len);
 
-        internal static unsafe int RsaPublicEncrypt(
+        internal static int RsaPublicEncrypt(
             int flen,
             ReadOnlySpan<byte> from,
             Span<byte> to,
             SafeRsaHandle rsa,
-            RsaPadding padding)
-        {
-            fixed (byte* fromPtr = &from.DangerousGetPinnableReference())
-            fixed (byte* toPtr = &to.DangerousGetPinnableReference())
-            {
-                return RsaPublicEncrypt(flen, fromPtr, toPtr, rsa, padding);
-            }
-        }
+            RsaPadding padding) =>
+            RsaPublicEncrypt(flen, ref from.DangerousGetPinnableReference(), ref to.DangerousGetPinnableReference(), rsa, padding);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaPublicEncrypt")]
-        private extern static unsafe int RsaPublicEncrypt(
+        private extern static int RsaPublicEncrypt(
             int flen,
-            byte* from,
-            byte* to,
+            ref byte from,
+            ref byte to,
             SafeRsaHandle rsa,
             RsaPadding padding);
 
-        internal static unsafe int RsaPrivateDecrypt(
+        internal static int RsaPrivateDecrypt(
             int flen,
             ReadOnlySpan<byte> from,
             Span<byte> to,
             SafeRsaHandle rsa,
-            RsaPadding padding)
-        {
-            fixed (byte* fromPtr = &from.DangerousGetPinnableReference())
-            fixed (byte* toPtr = &to.DangerousGetPinnableReference())
-            {
-                return RsaPrivateDecrypt(flen, fromPtr, toPtr, rsa, padding);
-            }
-        }
+            RsaPadding padding) =>
+            RsaPrivateDecrypt(flen, ref from.DangerousGetPinnableReference(), ref to.DangerousGetPinnableReference(), rsa, padding);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaPrivateDecrypt")]
-        private extern static unsafe int RsaPrivateDecrypt(
+        private extern static int RsaPrivateDecrypt(
             int flen,
-            byte* from,
-            byte* to,
+            ref byte from,
+            ref byte to,
             SafeRsaHandle rsa,
             RsaPadding padding);
 
@@ -75,31 +63,19 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaGenerateKeyEx")]
         internal static extern int RsaGenerateKeyEx(SafeRsaHandle rsa, int bits, SafeBignumHandle e);
 
-        internal static unsafe bool RsaSign(int type, ReadOnlySpan<byte> m, int m_len, Span<byte> sigret, out int siglen, SafeRsaHandle rsa)
-        {
-            fixed (byte* mPtr = &m.DangerousGetPinnableReference())
-            fixed (byte* sigretPtr = &sigret.DangerousGetPinnableReference())
-            {
-                return RsaSign(type, mPtr, m_len, sigretPtr, out siglen, rsa);
-            }
-        }
+        internal static bool RsaSign(int type, ReadOnlySpan<byte> m, int m_len, Span<byte> sigret, out int siglen, SafeRsaHandle rsa) =>
+            RsaSign(type, ref m.DangerousGetPinnableReference(), m_len, ref sigret.DangerousGetPinnableReference(), out siglen, rsa);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaSign")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern unsafe bool RsaSign(int type, byte* m, int m_len, byte* sigret, out int siglen, SafeRsaHandle rsa);
+        private static extern bool RsaSign(int type, ref byte m, int m_len, ref byte sigret, out int siglen, SafeRsaHandle rsa);
 
-        internal static unsafe bool RsaVerify(int type, ReadOnlySpan<byte> m, int m_len, ReadOnlySpan<byte> sigbuf, int siglen, SafeRsaHandle rsa)
-        {
-            fixed (byte* mPtr = &m.DangerousGetPinnableReference())
-            fixed (byte* sigbufPtr = &sigbuf.DangerousGetPinnableReference())
-            {
-                return RsaVerify(type, mPtr, m_len, sigbufPtr, siglen, rsa);
-            }
-        }
+        internal static bool RsaVerify(int type, ReadOnlySpan<byte> m, int m_len, ReadOnlySpan<byte> sigbuf, int siglen, SafeRsaHandle rsa) =>
+            RsaVerify(type, ref m.DangerousGetPinnableReference(), m_len, ref sigbuf.DangerousGetPinnableReference(), siglen, rsa);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaVerify")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern unsafe bool RsaVerify(int type, byte* m, int m_len, byte* sigbuf, int siglen, SafeRsaHandle rsa);
+        private static extern bool RsaVerify(int type, ref byte m, int m_len, ref byte sigbuf, int siglen, SafeRsaHandle rsa);
 
         internal static RSAParameters ExportRsaParameters(SafeRsaHandle key, bool includePrivateParameters)
         {

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptFinishHash.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptFinishHash.cs
@@ -10,15 +10,10 @@ internal partial class Interop
 {
     internal partial class BCrypt
     {
-        internal static unsafe NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, Span<byte> pbOutput, int cbOutput, int dwFlags)
-        {
-            fixed (byte* pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
-            {
-                return BCryptFinishHash(hHash, pbOutputPtr, cbOutput, dwFlags);
-            }
-        }
+        internal static NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, Span<byte> pbOutput, int cbOutput, int dwFlags) =>
+            BCryptFinishHash(hHash, ref pbOutput.DangerousGetPinnableReference(), cbOutput, dwFlags);
 
         [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        private static unsafe extern NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, byte* pbOutput, int cbOutput, int dwFlags);
+        private static extern NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, ref byte pbOutput, int cbOutput, int dwFlags);
     }
 }

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenRandom.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenRandom.cs
@@ -10,17 +10,15 @@ internal partial class Interop
 {
     internal partial class BCrypt
     {
-        internal static unsafe NTSTATUS BCryptGenRandom(byte* pbBuffer, int count)
+        internal static NTSTATUS BCryptGenRandom(ref byte pbBuffer, int count)
         {
-            Debug.Assert(pbBuffer != null);
             Debug.Assert(count >= 0);
-
-            return BCryptGenRandom(IntPtr.Zero, pbBuffer, count, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+            return BCryptGenRandom(IntPtr.Zero, ref pbBuffer, count, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
         }
 
         private const int BCRYPT_USE_SYSTEM_PREFERRED_RNG = 0x00000002;
 
         [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        private static extern unsafe NTSTATUS BCryptGenRandom(IntPtr hAlgorithm, byte* pbBuffer, int cbBuffer, int dwFlags);
+        private static extern NTSTATUS BCryptGenRandom(IntPtr hAlgorithm, ref byte pbBuffer, int cbBuffer, int dwFlags);
     }
 }

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptHashData.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptHashData.cs
@@ -11,16 +11,10 @@ internal partial class Interop
 {
     internal partial class BCrypt
     {
-        internal static unsafe NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, ReadOnlySpan<byte> pbInput, int cbInput, int dwFlags)
-        {
-            fixed (byte* pbInputPtr = &pbInput.DangerousGetPinnableReference())
-            {
-                return BCryptHashData(hHash, pbInputPtr, cbInput, dwFlags);
-            }
-        }
+        internal static NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, ReadOnlySpan<byte> pbInput, int cbInput, int dwFlags) =>
+            BCryptHashData(hHash, ref pbInput.DangerousGetPinnableReference(), cbInput, dwFlags);
 
         [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        private static extern unsafe NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, byte* pbInput, int cbInput, int dwFlags);
+        private static extern NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, ref byte pbInput, int cbInput, int dwFlags);
     }
 }
-

--- a/src/Common/src/Interop/Windows/NCrypt/Interop.EncryptDecrypt.cs
+++ b/src/Common/src/Interop/Windows/NCrypt/Interop.EncryptDecrypt.cs
@@ -10,28 +10,16 @@ internal static partial class Interop
 {
     internal static partial class NCrypt
     {
-        internal static unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags)
-        {
-            fixed (byte* pbInputPtr = &pbInput.DangerousGetPinnableReference())
-            fixed (byte* pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
-            {
-                return NCryptEncrypt(hKey, pbInputPtr, cbInput, pPaddingInfo, pbOutputPtr, cbOutput, out pcbResult, dwFlags);
-            }
-        }
+        internal static unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags) =>
+            NCryptEncrypt(hKey, ref pbInput.DangerousGetPinnableReference(), cbInput, pPaddingInfo, ref pbOutput.DangerousGetPinnableReference(), cbOutput, out pcbResult, dwFlags);
 
         [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        private static extern unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, byte* pbInput, int cbInput, void* pPaddingInfo, byte* pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+        private static extern unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, ref byte pbInput, int cbInput, void* pPaddingInfo, ref byte pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
 
-        internal static unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags)
-        {
-            fixed (byte* pbInputPtr = &pbInput.DangerousGetPinnableReference())
-            fixed (byte* pbOutputPtr = &pbOutput.DangerousGetPinnableReference())
-            {
-                return NCryptDecrypt(hKey, pbInputPtr, cbInput, pPaddingInfo, pbOutputPtr, cbOutput, out pcbResult, dwFlags);
-            }
-        }
+        internal static unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags) =>
+            NCryptDecrypt(hKey, ref pbInput.DangerousGetPinnableReference(), cbInput, pPaddingInfo, ref pbOutput.DangerousGetPinnableReference(), cbOutput, out pcbResult, dwFlags);
 
         [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        private static extern unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, byte* pbInput, int cbInput, void* pPaddingInfo, byte* pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+        private static extern unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, ref byte pbInput, int cbInput, void* pPaddingInfo, ref byte pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
     }
 }

--- a/src/Common/src/Interop/Windows/NCrypt/Interop.SignVerify.cs
+++ b/src/Common/src/Interop/Windows/NCrypt/Interop.SignVerify.cs
@@ -10,28 +10,16 @@ internal static partial class Interop
 {
     internal static partial class NCrypt
     {
-        internal static unsafe ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, Span<byte> pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags)
-        {
-            fixed (byte* pbHashValuePtr = &pbHashValue.DangerousGetPinnableReference())
-            fixed (byte* pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
-            {
-                return NCryptSignHash(hKey, pPaddingInfo, pbHashValuePtr, cbHashValue, pbSignaturePtr, cbSignature, out pcbResult, dwFlags);
-            }
-        }
+        internal static unsafe ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, Span<byte> pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags) =>
+            NCryptSignHash(hKey, pPaddingInfo, ref pbHashValue.DangerousGetPinnableReference(), cbHashValue, ref pbSignature.DangerousGetPinnableReference(), cbSignature, out pcbResult, dwFlags);
 
         [DllImport(Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        private static extern unsafe ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, byte* pbHashValue, int cbHashValue, byte* pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags);
+        private static extern unsafe ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ref byte pbHashValue, int cbHashValue, ref byte pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags);
 
-        internal static unsafe ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, ReadOnlySpan<byte> pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags)
-        {
-            fixed (byte* pbHashValuePtr = &pbHashValue.DangerousGetPinnableReference())
-            fixed (byte* pbSignaturePtr = &pbSignature.DangerousGetPinnableReference())
-            {
-                return NCryptVerifySignature(hKey, pPaddingInfo, pbHashValuePtr, cbHashValue, pbSignaturePtr, cbSignature, dwFlags);
-            }
-        }
+        internal static unsafe ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, ReadOnlySpan<byte> pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags) =>
+            NCryptVerifySignature(hKey, pPaddingInfo, ref pbHashValue.DangerousGetPinnableReference(), cbHashValue, ref pbSignature.DangerousGetPinnableReference(), cbSignature, dwFlags);
 
         [DllImport(Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        private static extern unsafe ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, byte* pbHashValue, int cbHashValue, byte* pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags);
+        private static extern unsafe ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ref byte pbHashValue, int cbHashValue, ref byte pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags);
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/ByteArrayHelpers.cs
+++ b/src/System.Net.Http/src/System/Net/Http/ByteArrayHelpers.cs
@@ -43,7 +43,7 @@ namespace System
 
         internal static unsafe string GetStringFromByteSpan(ReadOnlySpan<byte> bytes)
         {
-            // TODO: Use new Span-based Encoding overload when available
+            // TODO #22431: Use new Span-based Encoding overload when available
             fixed (byte* p = &bytes.DangerousGetPinnableReference())
             {
                 return Encoding.ASCII.GetString(p, bytes.Length);

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.OSX.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.OSX.cs
@@ -8,12 +8,11 @@ namespace System.Security.Cryptography
 {
     partial class RandomNumberGeneratorImplementation
     {
-        private unsafe void GetBytes(byte* pbBuffer, int count)
+        private void GetBytes(ref byte pbBuffer, int count)
         {
-            Debug.Assert(pbBuffer != null);
             Debug.Assert(count > 0);
 
-            Interop.AppleCrypto.GetRandomBytes(pbBuffer, count);
+            Interop.AppleCrypto.GetRandomBytes(ref pbBuffer, count);
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.Unix.cs
@@ -8,12 +8,11 @@ namespace System.Security.Cryptography
 {
     partial class RandomNumberGeneratorImplementation
     {
-        private unsafe void GetBytes(byte* pbBuffer, int count)
+        private void GetBytes(ref byte pbBuffer, int count)
         {
-            Debug.Assert(pbBuffer != null);
             Debug.Assert(count > 0);
 
-            if (!Interop.Crypto.GetRandomBytes(pbBuffer, count))
+            if (!Interop.Crypto.GetRandomBytes(ref pbBuffer, count))
             {
                 throw Interop.Crypto.CreateOpenSslCryptographicException();
             }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.Windows.cs
@@ -8,12 +8,11 @@ namespace System.Security.Cryptography
 {
     partial class RandomNumberGeneratorImplementation
     {
-        private unsafe void GetBytes(byte* pbBuffer, int count)
+        private void GetBytes(ref byte pbBuffer, int count)
         {
-            Debug.Assert(pbBuffer != null);
             Debug.Assert(count > 0);
 
-            Interop.BCrypt.NTSTATUS status = Interop.BCrypt.BCryptGenRandom(pbBuffer, count);
+            Interop.BCrypt.NTSTATUS status = Interop.BCrypt.BCryptGenRandom(ref pbBuffer, count);
             if (status != Interop.BCrypt.NTSTATUS.STATUS_SUCCESS)
                 throw Interop.BCrypt.CreateCryptographicException(status);
         }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.cs
@@ -18,14 +18,11 @@ namespace System.Security.Cryptography
             GetBytes(new Span<byte>(data, offset, count));
         }
 
-        public override unsafe void GetBytes(Span<byte> data)
+        public override void GetBytes(Span<byte> data)
         {
             if (data.Length > 0)
             {
-                fixed (byte* ptr = &data.DangerousGetPinnableReference())
-                {
-                    GetBytes(ptr, data.Length);
-                }
+                GetBytes(ref data.DangerousGetPinnableReference(), data.Length);
             }
         }
 


### PR DESCRIPTION
My recent PRs to add span-based overloads to crypto types employed a pattern where span-based interop signatures pinned the spans manually and then passed pointers to the actual P/Invoke declaration accepting a `byte*`.  We can instead let the runtime handle the pinning by declaring the P/Invokes in terms of `ref byte`.  In addition to reducing the code involved, there's also the tiny benefit in several cases of the data being pinned for less time.

cc: @bartonjs, @ektrah