### PR TITLE
Conditionally run namedPipes tests in uap if windows version contains fix

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -41,6 +41,8 @@ namespace System
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16215;
         public static bool IsWindows10Version16251OrGreater => IsWindows &&
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16251;
+        public static bool IsWindows10Version16256OrGreater => IsWindows &&
+            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16256;
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
 

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Read.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Read.cs
@@ -8,9 +8,10 @@ using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
+    
     public class NamedPipeTest_Read_ServerOut_ClientIn : PipeTest_Read
     {
+        protected override bool ShouldSkipTest() => PlatformDetection.IsWinRT && !PlatformDetection.IsWindows10Version16256OrGreater;
         protected override ServerClientPair CreateServerClientPair()
         {
             ServerClientPair ret = new ServerClientPair();
@@ -28,9 +29,9 @@ namespace System.IO.Pipes.Tests
         }
     }
     
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Read_ServerIn_ClientOut : PipeTest_Read
     {
+        protected override bool ShouldSkipTest() => PlatformDetection.IsWinRT && !PlatformDetection.IsWindows10Version16256OrGreater;
         protected override ServerClientPair CreateServerClientPair()
         {
             ServerClientPair ret = new ServerClientPair();
@@ -48,9 +49,9 @@ namespace System.IO.Pipes.Tests
         }
     }
     
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Read_ServerInOut_ClientInOut : PipeTest_Read
     {
+        protected override bool ShouldSkipTest() => PlatformDetection.IsWinRT && !PlatformDetection.IsWindows10Version16256OrGreater;
         protected override ServerClientPair CreateServerClientPair()
         {
             ServerClientPair ret = new ServerClientPair();
@@ -71,9 +72,9 @@ namespace System.IO.Pipes.Tests
         public override void WriteToReadOnlyPipe_Throws_NotSupportedException() { }
     }
     
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Read_ServerInOut_ClientInOut_APMWaitForConnection : PipeTest_Read
     {
+        protected override bool ShouldSkipTest() => PlatformDetection.IsWinRT && !PlatformDetection.IsWindows10Version16256OrGreater;
         protected override ServerClientPair CreateServerClientPair()
         {
             ServerClientPair ret = new ServerClientPair();

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Windows.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Windows.cs
@@ -13,9 +13,10 @@ namespace System.IO.Pipes.Tests
 {
     public partial class NamedPipeTest_RunAsClient : RemoteExecutorTestBase
     {
-        [Fact]
+        public static bool IsNotWinRTOrIsWindows10Version16256OrGreater => PlatformDetection.IsNotWinRT || PlatformDetection.IsWindows10Version16256OrGreater;
+
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes
-        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public async Task RunAsClient_Windows()
         {
             string pipeName = GetUniquePipeName();

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
@@ -17,6 +17,8 @@ namespace System.IO.Pipes.Tests
     /// </summary>
     public abstract class NamedPipeTest_Simple : NamedPipeTestBase
     {
+        public static bool IsNotWinRTOrIsWindows10Version16256OrGreater => PlatformDetection.IsNotWinRT || PlatformDetection.IsWindows10Version16256OrGreater;
+
         /// <summary>
         /// Yields every combination of testing options for the OneWayReadWrites test
         /// </summary>
@@ -32,7 +34,7 @@ namespace System.IO.Pipes.Tests
                             yield return new object[] { serverOption, clientOption, asyncServerOps, asyncClientOps };
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [MemberData(nameof(OneWayReadWritesMemberData))]
         public async Task OneWayReadWrites(PipeOptions serverOptions, PipeOptions clientOptions, bool asyncServerOps, bool asyncClientOps)
         {
@@ -101,7 +103,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public async Task ClonedServer_ActsAsOriginalServer()
         {
             byte[] msg1 = new byte[] { 5, 7, 9, 10 };
@@ -142,7 +144,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public async Task ClonedClient_ActsAsOriginalClient()
         {
             byte[] msg1 = new byte[] { 5, 7, 9, 10 };
@@ -181,7 +183,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public void ConnectOnAlreadyConnectedClient_Throws_InvalidOperationException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -199,7 +201,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public void WaitForConnectionOnAlreadyConnectedServer_Throws_InvalidOperationException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -217,7 +219,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public async Task CancelTokenOn_ServerWaitForConnectionAsync_Throws_OperationCanceledException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -237,7 +239,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
         public async Task CancelTokenOff_ServerWaitForConnectionAsyncWithOuterCancellation_Throws_OperationCanceledException()
         {
@@ -252,7 +254,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
         public async Task CancelTokenOn_ServerWaitForConnectionAsyncWithOuterCancellation_Throws_IOException()
         {
@@ -267,7 +269,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public async Task OperationsOnDisconnectedServer()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -304,7 +306,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public virtual async Task OperationsOnDisconnectedClient()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -349,7 +351,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix implemented on sockets, where disposal information doesn't propagate
         public async Task Windows_OperationsOnNamedServerWithDisposedClient()
         {
@@ -382,7 +384,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public void OperationsOnUnconnectedServer()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -416,7 +418,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public void OperationsOnUnconnectedClient()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -447,7 +449,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public async Task DisposedServerPipe_Throws_ObjectDisposedException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -463,7 +465,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public async Task DisposedClientPipe_Throws_ObjectDisposedException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -479,7 +481,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public async Task ReadAsync_DisconnectDuringRead_Returns0()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -501,7 +503,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [PlatformSpecific(TestPlatforms.Windows)] // Unix named pipes are on sockets, where small writes with an empty buffer will succeed immediately
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public async Task WriteAsync_DisconnectDuringWrite_Throws()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -522,7 +524,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [ActiveIssue("dotnet/corefx #16934", TargetFrameworkMonikers.NetFramework)] //Hangs forever in desktop as it doesn't have cancellation support
         public async Task Server_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
@@ -561,7 +563,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
         public async Task CancelTokenOff_Server_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
@@ -591,7 +593,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
         public async Task CancelTokenOn_Server_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
@@ -621,7 +623,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [ActiveIssue("dotnet/corefx #16934", TargetFrameworkMonikers.NetFramework)] //Hangs forever in desktop as it doesn't have cancellation support
         public async Task Client_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
@@ -658,7 +660,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
         public async Task CancelTokenOff_Client_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
@@ -687,7 +689,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
         public async Task CancelTokenOn_Client_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
@@ -716,7 +718,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ManyConcurrentOperations(bool cancelable)
@@ -754,7 +756,6 @@ namespace System.IO.Pipes.Tests
         }
     }
     
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerInOutRead_ClientInOutWrite : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -768,7 +769,6 @@ namespace System.IO.Pipes.Tests
         }
     }
     
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerInOutWrite_ClientInOutRead : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -782,7 +782,6 @@ namespace System.IO.Pipes.Tests
         }
     }
     
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerInOut_ClientIn : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -796,7 +795,6 @@ namespace System.IO.Pipes.Tests
         }
     }
     
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerInOut_ClientOut : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -810,7 +808,6 @@ namespace System.IO.Pipes.Tests
         }
     }
     
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerOut_ClientIn : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -824,7 +821,6 @@ namespace System.IO.Pipes.Tests
         }
     }
     
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerIn_ClientOut : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -14,10 +14,11 @@ namespace System.IO.Pipes.Tests
     /// The Specific NamedPipe tests cover edge cases or otherwise narrow cases that
     /// show up within particular server/client directional combinations.
     /// </summary>
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Specific : NamedPipeTestBase
     {
-        [Fact]
+        public static bool IsNotWinRTOrIsWindows10Version16256OrGreater => PlatformDetection.IsNotWinRT || PlatformDetection.IsWindows10Version16256OrGreater;
+
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public void InvalidConnectTimeout_Throws_ArgumentOutOfRangeException()
         {
             using (NamedPipeClientStream client = new NamedPipeClientStream("client1"))
@@ -27,7 +28,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public async Task ConnectToNonExistentServer_Throws_TimeoutException()
         {
             using (NamedPipeClientStream client = new NamedPipeClientStream(".", "notthere"))
@@ -39,7 +40,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public async Task CancelConnectToNonExistentServer_Throws_OperationCanceledException()
         {
             using (NamedPipeClientStream client = new NamedPipeClientStream(".", "notthere"))
@@ -55,7 +56,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix implementation uses bidirectional sockets
         public void ConnectWithConflictingDirections_Throws_UnauthorizedAccessException()
         {
@@ -76,7 +77,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [InlineData(PipeOptions.None)]
         [InlineData(PipeOptions.Asynchronous)]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix currently doesn't support message mode
@@ -167,7 +168,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix doesn't support MaxNumberOfServerInstances
         public async Task Windows_Get_NumberOfServerInstances_Succeed()
         {
@@ -189,7 +190,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // Win32 P/Invokes to verify the user name
         public async Task Windows_GetImpersonationUserName_Succeed()
         {
@@ -211,7 +212,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invoke to verify the user name
         public async Task Unix_GetImpersonationUserName_Succeed()
         {
@@ -231,14 +232,14 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.AnyUnix)] // Unix currently doesn't support message mode
         public void Unix_MessagePipeTransissionMode()
         {
             Assert.Throws<PlatformNotSupportedException>(() => new NamedPipeServerStream(GetUniquePipeName(), PipeDirection.InOut, 1, PipeTransmissionMode.Message));
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [InlineData(PipeDirection.In)]
         [InlineData(PipeDirection.Out)]
         [InlineData(PipeDirection.InOut)]
@@ -276,7 +277,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix implementation uses bidirectional sockets
         public static void Windows_BufferSizeRoundtripping()
         {
@@ -305,7 +306,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         public void PipeTransmissionMode_Returns_Byte()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -315,7 +316,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix doesn't currently support message mode
         public void Windows_SetReadModeTo__PipeTransmissionModeByte()
         {
@@ -356,7 +357,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.AnyUnix)] // Unix doesn't currently support message mode
         public void Unix_SetReadModeTo__PipeTransmissionModeByte()
         {
@@ -395,7 +396,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [InlineData(PipeDirection.Out, PipeDirection.In)]
         [InlineData(PipeDirection.In, PipeDirection.Out)]
         public void InvalidReadMode_Throws_ArgumentOutOfRangeException(PipeDirection serverDirection, PipeDirection clientDirection)
@@ -413,7 +414,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNotWinRTOrIsWindows10Version16256OrGreater))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Checks MaxLength for PipeName on Unix
         public void NameTooLong_MaxLengthPerPlatform()
         {

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Write.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Write.cs
@@ -8,9 +8,11 @@ using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
+    
     public class NamedPipeTest_Write_ServerOut_ClientIn : PipeTest_Write
     {
+        protected override bool ShouldSkipTest() => PlatformDetection.IsWinRT && !PlatformDetection.IsWindows10Version16256OrGreater;
+
         protected override ServerClientPair CreateServerClientPair()
         {
             ServerClientPair ret = new ServerClientPair();
@@ -28,9 +30,11 @@ namespace System.IO.Pipes.Tests
         }
     }
     
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
+    
     public class NamedPipeTest_Write_ServerIn_ClientOut : PipeTest_Write
     {
+        protected override bool ShouldSkipTest() => PlatformDetection.IsWinRT && !PlatformDetection.IsWindows10Version16256OrGreater;
+
         protected override ServerClientPair CreateServerClientPair()
         {
             ServerClientPair ret = new ServerClientPair();
@@ -48,9 +52,11 @@ namespace System.IO.Pipes.Tests
         }
     }
     
-    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
+    
     public class NamedPipeTest_Write_ServerInOut_ClientInOut : PipeTest_Write
     {
+        protected override bool ShouldSkipTest() => PlatformDetection.IsWinRT && !PlatformDetection.IsWindows10Version16256OrGreater;
+
         protected override ServerClientPair CreateServerClientPair()
         {
             ServerClientPair ret = new ServerClientPair();

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Write.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Write.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
-    
     public class NamedPipeTest_Write_ServerOut_ClientIn : PipeTest_Write
     {
         protected override bool ShouldSkipTest() => PlatformDetection.IsWinRT && !PlatformDetection.IsWindows10Version16256OrGreater;
@@ -30,7 +29,6 @@ namespace System.IO.Pipes.Tests
         }
     }
     
-    
     public class NamedPipeTest_Write_ServerIn_ClientOut : PipeTest_Write
     {
         protected override bool ShouldSkipTest() => PlatformDetection.IsWinRT && !PlatformDetection.IsWindows10Version16256OrGreater;
@@ -51,7 +49,6 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
     }
-    
     
     public class NamedPipeTest_Write_ServerInOut_ClientInOut : PipeTest_Write
     {

--- a/src/System.IO.Pipes/tests/PipeTest.Read.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Read.cs
@@ -16,7 +16,6 @@ namespace System.IO.Pipes.Tests
     /// </summary>
     public abstract partial class PipeTest_Read : PipeTestBase
     {
-
         protected virtual bool ShouldSkipTest() => false;
 
         [Fact]

--- a/src/System.IO.Pipes/tests/PipeTest.Read.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Read.cs
@@ -16,193 +16,223 @@ namespace System.IO.Pipes.Tests
     /// </summary>
     public abstract partial class PipeTest_Read : PipeTestBase
     {
+
+        protected virtual bool ShouldSkipTest() => false;
+
         [Fact]
         public void ReadWithNullBuffer_Throws_ArgumentNullException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.readablePipe;
-                Assert.True(pipe.IsConnected);
-                Assert.True(pipe.CanRead);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.readablePipe;
+                    Assert.True(pipe.IsConnected);
+                    Assert.True(pipe.CanRead);
 
-                // Null is an invalid Buffer
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Read(null, 0, 1));
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.ReadAsync(null, 0, 1); });
+                    // Null is an invalid Buffer
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Read(null, 0, 1));
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.ReadAsync(null, 0, 1); });
 
-                // Buffer validity is checked before Offset
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Read(null, -1, 1));
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.ReadAsync(null, -1, 1); });
+                    // Buffer validity is checked before Offset
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Read(null, -1, 1));
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.ReadAsync(null, -1, 1); });
 
