### PR TITLE
String literal spelling corrections - A through Z

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -964,7 +964,7 @@ namespace System.Collections.Concurrent
                 Debug.Assert(
                     count == (_tailIndex - _headIndex) ||
                     count == (_tailIndex + 1 - _headIndex),
-                    "Count should be the same as tail - head, but allowing for the possibilty that " +
+                    "Count should be the same as tail - head, but allowing for the possibility that " +
                     "a peek decremented _tailIndex before seeing that a freeze was happening.");
                 Debug.Assert(arrayIndex <= array.Length - count);
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContext.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContext.cs
@@ -76,7 +76,7 @@ namespace System.ComponentModel.Design
         {
             if (savedLicenseKeys == null || savedLicenseKeys[type.AssemblyQualifiedName] == null)
             {
-                Debug.WriteLineIf(s_runtimeLicenseContextSwitch.TraceVerbose, "savedLicenseKey is null or doesnt contain our type");
+                Debug.WriteLineIf(s_runtimeLicenseContextSwitch.TraceVerbose, "savedLicenseKey is null or doesn't contain our type");
                 if (savedLicenseKeys == null)
                 {
                     savedLicenseKeys = new Hashtable();

--- a/src/System.Data.Common/src/System/Data/DataColumn.cs
+++ b/src/System.Data.Common/src/System/Data/DataColumn.cs
@@ -1767,7 +1767,7 @@ namespace System.Data
 
         internal object ConvertXmlToObject(string s)
         {
-            Debug.Assert(s != null, "Caller is resposible for missing element/attribure case");
+            Debug.Assert(s != null, "Caller is resposible for missing element/attribute case");
             InsureStorage();
             return _storage.ConvertXmlToObject(s);
         }

--- a/src/System.Data.Common/src/System/Data/Filter/BinaryNode.cs
+++ b/src/System.Data.Common/src/System/Data/Filter/BinaryNode.cs
@@ -1096,7 +1096,7 @@ namespace System.Data
 
                             if ((vRight == DBNull.Value) || (right.IsSqlColumn && DataStorage.IsObjectSqlNull(vRight)))
                                 continue;
-                            Debug.Assert((!DataStorage.IsObjectNull(vLeft)) && (!DataStorage.IsObjectNull(vRight)), "Imposible..");
+                            Debug.Assert((!DataStorage.IsObjectNull(vLeft)) && (!DataStorage.IsObjectNull(vRight)), "Impossible.");
 
                             resultType = DataStorage.GetStorageType(vLeft.GetType());
 

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
@@ -219,7 +219,7 @@ namespace BasicEventSourceTests
                         Assert.True(timeSum < 2, $"FAILURE: {timeSum} < 2");    // But well under 2 sec.  
 
                             // Do all the things that depend on the count of events last so we know everything else is sane 
-                            Assert.True(4 <= evts.Count, "We expect two metrices at the begining trigger and two at the end trigger.  evts.Count = " + evts.Count);
+                            Assert.True(4 <= evts.Count, "We expect two metrics at the beginning trigger and two at the end trigger.  evts.Count = " + evts.Count);
                         Assert.True(evts.Count % 2 == 0, "We expect two metrics for every trigger.  evts.Count = " + evts.Count);
 
                         ValidateSingleEventCounter(evts[0], "Request", 0, 0, 0, float.PositiveInfinity, float.NegativeInfinity);

--- a/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
@@ -434,7 +434,7 @@ namespace System.IO.Ports.Tests
                 char[] charXmitBuffer = TCSupport.GetRandomChars(1023, TCSupport.CharacterOptions.ASCII);
                 int readResult;
 
-                Debug.WriteLine("Verifying that Read(char[], int, int) will compact data in the buffer buffer");
+                Debug.WriteLine("Verifying that Read(char[], int, int) will compact data in the buffer");
 
                 com1.Encoding = Encoding.ASCII;
                 com2.Encoding = Encoding.ASCII;

--- a/src/System.IO.Ports/tests/SerialStream/ReadTimeout.cs
+++ b/src/System.IO.Ports/tests/SerialStream/ReadTimeout.cs
@@ -373,7 +373,7 @@ namespace System.IO.Ports.Tests
                 com1.BaseStream.ReadTimeout = readTimeout;
 
                 Assert.True(readTimeout == com1.BaseStream.ReadTimeout,
-                    string.Format("Err_7071ahpsb!!! Expected ReadTimeout to be {0} actaul {1}", readTimeout,
+                    string.Format("Err_7071ahpsb!!! Expected ReadTimeout to be {0} actual {1}", readTimeout,
                         com1.BaseStream.ReadTimeout));
 
                 VerifyLongTimeout(readMethod, com1, com2);
@@ -408,7 +408,7 @@ namespace System.IO.Ports.Tests
                 com1.BaseStream.ReadTimeout = readTimeout;
 
                 Assert.True(readTimeout == com1.BaseStream.ReadTimeout,
-                    string.Format("Err_236897ahpbm!!! Expected ReadTimeout to be {0} actaul {1}", readTimeout,
+                    string.Format("Err_236897ahpbm!!! Expected ReadTimeout to be {0} actual {1}", readTimeout,
                         com1.BaseStream.ReadTimeout));
 
                 VerifyTimeout(readMethod, com1.BaseStream);
@@ -477,7 +477,7 @@ namespace System.IO.Ports.Tests
                 com1.BaseStream.ReadTimeout = 0;
 
                 Assert.True(0 == com1.BaseStream.ReadTimeout,
-                    string.Format("Err_72072ahps!!! Expected ReadTimeout to be {0} actaul {1}", 0,
+                    string.Format("Err_72072ahps!!! Expected ReadTimeout to be {0} actual {1}", 0,
                         com1.BaseStream.ReadTimeout));
 
                 Verify0Timeout(readMethod, com1.BaseStream);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -516,7 +516,7 @@ namespace System.Net.Sockets.Tests
                 }
 
                 Assert.True(
-                    accepted.WaitOne(TestSettings.PassingTestTimeout), "Test completed in alotted time");
+                    accepted.WaitOne(TestSettings.PassingTestTimeout), "Test completed in allotted time");
 
                 Assert.Equal(
                     SocketError.Success, acceptArgs.SocketError);

--- a/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilPatternFactory.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilPatternFactory.cs
@@ -226,7 +226,7 @@ namespace System.Xml.Xsl.Qil
         //-----------------------------------------------
         private static void CheckLogicArg(QilNode arg)
         {
-            Debug.Assert(arg != null, "Argulent shouldn't be null");
+            Debug.Assert(arg != null, "Argument shouldn't be null");
             Debug.Assert(arg.XmlType.TypeCode == XmlTypeCode.Boolean && arg.XmlType.IsSingleton,
                 "The operand must be boolean-typed"
             );

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathBuilder.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathBuilder.cs
@@ -452,7 +452,7 @@ namespace System.Xml.Xsl.XPath
             if (isReverseStep)
             {
                 Debug.Assert(nodeset.NodeType == QilNodeType.DocOrderDistinct,
-                    "ReverseAxe in Qil is actuly reverse and we compile them here in builder by wrapping to DocOrderDistinct()"
+                    "ReverseAxe in Qil is actually reverse and we compile them here in builder by wrapping to DocOrderDistinct()"
                 );
                 // The trick here is that we unwarp it back, compile as regular predicate and wrap again.
                 // this way this wat we hold invariant that path expresion are always DOD and make predicates on reverse axe

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/OutputScopeManager.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/OutputScopeManager.cs
@@ -146,7 +146,7 @@ namespace System.Xml.Xsl.Xslt
                 --record                             // in reverce direction
             )
             {
-                Debug.Assert(0 < record, "first record is lookup bariaer, so we don't need to check this condition runtime");
+                Debug.Assert(0 < record, "first record is lookup barrier, so we don't need to check this condition runtime");
                 if (_records[record].prefix == prefix)
                 {
                     return _records[record].nsUri;

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternBuilder.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternBuilder.cs
@@ -42,7 +42,7 @@ namespace System.Xml.Xsl.Xslt
 
         public virtual void StartBuild()
         {
-            Debug.Assert(!_inTheBuild, "XPathBuilder is buisy!");
+            Debug.Assert(!_inTheBuild, "XPathBuilder is busy!");
             _inTheBuild = true;
             return;
         }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XsltLoader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XsltLoader.cs
@@ -962,7 +962,7 @@ namespace System.Xml.Xsl.Xslt
                     {
                         // Try move to second attribute and if it is missing to first.
                         bool dummy = _input.MoveToXsltAttribute(3 + j, _decimalFormatAttributes[3 + j].name) || _input.MoveToXsltAttribute(3 + i, _decimalFormatAttributes[3 + i].name);
-                        Debug.Assert(dummy, "One of the atts should have lineInfo. if both are defualt they can't conflict.");
+                        Debug.Assert(dummy, "One of the attrs should have lineInfo. If both are default they can't conflict.");
                         ReportError(/*[XT1300]*/SR.Xslt_DecimalFormatSignsNotDistinct, _decimalFormatAttributes[3 + i].name, _decimalFormatAttributes[3 + j].name);
                         break;
                     }

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
@@ -1845,7 +1845,7 @@ namespace System.Xml.Tests
             }
             if (fTEST_FAIL)
             {
-                _output.WriteLine("Appear to have accidently closed the Reader");
+                _output.WriteLine("Appear to have accidentally closed the Reader");
                 Assert.True(false);
             }
             return;

--- a/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -42,7 +42,7 @@ namespace System.Tests
         [InlineData(2)] // setting ExitCode both from Main and from an Unloading event handler.
         [InlineData(3)] // using Exit(exitCode)
         [ActiveIssue("https://github.com/dotnet/corefx/issues/21415", TargetFrameworkMonikers.UapNotUapAot)]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20387 - ILC test pipeline does not accomodate tests in child processes built into custom assemblies.", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20387 - ILC test pipeline does not accommodate tests in child processes built into custom assemblies.", TargetFrameworkMonikers.UapAot)]
         public static void ExitCode_VoidMainAppReturnsSetValue(int mode)
         {
             int expectedExitCode = 123;

--- a/src/System.Runtime.Serialization.Xml/tests/Canonicalization/CryptoCanonicalization/CanonicalWriter.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Canonicalization/CryptoCanonicalization/CanonicalWriter.cs
@@ -822,7 +822,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
                 {
                     if (prefix.Length != 0)
                     {
-                        throw new InvalidOperationException("Invalid Namespaceffor empty Prefix.");
+                        throw new InvalidOperationException("Invalid Namespace for empty Prefix.");
                     }
                 }
                 else if (prefix.Length == 0)


### PR DESCRIPTION
Ola friends,

Now that XML docs are out of the way, I think we could make some more progress by beginning the next phase of spell checks, only this time and more critically, focusing on **string literals**.

I'm sure we're all aware, **string literals** require a bit more scrutiny and I might break things along the way but bear with me because, in the long run, I think these changes are still important in making our code better. Especially when we usually bubble up exception messages from the framework directly to our end users. :sunglasses:

Overall, I feel these types of spelling errors are fewer than XML docs errors because I think devs spend more time thinking about spelling in string literals.

This will be interesting to see if these PRs still build and pass tests on CI.

Thanks,
Brian

/cc @JonHanna @danmosemsft 

STATUS: In review.

:guitar: :dancer: ***["Para bailar La Bamba, para bailar La Bamba..."](https://www.youtube.com/watch?v=Jp6j5HJ-Cok)***
