### PR TITLE
[System.Data] hide AppDomain.Unload in SqlDependencyUtils.cs to a separate file

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -123,6 +123,7 @@
     <Compile Include="System\Data\SqlClient\SqlDependency.cs" />
     <Compile Include="System\Data\SqlClient\SqlDependencyListener.cs" />
     <Compile Include="System\Data\SqlClient\SqlDependencyUtils.cs" />
+    <Compile Include="System\Data\SqlClient\SqlDependencyUtils.AppDomain.cs" />
     <Compile Include="System\Data\SqlClient\SqlDelegatedTransaction.cs" />
     <Compile Include="System\Data\SqlClient\SqlEnums.cs" />
     <Compile Include="System\Data\SqlClient\SqlError.cs" />

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDependencyUtils.AppDomain.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDependencyUtils.AppDomain.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Data.SqlClient
+{
+    // these members were moved to a separate file in order
+    // to be able to skip them on platforms where AppDomain members are not supported 
+    // for example, some mobile profiles on mono
+    partial class SqlDependencyPerAppDomainDispatcher
+    {
+        private void SubscribeToAppDomainUnload()
+        {
+            // If rude abort - we'll leak.  This is acceptable for now.  
+            AppDomain.CurrentDomain.DomainUnload += new EventHandler(UnloadEventHandler);
+        }
+
+        private void UnloadEventHandler(object sender, EventArgs e)
+        {
+            // Make non-blocking call to ProcessDispatcher to ThreadPool.QueueUserWorkItem to complete 
+            // stopping of all start calls in this AppDomain.  For containers shared among various AppDomains,
+            // this will just be a ref-count subtract.  For non-shared containers, we will close the container
+            // and clean-up.
+            var dispatcher = SqlDependency.ProcessDispatcher;
+            dispatcher?.QueueAppDomainUnloading(SqlDependency.AppDomainKey);
+        }
+    }
+}


### PR DESCRIPTION
Some of our platforms in mono don't support AppDomain members/events and since we use corefx code (see https://github.com/mono/mono/pull/4893) we need to hide it from mono.
alternative solution - #ifdef.