### PR TITLE
Force System.Data.DataSetExtensions tests to build in chk

### DIFF
--- a/src/System.Data.DataSetExtensions/tests/System.Data.DataSetExtensions.Tests.csproj
+++ b/src/System.Data.DataSetExtensions/tests/System.Data.DataSetExtensions.Tests.csproj
@@ -2,6 +2,8 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
+    <!-- Tests crash when running in ret mode, [ActiveIssue(23407)] -->
+    <ILCBuildType>chk</ILCBuildType>
     <ProjectGuid>{2B38992F-9979-485F-B104-38C476D0B706}</ProjectGuid>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>


### PR DESCRIPTION
Linked to issue #23407
This change will make sure that the tests pass for now, since they are failing when building on ret