### PR TITLE
Add BinPlaceConfiguration for test projects to have a working directory per BuildConfiguration

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01931-01
+2.0.0-prerelease-02001-01

--- a/dir.props
+++ b/dir.props
@@ -236,6 +236,7 @@
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)/$(TargetOutputRelPath)</IntermediateOutputPath>
 
     <RuntimePath Condition="'$(RuntimePath)' == ''">$(BinDir)runtime/$(BuildConfiguration)/</RuntimePath>
+    <TestPath Condition="'$(TestPath)' == ''">$(TestWorkingDir)$(MSBuildProjectName)/$(BuildConfiguration)/</TestPath>
     <RefRootPath>$(BinDir)ref/</RefRootPath>
     <BuildConfigurationRefPath>$(RefRootPath)$(_bc_TargetGroup)/</BuildConfigurationRefPath>
     <BuildConfigurationRefPath Condition="$(_bc_TargetGroup.EndsWith('aot'))">$(RefRootPath)$(_bc_TargetGroup.TrimEnd('aot'))/</BuildConfigurationRefPath>

--- a/dir.targets
+++ b/dir.targets
@@ -31,7 +31,7 @@
       <RefPath>$(BuildConfigurationRefPath)</RefPath>
       <RuntimePath>$(RuntimePath)</RuntimePath>
       <!-- we want to bin place the test output into the working directory -->
-      <TestWorkingPath>$(TestPath)</TestWorkingPath>
+      <TestPath>$(TestPath)</TestPath>
     </BinPlaceConfiguration>
     <!-- binplace to directories for packages -->
     <BinPlaceConfiguration Condition="'$(IsNETCoreApp)' == 'true' AND '$(BuildingNETCoreAppVertical)' == 'true'" Include="netcoreapp-$(_bc_OSGroup)">

--- a/dir.targets
+++ b/dir.targets
@@ -22,9 +22,10 @@
 
     <BinPlaceRef Condition="'$(BinPlaceRef)' == '' And ('$(IsReferenceAssembly)' == 'true' OR '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRef>
     <BinPlaceRuntime Condition="'$(BinPlaceRuntime)' == '' And ('$(IsRuntimeAssembly)' == 'true' OR '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRuntime>
+    <BinPlaceTest Condition="'$(BinPlaceTest)' == '' And '$(IsTestProject)' == 'true'">true</BinPlaceTest>
   </PropertyGroup>
 
-  <ItemGroup Condition="'@(BinPlaceConfiguration)' == ''">
+  <ItemGroup Condition="'@(BinPlaceConfiguration)' == '' AND '$(IsTestProject)' != 'true'">
     <!-- binplace to directories for the target vertical -->
     <BinPlaceConfiguration Include="$(_bc_TargetGroup)-$(_bc_OSGroup)">
       <RefPath>$(BuildConfigurationRefPath)</RefPath>
@@ -79,6 +80,13 @@
     <BinPlaceConfiguration Condition="'$(BuildAllConfigurations)' == 'true'"
                            Include="@(_TargetGroupsWithIsAot->WithMetadataValue('IsAot', 'false'))">
       <RefPath>$(RefRootPath)%(Identity)/</RefPath>
+    </BinPlaceConfiguration>
+  </ItemGroup>
+
+  <!-- For tests we want to separate the bin directory and the working directory to have a working directory per build configuration. -->
+  <ItemGroup Condition="'@(BinPlaceConfiguration)' == '' AND '$(BinPlaceTest)' == 'true'">
+    <BinPlaceConfiguration Include="$(_bc_TargetGroup)-$(_bc_OSGroup)">
+      <TestWorkingPath>$(TestWorkingDir)$(MSBuildProjectName)/$(BuildConfiguration)/</TestWorkingPath>
     </BinPlaceConfiguration>
   </ItemGroup>
 

--- a/dir.targets
+++ b/dir.targets
@@ -25,11 +25,13 @@
     <BinPlaceTest Condition="'$(BinPlaceTest)' == '' And '$(IsTestProject)' == 'true'">true</BinPlaceTest>
   </PropertyGroup>
 
-  <ItemGroup Condition="'@(BinPlaceConfiguration)' == '' AND '$(IsTestProject)' != 'true'">
+  <ItemGroup Condition="'@(BinPlaceConfiguration)' == ''">
     <!-- binplace to directories for the target vertical -->
     <BinPlaceConfiguration Include="$(_bc_TargetGroup)-$(_bc_OSGroup)">
       <RefPath>$(BuildConfigurationRefPath)</RefPath>
       <RuntimePath>$(RuntimePath)</RuntimePath>