-                // Buffer validity is checked before Count
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Read(null, -1, -1));
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.ReadAsync(null, -1, -1); });
+                    // Buffer validity is checked before Count
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Read(null, -1, -1));
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.ReadAsync(null, -1, -1); });
+                }
             }
         }
 
         [Fact]
         public void ReadWithNegativeOffset_Throws_ArgumentOutOfRangeException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.readablePipe;
-                Assert.True(pipe.IsConnected);
-                Assert.True(pipe.CanRead);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.readablePipe;
+                    Assert.True(pipe.IsConnected);
+                    Assert.True(pipe.CanRead);
 
-                // Offset must be nonnegative
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => pipe.Read(new byte[6], -1, 1));
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => { pipe.ReadAsync(new byte[4], -1, 1); });
+                    // Offset must be nonnegative
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => pipe.Read(new byte[6], -1, 1));
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => { pipe.ReadAsync(new byte[4], -1, 1); });
+                }
             }
         }
 
         [Fact]
         public void ReadWithNegativeCount_Throws_ArgumentOutOfRangeException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.readablePipe;
-                Assert.True(pipe.IsConnected);
-                Assert.True(pipe.CanRead);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.readablePipe;
+                    Assert.True(pipe.IsConnected);
+                    Assert.True(pipe.CanRead);
 
