### PR TITLE
Disable tests that fail on ILC due to not actually running in AppX

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -44,6 +44,12 @@ namespace System
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
 
+        // Officially, .Net Native only supports processes running in an AppContainer. However, the majority of tests still work fine 
+        // in a normal Win32 process and we often do so as running in an AppContainer imposes a substantial tax in debuggability
+        // and investigatability. This predicate is used in ConditionalFacts to disable the specific tests that really need to be
+        // running in AppContainer when running on .NetNative.
+        public static bool IsNotNetNativeRunningAsConsoleApp => !(IsNetNative && !IsWinRT);
+
         // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool IsNotOneCoreUAP => (!IsWindows || 
             File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "httpapi.dll")));

--- a/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationLockCollectionTest.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationLockCollectionTest.cs
@@ -28,6 +28,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Configuration;
 using System.Collections;
 using Xunit;
@@ -37,7 +38,7 @@ namespace MonoTests.System.Configuration
 {
     public class ConfigurationLockCollectionTest
     {
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void InitialState()
         {
             SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
@@ -73,7 +74,7 @@ namespace MonoTests.System.Configuration
             Assert.Equal(col, col.SyncRoot);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void NonExistentItem()
         {
             SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
@@ -84,7 +85,7 @@ namespace MonoTests.System.Configuration
             Assert.Throws<ConfigurationErrorsException>(() => col.IsReadOnly("file"));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void Populate()
         {
             SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
@@ -98,7 +99,7 @@ namespace MonoTests.System.Configuration
             Assert.True(col.Contains("file"), "A4");
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void Populate_Error()
         {
             SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
@@ -107,7 +108,7 @@ namespace MonoTests.System.Configuration
             Assert.Throws<ConfigurationErrorsException>(() => col.Add("boo"));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void Enumerator()
         {
             SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
@@ -121,7 +122,7 @@ namespace MonoTests.System.Configuration
             Assert.False(e.MoveNext(), "A3");
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void SetFromList()
         {
             SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
@@ -139,7 +140,7 @@ namespace MonoTests.System.Configuration
             Assert.True(col.Contains("file"), "A2");
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         [ActiveIssue("dotnet/corefx #18195", TargetFrameworkMonikers.NetFramework)]
         public void DuplicateAdd()
         {
@@ -154,7 +155,7 @@ namespace MonoTests.System.Configuration
             Assert.Equal(1, app.LockAttributes.Count);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void IsReadOnly()
         {
             SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);

--- a/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
@@ -42,7 +42,7 @@ namespace MonoTests.System.Configuration
 
     public class ConfigurationManagerTest
     {
-        [Fact] // OpenExeConfiguration (ConfigurationUserLevel)
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))] // OpenExeConfiguration (ConfigurationUserLevel)
         [ActiveIssue("dotnet/corefx #19384", TargetFrameworkMonikers.NetFramework)]
         public void OpenExeConfiguration1_UserLevel_None()
         {
@@ -51,7 +51,7 @@ namespace MonoTests.System.Configuration
             Assert.Equal(TestUtil.ThisConfigFileName, fi.Name);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void OpenExeConfiguration1_UserLevel_PerUserRoaming()
         {
             string applicationData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
@@ -66,7 +66,7 @@ namespace MonoTests.System.Configuration
             Assert.Equal("user.config", fi.Name);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         [ActiveIssue(15065, TestPlatforms.AnyUnix)]
         public void OpenExeConfiguration1_UserLevel_PerUserRoamingAndLocal()
         {
@@ -140,7 +140,7 @@ namespace MonoTests.System.Configuration
             Assert.Equal(TestUtil.ThisApplicationPath + ".config", config.FilePath);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void exePath_UserLevelPerRoaming()
         {
             string applicationData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
@@ -155,7 +155,7 @@ namespace MonoTests.System.Configuration
             Assert.Equal("user.config", Path.GetFileName(filePath));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         [ActiveIssue(15066, TestPlatforms.AnyUnix)]
         public void exePath_UserLevelPerRoamingAndLocal()
         {
@@ -258,7 +258,7 @@ namespace MonoTests.System.Configuration
             Assert.Equal("machineconfig", fi.Name);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         // Doesn't pass on Mono
         // [Category("NotWorking")]
         [ActiveIssue("dotnet/corefx #19384", TargetFrameworkMonikers.NetFramework)]
@@ -281,13 +281,13 @@ namespace MonoTests.System.Configuration
             Assert.Equal("machine.config", fi.Name);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void GetSectionReturnsNativeObject()
         {
             Assert.True(ConfigurationManager.GetSection("appSettings") is NameValueCollection);
         }
 
-        [Fact]  // Test for bug #3412
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))] // Test for bug #3412
         // Doesn't pass on Mono
         // [Category("NotWorking")]
         public void TestAddRemoveSection()
@@ -343,7 +343,7 @@ namespace MonoTests.System.Configuration
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void TestContext()
         {
             var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
@@ -42,8 +42,8 @@ namespace System.ConfigurationTests
             }
         }
 
-        [Theory
-            InlineData(true)
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp)),
+            InlineData(true),
             InlineData(false)
             ]
         [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
@@ -56,8 +56,8 @@ namespace System.ConfigurationTests
             Assert.NotNull(settings.Context);
         }
 
-        [Theory
-            InlineData(true)
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp)),
+            InlineData(true),
             InlineData(false)
             ]
         [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
@@ -71,8 +71,8 @@ namespace System.ConfigurationTests
             Assert.NotNull(settings.Providers[typeof(LocalFileSettingsProvider).Name]);
         }
 
-        [Theory
-            InlineData(true)
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp)),
+            InlineData(true),
             InlineData(false)
             ]
         [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
@@ -87,8 +87,8 @@ namespace System.ConfigurationTests
             Assert.Equal("Foo", settings.StringProperty);
         }
 
-        [Theory
-            InlineData(true)
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp)),
+            InlineData(true),
             InlineData(false)
             ]
         [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
@@ -103,7 +103,7 @@ namespace System.ConfigurationTests
             Assert.Equal(10, settings.IntProperty);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
         public void Reload_SimpleSettings_Ok()
         {
@@ -140,7 +140,7 @@ namespace System.ConfigurationTests
         {
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
         public void SettingsProperty_SettingsWithAttributes_Ok()
         {

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ImplicitMachineConfigTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ImplicitMachineConfigTests.cs
@@ -10,7 +10,7 @@ namespace System.ConfigurationTests
 {
     public class ImplicitMachineConfigTests
     {
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void RuntimeAppSettingsAccessible()
         {
             var appSettings = ConfigurationManager.AppSettings;

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/LocalFileSettingsProviderTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/LocalFileSettingsProviderTests.cs
@@ -15,7 +15,7 @@ namespace System.ConfigurationTests
             ["SettingsKey"] = "SettingsKeyFoo"
         };
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void GetPropertyValues_NotStoredProperty_ValueEqualsNull()
         {
             var property = new SettingsProperty("PropertyName");
@@ -30,7 +30,7 @@ namespace System.ConfigurationTests
             Assert.Equal(null, propertyValues["PropertyName"].PropertyValue);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void GetPropertyValues_NotStoredConnectionStringProperty_ValueEqualsEmptyString()
         {
             var property = new SettingsProperty("PropertyName");


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/23000

Ports https://github.com/dotnet/corefx/pull/23295
