### PR TITLE
Expose/test span-based Version methods

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -3556,9 +3556,13 @@ namespace System
         public static bool operator <(System.Version v1, System.Version v2) { throw null; }
         public static bool operator <=(System.Version v1, System.Version v2) { throw null; }
         public static System.Version Parse(string input) { throw null; }
+        public static System.Version Parse(ReadOnlySpan<char> input) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(int fieldCount) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten) { throw null; }
+        public bool TryFormat(System.Span<char> destination, int fieldCount, out int charsWritten) { throw null; }
         public static bool TryParse(string input, out System.Version result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, out System.Version result) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size = 1)]
     public partial struct Void

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -198,6 +198,7 @@
     <Compile Include="System\UInt16Tests.netcoreapp.cs" />
     <Compile Include="System\UInt32Tests.netcoreapp.cs" />
     <Compile Include="System\UInt64Tests.netcoreapp.cs" />
+    <Compile Include="System\VersionTests.netcoreapp.cs" />
     <Compile Include="System\ComponentModel\DefaultValueAttributeTests.netcoreapp.cs" />
     <Compile Include="System\Reflection\AssemblyTests.netcoreapp.cs" />
     <Compile Include="System\Reflection\MethodBaseTests.netcoreapp.cs" />

--- a/src/System.Runtime/tests/System/VersionTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/VersionTests.netcoreapp.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Tests
+{
+    public partial class VersionTests
+    {
+        [Theory]
+        [MemberData(nameof(Parse_Valid_TestData))]
+        public static void Parse_Span_ValidInput_ReturnsExpected(string input, Version expected)
+        {
+            if (input == null)
+            {
+                return;
+            }
+
+            Assert.Equal(expected, Version.Parse(input.AsReadOnlySpan()));
+
+            Assert.True(Version.TryParse(input.AsReadOnlySpan(), out Version version));
+            Assert.Equal(expected, version);
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_Invalid_TestData))]
+        public static void Parse_Span_InvalidInput_ThrowsException(string input, Type exceptionType)
+        {
+            if (input == null)
+            {
+                return;
+            }
+
+            Assert.Throws(exceptionType, () => Version.Parse(input.AsReadOnlySpan()));
+
+            Assert.False(Version.TryParse(input.AsReadOnlySpan(), out Version version));
+            Assert.Null(version);
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public static void TryFormat_Invoke_WritesExpected(Version version, string[] expected)
+        {
+            char[] dest;
+            int charsWritten;
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                if (i > 0)
+                {
+                    // Too small
+                    dest = new char[expected[i].Length - 1];
+                    Assert.False(version.TryFormat(dest, i, out charsWritten));
+                    Assert.Equal(0, charsWritten);
+                }
+
+                // Just right
+                dest = new char[expected[i].Length];
+                Assert.True(version.TryFormat(dest, i, out charsWritten));
+                Assert.Equal(expected[i].Length, charsWritten);
+                Assert.Equal(expected[i], new string(dest, 0, charsWritten));
+
+                // More than needed
+                dest = new char[expected[i].Length + 10];
+                Assert.True(version.TryFormat(dest, i, out charsWritten));
+                Assert.Equal(expected[i].Length, charsWritten);
+                Assert.Equal(expected[i], new string(dest, 0, charsWritten));
+            }
+
+            int maxFieldCount = expected.Length - 1;
+            dest = new char[expected[maxFieldCount].Length];
+            Assert.True(version.TryFormat(dest, out charsWritten));
+            Assert.Equal(expected[maxFieldCount].Length, charsWritten);
+            Assert.Equal(expected[maxFieldCount], new string(dest, 0, charsWritten));
+
+            dest = new char[0];
+            AssertExtensions.Throws<ArgumentException>("fieldCount", () => version.TryFormat(dest, -1, out charsWritten)); // Index < 0
+            AssertExtensions.Throws<ArgumentException>("fieldCount", () => version.TryFormat(dest, maxFieldCount + 1, out charsWritten)); // Index > version.fieldCount
+        }
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/dotnet/coreclr/pull/13424
Fixes dotnet/corefx#22376
cc: @AlexGhiondea, @joperezr