### PR TITLE
Fix System.Text.Encodings.Web.HtmlEncoder.Create ParamName on exception

### DIFF
--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
@@ -50,14 +50,14 @@ namespace System.Text.Encodings.Web
         private AllowedCharactersBitmap _allowedCharacters;
         internal static readonly DefaultHtmlEncoder Singleton = new DefaultHtmlEncoder(new TextEncoderSettings(UnicodeRanges.BasicLatin));
 
-        public DefaultHtmlEncoder(TextEncoderSettings filter)
+        public DefaultHtmlEncoder(TextEncoderSettings settings)
         {
-            if (filter == null)
+            if (settings == null)
             {
-                throw new ArgumentNullException(nameof(filter));
+                throw new ArgumentNullException(nameof(settings));
             }
 
-            _allowedCharacters = filter.GetAllowedCharacters();
+            _allowedCharacters = settings.GetAllowedCharacters();
 
             // Forbid codepoints which aren't mapped to characters or which are otherwise always disallowed
             // (includes categories Cc, Cs, Co, Cn, Zs [except U+0020 SPACE], Zl, Zp)

--- a/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
@@ -33,6 +33,49 @@ namespace System.Text.Encodings.Web
         }
 
         [Fact]
+        public void HtmlEncode_PositiveTestCase_CreateWithSettings()
+        {
+            // Arrange
+            TextEncoderSettings settings = new TextEncoderSettings(UnicodeRanges.All);
+            HtmlEncoder encoder = HtmlEncoder.Create(settings);
+            StringWriter writer = new StringWriter();
+
+            // Act
+            encoder.Encode(writer, "Hello+there!");
+
+            // Assert
+            Assert.Equal("Hello&#x2B;there!", writer.ToString());
+        }
+
+        [Fact]
+        public void HtmlEncode_CreateNullRanges()
+        {
+            Assert.Throws<ArgumentNullException>("allowedRanges", () => HtmlEncoder.Create(default(UnicodeRange[])));
+        }
+
+        [Fact]
+        public void HtmlEncode_CreateNullSettings()
+        {
+            Assert.Throws<ArgumentNullException>("settings", () => HtmlEncoder.Create(default(TextEncoderSettings)));
+        }
+
+
+        [Fact]
+        public unsafe void TryEncodeUnicodeScalar_Null_Buffer()
+        {
+            Assert.Throws<ArgumentNullException>("buffer", () => HtmlEncoder.Default.TryEncodeUnicodeScalar(2, null, 1, out int _));
+        }
+
+        [Fact]
+        public unsafe void TryEncodeUnicodeScalar_InsufficientRoom()
+        {
+            char* buffer = stackalloc char[1];
+            int numberWritten;
+            Assert.False(HtmlEncoder.Default.TryEncodeUnicodeScalar(0x10000, buffer, 1, out numberWritten));
+            Assert.Equal(0, numberWritten);
+        }
+
+        [Fact]
         public void JavaScriptStringEncode_ParameterChecks()
         {
             Assert.Throws<ArgumentNullException>(() => EncoderExtensions.JavaScriptStringEncode(null, "Hello!", new StringWriter()));


### PR DESCRIPTION
Change argument name of `DefaultHtmlEncoder` ctor from `filter` to `settings` to match that of only public method that directly calls it, so any `ArgumentNullException` has the correct `ParamName` property.

Fixes #23602

Also include tests bringing coverage of `DefaultHtmlEncoder` and `HtmlEncoder` up to 100%.