### PR TITLE
Disable failing compression test on OSX High Sierra

### DIFF
--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -39,6 +39,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\Compression\ZipTestHelper.cs">
       <Link>Common\System\IO\Compression\ZipTestHelper.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="ZipFileConvenienceMethods.netcoreapp1.1.cs" />

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -15,8 +15,6 @@ namespace System.IO.Compression.Tests
 {
     public partial class ZipFileTest_ConvenienceMethods : ZipFileTestBase
     {
-        public static bool IsNotMacOsHighSierraOrHigher => PlatformDetection.IsNotMacOsHighSierraOrHigher;
-        
         [Fact]
         public async Task CreateFromDirectoryNormal()
         {
@@ -91,7 +89,7 @@ namespace System.IO.Compression.Tests
             AssertExtensions.Throws<ArgumentNullException>("sourceArchiveFileName", () => ZipFile.ExtractToDirectory(null, GetTestFilePath()));
         }
 
-        [ConditionalFact(nameof(IsNotMacOsHighSierraOrHigher))]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotMacOsHighSierraOrHigher))]
         public void ExtractToDirectoryUnicode()
         {
             string zipFileName = zfile("unicode.zip");
@@ -177,7 +175,7 @@ namespace System.IO.Compression.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsNotMacOsHighSierraOrHigher))]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotMacOsHighSierraOrHigher))]
         public void ExtractToDirectoryExtension_Unicode()
         {
             using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -15,6 +15,8 @@ namespace System.IO.Compression.Tests
 {
     public partial class ZipFileTest_ConvenienceMethods : ZipFileTestBase
     {
+        public static bool IsNotMacOsHighSierraOrHigher => PlatformDetection.IsNotMacOsHighSierraOrHigher;
+        
         [Fact]
         public async Task CreateFromDirectoryNormal()
         {
@@ -89,7 +91,7 @@ namespace System.IO.Compression.Tests
             AssertExtensions.Throws<ArgumentNullException>("sourceArchiveFileName", () => ZipFile.ExtractToDirectory(null, GetTestFilePath()));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotMacOsHighSierraOrHigher))]
         public void ExtractToDirectoryUnicode()
         {
             string zipFileName = zfile("unicode.zip");
@@ -175,7 +177,7 @@ namespace System.IO.Compression.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotMacOsHighSierraOrHigher))]
         public void ExtractToDirectoryExtension_Unicode()
         {
             using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/23276 to release/2.0.0

resolves https://github.com/dotnet/corefx/issues/21427