### PR TITLE
[release/uwp6.0] Disable two flaky tests in System.Net.*

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -309,6 +309,7 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(Loopbacks))]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23364", TargetFrameworkMonikers.UapAot)]
         public async Task SendRecv_Stream_TCP_AlternateBufferAndBufferList(IPAddress listenAt)
         {
             const int BytesToSend = 123456;

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -309,7 +309,7 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(Loopbacks))]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/23364", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23364, TargetFrameworkMonikers.UapAot)]
         public async Task SendRecv_Stream_TCP_AlternateBufferAndBufferList(IPAddress listenAt)
         {
             const int BytesToSend = 123456;

--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -75,6 +75,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/22904", TargetFrameworkMonikers.UapAot)]
         public async Task CloseAsync_Cancel_Success(Uri server)
         {
             await TestCancellation(async (cws) =>

--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -75,7 +75,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/22904", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(22904, TargetFrameworkMonikers.UapAot)]
         public async Task CloseAsync_Cancel_Success(Uri server)
         {
             await TestCancellation(async (cws) =>


### PR DESCRIPTION
Disabling this two flaky tests in the effort to have a clean build in the release branch. 

Related issues: https://github.com/dotnet/corefx/issues/22904 and https://github.com/dotnet/corefx/issues/23364

cc: @davidsh @danmosemsft 