### PR TITLE
Don't use a ProjectReference from test > src

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -24,7 +24,7 @@
     <Compile Include=".\AlwaysPassTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\src\Microsoft.XmlSerializer.Generator.csproj" />
+    <ReferenceFromRuntime Include="Microsoft.XmlSerializer.Generator" />
   </ItemGroup>
   <Target Name="GenerateSerializationAssembly" AfterTargets="Build" Condition=" '$(SkipTestsOnPlatform)' != 'true' " >
     <PropertyGroup>


### PR DESCRIPTION
Tests should not use project references to src projects.

This reference is triggering a rebuild of the src project during the
test phase which can result in a different binary.

This was found because it triggered another bug #23614 / #23618
that broke the test build