### PR TITLE
Some refactoring in System.ComponentModel.DataAnnotations

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociationAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociationAttribute.cs
@@ -14,11 +14,6 @@ namespace System.ComponentModel.DataAnnotations
     [Obsolete("This attribute is no longer in use and will be ignored if applied.")]
     public sealed class AssociationAttribute : Attribute
     {
-        private string _name;
-        private string _thisKey;
-        private string _otherKey;
-        private bool _isForeignKey;
-
         /// <summary>
         /// Full form of constructor
         /// </summary>
@@ -30,47 +25,34 @@ namespace System.ComponentModel.DataAnnotations
         /// on the other side of the association</param>
         public AssociationAttribute(string name, string thisKey, string otherKey)
         {
-            _name = name;
-            _thisKey = thisKey;
-            _otherKey = otherKey;
+            Name = name;
+            ThisKey = thisKey;
+            OtherKey = otherKey;
         }
 
         /// <summary>
         /// Gets the name of the association. For bi-directional associations, the name must
         /// be the same on both sides of the association
         /// </summary>
-        public string Name
-        {
-            get { return _name; }
-        }
+        public string Name { get; }
 
         /// <summary>
         /// Gets a comma separated list of the property names of the key values
         /// on this side of the association
         /// </summary>
-        public string ThisKey
-        {
-            get { return _thisKey; }
-        }
+        public string ThisKey { get; }
 
         /// <summary>
         /// Gets a comma separated list of the property names of the key values
         /// on the other side of the association
         /// </summary>
-        public string OtherKey
-        {
-            get { return _otherKey; }
-        }
+        public string OtherKey { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this association member represents
         /// the foreign key side of an association
         /// </summary>
-        public bool IsForeignKey
-        {
-            get { return _isForeignKey; }
-            set { _isForeignKey = value; }
-        }
+        public bool IsForeignKey { get; set; }
 
         /// <summary>
         /// Gets the collection of individual key members specified in the ThisKey string.

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociationAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociationAttribute.cs
@@ -57,33 +57,18 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         /// Gets the collection of individual key members specified in the ThisKey string.
         /// </summary>
-        public IEnumerable<string> ThisKeyMembers
-        {
-            get
-            {
-                return GetKeyMembers(ThisKey);
-            }
-        }
+        public IEnumerable<string> ThisKeyMembers => GetKeyMembers(ThisKey);
 
         /// <summary>
         /// Gets the collection of individual key members specified in the OtherKey string.
         /// </summary>
-        public IEnumerable<string> OtherKeyMembers
-        {
-            get
-            {
-                return GetKeyMembers(OtherKey);
-            }
-        }
+        public IEnumerable<string> OtherKeyMembers => GetKeyMembers(OtherKey);
 
         /// <summary>
         /// Parses the comma delimited key specified
         /// </summary>
         /// <param name="key">The key to parse</param>
         /// <returns>Array of individual key members</returns>
-        private static string[] GetKeyMembers(string key)
-        {
-            return key.Replace(" ", string.Empty).Split(',');
-        }
+        private static string[] GetKeyMembers(string key) => key.Replace(" ", string.Empty).Split(',');
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
@@ -73,10 +73,5 @@ namespace System.ComponentModel.DataAnnotations
 
             return OtherProperty;
         }
-
-        private static bool IsPublic(PropertyInfo p)
-        {
-            return (p.GetMethod != null && p.GetMethod.IsPublic) || (p.SetMethod != null && p.SetMethod.IsPublic);
-        }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
@@ -27,11 +27,9 @@ namespace System.ComponentModel.DataAnnotations
 
         public override bool RequiresValidationContext => true;
 
-        public override string FormatErrorMessage(string name)
-        {
-            return string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name,
-                OtherPropertyDisplayName ?? OtherProperty);
-        }
+        public override string FormatErrorMessage(string name) =>
+            string.Format(
+                CultureInfo.CurrentCulture, ErrorMessageString, name, OtherPropertyDisplayName ?? OtherProperty);
 
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
@@ -21,7 +21,7 @@ namespace System.ComponentModel.DataAnnotations
             OtherProperty = otherProperty;
         }
 
-        public string OtherProperty { get; private set; }
+        public string OtherProperty { get; }
 
         public string OtherPropertyDisplayName { get; internal set; }
 

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
@@ -53,14 +53,16 @@ namespace System.ComponentModel.DataAnnotations
             {
                 if (OtherPropertyDisplayName == null)
                 {
-                    OtherPropertyDisplayName = GetDisplayNameForProperty(validationContext.ObjectType, otherPropertyInfo);
+                    OtherPropertyDisplayName = GetDisplayNameForProperty(otherPropertyInfo);
                 }
+
                 return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
             }
+
             return null;
         }
 
-        private string GetDisplayNameForProperty(Type containerType, PropertyInfo property)
+        private string GetDisplayNameForProperty(PropertyInfo property)
         {
             var attributes = CustomAttributeExtensions.GetCustomAttributes(property, true);
             var display = attributes.OfType<DisplayAttribute>().FirstOrDefault();

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CustomValidationAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CustomValidationAttribute.cs
@@ -76,7 +76,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     specified type.
         /// </summary>
         /// <remarks>
-        ///     An invalid <paramref name="validatorType" /> or <paramref name="Method" /> will be cause
+        ///     An invalid <paramref name="validatorType" /> or <paramref name="method" /> will be cause
         ///     <see cref="IsValid(object, ValidationContext)" />> to return a <see cref="ValidationResult" />
         ///     and <see cref="ValidationAttribute.FormatErrorMessage" /> to return a summary error message.
         /// </remarks>

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CustomValidationAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CustomValidationAttribute.cs
@@ -60,8 +60,6 @@ namespace System.ComponentModel.DataAnnotations
         #region Member Fields
 
         private readonly Lazy<string> _malformedErrorMessage;
-        private readonly string _method;
-        private readonly Type _validatorType;
         private bool _isSingleArgumentMethod;
         private string _lastMessage;
         private MethodInfo _methodInfo;
@@ -88,8 +86,8 @@ namespace System.ComponentModel.DataAnnotations
         public CustomValidationAttribute(Type validatorType, string method)
             : base(() => SR.CustomValidationAttribute_ValidationError)
         {
-            _validatorType = validatorType;
-            _method = method;
+            ValidatorType = validatorType;
+            Method = method;
             _malformedErrorMessage = new Lazy<string>(CheckAttributeWellFormed);
         }
 
@@ -100,18 +98,12 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Gets the type that contains the validation method identified by <see cref="Method" />.
         /// </summary>
-        public Type ValidatorType
-        {
-            get { return _validatorType; }
-        }
+        public Type ValidatorType { get; }
 
         /// <summary>
         ///     Gets the name of the method in <see cref="ValidatorType" /> to invoke to perform validation.
         /// </summary>
-        public string Method
-        {
-            get { return _method; }
-        }
+        public string Method { get; }
 
         public override bool RequiresValidationContext 
         {
@@ -154,8 +146,8 @@ namespace System.ComponentModel.DataAnnotations
                             SR.CustomValidationAttribute_Type_Conversion_Failed,
                             (value != null ? value.GetType().ToString() : "null"),
                             _firstParameterType,
-                            _validatorType,
-                            _method));
+                            ValidatorType,
+                            Method));
             }
 
             // Invoke the method.  Catch TargetInvocationException merely to unwrap it.
