### PR TITLE
Miscellaneous typo corrections.

### DIFF
--- a/Documentation/project-docs/target-dotnetcore-with-msbuild.md
+++ b/Documentation/project-docs/target-dotnetcore-with-msbuild.md
@@ -47,7 +47,7 @@ Creating a .NET Core console application
 Building a console application for .NET Core requires some customization of the MSBuild build process.  A sample project for a .NET Core console application
 is [CoreApp](https://github.com/dotnet/corefxlab/tree/master/samples/NetCoreSample/CoreApp) in the [corefxlab](https://github.com/dotnet/corefxlab) repo.
 Another good option is to start with [coretemplate](https://github.com/mellinoe/coretemplate), which uses separate MSBuild targets files to target .NET Core
-instead of putting the the changes directly in the project file.  
+instead of putting the changes directly in the project file.  
 
 It is also possible to start by creating a project in Visual Studio and modify it to target .NET Core.  The instructions below show the minimal steps to get this working.
 In contrast to CoreApp or coretemplate, a project created this way won't include configurations for targeting Linux and Mac OS.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2645,7 +2645,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     This class is a type description provider that works with the IComNativeDescriptorHandler
         ///     interface.
-        //// </summary>
+        /// </summary>
         private sealed class ComNativeDescriptionProvider : TypeDescriptionProvider
         {
 #pragma warning disable 618
@@ -2656,14 +2656,14 @@ namespace System.ComponentModel
 
             /// <summary>
             ///     Returns the COM handler object.
-            //// </summary>
+            /// </summary>
             internal IComNativeDescriptorHandler Handler { get; set; }
 #pragma warning restore 618
             
             /// <summary>
             ///     Implements GetTypeDescriptor.  This creates a custom type
             ///     descriptor that walks the linked list for each of its calls.
-            //// </summary>
+            /// </summary>
             
             [SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")]
             public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object instance)
@@ -2689,7 +2689,7 @@ namespace System.ComponentModel
             /// <summary>
             ///     This type descriptor sits on top of a native
             ///     descriptor handler.
-            //// </summary>
+            /// </summary>
             private sealed class ComNativeTypeDescriptor : ICustomTypeDescriptor
             {
 #pragma warning disable 618
@@ -2698,7 +2698,7 @@ namespace System.ComponentModel
 
                 /// <summary>
                 ///     Creates a new ComNativeTypeDescriptor.
-                //// </summary>
+                /// </summary>
                 internal ComNativeTypeDescriptor(IComNativeDescriptorHandler handler, object instance)
                 {
                     _handler = handler;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -397,7 +397,7 @@ namespace System.Data.SqlClient
 
         // Event notification that transaction ended. This comes from the subscription to the Transaction's
         //  ended event via the internal connection. If it occurs without a prior Rollback or SinglePhaseCommit call,
-        //  it indicates the transaction was ended externally (generally that one the the DTC participants aborted
+        //  it indicates the transaction was ended externally (generally that one of the DTC participants aborted
         //  the transaction).
         internal void TransactionEnded(Transaction transaction)
         {

--- a/src/System.Linq.Parallel/tests/Helpers/UnorderedSources.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/UnorderedSources.cs
@@ -166,7 +166,7 @@ namespace System.Linq.Parallel.Tests
         /// <returns>Entries for test data.
         /// The first element is the left Labeled{ParallelQuery{int}} range, the second element is the left count,
         /// the third element is the right Labeled{ParallelQuery{int}} range, the fourth element is the right count,
-        /// and the fifth is the right start..</returns>
+        /// and the fifth is the right start.</returns>
         public static IEnumerable<object[]> BinaryRanges(IEnumerable<int> leftCounts, Func<int, int, int> rightStart, IEnumerable<int> rightCounts)
         {
             foreach (object[] left in Ranges(leftCounts))

--- a/src/System.Net.NameResolution/src/System/Net/IPHostEntry.cs
+++ b/src/System.Net.NameResolution/src/System/Net/IPHostEntry.cs
@@ -6,7 +6,7 @@ namespace System.Net
 {
     // Host information
     /// <devdoc>
-    ///    <para>Provides a container class for Internet host address information..</para>
+    ///    <para>Provides a container class for Internet host address information.</para>
     /// </devdoc>
     public class IPHostEntry
     {

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XmlQueryTypeFactory.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XmlQueryTypeFactory.cs
@@ -1529,7 +1529,7 @@ namespace System.Xml.Xsl
                 case XmlTypeCode.Element:
                     XmlSchemaType sourceSchemaType = sourceItem.SchemaType;
                     if (sourceSchemaType == XmlSchemaComplexType.UntypedAnyType) {
-                        // attfibutes of of xdt:untypedAny are attribute(*, xdt:untypedAtomic)*
+                        // attributes of xdt:untypedAny are attribute(*, xdt:untypedAtomic)*
                         card |= AddFilteredPrime(list, UntypedAttribute, filter) * XmlQueryCardinality.ZeroOrOne;
                     }
                     else {

--- a/src/System.Runtime/tests/System/AttributeTests.cs
+++ b/src/System.Runtime/tests/System/AttributeTests.cs
@@ -109,7 +109,7 @@ namespace System.Tests
 
             // The implementation of Attribute.GetHashCode uses reflection to
             // enumerate fields. On .NET core, we add `BindingFlags.DeclaredOnly`
-            // to fix a bug where the hash code of a a subclass of an attribute can
+            // to fix a bug where the hash code of a subclass of an attribute can
             // be equal to an instance of the parent class.
             // See https://github.com/dotnet/coreclr/pull/6240
             Assert.Equal(PlatformDetection.IsFullFramework, s1.GetHashCode().Equals(s2.GetHashCode()));

--- a/src/System.Threading/src/System/Threading/CountdownEvent.cs
+++ b/src/System.Threading/src/System/Threading/CountdownEvent.cs
@@ -375,7 +375,7 @@ namespace System.Threading
         /// thread-safe and may not be used concurrently with other members of this instance.
         /// </remarks>
         /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
-        /// disposed..</exception>
+        /// disposed.</exception>
         public void Reset()
         {
             Reset(_initialCount);


### PR DESCRIPTION
Small PR of uncategorized typos that I've collected during the journey.

**NOTES:**
* Covers XML docs
* Resolves missing / unmatched `</summary>` elements. ***Reduces compiler warnings by 5?!***
* Double words and double punctuation of sorts.

**STATUS:**
*:red_circle: In review.*

Thanks,
:mag_right: ***Linterman***

:alarm_clock: :sun_behind_rain_cloud: ***["I looked out this morning and the sun was gone... Turned on some music to start my day..."](https://www.youtube.com/watch?v=SSR6ZzjDZ94)***
