### PR TITLE
HttpListener: Use Encoding.Preamble

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -284,7 +284,7 @@ namespace System.Net
 
             writer.Write(FormatHeaders(_webHeaders));
             writer.Flush();
-            int preamble = encoding.GetPreamble().Length;
+            int preamble = encoding.Preamble.Length;
             EnsureResponseStream();
 
             /* Assumes that the ms was at position 0 */


### PR DESCRIPTION
Use the new `Encoding.Preamble` property to avoid unnecessary `byte[]` allocations for encodings that return cached instances from `Preamble` (e.g. all of the built-in encodings that have preambles).

I debated whether to even submit this PR as the encoding used is `Encoding.Default` (line 277), which in .NET Core is always going to be UTF8 without a preamble. Since the code for handling a potential preamble is present here, I decided to go ahead and make the change to avoid the potential `byte[]` allocation if the encoding is ever changed to one that has a preamble.

Reference: https://github.com/dotnet/coreclr/pull/13269

cc: @davidsh, @CIPop, @Priya91, @stephentoub