### PR TITLE
Use FromApp APIs to allow brokered file access

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.COPYFILE2_EXTENDED_PARAMETERS.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.COPYFILE2_EXTENDED_PARAMETERS.cs
@@ -3,12 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-#pragma warning disable CS0649 // never assigned to warning
+        [StructLayout(LayoutKind.Sequential)]
         internal struct COPYFILE2_EXTENDED_PARAMETERS
         {
             internal uint dwSize;
@@ -17,6 +18,5 @@ internal partial class Interop
             internal IntPtr pProgressRoutine;
             internal IntPtr pvCallbackContext;
         }
-#pragma warning restore CS0649
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.COPYFILE2_EXTENDED_PARAMETERS.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.COPYFILE2_EXTENDED_PARAMETERS.cs
@@ -9,11 +9,13 @@ internal partial class Interop
     internal partial class Kernel32
     {
 #pragma warning disable CS0649 // never assigned to warning
-        internal struct SECURITY_ATTRIBUTES
+        internal struct COPYFILE2_EXTENDED_PARAMETERS
         {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
+            internal uint dwSize;
+            internal uint dwCopyFlags;
+            internal IntPtr pfCancel;
+            internal IntPtr pProgressRoutine;
+            internal IntPtr pvCallbackContext;
         }
 #pragma warning restore CS0649
     }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.CREATEFILE2_EXTENDED_PARAMETERS.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CREATEFILE2_EXTENDED_PARAMETERS.cs
@@ -8,13 +8,14 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-#pragma warning disable CS0649 // never assigned to warning
-        internal struct SECURITY_ATTRIBUTES
+        internal struct CREATEFILE2_EXTENDED_PARAMETERS
         {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
+            internal uint dwSize;
+            internal uint dwFileAttributes;
+            internal uint dwFileFlags;
+            internal uint dwSecurityQosFlags;
+            internal IntPtr lpSecurityAttributes;
+            internal IntPtr hTemplateFile;
         }
-#pragma warning restore CS0649
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.CopyFile2.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CopyFile2.cs
@@ -11,14 +11,5 @@ internal partial class Interop
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, BestFitMapping = false)]
         internal static extern int CopyFile2(string pwszExistingFileName, string pwszNewFileName, ref COPYFILE2_EXTENDED_PARAMETERS pExtendedParameters);
-
-        internal struct COPYFILE2_EXTENDED_PARAMETERS
-        {
-            internal uint dwSize;
-            internal uint dwCopyFlags;
-            internal IntPtr pfCancel;
-            internal IntPtr pProgressRoutine;
-            internal IntPtr pvCallbackContext;
-        }
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.CreateFile2.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CreateFile2.cs
@@ -17,15 +17,5 @@ internal partial class Interop
             System.IO.FileShare dwShareMode,
             System.IO.FileMode dwCreationDisposition,
             [In] ref CREATEFILE2_EXTENDED_PARAMETERS parameters);
