### PR TITLE
XML doc spelling corrections - I through P.

### DIFF
--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/NotifyParentPropertyAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/NotifyParentPropertyAttribute.cs
@@ -32,7 +32,7 @@ namespace System.ComponentModel
         public static readonly NotifyParentPropertyAttribute Default = No;
 
         /// <summary>
-        /// <para>Initiailzes a new instance of the NotifyPropertyAttribute class 
+        /// <para>Initializes a new instance of the NotifyPropertyAttribute class 
         ///    that uses the specified value
         ///    to indicate whether the parent property should be notified when a child namespace property is modified.</para>
         /// </summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -33,7 +33,7 @@ namespace System.ComponentModel.Design
         /// <summary>
         ///     Creates a new DesignerOptionCollection with the given name, and adds it to 
         ///     the given parent.  The "value" parameter specifies an object whose public 
-        ///     properties will be used in the Propeties collection of the option collection.  
+        ///     properties will be used in the Properties collection of the option collection.  
         ///     The value parameter can be null if this options collection does not offer 
         ///     any properties.  Properties will be wrapped in such a way that passing 
         ///     anything into the component parameter of the property descriptor will be 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/IComponentInitializer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/IComponentInitializer.cs
@@ -20,7 +20,7 @@ namespace System.ComponentModel.Design
         ///     dragging a component to another container, for example.  The defaultValues
         ///     property contains a name/value dictionary of default values that should be applied
         ///     to properties. This dictionary may be null if no default values are specified.
-        ///     You may use the defaultValues dictionary to apply recommended defaults to proeprties
+        ///     You may use the defaultValues dictionary to apply recommended defaults to properties
         ///     but you should not modify component properties beyond what is stored in the
         ///     dictionary, because this is an existing component that may already have properties
         ///     set on it.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/IDesignerSerializationProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/IDesignerSerializationProvider.cs
@@ -15,15 +15,15 @@ namespace System.ComponentModel.Design.Serialization
     {
         /// <summary>
         ///     This will be called by the serialization manager when it 
-        ///     is trying to locate a serialzer for an object type.
+        ///     is trying to locate a serializer for an object type.
         ///     If this serialization provider can provide a serializer
         ///     that is of the correct type, it should return it.
         ///     Otherwise, it should return null.
         ///
         ///     In order to break order dependencies between multiple
         ///     serialization providers the serialization manager will
-        ///     loop through all serilaization provideres until the 
-        ///     serilaizer returned reaches steady state.  Because
+        ///     loop through all serialization providers until the 
+        ///     serializer returned reaches steady state.  Because
         ///     of this you should always check currentSerializer
         ///     before returning a new serializer.  If currentSerializer
         ///     is an instance of your serializer, then you should

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ServiceObjectContainer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ServiceObjectContainer.cs
@@ -56,7 +56,7 @@ namespace System.ComponentModel.Design
         /// <summary>
         ///     This property returns the default services that are implemented directly on this IServiceContainer.
         ///     the default implementation of this property is to return the IServiceContainer and ServiceContainer
-        ///     types.  You may override this proeprty and return your own types, modifying the default behavior
+        ///     types.  You may override this property and return your own types, modifying the default behavior
         ///     of GetService.
         /// </summary>
         protected virtual Type[] DefaultServices => s_defaultServices;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/StandardCommands.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/StandardCommands.cs
@@ -11,7 +11,7 @@ namespace System.ComponentModel.Design
     using System.Threading;
 
     /// <summary>
-    ///    <para>Specifies indentifiers for the standard set of commands that are available to
+    ///    <para>Specifies identifiers for the standard set of commands that are available to
     ///       most applications.</para>
     /// </summary>
     public class StandardCommands

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
@@ -1187,7 +1187,7 @@ namespace System.ComponentModel
         ///     other words, it indicates whether the state of the property is distinct
         ///     from when the component is first instantiated. If there is a default
         ///     value specified in this ReflectPropertyDescriptor, it will be compared against the
-        ///     property's current value to determine this. If there is't, the
+        ///     property's current value to determine this. If there isn't, the
         ///     ShouldSerializeXXX method is looked for and invoked if found.  If both
         ///     these routes fail, true will be returned.
         ///

--- a/src/System.Composition.TypedParts/tests/ReflectionTests.cs
+++ b/src/System.Composition.TypedParts/tests/ReflectionTests.cs
@@ -17,7 +17,7 @@ namespace System.Composition.TypedParts.Tests
         /// Non-deterministic
         /// </summary>
         /// <remarks>
-        /// Because MethodInfo.GetParameters() lazy intializes it's return value, 
+        /// Because MethodInfo.GetParameters() lazy initializes it's return value, 
         /// concurrent calls can create different ParameterInfo instances.
         /// This can cause arguments to an export's constructor to incorrectly
         /// revert to a default value during GetExport.

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
@@ -377,7 +377,7 @@ namespace System.Configuration
         }
 
         /// <summary>
