### PR TITLE
Re-enable optimizations in System.Collections.Tests for uapaot

### DIFF
--- a/src/System.Collections/tests/ILCConfigurations.rd.xml
+++ b/src/System.Collections/tests/ILCConfigurations.rd.xml
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-  <Library Name="System.Collections.Tests">
-    <Assembly Name="*Application*" DoNotInline="true" DoNotOptimize="true" />
-    <Assembly Name="System.Collections" DoNotInline="true" DoNotOptimize="true" />
-  </Library>
-</Directives>

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -164,9 +164,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="ILCConfigurations.rd.xml" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
The issue we were hitting was fixed in the nutc compiler.

Tracking issue was VSO 472947, note that the bug title is wrong.