### PR TITLE
XML doc spelling corrections - A through C.

### DIFF
--- a/src/Common/src/Interop/Windows/shell32/Interop.SHGetKnownFolderPath.cs
+++ b/src/Common/src/Interop/Windows/shell32/Interop.SHGetKnownFolderPath.cs
@@ -76,7 +76,7 @@ internal partial class Interop
             internal const string ComputerFolder = "{0AC0837C-BBF8-452A-850D-79D08E667CA7}";
 
             /// <summary>
-            /// (CSIDL_CONNECTIONS) Network Conections virtual folder
+            /// (CSIDL_CONNECTIONS) Network Connections virtual folder
             /// </summary>
             internal const string ConnectionsFolder = "{6F0CD92B-2E97-45D1-88FF-B0D186B8DEDD}";
 

--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -22,7 +22,7 @@ namespace System.Net.WebSockets
     /// Thread-safety:
     /// - It's acceptable to call ReceiveAsync and SendAsync in parallel.  One of each may run concurrently.
     /// - It's acceptable to have a pending ReceiveAsync while CloseOutputAsync or CloseAsync is called.
-    /// - Attemping to invoke any other operations in parallel may corrupt the instance.  Attempting to invoke
+    /// - Attempting to invoke any other operations in parallel may corrupt the instance.  Attempting to invoke
     ///   a send operation while another is in progress or a receive operation while another is in progress will
     ///   result in an exception.
     /// </remarks>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -939,7 +939,7 @@ namespace System.Collections.Concurrent
         /// <summary>
         /// Gets the number of key/value pairs contained in the <see
         /// cref="ConcurrentDictionary{TKey,TValue}"/>. Should only be used after all locks
-        /// have been aquired.
+        /// have been acquired.
         /// </summary>
         /// <exception cref="T:System.OverflowException">The dictionary contains too many
         /// elements.</exception>

--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -1020,7 +1020,7 @@ namespace System.Collections.Tests
     ///        (3) compare the key, if equal, go to step 4. Otherwise end.
     ///        (4) return the value contained in the bucket.
     ///     The problem is that after step 3 and before step 4. A writer can kick in a remove the old item and add a new one 
-    ///     in the same bukcet. In order to make this happen easily, I created two long with same hashcode.
+    ///     in the same bucket. In order to make this happen easily, I created two long with same hashcode.
     /// </summary>
     public class Hashtable_ItemThreadSafetyTests
     {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
@@ -178,7 +178,7 @@ namespace System.ComponentModel
 
         /// <summary>
         ///     Creates a MaskedTextProvider object from the specified mask.
-        ///     'culture' is used to set the separator characters to the correspondig locale character; if null, the current
+        ///     'culture' is used to set the separator characters to the corresponding locale character; if null, the current
         ///               culture is used.
         /// </summary>
         public MaskedTextProvider(string mask, CultureInfo culture)
@@ -188,7 +188,7 @@ namespace System.ComponentModel
 
         /// <summary>
         ///     Creates a MaskedTextProvider object from the specified mask.
-        ///     'culture' is used to set the separator characters to the correspondig locale character; if null, the current
+        ///     'culture' is used to set the separator characters to the corresponding locale character; if null, the current
         ///               culture is used.
         ///     'restrictToAscii' specifies whether the input characters should be restricted to ASCII characters only.
         /// </summary>
@@ -219,7 +219,7 @@ namespace System.ComponentModel
 
         /// <summary>
         ///     Creates a MaskedTextProvider object from the specified mask.
-        ///     'culture' is used to set the separator characters to the correspondig locale character; if null, the current
+        ///     'culture' is used to set the separator characters to the corresponding locale character; if null, the current
         ///               culture is used.
         ///     'allowPromptAsInput' specifies whether the prompt character should be accepted as a valid input or not.
         ///     'promptChar' specifies the character to be used for the prompt.
@@ -468,7 +468,7 @@ namespace System.ComponentModel
         ///     Creates a 'clean' (no text assigned) MaskedTextProvider instance with the same property values as the 
         ///     current instance.
         ///     Derived classes can override this method and call base.Clone to get proper cloning semantics but must
-        ///     implement the full-paramter contructor (passing parameters to the base constructor as well).
+        ///     implement the full-paramter constructor (passing parameters to the base constructor as well).
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2113:SecureLateBindingMethods")]
         public object Clone()
@@ -2470,7 +2470,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///     Test the characters in the specified string agaist the test string, starting from the specified position.
+        ///     Test the characters in the specified string against the test string, starting from the specified position.
         ///     If the test is successful, the characters in the test string are set appropriately.
         ///     On exit the testPosition contains last position where the primary operation was actually performed if successful, 
         ///     otherwise the first position that made the test fail. This position is relative to the test string.
@@ -2489,7 +2489,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///     Test the characters in the specified string agaist the test string, starting from the specified position.
+        ///     Test the characters in the specified string against the test string, starting from the specified position.
         ///     On exit the testPosition contains last position where the primary operation was actually performed if successful, 
         ///     otherwise the first position that made the test fail. This position is relative to the test string.
         ///     The successCount out param contains the number of characters that would be actually set (not escaped).

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -240,7 +240,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///     Called each time we access the attribtes on
+        ///     Called each time we access the attributes on
         ///     this member descriptor to give deriving classes
         ///     a chance to change them on the fly.
         /// </summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PasswordPropertyTextAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PasswordPropertyTextAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel
 {
     /// <summary>
     ///     If this attribute is placed on a property or a type, its text representation in a property window
-    ///     will appear as dots or astrisks to indicate a password field.  This indidation in no way
+    ///     will appear as dots or asterisks to indicate a password field.  This indication in no way
     ///     represents any type of encryption or security.
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]

--- a/src/System.Data.Common/src/System/Data/ConstraintCollection.cs
+++ b/src/System.Data.Common/src/System/Data/ConstraintCollection.cs
@@ -498,7 +498,7 @@ namespace System.Data
         }
 
         /// <summary>
