### PR TITLE
Fix duplicate types exception on WinRT interfaces

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -641,11 +641,12 @@ namespace Microsoft.CSharp.RuntimeBinder
             // don't want to do all the logic, we're just going to insert every type
             // that has a member of the given name, and allow the C# binder to filter
             // out all overrides.
-            
+
             // CONSIDER: using a hashset to filter out duplicate interface types.
             // Adopt a smarter algorithm to filter types before creating the exception.
-            HashSet<CType> callingTypes = new HashSet<CType>();
-            
+            HashSet<CType> distinctCallingTypes = new HashSet<CType>();
+            List<CType> callingTypes = new List<CType>();
+
             // Find that set of types now.
             symbmask_t mask = symbmask_t.MASK_MethodSymbol;
             switch (kind)
@@ -666,7 +667,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             bool bIsConstructor = name == NameManager.GetPredefinedName(PredefinedName.PN_CTOR);
             foreach(AggregateType t in callingType.TypeHierarchy)
             {
-                if (_symbolTable.AggregateContainsMethod(t.GetOwningAggregate(), Name, mask))
+                if (_symbolTable.AggregateContainsMethod(t.GetOwningAggregate(), Name, mask) && distinctCallingTypes.Add(t))
                 {
                     callingTypes.Add(t);
                 }
@@ -686,7 +687,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
                 foreach (AggregateType t in callingType.GetWinRTCollectionIfacesAll(SymbolLoader).Items)
                 {
-                    if (_symbolTable.AggregateContainsMethod(t.GetOwningAggregate(), Name, mask))
+                    if (_symbolTable.AggregateContainsMethod(t.GetOwningAggregate(), Name, mask) && distinctCallingTypes.Add(t))
                     {
                         callingTypes.Add(t);
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -635,15 +635,17 @@ namespace Microsoft.CSharp.RuntimeBinder
                 callingType = (AggregateType)callingObjectType;
             }
 
-            List<CType> callingTypes = new List<CType>();
-
             // The C# binder expects that only the base virtual method is inserted
             // into the list of candidates, and only the type containing the base
             // virtual method is inserted into the list of types. However, since we
             // don't want to do all the logic, we're just going to insert every type
             // that has a member of the given name, and allow the C# binder to filter
             // out all overrides.
-            //
+            
+            // CONSIDER: using a hashset to filter out duplicate interface types.
+            // Adopt a smarter algorithm to filter types before creating the exception.
+            HashSet<CType> callingTypes = new HashSet<CType>();
+            
             // Find that set of types now.
             symbmask_t mask = symbmask_t.MASK_MethodSymbol;
             switch (kind)


### PR DESCRIPTION
For certain WinRT types like `Windows.Foundation.Collections.IPropertySet`, when using the dynamic C# binder and calling a method, for example `Add(key, value)`, the binder creates the type hierarchy and tries to bind the base method.
The existing code tries to bind implemented interfaces both in the AggregateType's t ype hierarchy and  WinRT interfaces, and ends up with duplicates, which results in:

```Microsoft.CSharp.RuntimeBinder.RuntimeBinderException:The call is ambiguous between the following methods or properties: 'System.Collections.Generic.IDictionary<string,object>.Add(string, object)' and 'System.Collections.Generic.IDictionary<string,object>.Add(string, object)'```

The simple workaround for now is to use a `HashSet` to store these interfaces, so that we don't end up passing duplicates up the call chain.
A smarter way of filtering out types that we know for sure are not applicable should be considered in the future.

DevDiv #476163