### PR TITLE
Avoid byte[] allocations for IPAddress in System.Net.Sockets

### DIFF
--- a/src/Common/src/System/Net/Internals/IPAddressExtensions.cs
+++ b/src/Common/src/System/Net/Internals/IPAddressExtensions.cs
@@ -18,17 +18,19 @@ namespace System.Net.Sockets
 #pragma warning restore CS0618
 
                 case AddressFamily.InterNetworkV6:
-                    return new IPAddress(original.GetAddressBytes(), (uint)original.ScopeId);
+                    Span<byte> addressBytes;
+                    unsafe
+                    {
+                        // TODO https://github.com/dotnet/roslyn/issues/17287: Clean up once we can stackalloc into a span
+                        byte* mem = stackalloc byte[IPAddressParserStatics.IPv6AddressBytes];
+                        addressBytes = new Span<byte>(mem, IPAddressParserStatics.IPv6AddressBytes);
+                    }
+                    original.TryWriteBytes(addressBytes, out int bytesWritten);
+                    Debug.Assert(bytesWritten == IPAddressParserStatics.IPv6AddressBytes);
+                    return new IPAddress(addressBytes, (uint)original.ScopeId);
             }
 
             throw new InternalException();
-        }
-
-        public static long GetAddress(this IPAddress thisObj)
-        {
-            byte[] addressBytes = thisObj.GetAddressBytes();
-            Debug.Assert(addressBytes.Length == 4);
-            return (long)BitConverter.ToInt32(addressBytes, 0);
         }
     }
 }

--- a/src/Common/src/System/Net/InteropIPAddressExtensions.Unix.cs
+++ b/src/Common/src/System/Net/InteropIPAddressExtensions.Unix.cs
@@ -13,14 +13,9 @@ namespace System.Net
         {
             var nativeIPAddress = default(Interop.Sys.IPAddress);
 
-            byte[] bytes = ipAddress.GetAddressBytes();
-            Debug.Assert(bytes.Length == sizeof(uint) || bytes.Length == Interop.Sys.IPv6AddressBytes, $"Unexpected length: {bytes.Length}");
+            ipAddress.TryWriteBytes(new Span<byte>(nativeIPAddress.Address, Interop.Sys.IPv6AddressBytes), out int bytesWritten);
+            Debug.Assert(bytesWritten == sizeof(uint) || bytesWritten == Interop.Sys.IPv6AddressBytes, $"Unexpected length: {bytesWritten}");
 
-            for (int i = 0; i < bytes.Length && i < Interop.Sys.IPv6AddressBytes; i++)
-            {
-                nativeIPAddress.Address[i] = bytes[i];
-            }
-            
             if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
             {
                 nativeIPAddress.IsIPv6 = true;
@@ -39,13 +34,9 @@ namespace System.Net
             }
             else
             {
-                byte[] address = new byte[Interop.Sys.IPv6AddressBytes];
-                for (int b = 0; b < Interop.Sys.IPv6AddressBytes; b++)
-                {
-                    address[b] = nativeIPAddress.Address[b];
-                }
-
-                return new IPAddress(address, (long)nativeIPAddress.ScopeId);
+                return new IPAddress(
+                    new Span<byte>(nativeIPAddress.Address, Interop.Sys.IPv6AddressBytes),
+                    (long)nativeIPAddress.ScopeId);
             }
         }
     }

--- a/src/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -114,12 +114,12 @@ namespace System.Net
             return ipAddress;
         }
 
-        public static unsafe void GetIPv6Address(byte[] buffer, byte[] address, out uint scope)
+        public static unsafe void GetIPv6Address(byte[] buffer, Span<byte> address, out uint scope)
         {
             uint localScope;
             Interop.Error err;
             fixed (byte* rawAddress = buffer)
-            fixed (byte* ipAddress = address)
+            fixed (byte* ipAddress = &address.DangerousGetPinnableReference())
             {
                 err = Interop.Sys.GetIPv6Address(rawAddress, buffer.Length, ipAddress, address.Length, &localScope);
             }
@@ -145,9 +145,9 @@ namespace System.Net
             SetIPv4Address(buffer, addr);
         }
 
-        public static unsafe void SetIPv6Address(byte[] buffer, byte[] address, uint scope)
+        public static unsafe void SetIPv6Address(byte[] buffer, Span<byte> address, uint scope)
         {
-            fixed (byte* rawInput = address)
+            fixed (byte* rawInput = &address.DangerousGetPinnableReference())
             {
                 SetIPv6Address(buffer, rawInput, address.Length, scope);
             }

--- a/src/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -49,7 +49,7 @@ namespace System.Net
             }
         }
 
