### PR TITLE
Disable CopyFromScreen test which intermittently fails.

### DIFF
--- a/src/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.cs
@@ -1821,6 +1821,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(23650)]
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(0, 0, 0, 0, 10, 10)]


### PR DESCRIPTION
This test has been known to intermittently fail, including on .NET Framework. There is likely something unsafe or unreliable about the way we are using these operations, especially ones involving copying pixels from the screen.

See #23650 