### PR TITLE
Avoid unnecessary char[] allocation in GetComputerName

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetComputerName.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetComputerName.cs
@@ -9,18 +9,19 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "GetComputerNameW")]
-        private extern static int GetComputerName(char[] lpBuffer, ref uint nSize);
+        private static extern unsafe int GetComputerName(char* lpBuffer, ref uint nSize);
 
-        private const int MacMachineNameLength = 256;
+        // maximum length of the NETBIOS name (not including NULL)
+        private const int MAX_COMPUTERNAME_LENGTH = 15;
 
-        internal static string GetComputerName()
+        internal static unsafe string GetComputerName()
         {
-            char[] buffer = new char[MacMachineNameLength];
-            uint length = (uint)buffer.Length;
+            char* buffer = stackalloc char[MAX_COMPUTERNAME_LENGTH + 1];
+            uint length = MAX_COMPUTERNAME_LENGTH + 1;
 
-            Interop.Kernel32.GetComputerName(buffer, ref length);
-            return new string(buffer, 0, (int)length);
+            return GetComputerName(buffer, ref length) != 0 ?
+                new string(buffer, 0, (int)length) :
+                null;
         }
-
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetComputerName.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetComputerName.cs
@@ -20,7 +20,7 @@ internal partial class Interop
             char* buffer = stackalloc char[(int)length];
 
             return GetComputerName(buffer, ref length) != 0 ?
-                new string(buffer, 0, (int)length) :
+                new string(buffer, 0, checked((int)length)) :
                 null;
         }
     }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetComputerName.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetComputerName.cs
@@ -16,8 +16,8 @@ internal partial class Interop
 
         internal static unsafe string GetComputerName()
         {
-            char* buffer = stackalloc char[MAX_COMPUTERNAME_LENGTH + 1];
             uint length = MAX_COMPUTERNAME_LENGTH + 1;
+            char* buffer = stackalloc char[(int)length];
 
             return GetComputerName(buffer, ref length) != 0 ?
                 new string(buffer, 0, (int)length) :


### PR DESCRIPTION
Avoid the `char[]` allocation in the `GetComputerName` Win32 interop code (used to implement `Environment.MachineName` on Windows) by using `stackalloc`.

While we're at it, the size of the buffer can be reduced. The current length is 256, but this is only for historical reasons when the buffer needed to be large enough to support Unix host names when it'd be calling a PAL implementation in CoreCLR on Unix. We're no longer calling a PAL implementation, so we can reduce the size of the buffer to what's required for this function. According to the [MSDN documentation for `GetComputerName`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724295(v=vs.85).aspx):
 > The buffer size should be large enough to contain `MAX_COMPUTERNAME_LENGTH + 1` characters.

Also, update `GetComputerName` to return `null` on error so that the calling code in `Environment.Windows.cs` will throw `InvalidOperationException` as documented:

https://github.com/dotnet/corefx/blob/4a120148edaeb0e96aafbf15bd844b8022f63ad1/src/System.Runtime.Extensions/src/System/Environment.Windows.cs#L132-L143