-                // Count must be nonnegative
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => pipe.Read(new byte[3], 0, -1));
-                AssertExtensions.Throws<System.ArgumentOutOfRangeException>("count", () => { pipe.ReadAsync(new byte[7], 0, -1); });
+                    // Count must be nonnegative
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => pipe.Read(new byte[3], 0, -1));
+                    AssertExtensions.Throws<System.ArgumentOutOfRangeException>("count", () => { pipe.ReadAsync(new byte[7], 0, -1); });
+                }
             }
         }
 
         [Fact]
         public void ReadWithOutOfBoundsArray_Throws_ArgumentException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.readablePipe;
-                Assert.True(pipe.IsConnected);
-                Assert.True(pipe.CanRead);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.readablePipe;
+                    Assert.True(pipe.IsConnected);
+                    Assert.True(pipe.CanRead);
 
-                // offset out of bounds
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[1], 1, 1));
+                    // offset out of bounds
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[1], 1, 1));
 
-                // offset out of bounds for 0 count read
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[1], 2, 0));
+                    // offset out of bounds for 0 count read
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[1], 2, 0));
 
-                // offset out of bounds even for 0 length buffer
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[0], 1, 0));
+                    // offset out of bounds even for 0 length buffer
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[0], 1, 0));
 
-                // combination offset and count out of bounds
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[2], 1, 2));
+                    // combination offset and count out of bounds
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[2], 1, 2));
 
-                // edges
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[0], int.MaxValue, 0));
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[0], int.MaxValue, int.MaxValue));
+                    // edges
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[0], int.MaxValue, 0));
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[0], int.MaxValue, int.MaxValue));
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[5], 3, 4));
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Read(new byte[5], 3, 4));
 
-                // offset out of bounds
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[1], 1, 1); });
+                    // offset out of bounds
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[1], 1, 1); });
 
-                // offset out of bounds for 0 count read
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[1], 2, 0); });
+                    // offset out of bounds for 0 count read
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[1], 2, 0); });
 
-                // offset out of bounds even for 0 length buffer
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[0], 1, 0); });
+                    // offset out of bounds even for 0 length buffer
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[0], 1, 0); });
 
-                // combination offset and count out of bounds
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[2], 1, 2); });
+                    // combination offset and count out of bounds
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[2], 1, 2); });
 
-                // edges
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[0], int.MaxValue, 0); });
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[0], int.MaxValue, int.MaxValue); });
+                    // edges
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[0], int.MaxValue, 0); });
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[0], int.MaxValue, int.MaxValue); });
 
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[5], 3, 4); });
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.ReadAsync(new byte[5], 3, 4); });
+                }
             }
         }
 
         [Fact]
         public virtual void WriteToReadOnlyPipe_Throws_NotSupportedException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.readablePipe;
-                Assert.True(pipe.IsConnected);
-                Assert.False(pipe.CanWrite);
-                Assert.False(pipe.CanSeek);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.readablePipe;
+                    Assert.True(pipe.IsConnected);
+                    Assert.False(pipe.CanWrite);
+                    Assert.False(pipe.CanSeek);
 
-                Assert.Throws<NotSupportedException>(() => pipe.Write(new byte[5], 0, 5));
+                    Assert.Throws<NotSupportedException>(() => pipe.Write(new byte[5], 0, 5));
 
-                Assert.Throws<NotSupportedException>(() => pipe.WriteByte(123));
+                    Assert.Throws<NotSupportedException>(() => pipe.WriteByte(123));
 
-                Assert.Throws<NotSupportedException>(() => pipe.Flush());
+                    Assert.Throws<NotSupportedException>(() => pipe.Flush());
 
-                Assert.Throws<NotSupportedException>(() => pipe.OutBufferSize);
+                    Assert.Throws<NotSupportedException>(() => pipe.OutBufferSize);
 
-                Assert.Throws<NotSupportedException>(() => pipe.WaitForPipeDrain());
+                    Assert.Throws<NotSupportedException>(() => pipe.WaitForPipeDrain());
 