@@ -223,15 +215,15 @@ namespace System.ComponentModel.DataAnnotations
         /// <returns><c>null</c> or the appropriate error message.</returns>
         private string ValidateValidatorTypeParameter()
         {
-            if (_validatorType == null)
+            if (ValidatorType == null)
             {
                 return SR.CustomValidationAttribute_ValidatorType_Required;
             }
 
-            if (!_validatorType.IsVisible)
+            if (!ValidatorType.IsVisible)
             {
                 return string.Format(CultureInfo.CurrentCulture,
-                    SR.CustomValidationAttribute_Type_Must_Be_Public, _validatorType.Name);
+                    SR.CustomValidationAttribute_Type_Must_Be_Public, ValidatorType.Name);
             }
 
             return null;
@@ -243,27 +235,27 @@ namespace System.ComponentModel.DataAnnotations
         /// <returns><c>null</c> or the appropriate error message.</returns>
         private string ValidateMethodParameter()
         {
-            if (string.IsNullOrEmpty(_method))
+            if (string.IsNullOrEmpty(Method))
             {
                 return SR.CustomValidationAttribute_Method_Required;
             }
 
             // Named method must be public and static
-            var methodInfo = _validatorType.GetRuntimeMethods()
-                .SingleOrDefault(m => string.Equals(m.Name, _method, StringComparison.Ordinal)
+            var methodInfo = ValidatorType.GetRuntimeMethods()
+                .SingleOrDefault(m => string.Equals(m.Name, Method, StringComparison.Ordinal)
                                     && m.IsPublic && m.IsStatic);
             if (methodInfo == null)
             {
                 return string.Format(CultureInfo.CurrentCulture,
-                    SR.CustomValidationAttribute_Method_Not_Found, _method, _validatorType.Name);
+                    SR.CustomValidationAttribute_Method_Not_Found, Method, ValidatorType.Name);
             }
 
             // Method must return a ValidationResult
             if (methodInfo.ReturnType != typeof(ValidationResult))
             {
                 return string.Format(CultureInfo.CurrentCulture,
-                    SR.CustomValidationAttribute_Method_Must_Return_ValidationResult, _method,
-                    _validatorType.Name);
+                    SR.CustomValidationAttribute_Method_Must_Return_ValidationResult, Method,
+                    ValidatorType.Name);
             }
 
             ParameterInfo[] parameterInfos = methodInfo.GetParameters();
@@ -272,7 +264,7 @@ namespace System.ComponentModel.DataAnnotations
             if (parameterInfos.Length == 0 || parameterInfos[0].ParameterType.IsByRef)
             {
                 return string.Format(CultureInfo.CurrentCulture,
-                    SR.CustomValidationAttribute_Method_Signature, _method, _validatorType.Name);
+                    SR.CustomValidationAttribute_Method_Signature, Method, ValidatorType.Name);
             }
 
             // We accept 2 forms:
@@ -285,8 +277,8 @@ namespace System.ComponentModel.DataAnnotations
                 if ((parameterInfos.Length != 2) || (parameterInfos[1].ParameterType != typeof(ValidationContext)))
                 {
                     return string.Format(CultureInfo.CurrentCulture,
-                        SR.CustomValidationAttribute_Method_Signature, _method,
-                        _validatorType.Name);
+                        SR.CustomValidationAttribute_Method_Signature, Method,
+                        ValidatorType.Name);
                 }
             }
 

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CustomValidationAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CustomValidationAttribute.cs
@@ -204,10 +204,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     Checks whether the current attribute instance itself is valid for use.
         /// </summary>
         /// <returns>The error message why it is not well-formed, null if it is well-formed.</returns>
-        private string CheckAttributeWellFormed()
-        {
-            return ValidateValidatorTypeParameter() ?? ValidateMethodParameter();
-        }
+        private string CheckAttributeWellFormed() => ValidateValidatorTypeParameter() ?? ValidateMethodParameter();
 
         /// <summary>
         ///     Internal helper to determine whether <see cref="ValidatorType" /> is legal for use.

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DataTypeAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DataTypeAttribute.cs
@@ -62,13 +62,13 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Gets the DataType. If it equals DataType.Custom, <see cref="CustomDataType" /> should also be retrieved.
         /// </summary>
-        public DataType DataType { get; private set; }
+        public DataType DataType { get; }
 
         /// <summary>
         ///     Gets the string representing a custom data type. Returns a non-null value only if <see cref="DataType" /> is
         ///     DataType.Custom.
         /// </summary>
-        public string CustomDataType { get; private set; }
+        public string CustomDataType { get; }
 
         /// <summary>
         ///     Gets the default display format that gets used along with this DataType.

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayAttribute.cs
@@ -240,7 +240,7 @@ namespace System.ComponentModel.DataAnnotations
                         "GetAutoGenerateField"));
                 }
 
-                return _autoGenerateField.Value;
+                return _autoGenerateField.GetValueOrDefault();
             }
             set { _autoGenerateField = value; }
         }
@@ -270,7 +270,7 @@ namespace System.ComponentModel.DataAnnotations
                         "GetAutoGenerateFilter"));
                 }
 
-                return _autoGenerateFilter.Value;
+                return _autoGenerateFilter.GetValueOrDefault();
             }
             set { _autoGenerateFilter = value; }
         }
@@ -297,7 +297,7 @@ namespace System.ComponentModel.DataAnnotations
                         SR.DisplayAttribute_PropertyNotSet, "Order", "GetOrder"));
                 }
 
-                return _order.Value;
+                return _order.GetValueOrDefault();
             }
             set { _order = value; }
         }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayAttribute.cs
@@ -57,8 +57,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public string ShortName
         {
-            get { return _shortName.Value; }
-            set { _shortName.Value = value; }
+            get => _shortName.Value;
+            set => _shortName.Value = value;
         }
 
         /// <summary>
@@ -82,8 +82,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public string Name
         {
-            get { return _name.Value; }
-            set { _name.Value = value; }
+            get => _name.Value;
+            set => _name.Value = value;
         }
 
         /// <summary>
@@ -107,8 +107,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public string Description
         {
-            get { return _description.Value; }
-            set { _description.Value = value; }
+            get => _description.Value;
+            set => _description.Value = value;
         }
 
         /// <summary>
