### PR TITLE
Fix two bugs in HttpUtility and increase test coverage from 84.9% to 100%

### DIFF
--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -48,6 +48,8 @@ namespace System.Web
             if (encoding == null)
                 throw new ArgumentNullException(nameof(encoding));
 
+            query = HtmlDecode(query);
+
             if ((query.Length > 0) && (query[0] == '?'))
                 query = query.Substring(1);
 
@@ -56,15 +58,13 @@ namespace System.Web
             return result;
         }
 
-        private static void ParseQueryString(string query, Encoding encoding, NameValueCollection result)
+        private static void ParseQueryString(string decoded, Encoding encoding, NameValueCollection result)
         {
-            if (query.Length == 0)
+            if (decoded.Length == 0)
                 return;
 
-            var decoded = HtmlDecode(query);
             var decodedLength = decoded.Length;
             var namePos = 0;
-            var first = true;
             while (namePos <= decodedLength)
             {
                 int valuePos = -1, valueEnd = -1;
@@ -79,13 +79,6 @@ namespace System.Web
                         break;
                     }
 
-                if (first)
-                {
-                    first = false;
-                    if (decoded[namePos] == '?')
-                        namePos++;
-                }
-
                 string name;
                 if (valuePos == -1)
                 {
@@ -98,18 +91,13 @@ namespace System.Web
                 }
                 if (valueEnd < 0)
                 {
-                    namePos = -1;
                     valueEnd = decoded.Length;
                 }
-                else
-                {
-                    namePos = valueEnd + 1;
-                }
+
+                namePos = valueEnd + 1;
                 var value = UrlDecode(decoded.Substring(valuePos, valueEnd - valuePos), encoding);
 
                 result.Add(name, value);
-                if (namePos == -1)
-                    break;
             }
         }
 

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -288,7 +288,7 @@ namespace System.Web
 
         public static string JavaScriptStringEncode(string value)
         {
-            return JavaScriptStringEncode(value, false);
+            return HttpEncoder.JavaScriptStringEncode(value);
         }
 
         public static string JavaScriptStringEncode(string value, bool addDoubleQuotes)

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -269,7 +269,7 @@ namespace System.Web
          )]
         public static string UrlEncodeUnicode(string str)
         {
-            return HttpEncoder.UrlEncodeUnicode(str, ignoreAscii: false);
+            return HttpEncoder.UrlEncodeUnicode(str);
         }
 
         public static string UrlDecode(string str, Encoding e)

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -256,12 +256,12 @@ namespace System.Web
             if (str == null)
                 return null;
             var bytes = e.GetBytes(str);
-            return HttpEncoder.UrlEncode(bytes, 0, bytes.Length, false /* alwaysCreateNewReturnValue */);
+            return HttpEncoder.UrlEncode(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
         }
 
         public static byte[] UrlEncodeToBytes(byte[] bytes, int offset, int count)
         {
-            return HttpEncoder.UrlEncode(bytes, offset, count, true /* alwaysCreateNewReturnValue */);
+            return HttpEncoder.UrlEncode(bytes, offset, count, alwaysCreateNewReturnValue: true);
         }
 
         [Obsolete(
@@ -269,7 +269,7 @@ namespace System.Web
          )]
         public static string UrlEncodeUnicode(string str)
         {
-            return HttpEncoder.UrlEncodeUnicode(str, false /* ignoreAscii */);
+            return HttpEncoder.UrlEncodeUnicode(str, ignoreAscii: false);
         }
 
         public static string UrlDecode(string str, Encoding e)

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -30,9 +30,8 @@ namespace System.Web
                 {
                     sb.AppendFormat("{0}={1}&", keys[i], UrlEncode(this[keys[i]]));
                 }
-                if (sb.Length > 0)
-                    sb.Length--;
-                return sb.ToString();
+
+                return sb.ToString(0, sb.Length - 1);
             }
         }
 

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -248,7 +248,7 @@ namespace System.Web
         {
             if (bytes == null)
                 return null;
-            return UrlDecodeToBytes(bytes, 0, bytes != null ? bytes.Length : 0);
+            return UrlDecodeToBytes(bytes, 0, bytes.Length);
         }
 
         public static byte[] UrlEncodeToBytes(string str, Encoding e)

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -164,7 +164,6 @@ namespace System.Web
             return UrlEncode(str, Encoding.UTF8);
         }
 
