### PR TITLE
Disable System.Drawing.Tests flaky test failing in CI

### DIFF
--- a/src/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/BitmapTests.cs
@@ -955,6 +955,7 @@ namespace System.Drawing.Tests
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue(21886, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void MakeTransparent_GrayscalePixelFormat_ThrowsArgumentException()
         {


### PR DESCRIPTION
Relates to: #21886 

cc: @danmosemsft @mellinoe 