### PR TITLE
Add missing members to EncryptedXml.

### DIFF
--- a/src/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.cs
+++ b/src/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.cs
@@ -116,6 +116,8 @@ namespace System.Security.Cryptography.Xml
         public const string XmlEncTripleDESUrl = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
         public EncryptedXml() { }
         public EncryptedXml(System.Xml.XmlDocument document) { }
+        public EncryptedXml(System.Xml.XmlDocument document, System.Security.Policy.Evidence evidence) { }
+        public System.Security.Policy.Evidence DocumentEvidence { get { throw null; } set { } }
         public System.Text.Encoding Encoding { get { throw null; } set { } }
         public System.Security.Cryptography.CipherMode Mode { get { throw null; } set { } }
         public System.Security.Cryptography.PaddingMode Padding { get { throw null; } set { } }

--- a/src/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
+++ b/src/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
@@ -9,7 +9,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(IsPartialFacadeAssembly)'  == 'true'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
+    <Reference Include="System.Security.Permissions" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
+++ b/src/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
@@ -107,6 +107,7 @@
     <Reference Include="System.Security.Cryptography.Encoding" />
     <Reference Include="System.Security.Cryptography.Primitives" />
     <Reference Include="System.Security.Cryptography.X509Certificates" />
+    <Reference Include="System.Security.Permissions" />
     <Reference Include="System.Text.Encoding.Extensions" />
     <Reference Include="System.Xml.ReaderWriter" />
     <Reference Include="System.Xml.XPath" />

--- a/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
@@ -10,11 +10,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Xml;
@@ -47,28 +45,47 @@ namespace System.Security.Cryptography.Xml.Tests
             }
         }
 
+        private static readonly Encoding DefaultEncoding = Encoding.UTF8;
+        private const CipherMode DefaultCipherMode = CipherMode.CBC;
+        private const PaddingMode DefaultPaddingMode = PaddingMode.ISO10126;
+        private const string DefaultRecipient = "";
+        private static readonly XmlResolver DefaultXmlResolver = null;
+        private const int DefaultXmlDSigSearchDepth = 20;
+
         [Fact]
         public void Constructor_Default()
         {
             EncryptedXml encryptedXml = new EncryptedXml();
-            Assert.Equal(Encoding.UTF8, encryptedXml.Encoding);
-            Assert.Equal(CipherMode.CBC, encryptedXml.Mode);
-            Assert.Equal(PaddingMode.ISO10126, encryptedXml.Padding);
-            Assert.Equal(string.Empty, encryptedXml.Recipient);
-            Assert.Equal(null, encryptedXml.Resolver);
-            Assert.Equal(20, encryptedXml.XmlDSigSearchDepth);
+            Assert.Equal(DefaultEncoding, encryptedXml.Encoding);
+            Assert.Equal(DefaultCipherMode, encryptedXml.Mode);
+            Assert.Equal(DefaultPaddingMode, encryptedXml.Padding);
+            Assert.Equal(DefaultRecipient, encryptedXml.Recipient);
+            Assert.Equal(DefaultXmlResolver, encryptedXml.Resolver);
+            Assert.Equal(DefaultXmlDSigSearchDepth, encryptedXml.XmlDSigSearchDepth);
         }
 
         [Fact]
         public void Constructor_XmlDocument()
         {
             EncryptedXml encryptedXml = new EncryptedXml(null);
-            Assert.Equal(Encoding.UTF8, encryptedXml.Encoding);
-            Assert.Equal(CipherMode.CBC, encryptedXml.Mode);
-            Assert.Equal(PaddingMode.ISO10126, encryptedXml.Padding);
-            Assert.Equal(string.Empty, encryptedXml.Recipient);
-            Assert.Equal(null, encryptedXml.Resolver);
-            Assert.Equal(20, encryptedXml.XmlDSigSearchDepth);
+            Assert.Equal(DefaultEncoding, encryptedXml.Encoding);
+            Assert.Equal(DefaultCipherMode, encryptedXml.Mode);
+            Assert.Equal(DefaultPaddingMode, encryptedXml.Padding);
+            Assert.Equal(DefaultRecipient, encryptedXml.Recipient);
+            Assert.Equal(DefaultXmlResolver, encryptedXml.Resolver);
+            Assert.Equal(DefaultXmlDSigSearchDepth, encryptedXml.XmlDSigSearchDepth);
+        }
+
+        [Fact]
+        public void Constructor_XmlDocumentAndEvidence()
+        {
+            EncryptedXml encryptedXml = new EncryptedXml(null, null);
+            Assert.Equal(DefaultEncoding, encryptedXml.Encoding);
+            Assert.Equal(DefaultCipherMode, encryptedXml.Mode);
+            Assert.Equal(DefaultPaddingMode, encryptedXml.Padding);
+            Assert.Equal(DefaultRecipient, encryptedXml.Recipient);
+            Assert.Equal(DefaultXmlResolver, encryptedXml.Resolver);
+            Assert.Equal(DefaultXmlDSigSearchDepth, encryptedXml.XmlDSigSearchDepth);
         }
 
         [Theory]


### PR DESCRIPTION
While importing `EncryptedXml` into Mono (https://github.com/mono/mono/pull/5273), it was noticed that its following members are missing:

* [The `(XmlDocument, Evidence)` constructor.](https://msdn.microsoft.com/en-us/library/kc1kt87d(v=vs.110).aspx)
* [The `DocumentEvidence` property.](https://msdn.microsoft.com/en-us/library/system.security.cryptography.xml.encryptedxml.documentevidence(v=vs.110).aspx)

This PR adds them. The implementation is taken from [.NET Framework](https://referencesource.microsoft.com/#System.Security/system/security/cryptography/xml/encryptedxml.cs).

The behavior of the `EncryptedXmlTest.DecryptData_CipherReference_InvalidUri` test was changed. As far as I understand, both .NET Core and .NET Framework must behave the same way. According to [the documentation](https://msdn.microsoft.com/en-us/library/system.security.securitymanager.getstandardsandbox(v=vs.110).aspx), the `SecurityManager.GetStandardSandbox` must throw if the evidence is null. Previously, .NET Core wasn't throwing in this case, so this was changed as well.