-        /// Overriden from SettingsBase to support validation event.
+        /// Overridden from SettingsBase to support validation event.
         /// </summary>
         public override void Save()
         {
@@ -391,7 +391,7 @@ namespace System.Configuration
         }
 
         /// <summary>
-        /// Overriden from SettingsBase to support validation event.
+        /// Overridden from SettingsBase to support validation event.
         /// </summary>
         public override object this[string propertyName]
         {

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationElementCollectionType.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationElementCollectionType.cs
@@ -46,7 +46,7 @@ namespace System.Configuration
           Any access via indexes have to go through some transformation step.
 
           The Alternate version changes the inheritance stuff like the BasicMapAlternate,
-          where the "nearest" config file entries take precendence over the "parent"
+          where the "nearest" config file entries take precedence over the "parent"
           config file entries (see example above).
         **********************************************************************/
 

--- a/src/System.Data.Common/src/System/Data/DataColumn.cs
+++ b/src/System.Data.Common/src/System/Data/DataColumn.cs
@@ -79,7 +79,7 @@ namespace System.Data
         }
 
         /// <summary>
-        /// Inititalizes a new instance of the <see cref='System.Data.DataColumn'/> class
+        /// Initializes a new instance of the <see cref='System.Data.DataColumn'/> class
         /// using the specified column name.
         /// </summary>
         public DataColumn(string columnName) : this(columnName, typeof(string), null, MappingType.Element)
@@ -87,7 +87,7 @@ namespace System.Data
         }
 
         /// <summary>
-        /// Inititalizes a new instance of the <see cref='System.Data.DataColumn'/> class
+        /// Initializes a new instance of the <see cref='System.Data.DataColumn'/> class
         /// using the specified column name and data type.
         /// </summary>
         public DataColumn(string columnName, Type dataType) : this(columnName, dataType, null, MappingType.Element)

--- a/src/System.Data.Common/src/System/Data/DataRelation.cs
+++ b/src/System.Data.Common/src/System/Data/DataRelation.cs
@@ -53,12 +53,12 @@ namespace System.Data
         internal string _childTableNamespace = null;
 
         /// <summary>
-        /// this stores whether the  child element appears beneath the parent in the XML persised files.
+        /// This stores whether the  child element appears beneath the parent in the XML persisted files.
         /// </summary>
         internal bool _nested = false;
 
         /// <summary>
-        /// this stores whether the relationship should make sure that KeyConstraints and ForeignKeyConstraints
+        /// This stores whether the relationship should make sure that KeyConstraints and ForeignKeyConstraints
         /// exist when added to the ConstraintsCollections of the table.
         /// </summary>
         internal bool _createConstraints;

--- a/src/System.Data.Common/src/System/Data/DataSet.cs
+++ b/src/System.Data.Common/src/System/Data/DataSet.cs
@@ -3063,7 +3063,7 @@ namespace System.Data
         private void OnInitialized() => Initialized?.Invoke(this, EventArgs.Empty);
 
         /// <summary>
-        /// This method should be overriden by subclasses to restrict tables being removed.
+        /// This method should be overridden by subclasses to restrict tables being removed.
         /// </summary>
         protected internal virtual void OnRemoveTable(DataTable table) { }
 
@@ -3077,7 +3077,7 @@ namespace System.Data
         }
 
         /// <summary>
-        /// This method should be overriden by subclasses to restrict tables being removed.
+        /// This method should be overridden by subclasses to restrict tables being removed.
         /// </summary>
         protected virtual void OnRemoveRelation(DataRelation relation) { }
 

--- a/src/System.Data.Common/src/System/Data/DataTable.cs
+++ b/src/System.Data.Common/src/System/Data/DataTable.cs
@@ -179,7 +179,7 @@ namespace System.Data
         }
 
         /// <summary>
-        /// Intitalizes a new instance of the <see cref='System.Data.DataTable'/> class with the specified table
+        /// Initializes a new instance of the <see cref='System.Data.DataTable'/> class with the specified table
         ///    name.
         /// </summary>
         public DataTable(string tableName) : this()

--- a/src/System.Data.Common/src/System/Data/DataView.cs
+++ b/src/System.Data.Common/src/System/Data/DataView.cs
@@ -70,7 +70,7 @@ namespace System.Data
         private Dictionary<DataRow, DataRowView> _rowViewCache = new Dictionary<DataRow, DataRowView>(DataRowReferenceComparer.s_default);
 
         /// <summary>
