### PR TITLE
Replace "Initialize tools" to only download docker files

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -71,21 +71,26 @@
       }
     },
     {
+      "environment": {},
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Initialize tools",
+      "displayName": "Download docker files",
       "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "refName": "Shell1",
       "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "id": "10f1f9a1-74b0-47ab-87bf-e3c9c68e8b0d",
         "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "$(PB_GitDirectory)/init-tools.sh",
-        "arguments": "",
-        "workingFolder": "$(PB_GitDirectory)",
-        "failOnStandardError": "false"
+        "type": "InlineScript",
+        "scriptPath": "",
+        "args": "",
+        "cwd": "",
+        "failOnStandardError": "false",
+        "script": "if command -v curl > /dev/null; then\n    curl --retry 10 -sSL -o cleanup-docker.sh $(PB_VsoDockerFileDirUrl)cleanup-docker.sh\n    curl --retry 10 -sSL -o init-docker.sh $(PB_VsoDockerFileDirUrl)init-docker.sh\nelse\n    wget $(PB_VsoDockerFileDirUrl)cleanup-docker.sh -q -O cleanup-docker.sh\n    wget $(PB_VsoDockerFileDirUrl)init-docker.sh -q -O init-docker.sh\nfi"
       }
     },
     {
@@ -401,6 +406,9 @@
     },
     "PB_VsoRepositoryName": {
       "value": "DotNet-CoreFX-Trusted"
+    },
+    "PB_VsoDockerFileDirUrl": {
+      "value": "https://$(PB_VsoAccountName):$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Buildtools-Trusted/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/"
     },
     "SourceVersion": {
       "value": "HEAD",

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -90,7 +90,7 @@
         "args": "",
         "cwd": "",
         "failOnStandardError": "false",
-        "script": "if command -v curl > /dev/null; then\n    curl --retry 10 -sSL -o cleanup-docker.sh $(PB_VsoDockerFileDirUrl)cleanup-docker.sh\n    curl --retry 10 -sSL -o init-docker.sh $(PB_VsoDockerFileDirUrl)init-docker.sh\nelse\n    wget $(PB_VsoDockerFileDirUrl)cleanup-docker.sh -q -O cleanup-docker.sh\n    wget $(PB_VsoDockerFileDirUrl)init-docker.sh -q -O init-docker.sh\nfi"
+        "script": "if [[ ! -d $(DockerFileDir) ]]; then\n    mkdir -p $(DockerFileDir)\nfi\n\nif command -v curl > /dev/null; then\n    curl --retry 10 -sSL -o $(DockerFileDir)/cleanup-docker.sh $(VsoDockerFileDirUrl)cleanup-docker.sh\n    curl --retry 10 -sSL -o $(DockerFileDir)/init-docker.sh $(VsoDockerFileDirUrl)init-docker.sh\nelse\n    wget $(VsoDockerFileDirUrl)cleanup-docker.sh -q -O $(DockerFileDir)/cleanup-docker.sh\n    wget $(VsoDockerFileDirUrl)init-docker.sh -q -O $(DockerFileDir)/init-docker.sh\nfi"
       }
     },
     {
@@ -105,7 +105,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "$(Build.SourcesDirectory)/corefx/Tools/scripts/docker/init-docker.sh",
+        "filename": "$(DockerFileDir)/init-docker.sh",
         "arguments": "$(PB_DockerImageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -407,7 +407,10 @@
     "PB_VsoRepositoryName": {
       "value": "DotNet-CoreFX-Trusted"
     },
-    "PB_VsoDockerFileDirUrl": {
+    "DockerFileDir": {
+      "value": "tools/dockerscripts"
+    },
+    "VsoDockerFileDirUrl": {
       "value": "https://$(PB_VsoAccountName):$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Buildtools-Trusted/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/"
     },
     "SourceVersion": {


### PR DESCRIPTION
This way "Initialize tools" will be done later INSIDE docker, instead of
OUTSIDE. This fixes issue:

https://github.com/dotnet/core-eng/issues/1544

The inline script is:

if command -v curl > /dev/null; then
    curl --retry 10 -sSL -o cleanup-docker.sh $(PB_VsoDockerFileDirUrl)cleanup-docker.sh
    curl --retry 10 -sSL -o init-docker.sh $(PB_VsoDockerFileDirUrl)init-docker.sh
else
    wget $(PB_VsoDockerFileDirUrl)cleanup-docker.sh -q -O cleanup-docker.sh
    wget $(PB_VsoDockerFileDirUrl)init-docker.sh -q -O init-docker.sh
fi