@@ -132,8 +132,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public string Prompt
         {
-            get { return _prompt.Value; }
-            set { _prompt.Value = value; }
+            get => _prompt.Value;
+            set => _prompt.Value = value;
         }
 
         /// <summary>
@@ -157,8 +157,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public string GroupName
         {
-            get { return _groupName.Value; }
-            set { _groupName.Value = value; }
+            get => _groupName.Value;
+            set => _groupName.Value = value;
         }
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         public Type ResourceType
         {
-            get { return _resourceType; }
+            get => _resourceType;
             set
             {
                 if (_resourceType != value)
@@ -212,7 +212,7 @@ namespace System.ComponentModel.DataAnnotations
 
                 return _autoGenerateField.GetValueOrDefault();
             }
-            set { _autoGenerateField = value; }
+            set => _autoGenerateField = value;
         }
 
         /// <summary>
@@ -242,7 +242,7 @@ namespace System.ComponentModel.DataAnnotations
 
                 return _autoGenerateFilter.GetValueOrDefault();
             }
-            set { _autoGenerateFilter = value; }
+            set => _autoGenerateFilter = value;
         }
 
         /// <summary>
@@ -269,7 +269,7 @@ namespace System.ComponentModel.DataAnnotations
 
                 return _order.GetValueOrDefault();
             }
-            set { _order = value; }
+            set => _order = value;
         }
 
         #endregion
@@ -300,10 +300,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     but a public static property with a name matching the <see cref="ShortName" /> value couldn't be found
         ///     on the <see cref="ResourceType" />.
         /// </exception>
-        public string GetShortName()
-        {
-            return _shortName.GetLocalizableValue() ?? GetName();
-        }
+        public string GetShortName() => _shortName.GetLocalizableValue() ?? GetName();
 
         /// <summary>
         ///     Gets the UI display string for Name.
@@ -330,10 +327,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     but a public static property with a name matching the <see cref="Name" /> value couldn't be found
         ///     on the <see cref="ResourceType" />.
         /// </exception>
-        public string GetName()
-        {
-            return _name.GetLocalizableValue();
-        }
+        public string GetName() => _name.GetLocalizableValue();
 
         /// <summary>
         ///     Gets the UI display string for Description.
@@ -356,10 +350,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     but a public static property with a name matching the <see cref="Description" /> value couldn't be found
         ///     on the <see cref="ResourceType" />.
         /// </exception>
-        public string GetDescription()
-        {
-            return _description.GetLocalizableValue();
-        }
+        public string GetDescription() => _description.GetLocalizableValue();
 
         /// <summary>
         ///     Gets the UI display string for Prompt.
@@ -382,10 +373,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     but a public static property with a name matching the <see cref="Prompt" /> value couldn't be found
         ///     on the <see cref="ResourceType" />.
         /// </exception>
-        public string GetPrompt()
-        {
-            return _prompt.GetLocalizableValue();
-        }
+        public string GetPrompt() => _prompt.GetLocalizableValue();
 
         /// <summary>
         ///     Gets the UI display string for GroupName.
@@ -408,10 +396,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     but a public static property with a name matching the <see cref="GroupName" /> value couldn't be found
         ///     on the <see cref="ResourceType" />.
         /// </exception>
-        public string GetGroupName()
-        {
-            return _groupName.GetLocalizableValue();
-        }
+        public string GetGroupName() => _groupName.GetLocalizableValue();
 
         /// <summary>
         ///     Gets the value of <see cref="AutoGenerateField" /> if it has been set, or <c>null</c>.
@@ -422,10 +407,7 @@ namespace System.ComponentModel.DataAnnotations
         ///         When <see cref="AutoGenerateField" /> has not been set returns <c>null</c>.
         ///     </para>
         /// </returns>
-        public bool? GetAutoGenerateField()
-        {
-            return _autoGenerateField;
-        }
+        public bool? GetAutoGenerateField() => _autoGenerateField;
 
         /// <summary>
         ///     Gets the value of <see cref="AutoGenerateFilter" /> if it has been set, or <c>null</c>.
@@ -436,10 +418,7 @@ namespace System.ComponentModel.DataAnnotations
         ///         When <see cref="AutoGenerateFilter" /> has not been set returns <c>null</c>.
         ///     </para>
         /// </returns>
-        public bool? GetAutoGenerateFilter()
-        {
-            return _autoGenerateFilter;
-        }
+        public bool? GetAutoGenerateFilter() => _autoGenerateFilter;
 
         /// <summary>
         ///     Gets the value of <see cref="Order" /> if it has been set, or <c>null</c>.
@@ -455,10 +434,8 @@ namespace System.ComponentModel.DataAnnotations
         ///     of 10000.  This value allows for explicitly-ordered fields to be displayed before
         ///     and after the fields that don't specify an order.
         /// </remarks>
-        public int? GetOrder()
-        {
-            return _order;
-        }
+        public int? GetOrder() => _order;
+
         #endregion
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayAttribute.cs
@@ -58,13 +58,7 @@ namespace System.ComponentModel.DataAnnotations
         public string ShortName
         {
             get { return _shortName.Value; }
-            set
-            {
-                if (_shortName.Value != value)
-                {
-                    _shortName.Value = value;
-                }
-            }
+            set { _shortName.Value = value; }
         }
 
         /// <summary>
@@ -89,13 +83,7 @@ namespace System.ComponentModel.DataAnnotations
         public string Name
         {
             get { return _name.Value; }
-            set
-            {
-                if (_name.Value != value)
-                {
-                    _name.Value = value;
-                }
-            }
+            set { _name.Value = value; }
         }
 
         /// <summary>
@@ -120,13 +108,7 @@ namespace System.ComponentModel.DataAnnotations
         public string Description
         {
             get { return _description.Value; }
-            set
-            {
-                if (_description.Value != value)
-                {
-                    _description.Value = value;
-                }
-            }
+            set { _description.Value = value; }
         }
 
         /// <summary>
@@ -151,13 +133,7 @@ namespace System.ComponentModel.DataAnnotations
         public string Prompt
         {
             get { return _prompt.Value; }
-            set
-            {
-                if (_prompt.Value != value)
-                {
-                    _prompt.Value = value;
-                }
-            }
+            set { _prompt.Value = value; }
         }
 
         /// <summary>
@@ -182,13 +158,7 @@ namespace System.ComponentModel.DataAnnotations
         public string GroupName
         {
             get { return _groupName.Value; }
-            set
-            {
-                if (_groupName.Value != value)
-                {
-                    _groupName.Value = value;
-                }
-            }
+            set { _groupName.Value = value; }
         }
 
         /// <summary>

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayColumnAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayColumnAttribute.cs
@@ -28,10 +28,10 @@ namespace System.ComponentModel.DataAnnotations
             SortDescending = sortDescending;
         }
 
