### PR TITLE
Allow A4 as a default paper size in PrintDocument Tests.

### DIFF
--- a/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
@@ -244,16 +244,32 @@ namespace System.Drawing.Printing.Tests
 
         private void AssertDefaultPageSettings(PageSettings pageSettings)
         {
-            Assert.Equal(new Rectangle(0, 0, 850, 1100), pageSettings.Bounds);
+            // A4 and Letter are both common default sizes for systems to have.
+            switch (pageSettings.PaperSize.Kind)
+            {
+                case PaperKind.A4:
+                    Assert.Equal(new Rectangle(0, 0, 827, 1169), pageSettings.Bounds);
+                    Assert.Equal(827, pageSettings.PrintableArea.Width, 0);
+                    Assert.Equal(1169, pageSettings.PrintableArea.Height, 0);
+                    break;
+
+                case PaperKind.Letter:
+                    Assert.Equal(new Rectangle(0, 0, 850, 1100), pageSettings.Bounds);
+                    Assert.Equal(850, pageSettings.PrintableArea.Width, 0);
+                    Assert.Equal(1100, pageSettings.PrintableArea.Height, 0);
+                    break;
+
+                default:
+                    Assert.False(true, "Unexpected default paper size");
+                    break;
+            }
+
             Assert.True(pageSettings.Color);
             Assert.Equal(0, pageSettings.HardMarginX);
             Assert.Equal(0, pageSettings.HardMarginY);
             Assert.False(pageSettings.Landscape);
-            Assert.Equal(PaperKind.Letter, pageSettings.PaperSize.Kind);
             Assert.Equal(PaperSourceKind.FormSource, pageSettings.PaperSource.Kind);
             Assert.Equal(new PointF(0f, 0f), pageSettings.PrintableArea.Location);
-            Assert.Equal(850, pageSettings.PrintableArea.Width, 0);
-            Assert.Equal(1100, pageSettings.PrintableArea.Height, 0);
             Assert.Equal(PrinterResolutionKind.Custom, pageSettings.PrinterResolution.Kind);
             Assert.True(pageSettings.PrinterSettings.IsDefaultPrinter);
         }


### PR DESCRIPTION
A common setting for the default size for the default printer.

Fixes #23616