-                Assert.Throws<NotSupportedException>(() => { pipe.WriteAsync(new byte[5], 0, 5); });
+                    Assert.Throws<NotSupportedException>(() => { pipe.WriteAsync(new byte[5], 0, 5); });
+                }
             }
         }
 
         [Fact]
         public async Task ReadWithZeroLengthBuffer_Nop()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.readablePipe;
-                var buffer = new byte[] { };
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.readablePipe;
+                    var buffer = new byte[] { };
 
-                Assert.Equal(0, pipe.Read(buffer, 0, 0));
-                Task<int> read = pipe.ReadAsync(buffer, 0, 0);
-                Assert.Equal(0, await read);
+                    Assert.Equal(0, pipe.Read(buffer, 0, 0));
+                    Task<int> read = pipe.ReadAsync(buffer, 0, 0);
+                    Assert.Equal(0, await read);
+                }
             }
         }
 
         [Fact]
         public void ReadPipeUnsupportedMembers_Throws_NotSupportedException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.readablePipe;
-                Assert.True(pipe.IsConnected);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.readablePipe;
+                    Assert.True(pipe.IsConnected);
 
-                Assert.Throws<NotSupportedException>(() => pipe.Length);
+                    Assert.Throws<NotSupportedException>(() => pipe.Length);
 
-                Assert.Throws<NotSupportedException>(() => pipe.SetLength(10L));
+                    Assert.Throws<NotSupportedException>(() => pipe.SetLength(10L));
 
-                Assert.Throws<NotSupportedException>(() => pipe.Position);
+                    Assert.Throws<NotSupportedException>(() => pipe.Position);
 
-                Assert.Throws<NotSupportedException>(() => pipe.Position = 10L);
+                    Assert.Throws<NotSupportedException>(() => pipe.Position = 10L);
 
-                Assert.Throws<NotSupportedException>(() => pipe.Seek(10L, System.IO.SeekOrigin.Begin));
+                    Assert.Throws<NotSupportedException>(() => pipe.Seek(10L, System.IO.SeekOrigin.Begin));
+                }
             }
         }
 
         [Fact]
         public void ReadOnDisposedReadablePipe_Throws_ObjectDisposedException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.readablePipe;
-                pipe.Dispose();
-                byte[] buffer = new byte[] { 0, 0, 0, 0 };
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.readablePipe;
+                    pipe.Dispose();
+                    byte[] buffer = new byte[] { 0, 0, 0, 0 };
 
-                Assert.Throws<ObjectDisposedException>(() => pipe.Flush());
-                Assert.Throws<ObjectDisposedException>(() => pipe.Read(buffer, 0, buffer.Length));
-                Assert.Throws<ObjectDisposedException>(() => pipe.ReadByte());
-                Assert.Throws<ObjectDisposedException>(() => { pipe.ReadAsync(buffer, 0, buffer.Length); });
-                Assert.Throws<ObjectDisposedException>(() => pipe.IsMessageComplete);
-                Assert.Throws<ObjectDisposedException>(() => pipe.ReadMode);
+                    Assert.Throws<ObjectDisposedException>(() => pipe.Flush());
+                    Assert.Throws<ObjectDisposedException>(() => pipe.Read(buffer, 0, buffer.Length));
+                    Assert.Throws<ObjectDisposedException>(() => pipe.ReadByte());
+                    Assert.Throws<ObjectDisposedException>(() => { pipe.ReadAsync(buffer, 0, buffer.Length); });
+                    Assert.Throws<ObjectDisposedException>(() => pipe.IsMessageComplete);
+                    Assert.Throws<ObjectDisposedException>(() => pipe.ReadMode);
+                }
             }
         }
 
         [Fact]
         public void CopyToAsync_InvalidArgs_Throws()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                AssertExtensions.Throws<ArgumentNullException>("destination", () => { pair.readablePipe.CopyToAsync(null); });
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("bufferSize", () => { pair.readablePipe.CopyToAsync(new MemoryStream(), 0); });
-                Assert.Throws<NotSupportedException>(() => { pair.readablePipe.CopyToAsync(new MemoryStream(new byte[1], writable: false)); });
-                if (!pair.writeablePipe.CanRead)
+                using (ServerClientPair pair = CreateServerClientPair())
                 {
-                    Assert.Throws<NotSupportedException>(() => { pair.writeablePipe.CopyToAsync(new MemoryStream()); });
+                    AssertExtensions.Throws<ArgumentNullException>("destination", () => { pair.readablePipe.CopyToAsync(null); });
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("bufferSize", () => { pair.readablePipe.CopyToAsync(new MemoryStream(), 0); });
+                    Assert.Throws<NotSupportedException>(() => { pair.readablePipe.CopyToAsync(new MemoryStream(new byte[1], writable: false)); });
+                    if (!pair.writeablePipe.CanRead)
+                    {
+                        Assert.Throws<NotSupportedException>(() => { pair.writeablePipe.CopyToAsync(new MemoryStream()); });
+                    }
                 }
             }
         }
@@ -211,69 +241,81 @@ namespace System.IO.Pipes.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "There is a bug in netfx around async read on a broken PipeStream. See #2601 and #2899. This bug is fixed in netcore.")]
         public virtual async Task ReadFromPipeWithClosedPartner_ReadNoBytes()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                pair.writeablePipe.Dispose();
-                byte[] buffer = new byte[] { 0, 0, 0, 0 };
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    pair.writeablePipe.Dispose();
+                    byte[] buffer = new byte[] { 0, 0, 0, 0 };
 
-                // The pipe won't be marked as Broken until the first read, so prime it
-                // to test both the case where it's not yet marked as "Broken" and then 
-                // where it is.
-                Assert.Equal(0, pair.readablePipe.Read(buffer, 0, buffer.Length));
+                    // The pipe won't be marked as Broken until the first read, so prime it
+                    // to test both the case where it's not yet marked as "Broken" and then 
+                    // where it is.
+                    Assert.Equal(0, pair.readablePipe.Read(buffer, 0, buffer.Length));
 
-                Assert.Equal(0, pair.readablePipe.Read(buffer, 0, buffer.Length));
-                Assert.Equal(-1, pair.readablePipe.ReadByte());
-                Assert.Equal(0, await pair.readablePipe.ReadAsync(buffer, 0, buffer.Length));
+                    Assert.Equal(0, pair.readablePipe.Read(buffer, 0, buffer.Length));
+                    Assert.Equal(-1, pair.readablePipe.ReadByte());
+                    Assert.Equal(0, await pair.readablePipe.ReadAsync(buffer, 0, buffer.Length));
+                }
             }
         }
 
         [Fact]
         public async Task ValidWriteAsync_ValidReadAsync()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                Assert.True(pair.writeablePipe.IsConnected);