-
         public static string UrlPathEncode(string str)
         {
             return HttpEncoder.UrlPathEncode(str);

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -570,7 +570,7 @@ namespace System.Web.Util
         }
 
         [Obsolete("This method produces non-standards-compliant output and has interoperability issues. The preferred alternative is UrlEncode(*).")]
-        internal static string UrlEncodeUnicode(string value, bool ignoreAscii)
+        internal static string UrlEncodeUnicode(string value)
         {
             if (value == null)
             {
@@ -586,7 +586,7 @@ namespace System.Web.Util
 
                 if ((ch & 0xff80) == 0)
                 {  // 7 bit?
-                    if (ignoreAscii || HttpEncoderUtility.IsUrlSafeChar(ch))
+                    if (HttpEncoderUtility.IsUrlSafeChar(ch))
                     {
                         sb.Append(ch);
                     }

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -528,11 +528,6 @@ namespace System.Web.Util
 
         private static byte[] UrlEncodeNonAscii(byte[] bytes, int offset, int count)
         {
-            if (!ValidateUrlEncodingParameters(bytes, offset, count))
-            {
-                return null;
-            }
-
             int cNonAscii = 0;
 
             // count them first

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -517,10 +517,8 @@ namespace System.Web.Util
         //  Helper to encode the non-ASCII url characters only
         private static string UrlEncodeNonAscii(string str, Encoding e)
         {
-            if (string.IsNullOrEmpty(str))
-                return str;
-            if (e == null)
-                e = Encoding.UTF8;
+            Debug.Assert(!string.IsNullOrEmpty(str));
+            Debug.Assert(e != null);
             byte[] bytes = e.GetBytes(str);
             byte[] encodedBytes = UrlEncodeNonAscii(bytes, 0, bytes.Length);
             return Encoding.ASCII.GetString(encodedBytes);

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -211,41 +211,38 @@ namespace System.Web.Util
 
                     startIndex = i + 1;
                     count = 0;
-                }
 
-                switch (c)
-                {
-                    case '\r':
-                        b.Append("\\r");
-                        break;
-                    case '\t':
-                        b.Append("\\t");
-                        break;
-                    case '\"':
-                        b.Append("\\\"");
-                        break;
-                    case '\\':
-                        b.Append("\\\\");
-                        break;
-                    case '\n':
-                        b.Append("\\n");
-                        break;
-                    case '\b':
-                        b.Append("\\b");
-                        break;
-                    case '\f':
-                        b.Append("\\f");
-                        break;
-                    default:
-                        if (CharRequiresJavaScriptEncoding(c))
-                        {
+                    switch (c)
+                    {
+                        case '\r':
+                            b.Append("\\r");
+                            break;
+                        case '\t':
+                            b.Append("\\t");
+                            break;
+                        case '\"':
+                            b.Append("\\\"");
+                            break;
+                        case '\\':
+                            b.Append("\\\\");
+                            break;
+                        case '\n':
+                            b.Append("\\n");
+                            break;
+                        case '\b':
+                            b.Append("\\b");
+                            break;
+                        case '\f':
+                            b.Append("\\f");
+                            break;
+                        default:
                             AppendCharAsUnicodeJavaScript(b, c);
-                        }
-                        else
-                        {
-                            count++;
-                        }
-                        break;
+                            break;
+                    }
+                }
+                else
+                {
+                    count++;
                 }
             }
 

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -522,11 +522,11 @@ namespace System.Web.Util
             if (e == null)
                 e = Encoding.UTF8;
             byte[] bytes = e.GetBytes(str);
-            byte[] encodedBytes = UrlEncodeNonAscii(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
+            byte[] encodedBytes = UrlEncodeNonAscii(bytes, 0, bytes.Length);
             return Encoding.ASCII.GetString(encodedBytes);
         }
 
-        private static byte[] UrlEncodeNonAscii(byte[] bytes, int offset, int count, bool alwaysCreateNewReturnValue)
+        private static byte[] UrlEncodeNonAscii(byte[] bytes, int offset, int count)
         {
             if (!ValidateUrlEncodingParameters(bytes, offset, count))
             {
@@ -543,7 +543,7 @@ namespace System.Web.Util
             }
 
             // nothing to expand?
-            if (!alwaysCreateNewReturnValue && cNonAscii == 0)
+            if (cNonAscii == 0)
                 return bytes;
 
             // expand not 'safe' characters into %XX, spaces to +s

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -522,7 +522,7 @@ namespace System.Web.Util
             if (e == null)
                 e = Encoding.UTF8;
             byte[] bytes = e.GetBytes(str);
-            byte[] encodedBytes = UrlEncodeNonAscii(bytes, 0, bytes.Length, false /* alwaysCreateNewReturnValue */);
+            byte[] encodedBytes = UrlEncodeNonAscii(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
             return Encoding.ASCII.GetString(encodedBytes);
         }
 

--- a/src/System.Web.HttpUtility/src/System/Web/Util/UriUtil.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/UriUtil.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System.Web.Util
 {
     internal static class UriUtil
@@ -50,13 +52,11 @@ namespace System.Web.Util
                     // To retain the same string as originally given, find the authority in the original url and include
                     // everything up to that.
                     int authorityIndex = inputWithoutQueryFragment.IndexOf(authority, StringComparison.OrdinalIgnoreCase);
-                    if (authorityIndex != -1)
-                    {
-                        int schemeAndAuthorityLength = authorityIndex + authority.Length;
-                        schemeAndAuthority = inputWithoutQueryFragment.Substring(0, schemeAndAuthorityLength);
-                        path = inputWithoutQueryFragment.Substring(schemeAndAuthorityLength);
-                        return true;
-                    }
+                    Debug.Assert(authorityIndex != -1); // Otherwise authority would be null or empty.
+                    int schemeAndAuthorityLength = authorityIndex + authority.Length;
+                    schemeAndAuthority = inputWithoutQueryFragment.Substring(0, schemeAndAuthorityLength);
+                    path = inputWithoutQueryFragment.Substring(schemeAndAuthorityLength);
+                    return true;
                 }
             }
 

--- a/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -33,7 +33,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Web;
 using Xunit;
 
 namespace System.Web.Tests
@@ -51,6 +50,8 @@ namespace System.Web.Tests
                 new object[] {"&lt;script>", "<script>"},
                 new object[] {"&quot;a&amp;b&quot;", "\"a&b\""},
                 new object[] {"&#39;string&#39;", "'string'"},
+                new object[] {"abc + def!", "abc + def!"},
+                new object[] {"This is an &lt;element>!", "This is an <element>!"},
             };
 
         [Theory]
@@ -240,10 +241,8 @@ namespace System.Web.Tests
                 {
                     "\u00A0¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ",
                     @"&#160;&#161;&#162;&#163;&#164;&#165;&#166;&#167;&#168;&#169;&#170;&#171;&#172;&#173;&#174;&#175;&#176;&#177;&#178;&#179;&#180;&#181;&#182;&#183;&#184;&#185;&#186;&#187;&#188;&#189;&#190;&#191;&#192;&#193;&#194;&#195;&#196;&#197;&#198;&#199;&#200;&#201;&#202;&#203;&#204;&#205;&#206;&#207;&#208;&#209;&#210;&#211;&#212;&#213;&#214;&#215;&#216;&#217;&#218;&#219;&#220;&#221;&#222;&#223;&#224;&#225;&#226;&#227;&#228;&#229;&#230;&#231;&#232;&#233;&#234;&#235;&#236;&#237;&#238;&#239;&#240;&#241;&#242;&#243;&#244;&#245;&#246;&#247;&#248;&#249;&#250;&#251;&#252;&#253;&#254;&#255;",
-                },
+                }
             };
