### PR TITLE
Grammar check - "a [a,e]" rule.

### DIFF
--- a/src/Common/src/System/Data/Common/MultipartIdentifier.cs
+++ b/src/Common/src/System/Data/Common/MultipartIdentifier.cs
@@ -208,7 +208,7 @@ namespace System.Data.Common
                     case MPIState.MPI_RightQuote:
                         {
                             if (testchar == rightQuoteChar)
-                            { // If the next char is a another right quote then we were escaping the right quote
+                            { // If the next char is another right quote then we were escaping the right quote
                                 sb.Append(testchar);
                                 state = MPIState.MPI_ParseQuote;
                             }

--- a/src/Common/tests/System/Xml/XPath/FuncLocation/PathAxeComplexExprMatchesTests.cs
+++ b/src/Common/tests/System/Xml/XPath/FuncLocation/PathAxeComplexExprMatchesTests.cs
@@ -16,7 +16,7 @@ namespace XPathTests.FunctionalTests.Location.Paths.Axes.ComplexExpressions
     public static partial class MatchesTests
     {
         /// <summary>
-        /// Context node has a ancestor 'publication' so matches should return true
+        /// Context node has an ancestor 'publication' so matches should return true
         /// node()[starts-with(string(name()),'p')]//node()[local-name()=""]
         /// </summary>
         [Fact]

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Declarations/AggregateDeclaration.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Declarations/AggregateDeclaration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     //
     // AggregateDeclaration
     //
-    // AggregateDeclaration - represents a declaration of a aggregate type. With partial classes,
+    // AggregateDeclaration - represents a declaration of an aggregate type. With partial classes,
     // an aggregate type might be declared in multiple places.  This symbol represents
     // on of the declarations.
     //

--- a/src/System.CodeDom/src/Microsoft/CSharp/CSharpCodeGenerator.cs
+++ b/src/System.CodeDom/src/Microsoft/CSharp/CSharpCodeGenerator.cs
@@ -2541,7 +2541,7 @@ namespace Microsoft.CSharp
             Output.WriteLine();
 
             // CSharp needs to put assembly attributes after using statements.
-            // Since we need to create a empty namespace even if we don't need it,
+            // Since we need to create an empty namespace even if we don't need it,
             // using will generated after assembly attributes.
             var importList = new SortedSet<string>(StringComparer.Ordinal);
             foreach (CodeNamespace nspace in e.Namespaces)

--- a/src/System.Collections.Immutable/src/Resources/Strings.resx
+++ b/src/System.Collections.Immutable/src/Resources/Strings.resx
@@ -59,10 +59,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArrayInitializedStateNotEqual" xml:space="preserve">
-    <value>Object is not a array with the same initialization state as the array to compare it to.</value>
+    <value>Object is not an array with the same initialization state as the array to compare it to.</value>
   </data>
   <data name="ArrayLengthsNotEqual" xml:space="preserve">
-    <value>Object is not a array with the same number of elements as the array to compare it to.</value>
+    <value>Object is not an array with the same number of elements as the array to compare it to.</value>
   </data>
   <data name="CannotFindOldValue" xml:space="preserve">
     <value>Cannot find the old value</value>

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.Find.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.Find.cs
@@ -30,14 +30,14 @@ namespace System.Collections.Tests
 
             //[] Call Find an empty collection
             linkedList = new LinkedList<T>();
-            Assert.Null(linkedList.Find(headItems[0])); //"Err_2899hjaied Expected Find to return false with a non null item on a empty collection"
-            Assert.Null(linkedList.Find(default(T))); //"Err_5808ajiea Expected Find to return false with a null item on a empty collection"
+            Assert.Null(linkedList.Find(headItems[0])); //"Err_2899hjaied Expected Find to return false with a non null item on an empty collection"
+            Assert.Null(linkedList.Find(default(T))); //"Err_5808ajiea Expected Find to return false with a null item on an empty collection"
 
             //[] Call Find on a collection with one item in it
             linkedList = new LinkedList<T>();
             linkedList.AddLast(headItems[0]);
-            Assert.Null(linkedList.Find(headItems[1])); //"Err_2899hjaied Expected Find to return false with a non null item on a empty collection size=1"
-            Assert.Null(linkedList.Find(default(T))); //"Err_5808ajiea Expected Find to return false with a null item on a empty collection size=1"
+            Assert.Null(linkedList.Find(headItems[1])); //"Err_2899hjaied Expected Find to return false with a non null item on an empty collection size=1"
+            Assert.Null(linkedList.Find(default(T))); //"Err_5808ajiea Expected Find to return false with a null item on an empty collection size=1"
             VerifyFind(linkedList, new T[] { headItems[0] });
 
             //[] Call Find on a collection with two items in it

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.FindLast.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.FindLast.cs
@@ -37,14 +37,14 @@ namespace System.Collections.Tests
 
             //[] Call FindLast an empty collection
             linkedList = new LinkedList<T>();
-            Assert.Null(linkedList.FindLast(headItems[0])); //"Err_2899hjaied Expected FindLast to return false with a non null item on a empty collection"
-            Assert.Null(linkedList.FindLast(default(T))); //"Err_5808ajiea Expected FindLast to return false with a null item on a empty collection"
+            Assert.Null(linkedList.FindLast(headItems[0])); //"Err_2899hjaied Expected FindLast to return false with a non null item on an empty collection"
+            Assert.Null(linkedList.FindLast(default(T))); //"Err_5808ajiea Expected FindLast to return false with a null item on an empty collection"
 
             //[] Call FindLast on a collection with one item in it
             linkedList = new LinkedList<T>();
             linkedList.AddLast(headItems[0]);
-            Assert.Null(linkedList.FindLast(headItems[1])); //"Err_2899hjaied Expected FindLast to return false with a non null item on a empty collection size=1"
-            Assert.Null(linkedList.FindLast(default(T))); //"Err_5808ajiea Expected FindLast to return false with a null item on a empty collection size=1"
+            Assert.Null(linkedList.FindLast(headItems[1])); //"Err_2899hjaied Expected FindLast to return false with a non null item on an empty collection size=1"
+            Assert.Null(linkedList.FindLast(default(T))); //"Err_5808ajiea Expected FindLast to return false with a null item on an empty collection size=1"
             VerifyFindLast(linkedList, new T[] { headItems[0] });
 
             //[] Call FindLast on a collection with two items in it

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/Component.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/Component.cs
@@ -41,7 +41,7 @@ namespace System.ComponentModel
         internal bool CanRaiseEventsInternal => CanRaiseEvents;
 
         /// <summary>
-        ///    <para>Adds a event handler to listen to the Disposed event on the component.</para>
+        ///    <para>Adds an event handler to listen to the Disposed event on the component.</para>
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/IComponent.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/IComponent.cs
@@ -38,7 +38,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///    <para>Adds a event handler to listen to the Disposed event on the component.</para>
+        ///    <para>Adds an event handler to listen to the Disposed event on the component.</para>
         /// </summary>
         event EventHandler Disposed;
     }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MarshalByValueComponent.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MarshalByValueComponent.cs
@@ -42,7 +42,7 @@ namespace System.ComponentModel
         }
 
         /// <summary>
-        ///    <para>Adds a event handler to listen to the Disposed event on the component.</para>
+        ///    <para>Adds an event handler to listen to the Disposed event on the component.</para>
         /// </summary>
         public event EventHandler Disposed
         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
@@ -1782,7 +1782,7 @@ namespace System.ComponentModel
         ///     character and removes any remaining characters in the range unless the character at the specified position 
         ///     is to be escaped.
         ///     If specified range covers more than one assigned edit character, shift-left is performed after replacing
-        ///     the first character.  This is useful when in a edit box the user selects text and types a character to replace it.
+        ///     the first character.  This is useful when in an edit box the user selects text and types a character to replace it.
         ///     On exit the testPosition contains last position where the primary operation was actually performed if successful, 
         ///     otherwise the first position that made the test fail. This position is relative to the test string.
         ///     The MaskedTextResultHint out param gives more information about the operation result.

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -92,7 +92,7 @@ namespace System.Configuration
             // (1) Company name
             string part1 = Validate(_companyName, limitSize: true);
 
-            // (2) Domain or product name & a application urit hash
+            // (2) Domain or product name & an application urit hash
             string namePrefix = Validate(AppDomain.CurrentDomain.FriendlyName, limitSize: true);
             if (string.IsNullOrEmpty(namePrefix))
                 namePrefix = Validate(ProductName, limitSize: true);

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationElement.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationElement.cs
@@ -1336,7 +1336,7 @@ namespace System.Configuration
                             ((lockType != ConfigurationLockCollectionType.LockedElements) &&
                             (lockType != ConfigurationLockCollectionType.LockedElementsExceptionList) &&
                             typeof(ConfigurationElement).IsAssignableFrom(propToLock.Type)) ||
-                            // or if not locking elements but the property is a element
+                            // or if not locking elements but the property is an element
                             (((lockType == ConfigurationLockCollectionType.LockedElements) ||
                             (lockType == ConfigurationLockCollectionType.LockedElementsExceptionList)) &&
                             !typeof(ConfigurationElement).IsAssignableFrom(propToLock.Type))

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConnectionStringSettingsCollection.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConnectionStringSettingsCollection.cs
@@ -39,7 +39,7 @@ namespace System.Configuration
         }
 
         // the connection string behavior is strange in that is acts kind of like a