-        public string DisplayColumn { get; private set; }
+        public string DisplayColumn { get; }
 
-        public string SortColumn { get; private set; }
+        public string SortColumn { get; }
 
-        public bool SortDescending { get; private set; }
+        public bool SortDescending { get; }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
@@ -49,8 +49,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public string NullDisplayText
         {
-            get { return _nullDisplayText.Value; }
-            set { _nullDisplayText.Value = value; }
+            get => _nullDisplayText.Value;
+            set => _nullDisplayText.Value = value;
         }
 
         /// <summary>
@@ -75,8 +75,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
 		public Type NullDisplayTextResourceType
         {
-            get { return _nullDisplayText.ResourceType; }
-            set { _nullDisplayText.ResourceType = value; }
+            get => _nullDisplayText.ResourceType;
+            set => _nullDisplayText.ResourceType = value;
         }
 
         /// <summary>
@@ -103,9 +103,6 @@ namespace System.ComponentModel.DataAnnotations
         ///     but a public static property with a name matching the <see cref="NullDisplayText" /> value couldn't be found
         ///     on the <see cref="NullDisplayTextResourceType" />.
         /// </exception>
-        public string GetNullDisplayText()
-        {
-            return _nullDisplayText.GetLocalizableValue();
-        }
+        public string GetNullDisplayText() => _nullDisplayText.GetLocalizableValue();
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EditableAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EditableAttribute.cs
@@ -42,7 +42,7 @@ namespace System.ComponentModel.DataAnnotations
         ///         When <c>false</c>, the field/property is not editable.
         ///     </para>
         /// </value>
-        public bool AllowEdit { get; private set; }
+        public bool AllowEdit { get; }
 
         /// <summary>
         ///     Indicates whether or not the field/property allows an initial value

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EnumDataTypeAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EnumDataTypeAttribute.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 
 namespace System.ComponentModel.DataAnnotations
 {

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EnumDataTypeAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EnumDataTypeAttribute.cs
@@ -20,7 +20,7 @@ namespace System.ComponentModel.DataAnnotations
             EnumType = enumType;
         }
 
-        public Type EnumType { get; private set; }
+        public Type EnumType { get; }
 
         public override bool IsValid(object value)
         {

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EnumDataTypeAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EnumDataTypeAttribute.cs
@@ -107,16 +107,10 @@ namespace System.ComponentModel.DataAnnotations
             return Enum.IsDefined(EnumType, convertedValue);
         }
 
-        private static bool IsEnumTypeInFlagsMode(Type enumType)
-        {
-            return enumType.GetCustomAttributes(typeof(FlagsAttribute), false).Any();
-        }
+        private static bool IsEnumTypeInFlagsMode(Type enumType) =>
+            enumType.GetCustomAttributes(typeof(FlagsAttribute), false).Any();
 
-
-        private static string GetUnderlyingTypeValueString(Type enumType, object enumValue)
-        {
-            return
-                Convert.ChangeType(enumValue, Enum.GetUnderlyingType(enumType), CultureInfo.InvariantCulture).ToString();
-        }
+        private static string GetUnderlyingTypeValueString(Type enumType, object enumValue) =>
+            Convert.ChangeType(enumValue, Enum.GetUnderlyingType(enumType), CultureInfo.InvariantCulture).ToString();
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FileExtensionsAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FileExtensionsAttribute.cs
@@ -25,34 +25,23 @@ namespace System.ComponentModel.DataAnnotations
 
         public string Extensions
         {
-            get
-            {
-                // Default file extensions match those from jquery validate.
-                return string.IsNullOrWhiteSpace(_extensions) ? "png,jpg,jpeg,gif" : _extensions;
-            }
-            set { _extensions = value; }
+            // Default file extensions match those from jquery validate.
+            get => string.IsNullOrWhiteSpace(_extensions) ? "png,jpg,jpeg,gif" : _extensions;
+            set => _extensions = value;
         }
 
-        private string ExtensionsFormatted
-        {
-            get { return ExtensionsParsed.Aggregate((left, right) => left + ", " + right); }
-        }
+        private string ExtensionsFormatted => ExtensionsParsed.Aggregate((left, right) => left + ", " + right);
 
-
-        private string ExtensionsNormalized
-        {
-            get { return Extensions.Replace(" ", string.Empty).Replace(".", string.Empty).ToLowerInvariant(); }
-        }
+        private string ExtensionsNormalized =>
+            Extensions.Replace(" ", string.Empty).Replace(".", string.Empty).ToLowerInvariant();
 
         private IEnumerable<string> ExtensionsParsed
         {
             get { return ExtensionsNormalized.Split(',').Select(e => "." + e); }
         }
 