-                Assert.True(pair.readablePipe.IsConnected);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    Assert.True(pair.writeablePipe.IsConnected);
+                    Assert.True(pair.readablePipe.IsConnected);
 
-                byte[] sent = new byte[] { 123, 0, 5 };
-                byte[] received = new byte[] { 0, 0, 0 };
+                    byte[] sent = new byte[] { 123, 0, 5 };
+                    byte[] received = new byte[] { 0, 0, 0 };
 
-                Task write = pair.writeablePipe.WriteAsync(sent, 0, sent.Length);
-                Assert.Equal(sent.Length, await pair.readablePipe.ReadAsync(received, 0, sent.Length));
-                Assert.Equal(sent, received);
-                await write;
+                    Task write = pair.writeablePipe.WriteAsync(sent, 0, sent.Length);
+                    Assert.Equal(sent.Length, await pair.readablePipe.ReadAsync(received, 0, sent.Length));
+                    Assert.Equal(sent, received);
+                    await write;
+                }
             }
         }
 
         [Fact]
         public void ValidWrite_ValidRead()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                Assert.True(pair.writeablePipe.IsConnected);
-                Assert.True(pair.readablePipe.IsConnected);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    Assert.True(pair.writeablePipe.IsConnected);
+                    Assert.True(pair.readablePipe.IsConnected);
 
-                byte[] sent = new byte[] { 123, 0, 5 };
-                byte[] received = new byte[] { 0, 0, 0 };
+                    byte[] sent = new byte[] { 123, 0, 5 };
+                    byte[] received = new byte[] { 0, 0, 0 };
 
-                Task.Run(() => { pair.writeablePipe.Write(sent, 0, sent.Length); });
-                Assert.Equal(sent.Length, pair.readablePipe.Read(received, 0, sent.Length));
-                Assert.Equal(sent, received);
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // WaitForPipeDrain isn't supported on Unix
-                    pair.writeablePipe.WaitForPipeDrain();
+                    Task.Run(() => { pair.writeablePipe.Write(sent, 0, sent.Length); });
+                    Assert.Equal(sent.Length, pair.readablePipe.Read(received, 0, sent.Length));
+                    Assert.Equal(sent, received);
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // WaitForPipeDrain isn't supported on Unix
+                        pair.writeablePipe.WaitForPipeDrain();
+                }
             }
         }
 
         [Fact]
         public void ValidWriteByte_ValidReadByte()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                Assert.True(pair.writeablePipe.IsConnected);
-                Assert.True(pair.readablePipe.IsConnected);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    Assert.True(pair.writeablePipe.IsConnected);
+                    Assert.True(pair.readablePipe.IsConnected);
 
-                Task.Run(() => pair.writeablePipe.WriteByte(123));
-                Assert.Equal(123, pair.readablePipe.ReadByte());
+                    Task.Run(() => pair.writeablePipe.WriteByte(123));
+                    Assert.Equal(123, pair.readablePipe.ReadByte());
+                }
             }
         }
 
@@ -282,33 +324,36 @@ namespace System.IO.Pipes.Tests
         [MemberData(nameof(AsyncReadWriteChain_MemberData))]
         public async Task AsyncReadWriteChain_ReadWrite(int iterations, int writeBufferSize, int readBufferSize, bool cancelableToken)
         {
-            var writeBuffer = new byte[writeBufferSize];
-            var readBuffer = new byte[readBufferSize];
-            var rand = new Random();
-            var cancellationToken = cancelableToken ? new CancellationTokenSource().Token : CancellationToken.None;
-
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                // Repeatedly and asynchronously write to the writable pipe and read from the readable pipe,
-                // verifying that the correct data made it through.
-                for (int iter = 0; iter < iterations; iter++)
+                var writeBuffer = new byte[writeBufferSize];
+                var readBuffer = new byte[readBufferSize];
+                var rand = new Random();
+                var cancellationToken = cancelableToken ? new CancellationTokenSource().Token : CancellationToken.None;
+
+                using (ServerClientPair pair = CreateServerClientPair())
                 {
-                    rand.NextBytes(writeBuffer);
-                    Task writerTask = pair.writeablePipe.WriteAsync(writeBuffer, 0, writeBuffer.Length, cancellationToken);
-
-                    int totalRead = 0;
-                    while (totalRead < writeBuffer.Length)
+                    // Repeatedly and asynchronously write to the writable pipe and read from the readable pipe,
+                    // verifying that the correct data made it through.
+                    for (int iter = 0; iter < iterations; iter++)
                     {
-                        int numRead = await pair.readablePipe.ReadAsync(readBuffer, 0, readBuffer.Length, cancellationToken);
-                        Assert.True(numRead > 0);
-                        Assert.Equal<byte>(
-                            new ArraySegment<byte>(writeBuffer, totalRead, numRead),
-                            new ArraySegment<byte>(readBuffer, 0, numRead));
-                        totalRead += numRead;
-                    }
-                    Assert.Equal(writeBuffer.Length, totalRead);
+                        rand.NextBytes(writeBuffer);
+                        Task writerTask = pair.writeablePipe.WriteAsync(writeBuffer, 0, writeBuffer.Length, cancellationToken);
 
-                    await writerTask;
+                        int totalRead = 0;
+                        while (totalRead < writeBuffer.Length)
+                        {
+                            int numRead = await pair.readablePipe.ReadAsync(readBuffer, 0, readBuffer.Length, cancellationToken);
+                            Assert.True(numRead > 0);
+                            Assert.Equal<byte>(
+                                new ArraySegment<byte>(writeBuffer, totalRead, numRead),
+                                new ArraySegment<byte>(readBuffer, 0, numRead));
+                            totalRead += numRead;
+                        }
+                        Assert.Equal(writeBuffer.Length, totalRead);
+
+                        await writerTask;
+                    }
                 }
             }
         }
