### PR TITLE
Update package/assembly versions for assemblies to be serviced 1.0

### DIFF
--- a/src/System.IO.FileSystem.DriveInfo/pkg/System.IO.FileSystem.DriveInfo.pkgproj
+++ b/src/System.IO.FileSystem.DriveInfo/pkg/System.IO.FileSystem.DriveInfo.pkgproj
@@ -7,6 +7,9 @@
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.FileSystem.DriveInfo.builds" />
   </ItemGroup>
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+  </PropertyGroup>
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />

--- a/src/System.IO.FileSystem.DriveInfo/pkg/ValidationSuppression.txt
+++ b/src/System.IO.FileSystem.DriveInfo/pkg/ValidationSuppression.txt
@@ -1,0 +1,6 @@
+// The netfx facades have their versions locked, but we should
+// permit the netcoreapp implementations to use a higher runtime assembly
+// version than the ref assembly.
+// The refs shouldn't get bumped because that could push the 1.0 assembly to
+// a higher version than the 1.1 assembly.
+PermitHigherCompatibleImplementationVersion

--- a/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
+++ b/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <RootNamespace>System.IO.FileSystem.DriveInfo</RootNamespace>
     <AssemblyName>System.IO.FileSystem.DriveInfo</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.1</AssemblyVersion>
     <ProjectGuid>{29C14AD7-DC03-45DC-897D-8DACC762707E}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>

--- a/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
+++ b/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>4.0.2</Version>
+    <Version>4.0.3</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/System.Net.Http.WinHttpHandler/pkg/ValidationSuppression.txt
+++ b/src/System.Net.Http.WinHttpHandler/pkg/ValidationSuppression.txt
@@ -1,0 +1,6 @@
+// The netfx facades have their versions locked, but we should
+// permit the netcoreapp implementations to use a higher runtime assembly
+// version than the ref assembly.
+// The refs shouldn't get bumped because that could push the 1.0 assembly to
+// a higher version than the 1.1 assembly.
+PermitHigherCompatibleImplementationVersion

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{F75E3008-0562-42DF-BE72-C1384F12157E}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Net.Http.WinHttpHandler</AssemblyName>
-    <AssemblyVersion>4.0.0.2</AssemblyVersion>
+    <AssemblyVersion>4.0.0.3</AssemblyVersion>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
     <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.Net.Security/pkg/System.Net.Security.pkgproj
+++ b/src/System.Net.Security/pkg/System.Net.Security.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.Security.csproj">

--- a/src/System.Net.Security/pkg/ValidationSuppression.txt
+++ b/src/System.Net.Security/pkg/ValidationSuppression.txt
@@ -1,0 +1,6 @@
+// The netfx facades have their versions locked, but we should
+// permit the netcoreapp implementations to use a higher runtime assembly
+// version than the ref assembly.
+// The refs shouldn't get bumped because that could push the 1.0 assembly to
+// a higher version than the 1.1 assembly.
+PermitHigherCompatibleImplementationVersion

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -6,7 +6,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Net.Security</AssemblyName>
-    <AssemblyVersion>4.0.0.1</AssemblyVersion>
+    <AssemblyVersion>4.0.0.2</AssemblyVersion>
     <ProjectGuid>{89F37791-6254-4D60-AB96-ACD3CCA0E771}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);FEATURE_CORECLR</DefineConstants>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -33,6 +33,15 @@
     <Project Include="System.Security.Cryptography.X509Certificates\pkg\System.Security.Cryptography.X509Certificates.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="System.Net.Http.WinHttpHandler\pkg\System.Net.Http.WinHttpHandler.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="System.Net.Security\pkg\System.Net.Security.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="System.IO.FileSystem.DriveInfo\pkg\System.IO.FileSystem.DriveInfo.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >


### PR DESCRIPTION
cc @danmosemsft @ericstj 

fixes #23119 

@ericstj The System.IO.FileSystem.DriveInfo pkgproj doesn't have the last package version, and looking at nuget.org, the package version seems to be 4.3.0, but not sure which branch version is that. How do I update the package version of this lib here?