### PR TITLE
Avoid unnecessary intermediate Version allocation

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
@@ -46,15 +46,10 @@ namespace System.Xml.Xsl
     public sealed class XslCompiledTransform
     {
         // Reader settings used when creating XmlReader from inputUri
-        private static readonly XmlReaderSettings s_readerSettings = null;
+        private static readonly XmlReaderSettings s_readerSettings = new XmlReaderSettings();
 
         // Version for GeneratedCodeAttribute
-        private readonly string _version = typeof(XslCompiledTransform).Assembly.GetName().Version.ToString();
-
-        static XslCompiledTransform()
-        {
-            s_readerSettings = new XmlReaderSettings();
-        }
+        private static readonly Version s_version = typeof(XslCompiledTransform).Assembly.GetName().Version;
 
         // Options of compilation
         private bool _enableDebug = false;
@@ -227,9 +222,9 @@ namespace System.Xml.Xsl
             // If GeneratedCodeAttribute is not there, it is not a compiled stylesheet class
             if (generatedCodeAttr != null && generatedCodeAttr.Tool == typeof(XslCompiledTransform).FullName)
             {
-                if (new Version(_version).CompareTo(new Version(generatedCodeAttr.Version)) < 0)
+                if (s_version < Version.Parse(generatedCodeAttr.Version))
                 {
-                    throw new ArgumentException(SR.Format(SR.Xslt_IncompatibleCompiledStylesheetVersion, generatedCodeAttr.Version, _version), nameof(compiledStylesheet));
+                    throw new ArgumentException(SR.Format(SR.Xslt_IncompatibleCompiledStylesheetVersion, generatedCodeAttr.Version, s_version), nameof(compiledStylesheet));
                 }
 
                 FieldInfo fldData = compiledStylesheet.GetField(XmlQueryStaticData.DataFieldName, BindingFlags.Static | BindingFlags.NonPublic);

--- a/src/System.Runtime.Extensions/src/System/Runtime/Versioning/FrameworkName.cs
+++ b/src/System.Runtime.Extensions/src/System/Runtime/Versioning/FrameworkName.cs
@@ -198,7 +198,7 @@ namespace System.Runtime.Versioning
                     }
                     try
                     {
-                        _version = new Version(value);
+                        _version = Version.Parse(value);
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
Just a minor nit: `Version..ctor(string)` is [implemented](https://github.com/dotnet/coreclr/blob/a6045809b3720833459c9247aeb4aafe281d7841/src/mscorlib/shared/System/Version.cs#L81-L88) by calling `Version.Parse`, which allocates an intermediate `Version` instance. Avoid the unnecessary intermediate allocation by using `Version.Parse` directly in the two places `Version..ctor(string)` is used in CoreFX.

Also, some minor cleanup to `XslCompiledTransform` while making changes here.

cc: @krwq (for System.Xml)
cc: @AlexGhiondea, @joperezr (for System.Runtime.Extensions)