### PR TITLE
Update to buildtools 2.0.0-prerelease-01928-01

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01925-01
+2.0.0-prerelease-01928-01

--- a/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
@@ -18,9 +18,6 @@ namespace System.Net.WebSockets
 {
     internal abstract class WebSocketBase : WebSocket, IDisposable
     {
-#if DEBUG
-        private volatile string _closeStack;
-#endif
         private readonly OutstandingOperationHelper _closeOutstandingOperationHelper;
         private readonly OutstandingOperationHelper _closeOutputOutstandingOperationHelper;
         private readonly OutstandingOperationHelper _receiveOutstandingOperationHelper;
@@ -35,7 +32,6 @@ namespace System.Net.WebSockets
         private readonly SemaphoreSlim _sendFrameThrottle;
         // locking _ThisLock protects access to
         // - State
-        // - _closeStack
         // - _closeAsyncStartedReceive
         // - _closeReceivedTaskCompletionSource
         // - _closeNetworkConnectionTask

--- a/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\winrt\winrt.depproj" />
+    <ProjectReference Include="..\..\mscorlib.WinRT-Facade\ref\mscorlib.WinRT-Facade.csproj" />
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj" />
     <ProjectReference Include="..\..\System.IO\ref\System.IO.csproj" />

--- a/src/mscorlib.WinRT-Facade/ref/Configurations.props
+++ b/src/mscorlib.WinRT-Facade/ref/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      uap;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/mscorlib.WinRT-Facade/ref/TypeForwards.cs
+++ b/src/mscorlib.WinRT-Facade/ref/TypeForwards.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+// The following types are can be referenced by windows.winmd and are spec'ed to come from mscorlib
+[assembly: TypeForwardedTo(typeof(System.Attribute))]
+[assembly: TypeForwardedTo(typeof(System.Boolean))]
+[assembly: TypeForwardedTo(typeof(System.Byte))]
+[assembly: TypeForwardedTo(typeof(System.Char))]
+[assembly: TypeForwardedTo(typeof(System.Double))]
+[assembly: TypeForwardedTo(typeof(System.Enum))]
+[assembly: TypeForwardedTo(typeof(System.FlagsAttribute))]
+[assembly: TypeForwardedTo(typeof(System.Guid))]
+[assembly: TypeForwardedTo(typeof(System.Int16))]
+[assembly: TypeForwardedTo(typeof(System.Int32))]
+[assembly: TypeForwardedTo(typeof(System.Int64))]
+[assembly: TypeForwardedTo(typeof(System.IntPtr))]
+[assembly: TypeForwardedTo(typeof(System.MulticastDelegate))]
+[assembly: TypeForwardedTo(typeof(System.Object))]
+[assembly: TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsConst))]
+[assembly: TypeForwardedTo(typeof(System.Single))]
+[assembly: TypeForwardedTo(typeof(System.String))]
+[assembly: TypeForwardedTo(typeof(System.Type))]
+[assembly: TypeForwardedTo(typeof(System.UInt16))]
+[assembly: TypeForwardedTo(typeof(System.UInt32))]
+[assembly: TypeForwardedTo(typeof(System.UInt64))]
+[assembly: TypeForwardedTo(typeof(System.ValueType))]
+[assembly: TypeForwardedTo(typeof(void))] // System.Void
+
+// XAML compiler is checking for the following
+[assembly: TypeForwardedTo(typeof(System.Array))]

--- a/src/mscorlib.WinRT-Facade/ref/mscorlib.WinRT-Facade.csproj
+++ b/src/mscorlib.WinRT-Facade/ref/mscorlib.WinRT-Facade.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>mscorlib</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <UseECMAKey>true</UseECMAKey>
+    <!-- do not binplace, this is only used to help compile references
+         against Windows.winmd.  The real mscorlib comes from src/shims/shims.proj -->
+    <BinPlaceRef>false</BinPlaceRef>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TypeForwards.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
This brings the latest compiler to our desktop-MSBuild builds as well.

I had to fix one instance of an unused field in the networking code.
I checked and that field was present in desktop to control logging all
consuming codepaths are missing from core.

/cc @weshaggard @joperezr @benaadams 