-        public override string FormatErrorMessage(string name)
-        {
-            return string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, ExtensionsFormatted);
-        }
+        public override string FormatErrorMessage(string name) =>
+            string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, ExtensionsFormatted);
 
         public override bool IsValid(object value)
         {

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FilterUIHintAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FilterUIHintAttribute.cs
@@ -13,7 +13,7 @@ namespace System.ComponentModel.DataAnnotations
     [Obsolete("This attribute is no longer in use and will be ignored if applied.")]
     public sealed class FilterUIHintAttribute : Attribute
     {
-        private UIHintAttribute.UIHintImplementation _implementation;
+        private readonly UIHintAttribute.UIHintImplementation _implementation;
 
         /// <summary>
         /// Gets the name of the control that is most appropriate for this associated

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FilterUIHintAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FilterUIHintAttribute.cs
@@ -19,38 +19,20 @@ namespace System.ComponentModel.DataAnnotations
         /// Gets the name of the control that is most appropriate for this associated
         /// property or field
         /// </summary>
-        public string FilterUIHint
-        {
-            get
-            {
-                return _implementation.UIHint;
-            }
-        }
+        public string FilterUIHint => _implementation.UIHint;
 
         /// <summary>
         /// Gets the name of the presentation layer that supports the control type
         /// in <see cref="FilterUIHint"/>
         /// </summary>
-        public string PresentationLayer
-        {
-            get
-            {
-                return _implementation.PresentationLayer;
-            }
-        }
+        public string PresentationLayer => _implementation.PresentationLayer;
 
         /// <summary>
         /// Gets the name-value pairs used as parameters to the control's constructor
         /// </summary>
         /// <exception cref="InvalidOperationException"> is thrown if the current attribute
         /// is ill-formed.</exception>
-        public IDictionary<string, object> ControlParameters
-        {
-            get
-            {
-                return _implementation.ControlParameters;
-            }
-        }
+        public IDictionary<string, object> ControlParameters => _implementation.ControlParameters;
 
         /// <summary>
         /// Constructor that accepts the name of the control, without specifying
@@ -92,10 +74,7 @@ namespace System.ComponentModel.DataAnnotations
         /// Returns the hash code for this FilterUIHintAttribute.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
-        {
-            return _implementation.GetHashCode();
-        }
+        public override int GetHashCode() => _implementation.GetHashCode();
 
         /// <summary>
         /// Determines whether this instance of FilterUIHintAttribute and a specified object,

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FilterUIHintAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FilterUIHintAttribute.cs
@@ -23,7 +23,7 @@ namespace System.ComponentModel.DataAnnotations
         {
             get
             {
-                return this._implementation.UIHint;
+                return _implementation.UIHint;
             }
         }
 
@@ -35,7 +35,7 @@ namespace System.ComponentModel.DataAnnotations
         {
             get
             {
-                return this._implementation.PresentationLayer;
+                return _implementation.PresentationLayer;
             }
         }
 
@@ -48,7 +48,7 @@ namespace System.ComponentModel.DataAnnotations
         {
             get
             {
-                return this._implementation.ControlParameters;
+                return _implementation.ControlParameters;
             }
         }
 
@@ -84,7 +84,7 @@ namespace System.ComponentModel.DataAnnotations
         public FilterUIHintAttribute(string filterUIHint, string presentationLayer,
             params object[] controlParameters)
         {
-            this._implementation = new UIHintAttribute.UIHintImplementation(
+            _implementation = new UIHintAttribute.UIHintImplementation(
                 filterUIHint, presentationLayer, controlParameters);
         }
 
@@ -94,7 +94,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return this._implementation.GetHashCode();
+            return _implementation.GetHashCode();
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace System.ComponentModel.DataAnnotations
                 return false;
             }
 
-            return this._implementation.Equals(otherAttribute._implementation);
+            return _implementation.Equals(otherAttribute._implementation);
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/LocalizableString.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/LocalizableString.cs
@@ -49,7 +49,7 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         public string Value
         {
-            get { return _propertyValue; }
+            get => _propertyValue;
             set
             {
                 if (_propertyValue != value)
@@ -65,7 +65,7 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         public Type ResourceType
         {
-            get { return _resourceType; }
+            get => _resourceType;
             set
             {
                 if (_resourceType != value)

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
@@ -44,10 +44,7 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         public int Length { get; }
 
-        private static string DefaultErrorMessageString
-        {
-            get { return SR.MaxLengthAttribute_ValidationError; }
-        }
+        private static string DefaultErrorMessageString => SR.MaxLengthAttribute_ValidationError;
 
         /// <summary>
         ///     Determines whether a specified object is valid. (Overrides <see cref="ValidationAttribute.IsValid(object)" />)
@@ -96,11 +93,9 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         /// <param name="name">The name to include in the formatted string.</param>
         /// <returns>A localized string to describe the maximum acceptable length.</returns>
-        public override string FormatErrorMessage(string name)
-        {
+        public override string FormatErrorMessage(string name) =>
             // An error occurred, so we know the value is greater than the maximum if it was specified
-            return string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
-        }
+            string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
 
         /// <summary>
         ///     Checks that Length has a legal value.

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
@@ -42,7 +42,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Gets the maximum allowable length of the collection/string data.
         /// </summary>
-        public int Length { get; private set; }
+        public int Length { get; }
 
         private static string DefaultErrorMessageString
         {

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MinLengthAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MinLengthAttribute.cs
@@ -80,11 +80,9 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         /// <param name="name">The name to include in the formatted string.</param>
         /// <returns>A localized string to describe the minimum acceptable length.</returns>
-        public override string FormatErrorMessage(string name)
-        {
+        public override string FormatErrorMessage(string name) =>
             // An error occurred, so we know the value is less than the minimum
-            return string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
-        }
+            string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
 
         /// <summary>
         ///     Checks that Length has a legal value.

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MinLengthAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MinLengthAttribute.cs
@@ -30,7 +30,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Gets the minimum allowable length of the collection/string data.
         /// </summary>
-        public int Length { get; private set; }
+        public int Length { get; }
 
         /// <summary>
         ///     Determines whether a specified object is valid. (Overrides <see cref="ValidationAttribute.IsValid(object)" />)

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RangeAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RangeAttribute.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-using System.Reflection;
 
 namespace System.ComponentModel.DataAnnotations
 {

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RangeAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RangeAttribute.cs
@@ -69,7 +69,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     Gets the type of the <see cref="Minimum" /> and <see cref="Maximum" /> values (e.g. Int32, Double, or some custom
         ///     type)
         /// </summary>
-        public Type OperandType { get; private set; }
+        public Type OperandType { get; }
 
         private Func<object, object> Conversion { get; set; }
 

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
@@ -34,7 +34,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Gets the regular expression pattern to use
         /// </summary>
-        public string Pattern { get; private set; }
+        public string Pattern { get; }
 
         private Regex Regex { get; set; }
 

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ScaffoldColumnAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ScaffoldColumnAttribute.cs
@@ -12,6 +12,6 @@ namespace System.ComponentModel.DataAnnotations
             Scaffold = scaffold;
         }
 
-        public bool Scaffold { get; private set; }
+        public bool Scaffold { get; }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ColumnAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ColumnAttribute.cs
@@ -47,7 +47,7 @@ namespace System.ComponentModel.DataAnnotations.Schema
         /// </summary>
         public int Order
         {
-            get { return _order; }
+            get => _order;
             set
             {
                 if (value < 0)
@@ -64,7 +64,7 @@ namespace System.ComponentModel.DataAnnotations.Schema
         /// </summary>
         public string TypeName
         {
-            get { return _typeName; }
+            get => _typeName;
             set
             {
                 if (string.IsNullOrWhiteSpace(value))

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ColumnAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ColumnAttribute.cs
@@ -12,7 +12,6 @@ namespace System.ComponentModel.DataAnnotations.Schema
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public class ColumnAttribute : Attribute
     {
-        private readonly string _name;
         private int _order = -1;
         private string _typeName;
 
@@ -35,16 +34,13 @@ namespace System.ComponentModel.DataAnnotations.Schema
                     SR.ArgumentIsNullOrWhitespace, nameof(name)));
             }
 
-            _name = name;
+            Name = name;
         }
 
         /// <summary>
         ///     The name of the column the property is mapped to.
         /// </summary>
-        public string Name
-        {
-            get { return _name; }
-        }
+        public string Name { get; }
 
         /// <summary>
         ///     The zero-based order of the column the property is mapped to.

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/DatabaseGeneratedAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/DatabaseGeneratedAttribute.cs
@@ -27,6 +27,6 @@ namespace System.ComponentModel.DataAnnotations.Schema
         /// <summary>
         ///     The pattern used to generate values for the property in the database.
         /// </summary>
-        public DatabaseGeneratedOption DatabaseGeneratedOption { get; private set; }
+        public DatabaseGeneratedOption DatabaseGeneratedOption { get; }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ForeignKeyAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ForeignKeyAttribute.cs
@@ -14,8 +14,6 @@ namespace System.ComponentModel.DataAnnotations.Schema
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public class ForeignKeyAttribute : Attribute
     {
-        private readonly string _name;
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="ForeignKeyAttribute" /> class.
         /// </summary>
@@ -32,16 +30,13 @@ namespace System.ComponentModel.DataAnnotations.Schema
                     SR.ArgumentIsNullOrWhitespace, nameof(name)));
             }
 
-            _name = name;
+            Name = name;
         }
 
         /// <summary>
         ///     If placed on a foreign key property, the name of the associated navigation property.
         ///     If placed on a navigation property, the name of the associated foreign key(s).
         /// </summary>
-        public string Name
-        {
-            get { return _name; }
-        }
+        public string Name { get; }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/InversePropertyAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/InversePropertyAttribute.cs
@@ -12,8 +12,6 @@ namespace System.ComponentModel.DataAnnotations.Schema
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public class InversePropertyAttribute : Attribute
     {
-        private readonly string _property;
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="InversePropertyAttribute" /> class.
         /// </summary>
@@ -25,15 +23,13 @@ namespace System.ComponentModel.DataAnnotations.Schema
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                     SR.ArgumentIsNullOrWhitespace, nameof(property)));
             }
-            _property = property;
+
+            Property = property;
         }
 
         /// <summary>
         ///     The navigation property representing the other end of the same relationship.
         /// </summary>
-        public string Property
-        {
-            get { return _property; }
-        }
+        public string Property { get; }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/TableAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/TableAttribute.cs
@@ -39,7 +39,7 @@ namespace System.ComponentModel.DataAnnotations.Schema
         /// </summary>
         public string Schema
         {
-            get { return _schema; }
+            get => _schema;
             set
             {
                 if (string.IsNullOrWhiteSpace(value))
@@ -47,6 +47,7 @@ namespace System.ComponentModel.DataAnnotations.Schema
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                         SR.ArgumentIsNullOrWhitespace, nameof(value)));
                 }
+
                 _schema = value;
             }
         }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/TableAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/TableAttribute.cs
