### PR TITLE
make FillAsync throw on EOF

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingReadStream.cs
@@ -140,13 +140,13 @@ namespace System.Net.Http
 
                 if (_chunkBytesRemaining > 0)
                 {
-                    await _connection.CopyChunkToAsync(destination, _chunkBytesRemaining, cancellationToken).ConfigureAwait(false);
+                    await _connection.CopyToAsync(destination, _chunkBytesRemaining, cancellationToken).ConfigureAwait(false);
                     await ConsumeChunkBytes(_chunkBytesRemaining, cancellationToken).ConfigureAwait(false);
                 }
 
                 while (await TryGetNextChunk(cancellationToken).ConfigureAwait(false))
                 {
-                    await _connection.CopyChunkToAsync(destination, _chunkBytesRemaining, cancellationToken).ConfigureAwait(false);
+                    await _connection.CopyToAsync(destination, _chunkBytesRemaining, cancellationToken).ConfigureAwait(false);
                     await ConsumeChunkBytes(_chunkBytesRemaining, cancellationToken).ConfigureAwait(false);
                 }
             }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ContentLengthReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ContentLengthReadStream.cs
@@ -73,7 +73,7 @@ namespace System.Net.Http
                     return;
                 }
 
-                await _connection.CopyChunkToAsync(destination, _contentBytesRemaining, cancellationToken).ConfigureAwait(false);
+                await _connection.CopyToAsync(destination, _contentBytesRemaining, cancellationToken).ConfigureAwait(false);
 
                 _contentBytesRemaining = 0;
                 _connection.ReturnConnectionToPool();


### PR DESCRIPTION
Rearrange a bit of code so that FillAsync consistently throws an IOException on EOF.

Also, remove read-ahead buffering logic from ReadAsync.

@stephentoub @Priya91 @wfurt 