### PR TITLE
XML doc spelling corrections - Q through Z.

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
@@ -19,7 +19,7 @@ namespace System.Diagnostics
         /// <param name="args">The arguments to pass to the method.</param>
         /// <param name="start">true if this function should Start the Process; false if that responsibility is left up to the caller.</param>
         /// <param name="psi">The ProcessStartInfo to use, or null for a default.</param>
-        /// <param name="pasteArguments">true if this function should paste the arguments (e.g. surrounding with quotes); false if that reponsibility is left up to the caller.</param>
+        /// <param name="pasteArguments">true if this function should paste the arguments (e.g. surrounding with quotes); false if that responsibility is left up to the caller.</param>
         private static RemoteInvokeHandle RemoteInvoke(MethodInfo method, string[] args, RemoteInvokeOptions options, bool pasteArguments = true)
         {
             options = options ?? new RemoteInvokeOptions();

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DelegatingTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DelegatingTypeDescriptionProvider.cs
@@ -60,7 +60,7 @@ namespace System.ComponentModel
         ///     The name of the specified component, or null if the component has no name.
         ///     In many cases this will return the same value as GetComponentName. If the
         ///     component resides in a nested container or has other nested semantics, it may
-        ///     return a different fully qualfied name.
+        ///     return a different fully qualified name.
         ///
         ///     If not overridden, the default implementation of this method will call
         ///     GetTypeDescriptor.GetComponentName.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransaction.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransaction.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel.Design
 {
     /// <summary>
     ///     Identifies a transaction within a designer.  Transactions are
-    ///     used to wrap serveral changes into one unit of work, which 
+    ///     used to wrap several changes into one unit of work, which 
     ///     helps performance.
     /// </summary>
     public abstract class DesignerTransaction : IDisposable

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/IDesignerSerializationProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/IDesignerSerializationProvider.cs
@@ -15,15 +15,15 @@ namespace System.ComponentModel.Design.Serialization
     {
         /// <summary>
         ///     This will be called by the serialization manager when it 
-        ///     is trying to locate a serialzer for an object type.
+        ///     is trying to locate a serializer for an object type.
         ///     If this serialization provider can provide a serializer
         ///     that is of the correct type, it should return it.
         ///     Otherwise, it should return null.
         ///
         ///     In order to break order dependencies between multiple
         ///     serialization providers the serialization manager will
-        ///     loop through all serilaization provideres until the 
-        ///     serilaizer returned reaches steady state.  Because
+        ///     loop through all serialization providers until the 
+        ///     serializer returned reaches steady state.  Because
         ///     of this you should always check currentSerializer
         ///     before returning a new serializer.  If currentSerializer
         ///     is an instance of your serializer, then you should

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/INameCreationService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/INameCreationService.cs
@@ -28,7 +28,7 @@ namespace System.ComponentModel.Design.Serialization
         /// <summary>
         ///     Determines if the given name is valid.  A name 
         ///     creation service may have rules defining a valid
-        ///     name, and this method allows the sevice to enforce
+        ///     name, and this method allows the service to enforce
         ///     those rules.
         /// </summary>
         bool IsValidName(string name);
@@ -36,7 +36,7 @@ namespace System.ComponentModel.Design.Serialization
         /// <summary>
         ///     Determines if the given name is valid.  A name 
         ///     creation service may have rules defining a valid
-        ///     name, and this method allows the sevice to enforce
+        ///     name, and this method allows the service to enforce
         ///     those rules.  It is similar to IsValidName, except
         ///     that this method will throw an exception if the
         ///     name is invalid.  This allows implementors to provide

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/MemberRelationshipService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/MemberRelationshipService.cs
@@ -20,7 +20,7 @@ namespace System.ComponentModel.Design.Serialization
     ///    between these two objects is lost.  Serialization schemes that
     ///    wish to maintain this relationship may install a MemberRelationshipService
     ///    into the serialization manager.  When an object is deserialized
-    ///    this serivce will be notified of these relationships.  It is up to the service
+    ///    this service will be notified of these relationships.  It is up to the service
     ///    to act on these notifications if it wishes.  During serialization, the
     ///    service is also consulted.  If a relationship exists the same
     ///    relationship is maintained by the serializer.
@@ -126,7 +126,7 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///    Returns true if the provided relatinoship is supported.
+        ///    Returns true if the provided relationship is supported.
         /// </summary>
         public abstract bool SupportsRelationship(MemberRelationship source, MemberRelationship relationship);
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DesignTimeVisibleAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DesignTimeVisibleAttribute.cs
@@ -51,7 +51,7 @@ namespace System.ComponentModel
         public static readonly DesignTimeVisibleAttribute No = new DesignTimeVisibleAttribute(false);
 
         /// <summary>
-        ///     The default visiblity. (equal to Yes.)
+        ///     The default visibility. (equal to Yes.)
         /// </summary>
         public static readonly DesignTimeVisibleAttribute Default = Yes;
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ICancelAddNew.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ICancelAddNew.cs
@@ -11,7 +11,7 @@ namespace System.ComponentModel
     ///     to be either cancelled or committed.
     ///
     ///     Note: In some scenarios, specifically Windows Forms complex data binding,
-    ///     the list may recieve CancelNew or EndNew calls for items other than the
+    ///     the list may receive CancelNew or EndNew calls for items other than the
     ///     new item. These calls should be ignored, ie. the new item should only be
     ///     cancelled or committed when that item's index is specified.
     /// </summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
@@ -455,12 +455,12 @@ namespace System.ComponentModel
         public bool AllowPromptAsInput => _flagState[s_ALLOW_PROMPT_AS_INPUT];
 
         /// <summary>
-        ///     Retreives the number of editable characters that have been set.
+        ///     Retrieves the number of editable characters that have been set.
         /// </summary>
         public int AssignedEditPositionCount { get; private set; }
 
         /// <summary>
-        ///     Retreives the number of editable characters that have been set.
+        ///     Retrieves the number of editable characters that have been set.
         /// </summary>
         public int AvailableEditPositionCount => EditPositionCount - AssignedEditPositionCount;
 
@@ -468,7 +468,7 @@ namespace System.ComponentModel
         ///     Creates a 'clean' (no text assigned) MaskedTextProvider instance with the same property values as the 
         ///     current instance.
         ///     Derived classes can override this method and call base.Clone to get proper cloning semantics but must
-        ///     implement the full-paramter constructor (passing parameters to the base constructor as well).
+        ///     implement the full-parameter constructor (passing parameters to the base constructor as well).
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2113:SecureLateBindingMethods")]
         public object Clone()
@@ -1436,7 +1436,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///     Checks wheteher the specified position is available for assignment.  Returns false if it is assigned
+        ///     Checks whether the specified position is available for assignment.  Returns false if it is assigned
         ///     or it is not editable, true otherwise.
         /// </summary>
         public bool IsAvailablePosition(int position)
@@ -1452,7 +1452,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///     Checks wheteher the specified position in the test string is editable.
+        ///     Checks whether the specified position in the test string is editable.
         /// </summary>
         public bool IsEditPosition(int position)
         {
@@ -1472,7 +1472,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///     Checks wheteher the character in the specified position is a literal and the same as the specified character.
+        ///     Checks whether the character in the specified position is a literal and the same as the specified character.
         /// </summary>
         private static bool IsLiteralPosition(CharDescriptor charDescriptor)
         {
@@ -1480,7 +1480,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///     Checks wheteher the specified character is valid as part of a mask or an input string.  
+        ///     Checks whether the specified character is valid as part of a mask or an input string.  
         /// </summary>
         private static bool IsPrintableChar(char c)
         {
@@ -1488,7 +1488,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///     Checks wheteher the specified character is a valid input char.  
+        ///     Checks whether the specified character is a valid input char.  
         /// </summary>
         public static bool IsValidInputChar(char c)
         {
@@ -1496,7 +1496,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///     Checks wheteher the specified character is a valid input char.  
+        ///     Checks whether the specified character is a valid input char.  
         /// </summary>
         public static bool IsValidMaskChar(char c)
         {
@@ -1504,7 +1504,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///     Checks wheteher the specified character is a valid password char.
+        ///     Checks whether the specified character is a valid password char.
         /// </summary>
         public static bool IsValidPasswordChar(char c)
         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -726,7 +726,7 @@ namespace System.ComponentModel
         ///     The name of the specified component, or null if the component has no name.
         ///     In many cases this will return the same value as GetComponentName. If the
         ///     component resides in a nested container or has other nested semantics, it may
-        ///     return a different fully qualfied name.
+        ///     return a different fully qualified name.
         ///
         ///     If not overridden, the default implementation of this method will call
         ///     GetComponentName.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RunInstallerAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RunInstallerAttribute.cs
@@ -59,7 +59,7 @@ namespace System.ComponentModel
 
         /// <summary>
         ///    <para>
-        ///       Specifies the default visiblity, which is <see cref='System.ComponentModel.RunInstallerAttribute.No'/>. This <see langword='static '/>field is
+        ///       Specifies the default visibility, which is <see cref='System.ComponentModel.RunInstallerAttribute.No'/>. This <see langword='static '/>field is
         ///       read-only.
         ///    </para>
         /// </summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
@@ -26,7 +26,7 @@ namespace System.ComponentModel
     ///     These two filters specify that ReportElement toolbox items will only be 
     ///     enabled when a ReportDesigner is visible.  By specifying a filter type of
     ///     Require on the report designer class, this will disable any toolbox items
-    ///     that are not report elements.  If the report designer specifed a filter type
+    ///     that are not report elements.  If the report designer specified a filter type
     ///     of "Allow" instead of "Require", other components would be enabled when the
     ///     report designer was active.  ReportElements would still be disabled when 
     ///     other designers were active, however, because ReportElement requires designers

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptionProvider.cs
@@ -125,7 +125,7 @@ namespace System.ComponentModel
         ///     The name of the specified component, or null if the component has no name.
         ///     In many cases this will return the same value as GetComponentName. If the
         ///     component resides in a nested container or has other nested semantics, it may
-        ///     return a different fully qualfied name.
+        ///     return a different fully qualified name.
         ///
         ///     If not overridden, the default implementation of this method will call
         ///     GetTypeDescriptor.GetComponentName.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -1195,7 +1195,7 @@ namespace System.ComponentModel
         ///     The name of the specified component, or null if the component has no name.
         ///     In many cases this will return the same value as GetComponentName. If the
         ///     component resides in a nested container or has other nested semantics, it may
-        ///     return a different fully qualfied name.
+        ///     return a different fully qualified name.
         /// </summary>
         public static string GetFullComponentName(object component)
         {
@@ -3201,7 +3201,7 @@ namespace System.ComponentModel
             ///     The name of the specified component, or null if the component has no name.
             ///     In many cases this will return the same value as GetComponentName. If the
             ///     component resides in a nested container or has other nested semantics, it may
-            ///     return a different fully qualfied name.
+            ///     return a different fully qualified name.
             ///
             ///     If not overridden, the default implementation of this method will call
             ///     GetTypeDescriptor.GetComponentName.

--- a/src/System.Data.Common/src/System/Data/DataColumn.cs
+++ b/src/System.Data.Common/src/System/Data/DataColumn.cs
@@ -468,7 +468,7 @@ namespace System.Data
         internal DataExpression DataExpression => _expression;
 
         /// <summary>
-        /// The type of data stored in thecolumn.
+        /// The type of data stored in the column.
         /// </summary>
         [DefaultValue(typeof(string))]
         [RefreshProperties(RefreshProperties.All)]

--- a/src/System.Data.DataSetExtensions/src/System/Data/DataRowExtensions.cs
+++ b/src/System.Data.DataSetExtensions/src/System/Data/DataRowExtensions.cs
@@ -19,7 +19,7 @@ namespace System.Data
         /// Nullable when the generic type is nullable. 
         /// </summary>
         /// <param name="row">The input DataRow</param>
-        /// <param name="columnName">The input column name specificy which row value to retrieve.</param>
+        /// <param name="columnName">The input column name specifying which row value to retrieve.</param>
         /// <returns>The DataRow value for the column specified.</returns> 
         public static T Field<T>(this DataRow row, string columnName)
         {
@@ -34,7 +34,7 @@ namespace System.Data
         /// Nullable when the generic type is nullable. 
         /// </summary>
         /// <param name="row">The input DataRow</param>
-        /// <param name="column">The input DataColumn specificy which row value to retrieve.</param>
+        /// <param name="column">The input DataColumn specifying which row value to retrieve.</param>
         /// <returns>The DataRow value for the column specified.</returns> 
         public static T Field<T>(this DataRow row, DataColumn column)
         {
@@ -49,7 +49,7 @@ namespace System.Data
         /// Nullable when the generic type is nullable. 
         /// </summary>
         /// <param name="row">The input DataRow</param>
-        /// <param name="columnIndex">The input ordinal specificy which row value to retrieve.</param>
+        /// <param name="columnIndex">The input ordinal specifying which row value to retrieve.</param>
         /// <returns>The DataRow value for the column specified.</returns> 
         public static T Field<T>(this DataRow row, int columnIndex)
         {
@@ -64,7 +64,7 @@ namespace System.Data
         /// Nullable when the generic type is nullable. 
         /// </summary>
         /// <param name="row">The input DataRow</param>
-        /// <param name="columnIndex">The input ordinal specificy which row value to retrieve.</param>
+        /// <param name="columnIndex">The input ordinal specifying which row value to retrieve.</param>
         /// <param name="version">The DataRow version for which row value to retrieve.</param>
         /// <returns>The DataRow value for the column specified.</returns> 
         public static T Field<T>(this DataRow row, int columnIndex, DataRowVersion version)
@@ -80,7 +80,7 @@ namespace System.Data
         /// Nullable when the generic type is nullable. 
         /// </summary>
         /// <param name="row">The input DataRow</param>
-        /// <param name="columnName">The input column name specificy which row value to retrieve.</param>
+        /// <param name="columnName">The input column name specifying which row value to retrieve.</param>
         /// <param name="version">The DataRow version for which row value to retrieve.</param>
         /// <returns>The DataRow value for the column specified.</returns> 
         public static T Field<T>(this DataRow row, string columnName, DataRowVersion version)
@@ -96,7 +96,7 @@ namespace System.Data
         /// Nullable when the generic type is nullable. 
         /// </summary>
         /// <param name="row">The input DataRow</param>
-        /// <param name="column">The input DataColumn specificy which row value to retrieve.</param>
+        /// <param name="column">The input DataColumn specifying which row value to retrieve.</param>
         /// <param name="version">The DataRow version for which row value to retrieve.</param>
         /// <returns>The DataRow value for the column specified.</returns> 
         public static T Field<T>(this DataRow row, DataColumn column, DataRowVersion version)
@@ -121,7 +121,7 @@ namespace System.Data
         /// This method sets a new value for the specified column for the DataRow it�s called on. 
         /// </summary>
         /// <param name="row">The input DataRow.</param>
-        /// <param name="columnName">The input column name specificy which row value to retrieve.</param>
+        /// <param name="columnName">The input column name specifying which row value to retrieve.</param>
         /// <param name="value">The new row value for the specified column.</param>
         public static void SetField<T>(this DataRow row, string columnName, T value)
         {
@@ -133,7 +133,7 @@ namespace System.Data
         /// This method sets a new value for the specified column for the DataRow it�s called on. 
         /// </summary>
         /// <param name="row">The input DataRow.</param>
-        /// <param name="column">The input DataColumn specificy which row value to retrieve.</param>
+        /// <param name="column">The input DataColumn specifying which row value to retrieve.</param>
         /// <param name="value">The new row value for the specified column.</param>
         public static void SetField<T>(this DataRow row, DataColumn column, T value)
         {

--- a/src/System.Data.DataSetExtensions/src/System/Data/DataTableExtensions.cs
+++ b/src/System.Data.DataSetExtensions/src/System/Data/DataTableExtensions.cs
@@ -66,7 +66,7 @@ namespace System.Data
         /// <param name="options">The target DataTable to load.</param>
         /// <param name="errorHandler">Error handler for recoverable errors.
         /// Recoverable errors include:
-        ///   A source DataRow is in the deleted or detached state state.
+        ///   A source DataRow is in the deleted or detached state.
         ///   DataTable.LoadDataRow threw an exception, i.e. wrong # of columns in source row
         /// Unrecoverable errors include:
         ///   exceptions from IEnumerator, DataTable.BeginLoadData or DataTable.EndLoadData</param>

--- a/src/System.Data.DataSetExtensions/src/System/Data/SortExpressionBuilder.cs
+++ b/src/System.Data.DataSetExtensions/src/System/Data/SortExpressionBuilder.cs
@@ -70,7 +70,7 @@ namespace System.Data
         }
 
         /// <summary>
-        /// Represents a Combined selector of all selectors added thusfar.
+        /// Represents a Combined selector of all selectors added thus far.
         /// </summary>
         /// <returns>List of 'objects returned by each selector'. This list is the combined-selector</returns>
         public List<object> Select(T row)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/LocalDB.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/LocalDB.Windows.cs
@@ -152,7 +152,7 @@ namespace System.Data.SqlClient.SNI
         }
 
         /// <summary>
-        /// Retireves the part of the sqlUserInstance.dll from the registry
+        /// Retrieves the part of the sqlUserInstance.dll from the registry
         /// </summary>
         /// <param name="errorState">In case the dll path is not found, the error is set here.</param>
         /// <returns></returns>

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/HostsFileManager.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/HostsFileManager.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Test.Data.SqlClient
     /// using (var hostsFile = new HostsFileManager())
     /// {
     ///     // use the hostsFile methods to add/remove entries
-    ///     // simultanious usage of HostsFileManager in two app domains or processes on the same machine is not allowed
+    ///     // simultaneous usage of HostsFileManager in two app domains or processes on the same machine is not allowed
     /// }
     /// </summary>
     public sealed class HostsFileManager : IDisposable

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/ITDSClient.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/ITDSClient.cs
@@ -33,26 +33,26 @@ namespace Microsoft.SqlServer.TDS.EndPoint
         /// <summary>
         /// It is called when pre-login response arrives
         /// </summary>
-        /// <param name="message">TDS message recieved</param>
+        /// <param name="message">TDS message received</param>
         /// <returns>TDS message to send to the server</returns>
         TDSMessage OnPreLoginResponse(TDSMessage message);
 
         /// <summary>
         /// It is called when SPNEGO response arrives
         /// </summary>
-        /// <param name="packet">TDS message recieved</param>		
+        /// <param name="packet">TDS message received</param>		
         TDSMessage OnSSPIResponse(TDSMessage message);
 
         /// <summary>
         /// It is called when FedAuthInfoToken response arrives
         /// </summary>
-        /// <param name="packet">TDS message recieved</param>		
+        /// <param name="packet">TDS message received</param>		
         TDSMessage OnFedAuthInfoTokenResponse(TDSMessage message);
 
         /// <summary>
         /// It is called when login acknowledgement arrives.
         /// </summary>
-        /// <param name="packet">TDS message recieved</param>		
+        /// <param name="packet">TDS message received</param>		
         void OnLoginResponse(TDSMessage message);
 
         /// <summary>

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/ITDSClientContext.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/ITDSClientContext.cs
@@ -85,7 +85,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint
         string Query { get; set; }
 
         /// <summary>
-        /// Respose to the query
+        /// Response to the query
         /// </summary>
         IList<object[]> QueryResponse { get; set; }
 

--- a/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
+++ b/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
@@ -1,4 +1,4 @@
-﻿# DiagnosticSource Users Guide
+# DiagnosticSource Users Guide
 
 This document describes DiagnosticSource, a simple module that allows code 
 to be instrumented for production-time logging of **rich data payloads** for 
@@ -151,7 +151,7 @@ Thus the event names only need to be unique within a component.
 
 #### EventNames 
 
- * DO - keep the names reasonably short (< 16 characters).   Keep in mind that that event names 
+ * DO - keep the names reasonably short (< 16 characters).   Keep in mind that event names 
    are already qualified by the Listener so the name only needs to be unique within a listener. 
    Short names make the 'IsEnabled' faster.  
 

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -22,7 +22,7 @@ namespace System.Diagnostics
     /// 
     /// No methods on Activity allow exceptions to escape as a response to bad inputs.
     /// They are thrown and caught (that allows Debuggers and Monitors to see the error)
-    /// but the exception is supressed, and the operation does something reasonable (typically
+    /// but the exception is suppressed, and the operation does something reasonable (typically
     /// doing nothing).  
     /// </summary>
     public partial class Activity

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
@@ -53,7 +53,7 @@ namespace System.Diagnostics
         /// IsEnabled(string)  to check if consumer wants to get notifications for such events at all. 
         /// Based on it, producer may call IsEnabled(string, object, object) again with non-null context </param>
         /// <param name="arg2">Optional. An object that represents the additional context for IsEnabled. 
-        /// Null by default. Consumers shoud expect to receive null which may indicate that producer 
+        /// Null by default. Consumers should expect to receive null which may indicate that producer 
         /// called pure IsEnabled(string) or producer passed all necessary context in arg1</param>
         /// <seealso cref="IsEnabled(string)"/>
         public virtual bool IsEnabled(string name, object arg1, object arg2 = null)

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -28,9 +28,9 @@ namespace System.Diagnostics
     ///   list that will be forwarded to the EventSource.    If it is empty, values of properties of the 
     ///   diagnostic source payload are dumped as strings (using ToString()) and forwarded to the EventSource.  
     ///   For what people think of as serializable object strings, primitives this gives you want you want. 
-    ///   (the value of the property in string form) for what people think of as non-serialiable objects 
+    ///   (the value of the property in string form) for what people think of as non-serializable objects 
     ///   (e.g. HttpContext) the ToString() method is typically not defined, so you get the Object.ToString() 
-    ///   implemenation that prints the type name.  This is useful since this is the information you need 
+    ///   implementation that prints the type name.  This is useful since this is the information you need 
     ///   (the type of the property) to discover the field names so you can create a transform specification
     ///   that will pick off the properties you desire.  
     ///   

--- a/src/System.DirectoryServices/src/System/DirectoryServices/ReferalChasingOption.cs
+++ b/src/System.DirectoryServices/src/System/DirectoryServices/ReferalChasingOption.cs
@@ -10,7 +10,7 @@ namespace System.DirectoryServices
     public enum ReferralChasingOption
     {
         /// <devdoc>
-        /// Never chase the referred-to server. Setthing this option 
+        /// Never chase the referred-to server. Setting this option 
         /// prevents a client from contacting other servers in a referral process.
         /// </devdoc>
         None = 0,

--- a/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.cs
@@ -391,7 +391,7 @@ namespace System.Drawing
         ///       UpdateDIBColorTable function should be called to maintain
         ///       the identity palette mapping between the DIB and the display.
         /// </summary>
-        /// <returns>A valid bitmap handle if successul, IntPtr.Zero otherwise.</returns>
+        /// <returns>A valid bitmap handle if successful, IntPtr.Zero otherwise.</returns>
         [SuppressMessage("Microsoft.Interoperability", "CA1404:CallGetLastErrorImmediatelyAfterPInvoke")]
         private IntPtr CreateCompatibleDIB(IntPtr hdc, IntPtr hpal, int ulWidth, int ulHeight, ref IntPtr ppvBits)
         {

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
@@ -200,7 +200,7 @@ namespace System.Drawing
         public string Name => GetName(CurrentLanguage);
 
         /// <summary>
-        /// Retuns the name of this <see cref='FontFamily'/> in the specified language.
+        /// Returns the name of this <see cref='FontFamily'/> in the specified language.
         /// </summary>
         public string GetName(int language)
         {

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMap.cs
@@ -30,7 +30,7 @@ namespace System.Drawing.Imaging
             set { _oldColor = value; }
         }
         /// <summary>
-        /// Specifes the new <see cref='Color'/> to which to convert.
+        /// Specifies the new <see cref='Color'/> to which to convert.
         /// </summary>
         public Color NewColor
         {

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EmfType.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EmfType.cs
@@ -10,15 +10,15 @@ namespace System.Drawing.Imaging
     public enum EmfType
     {
         /// <summary>
-        /// Windows enhanced metafile. Contains GDI commands. Metafiles of this type are refered to as an EMF file.
+        /// Windows enhanced metafile. Contains GDI commands. Metafiles of this type are referred to as an EMF file.
         /// </summary>
         EmfOnly = MetafileType.Emf,
         /// <summary>
-        /// Windows enhanced metafile plus. Contains GDI+ commands. Metafiles of this type are refered to as an EMF+ file.
+        /// Windows enhanced metafile plus. Contains GDI+ commands. Metafiles of this type are referred to as an EMF+ file.
         /// </summary>
         EmfPlusOnly = MetafileType.EmfPlusOnly,
         /// <summary>
-        /// Dual Windows enhanced metafile. Contains equivalent GDI and GDI+ commands. Metafiles of this type are refered to as an EMF+ file.
+        /// Dual Windows enhanced metafile. Contains equivalent GDI and GDI+ commands. Metafiles of this type are referred to as an EMF+ file.
         /// </summary>
         EmfPlusDual = MetafileType.EmfPlusDual
     }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/PixelFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/PixelFormat.cs
@@ -48,7 +48,7 @@ namespace System.Drawing.Imaging
         DontCare = 0,
         // makes it into devtools, we can change this.
         /// <summary>
-        /// Specifies thatpixel format is 1 bit per pixel indexed color. The color table therefore has two colors in it.
+        /// Specifies that pixel format is 1 bit per pixel indexed color. The color table therefore has two colors in it.
         /// </summary>
         Format1bppIndexed = 1 | (1 << 8) | (int)Indexed | (int)Gdi,
         /// <summary>

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPreviewGraphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPreviewGraphics.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 namespace System.Drawing
 {
     /// <summary>
-    /// Retrives the printer graphics during preview.
+    /// Retrieves the printer graphics during preview.
     /// </summary>
     internal class PrintPreviewGraphics
     {

--- a/src/System.Drawing.Common/src/System/Drawing/StringFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringFormat.cs
@@ -17,7 +17,7 @@ namespace System.Drawing
         private int _length;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref='CharacterRange'/> class with the specifiedcoordinates.
+        /// Initializes a new instance of the <see cref='CharacterRange'/> class with the specified coordinates.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public CharacterRange(int First, int Length)

--- a/src/System.Drawing.Common/src/System/Drawing/StringFormatFlags.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringFormatFlags.cs
@@ -24,7 +24,7 @@ namespace System.Drawing
         /// Specifies that no part of any glyph overhangs the bounding rectangle. By default some glyphs
         /// overhang the rectangle slightly where necessary to appear at the edge visually. For example
         /// when an italic lower case letter f in a font such as Garamond is aligned at the far left
-        /// of a rectangle, the lower part of the f will reach slightly further left thanthe left edge
+        /// of a rectangle, the lower part of the f will reach slightly further left than the left edge
         /// of the rectangle. Setting this flag will ensure no painting outside the rectangle but will
         /// cause the aligned edges of adjacent lines of text to appear uneven.
         /// 

--- a/src/System.Drawing.Common/src/System/Drawing/Unit.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Unit.cs
@@ -30,7 +30,7 @@ namespace System.Drawing
         /// </summary>
         Inch = 4,
         /// <summary>
-        /// Specifes the document unit (1/300 inch) as the unit of measure.
+        /// Specifies the document unit (1/300 inch) as the unit of measure.
         /// </summary>
         Document = 5,
         /// <summary>

--- a/src/System.Drawing.Common/src/misc/DebugHandleTracker.cs
+++ b/src/System.Drawing.Common/src/misc/DebugHandleTracker.cs
@@ -429,7 +429,7 @@ namespace System.Internal
                     }
 
                     /// <summary>
-                    /// Rereives the string of the parsed stack trace
+                    /// Retrieves the string of the parsed stack trace
                     /// </summary>
                     public override string ToString()
                     {

--- a/src/System.Drawing.Common/src/misc/GDI/DeviceContext.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/DeviceContext.cs
@@ -12,7 +12,7 @@ namespace System.Drawing.Internal
     /// Represents a Win32 device context.  Provides operations for setting some of the properties of a device context.
     /// It's the managed wrapper for an HDC.
     ///
-    /// This class is divided into two files separating the code that needs to be compiled into reatail builds and
+    /// This class is divided into two files separating the code that needs to be compiled into retail builds and
     /// debugging code.
     /// </summary>
     internal sealed partial class DeviceContext : MarshalByRefObject, IDeviceContext, IDisposable
@@ -34,7 +34,7 @@ namespace System.Drawing.Internal
         /// DrawString (GDI+).  
         /// 
         /// Other properties are persisted from operation to operation until they are reset, like clipping, 
-        /// one can make several calls to Graphics or WindowsGraphics obect after setting the dc clip area and 
+        /// one can make several calls to Graphics or WindowsGraphics object after setting the dc clip area and 
         /// before resetting it; these kinds of properties are the ones implemented in this class.
         /// This kind of properties place an extra challenge in the scenario where a DeviceContext is obtained 
         /// from a Graphics object that has been used with GDI+, because GDI+ saves the hdc internally, rendering the 

--- a/src/System.Drawing.Common/src/misc/GDI/UnsafeNativeMethods.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/UnsafeNativeMethods.cs
@@ -22,7 +22,7 @@ namespace System.Drawing.Internal
         }
 
         /// <summary>
-        /// NOTE: DeleteDC is to be used to delete the hdc created from CreateCompatibleDC ONLY. All other hdcs shoul
+        /// NOTE: DeleteDC is to be used to delete the hdc created from CreateCompatibleDC ONLY. All other hdcs should
         /// be deleted with DeleteHDC.
         /// </summary>
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, EntryPoint = "DeleteDC", CharSet = CharSet.Auto)]

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.ChildRewriter.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.ChildRewriter.cs
@@ -292,7 +292,7 @@ namespace System.Linq.Expressions.Compiler
             }
 
             /// <summary>
-            /// Gets a Boolean value indicating whether the parent expression shoud be
+            /// Gets a Boolean value indicating whether the parent expression should be
             /// rewritten by using <see cref="Finish"/>.
             /// </summary>
             internal bool Rewrite => _action != RewriteAction.None;

--- a/src/System.Net.Requests/src/System/Net/CommandStream.cs
+++ b/src/System.Net.Requests/src/System/Net/CommandStream.cs
@@ -177,7 +177,7 @@ namespace System.Net
             }
         }
 
-        ///     Pipelined command resoluton.
+        ///     Pipelined command resolution.
         ///     How this works:
         ///     A list of commands that need to be sent to the FTP server are spliced together into a array,
         ///     each command such STOR, PORT, etc, is sent to the server, then the response is parsed into a string,

--- a/src/System.Net.Requests/src/System/Net/FtpWebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/FtpWebResponse.cs
@@ -141,7 +141,7 @@ namespace System.Net
         }
 
         /// <summary>
-        /// <para>Last status code retrived</para>
+        /// <para>Last status code retrieved</para>
         /// </summary>
         public FtpStatusCode StatusCode
         {
@@ -152,7 +152,7 @@ namespace System.Net
         }
 
         /// <summary>
-        /// <para>Last status line retrived</para>
+        /// <para>Last status line retrieved</para>
         /// </summary>
         public string StatusDescription
         {
@@ -163,7 +163,7 @@ namespace System.Net
         }
 
         /// <summary>
-        /// <para>Returns last modified date time for given file (null if not relavant/avail)</para>
+        /// <para>Returns last modified date time for given file (null if not relevant/avail)</para>
         /// </summary>
         public DateTime LastModified
         {

--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
@@ -1867,7 +1867,7 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
-        /// Generates a <see cref="XElement"/> from its XML respresentation.
+        /// Generates a <see cref="XElement"/> from its XML representation.
         /// </summary>
         /// <param name="reader">
         /// The <see cref="XmlReader"/> stream from which the <see cref="XElement"/>

--- a/src/System.Private.Xml/src/System/Xml/Core/HtmlRawTextWriterGenerator.cxx
+++ b/src/System.Private.Xml/src/System/Xml/Core/HtmlRawTextWriterGenerator.cxx
@@ -762,7 +762,7 @@ namespace System.Xml {
 //
         int indentLevel;
 
-        // for detecting SE SC sitution
+        // for detecting SE SC situation
         int endBlockPos;
 
         // settings

--- a/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilInvokeEarlyBound.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilInvokeEarlyBound.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 namespace System.Xml.Xsl.Qil
 {
     /// <summary>
-    /// A function invocation node which reperesents a call to an early bound Clr function.
+    /// A function invocation node which represents a call to an early bound Clr function.
     /// </summary>
     internal class QilInvokeEarlyBound : QilTernary
     {

--- a/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilInvokeLateBound.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilInvokeLateBound.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 namespace System.Xml.Xsl.Qil
 {
     /// <summary>
-    /// A function invocation node which reperesents a call to an late bound function.
+    /// A function invocation node which represents a call to an late bound function.
     /// </summary>
     internal class QilInvokeLateBound : QilBinary
     {

--- a/src/System.Private.Xml/src/System/Xml/Xsl/QIL/SubstitutionList.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/QIL/SubstitutionList.cs
@@ -24,7 +24,7 @@ namespace System.Xml.Xsl.Qil
         }
 
         /// <summary>
-        /// Add a substituion pair
+        /// Add a substitution pair
         /// </summary>
         /// <param name="find">a node to be replaced</param>
         /// <param name="replace">its replacement</param>
@@ -35,7 +35,7 @@ namespace System.Xml.Xsl.Qil
         }
 
         /// <summary>
-        /// Remove the last a substituion pair
+        /// Remove the last a substitution pair
         /// </summary>
         public void RemoveLastSubstitutionPair()
         {

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XmlQueryTypeFactory.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XmlQueryTypeFactory.cs
@@ -1346,7 +1346,7 @@ namespace System.Xml.Xsl
         }
 
         /// <summary>
-        /// Converts type of sequence of items to type of sequnce of atomic value
+        /// Converts type of sequence of items to type of sequence of atomic value
         //  See http://www.w3.org/TR/2004/xquery-semantics/#jd_data for the detailed description
         /// </summary>
         /// <param name="source">source type</param>

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
@@ -116,7 +116,7 @@ namespace System.Reflection.Metadata
         public int RemainingBytes => (int)(_endPointer - _currentPointer);
        
         /// <summary>
-        /// Repositions the reader to the start of the underluing memory block.
+        /// Repositions the reader to the start of the underlying memory block.
         /// </summary>
         public void Reset()
         {

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -3492,7 +3492,7 @@ public static partial class DataContractSerializerTests
     }
 
     /// <summary>
-    /// This case is a part of DCS_BasicPerSerializerRoundTripAndCompare_SampleTypes, but in thease scenarios it was not support in current version.
+    /// This case is a part of DCS_BasicPerSerializerRoundTripAndCompare_SampleTypes, but in these scenarios it was not support in current version.
     /// </summary>
     [Fact]
     [ActiveIssue("Not support")]

--- a/src/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -153,7 +153,7 @@ namespace System.Security.Claims
         /// <para>All <see cref="Claim"/>s are copied into this instance in a <see cref="List{Claim}"/>. Each Claim is examined and if Claim.Subject != this, then Claim.Clone(this) is called before the claim is added.</para>
         /// <para>Any 'External' claims are ignored.</para>
         /// </remarks>
-        /// <exception cref="InvalidOperationException">if 'identity' is a <see cref="ClaimsIdentity"/> and <see cref="ClaimsIdentity.Actor"/> results in a circular refrence back to 'this'.</exception>
+        /// <exception cref="InvalidOperationException">if 'identity' is a <see cref="ClaimsIdentity"/> and <see cref="ClaimsIdentity.Actor"/> results in a circular reference back to 'this'.</exception>
         public ClaimsIdentity(IIdentity identity, IEnumerable<Claim> claims, string authenticationType, string nameType, string roleType)
         {
             ClaimsIdentity claimsIdentity = identity as ClaimsIdentity;
@@ -450,7 +450,7 @@ namespace System.Security.Claims
         /// Adds a <see cref="IEnumerable{Claim}"/> to the internal list.
         /// </summary>
         /// <param name="claims">Enumeration of claims to add.</param>
-        /// <remarks>Each claim is examined and if <see cref="Claim.Subject"/> != this, then then Claim.Clone(this) is called before the claim is added.</remarks>
+        /// <remarks>Each claim is examined and if <see cref="Claim.Subject"/> != this, then Claim.Clone(this) is called before the claim is added.</remarks>
         /// <exception cref="ArgumentNullException">if 'claims' is null.</exception>
         public virtual void AddClaims(IEnumerable<Claim> claims)
         {

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
@@ -204,7 +204,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         /// <summary>
-        /// Create an ASN.1 DER-encoded PKCS#10 CertificationRequest object representating the current state
+        /// Create an ASN.1 DER-encoded PKCS#10 CertificationRequest object representing the current state
         /// of this object.
         /// </summary>
         /// <returns>A DER-encoded certificate signing request.</returns>
@@ -250,7 +250,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         /// <summary>
-        /// Create an ASN.1 DER-encoded PKCS#10 CertificationRequest representating the current state
+        /// Create an ASN.1 DER-encoded PKCS#10 CertificationRequest representing the current state
         /// of this object using the provided signature generator.
         /// </summary>
         /// <param name="signatureGenerator">

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXmlDebugLog.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXmlDebugLog.cs
@@ -70,7 +70,7 @@ namespace System.Security.Cryptography.Xml
             BeginCanonicalization,
 
             /// <summary>
-            ///     Verificaiton of the signature format itself is beginning
+            ///     Verification of the signature format itself is beginning
             /// </summary>
             BeginCheckSignatureFormat,
 
@@ -544,10 +544,10 @@ namespace System.Security.Cryptography.Xml
         }
 
         /// <summary>
-        ///     Log namespaces which are being propigated into the singature
+        ///     Log namespaces which are being propagated into the signature
         /// </summary>
         /// <param name="signedXml">SignedXml doing the signing or verification</param>
-        /// <param name="namespaces">namespaces being propigated</param>
+        /// <param name="namespaces">namespaces being propagated</param>
         internal static void LogNamespacePropagation(SignedXml signedXml, XmlNodeList namespaces)
         {
             Debug.Assert(signedXml != null, "signedXml != null");

--- a/src/System.Threading.Overlapped/src/System/Threading/DeferredDisposableLifetime.cs
+++ b/src/System.Threading.Overlapped/src/System/Threading/DeferredDisposableLifetime.cs
@@ -18,7 +18,7 @@ namespace System.Threading
         /// Indicates whether the object has been disposed.
         /// </param>
         /// <remarks>
-        /// If the refount reaches zero before the object is disposed, this method will be called with
+        /// If the refcount reaches zero before the object is disposed, this method will be called with
         /// <paramref name="disposed"/> set to false.  If the object is then disposed, this method will be
         /// called again, with <paramref name="disposed"/> set to true.  If the refcount reaches zero
         /// after the object has already been disposed, this will be called a single time, with 

--- a/src/System.Threading.Tasks/tests/Task/TaskAPMTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskAPMTest.cs
@@ -28,7 +28,7 @@ namespace System.Threading.Tasks.Tests
         private bool _hasReturnType;
 
         /// <summary>
-        /// Used to synchornize between Main thread and async thread, by blocking the main thread until
+        /// Used to synchronize between Main thread and async thread, by blocking the main thread until
         /// the thread that invokes the TaskCompleted method via AsyncCallback finishes
         /// </summary>
         private ManualResetEvent _mre = new ManualResetEvent(false);

--- a/src/System.Transactions.Local/src/System/Transactions/Transaction.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/Transaction.cs
@@ -452,7 +452,7 @@ namespace System.Transactions
         /// 
         /// If the transaction has not already been promoted, retrieving this value will cause promotion. Before retrieving the
         /// PromotedToken, the Transaction.PromoterType value should be checked to see if it is a promoter type (Guid) that the
-        /// caller understands. If the caller does not recognize the PromoterType value, retreiving the PromotedToken doesn't
+        /// caller understands. If the caller does not recognize the PromoterType value, retrieving the PromotedToken doesn't
         /// have much value because the caller doesn't know how to utilize it. But if the PromoterType is recognized, the
         /// caller should know how to utilize the PromotedToken to communicate with the promoting distributed transaction
         /// coordinator to enlist on the distributed transaction.
@@ -951,7 +951,7 @@ namespace System.Transactions
         /// 
         /// False if the transaction already has a durable enlistment or promotable single phase enlistment or
         /// if the transaction has already promoted. In this case, the caller will need to enlist in the transaction through other
-        /// means, such as Transaction.EnlistDurable or retreive the MSDTC export cookie or propagation token to enlist with MSDTC.
+        /// means, such as Transaction.EnlistDurable or retrieve the MSDTC export cookie or propagation token to enlist with MSDTC.
         /// </returns>
         // We apparently didn't spell Promotable like FXCop thinks it should be spelled.
         public bool EnlistPromotableSinglePhase(IPromotableSinglePhaseNotification promotableSinglePhaseNotification)


### PR DESCRIPTION
XML doc spelling corrections - Q through Z. :clap: :tada:

The fourth (and final) drop of spelling corrections for XML documentation comments. After all these XML doc corrections are merged and digested I'll take a pass looking inside actual C# string literals next. Let me know if that sounds good. :sunglasses: My gut feeling is there will be fewer errors in the string literals, but it requires a bit more scrutiny since I saw some literals that are intentionally misspelled like [HTTP referer](https://en.wikipedia.org/wiki/HTTP_referer). Hehe.

STATUS:
- [x] #23634 A through C - **Merged** :white_check_mark: 
- [ ] #23638 D through H - revised with feedback **Waiting Merge** :hourglass: 
- [ ] #23651 I through P - revised with feedback **Waiting Merge** :hourglass: 

/cc @JonHanna 

:boom: :fire: ***["Set it ablaze like a candle wick... Light it up, light it up..."](https://www.youtube.com/watch?v=qDcFryDXQ7U)***