### PR TITLE
Fix uapaot hang in a ConcurrentQueue test

### DIFF
--- a/src/System.Collections.Concurrent/tests/ConcurrentQueueTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentQueueTests.cs
@@ -97,10 +97,6 @@ namespace System.Collections.Concurrent.Tests
         [InlineData(3, 3, 1024)]
         public void MultipleProducerConsumer_AllItemsTransferred(int producers, int consumers, int itemsPerProducer)
         {
-            //ActiveIssue("https://github.com/dotnet/corefx/issues/22385 - Never terminates on Win10 RS3 - when built using CHK framework on ILC", TargetFrameworkMonikers.UapAot)
-            //if (PlatformDetection.IsNetNative && PlatformDetection.IsWindows10InsiderPreviewBuild16215OrGreater)
-            //    return;
-
             var cq = new ConcurrentQueue<int>();
             var tasks = new List<Task>();
 
@@ -120,6 +116,8 @@ namespace System.Collections.Concurrent.Tests
                             Interlocked.Add(ref sum, item);
                             Interlocked.Decrement(ref remainingItems);
                         }
+
+                        Thread.Sleep(1);
                     }
                 }));
             }


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/22385

`ConcurrentQueueTests.MultipleProducerConsumer_AllItemsTransferred` has been hanging on uapaot runs.

The test relies on multiple tasks executing which enqueue and dequeue items from a ConcurrentQueue. The dequeue tasks are supposed to continuously spin trying to dequeue until they've dequeued everything the test expects to have enqueued.

This works fine on CoreCLR, but we use the Windows threadpool on uapaot scenarios, and when that threadpool observes that the tasks that are running are CPU bound, it doesn't try to inject more threads. This causes a situation where the dequeue tasks are anxiously trying to dequeue, but the enqueue tasks are not given a chance to run, causing the test to run forever.

This isn't a product bug because the threadpool is doing its job correctly; there's nothing that requires it to add threads if the tasks that are running are really using the CPU. The fix here is to just modify the test so that the tasks that dequeue have a Sleep(1) in their loop so that they allow enqueue to run.

@kouvel @stephentoub PTAL