@@ -12,7 +12,6 @@ namespace System.ComponentModel.DataAnnotations.Schema
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class TableAttribute : Attribute
     {
-        private readonly string _name;
         private string _schema;
 
         /// <summary>
@@ -26,16 +25,14 @@ namespace System.ComponentModel.DataAnnotations.Schema
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                     SR.ArgumentIsNullOrWhitespace, nameof(name)));
             }
-            _name = name;
+
+            Name = name;
         }
 
         /// <summary>
         ///     The name of the table the class is mapped to.
         /// </summary>
-        public string Name
-        {
-            get { return _name; }
-        }
+        public string Name { get; }
 
         /// <summary>
         ///     The schema of the table the class is mapped to.

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/StringLengthAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/StringLengthAttribute.cs
@@ -26,7 +26,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Gets the maximum acceptable length of the string
         /// </summary>
-        public int MaximumLength { get; private set; }
+        public int MaximumLength { get; }
 
         /// <summary>
         ///     Gets or sets the minimum acceptable length of the string

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
@@ -107,12 +107,12 @@ namespace System.ComponentModel.DataAnnotations
             /// <summary>
             ///     Gets the name of the control that is most appropriate for this associated property or field
             /// </summary>
-            public string UIHint { get; private set; }
+            public string UIHint { get; }
 
             /// <summary>
             ///     Gets the name of the presentation layer that supports the control type in <see cref="UIHint" />
             /// </summary>