+      <!-- we want to bin place the test output into the working directory -->
+      <TestWorkingPath>$(TestPath)</TestWorkingPath>
     </BinPlaceConfiguration>
     <!-- binplace to directories for packages -->
     <BinPlaceConfiguration Condition="'$(IsNETCoreApp)' == 'true' AND '$(BuildingNETCoreAppVertical)' == 'true'" Include="netcoreapp-$(_bc_OSGroup)">
@@ -80,13 +82,6 @@
     <BinPlaceConfiguration Condition="'$(BuildAllConfigurations)' == 'true'"
                            Include="@(_TargetGroupsWithIsAot->WithMetadataValue('IsAot', 'false'))">
       <RefPath>$(RefRootPath)%(Identity)/</RefPath>
-    </BinPlaceConfiguration>
-  </ItemGroup>
-
-  <!-- For tests we want to separate the bin directory and the working directory to have a working directory per build configuration. -->
-  <ItemGroup Condition="'@(BinPlaceConfiguration)' == '' AND '$(BinPlaceTest)' == 'true'">
-    <BinPlaceConfiguration Include="$(_bc_TargetGroup)-$(_bc_OSGroup)">
-      <TestWorkingPath>$(TestWorkingDir)$(MSBuildProjectName)/$(BuildConfiguration)/</TestWorkingPath>
     </BinPlaceConfiguration>
   </ItemGroup>
 