-        /// Returns a matching constriant object.
+        /// Returns a matching constraint object.
         /// </summary>
         internal Constraint FindConstraint(Constraint constraint)
         {
@@ -512,7 +512,7 @@ namespace System.Data
         }
 
         /// <summary>
-        /// Returns a matching constriant object.
+        /// Returns a matching constraint object.
         /// </summary>
         internal UniqueConstraint FindKeyConstraint(DataColumn[] columns)
         {
@@ -529,7 +529,7 @@ namespace System.Data
         }
 
         /// <summary>
-        /// Returns a matching constriant object.
+        /// Returns a matching constraint object.
         /// </summary>
         internal UniqueConstraint FindKeyConstraint(DataColumn column)
         {
@@ -544,7 +544,7 @@ namespace System.Data
         }
 
         /// <summary>
-        /// Returns a matching constriant object.
+        /// Returns a matching constraint object.
         /// </summary>
         internal ForeignKeyConstraint FindForeignKeyConstraint(DataColumn[] parentColumns, DataColumn[] childColumns)
         {

--- a/src/System.Data.Common/src/System/Data/DataRowView.cs
+++ b/src/System.Data.Common/src/System/Data/DataRowView.cs
@@ -64,7 +64,7 @@ namespace System.Data
 
         /// <summary>Gets the specified column value or related child view or sets a value in specified column.</summary>
         /// <param name="property">Specified column or relation name when getting.  Specified column name when setting.</param>
-        /// <exception cref="ArgumentException"><see cref="DataColumnCollection.get_Item(string)"/> when <paramref name="property"/> is ambigous.</exception>
+        /// <exception cref="ArgumentException"><see cref="DataColumnCollection.get_Item(string)"/> when <paramref name="property"/> is ambiguous.</exception>
         /// <exception cref="ArgumentException">Unmatched <paramref name="property"/> when getting a value.</exception>
         /// <exception cref="DataException">Unmatched <paramref name="property"/> when setting a value.</exception>
         /// <exception cref="DataException"><see cref="System.Data.DataView.get_AllowEdit"/> when setting a value.</exception>

--- a/src/System.Data.Common/src/System/Data/DataView.cs
+++ b/src/System.Data.Common/src/System/Data/DataView.cs
@@ -27,7 +27,7 @@ namespace System.Data
 
         private string _sort = string.Empty;
 
-        /// <summary>Allow a user implemented comparision of two DataRow</summary>
+        /// <summary>Allow a user implemented comparison of two DataRow</summary>
         /// <remarks>User must use correct DataRowVersion in comparison or index corruption will happen</remarks>
         private System.Comparison<DataRow> _comparison;
 
@@ -419,7 +419,7 @@ namespace System.Data
             }
         }
 