-            public string PresentationLayer { get; private set; }
+            public string PresentationLayer { get; }
 
             public IDictionary<string, object> ControlParameters
             {

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
@@ -51,32 +51,20 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Gets the name of the control that is most appropriate for this associated property or field
         /// </summary>
-        public string UIHint
-        {
-            get { return _implementation.UIHint; }
-        }
+        public string UIHint => _implementation.UIHint;
 
         /// <summary>
         ///     Gets the name of the presentation layer that supports the control type in <see cref="UIHint" />
         /// </summary>
-        public string PresentationLayer
-        {
-            get { return _implementation.PresentationLayer; }
-        }
+        public string PresentationLayer => _implementation.PresentationLayer;
 
         /// <summary>
         ///     Gets the name-value pairs used as parameters to the control's constructor
         /// </summary>
         /// <exception cref="InvalidOperationException"> is thrown if the current attribute is ill-formed.</exception>
-        public IDictionary<string, object> ControlParameters
-        {
-            get { return _implementation.ControlParameters; }
-        }
+        public IDictionary<string, object> ControlParameters => _implementation.ControlParameters;
 
-        public override int GetHashCode()
-        {
-            return _implementation.GetHashCode();
-        }
+        public override int GetHashCode() => _implementation.GetHashCode();
 
         public override bool Equals(object obj)
         {

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 
 namespace System.ComponentModel.DataAnnotations

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
@@ -116,10 +116,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     <see cref="ValidationContext" /> to perform validation.
         ///     Base class returns false. Override in child classes as appropriate.
         /// </summary>
-        public virtual bool RequiresValidationContext
-        {
-            get { return false; }
-        }
+        public virtual bool RequiresValidationContext => false;
 
         #endregion
 
@@ -134,12 +131,9 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public string ErrorMessage
         {
-            get
-            {
-                // If _errorMessage is not set, return the default. This is done to preserve
-                // behavior prior to the fix where ErrorMessage showed the non-null message to use.
-                return _errorMessage ?? _defaultErrorMessage;
-            }
+            // If _errorMessage is not set, return the default. This is done to preserve
+            // behavior prior to the fix where ErrorMessage showed the non-null message to use.
+            get => _errorMessage ?? _defaultErrorMessage;
             set
             {
                 _errorMessage = value;
@@ -164,7 +158,7 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public string ErrorMessageResourceName
         {
-            get { return _errorMessageResourceName; }
+            get => _errorMessageResourceName;
             set
             {
                 _errorMessageResourceName = value;
@@ -185,7 +179,7 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public Type ErrorMessageResourceType
         {
-            get { return _errorMessageResourceType; }
+            get => _errorMessageResourceType;
             set
             {
                 _errorMessageResourceType = value;
@@ -316,10 +310,8 @@ namespace System.ComponentModel.DataAnnotations
         /// <param name="name">The user-visible name to include in the formatted message.</param>
         /// <returns>The localized string describing the validation error</returns>
         /// <exception cref="InvalidOperationException"> is thrown if the current attribute is malformed.</exception>
-        public virtual string FormatErrorMessage(string name)
-        {
-            return string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name);
-        }
+        public virtual string FormatErrorMessage(string name) =>
+            string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name);
 
         /// <summary>
         ///     Gets the value indicating whether or not the specified <paramref name="value" /> is valid

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
@@ -140,15 +140,11 @@ namespace System.ComponentModel.DataAnnotations
             }
         }
 
-        internal static bool IsPublic(PropertyInfo p)
-        {
-            return (p.GetMethod != null && p.GetMethod.IsPublic) || (p.SetMethod != null && p.SetMethod.IsPublic);
-        }
+        internal static bool IsPublic(PropertyInfo p) =>
+            (p.GetMethod != null && p.GetMethod.IsPublic) || (p.SetMethod != null && p.SetMethod.IsPublic);
 
-        internal static bool IsStatic(PropertyInfo p)
-        {
-            return (p.GetMethod != null && p.GetMethod.IsStatic) || (p.SetMethod != null && p.SetMethod.IsStatic);
-        }
+        internal static bool IsStatic(PropertyInfo p) =>
+            (p.GetMethod != null && p.GetMethod.IsStatic) || (p.SetMethod != null && p.SetMethod.IsStatic);
 
         /// <summary>
         ///     Private abstract class for all store items

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
@@ -163,7 +163,7 @@ namespace System.ComponentModel.DataAnnotations
 
             internal IEnumerable<ValidationAttribute> ValidationAttributes { get; }
 
-            internal DisplayAttribute DisplayAttribute { get; set; }
+            internal DisplayAttribute DisplayAttribute { get; }
         }
 
         /// <summary>

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
@@ -20,16 +20,12 @@ namespace System.ComponentModel.DataAnnotations
     /// </remarks>
     internal class ValidationAttributeStore
     {
-        private static readonly ValidationAttributeStore _singleton = new ValidationAttributeStore();
         private readonly Dictionary<Type, TypeStoreItem> _typeStoreItems = new Dictionary<Type, TypeStoreItem>();
 
         /// <summary>
         ///     Gets the singleton <see cref="ValidationAttributeStore" />
         /// </summary>
-        internal static ValidationAttributeStore Instance
-        {
-            get { return _singleton; }
-        }
+        internal static ValidationAttributeStore Instance { get; } = new ValidationAttributeStore();
 
         /// <summary>
         ///     Retrieves the type level validation attributes for the given type.
@@ -159,18 +155,13 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         private abstract class StoreItem
         {
-            private readonly IEnumerable<ValidationAttribute> _validationAttributes;
-
             internal StoreItem(IEnumerable<Attribute> attributes)
             {
-                _validationAttributes = attributes.OfType<ValidationAttribute>();
+                ValidationAttributes = attributes.OfType<ValidationAttribute>();
                 DisplayAttribute = attributes.OfType<DisplayAttribute>().SingleOrDefault();
             }
 
-            internal IEnumerable<ValidationAttribute> ValidationAttributes
-            {
-                get { return _validationAttributes; }
-            }
+            internal IEnumerable<ValidationAttribute> ValidationAttributes { get; }
 
             internal DisplayAttribute DisplayAttribute { get; set; }
         }
@@ -248,19 +239,14 @@ nameof(propertyName));
         /// </summary>
         private class PropertyStoreItem : StoreItem
         {
-            private readonly Type _propertyType;
-
             internal PropertyStoreItem(Type propertyType, IEnumerable<Attribute> attributes)
                 : base(attributes)
             {
                 Debug.Assert(propertyType != null);
-                _propertyType = propertyType;
+                PropertyType = propertyType;
             }
 
-            internal Type PropertyType
-            {
-                get { return _propertyType; }
-            }
+            internal Type PropertyType { get; }
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
@@ -244,15 +244,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         /// <param name="serviceType">The type of the service needed.</param>
         /// <returns>An instance of that service or null if it is not available.</returns>
-        public object GetService(Type serviceType)
-        {
-            if (_serviceProvider != null)
-            {
-                return _serviceProvider(serviceType);
-            }
+        public object GetService(Type serviceType) => _serviceProvider?.Invoke(serviceType);
 
-            return null;
-        }
         #endregion
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
@@ -122,10 +122,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Gets the type of the object being validated.  It will not be null.
         /// </summary>
-        public Type ObjectType
-        {
-            get { return ObjectInstance.GetType(); }
-        }
+        public Type ObjectType => ObjectInstance.GetType();
 
         /// <summary>
         ///     Gets or sets the user-visible name of the type or property being validated.
@@ -176,10 +173,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     This property will never be null, but the dictionary may be empty.  Changes made
         ///     to items in this dictionary will never affect the original dictionary specified in the constructor.
         /// </value>
-        public IDictionary<object, object> Items
-        {
-            get { return _items; }
-        }
+        public IDictionary<object, object> Items => _items;
 
         #endregion
 

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
@@ -30,9 +30,7 @@ namespace System.ComponentModel.DataAnnotations
         #region Member Fields
 
         private readonly Dictionary<object, object> _items;
-        private readonly object _objectInstance;
         private string _displayName;
-        private string _memberName;
         private Func<Type, object> _serviceProvider;
 
         #endregion
@@ -102,7 +100,7 @@ namespace System.ComponentModel.DataAnnotations
                 _items = new Dictionary<object, object>();
             }
 
-            _objectInstance = instance;
+            ObjectInstance = instance;
         }
 
         #endregion
@@ -119,10 +117,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     For example, the property being validated, as well as other properties on the instance might not have been
         ///     updated to their new values.
         /// </remarks>
-        public object ObjectInstance
-        {
-            get { return _objectInstance; }
-        }
+        public object ObjectInstance { get; }
 
         /// <summary>
         ///     Gets the type of the object being validated.  It will not be null.
@@ -172,11 +167,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     This name reflects the API name of the member being validated, not a localized name.  It should be set
         ///     only for property or parameter contexts.
         /// </value>
-        public string MemberName
-        {
-            get { return _memberName; }
-            set { _memberName = value; }
-        }
+        public string MemberName { get; set; }
 
         /// <summary>
         ///     Gets the dictionary of key/value pairs associated with this context.
@@ -204,7 +195,7 @@ namespace System.ComponentModel.DataAnnotations
             ValidationAttributeStore store = ValidationAttributeStore.Instance;
             DisplayAttribute displayAttribute = null;
 
-            if (string.IsNullOrEmpty(_memberName))
+            if (string.IsNullOrEmpty(MemberName))
             {
                 displayAttribute = store.GetTypeDisplayAttribute(this);
             }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationException.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationException.cs
@@ -83,7 +83,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Gets the <see>ValidationAttribute</see> instance that triggered this exception.
         /// </summary>
-        public ValidationAttribute ValidationAttribute { get; private set; }
+        public ValidationAttribute ValidationAttribute { get; }
 
         /// <summary>
         ///     Gets the <see cref="ValidationResult" /> instance that describes the validation error.
@@ -106,6 +106,6 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Gets the value that caused the validating attribute to trigger the exception
         /// </summary>
-        public object Value { get; private set; }
+        public object Value { get; }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationResult.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationResult.cs
@@ -26,9 +26,6 @@ namespace System.ComponentModel.DataAnnotations
         /// </remarks>
         public static readonly ValidationResult Success;
 
-        private readonly IEnumerable<string> _memberNames;
-        private string _errorMessage;
-
         #endregion
 
         #region All Constructors
@@ -60,8 +57,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </param>
         public ValidationResult(string errorMessage, IEnumerable<string> memberNames)
         {
-            _errorMessage = errorMessage;
-            _memberNames = memberNames ?? Array.Empty<string>();
+            ErrorMessage = errorMessage;
+            MemberNames = memberNames ?? Array.Empty<string>();
         }
 
         /// <summary>
@@ -76,8 +73,8 @@ namespace System.ComponentModel.DataAnnotations
                 throw new ArgumentNullException(nameof(validationResult));
             }
 
-            _errorMessage = validationResult._errorMessage;
-            _memberNames = validationResult._memberNames;
+            ErrorMessage = validationResult.ErrorMessage;
+            MemberNames = validationResult.MemberNames;
         }
 
         #endregion
