### PR TITLE
Override Read/Write(span) on System.Net.Http streams

### DIFF
--- a/src/Common/src/System/IO/DelegatingStream.cs
+++ b/src/Common/src/System/IO/DelegatingStream.cs
@@ -94,6 +94,13 @@ namespace System.Net.Http
             return _innerStream.Read(buffer, offset, count);
         }
 
+#if !NET46
+        public override int Read(Span<byte> destination)
+        {
+            return _innerStream.Read(destination);
+        }
+#endif
+
         public override int ReadByte()
         {
             return _innerStream.ReadByte();
@@ -137,6 +144,13 @@ namespace System.Net.Http
         {
             _innerStream.Write(buffer, offset, count);
         }
+
+#if !NET46
+        public override void Write(ReadOnlySpan<byte> source)
+        {
+            _innerStream.Write(source);
+        }
+#endif
 
         public override void WriteByte(byte value)
         {

--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -143,6 +143,13 @@ namespace System.Net.Http
                 throw new NotSupportedException(SR.net_http_content_readonly_stream);
             }
 
+#if !NET46
+            public override void Write(ReadOnlySpan<byte> source)
+            {
+                throw new NotSupportedException(SR.net_http_content_readonly_stream);
+            }
+#endif
+
             public override void WriteByte(byte value)
             {
                 throw new NotSupportedException(SR.net_http_content_readonly_stream);

--- a/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
@@ -199,7 +199,7 @@ namespace System.Net.Http.Functional.Tests
                 form.Add(new ByteArrayContent(bytes), "file", Guid.NewGuid().ToString());
             }
 
-            long totalAsyncRead = 0, totalSyncRead = 0;
+            long totalAsyncRead = 0, totalSyncArrayRead = 0, totalSyncSpanRead = 0;
             int bytesRead;
 
             using (Stream s = await form.ReadAsStreamAsync())
@@ -213,11 +213,18 @@ namespace System.Net.Http.Functional.Tests
                 s.Position = 0;
                 while ((bytesRead = s.Read(bytes, 0, bytes.Length)) > 0)
                 {
-                    totalSyncRead += bytesRead;
+                    totalSyncArrayRead += bytesRead;
+                }
+
+                s.Position = 0;
+                while ((bytesRead = s.Read(new Span<byte>(bytes, 0, bytes.Length))) > 0)
+                {
+                    totalSyncSpanRead += bytesRead;
                 }
             }
 
-            Assert.Equal(totalAsyncRead, totalSyncRead);
+            Assert.Equal(totalAsyncRead, totalSyncArrayRead);
+            Assert.Equal(totalAsyncRead, totalSyncSpanRead);
             Assert.InRange(totalAsyncRead, PerContent * ContentCount, long.MaxValue); 
         }
 
@@ -319,6 +326,7 @@ namespace System.Net.Http.Functional.Tests
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("origin", () => s.Seek(0, (SeekOrigin)42));
 
                 Assert.Throws<NotSupportedException>(() => s.Write(new byte[1], 0, 0));
+                Assert.Throws<NotSupportedException>(() => s.Write(new Span<byte>(new byte[1], 0, 0)));
                 Assert.Throws<NotSupportedException>(() => { s.WriteAsync(new byte[1], 0, 0); });
                 Assert.Throws<NotSupportedException>(() => s.SetLength(1));
             }
@@ -331,6 +339,7 @@ namespace System.Net.Http.Functional.Tests
             using (Stream s = await mc.ReadAsStreamAsync())
             {
                 Assert.Equal(0, s.Read(new byte[1], 0, 0));
+                Assert.Equal(0, s.Read(new Span<byte>(new byte[1], 0, 0)));
                 Assert.Equal(0, s.Position);
 
                 Assert.Equal(0, await s.ReadAsync(new byte[1], 0, 0));

--- a/src/System.Net.Http/tests/FunctionalTests/StreamContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/StreamContentTest.cs
@@ -239,6 +239,10 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(1, contentReadStream.Read(byteOnIndex5, 0, 1));
             Assert.Equal(data[5], byteOnIndex5[0]);
 
+            byte[] byteOnIndex6 = new byte[1];
+            Assert.Equal(1, contentReadStream.Read(new Span<byte>(byteOnIndex6, 0, 1)));
+            Assert.Equal(data[6], byteOnIndex6[0]);
+
             contentReadStream.ReadTimeout = 123;
             Assert.Equal(123, source.ReadTimeout);
             Assert.Equal(123, contentReadStream.ReadTimeout);
@@ -256,6 +260,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Throws<NotSupportedException>(() => contentReadStream.Flush());
             Assert.Throws<NotSupportedException>(() => contentReadStream.SetLength(1));
             Assert.Throws<NotSupportedException>(() => contentReadStream.Write(null, 0, 0));
+            Assert.Throws<NotSupportedException>(() => contentReadStream.Write(new Span<byte>(Array.Empty<byte>())));
             Assert.Throws<NotSupportedException>(() => contentReadStream.WriteByte(1));
 
             Assert.Equal(0, source.DisposeCount);

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -107,6 +107,11 @@
     <Compile Include="ManagedHandlerTest.cs" />
     <Compile Include="HttpClientHandlerTest.AcceptAllCerts.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+    <Compile Include="$(CommonTestPath)\System\IO\StreamSpanExtensions.netstandard.cs">
+      <Link>Common\System\IO\StreamSpanExtensions.netstandard.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
     <Reference Include="Windows" />
     <Compile Include="MultiInterfaceNonRewindableReadOnlyStream.cs" />


### PR DESCRIPTION
These streams are all in the common portion of the build that's also compiled for netfx.  We're going to be deleting that build of it, so rather than separating these out into separate partial files, I just followed the current convention in the project of using #if !NET46.

cc: @davidsh, @geoffkizer 