### PR TITLE
Fastpath same-object case in System.Net.CaseInsensitiveAscii.Equals

### DIFF
--- a/src/Common/src/System/Net/CaseInsensitiveAscii.cs
+++ b/src/Common/src/System/Net/CaseInsensitiveAscii.cs
@@ -85,17 +85,6 @@ namespace System.Net
             return result;
         }
 
-        // ASCII string case insensitive hash function
-        private int FastGetHashCode(string myString)
-        {
-            int myHashCode = myString.Length;
-            if (myHashCode != 0)
-            {
-                myHashCode ^= AsciiToLower[(byte)myString[0]] << 24 ^ AsciiToLower[(byte)myString[myHashCode - 1]] << 16;
-            }
-            return myHashCode;
-        }
-
         // ASCII string case insensitive comparer
         public new bool Equals(object firstObject, object secondObject)
         {
@@ -112,18 +101,21 @@ namespace System.Net
             }
 
             int index = firstString.Length;
-            if (index == secondString.Length && FastGetHashCode(firstString) == FastGetHashCode(secondString))
+            if (index == secondString.Length)
             {
-                while (index > 0)
+                if (index == 0 || AsciiToLower[firstString[0]] == AsciiToLower[secondString[0]])
                 {
-                    index--;
-                    if (AsciiToLower[firstString[index]] != AsciiToLower[secondString[index]])
+                    while (index > 1)
                     {
-                        return false;
+                        index--;
+                        if (AsciiToLower[firstString[index]] != AsciiToLower[secondString[index]])
+                        {
+                            return false;
+                        }
                     }
-                }
 
-                return true;
+                    return true;
+                }
             }
 
             return false;

--- a/src/Common/src/System/Net/CaseInsensitiveAscii.cs
+++ b/src/Common/src/System/Net/CaseInsensitiveAscii.cs
@@ -101,30 +101,31 @@ namespace System.Net
         {
             string firstString = firstObject as string;
             string secondString = secondObject as string;
-            if (firstString == null)
+            if ((object)firstString == (object)secondString)
             {
-                return secondString == null;
+                return true;
             }
-            if (secondString != null)
+
+            if (firstString == null | secondString == null)
             {
-                int index = firstString.Length;
-                if (index == secondString.Length)
+                return false;
+            }
+
+            int index = firstString.Length;
+            if (index == secondString.Length && FastGetHashCode(firstString) == FastGetHashCode(secondString))
+            {
+                while (index > 0)
                 {
-                    if (FastGetHashCode(firstString) == FastGetHashCode(secondString))
+                    index--;
+                    if (AsciiToLower[firstString[index]] != AsciiToLower[secondString[index]])
                     {
-                        int comparisons = firstString.Length;
-                        while (index > 0)
-                        {
-                            index--;
-                            if (AsciiToLower[firstString[index]] != AsciiToLower[secondString[index]])
-                            {
-                                return false;
-                            }
-                        }
-                        return true;
+                        return false;
                     }
                 }
+
+                return true;
             }
+
             return false;
         }
     }


### PR DESCRIPTION
The case gets hit running the tests for `System.Net.WebHeaderCollection` (and not for the both-null case, which is already pretty fast), so the benefit can be assumed to hit real code (interning probably makes it particularly common).

Also, Remove `System.Net.CaseInsensitiveAscii.FastGetHashCode()`.

Its checks are repeated in the loop, so do first-character check before loop (just in case it was successfully finding mismatches quickly) and don't do it in the loop itself.