-        /// This collection allows expression maintaince to (add / remove) from the index when it really should be a (change / move).
+        /// This collection allows expression maintenance to (add / remove) from the index when it really should be a (change / move).
         /// </summary>
         private readonly Dictionary<DataRow, DataRowView> _rowViewBuffer = new Dictionary<DataRow, DataRowView>(DataRowReferenceComparer.s_default);
 

--- a/src/System.Data.Common/src/System/Data/Filter/Operators.cs
+++ b/src/System.Data.Common/src/System/Data/Filter/Operators.cs
@@ -119,8 +119,8 @@ namespace System.Data
         internal const int priMax = 24;
 
         /// <summary>
-        ///     Mapping from Operator to prioritys
-        ///     CONSIDER: fast, but hard to maitain
+        ///     Mapping from Operator to priorities
+        ///     CONSIDER: fast, but hard to maintain
         /// </summary>
 
         private static readonly int[] s_priority = new int[] {

--- a/src/System.Data.Common/tests/System/Data/DataSetTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTest.cs
@@ -1673,7 +1673,7 @@ namespace System.Data.Tests
         }
 
         /// <summary>
-        /// Test for testing DataSet.Clear method with foriegn key relations
+        /// Test for testing DataSet.Clear method with foreign key relations
         /// This is expected to clear all the related datatable rows also
         /// </summary>
         [Fact]