-        public static unsafe void GetIPv6Address(byte[] buffer, byte[] address, out uint scope)
+        public static unsafe void GetIPv6Address(byte[] buffer, Span<byte> address, out uint scope)
         {
             for (int i = 0; i < address.Length; i++)
             {
@@ -72,7 +72,7 @@ namespace System.Net
             buffer[7] = unchecked((byte)(address >> 24));
         }
 
-        public static unsafe void SetIPv6Address(byte[] buffer, byte[] address, uint scope)
+        public static unsafe void SetIPv6Address(byte[] buffer, Span<byte> address, uint scope)
         {
             // No handling for Flow Information
             buffer[4] = (byte)0;

--- a/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -40,6 +40,9 @@
     <Compile Include="$(CommonPath)\System\Net\Sockets\SocketType.cs">
       <Link>Common\System\Net\Sockets\SocketType.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\IPAddressParserStatics.cs">
+      <Link>Common\System\Net\IPAddressParserStatics.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\IPEndPointStatics.cs">
       <Link>Common\System\Net\IPEndPointStatics.cs</Link>
     </Compile>

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -172,7 +172,9 @@ namespace System.Net
         public static IPHostEntry GetHostByAddr(IPAddress address)
         {
             // TODO #2891: Optimize this (or decide if this legacy code can be removed):
-            int addressAsInt = unchecked((int)address.GetAddress());
+#pragma warning disable CS0618 // Address is marked obsolete
+            int addressAsInt = unchecked((int)address.Address);
+#pragma warning restore CS0618
 
 #if BIGENDIAN
             // TODO #2891: above code needs testing for BIGENDIAN.

--- a/src/System.Net.NameResolution/tests/PalTests/Fakes/IPAddressFakeExtensions.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/Fakes/IPAddressFakeExtensions.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Net
+{
+    internal static class IPAddressFakeExtensions
+    {
+        public static bool TryWriteBytes(this IPAddress address, Span<byte> destination, out int bytesWritten)
+        {
+            byte[] bytes = address.GetAddressBytes();
+            if (bytes.Length >= destination.Length)
+            {
+                new ReadOnlySpan<byte>(bytes).CopyTo(destination);
+                bytesWritten = bytes.Length;
+                return true;
+            }
+            else
+            {
+                bytesWritten = 0;
+                return false;
+            }
+        }
+    }
+}

--- a/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
+++ b/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <Compile Include="NameResolutionPalTests.cs" />
     <Compile Include="Fakes\DebugThreadTracking.cs" />
+    <Compile Include="Fakes\IPAddressFakeExtensions.cs" />
     <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.cs</Link>
     </Compile>
@@ -40,6 +41,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\IPEndPointStatics.cs">
       <Link>Common\System\Net\IPEndPointStatics.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\IPAddressParserStatics.cs">
+      <Link>Common\System\Net\IPAddressParserStatics.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
@@ -64,10 +68,6 @@
     <!-- Debug only -->
     <Compile Include="$(CommonPath)\System\Net\DebugSafeHandle.cs">
       <Link>Common\System\Net\DebugSafeHandle.cs</Link>
-    </Compile>
-    <!-- System.Net.Internals -->
-    <Compile Include="$(CommonPath)\System\Net\Internals\IPAddressExtensions.cs">
-      <Link>Common\System\Net\Internals\IPAddressExtensions.cs</Link>
     </Compile>
     <!-- Interop -->
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
@@ -90,7 +90,9 @@ namespace System.Net.NetworkInformation
                         pingEventSafeWaitHandle,
                         IntPtr.Zero,
                         IntPtr.Zero,
-                        (uint)address.GetAddress(),
+#pragma warning disable CS0618 // Address is marked obsolete
+                        (uint)address.Address,
+#pragma warning restore CS0618
                         _requestBuffer,
                         (ushort)buffer.Length,
                         ref ipOptions,

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1130,11 +1130,14 @@ namespace System.Net.Sockets
 
             IPAddress localAddress = optionValue.LocalAddress ?? IPAddress.Any;
 
-            var opt = new Interop.Sys.IPv4MulticastOption {
-                MulticastAddress = unchecked((uint)optionValue.Group.GetAddress()),
-                LocalAddress = unchecked((uint)localAddress.GetAddress()),
+#pragma warning disable CS0618 // Address is marked obsolete
+            var opt = new Interop.Sys.IPv4MulticastOption
+            {
+                MulticastAddress = unchecked((uint)optionValue.Group.Address),
+                LocalAddress = unchecked((uint)localAddress.Address),
                 InterfaceIndex = optionValue.InterfaceIndex
             };
+#pragma warning restore CS0618
 
             Interop.Error err = Interop.Sys.SetIPv4MulticastOption(handle, optName, &opt);
             return GetErrorAndTrackSetting(handle, SocketOptionLevel.IP, optionName, err);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -323,13 +323,9 @@ namespace System.Net.Sockets
 
         public static unsafe IPPacketInformation GetIPPacketInformation(Interop.Winsock.ControlDataIPv6* controlBuffer)
         {
-            IPAddress address = IPAddress.IPv6None;
-            if (controlBuffer->length != UIntPtr.Zero)
-            {
-                var addressArray = new byte[Interop.Winsock.IPv6AddressLength];
-                Marshal.Copy((IntPtr)(controlBuffer->address), addressArray, 0, Interop.Winsock.IPv6AddressLength);
-                address = new IPAddress(addressArray);
-            }
+            IPAddress address = controlBuffer->length != UIntPtr.Zero ?
+                new IPAddress(new Span<byte>(controlBuffer->address, Interop.Winsock.IPv6AddressLength)) :
+                IPAddress.IPv6None;
 
             return new IPPacketInformation(address, (int)controlBuffer->index);
         }
@@ -491,11 +487,15 @@ namespace System.Net.Sockets
         {
             Interop.Winsock.IPMulticastRequest ipmr = new Interop.Winsock.IPMulticastRequest();
 
-            ipmr.MulticastAddress = unchecked((int)optionValue.Group.GetAddress());
+#pragma warning disable CS0618 // Address is marked obsolete
+            ipmr.MulticastAddress = unchecked((int)optionValue.Group.Address);
+#pragma warning restore CS0618
 
             if (optionValue.LocalAddress != null)
             {
-                ipmr.InterfaceAddress = unchecked((int)optionValue.LocalAddress.GetAddress());
+#pragma warning disable CS0618 // Address is marked obsolete
+                ipmr.InterfaceAddress = unchecked((int)optionValue.LocalAddress.Address);
+#pragma warning restore CS0618
             }
             else
             {  //this structure works w/ interfaces as well


### PR DESCRIPTION
Use the new span-based overloads to avoid byte[] allocations when constructing IPAddresses in System.Net.Sockets.

cc: @geoffkizer, @Priya91, @davidsh, @cipop