### PR TITLE
Fix wrong SkipOnTargetFramework in EnvironmentTests which were incorrectly not sipped in uapaot

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -276,7 +276,7 @@ namespace System.Tests
 
         // Requires recent RS3 builds
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version16251OrGreater))]
-        [SkipOnTargetFramework(~(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot))]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.UapNotUapAot)]
         [InlineData(Environment.SpecialFolder.LocalApplicationData)]
         [InlineData(Environment.SpecialFolder.Cookies)]
         [InlineData(Environment.SpecialFolder.History)]
@@ -293,7 +293,7 @@ namespace System.Tests
 
         // Requires recent RS3 builds
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version16251OrGreater))]
-        [SkipOnTargetFramework(~(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot))]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.UapNotUapAot)]
         [InlineData(Environment.SpecialFolder.ApplicationData)]
         [InlineData(Environment.SpecialFolder.MyMusic)]
         [InlineData(Environment.SpecialFolder.MyPictures)]


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/corefx/issues/23432

Will close the issue whenever is ported to release/uwp6.0

cc: @danmosemsft @tijoytom 