-        // basic map and partially like a add remove clear collection
+        // basic map and partially like an add remove clear collection
         // Overriding these methods allows for the specific behaviors to be
         // patterened
         protected override void BaseAdd(int index, ConfigurationElement element)

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
@@ -1747,7 +1747,7 @@ namespace System.Configuration
             else definitionUpdates = null;
         }
 
-        // Take a element name, and create an xml string that contains
+        // Take an element name, and create an xml string that contains
         // that element in an empty state
         private string WriteEmptyElement(string elementName)
         {

--- a/src/System.Data.Common/src/System/Data/DataTable.cs
+++ b/src/System.Data.Common/src/System/Data/DataTable.cs
@@ -1823,7 +1823,7 @@ namespace System.Data
         }
         private string GetInheritedNamespace(List<DataTable> visitedTables)
         {
-            // if there is nested relation: ie: this table is nested child of a another table and
+            // if there is nested relation: ie: this table is nested child of another table and
             // if it is not self nested, return parent tables NS: Meanwhile make sure
             DataRelation[] nestedRelations = NestedParentRelations;
             if (nestedRelations.Length > 0)

--- a/src/System.Data.Common/tests/System/Data/DataTableCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableCollectionTest.cs
@@ -243,7 +243,7 @@ namespace System.Data.Tests
             string tblname = "";
             /* checking for a recently input table, expecting true */
             Assert.Equal(true, tbcol.Contains(_tables[0].TableName));
-            /* trying to check with a empty string, expecting false */
+            /* trying to check with an empty string, expecting false */
             Assert.Equal(false, tbcol.Contains(tblname));
             /* trying to check for a table that donot exist, expecting false */
             Assert.Equal(false, tbcol.Contains("InvalidTableName"));
@@ -267,7 +267,7 @@ namespace System.Data.Tests
             Assert.Equal("Table3", array[2].TableName);
             Assert.Equal("Table4", array[3].TableName);
 
-            /* copying with in a array */
+            /* copying with in an array */
             DataTable[] array1 = new DataTable[6];
             tbcol.CopyTo(array1, 2);
             Assert.Equal(null, array1[0]);

--- a/src/System.Data.Common/tests/System/Data/DataTableReaderTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableReaderTest.cs
@@ -729,7 +729,7 @@ namespace System.Data.Tests
             Assert.Equal("col_int*5", schemaTable.Rows[11]["Expression"]);
             Assert.True((bool)schemaTable.Rows[11]["IsReadOnly"]);
 
-            // if expression depends on a external col, then set Expression as null..
+            // if expression depends on an external col, then set Expression as null..
             Assert.Equal("col_expression_ext", schemaTable.Rows[12]["ColumnName"]);
             Assert.Equal(DBNull.Value, schemaTable.Rows[12]["Expression"]);
             Assert.True((bool)schemaTable.Rows[12]["IsReadOnly"]);

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
@@ -88,7 +88,7 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void PublicFields()
         {
-            // FIXME: There is a error in msdn docs, it says thath MaxValue
+            // FIXME: There is an error in msdn docs, it says thath MaxValue
             // is 922,337,203,685,475.5807 when the actual value is
             //    922,337,203,685,477.5807
             Assert.Equal(922337203685477.5807m, SqlMoney.MaxValue.Value);

--- a/src/System.Data.DataSetExtensions/src/System/Data/TypedTableBase.cs
+++ b/src/System.Data.DataSetExtensions/src/System/Data/TypedTableBase.cs
@@ -32,7 +32,7 @@ namespace System.Data
             : base(info, context) { }
 
         /// <summary>
-        /// This property returns a enumerator of T for the TypedTable.  Note, this could
+        /// This property returns an enumerator of T for the TypedTable.  Note, this could
         /// execute the underlying Linq expression.
         /// </summary>
         /// <returns>IEnumerable of T.</returns>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -257,7 +257,7 @@ namespace System.Data.SqlClient
             }
             set
             {
-                // Don't allow the connection to be changed while in a async operation.
+                // Don't allow the connection to be changed while in an async operation.
                 if (_activeConnection != value && _activeConnection != null)
                 { // If new value...
                     if (cachedAsyncState.PendingAsyncOperation)
@@ -363,7 +363,7 @@ namespace System.Data.SqlClient
             }
             set
             {
-                // Don't allow the transaction to be changed while in a async operation.
+                // Don't allow the transaction to be changed while in an async operation.
                 if (_transaction != value && _activeConnection != null)
                 { // If new value...
                     if (cachedAsyncState.PendingAsyncOperation)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -1193,7 +1193,7 @@ namespace System.Data.SqlClient
                     /*
                         The error message should come back in the following format: "TCP Provider: MESSAGE TEXT"
                         If the message is received on a Win9x OS, the error message will not contain MESSAGE TEXT 
-                        If we get a error message with no message text, just return the entire message otherwise 
+                        If we get an error message with no message text, just return the entire message otherwise 
                         return just the message text.
                     */
                     if (len > 0)
@@ -2551,7 +2551,7 @@ namespace System.Data.SqlClient
             // situations where this can occur are: an invalid buffer received from client, login error
             // and the server refused our connection, and the case where we are trying to log in but
             // the server has reached its max connection limit.  Bottom line, we need to throw general
-            // error in the cases where we did not receive a error token along with the DONE_ERROR.
+            // error in the cases where we did not receive an error token along with the DONE_ERROR.
             if ((TdsEnums.DONE_ERROR == (TdsEnums.DONE_ERROR & status)) && stateObj.ErrorCount == 0 &&
                   stateObj._errorTokenReceived == false && (RunBehavior.Clean != (RunBehavior.Clean & run)))
             {

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressFramework/DataStressErrors.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressFramework/DataStressErrors.cs
@@ -140,7 +140,7 @@ namespace Stress.Data
         }
 
         /// <summary>
-        /// Reports that a fatal error has happened. This is a error that completely prevents the test from continuing, 
+        /// Reports that a fatal error has happened. This is an error that completely prevents the test from continuing, 
         /// for example a setup failure. Ordinary programming errors should not be handled by this method.
         /// </summary>
         /// <param name="description">A description of the error</param>

--- a/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
+++ b/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
@@ -104,7 +104,7 @@ Perhaps confusingly you make a DiagnosticSource by creating a DiagnosticListener
 	static DiagnosticSource mySource = new DiagnosticListener("System.Net.Http");
 
 Basically a DiagnosticListener is a named place where a source sends its information (events).  
-From an implementation point of view, DiagnosticSource is a abstract class that has the two
+From an implementation point of view, DiagnosticSource is an abstract class that has the two
 instrumentation methods, and DiagnosticListener is something that implements that abstract class.
 Thus every DiagnosticListener is a DiagnosticSource, and by making a DiagnosticListener you 
 implicitly make a DiagnosticSource as well. 

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
@@ -31,7 +31,7 @@ namespace System.Diagnostics
         /// </summary>
         /// <param name="name">The name of the event being written.</param>
         /// <param name="value">An object that represent the value being passed as a payload for the event.
-        /// This is often a anonymous type which contains several sub-values.</param>
+        /// This is often an anonymous type which contains several sub-values.</param>
         public abstract void Write(string name, object value);
 
         /// <summary>

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -871,7 +871,7 @@ namespace System.Diagnostics
         }
 
         /// <summary>
-        /// CallbackObserver is a adapter class that creates an observer (which you can pass
+        /// CallbackObserver is an adapter class that creates an observer (which you can pass
         /// to IObservable.Subscribe), and calls the given callback every time the 'next' 
         /// operation on the IObserver happens. 
         /// </summary>

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -651,7 +651,7 @@ namespace System.Diagnostics.Tests
         }
 
         /// <summary>
-        /// Used to make an observer out of a action delegate. 
+        /// Used to make an observer out of an action delegate. 
         /// </summary>
         public static IObserver<T> MakeObserver<T>(
             Action<T> onNext = null, Action onCompleted = null)

--- a/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
@@ -437,7 +437,7 @@ namespace System.Diagnostics.Tests
         }
 
         /// <summary>
-        /// CallbackObserver is a adapter class that creates an observer (which you can pass
+        /// CallbackObserver is an adapter class that creates an observer (which you can pass
         /// to IObservable.Subscribe), and calls the given callback every time the 'next' 
         /// operation on the IObserver happens. 
         /// </summary>

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
@@ -2078,7 +2078,7 @@ namespace System.DirectoryServices.AccountManagement
         // interact with other StoreCtxs to fulfill the request.
         //
         // This method is typically used by ResultSet implementations, when they're iterating over a collection
-        // (e.g., of group membership) and encounter a entry that represents a foreign principal.
+        // (e.g., of group membership) and encounter an entry that represents a foreign principal.
         internal override Principal ResolveCrossStoreRefToPrincipal(object o)
         {
             Debug.Assert(o is DirectoryEntry);
@@ -2200,7 +2200,7 @@ namespace System.DirectoryServices.AccountManagement
         }
 
         // Returns true if AccountInfo is supported for the specified principal, false otherwise.
-        // Used when a application tries to access the AccountInfo property of a newly-inserted
+        // Used when an application tries to access the AccountInfo property of a newly-inserted
         // (not yet persisted) AuthenticablePrincipal, to determine whether it should be allowed.
         internal override bool SupportsAccounts(AuthenticablePrincipal p)
         {
@@ -2213,7 +2213,7 @@ namespace System.DirectoryServices.AccountManagement
         }
 
         // Returns the set of credential types supported by this store for the specified principal.
-        // Used when a application tries to access the PasswordInfo property of a newly-inserted
+        // Used when an application tries to access the PasswordInfo property of a newly-inserted
         // (not yet persisted) AuthenticablePrincipal, to determine whether it should be allowed.
         // Also used to implement AuthenticablePrincipal.SupportedCredentialTypes.
         internal override CredentialTypes SupportedCredTypes(AuthenticablePrincipal p)

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
@@ -258,7 +258,7 @@ namespace System.DirectoryServices.AccountManagement
 
             GlobalDebug.WriteLineIf(GlobalDebug.Info, "ADStoreCtx", "GetAsPrincipal: using path={0}", (null != de ? de.Path : "searchResult"));
 
-            // Construct a appropriate Principal object.
+            // Construct an appropriate Principal object.
 
             bool targetIsFromGC = SDSUtils.IsObjectFromGC(path);
             try

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/SDSUtils.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/SDSUtils.cs
@@ -23,7 +23,7 @@ namespace System.DirectoryServices.AccountManagement
         {
             Principal p;
 
-            // Construct a appropriate Principal object.
+            // Construct an appropriate Principal object.
             // Make* constructs a Principal that is marked persisted
             // and not loaded (p.unpersisted = false, p.loaded = false).
 
@@ -85,7 +85,7 @@ namespace System.DirectoryServices.AccountManagement
         {
             Principal p;
 
-            // Construct a appropriate Principal object.
+            // Construct an appropriate Principal object.
             // Make* constructs a Principal that is marked persisted
             // and not loaded (p.unpersisted = false, p.loaded = false).
 

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/FindResultEnumerator.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/FindResultEnumerator.cs
@@ -154,7 +154,7 @@ namespace System.DirectoryServices.AccountManagement
         // Internal Constructors
         //
 
-        // Constructs a enumerator to enumerate over the supplied of ResultSet
+        // Constructs an enumerator to enumerate over the supplied of ResultSet
         // Note that resultSet can be null
         internal FindResultEnumerator(ResultSet resultSet)
         {

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/PrincipalCollection.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/PrincipalCollection.cs
@@ -429,7 +429,7 @@ namespace System.DirectoryServices.AccountManagement
             }
             else
             {
-                // They're trying to remove a already-persisted value.  We add it to the
+                // They're trying to remove an already-persisted value.  We add it to the
                 // removedValues list.  Then, if it's already been loaded into insertedValuesCompleted,
                 // we remove it from insertedValuesCompleted.
 

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx.cs
@@ -811,7 +811,7 @@ namespace System.DirectoryServices.AccountManagement
         // interact with other StoreCtxs to fulfill the request.
         //
         // This method is typically used by ResultSet implementations, when they're iterating over a collection
-        // (e.g., of group membership) and encounter a entry that represents a foreign principal.
+        // (e.g., of group membership) and encounter an entry that represents a foreign principal.
         internal override Principal ResolveCrossStoreRefToPrincipal(object o)
         {
             Debug.Assert(o is DirectoryEntry);
@@ -894,7 +894,7 @@ namespace System.DirectoryServices.AccountManagement
         //
 
         // Returns true if AccountInfo is supported for the specified principal, false otherwise.
-        // Used when a application tries to access the AccountInfo property of a newly-inserted
+        // Used when an application tries to access the AccountInfo property of a newly-inserted
         // (not yet persisted) AuthenticablePrincipal, to determine whether it should be allowed.
         internal override bool SupportsAccounts(AuthenticablePrincipal p)
         {
@@ -907,7 +907,7 @@ namespace System.DirectoryServices.AccountManagement
         }
 
         // Returns the set of credential types supported by this store for the specified principal.
-        // Used when a application tries to access the PasswordInfo property of a newly-inserted
+        // Used when an application tries to access the PasswordInfo property of a newly-inserted
         // (not yet persisted) AuthenticablePrincipal, to determine whether it should be allowed.
         // Also used to implement AuthenticablePrincipal.SupportedCredentialTypes.
         internal override CredentialTypes SupportedCredTypes(AuthenticablePrincipal p)

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx_LoadStore.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx_LoadStore.cs
@@ -207,7 +207,7 @@ namespace System.DirectoryServices.AccountManagement
 
             GlobalDebug.WriteLineIf(GlobalDebug.Info, "SAMStoreCtx", "GetAsPrincipal: using path={0}", de.Path);
 
-            // Construct a appropriate Principal object.
+            // Construct an appropriate Principal object.
             Principal p = SDSUtils.DirectoryEntryToPrincipal(de, this.OwningContext, null);
             Debug.Assert(p != null);
 

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/StoreCtx.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/StoreCtx.cs
@@ -206,7 +206,7 @@ namespace System.DirectoryServices.AccountManagement
         // interact with other StoreCtxs to fulfill the request.
         //
         // This method is typically used by ResultSet implementations, when they're iterating over a collection
-        // (e.g., of group membership) and encounter a entry that represents a foreign principal.
+        // (e.g., of group membership) and encounter an entry that represents a foreign principal.
         internal abstract Principal ResolveCrossStoreRefToPrincipal(object o);
 
         //
@@ -219,12 +219,12 @@ namespace System.DirectoryServices.AccountManagement
         internal abstract bool IsValidProperty(Principal p, string propertyName);
 
         // Returns true if AccountInfo is supported for the specified principal, false otherwise.
-        // Used when a application tries to access the AccountInfo property of a newly-inserted
+        // Used when an application tries to access the AccountInfo property of a newly-inserted
         // (not yet persisted) AuthenticablePrincipal, to determine whether it should be allowed.
         internal abstract bool SupportsAccounts(AuthenticablePrincipal p);
 
         // Returns the set of credential types supported by this store for the specified principal.
-        // Used when a application tries to access the PasswordInfo property of a newly-inserted
+        // Used when an application tries to access the PasswordInfo property of a newly-inserted
         // (not yet persisted) AuthenticablePrincipal, to determine whether it should be allowed.
         // Also used to implement AuthenticablePrincipal.SupportedCredentialTypes.
         internal abstract CredentialTypes SupportedCredTypes(AuthenticablePrincipal p);

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Utils.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Utils.cs
@@ -237,7 +237,7 @@ namespace System.DirectoryServices.AccountManagement
                   (identAuth.b5 == 0) &&
                   (identAuth.b6 == 5))
             {
-                // No, so it can't be a account or builtin SID.
+                // No, so it can't be an account or builtin SID.
                 // Probably something like \Everyone or \LOCAL.
                 return SidType.FakeObject;
             }

--- a/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
+++ b/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
@@ -2304,7 +2304,7 @@ namespace System.DirectoryServices.ActiveDirectory
                   (identAuth.b5 == 0) &&
                   (identAuth.b6 == 5))
             {
-                // No, so it can't be a account or builtin SID.
+                // No, so it can't be an account or builtin SID.
                 // Probably something like \Everyone or \LOCAL.
                 return SidType.FakeObject;
             }

--- a/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
@@ -60,7 +60,7 @@ namespace System.Drawing
         private static ReaderWriterLock s_rwImgListLock = new ReaderWriterLock();
 
         /// <summary>
-        ///     Flag to avoid a deadlock when waiting on a write-lock and a an attempt to acquire a read-lock is 
+        ///     Flag to avoid a deadlock when waiting on a write-lock and an attempt to acquire a read-lock is 
         ///     made in the same thread. If RWLock is currently owned by another thread, the current thread is going to wait on an 
         ///     event using CoWaitForMultipleHandles while pumps message. 
         ///     The comment above refers to the COM STA message pump, not to be confused with the UI message pump.

--- a/src/System.Dynamic.Runtime/tests/Dynamic.NamedAndOptional/Conformance.dynamic.namedandoptional.decl.other.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.NamedAndOptional/Conformance.dynamic.namedandoptional.decl.other.cs
@@ -8,7 +8,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.namedandoptional.decl.o
 {
     // <Area>Declaration of Methods with Optional Parameters</Area>
     // <Title>Declaration of Optional Params</Title>
-    // <Description>Simple Declaration of a an Extension method with optional parameters</Description>
+    // <Description>Simple Declaration of an Extension method with optional parameters</Description>
     // <Expects status=success></Expects>
     // <Code>
     public static class Extension
@@ -46,7 +46,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.namedandoptional.decl.o
 {
     // <Area>Declaration of Methods with Optional Parameters</Area>
     // <Title>Declaration of Optional Params</Title>
-    // <Description>Simple Declaration of a an Extension method with optional parameters</Description>
+    // <Description>Simple Declaration of an Extension method with optional parameters</Description>
     // <Expects status=success></Expects>
     // <Code>
     public static class Extension
@@ -95,7 +95,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.namedandoptional.decl.o
 {
     // <Area>Declaration of Methods with Optional Parameters</Area>
     // <Title>Declaration of Optional Params</Title>
-    // <Description>Simple Declaration of a an Extension method with optional parameters</Description>
+    // <Description>Simple Declaration of an Extension method with optional parameters</Description>
     // <Expects status=success></Expects>
     // <Code>
     public static class Extension

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputWindow.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputWindow.cs
@@ -17,7 +17,7 @@ namespace System.IO.Compression
     {
         // With Deflate64 we can have up to a 65536 length as well as up to a 65538 distance. This means we need a Window that is at
         // least 131074 bytes long so we have space to retrieve up to a full 64kb in lookback and place it in our buffer without 
-        // overwriting existing data. OutputWindow requires that the WindowSize be a exponent of 2, so we round up to 2^18.
+        // overwriting existing data. OutputWindow requires that the WindowSize be an exponent of 2, so we round up to 2^18.
         private const int WindowSize = 262144;
         private const int WindowMask = 262143;
 

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -460,7 +460,7 @@ namespace System.IO.Compression
             BinaryWriter writer = new BinaryWriter(_archive.ArchiveStream);
 
             // _entryname only gets set when we read in or call moveTo. MoveTo does a check, and
-            // reading in should not be able to produce a entryname longer than ushort.MaxValue
+            // reading in should not be able to produce an entryname longer than ushort.MaxValue
             Debug.Assert(_storedEntryNameBytes.Length <= ushort.MaxValue);
 
             // decide if we need the Zip64 extra field:
@@ -786,7 +786,7 @@ namespace System.IO.Compression
             BinaryWriter writer = new BinaryWriter(_archive.ArchiveStream);
 
             // _entryname only gets set when we read in or call moveTo. MoveTo does a check, and
-            // reading in should not be able to produce a entryname longer than ushort.MaxValue
+            // reading in should not be able to produce an entryname longer than ushort.MaxValue
             Debug.Assert(_storedEntryNameBytes.Length <= ushort.MaxValue);
 
             // decide if we need the Zip64 extra field:

--- a/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -203,7 +203,7 @@ namespace System.IO.Tests
             string[] expectedFullPaths = expectedPaths == null ? null : expectedPaths.Select(e => Path.GetFullPath(e)).ToArray();
 
             // On OSX we get a number of extra events tacked onto valid events. As such, we can not ever confidently
-            // say that a event won't occur, only that one will occur.
+            // say that an event won't occur, only that one will occur.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 if (verifyChanged = ((expectedEvents & WatcherChangeTypes.Changed) > 0))

--- a/src/System.IO.Packaging/src/System/IO/Packaging/ContentType.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/ContentType.cs
@@ -147,7 +147,7 @@ namespace System.IO.Packaging
         /// ReadOnly
         /// Consider following Content type - 
         /// type/subtype ; param1=value1 ; param2=value2 ; param3="value3"
-        /// This will return a enumerator over a dictionary of the parameter/value pairs. 
+        /// This will return an enumerator over a dictionary of the parameter/value pairs. 
         /// </summary>
         internal Dictionary<string, string>.Enumerator ParameterValuePairs
         {

--- a/src/System.IO.Ports/tests/SerialPort/ReadTo.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadTo.cs
@@ -314,7 +314,7 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-                Debug.WriteLine("Verifying read method thows ArgumentExcpetion with a null NewLine string");
+                Debug.WriteLine("Verifying read method throws ArgumentExcpetion with a null NewLine string");
                 com.Open();
 
                 VerifyReadException(com, null, typeof(ArgumentNullException));
@@ -326,7 +326,7 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-                Debug.WriteLine("Verifying read method thows ArgumentExcpetion with a empty NewLine string");
+                Debug.WriteLine("Verifying read method throws ArgumentExcpetion with an empty NewLine string");
                 com.Open();
 
                 VerifyReadException(com, "", typeof(ArgumentException));

--- a/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int.cs
@@ -27,10 +27,10 @@ namespace System.IO.Ports.Tests
         private const int defaultByteOffset = 0;
         private const int defaultByteCount = 1;
 
-        //The maximum buffer size when a exception occurs
+        //The maximum buffer size when an exception occurs
         private const int maxBufferSizeForException = 255;
 
-        //The maximum buffer size when a exception is not expected
+        //The maximum buffer size when an exception is not expected
         private const int maxBufferSize = 8;
 
         private enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };

--- a/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
@@ -28,10 +28,10 @@ namespace System.IO.Ports.Tests
         private const int defaultCharOffset = 0;
         private const int defaultCharCount = 1;
 
-        //The maximum buffer size when a exception occurs
+        //The maximum buffer size when an exception occurs
         private const int maxBufferSizeForException = 255;
 
-        //The maximum buffer size when a exception is not expected
+        //The maximum buffer size when an exception is not expected
         private const int maxBufferSize = 8;
 
         public enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };

--- a/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int.cs
@@ -23,10 +23,10 @@ namespace System.IO.Ports.Tests
         private const int DEFAULT_BUFFER_OFFSET = 0;
         private const int DEFAULT_BUFFER_COUNT = 1;
 
-        //The maximum buffer size when a exception occurs
+        //The maximum buffer size when an exception occurs
         private const int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
 
-        //The maximum buffer size when a exception is not expected
+        //The maximum buffer size when an exception is not expected
         private const int MAX_BUFFER_SIZE = 8;
 
         //The default number of times the write method is called when verifying write

--- a/src/System.IO.Ports/tests/SerialPort/Write_char_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_char_int_int.cs
@@ -23,10 +23,10 @@ namespace System.IO.Ports.Tests
         private const int DEFAULT_CHAR_OFFSET = 0;
         private const int DEFAULT_CHAR_COUNT = 1;
 
-        //The maximum buffer size when a exception occurs
+        //The maximum buffer size when an exception occurs
         private const int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
 
-        //The maximum buffer size when a exception is not expected
+        //The maximum buffer size when an exception is not expected
         private const int MAX_BUFFER_SIZE = 8;
 
         //The default number of times the write method is called when verifying write

--- a/src/System.IO.Ports/tests/SerialStream/BeginRead.cs
+++ b/src/System.IO.Ports/tests/SerialStream/BeginRead.cs
@@ -26,10 +26,10 @@ namespace System.IO.Ports.Tests
         private const int defaultByteOffset = 0;
         private const int defaultByteCount = 1;
 
-        // The maximum buffer size when a exception occurs
+        // The maximum buffer size when an exception occurs
         private const int maxBufferSizeForException = 255;
 
-        // The maximum buffer size when a exception is not expected
+        // The maximum buffer size when an exception is not expected
         private const int maxBufferSize = 8;
 
         // Maximum time to wait for processing the read command to complete

--- a/src/System.IO.Ports/tests/SerialStream/BeginWrite.cs
+++ b/src/System.IO.Ports/tests/SerialStream/BeginWrite.cs
@@ -23,10 +23,10 @@ namespace System.IO.Ports.Tests
         private const int DEFAULT_BUFFER_OFFSET = 0;
         private const int DEFAULT_BUFFER_COUNT = 1;
 
-        // The maximum buffer size when a exception occurs
+        // The maximum buffer size when an exception occurs
         private const int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
 
-        // The maximum buffer size when a exception is not expected
+        // The maximum buffer size when an exception is not expected
         private const int MAX_BUFFER_SIZE = 8;
 
         // The default number of times the write method is called when verifying write

--- a/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int.cs
@@ -25,10 +25,10 @@ namespace System.IO.Ports.Tests
         private const int defaultByteOffset = 0;
         private const int defaultByteCount = 1;
 
-        // The maximum buffer size when a exception occurs
+        // The maximum buffer size when an exception occurs
         private const int maxBufferSizeForException = 255;
 
-        // The maximum buffer size when a exception is not expected
+        // The maximum buffer size when an exception is not expected
         private const int maxBufferSize = 8;
 
         #region Test Cases

--- a/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int.cs
@@ -23,10 +23,10 @@ namespace System.IO.Ports.Tests
         private const int DEFAULT_BUFFER_OFFSET = 0;
         private const int DEFAULT_BUFFER_COUNT = 1;
 
-        // The maximum buffer size when a exception occurs
+        // The maximum buffer size when an exception occurs
         private const int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
 
-        // The maximum buffer size when a exception is not expected
+        // The maximum buffer size when an exception is not expected
         private const int MAX_BUFFER_SIZE = 8;
 
         // The default number of times the write method is called when verifying write

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -171,7 +171,7 @@ namespace System.Linq.Expressions.Compiler
 
             // Optimization: inline code for literal lambda's directly
             //
-            // This is worth it because otherwise we end up with a extra call
+            // This is worth it because otherwise we end up with an extra call
             // to DynamicMethod.CreateDelegate, which is expensive.
             //
             if (node.LambdaOperand != null)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionType.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionType.cs
@@ -334,7 +334,7 @@ namespace System.Linq.Expressions
         /// </summary>
         PostDecrementAssign,
         /// <summary>
-        /// A node that represents a exact type test.
+        /// A node that represents an exact type test.
         /// </summary>
         TypeEqual,
         /// <summary>

--- a/src/System.Net.Requests/src/System/Net/CommandStream.cs
+++ b/src/System.Net.Requests/src/System/Net/CommandStream.cs
@@ -179,7 +179,7 @@ namespace System.Net
 
         ///     Pipelined command resolution.
         ///     How this works:
-        ///     A list of commands that need to be sent to the FTP server are spliced together into a array,
+        ///     A list of commands that need to be sent to the FTP server are spliced together into an array,
         ///     each command such STOR, PORT, etc, is sent to the server, then the response is parsed into a string,
         ///     with the response, the delegate is called, which returns an instruction (either continue, stop, or read additional
         ///     responses from server).

--- a/src/System.Net.Security/src/System/Net/Security/SslConnectionInfo.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslConnectionInfo.Unix.cs
@@ -37,7 +37,7 @@ namespace System.Net.Security
             DataKeySize = dataKeySize;
             DataHashKeySize = dataHashKeySize;
 
-            //Openssl does not provide a way to return a exchange key size.
+            //Openssl does not provide a way to return an exchange key size.
             //It internally does calculate the key size before generating key to exchange
             //It is not a constant (Algorthim specific) either that we can hardcode and return. 
             KeyExchKeySize = 0;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3685,7 +3685,7 @@ namespace System.Net.Sockets
 
         // Routine Description:
         // 
-        //    BeginAccept - Does a async winsock accept, creating a new socket on success
+        //    BeginAccept - Does an async winsock accept, creating a new socket on success
         // 
         //     Works by creating a pending accept request the first time,
         //     and subsequent calls are queued so that when the first accept completes,

--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
@@ -268,7 +268,7 @@ namespace System.Collections.ObjectModel
         }
 
         /// <summary>
-        /// Disallow reentrant attempts to change this collection. E.g. a event handler
+        /// Disallow reentrant attempts to change this collection. E.g. an event handler
         /// of the CollectionChanged event is not allowed to make changes to this collection.
         /// </summary>
         /// <remarks>

--- a/src/System.Private.Reflection.Metadata.Ecma335/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Metadata.Ecma335/src/Resources/Strings.resx
@@ -410,10 +410,10 @@
     <value>Invalid exception region bounds: start offset ({0}) is greater than end offset ({1}).</value>
   </data>
   <data name="ArrayInitializedStateNotEqual" xml:space="preserve">
-    <value>Object is not a array with the same initialization state as the array to compare it to.</value>
+    <value>Object is not an array with the same initialization state as the array to compare it to.</value>
   </data>
   <data name="ArrayLengthsNotEqual" xml:space="preserve">
-    <value>Object is not a array with the same number of elements as the array to compare it to.</value>
+    <value>Object is not an array with the same number of elements as the array to compare it to.</value>
   </data>
   <data name="CannotFindOldValue" xml:space="preserve">
     <value>Cannot find the old value</value>

--- a/src/System.Private.Xml/src/System/Xml/Schema/XdrBuilder.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/XdrBuilder.cs
@@ -1120,7 +1120,7 @@ namespace System.Xml.Schema
                     goto cleanup;
                 }
 
-                // an attributes of type id is not supposed to have a default value
+                // an attribute of type id is not supposed to have a default value
                 if (builder._AttributeDef._Default != null && ttype == XmlTokenizedType.ID)
                 {
                     code = SR.Sch_DefaultIdValue;

--- a/src/System.Private.Xml/src/System/Xml/Schema/XdrBuilder.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/XdrBuilder.cs
@@ -1120,7 +1120,7 @@ namespace System.Xml.Schema
                     goto cleanup;
                 }
 
-                // a attributes of type id is not supposed to have a default value
+                // an attributes of type id is not supposed to have a default value
                 if (builder._AttributeDef._Default != null && ttype == XmlTokenizedType.ID)
                 {
                     code = SR.Sch_DefaultIdValue;

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBufferExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBufferExtensions.cs
@@ -12,7 +12,7 @@ using Windows.Storage.Streams;
 namespace System.Runtime.InteropServices.WindowsRuntime
 {
     /// <summary>
-    /// Contains a extension methods that expose operations on WinRT <code>Windows.Foundation.IBuffer</code>.
+    /// Contains extension methods that expose operations on WinRT <code>Windows.Foundation.IBuffer</code>.
     /// </summary>
     public static class WindowsRuntimeBufferExtensions
     {

--- a/src/System.Runtime.WindowsRuntime/tests/System/IO/AsWinRTStreamTests.cs
+++ b/src/System.Runtime.WindowsRuntime/tests/System/IO/AsWinRTStreamTests.cs
@@ -188,7 +188,7 @@ namespace System.IO
                 // asyncReadOp.Id in a progress callback must match the ID of the asyncReadOp to which the callback was assigned
                 Assert.Equal(readOpId, asyncReadOp.Id);
 
-                // asyncReadOp.Status must be 'Started' for a asyncReadOp in progress
+                // asyncReadOp.Status must be 'Started' for an asyncReadOp in progress
                 Assert.Equal(AsyncStatus.Started, asyncReadOp.Status);
 
                 // bytesCompleted must be in range [0, maxBytesToRead] asyncReadOp in progress
@@ -322,7 +322,7 @@ namespace System.IO
                     // asyncWriteOp.Id in a progress callback must match the ID of the asyncWriteOp to which the callback was assigned
                     Assert.Equal(writeOpId, asyncWriteOp.Id);
 
-                    // asyncWriteOp.Status must be 'Started' for a asyncWriteOp in progress
+                    // asyncWriteOp.Status must be 'Started' for an asyncWriteOp in progress
                     Assert.Equal(AsyncStatus.Started, asyncWriteOp.Status);
 
                     // bytesCompleted must be in range [0, maxBytesToWrite] asyncWriteOp in progress

--- a/src/System.Runtime/tests/System/AttributeTests.cs
+++ b/src/System.Runtime/tests/System/AttributeTests.cs
@@ -109,7 +109,7 @@ namespace System.Tests
 
             // The implementation of Attribute.GetHashCode uses reflection to
             // enumerate fields. On .NET core, we add `BindingFlags.DeclaredOnly`
-            // to fix a bug where the hash code of a a subclass of an attribute can
+            // to fix a bug where the hash code of a subclass of an attribute can
             // be equal to an instance of the parent class.
             // See https://github.com/dotnet/coreclr/pull/6240
             Assert.Equal(PlatformDetection.IsFullFramework, s1.GetHashCode().Equals(s2.GetHashCode()));

--- a/src/System.Runtime/tests/System/Reflection/MemberInfoTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Reflection/MemberInfoTests.netcoreapp.cs
@@ -267,7 +267,7 @@ namespace System.Reflection.Tests
         [Fact]
         public static void HasSameMetadataDefinitionAs__CornerCase_HasElementTypes()
         {
-            // HasSameMetadataDefinitionAs on a array/byref/pointer type is uninteresting (they'll never be an actual member of a type)
+            // HasSameMetadataDefinitionAs on an array/byref/pointer type is uninteresting (they'll never be an actual member of a type)
             // but for future compat, we'll establish their known behavior here. Since these types all return a MetadataToken of 0x02000000,
             // they'll all "match" each other.
 

--- a/src/System.Text.Encoding/tests/Decoder/DecoderConvert2.cs
+++ b/src/System.Text.Encoding/tests/Decoder/DecoderConvert2.cs
@@ -37,7 +37,7 @@ namespace System.Text.Tests
         private const int c_SIZE_OF_ARRAY = 127;
         private readonly RandomDataGenerator _generator = new RandomDataGenerator();
 
-        // PosTest1: Call Convert to convert a arbitrary byte array to character array by using ASCII decoder
+        // PosTest1: Call Convert to convert an arbitrary byte array to character array by using ASCII decoder
         [Fact]
         public void PosTest1()
         {
@@ -59,7 +59,7 @@ namespace System.Text.Tests
             decoder.Reset();
         }
 
-        // PosTest2: Call Convert to convert a arbitrary byte array to character array by using Unicode decoder"
+        // PosTest2: Call Convert to convert an arbitrary byte array to character array by using Unicode decoder"
         [Fact]
         public void PosTest2()
         {

--- a/src/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
+++ b/src/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
@@ -50,7 +50,7 @@ namespace System.Text.Tests
             yield return new object[] { Encoding.Unicode.GetEncoder(), 2 };
         }
         
-        // Call Convert to convert a arbitrary character array encoders
+        // Call Convert to convert an arbitrary character array encoders
         [Theory]
         [MemberData(nameof(Encoders_RandomInput))]
         public void EncoderConvertRandomCharArray(Encoder encoder)

--- a/src/System.Threading.Tasks/tests/CESchedulerPairTests.cs
+++ b/src/System.Threading.Tasks/tests/CESchedulerPairTests.cs
@@ -317,7 +317,7 @@ namespace System.Threading.Tasks.Tests
             conTask.Wait();
             Assert.True(conTask.Result, "The concurrenttask when executed successfully should have returned true");
 
-            //Now scehdule a exclusive task that is blocked(thereby preventing other concurrent tasks to finish)
+            //Now scehdule an exclusive task that is blocked(thereby preventing other concurrent tasks to finish)
             Task<bool> exclusiveTask = writers.StartNew<bool>(() => { blockMainThreadEvent.Set(); blockExclusiveTaskEvent.WaitOne(); return true; });
 
             //With exclusive task in execution mode, schedule a number of concurrent tasks and ensure they are not executed
@@ -328,7 +328,7 @@ namespace System.Threading.Tasks.Tests
             foreach (Task task in taskList)
             {
                 bool wasTaskStarted = (task.Status != TaskStatus.Running) && (task.Status != TaskStatus.RanToCompletion);
-                Assert.True(wasTaskStarted, "Concurrent tasks should not be executed when a exclusive task is getting executed");
+                Assert.True(wasTaskStarted, "Concurrent tasks should not be executed when an exclusive task is getting executed");
             }
 
             blockExclusiveTaskEvent.Set();

--- a/src/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
@@ -41,7 +41,7 @@ namespace System.Threading.Tasks.Tests
 
     public enum WorkloadType
     {
-        CreateChildTask, //Start a attached childTask in the workload
+        CreateChildTask, //Start an attached childTask in the workload
         CreateDetachedChildTask, //start a detached childTask in the workload
         ContinueInside, //Invoke continuewith as the workload inside the task
         RunWithUserScheduler, //create a task with custom task scheduler that runs that task inline

--- a/src/System.Transactions.Local/tests/TransactionScopeTest.cs
+++ b/src/System.Transactions.Local/tests/TransactionScopeTest.cs
@@ -761,7 +761,7 @@ namespace System.Transactions.Tests
                 irm.Value = 2;
                 ct.Commit();
 
-                /* Using a already committed transaction in a new 
+                /* Using an already committed transaction in a new 
                  * TransactionScope
                  */
                 TransactionScope scope = new TransactionScope(ct);


### PR DESCRIPTION
This PR covers **A through E** for the following grammar rule:

**Grammar Rule:**
https://owl.english.purdue.edu/owl/resource/591/01/
```
"A" goes before words that begin with consonants.
a cat
a dog
a purple onion
a buffalo
a big apple

"An" goes before words that begin with vowels:
an apricot
an egg
an Indian
an orbit
an uprising
```

**NOTES:**
* Some `*.resx` files were touched.
* Covers XML docs
* Covers source code comments too

**STATUS:**
:red_circle:  *In review. Don't merge yet!*

----

Holy cow :cow:, there are tons of these everywhere. Thinking I should start an OSS business doing this. haha :rofl: j/k

Thanks,
:mag_right: ***Linterman***

:zap: :runner: ***["I was struck by lighting. Walkin' down the street..."](https://www.youtube.com/watch?v=iypUpv9xelg)***