### PR TITLE
Remove invalid "bold" syntax in EventCounter docs

### DIFF
--- a/src/System.Diagnostics.Tracing/documentation/EventCounterTutorial.md
+++ b/src/System.Diagnostics.Tracing/documentation/EventCounterTutorial.md
@@ -49,10 +49,10 @@ So, with that, we logged the metric to the `EventCounter`, but unless we can act
 There is an extra keyword that you will need to specify the turn on the EventCounters.
 
 ```
-PerfView /onlyProviders=*Samples-EventCounterDemos-Minimal:**EventCounterIntervalSec=1** collect
+PerfView /onlyProviders=*Samples-EventCounterDemos-Minimal:EventCounterIntervalSec=1 collect
 ```
 
-Note the bold part about `EventCounterIntervalSec`, that indicate the frequency of the sampling.
+Note the part about `EventCounterIntervalSec`, that indicate the frequency of the sampling.
 
 As usual, turn on PerfView, and then run the sample code, we will have something like this
 


### PR DESCRIPTION
The use of `**` to try to call out a piece of preformatted code as bold doesn't actually work, because the preformatted code block overrides any Markdown syntax in the block. The EventCounter docs use this to try to call out a section of preformatted code as bold, and it causes confusion, as the user may think that the `**` sequence is needed (when it is actually invalid).

Small nit that confused me for a few minutes when trying to use EventCounters. Wanted to fix it to avoid further confusion by anyone else looking at these docs :).