### PR TITLE
Migrate corefx release/2.0.0 branch to git clone from VSO instead of unstable github

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -364,8 +364,19 @@
     "PB_ConfigurationGroup": {
       "value": "Release"
     },
+    "PB_VsoAccountName": {
+      "value": "dn-bot"
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "PB_VsoRepositoryName": {
+      "value": "DotNet-CoreFX-Trusted",
+      "allowOverride": true
+    },
     "PB_VsoCorefxGitUrl": {
-      "value": "http://github.com/dotnet/corefx.git"
+      "value": "https://$(PB_VsoAccountName):$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/$(PB_VsoRepositoryName)/"
     },
     "PB_GitDirectory": {
       "value": "/root/corefx"

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -447,7 +447,7 @@
       "allowOverride": true
     },
     "PB_VsoCorefxGitUrl": {
-      "value": "https://github.com/dotnet/corefx"
+      "value": "https://$(PB_VsoAccountName):$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/$(PB_VsoRepositoryName)/"
     },
     "PB_BuildArguments": {
       "value": "-buildArch=x64 -Release",


### PR DESCRIPTION
Migrate corefx release/2.0.0 branch to git clone from VSO instead of
unstable github