### PR TITLE
Undo a few JIT layout workarounds

### DIFF
--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -101,7 +101,7 @@ namespace System
             }
             return -1;
 
-        Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+        Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
             return (int)(byte*)index;
         Found1:
             return (int)(byte*)(index + 1);
@@ -179,7 +179,7 @@ namespace System
         Equal:
             return true;
 
-        NotEqual: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+        NotEqual: // Workaround for https://github.com/dotnet/coreclr/issues/13549
             return false;
         }
     }

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -136,12 +136,8 @@ namespace System
                 index += 1;
             }
 #if !netstandard10
-            if (Vector.IsHardwareAccelerated)
+            if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
             {
-                if ((int)(byte*)index >= length)
-                {
-                    goto NotFound;
-                }
                 nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
                 // Get comparison Vector
                 Vector<byte> vComparison = GetVector(value);
@@ -153,17 +149,11 @@ namespace System
                         index += Vector<byte>.Count;
                         continue;
                     }
-                    // Found match, reuse Vector vComparison to keep register pressure low
-                    vComparison = vMatches;
-                    // goto rather than inline return to keep function smaller https://github.com/dotnet/coreclr/issues/9692
-                    goto VectorFound;
+                    // Find offset of first match
+                    return (int)(byte*)index + LocateFirstFoundByte(vMatches);
                 }
 
-                if ((int)(byte*)index >= length)
-                {
-                    goto NotFound;
-                }
-                else
+                if ((int)(byte*)index < length)
                 {
                     unchecked
                     {
@@ -171,14 +161,10 @@ namespace System
                     }
                     goto SequentialScan;
                 }
-            VectorFound:
-                // Find offset of first match
-                return (int)(byte*)index + LocateFirstFoundByte(vComparison);
             }
-        NotFound: // Workaround for https://github.com/dotnet/coreclr/issues/9692
 #endif
             return -1;
-        Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+        Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
             return (int)(byte*)index;
         Found1:
             return (int)(byte*)(index + 1);
@@ -279,12 +265,8 @@ namespace System
                 index += 1;
             }
 #if !netstandard10
-            if (Vector.IsHardwareAccelerated)
+            if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
             {
-                if ((int)(byte*)index >= length)
-                {
-                    goto NotFound;
-                }
                 nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
                 // Get comparison Vector
                 Vector<byte> values0 = GetVector(value0);
@@ -301,17 +283,11 @@ namespace System
                         index += Vector<byte>.Count;
                         continue;
                     }
-                    // Found match, reuse Vector vComparison to keep register pressure low
-                    values0 = vMatches;
-                    // goto rather than inline return to keep function smaller https://github.com/dotnet/coreclr/issues/9692
-                    goto VectorFound;
+                    // Find offset of first match
+                    return (int)(byte*)index + LocateFirstFoundByte(vMatches);
                 }
 
-                if ((int)(byte*)index >= length)
-                {
-                    goto NotFound;
-                }
-                else
+                if ((int)(byte*)index < length)
                 {
                     unchecked
                     {
@@ -319,14 +295,10 @@ namespace System
                     }
                     goto SequentialScan;
                 }
-            VectorFound:
-                // Find offset of first match
-                return (int)(byte*)index + LocateFirstFoundByte(values0);
             }
-        NotFound: // Workaround for https://github.com/dotnet/coreclr/issues/9692
 #endif
             return -1;
-        Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+        Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
             return (int)(byte*)index;
         Found1:
             return (int)(byte*)(index + 1);
@@ -428,12 +400,8 @@ namespace System
                 index += 1;
             }
 #if !netstandard10
-            if (Vector.IsHardwareAccelerated)
+            if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
             {
-                if ((int)(byte*)index >= length)
-                {
-                    goto NotFound;
-                }
                 nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
                 // Get comparison Vector
                 Vector<byte> values0 = GetVector(value0);
@@ -454,17 +422,11 @@ namespace System
                         index += Vector<byte>.Count;
                         continue;
                     }
-                    // Found match, reuse Vector vComparison to keep register pressure low
-                    values0 = vMatches;
-                    // goto rather than inline return to keep function smaller https://github.com/dotnet/coreclr/issues/9692
-                    goto VectorFound;
+                    // Find offset of first match
+                    return (int)(byte*)index + LocateFirstFoundByte(vMatches);
                 }
 
-                if ((int)(byte*)index >= length)
-                {
-                    goto NotFound;
-                }
-                else
+                if ((int)(byte*)index < length)
                 {
                     unchecked
                     {
@@ -472,14 +434,10 @@ namespace System
                     }
                     goto SequentialScan;
                 }
-            VectorFound:
-                // Find offset of first match
-                return (int)(byte*)index + LocateFirstFoundByte(values0);
             }
-        NotFound: // Workaround for https://github.com/dotnet/coreclr/issues/9692
 #endif
             return -1;
-        Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+        Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
             return (int)(byte*)index;
         Found1:
             return (int)(byte*)(index + 1);
@@ -551,7 +509,7 @@ namespace System
         Equal:
             return true;
 
-        NotEqual: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+        NotEqual: // Workaround for https://github.com/dotnet/coreclr/issues/13549
             return false;
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
@@ -331,17 +331,14 @@ namespace System.Net.Http.Headers
                     tmpResult > int.MaxValue / 10 || // will overflow when shifting digits
                     (tmpResult == int.MaxValue / 10 && digit > 7)) // will overflow when adding in digit
                 {
-                    goto ReturnFalse; // Remove goto once https://github.com/dotnet/coreclr/issues/9692 is addressed
+                    result = 0;
+                    return false;
                 }
                 tmpResult = (tmpResult * 10) + digit;
             }
 
             result = tmpResult;
             return true;
-
-            ReturnFalse:
-            result = 0;
-            return false;
         }
 
         internal static bool TryParseInt64(string value, int offset, int length, out long result) // TODO #21281: Replace with int.TryParse(Span<char>) once it's available
@@ -362,17 +359,14 @@ namespace System.Net.Http.Headers
                     tmpResult > long.MaxValue / 10 || // will overflow when shifting digits
                     (tmpResult == long.MaxValue / 10 && digit > 7)) // will overflow when adding in digit
                 {
-                    goto ReturnFalse; // Remove goto once https://github.com/dotnet/coreclr/issues/9692 is addressed
+                    result = 0;
+                    return false;
                 }
                 tmpResult = (tmpResult * 10) + digit;
             }
 
             result = tmpResult;
             return true;
-
-            ReturnFalse:
-            result = 0;
-            return false;
         }
 
         internal static string DumpHeaders(params HttpHeaders[] headers)


### PR DESCRIPTION
Remove some `goto`s that were added to work around dotnet/coreclr#9692
(poor code layout for loop exit paths) -- the JIT's layout decisions
were improved in dotnet/coreclr#13314, and these particular `goto`s are
no longer needed; the same machine code is generated with or without
this change.
Some `goto`s previously tagged as workarounds for dotnet/coreclr#9692 are
still relevant for keeping codesize down pending dotnet/coreclr#13549;
update their comments accordingly.

Part of #23395.