-
-
 
         [Theory]
         [MemberData(nameof(HtmlEncodeDecodeData))]
@@ -252,6 +251,16 @@ namespace System.Web.Tests
         public void HtmlEncode(string decoded, string encoded)
         {
             Assert.Equal(encoded, HttpUtility.HtmlEncode(decoded));
+        }
+
+        [Theory]
+        [MemberData(nameof(HtmlEncodeDecodeData))]
+        [MemberData(nameof(HtmlEncodeData))]
+        [InlineData(null, null)]
+        [InlineData(2, "2")]
+        public void HtmlEncodeObject(string decoded, string encoded)
+        {
+            Assert.Equal(encoded, HttpUtility.HtmlEncode((object)decoded));
         }
 
         [Theory]
@@ -284,6 +293,8 @@ namespace System.Web.Tests
             {
                 yield return new object[] { null, "" };
                 yield return new object[] { "", "" };
+                yield return new object[] {"No escaping needed.", "No escaping needed."};
+                yield return new object[] {"The \t and \n will need to be escaped.", "The \\t and \\n will need to be escaped."};
                 for (char c = char.MinValue; c < TestMaxChar; c++)
                 {
                     if (c >= 0 && c <= 7 || c == 11 || c >= 14 && c <= 31 || c == 38 || c == 39 || c == 60 || c == 62 || c == 133 || c == 8232 || c == 8233)
@@ -365,6 +376,7 @@ namespace System.Web.Tests
                     new[] {new[] {UnicodeStr}}
                 },
                 new object[] {"name=value=test", new[] {"name"}, new[] {new[] {"value=test"}}},
+                new object[] {"name=value=test+phrase", new[] {"name"}, new[] {new[] {"value=test phrase"}}},
             };
 
         public static IEnumerable<object[]> ParseQueryStringDataQ =>