@@ -318,24 +363,27 @@ namespace System.IO.Pipes.Tests
         [MemberData(nameof(AsyncReadWriteChain_MemberData))]
         public async Task AsyncReadWriteChain_CopyToAsync(int iterations, int writeBufferSize, int readBufferSize, bool cancelableToken)
         {
-            var writeBuffer = new byte[writeBufferSize * iterations];
-            new Random().NextBytes(writeBuffer);
-            var cancellationToken = cancelableToken ? new CancellationTokenSource().Token : CancellationToken.None;
-
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                var readData = new MemoryStream();
-                Task copyTask = pair.readablePipe.CopyToAsync(readData, readBufferSize, cancellationToken);
+                var writeBuffer = new byte[writeBufferSize * iterations];
+                new Random().NextBytes(writeBuffer);
+                var cancellationToken = cancelableToken ? new CancellationTokenSource().Token : CancellationToken.None;
 
-                for (int iter = 0; iter < iterations; iter++)
+                using (ServerClientPair pair = CreateServerClientPair())
                 {
-                    await pair.writeablePipe.WriteAsync(writeBuffer, iter * writeBufferSize, writeBufferSize, cancellationToken);
-                }
-                pair.writeablePipe.Dispose();
+                    var readData = new MemoryStream();
+                    Task copyTask = pair.readablePipe.CopyToAsync(readData, readBufferSize, cancellationToken);
 
-                await copyTask;
-                Assert.Equal(writeBuffer.Length, readData.Length);
-                Assert.Equal(writeBuffer, readData.ToArray());
+                    for (int iter = 0; iter < iterations; iter++)
+                    {
+                        await pair.writeablePipe.WriteAsync(writeBuffer, iter * writeBufferSize, writeBufferSize, cancellationToken);
+                    }
+                    pair.writeablePipe.Dispose();
+
+                    await copyTask;
+                    Assert.Equal(writeBuffer.Length, readData.Length);
+                    Assert.Equal(writeBuffer, readData.ToArray());
+                }
             }
         }
 
@@ -353,19 +401,22 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public async Task ValidWriteAsync_ValidReadAsync_APM()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                Assert.True(pair.writeablePipe.IsConnected);
-                Assert.True(pair.readablePipe.IsConnected);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    Assert.True(pair.writeablePipe.IsConnected);
+                    Assert.True(pair.readablePipe.IsConnected);
 
-                byte[] sent = new byte[] { 123, 0, 5 };
-                byte[] received = new byte[] { 0, 0, 0 };
+                    byte[] sent = new byte[] { 123, 0, 5 };
+                    byte[] received = new byte[] { 0, 0, 0 };
 
-                Task write = Task.Factory.FromAsync<byte[], int, int>(pair.writeablePipe.BeginWrite, pair.writeablePipe.EndWrite, sent, 0, sent.Length, null);
-                Task<int> read = Task.Factory.FromAsync<byte[], int, int, int>(pair.readablePipe.BeginRead, pair.readablePipe.EndRead, received, 0, received.Length, null);
-                Assert.Equal(sent.Length, await read);
-                Assert.Equal(sent, received);
-                await write;
+                    Task write = Task.Factory.FromAsync<byte[], int, int>(pair.writeablePipe.BeginWrite, pair.writeablePipe.EndWrite, sent, 0, sent.Length, null);
+                    Task<int> read = Task.Factory.FromAsync<byte[], int, int, int>(pair.readablePipe.BeginRead, pair.readablePipe.EndRead, received, 0, received.Length, null);
+                    Assert.Equal(sent.Length, await read);
+                    Assert.Equal(sent, received);
+                    await write;
+                }
             }
         }
 
@@ -374,34 +425,37 @@ namespace System.IO.Pipes.Tests
         [MemberData(nameof(AsyncReadWriteChain_MemberData))]
         public async Task AsyncReadWriteChain_ReadWrite_APM(int iterations, int writeBufferSize, int readBufferSize, bool cancelableToken)
         {
-            var writeBuffer = new byte[writeBufferSize];
-            var readBuffer = new byte[readBufferSize];
-            var rand = new Random();
-            var cancellationToken = cancelableToken ? new CancellationTokenSource().Token : CancellationToken.None;
-
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                // Repeatedly and asynchronously write to the writable pipe and read from the readable pipe,
-                // verifying that the correct data made it through.
-                for (int iter = 0; iter < iterations; iter++)
+                var writeBuffer = new byte[writeBufferSize];
+                var readBuffer = new byte[readBufferSize];
+                var rand = new Random();
+                var cancellationToken = cancelableToken ? new CancellationTokenSource().Token : CancellationToken.None;
+
+                using (ServerClientPair pair = CreateServerClientPair())
                 {
-                    rand.NextBytes(writeBuffer);
-                    Task write = Task.Factory.FromAsync<byte[], int, int>(pair.writeablePipe.BeginWrite, pair.writeablePipe.EndWrite, writeBuffer, 0, writeBuffer.Length, null);
-
-                    int totalRead = 0;
-                    while (totalRead < writeBuffer.Length)
+                    // Repeatedly and asynchronously write to the writable pipe and read from the readable pipe,
+                    // verifying that the correct data made it through.
+                    for (int iter = 0; iter < iterations; iter++)
                     {
-                        Task<int> read = Task.Factory.FromAsync<byte[], int, int, int>(pair.readablePipe.BeginRead, pair.readablePipe.EndRead, readBuffer, 0, readBuffer.Length, null);
-                        int numRead = await read;
-                        Assert.True(numRead > 0);
-                        Assert.Equal<byte>(
-                            new ArraySegment<byte>(writeBuffer, totalRead, numRead),
-                            new ArraySegment<byte>(readBuffer, 0, numRead));
-                        totalRead += numRead;
-                    }
-                    Assert.Equal(writeBuffer.Length, totalRead);
+                        rand.NextBytes(writeBuffer);
+                        Task write = Task.Factory.FromAsync<byte[], int, int>(pair.writeablePipe.BeginWrite, pair.writeablePipe.EndWrite, writeBuffer, 0, writeBuffer.Length, null);
 
-                    await write;
+                        int totalRead = 0;
+                        while (totalRead < writeBuffer.Length)
+                        {
+                            Task<int> read = Task.Factory.FromAsync<byte[], int, int, int>(pair.readablePipe.BeginRead, pair.readablePipe.EndRead, readBuffer, 0, readBuffer.Length, null);
+                            int numRead = await read;
+                            Assert.True(numRead > 0);
+                            Assert.Equal<byte>(
+                                new ArraySegment<byte>(writeBuffer, totalRead, numRead),
+                                new ArraySegment<byte>(readBuffer, 0, numRead));
+                            totalRead += numRead;
+                        }
+                        Assert.Equal(writeBuffer.Length, totalRead);
+
+                        await write;
+                    }
                 }
             }
         }

