### PR TITLE
Fix the sgen issue when use NaN as the default value. 

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/src/Microsoft/XmlSerializer/Generator/XmlSerializationWriter.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Microsoft/XmlSerializer/Generator/XmlSerializationWriter.cs
@@ -2044,6 +2044,7 @@ namespace Microsoft.XmlSerializer.Generator
                 else if (type == typeof(Int32))
                     Writer.Write(((Int32)value).ToString(null, NumberFormatInfo.InvariantInfo));
                 else if (type == typeof(Double))
+                {
                     if (double.IsNaN((Double)value))
                     {
                         Writer.Write("double.NaN");
@@ -2052,6 +2053,7 @@ namespace Microsoft.XmlSerializer.Generator
                     {
                         Writer.Write(((Double)value).ToString("R", NumberFormatInfo.InvariantInfo));
                     }
+                }
                 else if (type == typeof(Boolean))
                     Writer.Write((bool)value ? "true" : "false");
                 else if ((type == typeof(Int16)) || (type == typeof(Int64)) || (type == typeof(UInt16)) || (type == typeof(UInt32)) || (type == typeof(UInt64)) || (type == typeof(Byte)) || (type == typeof(SByte)))
@@ -2064,6 +2066,7 @@ namespace Microsoft.XmlSerializer.Generator
                     Writer.Write(")");
                 }
                 else if (type == typeof(Single))
+                {
                     if (Single.IsNaN((Single)value))
                     {
                         Writer.Write("System.Single.NaN");
@@ -2073,6 +2076,7 @@ namespace Microsoft.XmlSerializer.Generator
                         Writer.Write(((Single)value).ToString("R", NumberFormatInfo.InvariantInfo));
                         Writer.Write("f");
                     }
+                }
                 else if (type == typeof(Decimal))
                 {
                     Writer.Write(((Decimal)value).ToString(null, NumberFormatInfo.InvariantInfo));

--- a/src/Microsoft.XmlSerializer.Generator/src/Microsoft/XmlSerializer/Generator/XmlSerializationWriter.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Microsoft/XmlSerializer/Generator/XmlSerializationWriter.cs
@@ -2044,7 +2044,14 @@ namespace Microsoft.XmlSerializer.Generator
                 else if (type == typeof(Int32))
                     Writer.Write(((Int32)value).ToString(null, NumberFormatInfo.InvariantInfo));
                 else if (type == typeof(Double))
-                    Writer.Write(((Double)value).ToString("R", NumberFormatInfo.InvariantInfo));
+                    if (double.IsNaN((Double)value))
+                    {
+                        Writer.Write("double.NaN");
+                    }
+                    else
+                    {
+                        Writer.Write(((Double)value).ToString("R", NumberFormatInfo.InvariantInfo));
+                    }
                 else if (type == typeof(Boolean))
                     Writer.Write((bool)value ? "true" : "false");
                 else if ((type == typeof(Int16)) || (type == typeof(Int64)) || (type == typeof(UInt16)) || (type == typeof(UInt32)) || (type == typeof(UInt64)) || (type == typeof(Byte)) || (type == typeof(SByte)))
@@ -2057,10 +2064,15 @@ namespace Microsoft.XmlSerializer.Generator
                     Writer.Write(")");
                 }
                 else if (type == typeof(Single))