@@ -407,10 +419,13 @@ namespace System.Web.Tests
         public void ParseQueryString_ToString()
         {
             var parsed = HttpUtility.ParseQueryString("");
+            Assert.Empty(parsed.ToString());
             parsed.Add("ReturnUrl", @"http://localhost/login/authenticate?ReturnUrl=http://localhost/secured_area&__provider__=google");
 
             var expected = "ReturnUrl=http%3a%2f%2flocalhost%2flogin%2fauthenticate%3fReturnUrl%3dhttp%3a%2f%2flocalhost%2fsecured_area%26__provider__%3dgoogle";
             Assert.Equal(expected, parsed.ToString());
+            Assert.Equal(expected, HttpUtility.ParseQueryString(expected).ToString());
+            Assert.Equal(expected, HttpUtility.ParseQueryString("&#x3F;" + expected).ToString());
         }
 
         #endregion ParseQueryString
@@ -428,6 +443,12 @@ namespace System.Web.Tests
                 new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=bar", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%u0061r"},
                 new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=b%ar", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%%u0061r"},
                 new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=b%uu0061r", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%uu0061r"},
+                new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=bar baz", "http://127.0.0.1:8080/appDir/page.aspx?foo=bar+baz"},
+                new object[] { "http://example.net/\U00010000", "http://example.net/\U00010000" },
+                new object[] { "http://example.net/\uFFFD", "http://example.net/\uD800" },
+                new object[] { "http://example.net/\uFFFDa", "http://example.net/\uD800a" },
+                new object[] { "http://example.net/\uFFFD", "http://example.net/\uDC00" },
+                new object[] { "http://example.net/\uFFFDa", "http://example.net/\uDC00a" }
             };
 
         public static IEnumerable<object[]> UrlDecodeDataToBytes =>
@@ -441,6 +462,12 @@ namespace System.Web.Tests
                 new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=b%uu0061r", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%uu0061r"},
                 new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=b%u0061r", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%u0061r"},
                 new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=b%%u0061r", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%%u0061r"},
+                new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=bar baz", "http://127.0.0.1:8080/appDir/page.aspx?foo=bar+baz"},
+                new object[] { "http://example.net/\U00010000", "http://example.net/\U00010000" },
+                new object[] { "http://example.net/\uFFFD", "http://example.net/\uD800" },
+                new object[] { "http://example.net/\uFFFDa", "http://example.net/\uD800a" },
+                new object[] { "http://example.net/\uFFFD", "http://example.net/\uDC00" },
+                new object[] { "http://example.net/\uFFFDa", "http://example.net/\uDC00a" }
             };
 
         [Theory]
@@ -450,11 +477,58 @@ namespace System.Web.Tests
             Assert.Equal(decoded, HttpUtility.UrlDecode(encoded));
         }
 
