### PR TITLE
System.Net.Http: Remove unnecessary null validator check

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Headers/ObjectCollection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ObjectCollection.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace System.Net.Http.Headers
 {
@@ -23,6 +24,7 @@ namespace System.Net.Http.Headers
         public ObjectCollection(Action<T> validator)
             : base(new List<T>())
         {
+            Debug.Assert(validator != null, $"{nameof(validator)} must not be null.");
             _validator = validator;
         }
 
@@ -35,19 +37,13 @@ namespace System.Net.Http.Headers
 
         protected override void InsertItem(int index, T item)
         {
-            if (_validator != null)
-            {
-                _validator(item);
-            }
+            _validator(item);
             base.InsertItem(index, item);
         }
 
         protected override void SetItem(int index, T item)
         {
-            if (_validator != null)
-            {
-                _validator(item);
-            }
+            _validator(item);
             base.SetItem(index, item);
         }
 


### PR DESCRIPTION
A null validator is never passed-in when creating `ObjectCollection<T>` instances internally, so we can avoid the unnecessary null checks.

cc: @davidsh, @CIPop, @Priya91