### PR TITLE
Update BuildTools

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01928-01
+2.0.0-prerelease-01929-04


### PR DESCRIPTION
This version of the build tools has the fix for the race condition problem when handling the resources during the compile time. because of the Assembly normalization target.

Fixes #23618 