+        [Fact]
+        public void UrlDecode_null()
+        {
+            Assert.Null(HttpUtility.UrlDecode(default(string), Encoding.UTF8));
+            Assert.Null(HttpUtility.UrlDecode(default(byte[]), Encoding.UTF8));
+            Assert.Null(HttpUtility.UrlDecode(null));
+            Assert.Null(HttpUtility.UrlDecode(null, 2, 0, Encoding.UTF8));
+            Assert.Throws<ArgumentNullException>("bytes", () => HttpUtility.UrlDecode(null, 2, 3, Encoding.UTF8));
+        }
+
+        [Fact]
+        public void UrlDecode_OutOfRange()
+        {
+            byte[] bytes = { 0, 1, 2 };
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => HttpUtility.UrlDecode(bytes, -1, 2, Encoding.UTF8));
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => HttpUtility.UrlDecode(bytes, 14, 2, Encoding.UTF8));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => HttpUtility.UrlDecode(bytes, 1, 12, Encoding.UTF8));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => HttpUtility.UrlDecode(bytes, 1, -12, Encoding.UTF8));
+        }
+
         [Theory]
         [MemberData(nameof(UrlDecodeDataToBytes))]
         public void UrlDecodeToBytes(string decoded, string encoded)
         {
             Assert.Equal(decoded, Encoding.UTF8.GetString(HttpUtility.UrlDecodeToBytes(encoded, Encoding.UTF8)));
+        }
+
+        [Theory]
+        [MemberData(nameof(UrlDecodeDataToBytes))]
+        public void UrlDecodeToBytes_DefaultEncoding(string decoded, string encoded)
+        {
+            Assert.Equal(decoded, Encoding.UTF8.GetString(HttpUtility.UrlDecodeToBytes(encoded)));
+        }
+
+        [Fact]
+        public void UrlDecodeToBytes_null()
+        {
+            Assert.Null(HttpUtility.UrlDecodeToBytes(default(byte[])));
+            Assert.Null(HttpUtility.UrlDecodeToBytes(default(string)));
+            Assert.Null(HttpUtility.UrlDecodeToBytes(default(string), Encoding.UTF8));
+            Assert.Null(HttpUtility.UrlDecodeToBytes(default(byte[]), 2, 0));
+            Assert.Throws<ArgumentNullException>("bytes", () => HttpUtility.UrlDecodeToBytes(default(byte[]), 2, 3));
+        }
+
+        [Fact]
+        public void UrlDecodeToBytes_OutOfRange()
+        {
+            byte[] bytes = { 0, 1, 2 };
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => HttpUtility.UrlDecodeToBytes(bytes, -1, 2));
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => HttpUtility.UrlDecodeToBytes(bytes, 14, 2));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => HttpUtility.UrlDecodeToBytes(bytes, 1, 12));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => HttpUtility.UrlDecodeToBytes(bytes, 1, -12));
         }
 
         [Theory]
@@ -529,10 +603,57 @@ namespace System.Web.Tests
             Assert.Equal(encoded, Encoding.UTF8.GetString(HttpUtility.UrlEncodeToBytes(decoded, Encoding.UTF8)));
         }
 
+        [Theory]
+        [MemberData(nameof(UrlEncodeData))]
+        public void UrlEncodeToBytes_DefaultEncoding(string decoded, string encoded)
+        {
+            Assert.Equal(encoded, Encoding.UTF8.GetString(HttpUtility.UrlEncodeToBytes(decoded)));
+        }
+
+        [Theory, MemberData(nameof(UrlEncodeData))]
+        public void UrlEncodeToBytesExplicitSize(string decoded, string encoded)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(decoded);
+            Assert.Equal(encoded, Encoding.UTF8.GetString(HttpUtility.UrlEncodeToBytes(bytes, 0, bytes.Length)));
+        }
+
+
+        [Theory]
+        [InlineData(" abc defgh", "abc+def", 1, 7)]
+        [InlineData(" abc defgh", "", 1, 0)]
+        public void UrlEncodeToBytesExplicitSize(string decoded, string encoded, int offset, int count)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(decoded);
+            Assert.Equal(encoded, Encoding.UTF8.GetString(HttpUtility.UrlEncodeToBytes(bytes, offset, count)));
+        }
+
+        [Theory]
+        [InlineData("abc def", " abc+defgh", 1, 7)]
+        [InlineData("", " abc defgh", 1, 0)]
+        public void UrlDecodeToBytesExplicitSize(string decoded, string encoded, int offset, int count)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(encoded);
+            Assert.Equal(decoded, Encoding.UTF8.GetString(HttpUtility.UrlDecodeToBytes(bytes, offset, count)));
+        }
+
         [Fact]
         public void UrlEncodeToBytes_null()
         {
             Assert.Null(HttpUtility.UrlEncodeToBytes(null, Encoding.UTF8));
+            Assert.Null(HttpUtility.UrlEncodeToBytes(default(byte[])));
+            Assert.Null(HttpUtility.UrlEncodeToBytes(default(string)));
+            Assert.Null(HttpUtility.UrlEncodeToBytes(null, 2, 0));
+            Assert.Throws<ArgumentNullException>("bytes", () => HttpUtility.UrlEncodeToBytes(null, 2, 3));
+        }
+
+        [Fact]
+        public void UrlEncodeToBytes_OutOfRange()
+        {
+            byte[] bytes = { 0, 1, 2 };
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => HttpUtility.UrlEncodeToBytes(bytes, -1, 2));
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => HttpUtility.UrlEncodeToBytes(bytes, 14, 2));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => HttpUtility.UrlEncodeToBytes(bytes, 1, 12));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => HttpUtility.UrlEncodeToBytes(bytes, 1, -12));
         }
 
         [Theory]
