### PR TITLE
Delete bad test from AsyncValueTaskMethodBuilderTests

### DIFF
--- a/src/System.Threading.Tasks.Extensions/tests/AsyncValueTaskMethodBuilderTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/AsyncValueTaskMethodBuilderTests.cs
@@ -83,36 +83,6 @@ namespace System.Threading.Tasks.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task AwaitOnCompleted_InvokesStateMachineMethods(bool awaitUnsafe)
-        {
-            AsyncValueTaskMethodBuilder<int> b = ValueTask<int>.CreateAsyncMethodBuilder();
-            var ignored = b.Task;
-
-            var callbackCompleted = new TaskCompletionSource<bool>();
-            IAsyncStateMachine foundSm = null;
-            var dsm = new DelegateStateMachine
-            {
-                MoveNextDelegate = () => callbackCompleted.SetResult(true),
-                SetStateMachineDelegate = sm => foundSm = sm
-            };
-
-            TaskAwaiter t = Task.CompletedTask.GetAwaiter();
-            if (awaitUnsafe)
-            {
-                b.AwaitUnsafeOnCompleted(ref t, ref dsm);
-            }
-            else
-            {
-                b.AwaitOnCompleted(ref t, ref dsm);
-            }
-
-            await callbackCompleted.Task;
-            Assert.Equal(dsm, foundSm);
-        }
-
-        [Theory]
         [InlineData(1, false)]
         [InlineData(2, false)]
         [InlineData(1, true)]
@@ -214,8 +184,7 @@ namespace System.Threading.Tasks.Tests
             internal Action MoveNextDelegate;
             public void MoveNext() => MoveNextDelegate?.Invoke();
 
-            internal Action<IAsyncStateMachine> SetStateMachineDelegate;
-            public void SetStateMachine(IAsyncStateMachine stateMachine) => SetStateMachineDelegate?.Invoke(stateMachine);
+            public void SetStateMachine(IAsyncStateMachine stateMachine) { }
         }
     }
 }


### PR DESCRIPTION
This test was failing on uapaot (https://github.com/dotnet/corefx/issues/22545). It turns out that the behavior it depends on was explicitly disabled in Release builds of S.P.CoreLib (see the issue for details).

Per @stephentoub, this test was added only to increase code coverage, and the machinery it depends on is being removed in CoreCLR soon too (https://github.com/dotnet/coreclr/pull/13105). With that in mind, we feel it's pretty safe to just delete the test.

@stephentoub PTAL

Fixes https://github.com/dotnet/corefx/issues/22545