-
-        internal struct CREATEFILE2_EXTENDED_PARAMETERS
-        {
-            internal uint dwSize;
-            internal uint dwFileAttributes;
-            internal uint dwFileFlags;
-            internal uint dwSecurityQosFlags;
-            internal IntPtr lpSecurityAttributes;
-            internal IntPtr hTemplateFile;
-        }
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.FILE_TIME.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.FILE_TIME.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        internal struct FILE_TIME
+        {
+            internal uint dwLowDateTime;
+            internal uint dwHighDateTime;
+
+            internal FILE_TIME(long fileTime)
+            {
+                dwLowDateTime = (uint)fileTime;
+                dwHighDateTime = (uint)(fileTime >> 32);
+            }
+
+            internal long ToTicks()
+            {
+                return ((long)dwHighDateTime << 32) + dwLowDateTime;
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.FINDEX_INFO_LEVELS.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.FINDEX_INFO_LEVELS.cs
@@ -2,19 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-#pragma warning disable CS0649 // never assigned to warning
-        internal struct SECURITY_ATTRIBUTES
+        internal enum FINDEX_INFO_LEVELS : uint
         {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
+            FindExInfoStandard = 0x0u,
+            FindExInfoBasic = 0x1u,
+            FindExInfoMaxInfoLevel = 0x2u,
         }
-#pragma warning restore CS0649
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.FINDEX_SEARCH_OPS.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.FINDEX_SEARCH_OPS.cs
@@ -2,19 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-#pragma warning disable CS0649 // never assigned to warning
-        internal struct SECURITY_ATTRIBUTES
+        internal enum FINDEX_SEARCH_OPS : uint
         {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
+            FindExSearchNameMatch = 0x0u,
+            FindExSearchLimitToDirectories = 0x1u,
+            FindExSearchLimitToDevices = 0x2u,
+            FindExSearchMaxSearchOp = 0x3u,
         }
-#pragma warning restore CS0649
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.FindFirstFileEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.FindFirstFileEx.cs
@@ -24,20 +24,5 @@ internal partial class Interop
             // use FindExInfoBasic since we don't care about short name and it has better perf
             return FindFirstFileExPrivate(fileName, FINDEX_INFO_LEVELS.FindExInfoBasic, ref data, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, 0);
         }
-
-        internal enum FINDEX_INFO_LEVELS : uint
-        {
-            FindExInfoStandard = 0x0u,
-            FindExInfoBasic = 0x1u,
-            FindExInfoMaxInfoLevel = 0x2u,
-        }
-
-        internal enum FINDEX_SEARCH_OPS : uint
-        {
-            FindExSearchNameMatch = 0x0u,
-            FindExSearchLimitToDirectories = 0x1u,
-            FindExSearchLimitToDevices = 0x2u,
-            FindExSearchMaxSearchOp = 0x3u,
-        }
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GET_FILEEX_INFO_LEVELS.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GET_FILEEX_INFO_LEVELS.cs
@@ -2,19 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-#pragma warning disable CS0649 // never assigned to warning
-        internal struct SECURITY_ATTRIBUTES
+        internal enum GET_FILEEX_INFO_LEVELS : uint
         {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
+            GetFileExInfoStandard = 0x0u,
+            GetFileExMaxInfoLevel = 0x1u,
         }
-#pragma warning restore CS0649
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetFileAttributesEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetFileAttributesEx.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
-using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -21,76 +19,6 @@ internal partial class Interop
         {
             name = PathInternal.EnsureExtendedPrefixOverMaxPath(name);
             return GetFileAttributesExPrivate(name, fileInfoLevel, ref lpFileInformation);
-        }
-
-        internal enum GET_FILEEX_INFO_LEVELS : uint
-        {
-            GetFileExInfoStandard = 0x0u,
-            GetFileExMaxInfoLevel = 0x1u,
-        }
-
-        internal struct WIN32_FILE_ATTRIBUTE_DATA
-        {
-            internal int fileAttributes;
-            internal uint ftCreationTimeLow;
-            internal uint ftCreationTimeHigh;
-            internal uint ftLastAccessTimeLow;
-            internal uint ftLastAccessTimeHigh;
-            internal uint ftLastWriteTimeLow;
-            internal uint ftLastWriteTimeHigh;
-            internal uint fileSizeHigh;
-            internal uint fileSizeLow;
-
-            internal void PopulateFrom(ref WIN32_FIND_DATA findData)
-            {
-                // Copy the information to data
-                fileAttributes = (int)findData.dwFileAttributes;
-                ftCreationTimeLow = findData.ftCreationTime.dwLowDateTime;
-                ftCreationTimeHigh = findData.ftCreationTime.dwHighDateTime;
-                ftLastAccessTimeLow = findData.ftLastAccessTime.dwLowDateTime;
-                ftLastAccessTimeHigh = findData.ftLastAccessTime.dwHighDateTime;
-                ftLastWriteTimeLow = findData.ftLastWriteTime.dwLowDateTime;
-                ftLastWriteTimeHigh = findData.ftLastWriteTime.dwHighDateTime;
-                fileSizeHigh = findData.nFileSizeHigh;
-                fileSizeLow = findData.nFileSizeLow;
-            }
-        }
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        internal unsafe struct WIN32_FIND_DATA
-        {
-            internal uint dwFileAttributes;
-            internal FILE_TIME ftCreationTime;
-            internal FILE_TIME ftLastAccessTime;
-            internal FILE_TIME ftLastWriteTime;
-            internal uint nFileSizeHigh;
-            internal uint nFileSizeLow;
-            internal uint dwReserved0;
-            internal uint dwReserved1;
-            private fixed char _cFileName[260];
-            private fixed char _cAlternateFileName[14];
-
-            internal ReadOnlySpan<char> cFileName
-            {
-                get { fixed (char* c = _cFileName) return new ReadOnlySpan<char>(c, 260); }
-            }
-        }
-
-        internal struct FILE_TIME
-        {
-            internal uint dwLowDateTime;
-            internal uint dwHighDateTime;
-
-            internal FILE_TIME(long fileTime)
-            {
-                dwLowDateTime = (uint)fileTime;
-                dwHighDateTime = (uint)(fileTime >> 32);
-            }
-
-            internal long ToTicks()
-            {
-                return ((long)dwHighDateTime << 32) + dwLowDateTime;
-            }
         }
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.ReplaceFile.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.ReplaceFile.cs
@@ -21,10 +21,7 @@ internal partial class Interop
         {
             replacedFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(replacedFileName);
             replacementFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(replacementFileName);
-            if (backupFileName != null)
-            {
-                backupFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(backupFileName);
-            }
+            backupFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(backupFileName);
 
             return ReplaceFilePrivate(
                 replacedFileName, replacementFileName, backupFileName,

--- a/src/Common/src/Interop/Windows/kernel32/Interop.ReplaceFile.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.ReplaceFile.cs
@@ -28,7 +28,6 @@ internal partial class Interop
                 dwReplaceFlags, lpExclude, lpReserved);
         }
 
-        internal const int REPLACEFILE_WRITE_THROUGH = 0x1;
         internal const int REPLACEFILE_IGNORE_MERGE_ERRORS = 0x2;
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.SECURITY_ATTRIBUTES.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.SECURITY_ATTRIBUTES.cs
@@ -3,18 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-#pragma warning disable CS0649 // never assigned to warning
+        [StructLayout(LayoutKind.Sequential)]
         internal struct SECURITY_ATTRIBUTES
         {
             internal uint nLength;
             internal IntPtr lpSecurityDescriptor;
             internal BOOL bInheritHandle;
         }
-#pragma warning restore CS0649
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.WIN32_FILE_ATTRIBUTE_DATA.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.WIN32_FILE_ATTRIBUTE_DATA.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        internal struct WIN32_FILE_ATTRIBUTE_DATA
+        {
+            internal int fileAttributes;
+            internal uint ftCreationTimeLow;
+            internal uint ftCreationTimeHigh;
+            internal uint ftLastAccessTimeLow;
+            internal uint ftLastAccessTimeHigh;
+            internal uint ftLastWriteTimeLow;
+            internal uint ftLastWriteTimeHigh;
+            internal uint fileSizeHigh;
+            internal uint fileSizeLow;
+
+            internal void PopulateFrom(ref WIN32_FIND_DATA findData)
+            {
+                // Copy the information to data
+                fileAttributes = (int)findData.dwFileAttributes;
+                ftCreationTimeLow = findData.ftCreationTime.dwLowDateTime;
+                ftCreationTimeHigh = findData.ftCreationTime.dwHighDateTime;
+                ftLastAccessTimeLow = findData.ftLastAccessTime.dwLowDateTime;
+                ftLastAccessTimeHigh = findData.ftLastAccessTime.dwHighDateTime;
+                ftLastWriteTimeLow = findData.ftLastWriteTime.dwLowDateTime;
+                ftLastWriteTimeHigh = findData.ftLastWriteTime.dwHighDateTime;
+                fileSizeHigh = findData.nFileSizeHigh;
+                fileSizeLow = findData.nFileSizeLow;
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.WIN32_FIND_DATA.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.WIN32_FIND_DATA.cs
@@ -20,12 +20,12 @@ internal partial class Interop
             internal uint nFileSizeLow;
             internal uint dwReserved0;
             internal uint dwReserved1;
-            private fixed char _cFileName[260];
+            private fixed char _cFileName[MAX_PATH];
             private fixed char _cAlternateFileName[14];
 
             internal ReadOnlySpan<char> cFileName
             {
-                get { fixed (char* c = _cFileName) return new ReadOnlySpan<char>(c, 260); }
+                get { fixed (char* c = _cFileName) return new ReadOnlySpan<char>(c, MAX_PATH); }
             }
         }
     }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.WIN32_FIND_DATA.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.WIN32_FIND_DATA.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal unsafe struct WIN32_FIND_DATA
+        {
+            internal uint dwFileAttributes;
+            internal FILE_TIME ftCreationTime;
+            internal FILE_TIME ftLastAccessTime;
+            internal FILE_TIME ftLastWriteTime;
+            internal uint nFileSizeHigh;
+            internal uint nFileSizeLow;
+            internal uint dwReserved0;
+            internal uint dwReserved1;
+            private fixed char _cFileName[260];
+            private fixed char _cAlternateFileName[14];
+
+            internal ReadOnlySpan<char> cFileName
+            {
+                get { fixed (char* c = _cFileName) return new ReadOnlySpan<char>(c, 260); }
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>System.IO.FileSystem</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <UWPCompatible Condition="'$(TargetGroup)'=='uap' or '$(TargetGroup)'=='uapaot'">true</UWPCompatible>
+    <UWPCompatible Condition="'$(TargetGroup)' == 'uap' or '$(TargetGroup)' == 'uapaot'">true</UWPCompatible>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsUnix)' == 'true'">
     <NoWarn>$(NoWarn);414</NoWarn>

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -6,11 +6,7 @@
     <AssemblyName>System.IO.FileSystem</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <!--
-      Currently the uap build is broken so forcing UWPCompatible = false to use Win32 code
-      https://github.com/dotnet/corefx/issues/16422
-    -->
-    <UWPCompatible>false</UWPCompatible>
+    <UWPCompatible Condition="'$(TargetGroup)'=='uap' or '$(TargetGroup)'=='uapaot'">true</UWPCompatible>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsUnix)' == 'true'">
     <NoWarn>$(NoWarn);414</NoWarn>
@@ -101,9 +97,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SECURITY_ATTRIBUTES.cs">
       <Link>Common\Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateDirectory.cs">
-      <Link>Common\Interop\Windows\Interop.CreateDirectory.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SecurityOptions.cs">
       <Link>Common\Interop\Windows\Interop.SecurityOptions.cs</Link>
     </Compile>
@@ -137,20 +130,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WriteFile_SafeHandle_IntPtr.cs">
       <Link>Common\Interop\Windows\Interop.WriteFile_IntPtr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.DeleteFile.cs">
-      <Link>Common\Interop\Windows\Interop.DeleteFile.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetFileInformationByHandle.cs">
       <Link>Common\Interop\Windows\Interop.SetFileInformationByHandle.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetFileAttributesEx.cs">
-      <Link>Common\Interop\Windows\Interop.GetFileAttributesEx.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetFileAttributes.cs">
-      <Link>Common\Interop\Windows\Interop.SetFileAttributes.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.MoveFileEx.cs">
-      <Link>Common\Interop\Windows\Interop.MoveFileEx.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCurrentDirectory.cs">
       <Link>Common\Interop\Windows\Interop.GetCurrentDirectory.cs</Link>
@@ -160,12 +141,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetLongPathName.cs">
       <Link>Common\Interop\Windows\Interop.GetLongPathName.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.RemoveDirectory.cs">
-      <Link>Common\Interop\Windows\Interop.RemoveDirectory.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FindFirstFileEx.cs">
-      <Link>Common\Interop\Windows\Interop.FindFirstFileEx.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FindNextFile.cs">
       <Link>Common\Interop\Windows\Interop.FindNextFile.cs</Link>
@@ -188,8 +163,34 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SafeCreateFile.cs">
       <Link>Common\Interop\Windows\Interop.SafeCreateFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ReplaceFile.cs">
-      <Link>Common\Interop\Windows\Interop.ReplaceFile.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WIN32_FIND_DATA.cs">
+      <Link>Common\Interop\Windows\Interop.WIN32_FIND_DATA.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FILE_TIME.cs">
+      <Link>Common\Interop\Windows\Interop.FILE_TIME.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FINDEX_INFO_LEVELS.cs">
+      <Link>Common\Interop\Windows\Interop.FINDEX_INFO_LEVELS.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FINDEX_SEARCH_OPS.cs">
+      <Link>Common\Interop\Windows\Interop.FINDEX_SEARCH_OPS.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WIN32_FILE_ATTRIBUTE_DATA.cs">
+      <Link>Common\Interop\Windows\Interop.WIN32_FILE_ATTRIBUTE_DATA.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GET_FILEEX_INFO_LEVELS.cs">
+      <Link>Common\Interop\Windows\Interop.GET_FILEEX_INFO_LEVELS.cs</Link>
+    </Compile>
+    <Compile Include="System\IO\FileSystem.Current.Win32.cs" />
+    <Compile Include="System\IO\FileSystemInfo.Win32.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetThreadErrorMode.cs">
+      <Link>Common\Interop\Windows\Interop.SetThreadErrorMode.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetLogicalDrive.cs">
+      <Link>Common\Interop\Windows\Interop.GetLogicalDrive.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.DeleteVolumeMountPoint.cs">
+      <Link>Common\Interop\Windows\Interop.DeleteVolumeMountPoint.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Memory\FixedBufferExtensions.cs">
       <Link>Common\System\Memory\FixedBufferExtensions.cs</Link>
@@ -197,54 +198,51 @@
   </ItemGroup>
   <!-- Windows : Win32 only -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(UWPCompatible)' != 'true'">
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.DeleteFile.cs">
+      <Link>Common\Interop\Windows\Interop.DeleteFile.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateDirectory.cs">
+      <Link>Common\Interop\Windows\Interop.CreateDirectory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetFileAttributes.cs">
+      <Link>Common\Interop\Windows\Interop.SetFileAttributes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.MoveFileEx.cs">
+      <Link>Common\Interop\Windows\Interop.MoveFileEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetFileAttributesEx.cs">
+      <Link>Common\Interop\Windows\Interop.GetFileAttributesEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.RemoveDirectory.cs">
+      <Link>Common\Interop\Windows\Interop.RemoveDirectory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FindFirstFileEx.cs">
+      <Link>Common\Interop\Windows\Interop.FindFirstFileEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ReplaceFile.cs">
+      <Link>Common\Interop\Windows\Interop.ReplaceFile.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateFile.cs">
+      <Link>Common\Interop\Windows\Interop.CreateFile.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.UnsafeCreateFile.cs">
       <Link>Common\Interop\Windows\Interop.UnsafeCreateFile.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CopyFile.cs">
       <Link>Common\Interop\Windows\Interop.CopyFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetLogicalDrive.cs">
-      <Link>Common\Interop\Windows\Interop.GetLogicalDrive.cs</Link>
-    </Compile>
-    <Compile Include="System\IO\FileSystem.Current.Win32.cs" />
-    <Compile Include="System\IO\FileSystemInfo.Win32.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateFile.cs">
-      <Link>Common\Interop\Windows\Interop.CreateFile.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CopyFileEx.cs">
       <Link>Common\Interop\Windows\Interop.CopyFileEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.DeleteVolumeMountPoint.cs">
-      <Link>Common\Interop\Windows\Interop.DeleteVolumeMountPoint.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetThreadErrorMode.cs">
-      <Link>Common\Interop\Windows\Interop.SetThreadErrorMode.cs</Link>
-    </Compile>
   </ItemGroup>
   <!-- Windows : UAP - Win32 + WinRT -->
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(UWPCompatible)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.UnsafeCreateFile.Uap.cs">
-      <Link>Common\Interop\Windows\Interop.UnsafeCreateFile.Uap.cs</Link>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(UWPCompatible)' == 'true'">
+    <Compile Include="System\IO\FromApp.Interop.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.COPYFILE2_EXTENDED_PARAMETERS.cs">
+      <Link>Common\Interop\Windows\Interop.COPYFILE2_EXTENDED_PARAMETERS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CopyFile.Uap.cs">
-      <Link>Common\Interop\Windows\Interop.CopyFile.Uap.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.DeleteVolumeMountPoint.Uap.cs">
-      <Link>Common\Interop\Windows\Interop.DeleteVolumeMountPoint.Uap.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetThreadErrorMode.Uap.cs">
-      <Link>Common\Interop\Windows\Interop.SetThreadErrorMode.Uap.cs</Link>
-    </Compile>
-    <Compile Include="System\IO\FileSystem.Current.MuxWin32WinRT.cs" />
-    <Compile Include="System\IO\FileSystemInfo.WinRT.cs" />
-    <Compile Include="System\IO\MultiplexingWin32WinRTFileSystem.cs" />
-    <Compile Include="System\IO\WinRTIOExtensions.cs" />
-    <Compile Include="System\IO\WinRTFileSystem.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CopyFile2.cs">
-      <Link>Common\Interop\Windows\Interop.CopyFile2.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateFile2.cs">
-      <Link>Common\Interop\Windows\Interop.CreateFile2.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CREATEFILE2_EXTENDED_PARAMETERS.cs">
+      <Link>Common\Interop\Windows\Interop.CREATEFILE2_EXTENDED_PARAMETERS.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Unix -->
@@ -376,10 +374,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Reference Include="System.Threading" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(UWPCompatible)' == 'true'">
-    <Reference Include="mscorlib" />
-    <Reference Include="Windows" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.FileSystem/src/System/IO/FromApp.Interop.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FromApp.Interop.cs
@@ -95,10 +95,7 @@ internal partial class Interop
         {
             replacedFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(replacedFileName);
             replacementFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(replacementFileName);
-            if (backupFileName != null)
-            {
-                backupFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(backupFileName);
-            }
+            backupFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(backupFileName);
 
             return ReplaceFileFromApp(
                 replacedFileName, replacementFileName, backupFileName,

--- a/src/System.IO.FileSystem/src/System/IO/FromApp.Interop.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FromApp.Interop.cs
@@ -1,0 +1,153 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+#pragma warning disable BCL0015
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport("FileApiInterop.dll", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern bool CopyFileFromApp(string lpExistingFileName, string lpNewFileName, bool bFailIfExists);
+
+        internal static int CopyFile(string src, string dst, bool failIfExists)
+        {
+            src = PathInternal.EnsureExtendedPrefixOverMaxPath(src);
+            dst = PathInternal.EnsureExtendedPrefixOverMaxPath(dst);
+            if (!CopyFileFromApp(src, dst, failIfExists))
+            {
+                return Marshal.GetLastWin32Error();
+            }
+            return Errors.ERROR_SUCCESS;
+        }
+
+        [DllImport("FileApiInterop.dll", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern bool CreateDirectoryFromApp(string lpPathName, ref SECURITY_ATTRIBUTES lpSecurityAttributes);
+
+        internal static bool CreateDirectory(string path, ref SECURITY_ATTRIBUTES lpSecurityAttributes)
+        {
+            // We always want to add for CreateDirectory to get around the legacy 248 character limitation
+            path = PathInternal.EnsureExtendedPrefix(path);
+            return CreateDirectoryFromApp(path, ref lpSecurityAttributes);
+        }
+
+        [DllImport("FileApiInterop.dll", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern bool DeleteFileFromApp(string lpFileName);
+
+        internal static bool DeleteFile(string path)
+        {
+            path = PathInternal.EnsureExtendedPrefixOverMaxPath(path);
+            return DeleteFileFromApp(path);
+        }
+
+        [DllImport("FileApiInterop.dll", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern SafeFindHandle FindFirstFileExFromApp(string lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, ref WIN32_FIND_DATA lpFindFileData, FINDEX_SEARCH_OPS fSearchOp, IntPtr lpSearchFilter, int dwAdditionalFlags);
+
+        internal static SafeFindHandle FindFirstFile(string fileName, ref WIN32_FIND_DATA data)
+        {
+            fileName = PathInternal.EnsureExtendedPrefixOverMaxPath(fileName);
+
+            // use FindExInfoBasic since we don't care about short name and it has better perf
+            return FindFirstFileExFromApp(fileName, FINDEX_INFO_LEVELS.FindExInfoBasic, ref data, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, 0);
+        }
+
+        [DllImport("FileApiInterop.dll", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern bool GetFileAttributesExFromApp(string lpFileName, GET_FILEEX_INFO_LEVELS fInfoLevelId, ref WIN32_FILE_ATTRIBUTE_DATA lpFileInformation);
+
+        internal static bool GetFileAttributesEx(string name, GET_FILEEX_INFO_LEVELS fileInfoLevel, ref WIN32_FILE_ATTRIBUTE_DATA lpFileInformation)
+        {
+            name = PathInternal.EnsureExtendedPrefixOverMaxPath(name);
+            return GetFileAttributesExFromApp(name, fileInfoLevel, ref lpFileInformation);
+        }
+
+        [DllImport("FileApiInterop.dll", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern bool MoveFileFromApp(string lpExistingFileName, string lpNewFileName);
+
+        internal static bool MoveFile(string src, string dst)
+        {
+            src = PathInternal.EnsureExtendedPrefixOverMaxPath(src);
+            dst = PathInternal.EnsureExtendedPrefixOverMaxPath(dst);
+            return MoveFileFromApp(src, dst);
+        }
+
+        [DllImport("FileApiInterop.dll", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern bool RemoveDirectoryFromApp(string lpPathName);
+
+        internal static bool RemoveDirectory(string path)
+        {
+            path = PathInternal.EnsureExtendedPrefixOverMaxPath(path);
+            return RemoveDirectoryFromApp(path);
+        }
+
+        [DllImport("FileApiInterop.dll", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern bool ReplaceFileFromApp(
+            string lpReplacedFileName, string lpReplacementFileName, string lpBackupFileName,
+            int dwReplaceFlags, IntPtr lpExclude, IntPtr lpReserved);
+
+        internal static bool ReplaceFile(
+            string replacedFileName, string replacementFileName, string backupFileName,
+            int dwReplaceFlags, IntPtr lpExclude, IntPtr lpReserved)
+        {
+            replacedFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(replacedFileName);
+            replacementFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(replacementFileName);
+            if (backupFileName != null)
+            {
+                backupFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(backupFileName);
+            }
+
+            return ReplaceFileFromApp(
+                replacedFileName, replacementFileName, backupFileName,
+                dwReplaceFlags, lpExclude, lpReserved);
+        }
+
+        internal const int REPLACEFILE_WRITE_THROUGH = 0x1;
+        internal const int REPLACEFILE_IGNORE_MERGE_ERRORS = 0x2;
+
+        [DllImport("FileApiInterop.dll", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern bool SetFileAttributesFromApp(string lpFileName, int dwFileAttributes);
+
+        internal static bool SetFileAttributes(string name, int attr)
+        {
+            name = PathInternal.EnsureExtendedPrefixOverMaxPath(name);
+            return SetFileAttributesFromApp(name, attr);
+        }
+
+        [DllImport("FileApiInterop.dll", EntryPoint = "CreateFile2FromApp", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern SafeFileHandle CreateFile2(
+            string lpFileName,
+            int dwDesiredAccess,
+            FileShare dwShareMode,
+            FileMode dwCreationDisposition,
+            [In] ref CREATEFILE2_EXTENDED_PARAMETERS parameters);
+
+        internal static unsafe SafeFileHandle UnsafeCreateFile(
+            string lpFileName,
+            int dwDesiredAccess,
+            FileShare dwShareMode,
+            ref SECURITY_ATTRIBUTES securityAttrs,
+            FileMode dwCreationDisposition,
+            int dwFlagsAndAttributes,
+            IntPtr hTemplateFile)
+        {
+            CREATEFILE2_EXTENDED_PARAMETERS parameters;
+            parameters.dwSize = (uint)Marshal.SizeOf<CREATEFILE2_EXTENDED_PARAMETERS>();
+
+            parameters.dwFileAttributes = (uint)dwFlagsAndAttributes & 0x0000FFFF;
+            parameters.dwSecurityQosFlags = (uint)dwFlagsAndAttributes & 0x000F0000;
+            parameters.dwFileFlags = (uint)dwFlagsAndAttributes & 0xFFF00000;
+
+            parameters.hTemplateFile = hTemplateFile;
+            fixed (SECURITY_ATTRIBUTES* lpSecurityAttributes = &securityAttrs)
+            {
+                parameters.lpSecurityAttributes = (IntPtr)lpSecurityAttributes;
+                return CreateFile2(lpFileName, dwDesiredAccess, dwShareMode, dwCreationDisposition, ref parameters);
+            }
+        }
+    }
+}
+#pragma warning restore BCL0015

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -46,11 +46,7 @@ namespace System.IO
 
         public override void ReplaceFile(string sourceFullPath, string destFullPath, string destBackupFullPath, bool ignoreMetadataErrors)
         {
-            int flags = Interop.Kernel32.REPLACEFILE_WRITE_THROUGH;
-            if (ignoreMetadataErrors)
-            {
-                flags |= Interop.Kernel32.REPLACEFILE_IGNORE_MERGE_ERRORS;
-            }
+            int flags = ignoreMetadataErrors ? Interop.Kernel32.REPLACEFILE_IGNORE_MERGE_ERRORS : 0;
 
             if (!Interop.Kernel32.ReplaceFile(destFullPath, sourceFullPath, destBackupFullPath, flags, IntPtr.Zero, IntPtr.Zero))
             {

--- a/src/System.IO.FileSystem/tests/Configurations.props
+++ b/src/System.IO.FileSystem/tests/Configurations.props
@@ -6,6 +6,7 @@
       netstandard-Windows_NT;
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    public class File_Copy_str_str : FileSystemTest
+    public partial class File_Copy_str_str : FileSystemTest
     {
         #region Utilities
 
@@ -184,7 +184,6 @@ namespace System.IO.Tests
             Assert.True(File.Exists(testFile));
             Assert.True(File.Exists(Path.Combine(TestDirectory, valid)));
         }
-
         #endregion
     }
 

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{F0D49126-6A1C-42D5-9428-4374C868BAF8}</ProjectGuid>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
@@ -13,6 +14,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Base\BaseGetSetAttributes.cs" />
     <Compile Include="Base\BaseGetSetTimes.cs" />
@@ -48,6 +51,9 @@
     <Compile Include="File\ReadWriteAllLinesAsync.cs" />
     <Compile Include="File\ReadWriteAllBytesAsync.cs" />
     <Compile Include="File\ReadWriteAllTextAsync.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uapaot' or '$(TargetGroup)' == 'uap'">
+    <Compile Include="WinRT_BrokeredFunctions.cs" />
   </ItemGroup>
   <ItemGroup>
     <!-- Rewritten -->
@@ -168,6 +174,10 @@
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uapaot' or '$(TargetGroup)' == 'uap'">
+    <Reference Include="mscorlib" />
+    <Reference Include="Windows" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />

--- a/src/System.IO.FileSystem/tests/WinRT_BrokeredFunctions.cs
+++ b/src/System.IO.FileSystem/tests/WinRT_BrokeredFunctions.cs
@@ -32,7 +32,6 @@ namespace System.IO.Tests
             }
             finally
             {
-                File.Delete(testFile);
                 File.Delete(destination);
             }
         }
@@ -68,11 +67,12 @@ namespace System.IO.Tests
         {
             string subFolder = Path.Combine(s_musicFolder, "FindFirstFile_SubFolder_" + Path.GetRandomFileName());
             Directory.CreateDirectory(subFolder);
-            string testFile = Path.Combine(subFolder, "FindFirstFile_SubFile_" + Path.GetRandomFileName());
-            CreateFileInBrokeredLocation(testFile);
+            string testFile = null;
 
             try
             {
+                testFile = Path.Combine(subFolder, "FindFirstFile_SubFile_" + Path.GetRandomFileName());
+                CreateFileInBrokeredLocation(testFile);
                 Assert.True(File.Exists(testFile), "testFile should exist");
             }
             finally
@@ -91,7 +91,7 @@ namespace System.IO.Tests
             try
             {
                 FileAttributes attr = File.GetAttributes(destination);
-                Assert.False(((attr & FileAttributes.ReadOnly) > 0 ), "new file in brokered location should not be readonly");
+                Assert.False((attr & FileAttributes.ReadOnly) == 0, "new file in brokered location should not be readonly");
             }
             finally
             {
@@ -183,7 +183,7 @@ namespace System.IO.Tests
         {
             // Temporary hack until FileStream is updated to support brokering
             string testFile = GetTestFilePath();
-            File.Create(testFile).Dispose();
+            File.WriteAllText(testFile, "CoreFX test file");
             File.Copy(testFile, path);
         }
 

--- a/src/System.IO.FileSystem/tests/WinRT_BrokeredFunctions.cs
+++ b/src/System.IO.FileSystem/tests/WinRT_BrokeredFunctions.cs
@@ -1,0 +1,207 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Xunit;
+using Windows.Storage;
+
+namespace System.IO.Tests
+{
+    [PlatformSpecific(TestPlatforms.Windows)]
+    [SkipOnTargetFramework(~(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot))]
+    public partial class WinRT_BrokeredFunctions : FileSystemTest
+    {
+        private static string s_musicFolder = StorageLibrary.GetLibraryAsync(KnownLibraryId.Music).AsTask().Result.SaveFolder.Path;
+
+        [Fact]
+        public void CopyFile_ToBrokeredLocation()
+        {
+            string testFile = GetTestFilePath();
+            File.Create(testFile).Dispose();
+
+            string destination = Path.Combine(s_musicFolder, "CopyToBrokeredLocation_" + Path.GetRandomFileName());
+            try
+            {
+                Assert.False(File.Exists(destination), "destination shouldn't exist before copying");
+                File.Copy(testFile, destination);
+                Assert.True(File.Exists(testFile), "testFile should exist after copying");
+                Assert.True(File.Exists(destination), "destination should exist after copying");
+            }
+            finally
+            {
+                File.Delete(testFile);
+                File.Delete(destination);
+            }
+        }
+
+        [Fact]
+        public void CreateDirectory()
+        {
+            string testFolder = Path.Combine(s_musicFolder, "CreateDirectory_" + Path.GetRandomFileName());
+            try
+            {
+                Assert.False(Directory.Exists(testFolder), "destination shouldn't exist");
+                Directory.CreateDirectory(testFolder);
+                Assert.True(Directory.Exists(testFolder), "destination should exist");
+            }
+            finally
+            {
+                Directory.Delete(testFolder);
+            }
+        }
+
+        [Fact]
+        public void DeleteFile()
+        {
+            string testFile = Path.Combine(s_musicFolder, "DeleteFile_" + Path.GetRandomFileName());
+            CreateFileInBrokeredLocation(testFile);
+            Assert.True(File.Exists(testFile), "testFile should exist before deleting");
+            File.Delete(testFile);
+            Assert.False(File.Exists(testFile), "testFile shouldn't exist after deleting");
+        }
+
+        [Fact]
+        public void FindFirstFile()
+        {
+            string subFolder = Path.Combine(s_musicFolder, "FindFirstFile_SubFolder_" + Path.GetRandomFileName());
+            Directory.CreateDirectory(subFolder);
+            string testFile = Path.Combine(subFolder, "FindFirstFile_SubFile_" + Path.GetRandomFileName());
+            CreateFileInBrokeredLocation(testFile);
+
+            try
+            {
+                Assert.True(File.Exists(testFile), "testFile should exist");
+            }
+            finally
+            {
+                Directory.Delete(subFolder, true);
+            }
+            Assert.False(File.Exists(testFile), "testFile shouldn't exist after a recursive delete");
+            Assert.False(Directory.Exists(subFolder), "subFolder shouldn't exist after a recursive delete");
+        }
+
+        [Fact]
+        public void GetFileAttributesEx()
+        {
+            string destination = Path.Combine(s_musicFolder, "GetFileAttributesEx_" + Path.GetRandomFileName());
+            CreateFileInBrokeredLocation(destination);
+            try
+            {
+                FileAttributes attr = File.GetAttributes(destination);
+                Assert.False(((attr & FileAttributes.ReadOnly) > 0 ), "new file in brokered location should not be readonly");
+            }
+            finally
+            {
+                File.Delete(destination);
+            }
+        }
+
+        [Fact]
+        public void MoveFile()
+        {
+            string testFile = GetTestFilePath();
+            File.Create(testFile).Dispose();
+
+            string destination = Path.Combine(s_musicFolder, "MoveFile_" + Path.GetRandomFileName());
+            try
+            {
+                Assert.False(File.Exists(destination), "destination shouldn't exist before moving");
+                File.Move(testFile, destination);
+                Assert.False(File.Exists(testFile), "testFile shouldn't exist after moving");
+                Assert.True(File.Exists(destination), "destination should exist after moving");
+            }
+            finally
+            {
+                File.Delete(destination);
+            }
+        }
+
+        [Fact]
+        public void RemoveDirectory()
+        {
+            string testFolder = Path.Combine(s_musicFolder, "CreateDirectory_" + Path.GetRandomFileName());
+            Assert.False(Directory.Exists(testFolder), "destination shouldn't exist");
+            Directory.CreateDirectory(testFolder);
+            Assert.True(Directory.Exists(testFolder), "destination should exist");
+            Directory.Delete(testFolder);
+            Assert.False(Directory.Exists(testFolder), "destination shouldn't exist");
+        }
+
+        [Fact]
+        public void ReplaceFile()
+        {
+            string testFile = GetTestFilePath();
+            File.Create(testFile).Dispose();
+
+            string destination = Path.Combine(s_musicFolder, "ReplaceFile_" + Path.GetRandomFileName());
+            File.Copy(testFile, destination);
+
+            // Need to be on the same drive
+            Assert.Equal(testFile[0], destination[0]);
+
+            string destinationBackup = Path.Combine(s_musicFolder, "ReplaceFile_" + Path.GetRandomFileName());
+            try
+            {
+                Assert.True(File.Exists(destination), "destination should exist before replacing");
+                Assert.False(File.Exists(destinationBackup), "destination shouldn't exist before replacing");
+                File.Replace(testFile, destination, destinationBackup);
+                Assert.False(File.Exists(testFile), "testFile shouldn't exist after replacing");
+                Assert.True(File.Exists(destination), "destination should exist after replacing");
+                Assert.True(File.Exists(destinationBackup), "destinationBackup should exist after replacing");
+            }
+            finally
+            {
+                File.Delete(destination);
+                File.Delete(destinationBackup);
+            }
+        }
+
+        [Fact]
+        public void SetFileAttributes()
+        {
+            string destination = Path.Combine(s_musicFolder, "SetFileAttributes_" + Path.GetRandomFileName());
+            CreateFileInBrokeredLocation(destination);
+            FileAttributes attr = File.GetAttributes(destination);
+            try
+            {
+                Assert.False(((attr & FileAttributes.ReadOnly) > 0), "new file in brokered location should not be readonly");
+                File.SetAttributes(destination, attr | FileAttributes.ReadOnly);
+                Assert.True(((File.GetAttributes(destination) & FileAttributes.ReadOnly) > 0), "file in brokered location should be readonly after setting FileAttributes");
+            }
+            finally
+            {
+                File.SetAttributes(destination, attr);
+                Assert.False(((File.GetAttributes(destination) & FileAttributes.ReadOnly) > 0), "file in brokered location should NOT be readonly after setting FileAttributes");
+                File.Delete(destination);
+            }
+        }
+
+        private void CreateFileInBrokeredLocation(string path)
+        {
+            // Temporary hack until FileStream is updated to support brokering
+            string testFile = GetTestFilePath();
+            File.Create(testFile).Dispose();
+            File.Copy(testFile, path);
+        }
+
+        // Temporarily blocking until the CoreCLR change is made [Fact]
+        public void WriteReadAllText()
+        {
+            string destination = Path.Combine(s_musicFolder, "WriteReadAllText_" + Path.GetRandomFileName());
+            string content = "WriteReadAllText";
+            File.WriteAllText(destination, content);
+            try
+            {
+                Assert.True(File.Exists(destination));
+                Assert.Equal(content, File.ReadAllText(destination));
+            }
+            finally
+            {
+                File.Delete(destination);
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/WinRT_BrokeredFunctions.cs
+++ b/src/System.IO.FileSystem/tests/WinRT_BrokeredFunctions.cs
@@ -160,6 +160,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ActiveIssue(23444)]
         public void SetFileAttributes()
         {
             string destination = Path.Combine(s_musicFolder, "SetFileAttributes_" + Path.GetRandomFileName());

--- a/src/System.IO.FileSystem/tests/WinRT_BrokeredFunctions.cs
+++ b/src/System.IO.FileSystem/tests/WinRT_BrokeredFunctions.cs
@@ -84,6 +84,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ActiveIssue(23444)]
         public void GetFileAttributesEx()
         {
             string destination = Path.Combine(s_musicFolder, "GetFileAttributesEx_" + Path.GetRandomFileName());


### PR DESCRIPTION
This changes our P/Invokes to use the FromApp variants, which
allow for brokered file access on UAP. These are only included
in the UAP build.

Adds tests for the brokered IO WinRT functions and removes a
dead option from movefile. This option was removed in Windows 8
and did not work correctly in prior OSes. (This was needed
for this change.)

This change depends on the referenced dll being packaged and
added to our dependencies. There is a related change for CoreCLR
that supports FileStream.

Note: I broke out the struct defines and put all of the new P/Invokes
in a single file. I want to keep them together and in the FileSystem dir
to help keep them from creeping out and allow for easy disabling
if required.

There is one known issue at this point with setting of attributes in
brokered locations. Everything else is to the point where it looks like
our code is correct.