@@ -543,9 +664,22 @@ namespace System.Web.Tests
         }
 
         [Fact]
-        public void UrlEncode_ByteArray_null()
+        public void UrlEncode_null()
         {
-            Assert.Null(HttpUtility.UrlEncode((byte[]) null));
+            Assert.Null(HttpUtility.UrlEncode((byte[])null));
+            Assert.Null(HttpUtility.UrlEncode((string)null));
+            Assert.Null(HttpUtility.UrlEncode(null, Encoding.UTF8));
+            Assert.Null(HttpUtility.UrlEncode(null, 2, 3));
+        }
+
+        [Fact]
+        public void UrlEncode_OutOfRange()
+        {
+            byte[] bytes = {0, 1, 2};
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => HttpUtility.UrlEncode(bytes, -1, 2));
+            Assert.Throws<ArgumentOutOfRangeException>("offset", () => HttpUtility.UrlEncode(bytes, 14, 2));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => HttpUtility.UrlEncode(bytes, 1, 12));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => HttpUtility.UrlEncode(bytes, 1, -12));
         }
 
         #endregion UrlEncode(ToBytes)
@@ -591,6 +725,15 @@ namespace System.Web.Tests
         [InlineData(" ", "%20")]
         [InlineData("\n", "%0a")]
         [InlineData("default.xxx?sdsd=sds", "default.xxx?sdsd=sds")]
+        [InlineData("?sdsd=sds", "?sdsd=sds")]
+        [InlineData("", "")]
+        [InlineData("http://example.net/default.xxx?sdsd=sds", "http://example.net/default.xxx?sdsd=sds")]
+        [InlineData("http://example.net:8080/default.xxx?sdsd=sds", "http://example.net:8080/default.xxx?sdsd=sds")]
+        [InlineData("http://eXample.net:80/default.xxx?sdsd=sds", "http://eXample.net:80/default.xxx?sdsd=sds")]
+        [InlineData("http://EXAMPLE.NET/default.xxx?sdsd=sds", "http://EXAMPLE.NET/default.xxx?sdsd=sds")]
+        [InlineData("http://EXAMPLE.NET/défault.xxx?sdsd=sds", "http://EXAMPLE.NET/d%c3%a9fault.xxx?sdsd=sds")]
+        [InlineData("file:///C/Users", "file:///C/Users")]
+        [InlineData("mailto:user@example.net", "mailto:user@example.net")]
         public void UrlPathEncode(string decoded, string encoded)
         {
             Assert.Equal(encoded, HttpUtility.UrlPathEncode(decoded));

--- a/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -30,6 +30,7 @@
 //
 
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -382,9 +383,17 @@ namespace System.Web.Tests
         public static IEnumerable<object[]> ParseQueryStringDataQ =>
             ParseQueryStringData.Select(a => new object[] { "?" + (string)a[0] }.Concat(a.Skip(1)).ToArray());
 
+        public static IEnumerable<object[]> ParseQueryStringDataEscapedQ =>
+            ParseQueryStringData.Select(a => new object[] { "&#x3F;" + (string)a[0] }.Concat(a.Skip(1)).ToArray());
+
+        public static IEnumerable<object[]> ParseQueryStringDataDecimalEscapedQ =>
+            ParseQueryStringData.Select(a => new object[] { "&#63;" + (string)a[0] }.Concat(a.Skip(1)).ToArray());
+
         [Theory]
         [MemberData(nameof(ParseQueryStringData))]
         [MemberData(nameof(ParseQueryStringDataQ))]
+        [MemberData(nameof(ParseQueryStringDataEscapedQ))]
+        [MemberData(nameof(ParseQueryStringDataDecimalEscapedQ))]
         public void ParseQueryString(string input, IList<string> keys, IList<IList<string>> values)
         {
             var parsed = HttpUtility.ParseQueryString(input);
@@ -395,6 +404,13 @@ namespace System.Web.Tests
                 string[] actualValues = parsed.GetValues(i);
                 Assert.Equal<string>(values[i], actualValues);
             }
+        }
+
+        [Fact]
+        public void ParseQueryStringWithNameBeginningWithQuestionMark()
+        {
+            NameValueCollection parsed = HttpUtility.ParseQueryString("??name=value");
+            Assert.Equal("value", parsed["?name"]);
         }
 
         [Fact]