--- a/src/System.IO.Pipes/tests/PipeTest.Write.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Write.cs
@@ -14,200 +14,229 @@ namespace System.IO.Pipes.Tests
     /// </summary>
     public abstract class PipeTest_Write : PipeTestBase
     {
+        protected virtual bool ShouldSkipTest() => false;
+
         [Fact]
         public void WriteWithNullBuffer_Throws_ArgumentNullException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.writeablePipe;
-                Assert.True(pipe.IsConnected);
-                Assert.True(pipe.CanWrite);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.writeablePipe;
+                    Assert.True(pipe.IsConnected);
+                    Assert.True(pipe.CanWrite);
 
-                // Null is an invalid Buffer
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Write(null, 0, 1));
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.WriteAsync(null, 0, 1); });
+                    // Null is an invalid Buffer
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Write(null, 0, 1));
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.WriteAsync(null, 0, 1); });
 
-                // Buffer validity is checked before Offset
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Write(null, -1, 1));
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.WriteAsync(null, -1, 1); });
+                    // Buffer validity is checked before Offset
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Write(null, -1, 1));
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.WriteAsync(null, -1, 1); });
 
-                // Buffer validity is checked before Count
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Write(null, -1, -1));
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.WriteAsync(null, -1, -1); });
+                    // Buffer validity is checked before Count
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => pipe.Write(null, -1, -1));
+                    AssertExtensions.Throws<ArgumentNullException>("buffer", () => { pipe.WriteAsync(null, -1, -1); });
 
+                }
             }
         }
 
         [Fact]
         public void WriteWithNegativeOffset_Throws_ArgumentOutOfRangeException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.writeablePipe;
-                Assert.True(pipe.IsConnected);
-                Assert.True(pipe.CanWrite);
-                Assert.False(pipe.CanSeek);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.writeablePipe;
+                    Assert.True(pipe.IsConnected);
+                    Assert.True(pipe.CanWrite);
+                    Assert.False(pipe.CanSeek);
 
-                // Offset must be nonnegative
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => pipe.Write(new byte[5], -1, 1));
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => { pipe.WriteAsync(new byte[5], -1, 1); });
+                    // Offset must be nonnegative
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => pipe.Write(new byte[5], -1, 1));
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => { pipe.WriteAsync(new byte[5], -1, 1); });
+                }
             }
         }
 
         [Fact]
         public void WriteWithNegativeCount_Throws_ArgumentOutOfRangeException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.writeablePipe;
-                Assert.True(pipe.IsConnected);
-                Assert.True(pipe.CanWrite);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.writeablePipe;
+                    Assert.True(pipe.IsConnected);
+                    Assert.True(pipe.CanWrite);
 
-                // Count must be nonnegative
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => pipe.Write(new byte[5], 0, -1));
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => { pipe.WriteAsync(new byte[5], 0, -1); });
+                    // Count must be nonnegative
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => pipe.Write(new byte[5], 0, -1));
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => { pipe.WriteAsync(new byte[5], 0, -1); });
+                }
             }
         }
 
         [Fact]
         public void WriteWithOutOfBoundsArray_Throws_ArgumentException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.writeablePipe;
-                Assert.True(pipe.IsConnected);
-                Assert.True(pipe.CanWrite);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.writeablePipe;
+                    Assert.True(pipe.IsConnected);
+                    Assert.True(pipe.CanWrite);
 
-                // offset out of bounds
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[1], 1, 1));
+                    // offset out of bounds
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[1], 1, 1));
 
-                // offset out of bounds for 0 count read
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[1], 2, 0));
+                    // offset out of bounds for 0 count read
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[1], 2, 0));
 
-                // offset out of bounds even for 0 length buffer
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[0], 1, 0));
+                    // offset out of bounds even for 0 length buffer
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[0], 1, 0));
 
-                // combination offset and count out of bounds
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[2], 1, 2));
+                    // combination offset and count out of bounds
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[2], 1, 2));
 
-                // edges
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[0], int.MaxValue, 0));
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[0], int.MaxValue, int.MaxValue));
+                    // edges
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[0], int.MaxValue, 0));
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[0], int.MaxValue, int.MaxValue));
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[5], 3, 4));
+                    AssertExtensions.Throws<ArgumentException>(null, () => pipe.Write(new byte[5], 3, 4));
 
-                // offset out of bounds
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[1], 1, 1); });
+                    // offset out of bounds
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[1], 1, 1); });
 
-                // offset out of bounds for 0 count read
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[1], 2, 0); });
+                    // offset out of bounds for 0 count read
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[1], 2, 0); });
 
-                // offset out of bounds even for 0 length buffer
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[0], 1, 0); });
+                    // offset out of bounds even for 0 length buffer
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[0], 1, 0); });
 
-                // combination offset and count out of bounds
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[2], 1, 2); });
+                    // combination offset and count out of bounds
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[2], 1, 2); });
 
-                // edges
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[0], int.MaxValue, 0); });
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[0], int.MaxValue, int.MaxValue); });
+                    // edges
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[0], int.MaxValue, 0); });
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[0], int.MaxValue, int.MaxValue); });
 
-                AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[5], 3, 4); });
+                    AssertExtensions.Throws<ArgumentException>(null, () => { pipe.WriteAsync(new byte[5], 3, 4); });
+                }
             }
         }
 
         [Fact]
         public virtual void ReadOnWriteOnlyPipe_Throws_NotSupportedException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.writeablePipe;
-                Assert.True(pipe.IsConnected);
-                Assert.False(pipe.CanRead);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.writeablePipe;
+                    Assert.True(pipe.IsConnected);
+                    Assert.False(pipe.CanRead);
 
-                Assert.Throws<NotSupportedException>(() => pipe.Read(new byte[9], 0, 5));
+                    Assert.Throws<NotSupportedException>(() => pipe.Read(new byte[9], 0, 5));
 
-                Assert.Throws<NotSupportedException>(() => pipe.ReadByte());
+                    Assert.Throws<NotSupportedException>(() => pipe.ReadByte());
 
-                Assert.Throws<NotSupportedException>(() => pipe.InBufferSize);
+                    Assert.Throws<NotSupportedException>(() => pipe.InBufferSize);
 
-                Assert.Throws<NotSupportedException>(() => { pipe.ReadAsync(new byte[10], 0, 5); });
+                    Assert.Throws<NotSupportedException>(() => { pipe.ReadAsync(new byte[10], 0, 5); });
+                }
             }
         }
 
         [Fact]
         public async Task WriteZeroLengthBuffer_Nop()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.writeablePipe;
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.writeablePipe;
 
