### PR TITLE
Disable SqlClient tests that use TestTdsServer, since TestTdsServer has issues that can cause connection test timeouts and other failures.

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -18,6 +18,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.Data.SqlClient.Tests
 {
+    [ActiveIssue("dotnet/corefx #17925", TestPlatforms.Any)]
     public class DiagnosticTest : RemoteExecutorTestBase
     {
         private const string BadConnectionString = "data source = bad; initial catalog = bad; uid = bad; password = bad; connection timeout = 1;";
@@ -26,7 +27,6 @@ namespace System.Data.SqlClient.Tests
         public static bool IsConnectionStringConfigured() => s_tcpConnStr != string.Empty;
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteScalarTest()
         {
@@ -49,7 +49,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteScalarErrorTest()
         {
@@ -74,7 +73,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteNonQueryTest()
         {
@@ -97,7 +95,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteNonQueryErrorTest()
         {
@@ -136,7 +133,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteReaderTest()
         {
@@ -160,7 +156,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteReaderErrorTest()
         {
@@ -187,7 +182,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteReaderWithCommandBehaviorTest()
         {
@@ -234,7 +228,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteXmlReaderErrorTest()
         {
@@ -261,7 +254,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteScalarAsyncTest()
         {
@@ -284,7 +276,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteScalarAsyncErrorTest()
         {
@@ -309,7 +300,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteNonQueryAsyncTest()
         {
@@ -332,7 +322,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteNonQueryAsyncErrorTest()
         {
@@ -356,7 +345,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteReaderAsyncTest()
         {
@@ -380,7 +368,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ExecuteReaderAsyncErrorTest()
         {
@@ -456,7 +443,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ConnectionOpenTest()
         {
@@ -478,7 +464,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ConnectionOpenErrorTest()
         {
@@ -496,7 +481,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ConnectionOpenAsyncTest()
         {
@@ -514,7 +498,6 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)] // Internals reflection not supported on uapaot
         public void ConnectionOpenAsyncErrorTest()
         {

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -11,8 +11,8 @@ namespace System.Data.SqlClient.Tests
 {
     public class SqlConnectionBasicTests
     {
-
         [Fact]
+        [ActiveIssue("dotnet/corefx #23435", TestPlatforms.Any)]
         public void ConnectionTest()
         {
             using (TestTdsServer server = TestTdsServer.StartTestServer())
@@ -24,11 +24,9 @@ namespace System.Data.SqlClient.Tests
             }
         }
 
-
-        [PlatformSpecific(TestPlatforms.Windows)]  // Integ auth on Test server is supported on Windows right now
-        // https://github.com/dotnet/corefx/issues/19218 And https://github.com/dotnet/corefx/issues/21598
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer), 
-                                                    nameof(PlatformDetection.IsNotArmProcess))] 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer), nameof(PlatformDetection.IsNotArmProcess))] 
+        [ActiveIssue("dotnet/corefx #23435", TestPlatforms.Any)]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void IntegratedAuthConnectionTest()
         {
             using (TestTdsServer server = TestTdsServer.StartTestServer())

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -25,7 +25,7 @@
     <Compile Include="SqlConnectionTest.RetrieveStatistics.cs" />
     <Compile Include="SqlErrorCollectionTest.cs" />
     <Compile Include="TcpDefaultForAzureTest.cs" />
-    <Compile Include="SqlConnectionTest.cs" />
+    <Compile Include="SqlConnectionBasicTests.cs" />
     <Compile Include="TestTdsServer.cs" />
     <Compile Include="..\ManualTests\DataCommon\DataTestUtility.cs" />
   </ItemGroup>


### PR DESCRIPTION
The TestTdsServer sometimes doesn't get setup in a timely manner, leading to test timeouts when trying to connect to it (even though the test server endpoint is on the same machine). There are also some other issues like errors during RemoveInvokeHandle.Dispose, or a one-off issue with encryption protocol negotiation while connecting to TestTdsServer.

Timeout issues:
https://github.com/dotnet/corefx/issues/23435
https://github.com/dotnet/corefx/issues/23123
https://github.com/dotnet/corefx/issues/20441
https://github.com/dotnet/corefx/issues/18604
https://github.com/dotnet/corefx/issues/17088

RemoveInvokeHandle.Dispose() issue:
https://github.com/dotnet/corefx/issues/17925

An SSL/TLS protocol issue when connecting to TestTdsServer:
https://github.com/dotnet/corefx/issues/23056

Also renamed SqlConnectionTest.cs to match its actual class name.