### PR TITLE
Add FileApiInterop.dll to uap corefx private package

### DIFF
--- a/external/dir.proj
+++ b/external/dir.proj
@@ -16,6 +16,7 @@
     <Project Include="portable\portable.depproj" />
     <Project Include="ilasm/ilasm.depproj" />
     <Project Include="docs/docs.depproj" />
+    <Project Include="ioNativeDependency/ioNativeDependency.depproj" />
     <Project Condition="'$(ILLinkTrimAssembly)' != 'false'" Include="ILLink/ILLink.depproj" />
   </ItemGroup>
 

--- a/external/ioNativeDependency/Configurations.props
+++ b/external/ioNativeDependency/Configurations.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      uap;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/external/ioNativeDependency/ioNativeDependency.depproj
+++ b/external/ioNativeDependency/ioNativeDependency.depproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <NugetRuntimeIdentifier>$(PackageRID)</NugetRuntimeIdentifier>
+    <RidSpecificAssets>true</RidSpecificAssets>
+    <OutputPath>$(RuntimePath)</OutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FileApiInterop">
+      <Version>1.0.0-preview-01</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -41,6 +41,10 @@
 
     <ExcludeFromDuplicateTypes Include="System.Private.Reflection.Metadata.Ecma335" />
 
+    <File Include="$(RuntimePath)\FileApiInterop.dll" Condition="'$(PackageTargetRuntime)' != ''">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+
     <!-- Permit the following implementation-only assemblies -->
     <ValidatePackageSuppression Condition="'$(PackageTargetRuntime)' != ''" Include="PermitInbox">
       <Value>


### PR DESCRIPTION
Porting change #23454 to release/uwp6.0 branch.

This will add FileApiInterop.dll to the uap corefx private package.

cc: @danmosemsft @JeremyKuhne @weshaggard @joshfree 