### PR TITLE
DataContractSerialization: Use Encoding.Preamble

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
@@ -206,9 +206,9 @@ namespace System.Xml
                 // Emit BOM
                 if (emitBOM)
                 {
-                    byte[] bom = _encoding.GetPreamble();
+                    ReadOnlySpan<byte> bom = _encoding.Preamble;
                     if (bom.Length > 0)
-                        _stream.Write(bom, 0, bom.Length);
+                        _stream.Write(bom);
                 }
             }
         }


### PR DESCRIPTION
Use the new `Encoding.Preamble` property to avoid unnecessary `byte[]` allocations for encodings that return cached instances from `Preamble` (e.g. all of the built-in encodings that have preambles).

Reference: https://github.com/dotnet/coreclr/pull/13269

cc: @shmao, @zhenlan, @stephentoub