@@ -87,19 +84,12 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Gets the collection of member names affected by this result.  The collection may be empty but will never be null.
         /// </summary>
-        public IEnumerable<string> MemberNames
-        {
-            get { return _memberNames; }
-        }
+        public IEnumerable<string> MemberNames { get; }
 
         /// <summary>
         ///     Gets the error message for this result.  It may be null.
         /// </summary>
-        public string ErrorMessage
-        {
-            get { return _errorMessage; }
-            set { _errorMessage = value; }
-        }
+        public string ErrorMessage { get; set; }
 
         #endregion
 

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationResult.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationResult.cs
@@ -108,10 +108,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     The <see cref="ErrorMessage" /> property value if specified,
         ///     otherwise, the base <see cref="Object.ToString" /> result.
         /// </returns>
-        public override string ToString()
-        {
-            return ErrorMessage ?? base.ToString();
-        }
+        public override string ToString() => ErrorMessage ?? base.ToString();
         #endregion Methods
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -92,11 +92,9 @@ namespace System.ComponentModel.DataAnnotations
         ///     When <paramref name="instance" /> doesn't match the
         ///     <see cref="ValidationContext.ObjectInstance" />on <paramref name="validationContext" />.
         /// </exception>
-        public static bool TryValidateObject(object instance, ValidationContext validationContext,
-            ICollection<ValidationResult> validationResults)
-        {
-            return TryValidateObject(instance, validationContext, validationResults, false /*validateAllProperties*/);
-        }
+        public static bool TryValidateObject(
+            object instance, ValidationContext validationContext, ICollection<ValidationResult> validationResults) =>
+            TryValidateObject(instance, validationContext, validationResults, false /*validateAllProperties*/);
 
         /// <summary>
         ///     Tests whether the given object instance is valid.

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -628,11 +628,11 @@ nameof(value));
                 Value = value;
             }
 
-            internal object Value { get; set; }
+            internal object Value { get; }
 
-            internal ValidationAttribute ValidationAttribute { get; set; }
+            internal ValidationAttribute ValidationAttribute { get; }
 
-            internal ValidationResult ValidationResult { get; set; }
+            internal ValidationResult ValidationResult { get; }
 
             internal Exception ThrowValidationException() => throw new ValidationException(ValidationResult, ValidationAttribute, Value);
         }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -64,10 +64,7 @@ namespace System.ComponentModel.DataAnnotations
             {
                 result = false;
 
-                if (validationResults != null)
-                {
-                    validationResults.Add(err.ValidationResult);
-                }
+                validationResults?.Add(err.ValidationResult);
             }
 
             return result;
@@ -157,10 +154,7 @@ namespace System.ComponentModel.DataAnnotations
             {
                 result = false;
 
-                if (validationResults != null)
-                {
-                    validationResults.Add(err.ValidationResult);
-                }
+                validationResults?.Add(err.ValidationResult);
             }
 
             return result;
@@ -207,10 +201,7 @@ namespace System.ComponentModel.DataAnnotations
             {
                 result = false;
 
-                if (validationResults != null)
-                {
-                    validationResults.Add(err.ValidationResult);
-                }
+                validationResults?.Add(err.ValidationResult);
             }
 
             return result;
@@ -234,11 +225,8 @@ namespace System.ComponentModel.DataAnnotations
 
             var attributes = _store.GetPropertyValidationAttributes(validationContext);
 
-            var err = GetValidationErrors(value, validationContext, attributes, false).FirstOrDefault();
-            if (err != null)
-            {
-                err.ThrowValidationException();
-            }
+            GetValidationErrors(value, validationContext, attributes, false).FirstOrDefault()
+                ?.ThrowValidationException();
         }
 
         /// <summary>
@@ -301,12 +289,7 @@ namespace System.ComponentModel.DataAnnotations
                     SR.Validator_InstanceMustMatchValidationContextInstance, nameof(instance));
             }
 
-            var err =
-                GetObjectValidationErrors(instance, validationContext, validateAllProperties, false).FirstOrDefault();
-            if (err != null)
-            {
-                err.ThrowValidationException();
-            }
+            GetObjectValidationErrors(instance, validationContext, validateAllProperties, false).FirstOrDefault()?.ThrowValidationException();
         }
 
         /// <summary>
@@ -334,12 +317,7 @@ namespace System.ComponentModel.DataAnnotations
                 throw new ArgumentNullException(nameof(validationContext));
             }
 
-            var err =
-                GetValidationErrors(value, validationContext, validationAttributes, false).FirstOrDefault();
-            if (err != null)
-            {
-                err.ThrowValidationException();
-            }
+            GetValidationErrors(value, validationContext, validationAttributes, false).FirstOrDefault()?.ThrowValidationException();
         }
 
         /// <summary>

--- a/src/System.ComponentModel.Annotations/tests/Schema/ColumnAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/Schema/ColumnAttributeTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.ComponentModel.DataAnnotations.Schema.Tests

--- a/src/System.ComponentModel.Annotations/tests/Schema/DatabaseGeneratedAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/Schema/DatabaseGeneratedAttributeTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.ComponentModel.DataAnnotations.Schema.Tests


### PR DESCRIPTION
* Use null propagation where appropriate.

* Fix parameter reference in XML documentation.

* Remove unnecessary `this.` qualifications.

* Properties to auto-properties where possible.

* Auto-properties get-only where appropriate.

* Use `GetValueOrDefault` rather than `Value` when known that `HasValue`

Avoids second check.

* Make field `readonly`.

* Remove unused parameter on private method.

* Remove `CompareAttribute.IsPublic`

Unused and private.

* Don't check to avoid redundant write to `LocalizableString.Value`

`LocalizableString.Value` protects itself from redundant writes with its current value, so checking from the outside is wasteful.

* Use expression-bodied properties and methods throughout.

* Remove unused `using`s.