-                {
-                    Writer.Write(((Single)value).ToString("R", NumberFormatInfo.InvariantInfo));
-                    Writer.Write("f");
-                }
+                    if (Single.IsNaN((Single)value))
+                    {
+                        Writer.Write("System.Single.NaN");
+                    }
+                    else
+                    {
+                        Writer.Write(((Single)value).ToString("R", NumberFormatInfo.InvariantInfo));
+                        Writer.Write("f");
+                    }
                 else if (type == typeof(Decimal))
                 {
                     Writer.Write(((Decimal)value).ToString(null, NumberFormatInfo.InvariantInfo));

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -2037,22 +2037,6 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
-    public static void Xml_DefaultValueAttributeSetToNaNTest()
-    {
-        var value = new DefaultValuesSetToNaN();
-        var actual = SerializeAndDeserialize(value,
-@"<?xml version=""1.0""?>
-<DefaultValuesSetToNaN xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
-  <DoubleField>0</DoubleField>
-  <SingleField>0</SingleField>
-  <DoubleProp>0</DoubleProp>
-  <FloatProp>0</FloatProp>
-</DefaultValuesSetToNaN>");
-        Assert.NotNull(actual);
-        Assert.Equal(value, actual);
-    }
-
-    [Fact]
     public static void XmlMembersMapping_SimpleType_HasWrapperElement()
     {
         string memberName = "GetData";

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -1597,6 +1597,22 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         Assert.True(value.Collection.SequenceEqual(actual.Collection));
     }
 
+    [Fact]
+    public static void Xml_DefaultValueAttributeSetToNaNTest()
+    {
+        var value = new DefaultValuesSetToNaN();
+        var actual = SerializeAndDeserialize(value,
+@"<?xml version=""1.0""?>
+<DefaultValuesSetToNaN xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
+  <DoubleField>0</DoubleField>
+  <SingleField>0</SingleField>
+  <DoubleProp>0</DoubleProp>
+  <FloatProp>0</FloatProp>
+</DefaultValuesSetToNaN>");
+        Assert.NotNull(actual);
+        Assert.Equal(value, actual);
+    }
+
     private static readonly string s_defaultNs = "http://tempuri.org/";
     private static T RoundTripWithXmlMembersMapping<T>(object requestBodyValue, string memberName, string baseline, bool skipStringCompare = false, string wrapperName = null)
     {

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -3553,35 +3553,6 @@ public class TypeWithDelegate : ISerializable
     }
 }
 
-public class DefaultValuesSetToNaN
-{
-    [DefaultValue(double.NaN)]
-    public double DoubleProp { get; set; }
-
-    [DefaultValue(float.NaN)]
-    public float FloatProp { get; set; }
-
-    [DefaultValue(Double.NaN)]
-    public Double DoubleField;
-
-    [DefaultValue(Single.NaN)]
-    public Single SingleField;
-
-    public override bool Equals(object obj)
-    {
-        var other = obj as DefaultValuesSetToNaN;
-        return other == null ? false :
-            other.DoubleProp == this.DoubleProp && other.FloatProp == this.FloatProp &&
-            other.DoubleField == this.DoubleField && other.SingleField == this.SingleField;
-    }
-
-    public override int GetHashCode()
-    {
-        return this.DoubleProp.GetHashCode() ^ this.FloatProp.GetHashCode() ^
-            this.DoubleField.GetHashCode() ^ this.SingleField.GetHashCode();
-    }
-}
-
 public class JsonTypes
 {
     public Dictionary<string, string> StringKeyValue

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -1137,3 +1137,32 @@ public class TypeWithVirtualGenericPropertyDerived<T> : TypeWithVirtualGenericPr
 {
     public override T Value { get; set; }
 }
+
+public class DefaultValuesSetToNaN
+{
+    [DefaultValue(double.NaN)]
+    public double DoubleProp { get; set; }
+
+    [DefaultValue(float.NaN)]
+    public float FloatProp { get; set; }
+
+    [DefaultValue(Double.NaN)]
+    public Double DoubleField;
+
+    [DefaultValue(Single.NaN)]
+    public Single SingleField;
+
+    public override bool Equals(object obj)
+    {
+        var other = obj as DefaultValuesSetToNaN;
+        return other == null ? false :
+            other.DoubleProp == this.DoubleProp && other.FloatProp == this.FloatProp &&
+            other.DoubleField == this.DoubleField && other.SingleField == this.SingleField;
+    }
+
+    public override int GetHashCode()
+    {
+        return this.DoubleProp.GetHashCode() ^ this.FloatProp.GetHashCode() ^
+            this.DoubleField.GetHashCode() ^ this.SingleField.GetHashCode();
+    }
+}


### PR DESCRIPTION
Fix the sgen issue when use NaN as the default value. 
Move the NaN test from XmlSerializerTest .runtimeonly to XmlSerializerTest so it will be included in Sgen test run.

Fix #19724

@shmao @zhenlan @mconnew 