--- a/src/System.Data.DataSetExtensions/tests/Mono/DataTableExtensionsTest.cs
+++ b/src/System.Data.DataSetExtensions/tests/Mono/DataTableExtensionsTest.cs
@@ -40,6 +40,8 @@ namespace MonoTests.System.Data
 {
     public class DataTableExtensionsTest
     {
+        private string _testDataSet = "testdataset1.xml";
+
         [Fact]
         public void CopyToDataTableNoArgNoRows()
         {
@@ -77,7 +79,7 @@ namespace MonoTests.System.Data
         public void AsEnumerable()
         {
             DataSet ds = new DataSet();
-            ds.ReadXml("Mono/testdataset1.xml");
+            ds.ReadXml(_testDataSet);
             DataTable dt = ds.Tables[0];
             Assert.Equal("ScoreList", dt.TableName);
             var dv = dt.AsEnumerable();

--- a/src/System.Data.DataSetExtensions/tests/Mono/EnumerableRowCollectionTest.cs
+++ b/src/System.Data.DataSetExtensions/tests/Mono/EnumerableRowCollectionTest.cs
@@ -39,11 +39,13 @@ namespace MonoTests.System.Data
 {
     public class EnumerableRowCollectionTest
     {
+        private string _testDataSet = "testdataset1.xml";
+        
         [Fact]
         public void QueryWhere()
         {
             var ds = new DataSet();
-            ds.ReadXml("Mono/testdataset1.xml");
+            ds.ReadXml(_testDataSet);
             var table = ds.Tables[0];
             /* schema generated as ...
             var table = ds.Tables.Add ("ScoreList");
@@ -70,7 +72,7 @@ namespace MonoTests.System.Data
         public void QueryWhereSelect ()
         {
             var ds = new DataSet ();
-            ds.ReadXml ("Mono/testdataset1.xml");
+            ds.ReadXml (_testDataSet);
             var table = ds.Tables [0];
             var q = from line in table.AsEnumerable ()
                 where line.Field<int> ("Score") > 80
@@ -91,7 +93,7 @@ namespace MonoTests.System.Data
         public void QueryWhereSelectOrderBy ()
         {
             var ds = new DataSet ();
-            ds.ReadXml ("Mono/testdataset1.xml");
+            ds.ReadXml (_testDataSet);
             var table = ds.Tables [0];
             var q = from line in table.AsEnumerable ()
                 where line.Field<int> ("Score") >= 80
@@ -121,7 +123,7 @@ namespace MonoTests.System.Data
         public void QueryWhereSelectOrderByDescending ()
         {
             var ds = new DataSet ();
-            ds.ReadXml ("Mono/testdataset1.xml");
+            ds.ReadXml (_testDataSet);
             var table = ds.Tables [0];
             var q = from line in table.AsEnumerable ()
                 where line.Field<int> ("Score") >= 80
@@ -151,7 +153,7 @@ namespace MonoTests.System.Data
         public void ThenBy ()
         {
             var ds = new DataSet ();
-            ds.ReadXml ("Mono/testdataset1.xml");
+            ds.ReadXml (_testDataSet);
             var table = ds.Tables [0];
             var q = from line in table.AsEnumerable ()
                 where line.Field<int> ("Score") >= 80
@@ -181,7 +183,7 @@ namespace MonoTests.System.Data
         public void ThenByDescending ()
         {
             var ds = new DataSet ();
-            ds.ReadXml ("Mono/testdataset1.xml");
+            ds.ReadXml (_testDataSet);
             var table = ds.Tables [0];
             var q = from line in table.AsEnumerable ()
                 where line.Field<int> ("Score") >= 80

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/System.Diagnostics.FileVersionInfo.Tests.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/System.Diagnostics.FileVersionInfo.Tests.csproj
@@ -54,7 +54,7 @@
   </PropertyGroup>
   <Target Name="MangleTestAssemblyExtension">
     <!-- Copy TestAssembly to file without .dll extension so that ILC preserves it as a data file rather than feeding it to the output executable. -->
-    <Copy SourceFiles="$(OutputPath)\System.Diagnostics.FileVersionInfo.TestAssembly.dll" DestinationFiles="$(OutputPath)\System.Diagnostics.FileVersionInfo.TestAssembly.ildll" />
+    <Copy SourceFiles="$(TestPath)\System.Diagnostics.FileVersionInfo.TestAssembly.dll" DestinationFiles="$(TestPath)\System.Diagnostics.FileVersionInfo.TestAssembly.ildll" />
   </Target>
 
 </Project>

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/FileUtil.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/FileUtil.cs
@@ -14,7 +14,7 @@ namespace System.Net.NetworkInformation.Tests
         /// </summary>
         public static void NormalizeLineEndings(string source, string normalizedDest)
         {
-            string contents = File.ReadAllText(TestFile(source));
+            string contents = File.ReadAllText(source);
             if (Environment.NewLine == "\r\n")
             {
                 if (!contents.Contains(Environment.NewLine))
@@ -31,15 +31,6 @@ namespace System.Net.NetworkInformation.Tests
             }
 
             File.WriteAllText(normalizedDest, contents);
-        }
-
-        /// <summary>
-        /// Gets a path to the desired test file
-        /// </summary>
-        /// <returns>The correct path to a valid test file</returns>
-        public static string TestFile(string source)
-        {
-            return Path.Combine("NetworkFiles", source);
         }
     }
 }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/MiscParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/MiscParsingTests.cs
@@ -30,27 +30,27 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public static void RawIntFileParsing()
         {
-            int val = StringParsingHelpers.ParseRawIntFile(FileUtil.TestFile("rawint"));
+            int val = StringParsingHelpers.ParseRawIntFile("rawint");
             Assert.Equal(12, val);
 
-            int max = StringParsingHelpers.ParseRawIntFile(FileUtil.TestFile("rawint_maxvalue"));
+            int max = StringParsingHelpers.ParseRawIntFile("rawint_maxvalue");
             Assert.Equal(int.MaxValue, max);
         }
 
         [Fact]
         public static void RawLongFileParsing()
         {
-            long val = StringParsingHelpers.ParseRawLongFile(FileUtil.TestFile("rawlong"));
+            long val = StringParsingHelpers.ParseRawLongFile("rawlong");
             Assert.Equal(3147483647L, val);
 
-            long max = StringParsingHelpers.ParseRawLongFile(FileUtil.TestFile("rawlong_maxvalue"));
+            long max = StringParsingHelpers.ParseRawLongFile("rawlong_maxvalue");
             Assert.Equal(long.MaxValue, max);
         }
 
         [Fact]
         public static void RawHexIntParsing()
         {
-            int val = StringParsingHelpers.ParseRawHexFileAsInt(FileUtil.TestFile("rawhexint"));
+            int val = StringParsingHelpers.ParseRawHexFileAsInt("rawhexint");
             Assert.Equal(10, val);
         }
     }

--- a/src/System.Runtime.Loader/tests/DefaultContext/System.Runtime.Loader.DefaultContext.Tests.csproj
+++ b/src/System.Runtime.Loader/tests/DefaultContext/System.Runtime.Loader.DefaultContext.Tests.csproj
@@ -20,7 +20,7 @@
     </ProjectReference>
   </ItemGroup>
   <Target Name="RenameTestAssembly" AfterTargets="AfterBuild">
-    <Move SourceFiles="$(OutputPath)\System.Runtime.Loader.Noop.Assembly.dll" DestinationFiles="$(OutputPath)\System.Runtime.Loader.Noop.Assembly_test.dll" />
+    <Move SourceFiles="$(TestPath)\System.Runtime.Loader.Noop.Assembly.dll" DestinationFiles="$(TestPath)\System.Runtime.Loader.Noop.Assembly_test.dll" />
   </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Xml/tests/Canonicalization/XmlCanonicalizationTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Canonicalization/XmlCanonicalizationTest.cs
@@ -188,9 +188,9 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
                         string rwTypeStr = input.Arguments[0].Value;
                         ReaderWriterFactory.ReaderWriterType rwType = (ReaderWriterFactory.ReaderWriterType)Enum.Parse(typeof(ReaderWriterFactory.ReaderWriterType), rwTypeStr, true);
                         Encoding encoding = Encoding.GetEncoding((string)input.Arguments[1].Value);
-                        string sampleXmlFileName = Path.Combine("baselines", input2.Arguments[0].Value);
+                        string sampleXmlFileName = input2.Arguments[0].Value;
                         bool mustSupportV14N = input.Arguments[2].Value == "true";
-                        string baselineFileName = Path.Combine("baselines", input2.Arguments[1].Value);
+                        string baselineFileName = input2.Arguments[1].Value;
 
                         bool testWithComments = input3.Arguments[0].Value == "true";
 
@@ -253,13 +253,13 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
             foreach (var input in params4.Inputs)
             {
                 count++;
-                string sampleXmlFileName = Path.Combine("baselines", input.Arguments[3].Value);
+                string sampleXmlFileName = input.Arguments[3].Value;
                 string rwTypeStr = input.Arguments[0].Value;
                 ReaderWriterFactory.ReaderWriterType rwType = (ReaderWriterFactory.ReaderWriterType)Enum.Parse(typeof(ReaderWriterFactory.ReaderWriterType), rwTypeStr, true);
                 Encoding encoding = Encoding.GetEncoding((string)input.Arguments[1].Value);
 
                 bool mustSupportV14N = input.Arguments[2].Value == "true";
-                string baselineFileName = Path.Combine("baselines", "ReaderWriter_C14N_BaselineXML_OnlyLF.xml");
+                string baselineFileName = "ReaderWriter_C14N_BaselineXML_OnlyLF.xml";
 
                 XmlDocument xmlDoc = new XmlDocument();
                 xmlDoc.PreserveWhitespace = true;
@@ -384,7 +384,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
                     mode = TestMode.StartAtSpecifiedElement;
                 }
 
-                xmlBuffer = new XmlBuffer(Path.Combine("baselines", input.Arguments[0].Value));
+                xmlBuffer = new XmlBuffer(input.Arguments[0].Value);
                 engine = new Engine(includeComments, inclusivePrefixes, mode == TestMode.FullDocument);
 
                 XmlReader reader = CreateReader(mode, xmlBuffer, startAt);


### PR DESCRIPTION
This changes depends on: https://github.com/dotnet/buildtools/pull/1652 and a BuildTools update once that is merged. 

Fixes: https://github.com/dotnet/buildtools/issues/1587

## New Behavior with this change

With this change we will have the next behavior when building/running tests:

- When building the tests we will still bin place the test assets to the `OutputDirectory` (`corefx\bin\OSGroup.Configuration\TestProject\TargetGroup/`)
- When running the tests we will bin place the tests assets to this new [`TestPath`](https://github.com/dotnet/corefx/pull/23633/files#diff-4de71e7a0fd952be821f8af2768281dcR34) which will be the `TestPath`. This new path will be the test's working directory where we will bin place the RunTests.cmd and necessary dependencies in tests.targets. Also the `testResults.xml` will be found here after the test execution.
- `TestPath` is set to be `bin/tests/<TestProject>/<BuildConfiguration>/` (i.e `corefx\bin\tests\System.Collections.Immutable.Tests\netcoreapp-Windows_NT-Debug-x64`) in `dir.props`
- This `TestPath` will be added to the `BinPlaceDir` in `FrameworkTargeting.targets` when `BinPlaceTest` is set to true. 
- Then in the [`BinPlaceFiles`](https://github.com/safern/buildtools/blob/4d39247ff2c152ac50ade6128a44afc6f9993ca2/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets#L243) target the test assets will be hardlinked to the `TestPath`.

This will isolate every test execution per build configuration and will allow people to run the same test project for all of the supported configurations on the same repo without having to clean the repo.

cc: @weshaggard @ericstj @joperezr 

FYI: @danmosemsft 