-                // Shouldn't throw
-                pipe.Write(Array.Empty<byte>(), 0, 0);
+                    // Shouldn't throw
+                    pipe.Write(Array.Empty<byte>(), 0, 0);
 
-                Task writeTask = pipe.WriteAsync(Array.Empty<byte>(), 0, 0);
-                await writeTask;
+                    Task writeTask = pipe.WriteAsync(Array.Empty<byte>(), 0, 0);
+                    await writeTask;
+                }
             }
         }
 
         [Fact]
         public void WritePipeUnsupportedMembers_Throws_NotSupportedException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.writeablePipe;
-                Assert.True(pipe.IsConnected);
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.writeablePipe;
+                    Assert.True(pipe.IsConnected);
 
-                Assert.Throws<NotSupportedException>(() => pipe.Length);
+                    Assert.Throws<NotSupportedException>(() => pipe.Length);
 
-                Assert.Throws<NotSupportedException>(() => pipe.SetLength(10L));
+                    Assert.Throws<NotSupportedException>(() => pipe.SetLength(10L));
 
-                Assert.Throws<NotSupportedException>(() => pipe.Position);
+                    Assert.Throws<NotSupportedException>(() => pipe.Position);
 
-                Assert.Throws<NotSupportedException>(() => pipe.Position = 10L);
+                    Assert.Throws<NotSupportedException>(() => pipe.Position = 10L);
 
-                Assert.Throws<NotSupportedException>(() => pipe.Seek(10L, System.IO.SeekOrigin.Begin));
+                    Assert.Throws<NotSupportedException>(() => pipe.Seek(10L, System.IO.SeekOrigin.Begin));
+                }
             }
         }
 
         [Fact]
         public void WriteToDisposedWriteablePipe_Throws_ObjectDisposedException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                PipeStream pipe = pair.writeablePipe;
-                pipe.Dispose();
-                byte[] buffer = new byte[] { 0, 0, 0, 0 };
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    PipeStream pipe = pair.writeablePipe;
+                    pipe.Dispose();
+                    byte[] buffer = new byte[] { 0, 0, 0, 0 };
 
-                Assert.Throws<ObjectDisposedException>(() => pipe.Write(buffer, 0, buffer.Length));
-                Assert.Throws<ObjectDisposedException>(() => pipe.WriteByte(5));
-                Assert.Throws<ObjectDisposedException>(() => { pipe.WriteAsync(buffer, 0, buffer.Length); });
-                Assert.Throws<ObjectDisposedException>(() => pipe.Flush());
-                Assert.Throws<ObjectDisposedException>(() => pipe.IsMessageComplete);
-                Assert.Throws<ObjectDisposedException>(() => pipe.ReadMode);
+                    Assert.Throws<ObjectDisposedException>(() => pipe.Write(buffer, 0, buffer.Length));
+                    Assert.Throws<ObjectDisposedException>(() => pipe.WriteByte(5));
+                    Assert.Throws<ObjectDisposedException>(() => { pipe.WriteAsync(buffer, 0, buffer.Length); });
+                    Assert.Throws<ObjectDisposedException>(() => pipe.Flush());
+                    Assert.Throws<ObjectDisposedException>(() => pipe.IsMessageComplete);
+                    Assert.Throws<ObjectDisposedException>(() => pipe.ReadMode);
+                }
             }
         }
 
         [Fact]
         public virtual void WriteToPipeWithClosedPartner_Throws_IOException()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-                    (pair.readablePipe is NamedPipeClientStream || pair.writeablePipe is NamedPipeClientStream))
+                using (ServerClientPair pair = CreateServerClientPair())
                 {
-                    // On Unix, NamedPipe*Stream is implemented in term of sockets, where information 
-                    // about shutdown is not immediately propagated.
-                    return;
+                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                        (pair.readablePipe is NamedPipeClientStream || pair.writeablePipe is NamedPipeClientStream))
+                    {
+                        // On Unix, NamedPipe*Stream is implemented in term of sockets, where information 
+                        // about shutdown is not immediately propagated.
+                        return;
+                    }
+
+                    pair.readablePipe.Dispose();
+                    byte[] buffer = new byte[] { 0, 0, 0, 0 };
+
+                    Assert.Throws<IOException>(() => pair.writeablePipe.Write(buffer, 0, buffer.Length));
+                    Assert.Throws<IOException>(() => pair.writeablePipe.WriteByte(123));
+                    Assert.Throws<IOException>(() => { pair.writeablePipe.WriteAsync(buffer, 0, buffer.Length); });
+                    Assert.Throws<IOException>(() => pair.writeablePipe.Flush());
                 }
-
-                pair.readablePipe.Dispose();
-                byte[] buffer = new byte[] { 0, 0, 0, 0 };
-
-                Assert.Throws<IOException>(() => pair.writeablePipe.Write(buffer, 0, buffer.Length));
-                Assert.Throws<IOException>(() => pair.writeablePipe.WriteByte(123));
-                Assert.Throws<IOException>(() => { pair.writeablePipe.WriteAsync(buffer, 0, buffer.Length); });
-                Assert.Throws<IOException>(() => pair.writeablePipe.Flush());
             }
         }
 
@@ -215,13 +244,16 @@ namespace System.IO.Pipes.Tests
         [ActiveIssue("dotnet/corefx #19287", TargetFrameworkMonikers.NetFramework)]
         public async Task ValidFlush_DoesntThrow()
         {
-            using (ServerClientPair pair = CreateServerClientPair())
+            if (!ShouldSkipTest())
             {
-                Task write = Task.Run(() => pair.writeablePipe.WriteByte(123));
-                pair.writeablePipe.Flush();
-                Assert.Equal(123, pair.readablePipe.ReadByte());
-                await write;
-                await pair.writeablePipe.FlushAsync();
+                using (ServerClientPair pair = CreateServerClientPair())
+                {
+                    Task write = Task.Run(() => pair.writeablePipe.WriteByte(123));
+                    pair.writeablePipe.Flush();
+                    Assert.Equal(123, pair.readablePipe.ReadByte());
+                    await write;
+                    await pair.writeablePipe.FlushAsync();
+                }
             }
         }
     }


### PR DESCRIPTION
Cc @danmosemsft @joshfree @safern 

Adding tests back conditionally for new Windows version. This doesn't close the related issue yet, because there are two more tests still failing (pingpong_async and PingPong_sync). I'll continue investigating those to see why did we get that regression.