-        /// <summary>Allow a user implemented comparision of two DataRow</summary>
+        /// <summary>Allow a user implemented comparison of two DataRow</summary>
         /// <remarks>User must use correct DataRowVersion in comparison or index corruption will happen</remarks>
         internal System.Comparison<DataRow> SortComparison
         {

--- a/src/System.Data.Common/src/System/Data/Selection.cs
+++ b/src/System.Data.Common/src/System/Data/Selection.cs
@@ -63,7 +63,7 @@ namespace System.Data
         private readonly DataTable _table;
         internal readonly IndexField[] _indexFields;
 
-        /// <summary>Allow a user implemented comparision of two DataRow</summary>
+        /// <summary>Allow a user implemented comparison of two DataRow</summary>
         /// <remarks>User must use correct DataRowVersion in comparison or index corruption will happen</remarks>
         private readonly System.Comparison<DataRow> _comparison;
 

--- a/src/System.Data.DataSetExtensions/src/System/Data/DataRowComparer.cs
+++ b/src/System.Data.DataSetExtensions/src/System/Data/DataRowComparer.cs
@@ -130,7 +130,7 @@ namespace System.Data
 
         /// <summary>
         /// This method compares to DataRows by doing a column by column value based
-        /// comparision.
+        /// comparison.
         /// </summary>
         /// <param name="leftRow">The first input DataRow</param>
         /// <param name="rightRow">The second input DataRow</param>

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/SqlClientTestGroup.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/SqlClientTestGroup.cs
@@ -196,7 +196,7 @@ namespace Stress.Data.SqlClient
         /// <param name="com"> The Sql Command to Execute</param>
         /// <param name="query">Indicates if data is being queried and where ExecuteQuery or Non-query to be used with the reader</param>
         /// <param name="xml">Indicates if the query should be executed as an Xml</param>
-        /// <param name="cancelled">Indicates if command was cancelled and is used to throw exception if a Command cancelation related exception is encountered</param>
+        /// <param name="cancelled">Indicates if command was cancelled and is used to throw exception if a Command cancellation related exception is encountered</param>
         /// <param name="cts">The Cancellation Token Source</param>
         private void SqlCommandEndExecute(Random rnd, IAsyncResult result, SqlCommand com, bool query, bool xml, bool cancelled, CancellationTokenSource cts = null)
         {

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SSPIResponse.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SSPIResponse.cs
@@ -10,7 +10,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint.SSPI
     public class SSPIResponse
     {
         /// <summary>
-        /// Payload to proceed to the next step of authentcation
+        /// Payload to proceed to the next step of authentication
         /// </summary>
         public byte[] Payload { get; set; }
 

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SecConstants.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SecConstants.cs
@@ -5,12 +5,12 @@
 namespace Microsoft.SqlServer.TDS.EndPoint.SSPI
 {
     /// <summary>
-    /// Constants that are used accros security API
+    /// Constants that are used across security API
     /// </summary>
     internal static class SecConstants
     {
         /// <summary>
-        /// Security packages used for SSPI authenication
+        /// Security packages used for SSPI authentication
         /// </summary>
         internal const string Negotiate = "negotiate";
         internal const string Kerberos = "kerberos";

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/FeatureExtAck/TDSFeatureExtAckToken.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/FeatureExtAck/TDSFeatureExtAckToken.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SqlServer.TDS.FeatureExtAck
     public class TDSFeatureExtAckToken : TDSPacketToken
     {
         /// <summary>
-        /// Collection of feature extension acknoeldged options
+        /// Collection of feature extension acknowledged options
         /// </summary>
         public IList<TDSFeatureExtAckOption> Options { get; set; }
 

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/Login7/TDSLogin7TokenOptionalFlags1.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/Login7/TDSLogin7TokenOptionalFlags1.cs
@@ -116,7 +116,7 @@ namespace Microsoft.SqlServer.TDS.Login7
         }
 
         /// <summary>
-        /// Initialization construcgtor
+        /// Initialization constructor
         /// </summary>
         public TDSLogin7TokenOptionalFlags1(byte flags)
         {

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/Login7/TDSLogin7TokenOptionalFlags2.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/Login7/TDSLogin7TokenOptionalFlags2.cs
@@ -75,7 +75,7 @@ namespace Microsoft.SqlServer.TDS.Login7
         }
 
         /// <summary>
-        /// Initialization construcgtor
+        /// Initialization constructor
         /// </summary>
         public TDSLogin7TokenOptionalFlags2(byte flags)
         {

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/Login7/TDSLogin7TokenOptionalFlags3.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/Login7/TDSLogin7TokenOptionalFlags3.cs
@@ -60,7 +60,7 @@ namespace Microsoft.SqlServer.TDS.Login7
         }
 
         /// <summary>
-        /// Initialization construcgtor
+        /// Initialization constructor
         /// </summary>
         public TDSLogin7TokenOptionalFlags3(byte flags)
         {

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/Login7/TDSLogin7TokenTypeFlags.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/Login7/TDSLogin7TokenTypeFlags.cs
@@ -60,7 +60,7 @@ namespace Microsoft.SqlServer.TDS.Login7
         }
 
         /// <summary>
-        /// Initialization construcgtor
+        /// Initialization constructor
         /// </summary>
         public TDSLogin7TokenTypeFlags(byte flags)
         {

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -124,9 +124,9 @@ namespace System.Diagnostics
     ///     "MyDiagnosticSource/SecurityStart@Activity2Start\r\n" + 
     ///     "MyDiagnosticSource/SecurityStop@Activity2Stop\r\n" 
     /// 
-    /// Defines that RequestStart will be logged with the EventSource Event Activity1Start (and the cooresponding stop) which
-    /// means that all events caused between these two markers will have an activity ID assocatied with this start event.  
-    /// Simmilarly SecurityStart is mapped to Activity2Start.    
+    /// Defines that RequestStart will be logged with the EventSource Event Activity1Start (and the corresponding stop) which
+    /// means that all events caused between these two markers will have an activity ID associated with this start event.  
+    /// Similarly SecurityStart is mapped to Activity2Start.    
     /// 
     /// Note you can map many DiangosticSource events to the same EventSource Event (e.g. Activity1Start).  As long as the
     /// activities don't nest, you can reuse the same event name (since the payloads have the DiagnosticSource name which can

--- a/src/System.Drawing.Common/src/System/Drawing/Font.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.cs
@@ -171,7 +171,7 @@ namespace System.Drawing
         }
 
         /// <summary>
-        /// Constructor to initialize fields from an exisiting native GDI+ object reference. Used by ToLogFont.
+        /// Constructor to initialize fields from an existing native GDI+ object reference. Used by ToLogFont.
         /// </summary>
         private Font(IntPtr nativeFont, byte gdiCharSet, bool gdiVerticalFont)
         {
@@ -424,17 +424,17 @@ namespace System.Drawing
         /// be valid if this font was created from a classic GDI font definition,
         /// like a LOGFONT or HFONT, or it was passed into the constructor.
         ///
-        /// This is here for compatability with native Win32 intrinsic controls
+        /// This is here for compatibility with native Win32 intrinsic controls
         /// on non-Unicode platforms.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public byte GdiCharSet => _gdiCharSet;
 
         /// <summary>
-        /// Determines if this font was created to represt a GDI vertical font. This will only be valid if this font
+        /// Determines if this font was created to represent a GDI vertical font. This will only be valid if this font
         /// was created from a classic GDIfont definition, like a LOGFONT or HFONT, or it was passed into the constructor.
         ///
-        /// This is here for compatability with native Win32 intrinsic controls on non-Unicode platforms.
+        /// This is here for compatibility with native Win32 intrinsic controls on non-Unicode platforms.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool GdiVerticalFont => _gdiVerticalFont;

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
@@ -433,7 +433,7 @@ namespace System.Drawing
         }
 
         /// <summary>
-        /// Represents an object used in conection with the printing API, it is used to hold a reference to a
+        /// Represents an object used in connection with the printing API, it is used to hold a reference to a
         /// PrintPreviewGraphics (fake graphics) or a printer DeviceContext (and maybe more in the future).
         /// </summary>
         internal object PrintingHelper

--- a/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
@@ -16,7 +16,7 @@ namespace System.Drawing
     ///     A common pattern for using this class is as follows (See PictureBox control):
     ///     1. The winform app (user's code) calls ImageAnimator.Animate() from the main thread.
     ///     2. Animate() spawns the animating (worker) thread in the background, which will update the image 
-    ///        frames and raise the OnFrameChanged event, which handler will be executed in the main thred.
+    ///        frames and raise the OnFrameChanged event, which handler will be executed in the main thread.
     ///     3. The main thread triggers a paint event (Invalidate()) from the OnFrameChanged handler.
     ///     4. From the OnPaint event, the main thread calls ImageAnimator.UpdateFrames() and then paints the 
     ///        image (updated frame).
@@ -29,7 +29,7 @@ namespace System.Drawing
     ///     
     ///     This class is safe for multi-threading but Image is not; multithreaded applications must use a critical
     ///     section lock using the image ref the image access is not from the same thread that executes ImageAnimator
-    ///     code.  If the user code locks on the image ref forever a deadlock will happen preventing the animiation 
+    ///     code.  If the user code locks on the image ref forever a deadlock will happen preventing the animation 
     ///     from occurring.
     /// </summary>                                
     public sealed partial class ImageAnimator
@@ -60,7 +60,7 @@ namespace System.Drawing
         private static ReaderWriterLock s_rwImgListLock = new ReaderWriterLock();
 
         /// <summary>
-        ///     Flag to avoid a deadlock when waiting on a write-lock and a an attemp to acquire a read-lock is 
+        ///     Flag to avoid a deadlock when waiting on a write-lock and a an attempt to acquire a read-lock is 
         ///     made in the same thread. If RWLock is currently owned by another thread, the current thread is going to wait on an 
         ///     event using CoWaitForMultipleHandles while pumps message. 
         ///     The comment above refers to the COM STA message pump, not to be confused with the UI message pump.
@@ -74,7 +74,7 @@ namespace System.Drawing
         ///     waiting for finalizer thread. RWLock is a fair lock. If a thread waits for a writer lock, then it needs
         ///     a reader lock while pumping message, the thread is blocked forever.
         ///     This TLS variable is used to flag the above situation and avoid the deadlock, it is ThreadStatic so each
-        ///     thread calling into ImageAnimator is garded against this problem.
+        ///     thread calling into ImageAnimator is guarded against this problem.
         /// </summary>
 
 

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -734,7 +734,7 @@ namespace System.Drawing
         }
 
         /// <summary>
-        /// Gets or sets an array of cutom dashes and spaces. The dashes are made up of line segments.
+        /// Gets or sets an array of custom dashes and spaces. The dashes are made up of line segments.
         /// </summary>
         public float[] DashPattern
         {
@@ -800,7 +800,7 @@ namespace System.Drawing
         }
 
         /// <summary>
-        /// Gets or sets an array of cutom dashes and spaces. The dashes are made up of line segments.
+        /// Gets or sets an array of custom dashes and spaces. The dashes are made up of line segments.
         /// </summary>
         public float[] CompoundArray
         {

--- a/src/System.Drawing.Common/src/misc/GDI/DeviceContext.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/DeviceContext.cs
@@ -23,9 +23,9 @@ namespace System.Drawing.Internal
         /// 
         /// The hDc is released/deleted only when owned by the object, meaning it was created internally; 
         /// in this case, the object is responsible for releasing/deleting it. 
-        /// In the case the object is created from an exisiting hdc, it is not released; this is consistent 
+        /// In the case the object is created from an existing hdc, it is not released; this is consistent 
         /// with the Win32 guideline that says if you call GetDC/CreateDC/CreatIC/CreateEnhMetafile, you are 
-        /// responsible for calling ReleaseDC/DeleteDC/DeleteEnhMetafile respectivelly.
+        /// responsible for calling ReleaseDC/DeleteDC/DeleteEnhMetafile respectively.
         /// 
         /// This class implements some of the operations commonly performed on the properties of a dc in WinForms, 
         /// specially for interacting with GDI+, like clipping and coordinate transformation.  
@@ -36,7 +36,7 @@ namespace System.Drawing.Internal
         /// Other properties are persisted from operation to operation until they are reset, like clipping, 
         /// one can make several calls to Graphics or WindowsGraphics obect after setting the dc clip area and 
         /// before resetting it; these kinds of properties are the ones implemented in this class.
-        /// This kind of properties place an extra chanllenge in the scenario where a DeviceContext is obtained 
+        /// This kind of properties place an extra challenge in the scenario where a DeviceContext is obtained 
         /// from a Graphics object that has been used with GDI+, because GDI+ saves the hdc internally, rendering the 
         /// DeviceContext underlying hdc out of sync.  DeviceContext needs to support these kind of properties to 
         /// be able to keep the GDI+ and GDI HDCs in sync.
@@ -49,7 +49,7 @@ namespace System.Drawing.Internal
         /// 5. View port origin.
         /// 6. Window extent
         /// 
-        /// Other non-persisted properties just for information: Background/Forground color, Palette, Color adjustment,
+        /// Other non-persisted properties just for information: Background/Foreground color, Palette, Color adjustment,
         /// Color space, ICM mode and profile, Current pen position, Binary raster op (not supported by GDI+), 
         /// Background mode, Logical Pen, DC pen color, ARc direction, Miter limit, Logical brush, DC brush color,
         /// Brush origin, Polygon filling mode, Bitmap stretching mode, Logical font, Intercharacter spacing, 
@@ -132,7 +132,7 @@ namespace System.Drawing.Internal
 
 
         /// <summary>
-        /// Constructor to contruct a DeviceContext object from an window handle.
+        /// Constructor to construct a DeviceContext object from an window handle.
         /// </summary>
         private DeviceContext(IntPtr hWnd)
         {
@@ -149,7 +149,7 @@ namespace System.Drawing.Internal
         }
 
         /// <summary>
-        /// Constructor to contruct a DeviceContext object from an existing Win32 device context handle.
+        /// Constructor to construct a DeviceContext object from an existing Win32 device context handle.
         /// </summary>
         private DeviceContext(IntPtr hDC, DeviceContextType dcType)
         {

--- a/src/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
@@ -15,7 +15,7 @@ namespace System.Drawing.Internal
     /// and compatibility issues found in GDI+ Graphics class.
     ///
     /// Note: WindowsGraphics is a stateful component, DC properties are persisted from method calls, as opposed to
-    /// Graphics (GDI+) which performs attomic operations and always restores the hdc. The underlying hdc is always
+    /// Graphics (GDI+) which performs atomic operations and always restores the hdc. The underlying hdc is always
     /// saved and restored on dispose so external HDCs won't be modified by WindowsGraphics. So we don't need to
     /// restore previous objects into the dc in method calls.
     ///</summary>

--- a/src/System.IO.Ports/tests/Support/PortsTest.cs
+++ b/src/System.IO.Ports/tests/Support/PortsTest.cs
@@ -28,7 +28,7 @@ namespace System.IO.PortsTests
 
         /// <summary>
         /// Shows that we can inhibit transmission using hardware flow control
-        /// Some kinds of virtual port or RS485 adaptor can't do this
+        /// Some kinds of virtual port or RS485 adapter can't do this
         /// </summary>
         public static bool HasHardwareFlowControl => TCSupport.HardwareWriteBlockingAvailable;
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
@@ -398,7 +398,7 @@ namespace System.Net.Http
             public bool IsUsable() => !_connection.ReadAheadCompleted;
 
             /// <summary>Gets whether the connection is currently usable, factoring in expiration time.</summary>
-            /// <param name="now">The current time.  Passed in to ammortize the cost of calling DateTime.UtcNow.</param>
+            /// <param name="now">The current time.  Passed in to amortize the cost of calling DateTime.UtcNow.</param>
             /// <returns>
             /// true if we believe the connection can be reused; otherwise, false.  There is an inherent race condition here,
             /// in that the server could terminate the connection or otherwise make it unusable immediately after we check it,

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/InstructionEncoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/InstructionEncoder.cs
@@ -20,7 +20,7 @@ namespace System.Reflection.Metadata.Ecma335
         /// Builder tracking labels, branches and exception handlers.
         /// </summary>
         /// <remarks>
-        /// If null the encoder doesn't support constuction of control flow.
+        /// If null the encoder doesn't support construction of control flow.
         /// </remarks>
         public ControlFlowBuilder ControlFlowBuilder { get; }
 

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationsImplementation.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationsImplementation.cs
@@ -18,7 +18,7 @@ namespace System.IO
     /// we want the <c>ReadAsync</c> / <c>WriteAsync</c> / <c>FlushAsync</c> / etc. operation to be implemented
     /// differently. This is for best performance as we can take advantage of the specifics of particular stream
     /// types. For instance, <c>ReadAsync</c> currently has a special implementation for memory streams.
-    /// Moreover, knowledge about the actual runtime type of the <c>IBuffer</c> can also help chosing the optimal
+    /// Moreover, knowledge about the actual runtime type of the <c>IBuffer</c> can also help choosing the optimal
     /// implementation. This type provides static methods that encapsulate the performance logic and can be used
     /// by <c>NetFxToWinRtStreamAdapter</c>.</summary>
     internal static class StreamOperationsImplementation

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoIdGenerator.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoIdGenerator.cs
@@ -20,7 +20,7 @@ namespace System.Threading.Tasks
 
         /// <summary>
         /// We want to avoid ending up with the same ID as a Windows-implemented async info.
-        /// At the same time we want to be reproducable. So we use a random generator with a fixed seed.
+        /// At the same time we want to be reproducible. So we use a random generator with a fixed seed.
         /// </summary>
         private static Random s_idGenerator = new Random(19830118);
 
@@ -44,7 +44,7 @@ namespace System.Threading.Tasks
         /// Initialises the specified <code>id</code> to a unique Id-value that can be used for an IAsyncInfo object under the
         /// assumption that another thread may also attempt to initialise <code>id</code>. The thread that changes <code>id</code>
         /// first from <code>AsyncInfoIdGenerator.InvalidId</code> to another value wins and all other threads will respect that
-        /// choice and leave <code>id</code> unchanged. The method returns the Id that was ageed upon by the race.
+        /// choice and leave <code>id</code> unchanged. The method returns the Id that was agreed upon by the race.
         /// </summary>
         /// <param name="id">The IAsyncInfo ID to initialise.</param>
         /// <returns>The unique value to which the specified reference target was initialised.</returns>

--- a/src/System.Security.Claims/src/System/Security/Claims/Claim.cs
+++ b/src/System.Security.Claims/src/System/Security/Claims/Claim.cs
@@ -251,7 +251,7 @@ namespace System.Security.Claims
         /// <param name="originalIssuer">The original issuer of this claim. If this parameter is empty or null, then originalIssuer == issuer.</param>
         /// <param name="subject">The subject that this claim describes.</param>
         /// <param name="propertyKey">This allows adding a property when adding a Claim.</param>
-        /// <param name="propertyValue">The value associcated with the property.</param>
+        /// <param name="propertyValue">The value associated with the property.</param>
         internal Claim(string type, string value, string valueType, string issuer, string originalIssuer, ClaimsIdentity subject, string propertyKey, string propertyValue)
         {
             if (type == null)

--- a/src/System.Threading.Overlapped/src/System/Threading/ClrThreadPoolBoundHandle.cs
+++ b/src/System.Threading.Overlapped/src/System/Threading/ClrThreadPoolBoundHandle.cs
@@ -264,7 +264,7 @@ namespace System.Threading
         /// </summary>
         /// <param name="overlapped">
         ///     An unmanaged pointer to the <see cref="NativeOverlapped"/> structure from which to return the 
-        ///     asscociated user-provided object.
+        ///     associated user-provided object.
         /// </param>
         /// <returns>
         ///     A user-provided object that distinguishes this <see cref="NativeOverlapped"/> 


### PR DESCRIPTION
Greetings,

[I've](https://github.com/aspnet/Security/pull/1391) [been](https://github.com/aspnet/Common/pull/260) on a [rampage](https://github.com/aspnet/Identity/pull/1400) to [clean Microsoft's source code of spelling and grammar mishaps](https://github.com/aspnet/Mvc/pull/6722) and `corefx` is my next target. :car: :police_car: :smiley: 

Turns out `corefx` is huge. And it's going to take me a while and there are **tons** of typos in this repo.

As a strategy, I decided to start with XML docs comments as that would probably bring the most value for y'all (and us consumers downstream). I'm trying to keep these PRs somewhat digestible so they can be easily be reviewed by a casual glance. This PR cleans up all the XML doc typos from A through C. Also contains a few extra I found along the way while perusing source files.

So, a couple of questions:
* Do you want me to continue?
* Would you like me to also check //inline code comments too?

Feel free to trash this PR if you think it's silly.

Thanks,
Brian

:thought_balloon: :mag: ***["I want to know... what you're thinking..."](https://www.youtube.com/watch?v=ijAYN9zVnwg)***