### PR TITLE
Remove Span(T[],int) ctor from System.Runtime

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -1836,7 +1836,6 @@ namespace System
     {
         public static ReadOnlySpan<T> Empty { get { throw null; } }
         public ReadOnlySpan(T[] array) { throw null; }
-        public ReadOnlySpan(T[] array, int start) { throw null; }
         public ReadOnlySpan(T[] array, int start, int length) { throw null; }
         [CLSCompliant(false)]
         public unsafe ReadOnlySpan(void* pointer, int length) { throw null; }
@@ -2022,7 +2021,6 @@ namespace System
     {
         public static Span<T> Empty { get { throw null; } }
         public Span(T[] array) { throw null; }
-        public Span(T[] array, int start) { throw null; }
         public Span(T[] array, int start, int length) { throw null; }
         [CLSCompliant(false)]
         public unsafe Span(void* pointer, int length) { throw null; }


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/23530 removed the {ReadOnly}Span(T[],int) ctor from the System.Memory ref, but it missed removing it from the System.Runtime ref.  corefx will fail to build against the latest coreclr without those being removed, too.

cc: @ahsonkhan, @jkotas