### PR TITLE
Remove some assertions from AssertDefaultPageSettings in PrintDocumentTests.cs.

### DIFF
--- a/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
@@ -249,14 +249,10 @@ namespace System.Drawing.Printing.Tests
             {
                 case PaperKind.A4:
                     Assert.Equal(new Rectangle(0, 0, 827, 1169), pageSettings.Bounds);
-                    Assert.Equal(827, pageSettings.PrintableArea.Width, 0);
-                    Assert.Equal(1169, pageSettings.PrintableArea.Height, 0);
                     break;
 
                 case PaperKind.Letter:
                     Assert.Equal(new Rectangle(0, 0, 850, 1100), pageSettings.Bounds);
-                    Assert.Equal(850, pageSettings.PrintableArea.Width, 0);
-                    Assert.Equal(1100, pageSettings.PrintableArea.Height, 0);
                     break;
 
                 default:
@@ -264,12 +260,8 @@ namespace System.Drawing.Printing.Tests
                     break;
             }
 
-            Assert.True(pageSettings.Color);
-            Assert.Equal(0, pageSettings.HardMarginX);
-            Assert.Equal(0, pageSettings.HardMarginY);
             Assert.False(pageSettings.Landscape);
             Assert.Equal(PaperSourceKind.FormSource, pageSettings.PaperSource.Kind);
-            Assert.Equal(new PointF(0f, 0f), pageSettings.PrintableArea.Location);
             Assert.Equal(PrinterResolutionKind.Custom, pageSettings.PrinterResolution.Kind);
             Assert.True(pageSettings.PrinterSettings.IsDefaultPrinter);
         }


### PR DESCRIPTION
After some system update (or maybe some other system configuration change), these assertions started to fail for me on my machine. They seem to be system-dependent, and not some sort of global default, so I've just removed them.

@KostaVlev 