### PR TITLE
[release/uwp6.0] Wrap CultureCulture assignments in RemoteInvoke

### DIFF
--- a/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
+++ b/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
@@ -112,6 +112,12 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Data.Common/tests/System/Data/DataColumnTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnTest2.cs
@@ -27,26 +27,12 @@ using System.ComponentModel;
 using System.Globalization;
 
 
-
 using Xunit;
 
 namespace System.Data.Tests
 {
-    public class DataColumnTest2 : IDisposable
+    public class DataColumnTest2
     {
-        private CultureInfo _originalCulture;
-
-        public DataColumnTest2()
-        {
-            _originalCulture = CultureInfo.CurrentCulture; ;
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
-        }
-
-        public void Dispose()
-        {
-            CultureInfo.CurrentCulture = _originalCulture;
-        }
-
         [Fact]
         public void AllowDBNull()
         {

--- a/src/System.Data.Common/tests/System/Data/DataSetAssertion.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetAssertion.cs
@@ -26,15 +26,16 @@
 
 
 using System.Collections;
+using System.Diagnostics;
 using System.IO;
 using System.Xml;
 using Xunit;
 
 namespace System.Data.Tests
 {
-    public class DataSetAssertion
+    public static class DataSetAssertion
     {
-        public string GetNormalizedSchema(string source)
+        public static string GetNormalizedSchema(string source)
         {
             /*
                         // Due to the implementation difference, we must have
@@ -55,7 +56,7 @@ namespace System.Data.Tests
             return writer.ToString();
         }
 
-        private void SortAttributes(XmlElement el)
+        private static void SortAttributes(XmlElement el)
         {
             SortAttributesAttributes(el);
             ArrayList al = new ArrayList();
@@ -70,7 +71,7 @@ namespace System.Data.Tests
                 el.RemoveChild(n);
         }
 
-        private void SortAttributesAttributes(XmlElement el)
+        private static void SortAttributesAttributes(XmlElement el)
         {
             ArrayList al = new ArrayList();
             foreach (XmlAttribute a in el.Attributes)
@@ -87,7 +88,7 @@ namespace System.Data.Tests
                     el.SetAttributeNode(a);
         }
 
-        public void AssertDataSet(string label, DataSet ds, string name, int tableCount, int relCount)
+        public static void AssertDataSet(string label, DataSet ds, string name, int tableCount, int relCount)
         {
             Assert.Equal(name, ds.DataSetName);
             Assert.Equal(tableCount, ds.Tables.Count);
@@ -95,7 +96,7 @@ namespace System.Data.Tests
                 Assert.Equal(relCount, ds.Relations.Count);
         }
 
-        public void AssertDataTable(string label, DataTable dt, string name, int columnCount, int rowCount, int parentRelationCount, int childRelationCount, int constraintCount, int primaryKeyLength)
+        public static void AssertDataTable(string label, DataTable dt, string name, int columnCount, int rowCount, int parentRelationCount, int childRelationCount, int constraintCount, int primaryKeyLength)
         {
             Assert.Equal(name, dt.TableName);
             Assert.Equal(columnCount, dt.Columns.Count);
@@ -106,18 +107,18 @@ namespace System.Data.Tests
             Assert.Equal(primaryKeyLength, dt.PrimaryKey.Length);
         }
 
-        public void AssertReadXml(DataSet ds, string label, string xml, XmlReadMode readMode, XmlReadMode resultMode, string datasetName, int tableCount)
+        public static void AssertReadXml(DataSet ds, string label, string xml, XmlReadMode readMode, XmlReadMode resultMode, string datasetName, int tableCount)
         {
-            AssertReadXml(ds, label, xml, readMode, resultMode, datasetName, tableCount, ReadState.EndOfFile, null, null);
+            DataSetAssertion.AssertReadXml(ds, label, xml, readMode, resultMode, datasetName, tableCount, ReadState.EndOfFile, null, null);
         }
 
-        public void AssertReadXml(DataSet ds, string label, string xml, XmlReadMode readMode, XmlReadMode resultMode, string datasetName, int tableCount, ReadState state)
+        public static void AssertReadXml(DataSet ds, string label, string xml, XmlReadMode readMode, XmlReadMode resultMode, string datasetName, int tableCount, ReadState state)
         {
-            AssertReadXml(ds, label, xml, readMode, resultMode, datasetName, tableCount, state, null, null);
+            DataSetAssertion.AssertReadXml(ds, label, xml, readMode, resultMode, datasetName, tableCount, state, null, null);
         }
 
         // a bit detailed version
-        public void AssertReadXml(DataSet ds, string label, string xml, XmlReadMode readMode, XmlReadMode resultMode, string datasetName, int tableCount, ReadState state, string readerLocalName, string readerNS)
+        public static void AssertReadXml(DataSet ds, string label, string xml, XmlReadMode readMode, XmlReadMode resultMode, string datasetName, int tableCount, ReadState state, string readerLocalName, string readerNS)
         {
             XmlReader xtr = new XmlTextReader(xml, XmlNodeType.Element, null);
             Assert.Equal(resultMode, ds.ReadXml(xtr, readMode));
@@ -129,7 +130,7 @@ namespace System.Data.Tests
                 Assert.Equal(readerNS, xtr.NamespaceURI);
         }
 
-        public void AssertDataRelation(string label, DataRelation rel, string name, bool nested,
+        public static void AssertDataRelation(string label, DataRelation rel, string name, bool nested,
             string[] parentColNames, string[] childColNames,
             bool existsUK, bool existsFK)
         {
@@ -151,7 +152,7 @@ namespace System.Data.Tests
                 Assert.Null(rel.ChildKeyConstraint);
         }
 
-        public void AssertUniqueConstraint(string label, UniqueConstraint uc,
+        public static void AssertUniqueConstraint(string label, UniqueConstraint uc,
             string name, bool isPrimaryKey, string[] colNames)
         {
             Assert.Equal(name, uc.ConstraintName);
@@ -161,7 +162,7 @@ namespace System.Data.Tests
             Assert.Equal(colNames.Length, uc.Columns.Length);
         }
 
-        public void AssertForeignKeyConstraint(string label,
+        public static void AssertForeignKeyConstraint(string label,
             ForeignKeyConstraint fk, string name,
             AcceptRejectRule acceptRejectRule, Rule delRule, Rule updateRule,
             string[] colNames, string[] relColNames)
@@ -178,7 +179,7 @@ namespace System.Data.Tests
             Assert.Equal(relColNames.Length, fk.RelatedColumns.Length);
         }
 
-        public void AssertDataColumn(string label, DataColumn col,
+        public static void AssertDataColumn(string label, DataColumn col,
             string colName, bool allowDBNull,
             bool autoIncr, int autoIncrSeed, int autoIncrStep,
             string caption, MappingType colMap,

--- a/src/System.Data.Common/tests/System/Data/DataSetInferXmlSchemaTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetInferXmlSchemaTest.cs
@@ -31,7 +31,7 @@ using Xunit;
 
 namespace System.Data.Tests
 {
-    public class DataSetInferXmlSchemaTest : DataSetAssertion
+    public class DataSetInferXmlSchemaTest
     {
         private string _xml1 = "<root/>";
         private string _xml2 = "<root attr='value' />";
@@ -174,26 +174,26 @@ namespace System.Data.Tests
         {
             DataSet ds = new DataSet();
             ds.InferXmlSchema((XmlReader)null, null);
-            AssertDataSet("null", ds, "NewDataSet", 0, 0);
+            DataSetAssertion.AssertDataSet("null", ds, "NewDataSet", 0, 0);
         }
 
         [Fact]
         public void SingleElement()
         {
             DataSet ds = GetDataSet(_xml1, null);
-            AssertDataSet("xml1", ds, "root", 0, 0);
+            DataSetAssertion.AssertDataSet("xml1", ds, "root", 0, 0);
 
             ds = GetDataSet(_xml4, null);
-            AssertDataSet("xml4", ds, "root", 0, 0);
+            DataSetAssertion.AssertDataSet("xml4", ds, "root", 0, 0);
 
             // namespaces
             ds = GetDataSet(_xml14, null);
-            AssertDataSet("xml14", ds, "root", 0, 0);
+            DataSetAssertion.AssertDataSet("xml14", ds, "root", 0, 0);
             Assert.Equal(string.Empty, ds.Prefix);
             Assert.Equal("urn:foo", ds.Namespace);
 
             ds = GetDataSet(_xml17, null);
-            AssertDataSet("xml17", ds, "root", 0, 0);
+            DataSetAssertion.AssertDataSet("xml17", ds, "root", 0, 0);
             Assert.Equal("urn:foo", ds.Namespace);
         }
 
@@ -201,61 +201,61 @@ namespace System.Data.Tests
         public void SingleElementWithAttribute()
         {
             DataSet ds = GetDataSet(_xml2, null);
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "root", 1, 0, 0, 0, 0, 0);
-            AssertDataColumn("col", dt.Columns[0], "attr", true, false, 0, 1, "attr", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("col", dt.Columns[0], "attr", true, false, 0, 1, "attr", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
         }
 
         [Fact]
         public void SingleElementWithTwoAttribute()
         {
             DataSet ds = GetDataSet(_xml3, null);
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "root", 2, 0, 0, 0, 0, 0);
-            AssertDataColumn("col", dt.Columns[0], "attr", true, false, 0, 1, "attr", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("col", dt.Columns[1], "attr2", true, false, 0, 1, "attr2", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "root", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("col", dt.Columns[0], "attr", true, false, 0, 1, "attr", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("col", dt.Columns[1], "attr2", true, false, 0, 1, "attr2", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
         }
 
         [Fact]
         public void SingleChild()
         {
             DataSet ds = GetDataSet(_xml5, null);
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "root", 1, 0, 0, 0, 0, 0);
-            AssertDataColumn("col", dt.Columns[0], "child", true, false, 0, 1, "child", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("col", dt.Columns[0], "child", true, false, 0, 1, "child", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
 
             ds = GetDataSet(_xml6, null);
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
             dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "root", 1, 0, 0, 0, 0, 0);
-            AssertDataColumn("col", dt.Columns[0], "col1", true, false, 0, 1, "col1", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("col", dt.Columns[0], "col1", true, false, 0, 1, "col1", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
         }
 
         [Fact]
         public void SimpleElementTable()
         {
             DataSet ds = GetDataSet(_xml7, null);
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "root", 3, 0, 0, 0, 0, 0);
-            AssertDataColumn("col", dt.Columns[0], "col1", true, false, 0, 1, "col1", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("col2", dt.Columns[1], "col2", true, false, 0, 1, "col2", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
-            AssertDataColumn("col3", dt.Columns[2], "col3", true, false, 0, 1, "col3", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "root", 3, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("col", dt.Columns[0], "col1", true, false, 0, 1, "col1", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("col2", dt.Columns[1], "col2", true, false, 0, 1, "col2", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("col3", dt.Columns[2], "col3", true, false, 0, 1, "col3", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
         }
 
         [Fact]
         public void SimpleDataSet()
         {
             DataSet ds = GetDataSet(_xml8, null);
-            AssertDataSet("ds", ds, "set", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "set", 1, 0);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "tab", 3, 0, 0, 0, 0, 0);
-            AssertDataColumn("col", dt.Columns[0], "col1", true, false, 0, 1, "col1", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("col2", dt.Columns[1], "col2", true, false, 0, 1, "col2", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
-            AssertDataColumn("col3", dt.Columns[2], "col3", true, false, 0, 1, "col3", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "tab", 3, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("col", dt.Columns[0], "col1", true, false, 0, 1, "col1", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("col2", dt.Columns[1], "col2", true, false, 0, 1, "col2", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("col3", dt.Columns[2], "col3", true, false, 0, 1, "col3", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
         }
 
         [Fact]
@@ -264,36 +264,36 @@ namespace System.Data.Tests
             // FIXME: Also test ReadXml (, XmlReadMode.InferSchema) and
             // make sure that ReadXml() stores DataRow to el1 (and maybe to others)
             DataSet ds = GetDataSet(_xml9, null);
-            AssertDataSet("ds", ds, "NewDataSet", 4, 3);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 4, 3);
             DataTable dt = ds.Tables[0];
 
-            AssertDataTable("dt1", dt, "el1", 3, 0, 0, 1, 1, 1);
-            AssertDataColumn("el1_Id", dt.Columns[0], "el1_Id", false, true, 0, 1, "el1_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
-            AssertDataColumn("el1_attr1", dt.Columns[1], "attr1", true, false, 0, 1, "attr1", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
-            AssertDataColumn("el1_attrA", dt.Columns[2], "attrA", true, false, 0, 1, "attrA", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt1", dt, "el1", 3, 0, 0, 1, 1, 1);
+            DataSetAssertion.AssertDataColumn("el1_Id", dt.Columns[0], "el1_Id", false, true, 0, 1, "el1_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
+            DataSetAssertion.AssertDataColumn("el1_attr1", dt.Columns[1], "attr1", true, false, 0, 1, "attr1", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("el1_attrA", dt.Columns[2], "attrA", true, false, 0, 1, "attrA", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
 
             dt = ds.Tables[1];
-            AssertDataTable("dt2", dt, "el2", 6, 0, 1, 2, 2, 1);
-            AssertDataColumn("el2_Id", dt.Columns[0], "el2_Id", false, true, 0, 1, "el2_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
-            AssertDataColumn("el2_col2", dt.Columns[1], "column2", true, false, 0, 1, "column2", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
-            AssertDataColumn("el2_col3", dt.Columns[2], "column3", true, false, 0, 1, "column3", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
-            AssertDataColumn("el2_attr2", dt.Columns[3], "attr2", true, false, 0, 1, "attr2", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 3, string.Empty, false, false);
-            AssertDataColumn("el2_attrB", dt.Columns[4], "attrB", true, false, 0, 1, "attrB", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 4, string.Empty, false, false);
-            AssertDataColumn("el2_el1Id", dt.Columns[5], "el1_Id", true, false, 0, 1, "el1_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 5, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt2", dt, "el2", 6, 0, 1, 2, 2, 1);
+            DataSetAssertion.AssertDataColumn("el2_Id", dt.Columns[0], "el2_Id", false, true, 0, 1, "el2_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
+            DataSetAssertion.AssertDataColumn("el2_col2", dt.Columns[1], "column2", true, false, 0, 1, "column2", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("el2_col3", dt.Columns[2], "column3", true, false, 0, 1, "column3", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("el2_attr2", dt.Columns[3], "attr2", true, false, 0, 1, "attr2", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 3, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("el2_attrB", dt.Columns[4], "attrB", true, false, 0, 1, "attrB", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 4, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("el2_el1Id", dt.Columns[5], "el1_Id", true, false, 0, 1, "el1_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 5, string.Empty, false, false);
 
             dt = ds.Tables[2];
-            AssertDataTable("dt3", dt, "el3", 4, 0, 1, 0, 1, 0);
-            AssertDataColumn("el3_attr3", dt.Columns[0], "attr3", true, false, 0, 1, "attr3", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("el3_attrC", dt.Columns[1], "attrC", true, false, 0, 1, "attrC", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
-            AssertDataColumn("el3_Text", dt.Columns[2], "el3_Text", true, false, 0, 1, "el3_Text", MappingType.SimpleContent, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
-            AssertDataColumn("el3_el2Id", dt.Columns[3], "el2_Id", true, false, 0, 1, "el2_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 3, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt3", dt, "el3", 4, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataColumn("el3_attr3", dt.Columns[0], "attr3", true, false, 0, 1, "attr3", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("el3_attrC", dt.Columns[1], "attrC", true, false, 0, 1, "attrC", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("el3_Text", dt.Columns[2], "el3_Text", true, false, 0, 1, "el3_Text", MappingType.SimpleContent, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("el3_el2Id", dt.Columns[3], "el2_Id", true, false, 0, 1, "el2_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 3, string.Empty, false, false);
 
             dt = ds.Tables[3];
-            AssertDataTable("dt4", dt, "el4", 4, 0, 1, 0, 1, 0);
-            AssertDataColumn("el3_attr4", dt.Columns[0], "attr4", true, false, 0, 1, "attr4", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("el4_attrD", dt.Columns[1], "attrD", true, false, 0, 1, "attrD", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
-            AssertDataColumn("el4_Text", dt.Columns[2], "el4_Text", true, false, 0, 1, "el4_Text", MappingType.SimpleContent, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
-            AssertDataColumn("el4_el2Id", dt.Columns[3], "el2_Id", true, false, 0, 1, "el2_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 3, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt4", dt, "el4", 4, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataColumn("el3_attr4", dt.Columns[0], "attr4", true, false, 0, 1, "attr4", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("el4_attrD", dt.Columns[1], "attrD", true, false, 0, 1, "attrD", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("el4_Text", dt.Columns[2], "el4_Text", true, false, 0, 1, "el4_Text", MappingType.SimpleContent, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("el4_el2Id", dt.Columns[3], "el2_Id", true, false, 0, 1, "el2_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 3, string.Empty, false, false);
         }
 
         [Fact]
@@ -302,10 +302,10 @@ namespace System.Data.Tests
             // Note that text part is ignored.
 
             DataSet ds = GetDataSet(_xml10, null);
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "root", 1, 0, 0, 0, 0, 0);
-            AssertDataColumn("col", dt.Columns[0], "b", true, false, 0, 1, "b", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("col", dt.Columns[0], "b", true, false, 0, 1, "b", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
         }
 
         [Fact]
@@ -314,10 +314,10 @@ namespace System.Data.Tests
             // Note that 1) significant whitespace is ignored, and 
             // 2) xml:space is treated as column (and also note namespaces).
             DataSet ds = GetDataSet(_xml11, null);
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "root", 1, 0, 0, 0, 0, 0);
-            AssertDataColumn("element", dt.Columns[0], "child_after_significant_space", true, false, 0, 1, "child_after_significant_space", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("element", dt.Columns[0], "child_after_significant_space", true, false, 0, 1, "child_after_significant_space", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
             Assert.Equal(1, dt.Columns.Count);
         }
 
@@ -334,7 +334,7 @@ namespace System.Data.Tests
             ("      \n\n"));
             XmlReader xr = new XmlNodeReader(doc);
             ds.InferXmlSchema(xr, null);
-            AssertDataSet("pure_whitespace", ds, "root", 0, 0);
+            DataSetAssertion.AssertDataSet("pure_whitespace", ds, "root", 0, 0);
         }
 
         [Fact]
@@ -343,59 +343,59 @@ namespace System.Data.Tests
             // FIXME: Also test ReadXml (, XmlReadMode.InferSchema) and
             // make sure that ReadXml() stores DataRow to el1 (and maybe to others)
             DataSet ds = GetDataSet(_xml15, null);
-            AssertDataSet("ds", ds, "root", 2, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "root", 2, 0);
 
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "table1", 2, 0, 0, 0, 0, 0);
-            AssertDataColumn("col1_1", dt.Columns[0], "col1_1", true, false, 0, 1, "col1_1", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("col1_2", dt.Columns[1], "col1_2", true, false, 0, 1, "col1_2", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "table1", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("col1_1", dt.Columns[0], "col1_1", true, false, 0, 1, "col1_1", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("col1_2", dt.Columns[1], "col1_2", true, false, 0, 1, "col1_2", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
 
             dt = ds.Tables[1];
-            AssertDataTable("dt", dt, "table2", 2, 0, 0, 0, 0, 0);
-            AssertDataColumn("col2_1", dt.Columns[0], "col2_1", true, false, 0, 1, "col2_1", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("col2_2", dt.Columns[1], "col2_2", true, false, 0, 1, "col2_2", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "table2", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("col2_1", dt.Columns[0], "col2_1", true, false, 0, 1, "col2_1", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("col2_2", dt.Columns[1], "col2_2", true, false, 0, 1, "col2_2", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
         }
 
         [Fact]
         public void ConflictSimpleComplexColumns()
         {
             DataSet ds = GetDataSet(_xml18, null);
-            AssertDataSet("ds", ds, "set", 2, 1);
+            DataSetAssertion.AssertDataSet("ds", ds, "set", 2, 1);
 
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "table", 1, 0, 0, 1, 1, 1);
-            AssertDataColumn("table_Id", dt.Columns[0], "table_Id", false, true, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
+            DataSetAssertion.AssertDataTable("dt", dt, "table", 1, 0, 0, 1, 1, 1);
+            DataSetAssertion.AssertDataColumn("table_Id", dt.Columns[0], "table_Id", false, true, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
 
             dt = ds.Tables[1];
-            AssertDataTable("dt", dt, "col", 2, 0, 1, 0, 1, 0);
-            AssertDataColumn("another_col", dt.Columns[0], "another_col", true, false, 0, 1, "another_col", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("table_refId", dt.Columns[1], "table_Id", true, false, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "col", 2, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataColumn("another_col", dt.Columns[0], "another_col", true, false, 0, 1, "another_col", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("table_refId", dt.Columns[1], "table_Id", true, false, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
 
             DataRelation dr = ds.Relations[0];
-            AssertDataRelation("rel", dr, "table_col", true, new string[] { "table_Id" }, new string[] { "table_Id" }, true, true);
-            AssertUniqueConstraint("uniq", dr.ParentKeyConstraint, "Constraint1", true, new string[] { "table_Id" });
-            AssertForeignKeyConstraint("fkey", dr.ChildKeyConstraint, "table_col", AcceptRejectRule.None, Rule.Cascade, Rule.Cascade, new string[] { "table_Id" }, new string[] { "table_Id" });
+            DataSetAssertion.AssertDataRelation("rel", dr, "table_col", true, new string[] { "table_Id" }, new string[] { "table_Id" }, true, true);
+            DataSetAssertion.AssertUniqueConstraint("uniq", dr.ParentKeyConstraint, "Constraint1", true, new string[] { "table_Id" });
+            DataSetAssertion.AssertForeignKeyConstraint("fkey", dr.ChildKeyConstraint, "table_col", AcceptRejectRule.None, Rule.Cascade, Rule.Cascade, new string[] { "table_Id" }, new string[] { "table_Id" });
         }
 
         [Fact]
         public void ConflictColumnTable()
         {
             DataSet ds = GetDataSet(_xml19, null);
-            AssertDataSet("ds", ds, "set", 2, 1);
+            DataSetAssertion.AssertDataSet("ds", ds, "set", 2, 1);
 
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "table", 1, 0, 0, 1, 1, 1);
-            AssertDataColumn("table_Id", dt.Columns[0], "table_Id", false, true, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
+            DataSetAssertion.AssertDataTable("dt", dt, "table", 1, 0, 0, 1, 1, 1);
+            DataSetAssertion.AssertDataColumn("table_Id", dt.Columns[0], "table_Id", false, true, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
 
             dt = ds.Tables[1];
-            AssertDataTable("dt", dt, "col", 2, 0, 1, 0, 1, 0);
-            AssertDataColumn("table_refId", dt.Columns["table_Id"], "table_Id", true, false, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, /*0*/-1, string.Empty, false, false);
-            AssertDataColumn("another_col", dt.Columns["another_col"], "another_col", true, false, 0, 1, "another_col", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, /*1*/-1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "col", 2, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataColumn("table_refId", dt.Columns["table_Id"], "table_Id", true, false, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, /*0*/-1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("another_col", dt.Columns["another_col"], "another_col", true, false, 0, 1, "another_col", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, /*1*/-1, string.Empty, false, false);
 
             DataRelation dr = ds.Relations[0];
-            AssertDataRelation("rel", dr, "table_col", true, new string[] { "table_Id" }, new string[] { "table_Id" }, true, true);
-            AssertUniqueConstraint("uniq", dr.ParentKeyConstraint, "Constraint1", true, new string[] { "table_Id" });
-            AssertForeignKeyConstraint("fkey", dr.ChildKeyConstraint, "table_col", AcceptRejectRule.None, Rule.Cascade, Rule.Cascade, new string[] { "table_Id" }, new string[] { "table_Id" });
+            DataSetAssertion.AssertDataRelation("rel", dr, "table_col", true, new string[] { "table_Id" }, new string[] { "table_Id" }, true, true);
+            DataSetAssertion.AssertUniqueConstraint("uniq", dr.ParentKeyConstraint, "Constraint1", true, new string[] { "table_Id" });
+            DataSetAssertion.AssertForeignKeyConstraint("fkey", dr.ChildKeyConstraint, "table_col", AcceptRejectRule.None, Rule.Cascade, Rule.Cascade, new string[] { "table_Id" }, new string[] { "table_Id" });
         }
 
         [Fact]
@@ -403,22 +403,22 @@ namespace System.Data.Tests
         {
             // Conflicts between a column and a table, additionally an attribute.
             DataSet ds = GetDataSet(_xml20, null);
-            AssertDataSet("ds", ds, "set", 2, 1);
+            DataSetAssertion.AssertDataSet("ds", ds, "set", 2, 1);
 
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "table", 1, 0, 0, 1, 1, 1);
-            AssertDataColumn("table_Id", dt.Columns[0], "table_Id", false, true, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
+            DataSetAssertion.AssertDataTable("dt", dt, "table", 1, 0, 0, 1, 1, 1);
+            DataSetAssertion.AssertDataColumn("table_Id", dt.Columns[0], "table_Id", false, true, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
 
             dt = ds.Tables[1];
-            AssertDataTable("dt", dt, "col", 3, 0, 1, 0, 1, 0);
-            AssertDataColumn("another_col", dt.Columns[0], "another_col", true, false, 0, 1, "another_col", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("table_refId", dt.Columns["table_Id"], "table_Id", true, false, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, /*1*/-1, string.Empty, false, false);
-            AssertDataColumn("attr", dt.Columns["attr"], "attr", true, false, 0, 1, "attr", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, /*2*/-1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("dt", dt, "col", 3, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataColumn("another_col", dt.Columns[0], "another_col", true, false, 0, 1, "another_col", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("table_refId", dt.Columns["table_Id"], "table_Id", true, false, 0, 1, "table_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, /*1*/-1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("attr", dt.Columns["attr"], "attr", true, false, 0, 1, "attr", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, /*2*/-1, string.Empty, false, false);
 
             DataRelation dr = ds.Relations[0];
-            AssertDataRelation("rel", dr, "table_col", true, new string[] { "table_Id" }, new string[] { "table_Id" }, true, true);
-            AssertUniqueConstraint("uniq", dr.ParentKeyConstraint, "Constraint1", true, new string[] { "table_Id" });
-            AssertForeignKeyConstraint("fkey", dr.ChildKeyConstraint, "table_col", AcceptRejectRule.None, Rule.Cascade, Rule.Cascade, new string[] { "table_Id" }, new string[] { "table_Id" });
+            DataSetAssertion.AssertDataRelation("rel", dr, "table_col", true, new string[] { "table_Id" }, new string[] { "table_Id" }, true, true);
+            DataSetAssertion.AssertUniqueConstraint("uniq", dr.ParentKeyConstraint, "Constraint1", true, new string[] { "table_Id" });
+            DataSetAssertion.AssertForeignKeyConstraint("fkey", dr.ChildKeyConstraint, "table_col", AcceptRejectRule.None, Rule.Cascade, Rule.Cascade, new string[] { "table_Id" }, new string[] { "table_Id" });
         }
 
         [Fact]
@@ -456,14 +456,14 @@ namespace System.Data.Tests
             string xml = "<root attr='val' xmlns:a='urn:foo' a:foo='hogehoge' />";
             DataSet ds = new DataSet();
             ds.InferXmlSchema(new StringReader(xml), null);
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
-            AssertDataTable("dt", ds.Tables[0], "root", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataTable("dt", ds.Tables[0], "root", 2, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
             ds.InferXmlSchema(new StringReader(xml), new string[] { "urn:foo" });
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
             // a:foo is ignored
-            AssertDataTable("dt", ds.Tables[0], "root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("dt", ds.Tables[0], "root", 1, 0, 0, 0, 0, 0);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataSetReadXmlSchemaTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetReadXmlSchemaTest.cs
@@ -26,13 +26,14 @@
 
 
 using System.IO;
+using System.Diagnostics;
 using System.Globalization;
 using System.Xml;
 using Xunit;
 
 namespace System.Data.Tests
 {
-    public class DataSetReadXmlSchemaTest : DataSetAssertion, IDisposable
+    public class DataSetReadXmlSchemaTest : RemoteExecutorTestBase
     {
         private DataSet CreateTestSet()
         {
@@ -48,19 +49,6 @@ namespace System.Data.Tests
             ds.Tables[0].Rows.Add(new object[] { "ppp", "www", "xxx" });
             ds.Relations.Add("Rel1", ds.Tables[0].Columns[2], ds.Tables[1].Columns[0]);
             return ds;
-        }
-
-        private CultureInfo _currentCultureBackup;
-
-        public DataSetReadXmlSchemaTest()
-        {
-            _currentCultureBackup = CultureInfo.CurrentCulture; ;
-            CultureInfo.CurrentCulture = new CultureInfo("fi-FI");
-        }
-
-        public void Dispose()
-        {
-            CultureInfo.CurrentCulture = _currentCultureBackup;
         }
 
         [Fact]
@@ -125,39 +113,39 @@ namespace System.Data.Tests
 
             string xs = string.Format(xsbase, simple);
             ds.ReadXmlSchema(new StringReader(xs));
-            AssertDataSet("simple", ds, "hoge", 1, 0);
-            AssertDataTable("simple", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataSet("simple", ds, "hoge", 1, 0);
+            DataSetAssertion.AssertDataTable("simple", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             // reference to global complex type
             ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(xs2));
-            AssertDataSet("external complexType", ds, "hoge", 2, 1);
-            AssertDataTable("external Tab1", ds.Tables[0], "Root", 1, 0, 0, 1, 1, 1);
-            AssertDataTable("external Tab2", ds.Tables[1], "Child", 3, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataSet("external complexType", ds, "hoge", 2, 1);
+            DataSetAssertion.AssertDataTable("external Tab1", ds.Tables[0], "Root", 1, 0, 0, 1, 1, 1);
+            DataSetAssertion.AssertDataTable("external Tab2", ds.Tables[1], "Child", 3, 0, 1, 0, 1, 0);
 
             // xsbase2 + complex -> datatable
             ds = new DataSet();
             xs = string.Format(xsbase2, complex);
             ds.ReadXmlSchema(new StringReader(xs));
-            AssertDataSet("complex", ds, "hoge", 2, 1);
-            AssertDataTable("complex", ds.Tables[0], "Root", 1, 0, 0, 1, 1, 1);
+            DataSetAssertion.AssertDataSet("complex", ds, "hoge", 2, 1);
+            DataSetAssertion.AssertDataTable("complex", ds.Tables[0], "Root", 1, 0, 0, 1, 1, 1);
             DataTable dt = ds.Tables[1];
-            AssertDataTable("complex", dt, "Child", 3, 0, 1, 0, 1, 0);
-            AssertDataColumn("a1", dt.Columns["a1"], "a1", true, false, 0, 1, "a1", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, /*0*/-1, string.Empty, false, false);
-            AssertDataColumn("a2", dt.Columns["a2"], "a2", true, false, 0, 1, "a2", MappingType.Attribute, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, /*1*/-1, string.Empty, false, false);
-            AssertDataColumn("Root_Id", dt.Columns[2], "Root_Id", true, false, 0, 1, "Root_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("complex", dt, "Child", 3, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataColumn("a1", dt.Columns["a1"], "a1", true, false, 0, 1, "a1", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, /*0*/-1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("a2", dt.Columns["a2"], "a2", true, false, 0, 1, "a2", MappingType.Attribute, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, /*1*/-1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("Root_Id", dt.Columns[2], "Root_Id", true, false, 0, 1, "Root_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 2, string.Empty, false, false);
 
             // xsbase + complex -> dataset
             ds = new DataSet();
             xs = string.Format(xsbase, complex);
             ds.ReadXmlSchema(new StringReader(xs));
-            AssertDataSet("complex", ds, "Root", 1, 0);
+            DataSetAssertion.AssertDataSet("complex", ds, "Root", 1, 0);
 
             ds = new DataSet();
             xs = string.Format(xsbase2, elref);
             ds.ReadXmlSchema(new StringReader(xs));
-            AssertDataSet("complex", ds, "hoge", 1, 0);
-            AssertDataTable("complex", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataSet("complex", ds, "hoge", 1, 0);
+            DataSetAssertion.AssertDataTable("complex", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
         }
 
         [Fact]
@@ -181,8 +169,8 @@ namespace System.Data.Tests
 </xsd:schema>";
             var ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(schema));
-            AssertDataSet("ds", ds, "doc", 1, 0);
-            AssertDataTable("table", ds.Tables[0], "elem", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "doc", 1, 0);
+            DataSetAssertion.AssertDataTable("table", ds.Tables[0], "elem", 2, 0, 0, 0, 0, 0);
         }
 
         [Fact]
@@ -206,8 +194,8 @@ namespace System.Data.Tests
             var ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(xs));
             // Here "unusedType" table is never imported.
-            AssertDataSet("ds", ds, "hoge", 1, 0);
-            AssertDataTable("dt", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "hoge", 1, 0);
+            DataSetAssertion.AssertDataTable("dt", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
         }
 
         [Fact]
@@ -221,7 +209,7 @@ namespace System.Data.Tests
             var ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(xs));
             // nothing is imported.
-            AssertDataSet("ds", ds, "NewDataSet", 0, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 0, 0);
         }
 
         [Fact]
@@ -243,7 +231,7 @@ namespace System.Data.Tests
 
             var ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(xs));
-            AssertDataSet("ds", ds, "Root", 0, 0); // name is "Root"
+            DataSetAssertion.AssertDataSet("ds", ds, "Root", 0, 0); // name is "Root"
 
             // But when explicit msdata:IsDataSet value is "false", then
             // treat as usual.
@@ -251,7 +239,7 @@ namespace System.Data.Tests
 
             ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(xs));
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
         }
 
         [Fact]
@@ -302,13 +290,16 @@ namespace System.Data.Tests
             var ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(xs));
             // Child should not be regarded as DataSet element
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
         }
 
         [Fact]
         public void LocaleOnRootWithoutIsDataSet()
         {
-            string xs = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:msdata='urn:schemas-microsoft-com:xml-msdata'>
+            RemoteInvoke(() =>
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("fi-FI");
+                string xs = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:msdata='urn:schemas-microsoft-com:xml-msdata'>
 	<xs:element name='Root' msdata:Locale='ja-JP'>
 		<xs:complexType>
 			<xs:sequence>
@@ -319,15 +310,18 @@ namespace System.Data.Tests
 	</xs:element>
 </xs:schema>";
 
-            var ds = new DataSet();
-            ds.ReadXmlSchema(new StringReader(xs));
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
-            Assert.Equal("fi-FI", ds.Locale.Name); // DataSet's Locale comes from current thread
-            DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "Root", 2, 0, 0, 0, 0, 0);
-            Assert.Equal("ja-JP", dt.Locale.Name); // DataTable's Locale comes from msdata:Locale
-            AssertDataColumn("col1", dt.Columns[0], "Attr", true, false, 0, 1, "Attr", MappingType.Attribute, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("col2", dt.Columns[1], "Child", false, false, 0, 1, "Child", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+                var ds = new DataSet();
+                ds.ReadXmlSchema(new StringReader(xs));
+                DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+                Assert.Equal("fi-FI", ds.Locale.Name); // DataSet's Locale comes from current thread
+                DataTable dt = ds.Tables[0];
+                DataSetAssertion.AssertDataTable("dt", dt, "Root", 2, 0, 0, 0, 0, 0);
+                Assert.Equal("ja-JP", dt.Locale.Name); // DataTable's Locale comes from msdata:Locale
+                DataSetAssertion.AssertDataColumn("col1", dt.Columns[0], "Attr", true, false, 0, 1, "Attr", MappingType.Attribute, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+                DataSetAssertion.AssertDataColumn("col2", dt.Columns[1], "Child", false, false, 0, 1, "Child", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
 
@@ -440,10 +434,10 @@ namespace System.Data.Tests
             // No prefixes on tables and columns
             var ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(xs));
-            AssertDataSet("ds", ds, "DS", 3, 1);
+            DataSetAssertion.AssertDataSet("ds", ds, "DS", 3, 1);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("R3", dt, "R3", 3, 0, 0, 0, 0, 0);
-            AssertDataColumn("col1", dt.Columns[0], "Attr", true, false, 0, 1, "Attr", MappingType.Attribute, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("R3", dt, "R3", 3, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("col1", dt.Columns[0], "Attr", true, false, 0, 1, "Attr", MappingType.Attribute, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
         }
 
         [Fact]
@@ -469,17 +463,17 @@ namespace System.Data.Tests
 
         private void ReadTest1Check(DataSet ds)
         {
-            AssertDataSet("dataset", ds, "NewDataSet", 2, 1);
-            AssertDataTable("tbl1", ds.Tables[0], "Table1", 3, 0, 0, 1, 1, 0);
-            AssertDataTable("tbl2", ds.Tables[1], "Table2", 3, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataSet("dataset", ds, "NewDataSet", 2, 1);
+            DataSetAssertion.AssertDataTable("tbl1", ds.Tables[0], "Table1", 3, 0, 0, 1, 1, 0);
+            DataSetAssertion.AssertDataTable("tbl2", ds.Tables[1], "Table2", 3, 0, 1, 0, 1, 0);
 
             DataRelation rel = ds.Relations[0];
-            AssertDataRelation("rel", rel, "Rel1", false,
+            DataSetAssertion.AssertDataRelation("rel", rel, "Rel1", false,
                 new string[] { "Column1_3" },
                 new string[] { "Column2_1" }, true, true);
-            AssertUniqueConstraint("uc", rel.ParentKeyConstraint,
+            DataSetAssertion.AssertUniqueConstraint("uc", rel.ParentKeyConstraint,
                 "Constraint1", false, new string[] { "Column1_3" });
-            AssertForeignKeyConstraint("fk", rel.ChildKeyConstraint, "Rel1",
+            DataSetAssertion.AssertForeignKeyConstraint("fk", rel.ChildKeyConstraint, "Rel1",
                 AcceptRejectRule.None, Rule.Cascade, Rule.Cascade,
                 new string[] { "Column2_1" },
                 new string[] { "Column1_3" });
@@ -491,11 +485,11 @@ namespace System.Data.Tests
         {
             var ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(@"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'><!-- empty --></xs:schema>"));
-            AssertDataSet("001", ds, "NewDataSet", 0, 0);
+            DataSetAssertion.AssertDataSet("001", ds, "NewDataSet", 0, 0);
 
             ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(@"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'><xs:element name='foo' /></xs:schema>"));
-            AssertDataSet("002", ds, "NewDataSet", 0, 0);
+            DataSetAssertion.AssertDataSet("002", ds, "NewDataSet", 0, 0);
 
             ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(
@@ -503,7 +497,7 @@ namespace System.Data.Tests
                     <xs:element name='foo' type='xs:integer' />
                     <xs:element name='bar' type='xs:string' />
                 </xs:schema>"));
-            AssertDataSet("003", ds, "NewDataSet", 0, 0);
+            DataSetAssertion.AssertDataSet("003", ds, "NewDataSet", 0, 0);
 
             ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(
@@ -515,7 +509,7 @@ namespace System.Data.Tests
                       </xs:restriction>
                     </xs:simpleType>
                 </xs:schema>"));
-            AssertDataSet("004", ds, "NewDataSet", 0, 0);
+            DataSetAssertion.AssertDataSet("004", ds, "NewDataSet", 0, 0);
         }
 
         [Fact]
@@ -533,11 +527,11 @@ namespace System.Data.Tests
                   </xs:simpleContent>
                 </xs:complexType>
                 </xs:schema>"));
-            AssertDataSet("005", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("005", ds, "NewDataSet", 1, 0);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("tab", dt, "foo", 2, 0, 0, 0, 0, 0);
-            AssertDataColumn("attr", dt.Columns[0], "attr", true, false, 0, 1, "attr", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("text", dt.Columns[1], "foo_text", false, false, 0, 1, "foo_text", MappingType.SimpleContent, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("tab", dt, "foo", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("attr", dt.Columns[0], "attr", true, false, 0, 1, "attr", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("text", dt.Columns[1], "foo_text", false, false, 0, 1, "foo_text", MappingType.SimpleContent, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
 
             ds = new DataSet();
             ds.ReadXmlSchema(new StringReader(
@@ -548,11 +542,11 @@ namespace System.Data.Tests
                       <xs:attribute name='att2' type='xs:int' default='2' />
                     </xs:complexType>
                 </xs:schema>"));
-            AssertDataSet("006", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("006", ds, "NewDataSet", 1, 0);
             dt = ds.Tables[0];
-            AssertDataTable("tab", dt, "foo", 2, 0, 0, 0, 0, 0);
-            AssertDataColumn("att1", dt.Columns["att1"], "att1", true, false, 0, 1, "att1", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, /*0*/-1, string.Empty, false, false);
-            AssertDataColumn("att2", dt.Columns["att2"], "att2", true, false, 0, 1, "att2", MappingType.Attribute, typeof(int), 2, string.Empty, -1, string.Empty, /*1*/-1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("tab", dt, "foo", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("att1", dt.Columns["att1"], "att1", true, false, 0, 1, "att1", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, /*0*/-1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("att2", dt.Columns["att2"], "att2", true, false, 0, 1, "att2", MappingType.Attribute, typeof(int), 2, string.Empty, -1, string.Empty, /*1*/-1, string.Empty, false, false);
         }
 
         [Fact]
@@ -576,15 +570,15 @@ namespace System.Data.Tests
                     </xs:sequence>
                   </xs:complexType>
                 </xs:schema>"));
-            AssertDataSet("007", ds, "NewDataSet", 2, 1);
+            DataSetAssertion.AssertDataSet("007", ds, "NewDataSet", 2, 1);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("tab1", dt, "uno", 1, 0, 0, 1, 1, 1);
-            AssertDataColumn("id", dt.Columns[0], "uno_Id", false, true, 0, 1, "uno_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, "urn:foo", 0, string.Empty, false, true);
+            DataSetAssertion.AssertDataTable("tab1", dt, "uno", 1, 0, 0, 1, 1, 1);
+            DataSetAssertion.AssertDataColumn("id", dt.Columns[0], "uno_Id", false, true, 0, 1, "uno_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, "urn:foo", 0, string.Empty, false, true);
 
             dt = ds.Tables[1];
-            AssertDataTable("tab2", dt, "des", 2, 0, 1, 0, 1, 0);
-            AssertDataColumn("child", dt.Columns[0], "tres", false, false, 0, 1, "tres", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("id", dt.Columns[1], "uno_Id", true, false, 0, 1, "uno_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("tab2", dt, "des", 2, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataColumn("child", dt.Columns[0], "tres", false, false, 0, 1, "tres", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("id", dt.Columns[1], "uno_Id", true, false, 0, 1, "uno_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
 
             // External simple type element
             ds = new DataSet();
@@ -605,15 +599,15 @@ namespace System.Data.Tests
                     </xs:sequence>
                   </xs:complexType>
                 </xs:schema>"));
-            AssertDataSet("008", ds, "NewDataSet", 2, 1);
+            DataSetAssertion.AssertDataSet("008", ds, "NewDataSet", 2, 1);
             dt = ds.Tables[0];
-            AssertDataTable("tab1", dt, "uno", 1, 0, 0, 1, 1, 1);
-            AssertDataColumn("id", dt.Columns[0], "uno_Id", false, true, 0, 1, "uno_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, "urn:foo", 0, string.Empty, false, true);
+            DataSetAssertion.AssertDataTable("tab1", dt, "uno", 1, 0, 0, 1, 1, 1);
+            DataSetAssertion.AssertDataColumn("id", dt.Columns[0], "uno_Id", false, true, 0, 1, "uno_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, "urn:foo", 0, string.Empty, false, true);
 
             dt = ds.Tables[1];
-            AssertDataTable("tab2", dt, "des", 2, 0, 1, 0, 1, 0);
-            AssertDataColumn("child", dt.Columns[0], "tres", false, false, 0, 1, "tres", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, "urn:foo", 0, string.Empty, false, false);
-            AssertDataColumn("id", dt.Columns[1], "uno_Id", true, false, 0, 1, "uno_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("tab2", dt, "des", 2, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataColumn("child", dt.Columns[0], "tres", false, false, 0, 1, "tres", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, "urn:foo", 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("id", dt.Columns[1], "uno_Id", true, false, 0, 1, "uno_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
         }
 
         [Fact]
@@ -639,12 +633,12 @@ namespace System.Data.Tests
 		                </xsd:complexType>
 	                </xsd:element>
                 </xsd:schema>"));
-            AssertDataSet("013", ds, "root", 1, 0);
+            DataSetAssertion.AssertDataSet("013", ds, "root", 1, 0);
 
             DataTable dt = ds.Tables[0];
-            AssertDataTable("root", dt, "e", 2, 0, 0, 0, 0, 0);
-            AssertDataColumn("attr", dt.Columns[0], "a", true, false, 0, 1, "a", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("simple", dt.Columns[1], "e_text", false, false, 0, 1, "e_text", MappingType.SimpleContent, typeof(decimal), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("root", dt, "e", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("attr", dt.Columns[0], "a", true, false, 0, 1, "a", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("simple", dt.Columns[1], "e_text", false, false, 0, 1, "e_text", MappingType.SimpleContent, typeof(decimal), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
         }
 
         [Fact]
@@ -728,16 +722,16 @@ namespace System.Data.Tests
                      </xs:appinfo>
                   </xs:annotation>
                 </xs:schema>"));
-            AssertDataSet("101", ds, "root", 2, 1);
+            DataSetAssertion.AssertDataSet("101", ds, "root", 2, 1);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("parent_table", dt, "p", 2, 0, 0, 1, 0, 0);
-            AssertDataColumn("pk", dt.Columns[0], "pk", false, false, 0, 1, "pk", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("parent_table", dt, "p", 2, 0, 0, 1, 0, 0);
+            DataSetAssertion.AssertDataColumn("pk", dt.Columns[0], "pk", false, false, 0, 1, "pk", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
 
             dt = ds.Tables[1];
-            AssertDataTable("child_table", dt, "c", 2, 0, 1, 0, 0, 0);
-            AssertDataColumn("fk", dt.Columns[0], "fk", false, false, 0, 1, "fk", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("child_table", dt, "c", 2, 0, 1, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("fk", dt.Columns[0], "fk", false, false, 0, 1, "fk", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
 
-            AssertDataRelation("rel", ds.Relations[0], "rel", false, new string[] { "pk" }, new string[] { "fk" }, false, false);
+            DataSetAssertion.AssertDataRelation("rel", ds.Relations[0], "rel", false, new string[] { "pk" }, new string[] { "fk" }, false, false);
         }
 
         [Fact]
@@ -779,16 +773,16 @@ namespace System.Data.Tests
                  </xs:complexType>
                 </xs:element>
                 </xs:schema>"));
-            AssertDataSet("102", ds, "ds", 2, 1);
+            DataSetAssertion.AssertDataSet("102", ds, "ds", 2, 1);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("parent_table", dt, "p", 2, 0, 0, 1, 0, 0);
-            AssertDataColumn("pk", dt.Columns[0], "pk", false, false, 0, 1, "pk", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("parent_table", dt, "p", 2, 0, 0, 1, 0, 0);
+            DataSetAssertion.AssertDataColumn("pk", dt.Columns[0], "pk", false, false, 0, 1, "pk", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
 
             dt = ds.Tables[1];
-            AssertDataTable("child_table", dt, "c", 2, 0, 1, 0, 0, 0);
-            AssertDataColumn("fk", dt.Columns[0], "fk", false, false, 0, 1, "fk", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("child_table", dt, "c", 2, 0, 1, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("fk", dt.Columns[0], "fk", false, false, 0, 1, "fk", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
 
-            AssertDataRelation("rel", ds.Relations[0], "rel", true, new string[] { "pk" }, new string[] { "fk" }, false, false);
+            DataSetAssertion.AssertDataRelation("rel", ds.Relations[0], "rel", true, new string[] { "pk" }, new string[] { "fk" }, false, false);
         }
 
         [Fact]
@@ -806,17 +800,17 @@ namespace System.Data.Tests
 	                </xs:sequence>
                   </xs:complexType>
                 </xs:schema>"));
-            AssertDataSet("012", ds, "NewDataSet", 2, 1);
+            DataSetAssertion.AssertDataSet("012", ds, "NewDataSet", 2, 1);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("parent", dt, "Foo", 1, 0, 0, 1, 1, 1);
-            AssertDataColumn("key", dt.Columns[0], "Foo_Id", false, true, 0, 1, "Foo_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
+            DataSetAssertion.AssertDataTable("parent", dt, "Foo", 1, 0, 0, 1, 1, 1);
+            DataSetAssertion.AssertDataColumn("key", dt.Columns[0], "Foo_Id", false, true, 0, 1, "Foo_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
 
             dt = ds.Tables[1];
-            AssertDataTable("repeated", dt, "Bar", 2, 0, 1, 0, 1, 0);
-            AssertDataColumn("data", dt.Columns[0], "Bar_Column", false, false, 0, 1, "Bar_Column", MappingType.SimpleContent, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("refkey", dt.Columns[1], "Foo_Id", true, false, 0, 1, "Foo_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("repeated", dt, "Bar", 2, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataColumn("data", dt.Columns[0], "Bar_Column", false, false, 0, 1, "Bar_Column", MappingType.SimpleContent, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("refkey", dt.Columns[1], "Foo_Id", true, false, 0, 1, "Foo_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
 
-            AssertDataRelation("rel", ds.Relations[0], "Foo_Bar", true, new string[] { "Foo_Id" }, new string[] { "Foo_Id" }, true, true);
+            DataSetAssertion.AssertDataRelation("rel", ds.Relations[0], "Foo_Bar", true, new string[] { "Foo_Id" }, new string[] { "Foo_Id" }, true, true);
         }
 
         [Fact]
@@ -835,25 +829,25 @@ namespace System.Data.Tests
 	                </xsd:element>
 	                <xsd:element name=""y"" />
                 </xsd:schema>"));
-            AssertDataSet("014", ds, "NewDataSet", 3, 2);
+            DataSetAssertion.AssertDataSet("014", ds, "NewDataSet", 3, 2);
 
             DataTable dt = ds.Tables[0];
-            AssertDataTable("parent", dt, "root", 1, 0, 0, 2, 1, 1);
-            AssertDataColumn("key", dt.Columns[0], "root_Id", false, true, 0, 1, "root_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
+            DataSetAssertion.AssertDataTable("parent", dt, "root", 1, 0, 0, 2, 1, 1);
+            DataSetAssertion.AssertDataColumn("key", dt.Columns[0], "root_Id", false, true, 0, 1, "root_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, true);
 
             dt = ds.Tables[1];
-            AssertDataTable("repeated", dt, "x", 2, 0, 1, 0, 1, 0);
-            AssertDataColumn("data_1", dt.Columns[0], "x_Column", false, false, 0, 1, "x_Column", MappingType.SimpleContent, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("refkey_1", dt.Columns[1], "root_Id", true, false, 0, 1, "root_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("repeated", dt, "x", 2, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataColumn("data_1", dt.Columns[0], "x_Column", false, false, 0, 1, "x_Column", MappingType.SimpleContent, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("refkey_1", dt.Columns[1], "root_Id", true, false, 0, 1, "root_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
 
             dt = ds.Tables[2];
-            AssertDataTable("repeated", dt, "y", 2, 0, 1, 0, 1, 0);
-            AssertDataColumn("data", dt.Columns[0], "y_Column", false, false, 0, 1, "y_Column", MappingType.SimpleContent, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("refkey", dt.Columns[1], "root_Id", true, false, 0, 1, "root_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("repeated", dt, "y", 2, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataColumn("data", dt.Columns[0], "y_Column", false, false, 0, 1, "y_Column", MappingType.SimpleContent, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("refkey", dt.Columns[1], "root_Id", true, false, 0, 1, "root_Id", MappingType.Hidden, typeof(int), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
 
-            AssertDataRelation("rel", ds.Relations[0], "root_x", true, new string[] { "root_Id" }, new string[] { "root_Id" }, true, true);
+            DataSetAssertion.AssertDataRelation("rel", ds.Relations[0], "root_x", true, new string[] { "root_Id" }, new string[] { "root_Id" }, true, true);
 
-            AssertDataRelation("rel", ds.Relations[1], "root_y", true, new string[] { "root_Id" }, new string[] { "root_Id" }, true, true);
+            DataSetAssertion.AssertDataRelation("rel", ds.Relations[1], "root_y", true, new string[] { "root_Id" }, new string[] { "root_Id" }, true, true);
         }
 
         [Fact]
@@ -955,7 +949,7 @@ namespace System.Data.Tests
             Assert.Equal(0, ds.Tables[0].Constraints.Count);
             Assert.Equal(0, ds.Tables[1].Constraints.Count);
 
-            AssertDataRelation("TestRel", ds.Relations[0], "rel", false, new string[] { "col 1", "col2" },
+            DataSetAssertion.AssertDataRelation("TestRel", ds.Relations[0], "rel", false, new string[] { "col 1", "col2" },
                     new string[] { "col1", "col  2" }, false, false);
         }
     }

--- a/src/System.Data.Common/tests/System/Data/DataSetReadXmlTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetReadXmlTest.cs
@@ -31,7 +31,7 @@ using Xunit;
 
 namespace System.Data.Tests
 {
-    public class DataSetReadXmlTest : DataSetAssertion
+    public class DataSetReadXmlTest
     {
         private const string xml1 = "";
         private const string xml2 = "<root/>";
@@ -72,55 +72,55 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.Auto, XmlReadMode.Auto,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple element2
             ds = new DataSet();
-            AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // text in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple table pattern:
             // root becomes a table and test becomes a column.
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
-            AssertDataTable("xml6", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("xml6", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
-            AssertDataTable("xml7", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("xml7", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "dataset", 1);
-            AssertDataTable("xml8", ds.Tables[0], "table", 2, 1, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("xml8", ds.Tables[0], "table", 2, 1, 0, 0, 0, 0);
         }
 
         [Fact]
@@ -130,49 +130,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
         }
@@ -184,49 +184,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
         }
@@ -238,49 +238,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
         }
@@ -292,55 +292,55 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple element2
             ds = new DataSet();
-            AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // text in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple table pattern:
             // root becomes a table and test becomes a column.
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
-            AssertDataTable("xml6", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("xml6", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
-            AssertDataTable("xml7", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("xml7", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "dataset", 1);
-            AssertDataTable("xml8", ds.Tables[0], "table", 2, 1, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("xml8", ds.Tables[0], "table", 2, 1, 0, 0, 0, 0);
         }
 
         [Fact]
@@ -350,49 +350,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
         }
@@ -404,33 +404,33 @@ namespace System.Data.Tests
 
             // ignored
             ds = new DataSet();
-            AssertReadXml(ds, "Fragment", diff1,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", diff1,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            AssertReadXml(ds, "IgnoreSchema", diff1,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", diff1,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            AssertReadXml(ds, "InferSchema", diff1,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", diff1,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            AssertReadXml(ds, "ReadSchema", diff1,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", diff1,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // Auto, DiffGram ... treated as DiffGram
             ds = new DataSet();
-            AssertReadXml(ds, "Auto", diff1,
+            DataSetAssertion.AssertReadXml(ds, "Auto", diff1,
                 XmlReadMode.Auto, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            AssertReadXml(ds, "DiffGram", diff1,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", diff1,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
         }
@@ -442,34 +442,34 @@ namespace System.Data.Tests
 
             // Fragment ... skipped
             ds = new DataSet();
-            AssertReadXml(ds, "Fragment", diff2,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", diff2,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // others ... kept 
             ds = new DataSet();
-            AssertReadXml(ds, "IgnoreSchema", diff2,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", diff2,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            AssertReadXml(ds, "InferSchema", diff2,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", diff2,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            AssertReadXml(ds, "ReadSchema", diff2,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", diff2,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             // Auto, DiffGram ... treated as DiffGram
             ds = new DataSet();
-            AssertReadXml(ds, "Auto", diff2,
+            DataSetAssertion.AssertReadXml(ds, "Auto", diff2,
                 XmlReadMode.Auto, XmlReadMode.DiffGram,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            AssertReadXml(ds, "DiffGram", diff2,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", diff2,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0, ReadState.Interactive);
         }
@@ -481,36 +481,36 @@ namespace System.Data.Tests
 
             // ignored
             ds = new DataSet();
-            AssertReadXml(ds, "IgnoreSchema", schema1,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", schema1,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            AssertReadXml(ds, "InferSchema", schema1,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", schema1,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0);
 
             // misc ... consume schema
             ds = new DataSet();
-            AssertReadXml(ds, "Fragment", schema1,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", schema1,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 1);
-            AssertDataTable("fragment", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("fragment", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            AssertReadXml(ds, "ReadSchema", schema1,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", schema1,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 1);
-            AssertDataTable("readschema", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("readschema", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            AssertReadXml(ds, "Auto", schema1,
+            DataSetAssertion.AssertReadXml(ds, "Auto", schema1,
                 XmlReadMode.Auto, XmlReadMode.ReadSchema,
                 "NewDataSet", 1);
-            AssertDataTable("auto", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("auto", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            AssertReadXml(ds, "DiffGram", schema1,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", schema1,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 1);
         }
@@ -522,37 +522,37 @@ namespace System.Data.Tests
 
             // ignored
             ds = new DataSet();
-            AssertReadXml(ds, "IgnoreSchema", schema2,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", schema2,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            AssertReadXml(ds, "InferSchema", schema2,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", schema2,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             // Fragment ... consumed both
             ds = new DataSet();
-            AssertReadXml(ds, "Fragment", schema2,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", schema2,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 1);
-            AssertDataTable("fragment", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("fragment", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             // rest ... treated as schema
             ds = new DataSet();
-            AssertReadXml(ds, "Auto", schema2,
+            DataSetAssertion.AssertReadXml(ds, "Auto", schema2,
                 XmlReadMode.Auto, XmlReadMode.ReadSchema,
                 "NewDataSet", 1, ReadState.Interactive);
-            AssertDataTable("auto", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("auto", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            AssertReadXml(ds, "DiffGram", schema2,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", schema2,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 1, ReadState.Interactive);
-            AssertDataTable("diffgram", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("diffgram", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            AssertReadXml(ds, "ReadSchema", schema2,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", schema2,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 1, ReadState.Interactive);
         }
@@ -563,14 +563,14 @@ namespace System.Data.Tests
             // simple element -> simple table
             var ds = new DataSet();
 
-            AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
-            AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
-            AssertDataTable("seq1", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("seq1", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
         }
 
         [Fact]
@@ -579,31 +579,31 @@ namespace System.Data.Tests
             // simple element -> simple dataset
             var ds = new DataSet();
 
-            AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
-            AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
-            AssertDataTable("#1", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("#1", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
 
             // simple table -> simple dataset
             ds = new DataSet();
 
-            AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
-            AssertDataTable("#2", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("#2", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
 
             // Return value became IgnoreSchema, since there is
             // already schema information in the dataset.
             // Columns are kept 1 as old table holds.
             // Rows are up to 2 because of accumulative read.
-            AssertReadXml(ds, "SimpleTable2-2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2-2", xml7,
                 XmlReadMode.Auto, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 1);
-            AssertDataTable("#3", ds.Tables[0], "root", 1, 2, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("#3", ds.Tables[0], "root", 1, 2, 0, 0, 0, 0);
         }
 
         [Fact]
@@ -627,7 +627,7 @@ namespace System.Data.Tests
             ds.Tables.Add(dt);
             dt.Columns.Add("col");
             ds.ReadXml(new StringReader(xml1), XmlReadMode.IgnoreSchema);
-            AssertDataSet("ds", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("ds", ds, "NewDataSet", 1, 0);
             Assert.Equal(1, dt.Rows.Count);
             dt.Clear();
 
@@ -727,7 +727,7 @@ namespace System.Data.Tests
             var ds = new DataSet();
             ds.ReadXml(new StringReader(xml));
 
-            AssertReadXml(ds, "SameNameParentChild", xml,
+            DataSetAssertion.AssertReadXml(ds, "SameNameParentChild", xml,
                 XmlReadMode.Auto, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 1);
         }
@@ -739,7 +739,7 @@ namespace System.Data.Tests
             var ds = new DataSet();
             ds.ReadXml(new StringReader(xml));
 
-            AssertReadXml(ds, "SameColumnName", xml,
+            DataSetAssertion.AssertReadXml(ds, "SameColumnName", xml,
                 XmlReadMode.Auto, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 1);
         }

--- a/src/System.Data.Common/tests/System/Data/DataSetTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTest.cs
@@ -37,23 +37,15 @@ using System.IO;
 using System.Data.SqlTypes;
 using System.Globalization;
 using System.Text;
+using System.Diagnostics;
 
 namespace System.Data.Tests
 {
-    public class DataSetTest : DataSetAssertion, IDisposable
+    public class DataSetTest : RemoteExecutorTestBase
     {
-        private CultureInfo _currentCultureBackup;
-
         public DataSetTest()
         {
-            _currentCultureBackup = CultureInfo.CurrentCulture; ;
-            CultureInfo.CurrentCulture = new CultureInfo("fi-FI");
             MyDataSet.count = 0;
-        }
-
-        public void Dispose()
-        {
-            CultureInfo.CurrentCulture = _currentCultureBackup;
         }
 
         [Fact]
@@ -186,7 +178,7 @@ namespace System.Data.Tests
             TextWriter writer = new StringWriter();
             ds.WriteXmlSchema(writer);
 
-            string TextString = GetNormalizedSchema(writer.ToString());
+            string TextString = DataSetAssertion.GetNormalizedSchema(writer.ToString());
             //			string TextString = writer.ToString ();
 
             string substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
@@ -517,86 +509,94 @@ namespace System.Data.Tests
         [Fact]
         public void WriteXmlSchema()
         {
-            var ds = new DataSet();
-            ds.ReadXml(new StringReader(DataProvider.region));
-            TextWriter writer = new StringWriter();
-            ds.WriteXmlSchema(writer);
+            RemoteInvoke(() =>
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("fi-FI");
+
+                var ds = new DataSet();
+                ds.ReadXml(new StringReader(DataProvider.region));
+                TextWriter writer = new StringWriter();
+                ds.WriteXmlSchema(writer);
 
 
-            string TextString = GetNormalizedSchema(writer.ToString());
-            //			string TextString = writer.ToString ();
+                string TextString = DataSetAssertion.GetNormalizedSchema(writer.ToString());
+                // string TextString = writer.ToString ();
 
-            string substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("<?xml version=\"1.0\" encoding=\"utf-16\"?>", substring);
+                string substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("<?xml version=\"1.0\" encoding=\"utf-16\"?>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            // This is original DataSet.WriteXmlSchema() output
-            //			Assert.Equal ("<xs:schema id=\"Root\" xmlns=\"\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\">", substring);
-            Assert.Equal("<xs:schema id=\"Root\" xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                // This is original DataSet.WriteXmlSchema() output
+                // Assert.Equal ("<xs:schema id=\"Root\" xmlns=\"\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\">", substring);
+                Assert.Equal("<xs:schema id=\"Root\" xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("  <xs:element msdata:IsDataSet=\"true\" msdata:Locale=\"en-US\" name=\"Root\">", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("  <xs:element msdata:IsDataSet=\"true\" msdata:Locale=\"en-US\" name=\"Root\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("    <xs:complexType>", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("    <xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("      <xs:choice maxOccurs=\"unbounded\" minOccurs=\"0\">", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("      <xs:choice maxOccurs=\"unbounded\" minOccurs=\"0\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("        <xs:element name=\"Region\">", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("        <xs:element name=\"Region\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("          <xs:complexType>", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("          <xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("            <xs:sequence>", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("            <xs:sequence>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            // This is original DataSet.WriteXmlSchema() output
-            //			Assert.Equal ("              <xs:element name=\"RegionID\" type=\"xs:string\" minOccurs=\"0\" />", substring);
-            Assert.Equal("              <xs:element minOccurs=\"0\" name=\"RegionID\" type=\"xs:string\" />", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                // This is original DataSet.WriteXmlSchema() output
+                // Assert.Equal ("              <xs:element name=\"RegionID\" type=\"xs:string\" minOccurs=\"0\" />", substring);
+                Assert.Equal("              <xs:element minOccurs=\"0\" name=\"RegionID\" type=\"xs:string\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            // This is original DataSet.WriteXmlSchema() output
-            //			Assert.Equal ("              <xs:element name=\"RegionDescription\" type=\"xs:string\" minOccurs=\"0\" />", substring);
-            Assert.Equal("              <xs:element minOccurs=\"0\" name=\"RegionDescription\" type=\"xs:string\" />", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                // This is original DataSet.WriteXmlSchema() output
+                // Assert.Equal ("              <xs:element name=\"RegionDescription\" type=\"xs:string\" minOccurs=\"0\" />", substring);
+                Assert.Equal("              <xs:element minOccurs=\"0\" name=\"RegionDescription\" type=\"xs:string\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("            </xs:sequence>", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("            </xs:sequence>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("          </xs:complexType>", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("          </xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("        </xs:element>", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("        </xs:element>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("      </xs:choice>", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("      </xs:choice>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("    </xs:complexType>", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("    </xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
-            Assert.Equal("  </xs:element>", substring);
+                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
+                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                Assert.Equal("  </xs:element>", substring);
 
-            Assert.Equal("</xs:schema>", TextString);
+                Assert.Equal("</xs:schema>", TextString);
+
+                return SuccessExitCode;
+            }).Dispose();
+
         }
 
         [Fact]
@@ -1037,11 +1037,11 @@ namespace System.Data.Tests
             string xml = "<FullTextResponse><Domains><AvailResponse info='y' name='novell-ximian-group' /><AvailResponse info='n' name='ximian' /></Domains></FullTextResponse>";
             var ds = new DataSet();
             ds.ReadXml(new StringReader(xml));
-            AssertDataSet("ds", ds, "FullTextResponse", 2, 1);
+            DataSetAssertion.AssertDataSet("ds", ds, "FullTextResponse", 2, 1);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt1", dt, "Domains", 1, 1, 0, 1, 1, 1);
+            DataSetAssertion.AssertDataTable("dt1", dt, "Domains", 1, 1, 0, 1, 1, 1);
             dt = ds.Tables[1];
-            AssertDataTable("dt2", dt, "AvailResponse", 3, 2, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataTable("dt2", dt, "AvailResponse", 3, 2, 1, 0, 1, 0);
             StringWriter sw = new StringWriter();
             XmlTextWriter xtw = new XmlTextWriter(sw);
             xtw.QuoteChar = '\'';
@@ -1565,16 +1565,19 @@ namespace System.Data.Tests
         [Fact]
         public void WriteXmlModeSchema1()
         {
-            string SerializedDataTable =
+            RemoteInvoke(() =>
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("fi-FI");
+                string SerializedDataTable =
 @"<rdData>
   <MyDataTable CustomerID='VINET' CompanyName='Vins et alcools Chevalier' ContactName='Paul Henriot' />
 </rdData>";
-            string expected =
-@"<rdData>
+                string expected =
+    @"<rdData>
   <xs:schema id=""rdData"" xmlns="""" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" xmlns:msdata=""urn:schemas-microsoft-com:xml-msdata"">
     <xs:element name=""rdData"" msdata:IsDataSet=""true"" " +
-              @"msdata:Locale=""en-US"">" +
-@"
+                  @"msdata:Locale=""en-US"">" +
+    @"
       <xs:complexType>
         <xs:choice minOccurs=""0"" maxOccurs=""unbounded"">
           <xs:element name=""MyDataTable"">
@@ -1590,14 +1593,17 @@ namespace System.Data.Tests
   </xs:schema>
   <MyDataTable CustomerID=""VINET"" CompanyName=""Vins et alcools Chevalier"" ContactName=""Paul Henriot"" />
 </rdData>";
-            DataSet set;
-            set = new DataSet();
-            set.ReadXml(new StringReader(SerializedDataTable));
+                DataSet set;
+                set = new DataSet();
+                set.ReadXml(new StringReader(SerializedDataTable));
 
-            StringWriter w = new StringWriter();
-            set.WriteXml(w, XmlWriteMode.WriteSchema);
-            string result = w.ToString();
-            Assert.Equal(expected.Replace("\r", ""), result.Replace("\r", ""));
+                StringWriter w = new StringWriter();
+                set.WriteXml(w, XmlWriteMode.WriteSchema);
+                string result = w.ToString();
+                Assert.Equal(expected.Replace("\r", ""), result.Replace("\r", ""));
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
@@ -27,7 +27,7 @@
 using Xunit;
 using System.Text;
 using System.IO;
-
+using System.Diagnostics;
 using System.Xml;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization.Formatters.Tests;
@@ -35,7 +35,7 @@ using System.Globalization;
 
 namespace System.Data.Tests
 {
-    public class DataSetTest2
+    public class DataSetTest2 : RemoteExecutorTestBase
     {
         private DataSet _ds = null;
         private bool _eventRaised = false;
@@ -1007,20 +1007,18 @@ namespace System.Data.Tests
         [Fact]
         public void DataSetSpecificCulture()
         {
-            CultureInfo orig = CultureInfo.CurrentCulture;
-            try
+            RemoteInvoke(() =>
             {
                 CultureInfo.CurrentCulture = new CultureInfo("cs-CZ");
+
                 var ds = new DataSet();
                 ds.Locale = CultureInfo.GetCultureInfo(1033);
                 var dt = ds.Tables.Add("machine");
                 dt.Locale = ds.Locale;
                 Assert.Same(dt, ds.Tables["MACHINE"]);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = orig;
-            }
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataTableReadXmlSchemaTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableReadXmlSchemaTest.cs
@@ -30,7 +30,7 @@ using Xunit;
 
 namespace System.Data.Tests
 {
-    public class DataTableReadXmlSchemaTest : DataSetAssertion, IDisposable
+    public class DataTableReadXmlSchemaTest
     {
         private DataSet CreateTestSet()
         {
@@ -46,19 +46,6 @@ namespace System.Data.Tests
             ds.Tables[0].Rows.Add(new object[] { "ppp", "www", "xxx" });
             ds.Relations.Add("Rel1", ds.Tables[0].Columns[2], ds.Tables[1].Columns[0]);
             return ds;
-        }
-
-        private CultureInfo _currentCultureBackup;
-
-        public DataTableReadXmlSchemaTest()
-        {
-            _currentCultureBackup = CultureInfo.CurrentCulture; ;
-            CultureInfo.CurrentCulture = new CultureInfo("fi-FI");
-        }
-
-        public void Dispose()
-        {
-            CultureInfo.CurrentCulture = _currentCultureBackup;
         }
 
         [Fact]
@@ -83,7 +70,7 @@ namespace System.Data.Tests
             var ds = new DataSet();
             ds.Tables.Add(new DataTable("elem"));
             ds.Tables[0].ReadXmlSchema(new StringReader(schema));
-            AssertDataTable("table", ds.Tables[0], "elem", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("table", ds.Tables[0], "elem", 2, 0, 0, 0, 0, 0);
         }
 
         [Fact]
@@ -110,7 +97,7 @@ namespace System.Data.Tests
                 ds.Tables.Add(new DataTable("Root"));
                 ds.Tables.Add(new DataTable("unusedType"));
                 ds.Tables[0].ReadXmlSchema(new StringReader(xs));
-                AssertDataTable("dt", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
+                DataSetAssertion.AssertDataTable("dt", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
                 // Here "unusedType" table is never imported.
                 ds.Tables[1].ReadXmlSchema(new StringReader(xs));
             });
@@ -137,7 +124,7 @@ namespace System.Data.Tests
                 var ds = new DataSet();
                 ds.Tables.Add(new DataTable("Root"));
                 ds.Tables[0].ReadXmlSchema(new StringReader(xs));
-                AssertDataTable("dt", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
+                DataSetAssertion.AssertDataTable("dt", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
                 // Even if a global element uses a complexType, it will be
                 // ignored if the element has msdata:IsDataSet='true'
@@ -196,10 +183,10 @@ namespace System.Data.Tests
             ds.Tables.Add("Root");
             ds.Tables[0].ReadXmlSchema(new StringReader(xs));
             DataTable dt = ds.Tables[0];
-            AssertDataTable("dt", dt, "Root", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataTable("dt", dt, "Root", 2, 0, 0, 0, 0, 0);
             Assert.Equal("ja-JP", dt.Locale.Name); // DataTable's Locale comes from msdata:Locale
-            AssertDataColumn("col1", dt.Columns[0], "Attr", true, false, 0, 1, "Attr", MappingType.Attribute, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("col2", dt.Columns[1], "Child", false, false, 0, 1, "Child", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("col1", dt.Columns[0], "Attr", true, false, 0, 1, "Attr", MappingType.Attribute, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("col2", dt.Columns[1], "Child", false, false, 0, 1, "Child", MappingType.Element, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
         }
 
         [Fact]
@@ -255,23 +242,23 @@ namespace System.Data.Tests
             ds.Tables.Add(new DataTable("R3"));
             ds.Tables[0].ReadXmlSchema(new StringReader(xs));
             DataTable dt = ds.Tables[0];
-            AssertDataTable("R3", dt, "R3", 3, 0, 0, 0, 0, 0);
-            AssertDataColumn("col1", dt.Columns[0], "Attr", true, false, 0, 1, "Attr", MappingType.Attribute, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("R3", dt, "R3", 3, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("col1", dt.Columns[0], "Attr", true, false, 0, 1, "Attr", MappingType.Attribute, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
         }
 
         private void ReadTest1Check(DataSet ds)
         {
-            AssertDataSet("dataset", ds, "NewDataSet", 2, 1);
-            AssertDataTable("tbl1", ds.Tables[0], "Table1", 3, 0, 0, 1, 1, 0);
-            AssertDataTable("tbl2", ds.Tables[1], "Table2", 3, 0, 1, 0, 1, 0);
+            DataSetAssertion.AssertDataSet("dataset", ds, "NewDataSet", 2, 1);
+            DataSetAssertion.AssertDataTable("tbl1", ds.Tables[0], "Table1", 3, 0, 0, 1, 1, 0);
+            DataSetAssertion.AssertDataTable("tbl2", ds.Tables[1], "Table2", 3, 0, 1, 0, 1, 0);
 
             DataRelation rel = ds.Relations[0];
-            AssertDataRelation("rel", rel, "Rel1", false,
+            DataSetAssertion.AssertDataRelation("rel", rel, "Rel1", false,
                 new string[] { "Column1_3" },
                 new string[] { "Column2_1" }, true, true);
-            AssertUniqueConstraint("uc", rel.ParentKeyConstraint,
+            DataSetAssertion.AssertUniqueConstraint("uc", rel.ParentKeyConstraint,
                 "Constraint1", false, new string[] { "Column1_3" });
-            AssertForeignKeyConstraint("fk", rel.ChildKeyConstraint, "Rel1",
+            DataSetAssertion.AssertForeignKeyConstraint("fk", rel.ChildKeyConstraint, "Rel1",
                 AcceptRejectRule.None, Rule.Cascade, Rule.Cascade,
                 new string[] { "Column2_1" },
                 new string[] { "Column1_3" });
@@ -293,11 +280,11 @@ namespace System.Data.Tests
                   </xs:simpleContent>
                 </xs:complexType>
                 </xs:schema>"));
-            AssertDataSet("005", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("005", ds, "NewDataSet", 1, 0);
             DataTable dt = ds.Tables[0];
-            AssertDataTable("tab", dt, "foo", 2, 0, 0, 0, 0, 0);
-            AssertDataColumn("attr", dt.Columns[0], "attr", true, false, 0, 1, "attr", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("text", dt.Columns[1], "foo_text", false, false, 0, 1, "foo_text", MappingType.SimpleContent, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("tab", dt, "foo", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("attr", dt.Columns[0], "attr", true, false, 0, 1, "attr", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("text", dt.Columns[1], "foo_text", false, false, 0, 1, "foo_text", MappingType.SimpleContent, typeof(long), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
 
             ds = new DataSet();
             ds.Tables.Add(new DataTable("foo"));
@@ -309,11 +296,11 @@ namespace System.Data.Tests
                       <xs:attribute name='att2' type='xs:int' default='2' />
                     </xs:complexType>
                 </xs:schema>"));
-            AssertDataSet("006", ds, "NewDataSet", 1, 0);
+            DataSetAssertion.AssertDataSet("006", ds, "NewDataSet", 1, 0);
             dt = ds.Tables[0];
-            AssertDataTable("tab", dt, "foo", 2, 0, 0, 0, 0, 0);
-            AssertDataColumn("att1", dt.Columns["att1"], "att1", true, false, 0, 1, "att1", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, /*0*/-1, string.Empty, false, false);
-            AssertDataColumn("att2", dt.Columns["att2"], "att2", true, false, 0, 1, "att2", MappingType.Attribute, typeof(int), 2, string.Empty, -1, string.Empty, /*1*/-1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("tab", dt, "foo", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("att1", dt.Columns["att1"], "att1", true, false, 0, 1, "att1", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, /*0*/-1, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("att2", dt.Columns["att2"], "att2", true, false, 0, 1, "att2", MappingType.Attribute, typeof(int), 2, string.Empty, -1, string.Empty, /*1*/-1, string.Empty, false, false);
         }
 
         [Fact]
@@ -341,9 +328,9 @@ namespace System.Data.Tests
 	                </xsd:element>
                 </xsd:schema>"));
             DataTable dt = ds.Tables[0];
-            AssertDataTable("root", dt, "e", 2, 0, 0, 0, 0, 0);
-            AssertDataColumn("attr", dt.Columns[0], "a", true, false, 0, 1, "a", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
-            AssertDataColumn("simple", dt.Columns[1], "e_text", false, false, 0, 1, "e_text", MappingType.SimpleContent, typeof(decimal), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
+            DataSetAssertion.AssertDataTable("root", dt, "e", 2, 0, 0, 0, 0, 0);
+            DataSetAssertion.AssertDataColumn("attr", dt.Columns[0], "a", true, false, 0, 1, "a", MappingType.Attribute, typeof(string), DBNull.Value, string.Empty, -1, string.Empty, 0, string.Empty, false, false);
+            DataSetAssertion.AssertDataColumn("simple", dt.Columns[1], "e_text", false, false, 0, 1, "e_text", MappingType.SimpleContent, typeof(decimal), DBNull.Value, string.Empty, -1, string.Empty, 1, string.Empty, false, false);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -29,19 +29,16 @@
 
 using System.Collections.Generic;
 using System.Data.SqlTypes;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization.Formatters.Tests;
 using System.Xml;
-
-
-
 using Xunit;
 
 namespace System.Data.Tests
 {
-    public class DataTableTest : DataSetAssertion
+    public class DataTableTest : RemoteExecutorTestBase
     {
         public DataTableTest()
         {
@@ -847,10 +844,8 @@ Assert.False(true);
         [Fact]
         public void PropertyExceptions()
         {
-            CultureInfo orig = CultureInfo.CurrentCulture;
-            try
+            RemoteInvoke(() =>
             {
-                CultureInfo.CurrentCulture = new CultureInfo("en-US");
                 DataSet set = new DataSet();
                 DataTable table = new DataTable();
                 DataTable table1 = new DataTable();
@@ -882,40 +877,23 @@ Assert.False(true);
                 DataRelation dr = new DataRelation("DR", table.Columns[0], table1.Columns[0]);
                 set.Relations.Add(dr);
 
-                try
+                Assert.Throws<ArgumentException>(() =>
                 {
                     table.CaseSensitive = true;
                     table1.CaseSensitive = true;
-                    Assert.False(true);
-                }
-                catch (ArgumentException)
-                {
-                }
+                });
 
-                try
+                Assert.Throws<ArgumentException>(() =>
                 {
                     CultureInfo cultureInfo = new CultureInfo("en-gb");
                     table.Locale = cultureInfo;
                     table1.Locale = cultureInfo;
-                    Assert.False(true);
-                }
-                catch (ArgumentException)
-                {
-                }
+                });
 
-                try
-                {
-                    table.Prefix = "Prefix#1";
-                    Assert.False(true);
-                }
-                catch (DataException)
-                {
-                }
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = orig;
-            }
+                Assert.Throws<DataException>(() => table.Prefix = "Prefix#1");
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
@@ -3323,16 +3301,16 @@ Assert.False(true);
         [Fact]
         public void WriteXmlSchema()
         {
-            CultureInfo orig = CultureInfo.CurrentCulture;
-            try
+            RemoteInvoke(() =>
             {
                 CultureInfo.CurrentCulture = new CultureInfo("en-GB");
+
                 var ds = new DataSet();
                 ds.ReadXml(new StringReader(DataProvider.region));
                 TextWriter writer = new StringWriter();
                 ds.Tables[0].WriteXmlSchema(writer);
 
-                string TextString = GetNormalizedSchema(writer.ToString());
+                string TextString = DataSetAssertion.GetNormalizedSchema(writer.ToString());
                 //string TextString = writer.ToString ();
 
                 string substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
@@ -3401,11 +3379,9 @@ Assert.False(true);
                 Assert.Equal("  </xs:element>", substring);
 
                 Assert.Equal("</xs:schema>", TextString);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = orig;
-            }
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
@@ -4037,7 +4013,7 @@ Assert.False(true);
 
     [Serializable]
 
-    public class AppDomainsAndFormatInfo
+    public class AppDomainsAndFormatInfo : RemoteExecutorTestBase
     {
         public void Remote()
         {
@@ -4048,56 +4024,51 @@ Assert.False(true);
         [Fact]
         public void Bug55978()
         {
-            CultureInfo orig = CultureInfo.CurrentCulture;
-            try
+            DataTable dt = new DataTable();
+            dt.Columns.Add("StartDate", typeof(DateTime));
+
+            DataRow dr;
+            DateTime date = DateTime.Now;
+
+            for (int i = 0; i < 10; i++)
             {
-                CultureInfo.CurrentCulture = new CultureInfo("en-US");
-                DataTable dt = new DataTable();
-                dt.Columns.Add("StartDate", typeof(DateTime));
-
-                DataRow dr;
-                DateTime date = DateTime.Now;
-
-                for (int i = 0; i < 10; i++)
-                {
-                    dr = dt.NewRow();
-                    dr["StartDate"] = date.AddDays(i);
-                    dt.Rows.Add(dr);
-                }
-
-                DataView dv = dt.DefaultView;
-                dv.RowFilter = string.Format(CultureInfo.InvariantCulture,
-                                  "StartDate >= '{0}' and StartDate <= '{1}'",
-                                  DateTime.Now.AddDays(2),
-                                  DateTime.Now.AddDays(4));
-                Assert.Equal(10, dt.Rows.Count);
-                Assert.Equal(2, dv.Count);
+                dr = dt.NewRow();
+                dr["StartDate"] = date.AddDays(i);
+                dt.Rows.Add(dr);
             }
-            finally
-            {
-                CultureInfo.CurrentCulture = orig;
-            }
+
+            DataView dv = dt.DefaultView;
+            dv.RowFilter = string.Format(CultureInfo.InvariantCulture,
+                                "StartDate >= '{0}' and StartDate <= '{1}'",
+                                DateTime.Now.AddDays(2),
+                                DateTime.Now.AddDays(4));
+            Assert.Equal(10, dt.Rows.Count);
+            Assert.Equal(2, dv.Count);
+
         }
 
         [Fact]
         public void Bug82109()
         {
-            DataTable tbl = new DataTable();
-            tbl.Columns.Add("data", typeof(DateTime));
-            DataRow row = tbl.NewRow();
-            row["Data"] = new DateTime(2007, 7, 1);
-            tbl.Rows.Add(row);
+            RemoteInvoke(() =>
+            {
+                DataTable tbl = new DataTable();
+                tbl.Columns.Add("data", typeof(DateTime));
+                DataRow row = tbl.NewRow();
+                row["Data"] = new DateTime(2007, 7, 1);
+                tbl.Rows.Add(row);
 
-            CultureInfo currentCulture = CultureInfo.CurrentCulture; ;
-            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
-            Select(tbl);
+                CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+                Select(tbl);
 
-            CultureInfo.CurrentCulture = new CultureInfo("it-IT");
-            Select(tbl);
+                CultureInfo.CurrentCulture = new CultureInfo("it-IT");
+                Select(tbl);
 
-            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
-            Select(tbl);
-            CultureInfo.CurrentCulture = currentCulture;
+                CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+                Select(tbl);
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         private static void Select(DataTable tbl)

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBooleanTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBooleanTest.cs
@@ -38,7 +38,6 @@ namespace System.Data.Tests.SqlTypes
 
         public SqlBooleanTest()
         {
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
             _sqlTrue = new SqlBoolean(true);
             _sqlFalse = new SqlBoolean(false);
         }

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlByteTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlByteTest.cs
@@ -36,11 +36,6 @@ namespace System.Data.Tests.SqlTypes
     {
         private const string Error = " does not work correctly";
 
-        public SqlByteTest()
-        {
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
-        }
-
         // Test constructor
         [Fact]
         public void Create()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBytesTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBytesTest.cs
@@ -31,11 +31,6 @@ namespace System.Data.Tests.SqlTypes
 {
     public class SqlBytesTest
     {
-        public SqlBytesTest()
-        {
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
-        }
-
         // Test constructor
         [Fact]
         public void SqlBytesItem()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlCharsTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlCharsTest.cs
@@ -26,25 +26,13 @@ using System.IO;
 using System.Xml;
 using System.Data.SqlTypes;
 using System.Globalization;
-
 using System.Xml.Serialization;
 
 namespace System.Data.Tests.SqlTypes
 {
-    public class SqlCharsTest : IDisposable
+    public class SqlCharsTest
     {
         private CultureInfo _originalCulture;
-
-        public SqlCharsTest()
-        {
-            _originalCulture = CultureInfo.CurrentCulture; ;
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
-        }
-
-        public void Dispose()
-        {
-            CultureInfo.CurrentCulture = _originalCulture;
-        }
 
         // Test constructor
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDateTimeTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDateTimeTest.cs
@@ -50,7 +50,6 @@ namespace System.Data.Tests.SqlTypes
 
         public SqlDateTimeTest()
         {
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
             _test1 = new SqlDateTime(2002, 10, 19, 9, 40, 0);
             _test2 = new SqlDateTime(2003, 11, 20, 10, 50, 1);
             _test3 = new SqlDateTime(2003, 11, 20, 10, 50, 1);

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDecimalTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDecimalTest.cs
@@ -34,7 +34,7 @@ using System.IO;
 
 namespace System.Data.Tests.SqlTypes
 {
-    public class SqlDecimalTest : IDisposable
+    public class SqlDecimalTest
     {
         private CultureInfo _originalCulture;
         private SqlDecimal _test1;
@@ -45,18 +45,11 @@ namespace System.Data.Tests.SqlTypes
 
         public SqlDecimalTest()
         {
-            _originalCulture = CultureInfo.CurrentCulture; ;
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
             _test1 = new SqlDecimal(6464.6464m);
             _test2 = new SqlDecimal(10000.00m);
             _test3 = new SqlDecimal(10000.00m);
             _test4 = new SqlDecimal(-6m);
             _test5 = new SqlDecimal(decimal.MaxValue);
-        }
-
-        public void Dispose()
-        {
-            CultureInfo.CurrentCulture = _originalCulture;
         }
 
         // Test constructor

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDoubleTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDoubleTest.cs
@@ -35,20 +35,9 @@ using Xunit;
 
 namespace System.Data.Tests.SqlTypes
 {
-    public class SqlDoubleTest : IDisposable
+    public class SqlDoubleTest
     {
         private CultureInfo _originalCulture;
-
-        public SqlDoubleTest()
-        {
-            _originalCulture = CultureInfo.CurrentCulture; ;
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
-        }
-
-        public void Dispose()
-        {
-            CultureInfo.CurrentCulture = _originalCulture;
-        }
 
         // Test constructor
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
@@ -41,7 +41,6 @@ namespace System.Data.Tests.SqlTypes
 
         public SqlMoneyTest()
         {
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
             _test1 = new SqlMoney(6464.6464d);
             _test2 = new SqlMoney(90000.0m);
             _test3 = new SqlMoney(90000.0m);

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlSingleTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlSingleTest.cs
@@ -34,11 +34,6 @@ namespace System.Data.Tests.SqlTypes
 {
     public class SqlSingleTest
     {
-        public SqlSingleTest()
-        {
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
-        }
-
         // Test constructor
         [Fact]
         public void Create()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
@@ -31,17 +31,16 @@ using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
 using System.Text;
-
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Data.Tests.SqlTypes
 {
-    public class SqlStringTest : IDisposable
+    public class SqlStringTest : RemoteExecutorTestBase
     {
         private SqlString _test1;
         private SqlString _test2;
         private SqlString _test3;
-        private CultureInfo _originalCulture;
 
         static SqlStringTest()
         {
@@ -50,16 +49,9 @@ namespace System.Data.Tests.SqlTypes
 
         public SqlStringTest()
         {
-            _originalCulture = CultureInfo.CurrentCulture; ;
-            CultureInfo.CurrentCulture = new CultureInfo("en-AU");
             _test1 = new SqlString("First TestString");
             _test2 = new SqlString("This is just a test SqlString");
             _test3 = new SqlString("This is just a test SqlString");
-        }
-
-        public void Dispose()
-        {
-            CultureInfo.CurrentCulture = _originalCulture;
         }
 
         [Fact]
@@ -180,24 +172,32 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Properties()
         {
-            // CompareInfo
-            Assert.Equal(3081, _test1.CompareInfo.LCID);
+            RemoteInvoke(() =>
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("en-AU");
+                var one = new SqlString("First TestString");
 
-            // CultureInfo
-            Assert.Equal(3081, _test1.CultureInfo.LCID);
+                // CompareInfo
+                Assert.Equal(3081, one.CompareInfo.LCID);
 
-            // LCID
-            Assert.Equal(3081, _test1.LCID);
+                // CultureInfo
+                Assert.Equal(3081, one.CultureInfo.LCID);
 
-            // IsNull
-            Assert.True(!_test1.IsNull);
-            Assert.True(SqlString.Null.IsNull);
+                // LCID
+                Assert.Equal(3081, one.LCID);
 
-            // SqlCompareOptions
-            Assert.Equal("IgnoreCase, IgnoreKanaType, IgnoreWidth", _test1.SqlCompareOptions.ToString());
+                // IsNull
+                Assert.True(!one.IsNull);
+                Assert.True(SqlString.Null.IsNull);
 
-            // Value
-            Assert.Equal("First TestString", _test1.Value);
+                // SqlCompareOptions
+                Assert.Equal("IgnoreCase, IgnoreKanaType, IgnoreWidth", one.SqlCompareOptions.ToString());
+
+                // Value
+                Assert.Equal("First TestString", one.Value);
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         // PUBLIC METHODS

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlXmlTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlXmlTest.cs
@@ -31,21 +31,8 @@ using Xunit;
 
 namespace System.Data.Tests.SqlTypes
 {
-    public class SqlXmlTest : IDisposable
+    public class SqlXmlTest
     {
-        private CultureInfo _originalCulture;
-
-        public SqlXmlTest()
-        {
-            _originalCulture = CultureInfo.CurrentCulture; ;
-            CultureInfo.CurrentCulture = new CultureInfo("en-US");
-        }
-
-        public void Dispose()
-        {
-            CultureInfo.CurrentCulture = _originalCulture;
-        }
-
         // Test constructor
         [Fact] // .ctor (Stream)
                //[Category ("NotDotNet")] // Name cannot begin with the '.' character, hexadecimal value 0x00. Line 1, position 2


### PR DESCRIPTION
Setting current culture or UI culture should be set remotely in our tests.
The change also removes class derivation from DataSetAssertion so as to force correct inheritance behavior.

Related issue: #23282 
PR of fix: #23392 (this fix was ported against release/uwp6.0 to make current PR)

cc: @danmosemsft 