### PR TITLE
Remove dead code from CreateArray in Microsoft.CSharp & tidy the rest

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1357,13 +1357,15 @@ namespace Microsoft.CSharp.RuntimeBinder
                     int numIndexArguments = ExpressionIterator.Count(optionalIndexerArguments);
                     // We could have an array access here. See if its just an array.
                     Type type = argument.Type;
-                    if (type.IsArray || type == typeof(string))
+                    Debug.Assert(type != typeof(string));
+                    if (type.IsArray)
                     {
                         if (type.IsArray && type.GetArrayRank() != numIndexArguments)
                         {
                             throw _semanticChecker.ErrorContext.Error(ErrorCode.ERR_BadIndexCount, type.GetArrayRank());
                         }
                         
+                        Debug.Assert(callingObject.Type is ArrayType);
                         return CreateArray(callingObject, optionalIndexerArguments);
                     }
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -766,7 +766,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private Expr CreateArray(Expr callingObject, Expr optionalIndexerArguments)
         {
-            return _binder.BindArrayIndexCore(0, callingObject, optionalIndexerArguments);
+            return _binder.BindArrayIndexCore(callingObject, optionalIndexerArguments);
         }
 
         /////////////////////////////////////////////////////////////////////////////////

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1432,12 +1432,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 // user defined conversions (since the convert is guaranteed to return one of
                 // the primitive types), and we check for overflow since we don't want truncation.
 
-                CType pDestType = _binder.chooseArrayIndexType(argument);
-                if (null == pDestType)
-                {
-                    pDestType = SymbolLoader.GetPredefindType(PredefinedType.PT_INT);
-                }
-
+                CType pDestType = _binder.ChooseArrayIndexType(argument);
                 return _binder.mustCast(
                     _binder.mustConvert(argument, pDestType),
                     destinationType,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
@@ -158,20 +158,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public ExprBlock CreateBlock(ExprStatement pOptionalStatements) => new ExprBlock(pOptionalStatements);
 
-        public ExprArrayIndex CreateArrayIndex(Expr array, Expr index)
-        {
-            CType type = array.Type;
-            if (type is ArrayType arr)
-            {
-                type = arr.GetElementType();
-            }
-            else if (type == null)
-            {
-                type = Types.GetPredefAgg(PredefinedType.PT_INT).getThisType();
-            }
-
-            return new ExprArrayIndex(type, array, index);
-        }
+        public ExprArrayIndex CreateArrayIndex(CType type, Expr array, Expr index) =>
+            new ExprArrayIndex(type, array, index);
 
         public ExprBinOp CreateBinop(ExpressionKind exprKind, CType type, Expr left, Expr right) => 
             new ExprBinOp(exprKind, type, left, right);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -408,7 +408,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return GenerateOptimizedAssignment(op1, op2);
         }
 
-        internal Expr BindArrayIndexCore(BindingFlag bindFlags, Expr pOp1, Expr pOp2)
+        internal Expr BindArrayIndexCore(Expr pOp1, Expr pOp2)
         {
             Expr pExpr;
             bool bIsError = !pOp1.IsOK || !pOp2.IsOK;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -435,7 +435,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // Allocate a new expression, the type is the element type of the array.
             // Array index operations are always lvalues.
             Expr pExpr = GetExprFactory().CreateArrayIndex(elementType, pOp1, transformedIndices);
-            pExpr.Flags |= EXPRFLAG.EXF_LVALUE | EXPRFLAG.EXF_ASSGOP;
 
             if (bIsError)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -416,7 +416,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             ArrayType pArrayType = pOp1.Type as ArrayType;
             Debug.Assert(pArrayType != null);
-            checkUnsafe(pArrayType.GetElementType()); // added to the binder so we don't bind to pointer ops
+            CType elementType = pArrayType.GetElementType();
+            checkUnsafe(elementType); // added to the binder so we don't bind to pointer ops
             // Check the rank of the array against the number of indices provided, and
             // convert the indexes to ints
 
@@ -433,7 +434,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             // Allocate a new expression, the type is the element type of the array.
             // Array index operations are always lvalues.
-            Expr pExpr = GetExprFactory().CreateArrayIndex(pOp1, transformedIndices);
+            Expr pExpr = GetExprFactory().CreateArrayIndex(elementType, pOp1, transformedIndices);
             pExpr.Flags |= EXPRFLAG.EXF_LVALUE | EXPRFLAG.EXF_ASSGOP;
 
             if (bIsError)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -444,48 +444,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return pExpr;
         }
 