--- a/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -384,10 +384,14 @@ namespace System.Web.Tests
             ParseQueryStringData.Select(a => new object[] { "?" + (string)a[0] }.Concat(a.Skip(1)).ToArray());
 
         public static IEnumerable<object[]> ParseQueryStringDataEscapedQ =>
-            ParseQueryStringData.Select(a => new object[] { "&#x3F;" + (string)a[0] }.Concat(a.Skip(1)).ToArray());
+            PlatformDetection.IsFullFramework
+                ? Enumerable.Empty<object[]>()
+                : ParseQueryStringData.Select(a => new object[] { "&#x3F;" + (string)a[0] }.Concat(a.Skip(1)).ToArray());
 
         public static IEnumerable<object[]> ParseQueryStringDataDecimalEscapedQ =>
-            ParseQueryStringData.Select(a => new object[] { "&#63;" + (string)a[0] }.Concat(a.Skip(1)).ToArray());
+            PlatformDetection.IsFullFramework
+                ? Enumerable.Empty<object[]>()
+                : ParseQueryStringData.Select(a => new object[] { "&#63;" + (string)a[0] }.Concat(a.Skip(1)).ToArray());
 
         [Theory]
         [MemberData(nameof(ParseQueryStringData))]
@@ -406,7 +410,7 @@ namespace System.Web.Tests
             }
         }
 
-        [Fact]
+        [Fact, SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Issue #23574 isn't fixed on NetFX")]
         public void ParseQueryStringWithNameBeginningWithQuestionMark()
         {
             NameValueCollection parsed = HttpUtility.ParseQueryString("??name=value");


### PR DESCRIPTION
* Use named arguments instead of comments.

* Add more `HttpUtilityTests`

* Remove `ignoreAscii` parameter from `UrlEncodeUnicode` method

Only ever false.

* Remove `alwasyCreateNewReturnValue` from `UrlEncodeNonAscii`

Always false.

* Remove `ValidateUrlEncodingParameters` check from `UrlEncodeNonAscii`

Cases covered can't happen as bytes comes from `Encoding.GetBytes` call and sizes are based on that.

* Remove `string.IsnullOrEmpty` and `e == null` branches from `UrlEncodeNonAscii`

Guaranteed by only caller not to be hit. Replace with assertions.

* Remove `bytes == null` branch from `UrlDecodeToBytes`

Exists in a `bytes != null` branch, so never true.

* Remove `sb.Length` test from `HttpQSCollection.ToString()`

In a path for which there will always be at least one value added, so always true, so just use offset & length overload of `ToString`.

* Remove check that `authorityIndex != -1`.

Cannot be false in the branch it is in.

* Change `JavaScriptStringEncode` call to avoid unnecessary branch.

Can just call `HttpEncoder.JavaScriptStringEncode` directly.

* Move switch for determining js escape into first `CharRequiresJavaScriptEncoding` branch.

Removes need for double-check.

* Correctly parse bare HTML-encoded ? in `HttpUtility.ParseQueryString`

Also simplify `HttpUtility.ParseQueryString` since the fix involves always removing initial question marks in the first pass, so the loop can be simpler and avoid the cause of `#23574`

Fixes #23573, fixes #23574
