### PR TITLE
Initialize tools twice, to fix corefx build breaks and enable RHEL6

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -71,24 +71,41 @@
       }
     },
     {
-      "environment": {},
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Download docker files",
+      "displayName": "Create host machine tools sandbox",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "10f1f9a1-74b0-47ab-87bf-e3c9c68e8b0d",
-        "versionSpec": "0.*",
+        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
+        "versionSpec": "2.*",
         "definitionType": "task"
       },
       "inputs": {
-        "type": "InlineScript",
-        "scriptPath": "",
-        "args": "",
-        "cwd": "",
-        "failOnStandardError": "false",
-        "script": "if [[ ! -d $(DockerFileDir) ]]; then\n    mkdir -p $(DockerFileDir)\nfi\n\nif command -v curl > /dev/null; then\n    curl --retry 10 -sSL -o $(DockerFileDir)/cleanup-docker.sh $(VsoDockerFileDirUrl)cleanup-docker.sh\n    curl --retry 10 -sSL -o $(DockerFileDir)/init-docker.sh $(VsoDockerFileDirUrl)init-docker.sh\nelse\n    wget $(VsoDockerFileDirUrl)cleanup-docker.sh -q -O $(DockerFileDir)/cleanup-docker.sh\n    wget $(VsoDockerFileDirUrl)init-docker.sh -q -O $(DockerFileDir)/init-docker.sh\nfi\n\nsudo chmod +x $(DockerFileDir)/cleanup-docker.sh\nsudo chmod +x $(DockerFileDir)/init-docker.sh"
+        "SourceFolder": "$(PB_GitDirectory)",
+        "Contents": "init-tools.sh\nBuildToolsVersion.txt\nDotnetCLIVersion.txt\ninit-tools.msbuild",
+        "TargetFolder": "$(DockerHost_Sandbox)",
+        "CleanTargetFolder": "false",
+        "OverWrite": "false",
+        "flattenFolders": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Initialize tools in sandbox for host machine",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(DockerHost_Sandbox)/init-tools.sh",
+        "arguments": "",
+        "workingFolder": "$(DockerHost_Sandbox)",
+        "failOnStandardError": "false"
       }
     },
     {
@@ -103,9 +120,9 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "$(DockerFileDir)/init-docker.sh",
+        "filename": "$(DockerHost_ToolsDirectory)/scripts/docker/init-docker.sh",
         "arguments": "$(PB_DockerImageName)",
-        "workingFolder": "",
+        "workingFolder": "$(DockerHost_Sandbox)",
         "failOnStandardError": "false"
       }
     },
@@ -248,7 +265,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "$(PB_GitDirectory)/Tools/scripts/docker/cleanup-docker.sh",
+        "filename": "$(DockerHost_ToolsDirectory)/scripts/docker/cleanup-docker.sh",
         "arguments": "",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -331,6 +348,12 @@
       "value": null,
       "isSecret": true
     },
+    "DockerHost_Sandbox": {
+      "value": "$(Build.StagingDirectory)/HostSandbox"
+    },
+    "DockerHost_ToolsDirectory": {
+      "value": "$(DockerHost_Sandbox)/Tools"
+    },
     "OfficialBuildId": {
       "value": "$(Build.BuildNumber)",
       "allowOverride": true
@@ -404,12 +427,6 @@
     },
     "PB_VsoRepositoryName": {
       "value": "DotNet-CoreFX-Trusted"
-    },
-    "DockerFileDir": {
-      "value": "tools/dockerscripts"
-    },
-    "VsoDockerFileDirUrl": {
-      "value": "https://$(PB_VsoAccountName):$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Buildtools-Trusted/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/"
     },
     "SourceVersion": {
       "value": "HEAD",

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -104,7 +104,7 @@
       "inputs": {
         "filename": "$(DockerHost_Sandbox)/init-tools.sh",
         "arguments": "",
-        "workingFolder": "$(DockerHost_Sandbox)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },
@@ -122,7 +122,7 @@
       "inputs": {
         "filename": "$(DockerHost_ToolsDirectory)/scripts/docker/init-docker.sh",
         "arguments": "$(PB_DockerImageName)",
-        "workingFolder": "$(DockerHost_Sandbox)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },


### PR DESCRIPTION
Initialize tools twice, to fix corefx build breaks and enable RHEL6