### PR TITLE
Fix IPv6 address parsing when last number is too long

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/IPv6AddressHelper.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPv6AddressHelper.cs
@@ -242,9 +242,12 @@ namespace System
 
             if (sequenceLength != 0)
             {
+                if (sequenceLength > 4)
+                {
+                    return false;
+                }
+
                 ++sequenceCount;
-                lastSequence = i - sequenceLength;
-                sequenceLength = 0;
             }
 
             // these sequence counts are -1 because it is implied in end-of-sequence
@@ -252,7 +255,6 @@ namespace System
             const int ExpectedSequenceCount = 8;
             return
                 !expectingNumber &&
-                (sequenceLength <= 4) &&
                 (haveCompressor ? (sequenceCount < ExpectedSequenceCount) : (sequenceCount == ExpectedSequenceCount)) &&
                 !needsClosingBracket;
         }

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -335,6 +335,15 @@ namespace System.Net.Primitives.Functional.Tests
             new object[] { "::%1a" }, // alphanumeric scope
             new object[] { "[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:443/" }, // errneous ending slash after ignored port
             new object[] { "::1234%0x12" }, // invalid scope ID
+
+            new object[] { "e3fff:ffff:ffff:ffff:ffff:ffff:ffff:abcd" }, // 1st number too long
+            new object[] { "3fff:effff:ffff:ffff:ffff:ffff:ffff:abcd" }, // 2nd number too long
+            new object[] { "3fff:ffff:effff:ffff:ffff:ffff:ffff:abcd" }, // 3rd number too long
+            new object[] { "3fff:ffff:ffff:effff:ffff:ffff:ffff:abcd" }, // 4th number too long
+            new object[] { "3fff:ffff:ffff:ffff:effff:ffff:ffff:abcd" }, // 5th number too long
+            new object[] { "3fff:ffff:ffff:ffff:ffff:effff:ffff:abcd" }, // 6th number too long
+            new object[] { "3fff:ffff:ffff:ffff:ffff:ffff:effff:abcd" }, // 7th number too long
+            new object[] { "3fff:ffff:ffff:ffff:ffff:ffff:ffff:eabcd" }, // 8th number too long
         };
 
         [Theory]

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsingSpan.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsingSpan.cs
@@ -7,165 +7,42 @@ using Xunit;
 
 namespace System.Net.Primitives.Functional.Tests
 {
-    public sealed class IPAddressParsingSpan : IPAddressParsing
+    public sealed class IPAddressParsing_Span : IPAddressParsing
     {
-        const int IPv4MaxLength = 15;
+        public override IPAddress Parse(string ipString) => IPAddress.Parse(ipString.AsReadOnlySpan());
+        public override bool TryParse(string ipString, out IPAddress address) => IPAddress.TryParse(ipString.AsReadOnlySpan(), out address);
+
 
         [Theory]
         [MemberData(nameof(ValidIpv4Addresses))]
-        public void ParseIPv4Span_ValidAddress_Success(string address, string expected)
+        [MemberData(nameof(ValidIpv6Addresses))]
+        public void TryFormat_ProvidedBufferLargerThanNeeded_Success(string addressString, string expected)
         {
-            IPAddress ip = IPAddress.Parse(address.AsReadOnlySpan());
+            IPAddress address = IPAddress.Parse(addressString);
 
-            // Validate the ToString of the parsed address matches the expected value
-            Assert.Equal(expected, ip.ToString());
-            Assert.Equal(AddressFamily.InterNetwork, ip.AddressFamily);
+            const int IPv4MaxLength = 15; // TryFormat currently requires at least this amount of space for IPv4 addresses
+            int requiredLength = address.AddressFamily == AddressFamily.InterNetwork ?
+                IPv4MaxLength :
+                address.ToString().Length;
 
-            // Validate the ToString representation can be parsed as well back into the same IP
-            IPAddress ip2 = IPAddress.Parse(address.AsReadOnlySpan());
-            Assert.Equal(ip, ip2);
-        }
-
-        [Theory]
-        [MemberData(nameof(ValidIpv4Addresses))]
-        public void TryParseIPv4Span_ValidAddress_Success(string address, string expected)
-        {
-            Assert.True(IPAddress.TryParse(address.AsReadOnlySpan(), out IPAddress ip));
-
-            // Validate the ToString of the parsed address matches the expected value
-            Assert.Equal(expected, ip.ToString());
-            Assert.Equal(AddressFamily.InterNetwork, ip.AddressFamily);
-
-            // Validate the ToString representation can be parsed as well back into the same IP
-            Assert.True(IPAddress.TryParse(ip.ToString().AsReadOnlySpan(), out IPAddress ip2));
-            Assert.Equal(ip, ip2);
-        }
-
-        [Theory]
-        [MemberData(nameof(ValidIpv4Addresses))]
-        public void TryFormatIPv4_ValidAddress_Success(string address, string expected)
-        {
-            const int IPv4MaxPlusOneLength = IPv4MaxLength + 1;
-
-            var ip = IPAddress.Parse(address);
-
-            var exactSize = new char[IPv4MaxLength];
-            Assert.True(ip.TryFormat(new Span<char>(exactSize), out int charsWritten));
+            var largerThanRequired = new char[requiredLength + 1];
+            Assert.True(address.TryFormat(new Span<char>(largerThanRequired), out int charsWritten));
             Assert.Equal(expected.Length, charsWritten);
-            Assert.Equal(expected, new string(exactSize, 0, charsWritten));
-
-            var largerThanRequired = new char[IPv4MaxPlusOneLength];
-            Assert.True(ip.TryFormat(new Span<char>(largerThanRequired), out charsWritten));
-            Assert.Equal(expected.Length, charsWritten);
-            Assert.Equal(expected, new string(largerThanRequired, 0, charsWritten));
+            Assert.Equal(
+                address.AddressFamily == AddressFamily.InterNetworkV6 ? expected.ToLowerInvariant() : expected,
+                new string(largerThanRequired, 0, charsWritten));
         }
 
         [Theory]
         [MemberData(nameof(ValidIpv4Addresses))]
-        public void TryFormatIPv4_ProvidedBufferTooSmall_Failure(string address, string expected)
+        [MemberData(nameof(ValidIpv6Addresses))]
+        public void TryFormat_ProvidedBufferTooSmall_Failure(string addressString, string expected)
         {
-            const int bufferSize = IPv4MaxLength - 1;
-            var ip = IPAddress.Parse(address);
-
-            var result = new char[bufferSize];
-            Assert.False(ip.TryFormat(new Span<char>(result), out int charsWritten));
+            IPAddress address = IPAddress.Parse(addressString);
+            var result = new char[address.ToString().Length - 1];
+            Assert.False(address.TryFormat(new Span<char>(result), out int charsWritten));
             Assert.Equal(0, charsWritten);
-            Assert.Equal<char>(new char[bufferSize], result);
+            Assert.Equal<char>(new char[result.Length], result);
         }
-
-        [Theory]
-        [MemberData(nameof(InvalidIpv4Addresses))]
-        [MemberData(nameof(InvalidIpv4AddressesStandalone))]
-        public void TryParseIPv4_InvalidAddress_Failure(string address)
-        {
-            Assert.False(IPAddress.TryParse(address.AsReadOnlySpan(), out IPAddress ip));
-            Assert.Equal(null, ip);
-        }
-
-        [Theory]
-        [MemberData(nameof(ValidIpv6Addresses))]
-        public void ParseIPv6Span_ValidAddress_RoundtripMatchesExpected(string address, string expected)
-        {
-            IPAddress ip = IPAddress.Parse(address.AsReadOnlySpan());
-
-            // Validate the ToString of the parsed address matches the expected value
-            Assert.Equal(expected.ToLowerInvariant(), ip.ToString());
-            Assert.Equal(AddressFamily.InterNetworkV6, ip.AddressFamily);
-
-            // Validate the ToString representation can be parsed as well back into the same IP
-            IPAddress ip2 = IPAddress.Parse(address.AsReadOnlySpan());
-            Assert.Equal(ip, ip2);
-
-            // Validate that anything that doesn't already start with brackets
-            // can be surrounded with brackets and still parse successfully.
-            if (!address.StartsWith("["))
-            {
-                Assert.Equal(
-                    expected.ToLowerInvariant(),
-                    IPAddress.Parse(("[" + address + "]").AsReadOnlySpan()).ToString());
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(ValidIpv6Addresses))]
-        public void TryParseIPv6Span_ValidAddress_RoundtripMatchesExpected(string address, string expected)
-        {
-            Assert.True(IPAddress.TryParse(address.AsReadOnlySpan(), out IPAddress ip));
-
-            // Validate the ToString of the parsed address matches the expected value
-            Assert.Equal(expected.ToLowerInvariant(), ip.ToString());
-            Assert.Equal(AddressFamily.InterNetworkV6, ip.AddressFamily);
-
-            // Validate the ToString representation can be parsed as well back into the same IP
-            Assert.True(IPAddress.TryParse(ip.ToString().AsReadOnlySpan(), out IPAddress ip2));
-            Assert.Equal(ip, ip2);
-
-            // Validate that anything that doesn't already start with brackets
-            // can be surrounded with brackets and still parse successfully.
-            if (!address.StartsWith("["))
-            {
-                Assert.True(IPAddress.TryParse(("[" + address + "]").AsReadOnlySpan(), out IPAddress ip3));
-                Assert.Equal(expected.ToLowerInvariant(), ip3.ToString());
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(ValidIpv6Addresses))]
-        public void TryFormatIPv6_ValidAddress_Success(string address, string expected)
-        {
-            var ip = IPAddress.Parse(address);
-
-            var exactSize = new char[expected.Length];
-            Assert.True(ip.TryFormat(new Span<char>(exactSize), out int charsWritten));
-            Assert.Equal(expected.Length, charsWritten);
-            Assert.Equal(expected.ToLowerInvariant(), new string(exactSize, 0, charsWritten));
-
-            var largerThanRequired = new char[expected.Length + 1];
-            Assert.True(ip.TryFormat(new Span<char>(largerThanRequired), out charsWritten));
-            Assert.Equal(expected.Length, charsWritten);
-            Assert.Equal(expected.ToLowerInvariant(), new string(largerThanRequired, 0, charsWritten));
-        }
-
-        [Theory]
-        [MemberData(nameof(ValidIpv6Addresses))]
-        public void TryFormatIPv6_ProvidedBufferTooSmall_Failure(string address, string expected)
-        {
-            int bufferSize = expected.Length - 1;
-            var result = new char[bufferSize];
-            var ip = IPAddress.Parse(address);
-
-            Assert.False(ip.TryFormat(new Span<char>(result), out int charsWritten));
-            Assert.Equal(0, charsWritten);
-            Assert.Equal<char>(new char[bufferSize], result);
-        }
-
-        [Theory]
-        [MemberData(nameof(InvalidIpv6Addresses))]
-        public void TryParseIPv6_InvalidAddress_ReturnsFalse(string invalidAddress)
-        {
-            Assert.False(IPAddress.TryParse(invalidAddress.AsReadOnlySpan(), out IPAddress ip));
-            Assert.Equal(null, ip);
-        }
-
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsingSpan.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsingSpan.cs
@@ -75,6 +75,7 @@ namespace System.Net.Primitives.Functional.Tests
 
         [Theory]
         [MemberData(nameof(InvalidIpv4Addresses))]
+        [MemberData(nameof(InvalidIpv4AddressesStandalone))]
         public void TryParseIPv4_InvalidAddress_Failure(string address)
         {
             Assert.False(IPAddress.TryParse(address.AsReadOnlySpan(), out IPAddress ip));


### PR DESCRIPTION
When given an IPv6 address where the last number has more than four digits, rather than failing the parse we end up just using the last four digits.  The last commit fixes that.  The first three commits add a bunch more test cases, fix some duplication, and fix a test issue recently introduced where the IPAddress parsing tests weren't running on netfx.

Fixes https://github.com/dotnet/corefx/issues/23639
cc: @davidsh, @geoffkizer, @joseph-newton