### PR TITLE
Fix Markdown link

### DIFF
--- a/Documentation/project-docs/dogfooding.md
+++ b/Documentation/project-docs/dogfooding.md
@@ -124,8 +124,7 @@ required to execute the application...`, you've hit this bug.
 Note #2: On non-Windows platforms, self-contained applications aren't runnable by default. You will
 see an error "Permission denied" when running the application. This is because of a
 [breaking change in the .NET Core runtime](https://github.com/dotnet/corefx/issues/15516) between 1.0 and 2.0.
-Either this breaking change needs to be fixed, or [NuGet will have to workaround the change]
-(https://github.com/NuGet/Home/issues/4424).
+Either this breaking change needs to be fixed, or [NuGet will have to workaround the change](https://github.com/NuGet/Home/issues/4424).
 
 To workaround this issue, run `chmod u+x bin/Debug/netcoreapp2.0/RID/publish/App` before executing
 your application.


### PR DESCRIPTION
I was reading through the docs and noticed this link did not work. It's a minor change, but I hope it helps.