### PR TITLE
SslStream - Making the reset buffer logic clearer

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -219,9 +219,8 @@ namespace System.Net.Security
                 // To maximize the buffer space available for the next read,
                 // copy the existing data down to the beginning of the buffer.
                 Buffer.BlockCopy(_internalBuffer, _internalOffset, _internalBuffer, 0, _internalBufferCount);
+                _internalOffset = 0;
             }
-
-            _internalOffset = 0;
         }
 
         //

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -514,9 +514,7 @@ namespace System.Net.Security
             {
                 return minSize;
             }
-
-            ResetReadBuffer();
-
+                        
             int bytesRead;
             if (asyncRequest != null)
             {
@@ -546,11 +544,7 @@ namespace System.Net.Security
             _internalOffset += byteCount;
             _internalBufferCount -= byteCount;
 
-            if (_internalBufferCount == 0)
-            {
-                // No remaining buffered bytes, so reset the offset to the beginning for the next read.
-                _internalOffset = 0;
-            }
+            ReturnReadBufferIfEmpty();
         }
 
         private int CopyDecryptedData(byte[] buffer, int offset, int count)
@@ -663,6 +657,7 @@ namespace System.Net.Security
 
         private int StartFrameHeader(byte[] buffer, int offset, int count, AsyncProtocolRequest asyncRequest)
         {
+            ResetReadBuffer();
             int readBytes = EnsureBufferedBytes(SecureChannel.ReadHeaderSize, asyncRequest, s_readHeaderCallback);
             if (readBytes == -1)
             {


### PR DESCRIPTION
These are to make the "returning" of the buffer logic clearer. Also the asserts caught the fact that the logic was a little odd. We don't need to resize the buffer anymore therefore we don't have to call the "ensureinternalbuffersize" on each read (for the header and the frame). 

So I have removed that, renamed to "ResetReadBuffer". Removed one of the extra checks on the if statement for "if buffercount > 0 && bufferoffset >0". So this has the buffercount removed and an assert added to make sure we only ever get here if the buffer is null or if it has data (if it doesn't have data it should be released).

Finally I added an extra assert to double check there are no decrypted bytes left.

Using @geoffkizer benchmark on Azure windows 4 cores I see no difference in the 256 byte test a slight uptick in the bigger buffer but nothing to write home about. 