--- a/src/System.Data.DataSetExtensions/src/System/Data/SortExpressionBuilder.cs
+++ b/src/System.Data.DataSetExtensions/src/System/Data/SortExpressionBuilder.cs
@@ -9,7 +9,7 @@ namespace System.Data
 {
 
     /// <summary>
-    /// This class represents a combined sort expression build using mutiple sort expressions.
+    /// This class represents a combined sort expression build using multiple sort expressions.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     internal class SortExpressionBuilder<T> : IComparer<List<object>>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -473,7 +473,7 @@ namespace System.Data.SqlClient.SNI
         /// Gets the Local db Named pipe data source if the input is a localDB server. 
         /// </summary>
         /// <param name="fullServerName">The data source</param>
-        /// <param name="error">Set true when an error occured while getting LocalDB up</param>
+        /// <param name="error">Set true when an error occurred while getting LocalDB up</param>
         /// <returns></returns>
         private string GetLocalDBDataSource(string fullServerName, out bool error)
         {

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/SqlClientTestGroup.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/SqlClientTestGroup.cs
@@ -38,8 +38,8 @@ namespace Stress.Data.SqlClient
         /// This significantly increases the probability of hitting some bugs, such as:
         ///     vstfdevdiv 674236 (SqlConnection.Open() throws InvalidOperationException for absolutely valid connection request)
         ///     sqlbuvsts 328845 (InvalidOperationException: The requested operation cannot be completed because the connection has been broken.) (this is LSE QFE)
-        /// However, calling ClearAllPools all the time might also significantly decrease te probability of hitting some other bug,
-        /// so this thread will alternate between hammering on ClearAllPools for several minutes, and then doing nother for several minutes.
+        /// However, calling ClearAllPools all the time might also significantly decrease the probability of hitting some other bug,
+        /// so this thread will alternate between hammering on ClearAllPools for several minutes, and then doing nothing for several minutes.
         /// </summary>
         private static Thread s_clearAllPoolsThread;
 

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.Servers/GenericTDSServerSession.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.Servers/GenericTDSServerSession.cs
@@ -398,7 +398,7 @@ namespace Microsoft.SqlServer.TDS.Servers
         }
 
         /// <summary>
-        /// Indlate recovery data
+        /// Inflate recovery data
         /// </summary>
         private void _InflateRecoveryData(TDSSessionRecoveryData data)
         {

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/LanguageString.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/LanguageString.cs
@@ -7,7 +7,7 @@ using System;
 namespace Microsoft.SqlServer.TDS
 {
     /// <summary>
-    /// Class that contains langauge names and can convert between enumeration and strings
+    /// Class that contains language names and can convert between enumeration and strings
     /// </summary>
     public static class LanguageString
     {

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/SessionState/TDSSessionStateOption.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/SessionState/TDSSessionStateOption.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SqlServer.TDS.SessionState
     public abstract class TDSSessionStateOption : IDeflatable, IInflatable
     {
         /// <summary>
-        /// Property that tells the caller how much of the data from the stream was read by infation logic
+        /// Property that tells the caller how much of the data from the stream was read by inflation logic
         /// </summary>
         internal uint InflationSize { get; set; }
 

--- a/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
+++ b/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
@@ -1,4 +1,4 @@
-﻿# DiagnosticSource Users Guide
+# DiagnosticSource Users Guide
 
 This document describes DiagnosticSource, a simple module that allows code 
 to be instrumented for production-time logging of **rich data payloads** for 
@@ -125,7 +125,7 @@ Thus the event names only need to be unique within a component.
    most important scenarios involve turning on whole listeners and not needing to filter
    for particular events.    You may need to split
    a source into multiple smaller ones to achieve this, and this is OK.   For example there
-   are both incomming Http request and outgoing Http requests and you may only need one 
+   are both incoming HTTP requests and outgoing HTTP requests and you may only need one 
    or the other, so having a System.Net.Http.Incomming and System.Net.Http.OutGoing for
    each sub-case is good.  
 
@@ -406,7 +406,7 @@ And consumers may use such properties to filter events more precisely.
 ```
 
 Note that producer is not aware of filter consumer has provided. DiagnosticListener 
-will invoke provided filter ommiting additional arguments if necessary, thus the filter
+will invoke provided filter omitting additional arguments if necessary, thus the filter
 should expect to receive null context.
 Producers should enclose IsEnabled call with event name and context with pure IsEnabled
 call for event name, so consumers must ensure that filter allows events without context

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -28,9 +28,9 @@ namespace System.Diagnostics
     ///   list that will be forwarded to the EventSource.    If it is empty, values of properties of the 
     ///   diagnostic source payload are dumped as strings (using ToString()) and forwarded to the EventSource.  
     ///   For what people think of as serializable object strings, primitives this gives you want you want. 
-    ///   (the value of the property in string form) for what people think of as non-serialiable objects 
+    ///   (the value of the property in string form) for what people think of as non-serializable objects 
     ///   (e.g. HttpContext) the ToString() method is typically not defined, so you get the Object.ToString() 
-    ///   implemenation that prints the type name.  This is useful since this is the information you need 
+    ///   implementation that prints the type name.  This is useful since this is the information you need 
     ///   (the type of the property) to discover the field names so you can create a transform specification
     ///   that will pick off the properties you desire.  
     ///   

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
@@ -458,7 +458,7 @@ namespace System.DirectoryServices.AccountManagement
 
         /// <summary>
         /// If The enabled property was set on the principal then perform actions 
-        /// neccessary on the principal to set the enabled status to match
+        /// necessary on the principal to set the enabled status to match
         /// the set value.
         /// </summary>
         /// <param name="p"></param>
@@ -821,7 +821,7 @@ namespace System.DirectoryServices.AccountManagement
         /// just check bit 0x0010.  On DL platforms this attribute does not exist so we must read lockoutTime and return locked if
         /// this is greater than 0
         /// </summary>
-        /// <param name="p">Princiapl to check status</param>
+        /// <param name="p">Principal to check status</param>
         /// <returns>true is account is locked, false if not</returns>
         internal override bool IsLockedOut(AuthenticablePrincipal p)
         {
@@ -896,7 +896,7 @@ namespace System.DirectoryServices.AccountManagement
 
         // methods for manipulating passwords
         /// <summary>
-        /// Set the password on the principal. This function requires administrator privilages
+        /// Set the password on the principal. This function requires administrator privileges
         /// </summary>
         /// <param name="p">Principal to modify</param>
         /// <param name="newPassword">New password</param>

--- a/src/System.DirectoryServices/src/System/DirectoryServices/DirectorySearcher.cs
+++ b/src/System.DirectoryServices/src/System/DirectoryServices/DirectorySearcher.cs
@@ -398,7 +398,7 @@ namespace System.DirectoryServices
         public bool Asynchronous { get; set; }
 
         /// <devdoc>
-        /// Gets or sets a value indicateing whether the search should also return deleted objects that match the search  
+        /// Gets or sets a value indicating whether the search should also return deleted objects that match the search  
         /// filter.
         /// </devdoc>
         [DefaultValue(false)]

--- a/src/System.DirectoryServices/src/System/DirectoryServices/SchemaNameCollection.cs
+++ b/src/System.DirectoryServices/src/System/DirectoryServices/SchemaNameCollection.cs
@@ -148,7 +148,7 @@ namespace System.DirectoryServices
         }
 
         /// <devdoc>
-        /// nserts an item at the specified position in the collection.
+        /// Inserts an item at the specified position in the collection.
         /// </devdoc>
         public void Insert(int index, string value)
         {

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
@@ -47,7 +47,7 @@ namespace System.Drawing
         ///
         /// The <paramref name="createDefaultOnFail"/> parameter determines how errors are handled when creating a
         /// font based on a font family that does not exist on the end user's system at run time. If this parameter is
-        /// true, then a fall-back fontwill always be used instead. If this parameter is false, an exception will be thrown.
+        /// true, then a fall-back font will always be used instead. If this parameter is false, an exception will be thrown.
         /// </summary>
         internal FontFamily(string name, bool createDefaultOnFail)
         {

--- a/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
@@ -865,7 +865,7 @@ namespace System.Drawing
         public class ENHMETAHEADER
         {
             /// The ENHMETAHEADER structure is defined natively as a union with WmfHeader.  
-            /// Extreme care should be taken if changing the layout of the corresponding managaed 
+            /// Extreme care should be taken if changing the layout of the corresponding managed 
             /// structures to minimize the risk of buffer overruns.  The affected managed classes 
             /// are the following: ENHMETAHEADER, MetaHeader, MetafileHeaderWmf, MetafileHeaderEmf.
             public int iType;

--- a/src/System.Drawing.Common/src/System/Drawing/IDeviceContext.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/IDeviceContext.cs
@@ -13,7 +13,7 @@ namespace System.Drawing
     /// special care, for instance using other Win32 functions like CreateDC or CreateCompatibleDC require 
     /// DeleteDC instead of ReleaseDC to properly free the dc handle.  
     /// 
-    /// See the DeviceContext class for an implemenation of this interface, it uses the Dispose method
+    /// See the DeviceContext class for an implementation of this interface, it uses the Dispose method
     /// for freeing non-display dc handles.
     /// 
     /// This is a low-level API that is expected to be used with TextRenderer or PInvoke calls.

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameters.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameters.cs
@@ -35,7 +35,7 @@ namespace System.Drawing.Imaging
         /// <summary>
         /// Copy the EncoderParameters data into a chunk of memory to be consumed by native GDI+ code.
         ///
-        /// We need to marshal the EncoderParameters info from/to native GDI+ ourselve since the definition of the managed/unmanaged classes
+        /// We need to marshal the EncoderParameters info from/to native GDI+ ourselves since the definition of the managed/unmanaged classes
         /// are different and the native class is a bit weird. The native EncoderParameters class is defined in GDI+ as follows:
         /// 
         /// class EncoderParameters {

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeaderEmf.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeaderEmf.cs
@@ -10,7 +10,7 @@ namespace System.Drawing.Imaging
     internal class MetafileHeaderEmf
     {
         /// The ENHMETAHEADER structure is defined natively as a union with WmfHeader.  
-        /// Extreme care should be taken if changing the layout of the corresponding managaed 
+        /// Extreme care should be taken if changing the layout of the corresponding managed 
         /// structures to minimize the risk of buffer overruns.  The affected managed classes 
         /// are the following: ENHMETAHEADER, MetaHeader, MetafileHeaderWmf, MetafileHeaderEmf.
         public MetafileType type = MetafileType.Invalid;

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeaderWmf.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeaderWmf.cs
@@ -10,7 +10,7 @@ namespace System.Drawing.Imaging
     internal class MetafileHeaderWmf
     {
         /// The ENHMETAHEADER structure is defined natively as a union with WmfHeader.  
-        /// Extreme care should be taken if changing the layout of the corresponding managaed 
+        /// Extreme care should be taken if changing the layout of the corresponding managed 
         /// structures to minimize the risk of buffer overruns.  The affected managed classes 
         /// are the following: ENHMETAHEADER, MetaHeader, MetafileHeaderWmf, MetafileHeaderEmf.
         public MetafileType type = MetafileType.Invalid;

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/PixelFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/PixelFormat.cs
@@ -33,7 +33,7 @@ namespace System.Drawing.Imaging
         /// </summary>
         Alpha = 0x00040000,
         /// <summary>
-        /// Specifies that pixel format contains pre-multipled alpha values.
+        /// Specifies that pixel format contains pre-multiplied alpha values.
         /// </summary>
         PAlpha = 0x00080000, // What's this?
         Extended = 0x00100000,

--- a/src/System.Drawing.Common/src/System/Drawing/Text/PrivateFontCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/PrivateFontCollection.cs
@@ -10,7 +10,7 @@ using System.IO;
 namespace System.Drawing.Text
 {
     /// <summary>
-    /// Encapsulates a collection of <see cref='System.Drawing.Font'/> objecs.
+    /// Encapsulates a collection of <see cref='System.Drawing.Font'/> objects.
     /// </summary>
     public sealed partial class PrivateFontCollection : FontCollection
     {

--- a/src/System.Drawing.Common/src/misc/GDI/DeviceContext.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/DeviceContext.cs
@@ -34,7 +34,7 @@ namespace System.Drawing.Internal
         /// DrawString (GDI+).  
         /// 
         /// Other properties are persisted from operation to operation until they are reset, like clipping, 
-        /// one can make several calls to Graphics or WindowsGraphics obect after setting the dc clip area and 
+        /// one can make several calls to Graphics or WindowsGraphics object after setting the dc clip area and 
         /// before resetting it; these kinds of properties are the ones implemented in this class.
         /// This kind of properties place an extra challenge in the scenario where a DeviceContext is obtained 
         /// from a Graphics object that has been used with GDI+, because GDI+ saves the hdc internally, rendering the 

--- a/src/System.Drawing.Common/src/misc/GDI/DeviceContexts.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/DeviceContexts.cs
@@ -6,7 +6,7 @@ namespace System.Drawing.Internal
 {
     /// <summary>
     /// Keeps a cache of some graphics primitives. Created to improve performance of TextRenderer.MeasureText methods
-    /// that don't receive a WindowsGraphics. This class mantains a cache of MRU WindowsFont objects in the process.
+    /// that don't receive a WindowsGraphics. This class maintains a cache of MRU WindowsFont objects in the process.
     /// </summary>
     internal static class DeviceContexts
     {

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
@@ -454,7 +454,7 @@ namespace System.Net.Http
         /// </summary>
         /// <remarks>
         /// Implemented as a non-generic base type with a generic derived type to support
-        /// passing in arbitrary funcs and associated state while mininimizing allocations.
+        /// passing in arbitrary funcs and associated state while minimizing allocations.
         /// The <see cref="CreateConnectionAsync"/> method will be implemented on the derived
         /// type that is able to work with the supplied state generically.
         /// </remarks>

--- a/src/System.Private.Xml/src/System/Xml/Schema/XmlValueConverter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/XmlValueConverter.cs
@@ -490,7 +490,7 @@ namespace System.Xml.Schema
 
         /// <summary>
         /// This method is called when a valid conversion cannot be found.  By default, this method throws an error.  It can
-        /// be overriden in derived classes to support list conversions.
+        /// be overridden in derived classes to support list conversions.
         /// </summary>
         protected virtual object ChangeListType(object value, Type destinationType, IXmlNamespaceResolver nsResolver)
         {

--- a/src/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlIlVisitor.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlIlVisitor.cs
@@ -2375,7 +2375,7 @@ namespace System.Xml.Xsl.IlGen
         }
 
         /// <summary>
-        /// Generate code for for QilNodeType.DocOrderDistinct.
+        /// Generate code for QilNodeType.DocOrderDistinct.
         /// </summary>
         protected override QilNode VisitDocOrderDistinct(QilUnary ndDod)
         {
@@ -2537,7 +2537,7 @@ namespace System.Xml.Xsl.IlGen
         }
 
         /// <summary>
-        /// Generate code for for QilNodeType.Invoke.
+        /// Generate code for QilNodeType.Invoke.
         /// </summary>
         protected override QilNode VisitInvoke(QilInvoke ndInvoke)
         {
@@ -2578,7 +2578,7 @@ namespace System.Xml.Xsl.IlGen
         }
 
         /// <summary>
-        /// Generate code for for QilNodeType.Content.
+        /// Generate code for QilNodeType.Content.
         /// </summary>
         protected override QilNode VisitContent(QilUnary ndContent)
         {
@@ -2587,7 +2587,7 @@ namespace System.Xml.Xsl.IlGen
         }
 
         /// <summary>
-        /// Generate code for for QilNodeType.Attribute.
+        /// Generate code for QilNodeType.Attribute.
         /// </summary>
         protected override QilNode VisitAttribute(QilBinary ndAttr)
         {
@@ -2612,7 +2612,7 @@ namespace System.Xml.Xsl.IlGen
         }
 
         /// <summary>
-        /// Generate code for for QilNodeType.Parent.
+        /// Generate code for QilNodeType.Parent.
         /// </summary>
         protected override QilNode VisitParent(QilUnary ndParent)
         {
@@ -2632,7 +2632,7 @@ namespace System.Xml.Xsl.IlGen
         }
 
         /// <summary>
-        /// Generate code for for QilNodeType.Root.
+        /// Generate code for QilNodeType.Root.
         /// </summary>
         protected override QilNode VisitRoot(QilUnary ndRoot)
         {
@@ -2676,7 +2676,7 @@ namespace System.Xml.Xsl.IlGen
         }
 
         /// <summary>
-        /// Generate code for for QilNodeType.DescendantOrSelf.
+        /// Generate code for QilNodeType.DescendantOrSelf.
         /// </summary>
         protected override QilNode VisitDescendantOrSelf(QilUnary ndDesc)
         {
@@ -2746,7 +2746,7 @@ namespace System.Xml.Xsl.IlGen
         }
 
         /// <summary>
-        /// Generate code for for QilNodeType.Deref.
+        /// Generate code for QilNodeType.Deref.
         /// </summary>
         protected override QilNode VisitDeref(QilBinary ndDeref)
         {
@@ -3028,7 +3028,7 @@ namespace System.Xml.Xsl.IlGen
         }
 
         /// <summary>
-        /// Generate code for for QilNodeType.RtfCtor.
+        /// Generate code for QilNodeType.RtfCtor.
         /// </summary>
         protected override QilNode VisitRtfCtor(QilBinary ndRtf)
         {
@@ -3548,7 +3548,7 @@ namespace System.Xml.Xsl.IlGen
         }
 
         /// <summary>
-        /// Generate code for for QilNodeType.XsltInvokeLateBound.
+        /// Generate code for QilNodeType.XsltInvokeLateBound.
         /// </summary>
         protected override QilNode VisitXsltInvokeLateBound(QilInvokeLateBound ndInvoke)
         {
@@ -3594,7 +3594,7 @@ namespace System.Xml.Xsl.IlGen
         }
 
         /// <summary>
-        /// Generate code for for QilNodeType.XsltInvokeEarlyBound.
+        /// Generate code for QilNodeType.XsltInvokeEarlyBound.
         /// </summary>
         protected override QilNode VisitXsltInvokeEarlyBound(QilInvokeEarlyBound ndInvoke)
         {

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/EarlyBoundInfo.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/EarlyBoundInfo.cs
@@ -53,7 +53,7 @@ namespace System.Xml.Xsl.Runtime
         }
 
         /// <summary>
-        /// Override GetHashCode since Equals is overriden.
+        /// Override GetHashCode since Equals is overridden.
         /// </summary>
         public override int GetHashCode()
         {

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlAttributeCache.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlAttributeCache.cs
@@ -167,7 +167,7 @@ namespace System.Xml.Xsl.Runtime
         }
 
         /// <summary>
-        /// Send cached, non-overriden attributes to the specified writer.  Calling this method has
+        /// Send cached, non-overridden attributes to the specified writer.  Calling this method has
         /// the side effect of clearing the attribute cache.
         /// </summary>
         internal override void StartElementContent()

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlExtensionFunction.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlExtensionFunction.cs
@@ -331,7 +331,7 @@ namespace System.Xml.Xsl.Runtime
         }
 
         /// <summary>
-        /// Infer an Xml type from a Clr type using Xslt infererence rules
+        /// Infer an Xml type from a Clr type using Xslt inference rules
         /// </summary>
         private XmlQueryType InferXmlType(Type clrType)
         {

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XmlQueryType.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XmlQueryType.cs
@@ -70,7 +70,7 @@ namespace System.Xml.Xsl
         /// SchemaType will follow these rules:
         ///   1. If TypeCode is an atomic type code, then SchemaType will be the corresponding non-null simple type
         ///   2. If TypeCode is Element or Attribute, then SchemaType will be the non-null content type
-        ///   3. If TypeCode is Item, Node, Comment, PI, Text, Document, Namespacce, None, then SchemaType will be AnyType
+        ///   3. If TypeCode is Item, Node, Comment, PI, Text, Document, Namespace, None, then SchemaType will be AnyType
         /// </summary>
         public abstract XmlSchemaType SchemaType { get; }
 

--- a/src/System.Private.Xml/tests/XmlSchema/TestFiles/TestData/XMLSchema.xsd
+++ b/src/System.Private.Xml/tests/XmlSchema/TestFiles/TestData/XMLSchema.xsd
@@ -391,7 +391,7 @@
      <xs:annotation>
       <xs:documentation>
       Not allowed if simpleContent child is chosen.
-      May be overriden by setting on complexContent child.</xs:documentation>
+      May be overridden by setting on complexContent child.</xs:documentation>
     </xs:annotation>
     </xs:attribute>
     <xs:attribute name="abstract" type="xs:boolean" use="optional" default="false"/>

--- a/src/System.Reflection.Metadata/tests/Metadata/Ecma335/MetadataBuilderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Ecma335/MetadataBuilderTests.cs
@@ -203,7 +203,7 @@ namespace System.Reflection.Metadata.Ecma335.Tests
         }
 
         /// <summary>
-        /// Add methods do miminal validation to avoid overhead.
+        /// Add methods do minimal validation to avoid overhead.
         /// </summary>
         [Fact]
         public void Add_ArgumentErrors()

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBufferExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBufferExtensions.cs
@@ -309,7 +309,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
 
         /// <summary>
-        /// Checks if the underlying memory backing two <code>IBuffer</code> intances is actually the same memory.
+        /// Checks if the underlying memory backing two <code>IBuffer</code> instances is actually the same memory.
         /// When applied to <code>IBuffer</code> instances backed by managed arrays this method is preferable to a naive comparison
         /// (such as <code>((IBufferByteAccess) buffer).Buffer == ((IBufferByteAccess) otherBuffer).Buffer</code>) because it avoids
         /// pinning the backing array which would be necessary if a direct memory pointer was obtained.

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RijndaelImplementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RijndaelImplementation.cs
@@ -11,7 +11,7 @@ namespace Internal.Cryptography
     /// Internal implementation of Rijndael.
     /// This class is returned from Rijndael.Create() instead of the public RijndaelManaged to 
     /// be consistent with the rest of the static Create() methods which return opaque types.
-    /// They both have have the same implementation.
+    /// They both have the same implementation.
     /// </summary>
     internal sealed class RijndaelImplementation : Rijndael
     {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedXml.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedXml.cs
@@ -95,7 +95,7 @@ namespace System.Security.Cryptography.Xml
         }
 
         /// <summary>
-        /// This mentod validates the _xmlDsigSearchDepthCounter counter
+        /// This method validates the _xmlDsigSearchDepthCounter counter
         /// if the counter is over the limit defined by admin or developer.
         /// </summary>
         /// <returns>returns true if the limit has reached otherwise false</returns>

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXmlDebugLog.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXmlDebugLog.cs
@@ -1030,7 +1030,7 @@ namespace System.Security.Cryptography.Xml
         }
 
         /// <summary>
-        /// Write informaiton when user hits the Signed XML recursion depth limit issue.
+        /// Write information when user hits the Signed XML recursion depth limit issue.
         /// This is helpful in debugging this kind of issues.
         /// </summary>
         /// <param name="signedXml">SignedXml object verifying the signature</param>

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -915,8 +915,8 @@ namespace System.Security.Principal
         }
 
         /// <summary>
-        /// Intenal method to initialize the claim collection.
-        /// Lazy init is used so claims are not initialzed until needed
+        /// Internal method to initialize the claim collection.
+        /// Lazy init is used so claims are not initialized until needed
         /// </summary>        
         private void InitializeClaims()
         {

--- a/src/System.Threading.Tasks.Dataflow/src/XmlDocs/System.Threading.Tasks.Dataflow.xml
+++ b/src/System.Threading.Tasks.Dataflow/src/XmlDocs/System.Threading.Tasks.Dataflow.xml
@@ -73,7 +73,7 @@
     </member>
     <member name="M:System.Threading.Tasks.Dataflow.ActionBlock`1.ToString">
       <summary>Returns a string that represents the formatted name of this <see cref="T:System.Threading.Tasks.Dataflow.IDataflowBlock" /> instance.</summary>
-      <returns>A string that represents the formatted name of this <see cref="T:System.Threading.Tasks.Dataflow.IDataflowBlock" /> nstance.</returns>
+      <returns>A string that represents the formatted name of this <see cref="T:System.Threading.Tasks.Dataflow.IDataflowBlock" /> instance.</returns>
     </member>
     <member name="T:System.Threading.Tasks.Dataflow.BatchBlock`1">
       <summary>Provides a dataflow block that batches inputs into arrays.</summary>

--- a/src/System.Threading/src/System/Threading/ReaderWriterLock.cs
+++ b/src/System.Threading/src/System/Threading/ReaderWriterLock.cs
@@ -21,7 +21,7 @@ namespace System.Threading
     ///    whether there were any intermediate writes. Downgrading from a writer lock restores the state of the lock.
     /// 7. Supports functionality to release all locks owned by a thread (see <see cref="ReleaseLock"/>).
     ///    <see cref="RestoreLock(ref LockCookie)"/> restores the lock state.
-    /// 8. Recovers from most common failures such as creation of events. In other words, the lock mainitains consistent
+    /// 8. Recovers from most common failures such as creation of events. In other words, the lock maintains consistent
     ///    internal state and remains usable
     /// </summary>
     public sealed class ReaderWriterLock : CriticalFinalizerObject

--- a/src/System.Transactions.Local/src/System/Transactions/DistributedTransaction.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/DistributedTransaction.cs
@@ -49,7 +49,7 @@ namespace System.Transactions.Distributed
     /// <summary>
     /// A Transaction object represents a single transaction.  It is created by TransactionManager
     /// objects through CreateTransaction or through deserialization.  Alternatively, the static Create
-    /// methodis provided, which creates a "default" TransactionManager and requests that it create
+    /// methods provided, which creates a "default" TransactionManager and requests that it create
     /// a new transaction with default values.  A transaction can only be committed by 
     /// the client application that created the transaction.  If a client application wishes to allow 
     /// access to the transaction by multiple threads, but wants to prevent those other threads from 


### PR DESCRIPTION
XML doc spelling corrections - I through P.

The third drop of spelling corrections.

NOTES:
* Few ways to spell **Initialises** vs **Initializes**; both being correct I think. Of those misspellings with the "z" version, I've corrected them.

* There are a few in this batch that I wasn't sure of. These are marked with `!!`. I'll correct them when I have some feedback on them.

STATUS:
- [x] #23634 A through C - **Merged** :white_check_mark: 
- [ ] #23638 D through H - revised with feedback **Waiting Merge** :hourglass: 

:violin: :palm_tree: ***["'Cause it's a bittersweet symphony, this life..."](https://www.youtube.com/watch?v=1lyu1KKwC74)***