### PR TITLE
Fix output buffer assumptions in CSP symmetric transforms.

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
@@ -686,7 +686,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
         [InlineData(false)]
         public static void MultipleBlockDecryptTransform(bool blockAlignedOutput)
         {
-            const string expectedOutput = "This is a 128-bit block test";
+            const string ExpectedOutput = "This is a 128-bit block test";
 
             int outputPadding = blockAlignedOutput ? 0 : 3;
             byte[] key = "0123456789ABCDEFFEDCBA9876543210".HexToByteArray();
@@ -706,7 +706,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             }
 
             string decrypted = Encoding.ASCII.GetString(outputBytes, 0, outputOffset);
-            Assert.Equal(expectedOutput, decrypted);
+            Assert.Equal(ExpectedOutput, decrypted);
         }
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using Test.Cryptography;
 using Xunit;
 
@@ -628,6 +629,84 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
 
                 return output.ToArray();
             }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void EncryptWithLargeOutputBuffer(bool blockAlignedOutput)
+        {
+            using (Aes alg = AesFactory.Create())
+            using (ICryptoTransform xform = alg.CreateEncryptor())
+            {
+                // 8 blocks, plus maybe three bytes
+                int outputPadding = blockAlignedOutput ? 0 : 3;
+                byte[] output = new byte[alg.BlockSize + outputPadding];
+                // 2 blocks of 0x00
+                byte[] input = new byte[alg.BlockSize / 4];
+                int outputOffset = 0;
+
+                outputOffset += xform.TransformBlock(input, 0, input.Length, output, outputOffset);
+                byte[] overflow = xform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                Buffer.BlockCopy(overflow, 0, output, outputOffset, overflow.Length);
+                outputOffset += overflow.Length;
+
+                Assert.Equal(3 * (alg.BlockSize / 8), outputOffset);
+                string outputAsHex = output.ByteArrayToHex();
+                Assert.NotEqual(new string('0', outputOffset * 2), outputAsHex.Substring(0, outputOffset * 2));
+                Assert.Equal(new string('0', (output.Length - outputOffset) * 2), outputAsHex.Substring(outputOffset * 2));
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public static void TransformWithTooShortOutputBuffer(bool encrypt, bool blockAlignedOutput)
+        {
+            using (Aes alg = AesFactory.Create())
+            using (ICryptoTransform xform = encrypt ? alg.CreateEncryptor() : alg.CreateDecryptor())
+            {
+                // 1 block, plus maybe three bytes
+                int outputPadding = blockAlignedOutput ? 0 : 3;
+                byte[] output = new byte[alg.BlockSize / 8 + outputPadding];
+                // 3 blocks of 0x00
+                byte[] input = new byte[3 * (alg.BlockSize / 8)];
+
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => xform.TransformBlock(input, 0, input.Length, output, 0));
+
+                Assert.Equal(new byte[output.Length], output);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void MultipleBlockDecryptTransform(bool blockAlignedOutput)
+        {
+            const string expectedOutput = "This is a 128-bit block test";
+
+            int outputPadding = blockAlignedOutput ? 0 : 3;
+            byte[] key = "0123456789ABCDEFFEDCBA9876543210".HexToByteArray();
+            byte[] iv = "0123456789ABCDEF0123456789ABCDEF".HexToByteArray();
+            byte[] outputBytes = new byte[iv.Length * 2 + outputPadding];
+            byte[] input = "D1BF87C650FCD10B758445BE0E0A99D14652480DF53423A8B727D30C8C010EDE".HexToByteArray();
+            int outputOffset = 0;
+
+            using (Aes alg = AesFactory.Create())
+            using (ICryptoTransform xform = alg.CreateDecryptor(key, iv))
+            {
+                Assert.Equal(2 * alg.BlockSize, (outputBytes.Length - outputPadding) * 8);
+                outputOffset += xform.TransformBlock(input, 0, input.Length, outputBytes, outputOffset);
+                byte[] overflow = xform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                Buffer.BlockCopy(overflow, 0, outputBytes, outputOffset, overflow.Length);
+                outputOffset += overflow.Length;
+            }
+
+            string decrypted = Encoding.ASCII.GetString(outputBytes, 0, outputOffset);
+            Assert.Equal(expectedOutput, decrypted);
         }
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
@@ -665,8 +665,10 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
         [InlineData(false, false)]
         public static void TransformWithTooShortOutputBuffer(bool encrypt, bool blockAlignedOutput)
         {
+            // The CreateDecryptor call reads the Key/IV property to initialize them, bypassing an
+            // uninitialized state protection.
             using (Aes alg = AesFactory.Create())
-            using (ICryptoTransform xform = encrypt ? alg.CreateEncryptor() : alg.CreateDecryptor())
+            using (ICryptoTransform xform = encrypt ? alg.CreateEncryptor() : alg.CreateDecryptor(alg.Key, alg.IV))
             {
                 // 1 block, plus maybe three bytes
                 int outputPadding = blockAlignedOutput ? 0 : 3;

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherTests.cs
@@ -281,7 +281,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
         [InlineData(false)]
         public static void MultipleBlockDecryptTransform(bool blockAlignedOutput)
         {
-            const string expectedOutput = "This is a test";
+            const string ExpectedOutput = "This is a test";
 
             int outputPadding = blockAlignedOutput ? 0 : 3;
             byte[] key = "87FF0737F868378F".HexToByteArray();
@@ -301,7 +301,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             }
 
             string decrypted = Encoding.ASCII.GetString(outputBytes, 0, outputOffset);
-            Assert.Equal(expectedOutput, decrypted);
+            Assert.Equal(ExpectedOutput, decrypted);
         }
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherTests.cs
@@ -225,5 +225,83 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
                 }
             }
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void EncryptWithLargeOutputBuffer(bool blockAlignedOutput)
+        {
+            using (DES alg = DESFactory.Create())
+            using (ICryptoTransform xform = alg.CreateEncryptor())
+            {
+                // 8 blocks, plus maybe three bytes
+                int outputPadding = blockAlignedOutput ? 0 : 3;
+                byte[] output = new byte[alg.BlockSize + outputPadding];
+                // 2 blocks of 0x00
+                byte[] input = new byte[alg.BlockSize / 4];
+                int outputOffset = 0;
+
+                outputOffset += xform.TransformBlock(input, 0, input.Length, output, outputOffset);
+                byte[] overflow = xform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                Buffer.BlockCopy(overflow, 0, output, outputOffset, overflow.Length);
+                outputOffset += overflow.Length;
+
+                Assert.Equal(3 * (alg.BlockSize / 8), outputOffset);
+                string outputAsHex = output.ByteArrayToHex();
+                Assert.NotEqual(new string('0', outputOffset * 2), outputAsHex.Substring(0, outputOffset * 2));
+                Assert.Equal(new string('0', (output.Length - outputOffset) * 2), outputAsHex.Substring(outputOffset * 2));
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public static void TransformWithTooShortOutputBuffer(bool encrypt, bool blockAlignedOutput)
+        {
+            using (DES alg = DESFactory.Create())
+            using (ICryptoTransform xform = encrypt ? alg.CreateEncryptor() : alg.CreateDecryptor())
+            {
+                // 1 block, plus maybe three bytes
+                int outputPadding = blockAlignedOutput ? 0 : 3;
+                byte[] output = new byte[alg.BlockSize / 8 + outputPadding];
+                // 3 blocks of 0x00
+                byte[] input = new byte[3 * (alg.BlockSize / 8)];
+
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => xform.TransformBlock(input, 0, input.Length, output, 0));
+                
+                Assert.Equal(new byte[output.Length], output);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void MultipleBlockDecryptTransform(bool blockAlignedOutput)
+        {
+            const string expectedOutput = "This is a test";
+
+            int outputPadding = blockAlignedOutput ? 0 : 3;
+            byte[] key = "87FF0737F868378F".HexToByteArray();
+            byte[] iv = "0123456789ABCDEF".HexToByteArray();
+            byte[] outputBytes = new byte[iv.Length * 2 + outputPadding];
+            byte[] input = "CB67F70BA8B50EED2C0691298988865F".HexToByteArray();
+            int outputOffset = 0;
+
+            using (DES alg = DESFactory.Create())
+            using (ICryptoTransform xform = alg.CreateDecryptor(key, iv))
+            {
+                Assert.Equal(2 * alg.BlockSize, (outputBytes.Length - outputPadding) * 8);
+                outputOffset += xform.TransformBlock(input, 0, input.Length, outputBytes, outputOffset);
+                byte[] overflow = xform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                Buffer.BlockCopy(overflow, 0, outputBytes, outputOffset, overflow.Length);
+                outputOffset += overflow.Length;
+            }
+
+            string decrypted = Encoding.ASCII.GetString(outputBytes, 0, outputOffset);
+            Assert.Equal(expectedOutput, decrypted);
+        }
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
@@ -297,7 +297,7 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
         [InlineData(false)]
         public static void MultipleBlockDecryptTransform(bool blockAlignedOutput)
         {
-            const string expectedOutput = "This is a test";
+            const string ExpectedOutput = "This is a test";
 
             int outputPadding = blockAlignedOutput ? 0 : 3;
             byte[] key = "0123456789ABCDEF".HexToByteArray();
@@ -317,7 +317,7 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
             }
 
             string decrypted = Encoding.ASCII.GetString(outputBytes, 0, outputOffset);
-            Assert.Equal(expectedOutput, decrypted);
+            Assert.Equal(ExpectedOutput, decrypted);
         }
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
@@ -241,5 +241,83 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
                 }
             }
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void EncryptWithLargeOutputBuffer(bool blockAlignedOutput)
+        {
+            using (RC2 alg = RC2Factory.Create())
+            using (ICryptoTransform xform = alg.CreateEncryptor())
+            {
+                // 8 blocks, plus maybe three bytes
+                int outputPadding = blockAlignedOutput ? 0 : 3;
+                byte[] output = new byte[alg.BlockSize + outputPadding];
+                // 2 blocks of 0x00
+                byte[] input = new byte[alg.BlockSize / 4];
+                int outputOffset = 0;
+
+                outputOffset += xform.TransformBlock(input, 0, input.Length, output, outputOffset);
+                byte[] overflow = xform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                Buffer.BlockCopy(overflow, 0, output, outputOffset, overflow.Length);
+                outputOffset += overflow.Length;
+
+                Assert.Equal(3 * (alg.BlockSize / 8), outputOffset);
+                string outputAsHex = output.ByteArrayToHex();
+                Assert.NotEqual(new string('0', outputOffset * 2), outputAsHex.Substring(0, outputOffset * 2));
+                Assert.Equal(new string('0', (output.Length - outputOffset) * 2), outputAsHex.Substring(outputOffset * 2));
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public static void TransformWithTooShortOutputBuffer(bool encrypt, bool blockAlignedOutput)
+        {
+            using (RC2 alg = RC2Factory.Create())
+            using (ICryptoTransform xform = encrypt ? alg.CreateEncryptor() : alg.CreateDecryptor())
+            {
+                // 1 block, plus maybe three bytes
+                int outputPadding = blockAlignedOutput ? 0 : 3;
+                byte[] output = new byte[alg.BlockSize / 8 + outputPadding];
+                // 3 blocks of 0x00
+                byte[] input = new byte[3 * (alg.BlockSize / 8)];
+
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => xform.TransformBlock(input, 0, input.Length, output, 0));
+
+                Assert.Equal(new byte[output.Length], output);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void MultipleBlockDecryptTransform(bool blockAlignedOutput)
+        {
+            const string expectedOutput = "This is a test";
+
+            int outputPadding = blockAlignedOutput ? 0 : 3;
+            byte[] key = "0123456789ABCDEF".HexToByteArray();
+            byte[] iv = "0123456789ABCDEF".HexToByteArray();
+            byte[] outputBytes = new byte[iv.Length * 2 + outputPadding];
+            byte[] input = "DB5400368C7E67FF5F9E1FA99641EB69".HexToByteArray();
+            int outputOffset = 0;
+
+            using (RC2 alg = RC2Factory.Create())
+            using (ICryptoTransform xform = alg.CreateDecryptor(key, iv))
+            {
+                Assert.Equal(2 * alg.BlockSize, (outputBytes.Length - outputPadding) * 8);
+                outputOffset += xform.TransformBlock(input, 0, input.Length, outputBytes, outputOffset);
+                byte[] overflow = xform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                Buffer.BlockCopy(overflow, 0, outputBytes, outputOffset, overflow.Length);
+                outputOffset += overflow.Length;
+            }
+
+            string decrypted = Encoding.ASCII.GetString(outputBytes, 0, outputOffset);
+            Assert.Equal(expectedOutput, decrypted);
+        }
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
@@ -345,7 +345,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
         [InlineData(false)]
         public static void MultipleBlockDecryptTransform(bool blockAlignedOutput)
         {
-            const string expectedOutput = "This is a test";
+            const string ExpectedOutput = "This is a test";
 
             int outputPadding = blockAlignedOutput ? 0 : 3;
             byte[] key = "0123456789ABCDEFFEDCBA9876543210ABCDEF0123456789".HexToByteArray();
@@ -365,7 +365,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
 
             string decrypted = Encoding.ASCII.GetString(outputBytes, 0, outputOffset);
-            Assert.Equal(expectedOutput, decrypted);
+            Assert.Equal(ExpectedOutput, decrypted);
         }
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text;
 using Test.Cryptography;
 using Xunit;
 
@@ -287,6 +288,84 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
                 byte[] expectedDecrypted = "e867f915e275eab27d6951165d26dec6dd0acafcfc".HexToByteArray();
                 Assert.Equal<byte>(expectedDecrypted, decrypted);
             }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void EncryptWithLargeOutputBuffer(bool blockAlignedOutput)
+        {
+            using (TripleDES alg = TripleDESFactory.Create())
+            using (ICryptoTransform xform = alg.CreateEncryptor())
+            {
+                // 8 blocks, plus maybe three bytes
+                int outputPadding = blockAlignedOutput ? 0 : 3;
+                byte[] output = new byte[alg.BlockSize + outputPadding];
+                // 2 blocks of 0x00
+                byte[] input = new byte[alg.BlockSize / 4];
+                int outputOffset = 0;
+
+                outputOffset += xform.TransformBlock(input, 0, input.Length, output, outputOffset);
+                byte[] overflow = xform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                Buffer.BlockCopy(overflow, 0, output, outputOffset, overflow.Length);
+                outputOffset += overflow.Length;
+
+                Assert.Equal(3 * (alg.BlockSize / 8), outputOffset);
+                string outputAsHex = output.ByteArrayToHex();
+                Assert.NotEqual(new string('0', outputOffset * 2), outputAsHex.Substring(0, outputOffset * 2));
+                Assert.Equal(new string('0', (output.Length - outputOffset) * 2), outputAsHex.Substring(outputOffset * 2));
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public static void TransformWithTooShortOutputBuffer(bool encrypt, bool blockAlignedOutput)
+        {
+            using (TripleDES alg = TripleDESFactory.Create())
+            using (ICryptoTransform xform = encrypt ? alg.CreateEncryptor() : alg.CreateDecryptor())
+            {
+                // 1 block, plus maybe three bytes
+                int outputPadding = blockAlignedOutput ? 0 : 3;
+                byte[] output = new byte[alg.BlockSize / 8 + outputPadding];
+                // 3 blocks of 0x00
+                byte[] input = new byte[3 * (alg.BlockSize / 8)];
+
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => xform.TransformBlock(input, 0, input.Length, output, 0));
+
+                Assert.Equal(new byte[output.Length], output);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void MultipleBlockDecryptTransform(bool blockAlignedOutput)
+        {
+            const string expectedOutput = "This is a test";
+
+            int outputPadding = blockAlignedOutput ? 0 : 3;
+            byte[] key = "0123456789ABCDEFFEDCBA9876543210ABCDEF0123456789".HexToByteArray();
+            byte[] iv = "0123456789ABCDEF".HexToByteArray();
+            byte[] outputBytes = new byte[iv.Length * 2 + outputPadding];
+            byte[] input = "A61C8F1D393202E1E3C71DCEAB9B08DB".HexToByteArray();
+            int outputOffset = 0;
+
+            using (TripleDES alg = TripleDESFactory.Create())
+            using (ICryptoTransform xform = alg.CreateDecryptor(key, iv))
+            {
+                Assert.Equal(2 * alg.BlockSize, (outputBytes.Length - outputPadding) * 8);
+                outputOffset += xform.TransformBlock(input, 0, input.Length, outputBytes, outputOffset);
+                byte[] overflow = xform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                Buffer.BlockCopy(overflow, 0, outputBytes, outputOffset, overflow.Length);
+                outputOffset += overflow.Length;
+            }
+
+            string decrypted = Encoding.ASCII.GetString(outputBytes, 0, outputOffset);
+            Assert.Equal(expectedOutput, decrypted);
         }
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
@@ -333,7 +333,17 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
                 // 3 blocks of 0x00
                 byte[] input = new byte[3 * (alg.BlockSize / 8)];
 
-                Assert.Throws<ArgumentOutOfRangeException>(
+                Type exceptionType = typeof(ArgumentOutOfRangeException);
+
+                // TripleDESCryptoServiceProvider doesn't throw the ArgumentOutOfRangeException,
+                // giving a CryptographicException when CAPI reports the destination too small.
+                if (PlatformDetection.IsFullFramework)
+                {
+                    exceptionType = typeof(CryptographicException);
+                }
+
+                Assert.Throws(
+                    exceptionType,
                     () => xform.TransformBlock(input, 0, input.Length, output, 0));
 
                 Assert.Equal(new byte[output.Length], output);

--- a/src/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
@@ -232,7 +232,7 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
         [InlineData(false)]
         public static void MultipleBlockDecryptTransform(bool blockAlignedOutput)
         {
-            const string expectedOutput = "This is a 128-bit block test";
+            const string ExpectedOutput = "This is a 128-bit block test";
 
             int outputPadding = blockAlignedOutput ? 0 : 3;
             byte[] key = "0123456789ABCDEFFEDCBA9876543210".HexToByteArray();
@@ -252,7 +252,7 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
             }
 
             string decrypted = Encoding.ASCII.GetString(outputBytes, 0, outputOffset);
-            Assert.Equal(expectedOutput, decrypted);
+            Assert.Equal(ExpectedOutput, decrypted);
         }
 
         private class RijndaelLegalSizesBreaker : RijndaelMinimal

--- a/src/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
@@ -177,6 +177,84 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
             }
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void EncryptWithLargeOutputBuffer(bool blockAlignedOutput)
+        {
+            using (Rijndael alg = Rijndael.Create())
+            using (ICryptoTransform xform = alg.CreateEncryptor())
+            {
+                // 8 blocks, plus maybe three bytes
+                int outputPadding = blockAlignedOutput ? 0 : 3;
+                byte[] output = new byte[alg.BlockSize + outputPadding];
+                // 2 blocks of 0x00
+                byte[] input = new byte[alg.BlockSize / 4];
+                int outputOffset = 0;
+
+                outputOffset += xform.TransformBlock(input, 0, input.Length, output, outputOffset);
+                byte[] overflow = xform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                Buffer.BlockCopy(overflow, 0, output, outputOffset, overflow.Length);
+                outputOffset += overflow.Length;
+
+                Assert.Equal(3 * (alg.BlockSize / 8), outputOffset);
+                string outputAsHex = output.ByteArrayToHex();
+                Assert.NotEqual(new string('0', outputOffset * 2), outputAsHex.Substring(0, outputOffset * 2));
+                Assert.Equal(new string('0', (output.Length - outputOffset) * 2), outputAsHex.Substring(outputOffset * 2));
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public static void TransformWithTooShortOutputBuffer(bool encrypt, bool blockAlignedOutput)
+        {
+            using (Rijndael alg = Rijndael.Create())
+            using (ICryptoTransform xform = encrypt ? alg.CreateEncryptor() : alg.CreateDecryptor())
+            {
+                // 1 block, plus maybe three bytes
+                int outputPadding = blockAlignedOutput ? 0 : 3;
+                byte[] output = new byte[alg.BlockSize / 8 + outputPadding];
+                // 3 blocks of 0x00
+                byte[] input = new byte[3 * (alg.BlockSize / 8)];
+
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => xform.TransformBlock(input, 0, input.Length, output, 0));
+
+                Assert.Equal(new byte[output.Length], output);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void MultipleBlockDecryptTransform(bool blockAlignedOutput)
+        {
+            const string expectedOutput = "This is a 128-bit block test";
+
+            int outputPadding = blockAlignedOutput ? 0 : 3;
+            byte[] key = "0123456789ABCDEFFEDCBA9876543210".HexToByteArray();
+            byte[] iv = "0123456789ABCDEF0123456789ABCDEF".HexToByteArray();
+            byte[] outputBytes = new byte[iv.Length * 2 + outputPadding];
+            byte[] input = "D1BF87C650FCD10B758445BE0E0A99D14652480DF53423A8B727D30C8C010EDE".HexToByteArray();
+            int outputOffset = 0;
+
+            using (Rijndael alg = Rijndael.Create())
+            using (ICryptoTransform xform = alg.CreateDecryptor(key, iv))
+            {
+                Assert.Equal(2 * alg.BlockSize, (outputBytes.Length - outputPadding) * 8);
+                outputOffset += xform.TransformBlock(input, 0, input.Length, outputBytes, outputOffset);
+                byte[] overflow = xform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                Buffer.BlockCopy(overflow, 0, outputBytes, outputOffset, overflow.Length);
+                outputOffset += overflow.Length;
+            }
+
+            string decrypted = Encoding.ASCII.GetString(outputBytes, 0, outputOffset);
+            Assert.Equal(expectedOutput, decrypted);
+        }
+
         private class RijndaelLegalSizesBreaker : RijndaelMinimal
         {
             public RijndaelLegalSizesBreaker()

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
@@ -931,7 +931,6 @@ namespace Internal.NativeCrypto
             Debug.Assert(outputCount >= 0);
             Debug.Assert(outputCount <= output.Length - outputOffset);
             Debug.Assert((inputCount % 8) == 0);
-            Debug.Assert((outputCount % 8) == 0);
 
             // Figure out how big the encrypted data will be
             int cbEncryptedData = inputCount;
@@ -955,6 +954,16 @@ namespace Internal.NativeCrypto
                 throw GetErrorCode().ToCryptographicException();
             }
             Debug.Assert(encryptedDataLength == cbEncryptedData);
+
+            if (isFinal)
+            {
+                Debug.Assert(outputCount == inputCount);
+            }
+            else
+            {
+                Debug.Assert(outputCount >= encryptedDataLength);
+                outputCount = encryptedDataLength;
+            }
 
             // If isFinal, padding was added so ignore it by using outputCount as size
             Buffer.BlockCopy(encryptedData, 0, output, outputOffset, outputCount);
@@ -981,7 +990,6 @@ namespace Internal.NativeCrypto
             Debug.Assert(outputCount >= 0);
             Debug.Assert(outputCount <= output.Length - outputOffset);
             Debug.Assert((inputCount % 8) == 0);
-            Debug.Assert((outputCount % 8) == 0);
 
             byte[] dataTobeDecrypted = new byte[inputCount];
             Buffer.BlockCopy(input, inputOffset, dataTobeDecrypted, 0, inputCount);
@@ -993,7 +1001,7 @@ namespace Internal.NativeCrypto
                 throw GetErrorCode().ToCryptographicException();
             }
 
-            Buffer.BlockCopy(dataTobeDecrypted, 0, output, outputOffset, outputCount);
+            Buffer.BlockCopy(dataTobeDecrypted, 0, output, outputOffset, decryptedDataLength);
 
             return decryptedDataLength;
         }


### PR DESCRIPTION
The CAPI DecryptData and EncryptData methods made assumptions about the
calling patterns, in particular that the output buffer would be perfectly sized for
the desired output.

This change adds tests which violate those assumptions, but work on netfx and
with the corefx CNG implementation. Then follows up on making the tests pass.

Fixes #23311.