-        private Expr bindIndexer(Expr pObject, Expr args, BindingFlag bindFlags)
-        {
-            CType type = pObject.Type;
-
-            if (!(type is AggregateType) && !(type is TypeParameterType))
-            {
-                throw ErrorContext.Error(ErrorCode.ERR_BadIndexLHS, type);
-            }
-
-            Name pName = NameManager.GetPredefinedName(PredefinedName.PN_INDEXERINTERNAL);
-
-            MemberLookup mem = new MemberLookup();
-            if (!mem.Lookup(GetSemanticChecker(), type, pObject, ContextForMemberLookup(), pName, 0,
-                            MemLookFlags.Indexer))
-            {
-                throw mem.ReportErrors();
-            }
-
-            Debug.Assert(mem.SymFirst() is IndexerSymbol);
-
-            ExprMemberGroup grp = GetExprFactory().CreateMemGroup((EXPRFLAG)mem.GetFlags(),
-                pName, BSYMMGR.EmptyTypeArray(), mem.SymFirst().getKind(), mem.GetSourceType(), null/*pMPS*/, mem.GetObject(), mem.GetResults());
-
-            Expr pResult = BindMethodGroupToArguments(bindFlags, grp, args);
-            IExprWithObject exprWithObject = pResult as IExprWithObject;
-            Debug.Assert(exprWithObject != null);
-            if (exprWithObject?.OptionalObject == null)
-            {
-                // We must be in an error scenario where the object was not allowed. 
-                // This can happen if the user tries to access the indexer off the
-                // type and not an instance or if the incorrect type/number of arguments 
-                // were passed for binding.
-                if (exprWithObject != null)
-                {
-                    exprWithObject.OptionalObject = pObject;
-                }
-
-                pResult.SetError();
-            }
-            return pResult;
-        }
-
         ////////////////////////////////////////////////////////////////////////////////
         // Create a cast node with the given expression flags. 
         private void bindSimpleCast(Expr exprSrc, ExprClass typeDest, out Expr pexprDest)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ArrayIndex.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ArrayIndex.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Array = array;
             Index = index;
+            Flags = EXPRFLAG.EXF_LVALUE | EXPRFLAG.EXF_ASSGOP;
         }
 
         public Expr Array { get; set; }

--- a/src/Microsoft.CSharp/tests/IndexingTests.cs
+++ b/src/Microsoft.CSharp/tests/IndexingTests.cs
@@ -75,5 +75,29 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             string answer = ifaceTyped[d];
             Assert.Equal("23", answer);
         }
+
+        [Fact]
+        public void ArrayLongIndexed()
+        {
+            dynamic arr = new[] {1, 2, 3};
+            dynamic ind = 2L;
+            Assert.Equal(3, arr[ind]);
+        }
+
+        [Fact]
+        public void BadArrayIndexer()
+        {
+            dynamic arr = new[] {1, 2, 3};
+            dynamic ind = "a";
+            Assert.Throws<RuntimeBinderException>(() => arr[ind]);
+        }
+
+        [Fact]
+        public void BadArrayIndexerCouldHaveCast()
+        {
+            dynamic arr = new[] { 1, 2, 3 };
+            dynamic ind = 2m;
+            Assert.Throws<RuntimeBinderException>(() => arr[ind]);
+        }
     }
 }


### PR DESCRIPTION
* Remove dead code from `BindArrayIndexCore`

Is only ever called with expression typed `ArrayType` so remove path for other types.

* Remove unused `BindingFlags` argument.

* Include fallback within `ChooseArrayIndexType`

`Int32` is always used when it fails to find a match, so move that logic into it, itself.

* Remove branch for `CreateArrayIndex` called with non-array.

Never happens.

Also, element type was already found for unsafe check, so pass it in.

* Move ArrayType flag setting into ArrayType ctor

* Remove bindInder

Only caller was removed as dead code.