### PR TITLE
fix improperly generated method tokens in XSL IlGen

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Xsl/IlGen/GenerateHelper.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/IlGen/GenerateHelper.cs
@@ -866,38 +866,6 @@ namespace System.Xml.Xsl.IlGen
             }
         }
 
-        // BUGBUG: This method is only necessary to work around VS Bug 478350
-        public void CallToken(MethodInfo meth)
-        {
-            Debug.Assert(!(_methInfo is ConstructorBuilder));
-            MethodBuilder methBldr = _methInfo as MethodBuilder;
-
-            if (methBldr != null)
-            {
-                // Using regular reflection emit, so get a token for the specified method.
-                // The token is only valid within scope of this method's body.
-                OpCode opcode = meth.IsVirtual || meth.IsAbstract ? OpCodes.Callvirt : OpCodes.Call;
-
-                TraceCall(opcode, meth);
-
-                _ilgen.Emit(opcode, ((ModuleBuilder)methBldr.Module).MetadataToken);
-
-                if (_lastSourceInfo != null)
-                {
-                    // Emit a "no source" sequence point, otherwise the debugger would return to the wrong line
-                    // once the call has finished.  We are guaranteed not to emit adjacent sequence points because
-                    // the Call instruction precedes this sequence point, and a nop instruction precedes other
-                    // sequence points.
-                    MarkSequencePoint(SourceLineInfo.NoSource);
-                }
-            }
-            else
-            {
-                // Using LCG, so no need to workaround
-                Call(meth);
-            }
-        }
-
         public void Construct(ConstructorInfo constr)
         {
             Emit(OpCodes.Newobj, constr);

--- a/src/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlIlVisitor.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlIlVisitor.cs
@@ -2264,7 +2264,7 @@ namespace System.Xml.Xsl.IlGen
             XmlILStorageMethods methods = XmlILMethods.StorageMethods[itemStorageType];
             locCache = _helper.DeclareLocal("$$$cache", methods.SeqType);
             _helper.Emit(OpCodes.Ldloc, locCache);
-            _helper.CallToken(methods.SeqReuse);
+            _helper.Call(methods.SeqReuse);
             _helper.Emit(OpCodes.Stloc, locCache);
             _helper.Emit(OpCodes.Ldloc, locCache);
 
@@ -4869,14 +4869,14 @@ namespace System.Xml.Xsl.IlGen
             {
                 // cache = XmlQuerySequence.CreateOrReuse(cache, item);
                 NestedVisitEnsureStack(nd, cacheType, false);
-                _helper.CallToken(methods.SeqReuseSgl);
+                _helper.Call(methods.SeqReuseSgl);
                 _helper.Emit(OpCodes.Stloc, locCache);
             }
             else
             {
                 // XmlQuerySequence<T> cache;
                 // cache = XmlQuerySequence.CreateOrReuse(cache);
-                _helper.CallToken(methods.SeqReuse);
+                _helper.Call(methods.SeqReuse);
                 _helper.Emit(OpCodes.Stloc, locCache);
                 _helper.Emit(OpCodes.Ldloc, locCache);
 

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
@@ -16,6 +16,7 @@
     <Compile Include="Errata4.cs" />
     <Compile Include="OutputSettings.cs" />
     <Compile Include="TempFiles.cs" />
+    <Compile Include="XslCompilerTests.cs" />
     <Compile Include="XsltApiV2.cs" />
     <Compile Include="XsltArgumentList.cs" />
     <Compile Include="XsltArgumentListMultith.cs" />

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompilerTests.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompilerTests.cs
@@ -1,0 +1,44 @@
+﻿using System.IO;
+using System.Xml.Xsl;
+using Xunit;
+
+namespace System.Xml.Tests
+{
+    public class XslCompilerTests
+    {
+        [Fact]
+        public void ValueOfInDebugMode()
+        {
+            string xml = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>
+<Class>
+    <Info>This is my class info</Info>
+</Class>";
+
+            string xsl = @"<xsl:stylesheet version=""1.0"" xmlns:xsl=""http://www.w3.org/1999/XSL/Transform"">
+
+    <xsl:output method=""text"" indent=""yes"" />
+    
+    <xsl:template match=""Class"">
+        <xsl:value-of select=""Info"" />
+    </xsl:template>
+</xsl:stylesheet>";
+
+            using (var outWriter = new StringWriter())
+            {
+                using (var xslStringReader = new StringReader(xsl))
+                using (var xmlStringReader = new StringReader(xml))
+                using (var xslReader = XmlReader.Create(xslStringReader))
+                using (var xmlReader = XmlReader.Create(xmlStringReader))
+                {
+                    var transform = new XslCompiledTransform(true);
+                    var argsList = new XsltArgumentList();
+
+                    transform.Load(xslReader);
+                    transform.Transform(xmlReader, argsList, outWriter);
+                }
+
+                Assert.Equal("This is my class info", outWriter.ToString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/23343

Current implementation of Call instruction used when compiling XSL in debug mode is invalid and original desktop implementation can't be used due to lack of `System.Reflection.Emit.ModuleBuilder.GetMethodToken(MethodInfo)`.

I've noted that this API is used only because of the workaround put in place related to really old bug (I could not find it in the database but based on the comments it seems that some platforms were missing LCG at that time) so I've decided to remove the workaround since I believe LCG is available for more than 10 years already.