### PR TITLE
System.Private.Xml: Use Encoding.Preamble

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -180,10 +180,10 @@ namespace System.Xml
 
             if (!stream.CanSeek || stream.Position == 0)
             {
-                byte[] bom = encoding.GetPreamble();
+                ReadOnlySpan<byte> bom = encoding.Preamble;
                 if (bom.Length != 0)
                 {
-                    this.stream.Write(bom, 0, bom.Length);
+                    this.stream.Write(bom);
                 }
             }
 

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.cxx
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.cxx
@@ -210,9 +210,9 @@ namespace System.Xml {
 
             // Output UTF-8 byte order mark if Encoding object wants it
             if ( !stream.CanSeek || stream.Position == 0 ) {
-                byte[] bom = encoding.GetPreamble();
+                ReadOnlySpan<byte> bom = encoding.Preamble;
                 if ( bom.Length != 0 ) {
-                    Buffer.BlockCopy( bom, 0, bufBytes, 1, bom.Length );
+                    bom.CopyTo(new Span<byte>(bufBytes, 1));
                     bufPos += bom.Length;
                     textPos += bom.Length;
                 }
@@ -237,9 +237,9 @@ namespace System.Xml {
             encoder = encoding.GetEncoder();
 
             if ( !stream.CanSeek || stream.Position == 0 ) {
-                byte[] bom = encoding.GetPreamble();
+                ReadOnlySpan<byte> bom = encoding.Preamble;
                 if ( bom.Length != 0 ) {
-                    this.stream.Write( bom, 0, bom.Length );
+                    this.stream.Write( bom );
                 }
             }
 #endif

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -2915,20 +2915,7 @@ namespace System.Xml
             SetupEncoding(encoding);
 
             // eat preamble
-            ReadOnlySpan<byte> preamble = _ps.encoding.Preamble;
-            int preambleLen = preamble.Length;
-            int i;
-            for (i = 0; i < preambleLen && i < _ps.bytesUsed; i++)
-            {
-                if (_ps.bytes[i] != preamble[i])
-                {
-                    break;
-                }
-            }
-            if (i == preambleLen)
-            {
-                _ps.bytePos = preambleLen;
-            }
+            EatPreamble();
 
             _documentStartBytePos = _ps.bytePos;
 
@@ -3222,6 +3209,24 @@ namespace System.Xml
                         _ps.decoder = encoding.GetDecoder();
                         break;
                 }
+            }
+        }
+
+        private void EatPreamble()
+        {
+            ReadOnlySpan<byte> preamble = _ps.encoding.Preamble;
+            int preambleLen = preamble.Length;
+            int i;
+            for (i = 0; i < preambleLen && i < _ps.bytesUsed; i++)
+            {
+                if (_ps.bytes[i] != preamble[i])
+                {
+                    break;
+                }
+            }
+            if (i == preambleLen)
+            {
+                _ps.bytePos = preambleLen;
             }
         }
 

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -2914,8 +2914,8 @@ namespace System.Xml
             }
             SetupEncoding(encoding);
 
-            // eat preamble 
-            byte[] preamble = _ps.encoding.GetPreamble();
+            // eat preamble
+            ReadOnlySpan<byte> preamble = _ps.encoding.Preamble;
             int preambleLen = preamble.Length;
             int i;
             for (i = 0; i < preambleLen && i < _ps.bytesUsed; i++)

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -992,8 +992,8 @@ namespace System.Xml
             }
             SetupEncoding(encoding);
 
-            // eat preamble 
-            byte[] preamble = _ps.encoding.GetPreamble();
+            // eat preamble
+            ReadOnlySpan<byte> preamble = _ps.encoding.Preamble;
             int preambleLen = preamble.Length;
             int i;
             for (i = 0; i < preambleLen && i < _ps.bytesUsed; i++)

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -993,20 +993,7 @@ namespace System.Xml
             SetupEncoding(encoding);
 
             // eat preamble
-            ReadOnlySpan<byte> preamble = _ps.encoding.Preamble;
-            int preambleLen = preamble.Length;
-            int i;
-            for (i = 0; i < preambleLen && i < _ps.bytesUsed; i++)
-            {
-                if (_ps.bytes[i] != preamble[i])
-                {
-                    break;
-                }
-            }
-            if (i == preambleLen)
-            {
-                _ps.bytePos = preambleLen;
-            }
+            EatPreamble();
 
             _documentStartBytePos = _ps.bytePos;
 

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriter.cs
@@ -125,10 +125,10 @@ namespace System.Xml
             // Output UTF-8 byte order mark if Encoding object wants it
             if (!stream.CanSeek || stream.Position == 0)
             {
-                byte[] bom = encoding.GetPreamble();
+                ReadOnlySpan<byte> bom = encoding.Preamble;
                 if (bom.Length != 0)
                 {
-                    Buffer.BlockCopy(bom, 0, bufBytes, 1, bom.Length);
+                    bom.CopyTo(new Span<byte>(bufBytes, 1));
                     bufPos += bom.Length;
                     textPos += bom.Length;
                 }


### PR DESCRIPTION
Use the new `Encoding.Preamble` property to avoid unnecessary `byte[]` allocations for encodings that return cached instances from `Preamble` (e.g. all of the built-in encodings that have preambles).

Reference: https://github.com/dotnet/coreclr/pull/13269
Reference: https://github.com/dotnet/corefx/pull/23049

cc: @sepidehMS, @krwq, @stephentoub 

Note: I went ahead and updated `XmlRawTextWriterGenerator.cxx`, but judging by the formatting differences in `XmlEncodedRawTextWriter.cs` and `XmlUtf8RawTextWriter.cs` it doesn't appear to be used currently.