### PR TITLE
release/2.0: Handle EAGAIN in Console.Write (#23539)

### DIFF
--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -232,6 +232,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.OpenFlags.cs">
       <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Poll.cs">
+      <Link>Common\Interop\Unix\Interop.Poll.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEUid.cs">
       <Link>Common\Interop\Unix\Interop.GetEUid.cs</Link>
     </Compile>

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -977,6 +977,17 @@ namespace System
                         // that ended, so simply pretend we were successful.
                         return;
                     }
+                    else if (errorInfo.Error == Interop.Error.EAGAIN) // aka EWOULDBLOCK
+                    {
+                        // May happen if the file handle is configured as non-blocking.
+                        // In that case, we need to wait to be able to write and then
+                        // try again. We poll, but don't actually care about the result,
+                        // only the blocking behavior, and thus ignore any poll errors
+                        // and loop around to do another write (which may correctly fail
+                        // if something else has gone wrong).
+                        Interop.Sys.Poll(fd, Interop.Sys.PollEvents.POLLOUT, Timeout.Infinite, out Interop.Sys.PollEvents triggered);
+                        continue;
+                    }
                     else
                     {
                         // Something else... fail.

--- a/src/System.Console/tests/NonStandardConfiguration.Unix.cs
+++ b/src/System.Console/tests/NonStandardConfiguration.Unix.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+
+namespace System.Tests
+{
+    public partial class NonStandardConfigurationTests : RemoteExecutorTestBase
+    {
+        [PlatformSpecific(TestPlatforms.AnyUnix)] // Uses P/Invokes
+        [Fact]
+        public void NonBlockingStdout_AllDataReceived()
+        {
+            RemoteInvokeHandle remote = RemoteInvoke(() =>
+            {
+                char[] data = Enumerable.Repeat('a', 1024).ToArray();
+
+                const int StdoutFd = 1;
+                Assert.Equal(0, Interop.Sys.Fcntl.DangerousSetIsNonBlocking((IntPtr)StdoutFd, 1));
+
+                for (int i = 0; i < 10_000; i++)
+                {
+                    Console.Write(data);
+                }
+
+                return SuccessExitCode;
+            }, new RemoteInvokeOptions { StartInfo = new ProcessStartInfo() { RedirectStandardOutput = true } });
+
+            using (remote)
+            {
+                Assert.Equal(
+                    new string('a', 1024 * 10_000),
+                    remote.Process.StandardOutput.ReadToEnd());
+            }
+        }
+    }
+}

--- a/src/System.Console/tests/System.Console.Tests.csproj
+++ b/src/System.Console/tests/System.Console.Tests.csproj
@@ -15,7 +15,6 @@
       <Link>Common\tests\System\PlatformDetection.cs</Link>
     </Compile>
     <Compile Include="CancelKeyPress.cs" />
-    <Compile Include="CancelKeyPress.Unix.cs" Condition="'$(TargetsWindows)' != 'true'" />
     <Compile Include="Helpers.cs" />
     <Compile Include="ReadAndWrite.cs" />
     <Compile Include="ConsoleKeyInfoTests.cs" />
@@ -25,7 +24,6 @@
     <Compile Include="SetOut.cs" />
     <Compile Include="NegativeTesting.cs" />
     <Compile Include="ConsoleEncoding.cs" />
-    <Compile Include="ConsoleEncoding.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="SyncTextReader.cs" />
     <Compile Include="SyncTextWriter.cs" />
     <Compile Include="Timeout.cs" />
@@ -50,6 +48,19 @@
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
     <Compile Include="WindowAndCursorProps.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'" >
+    <Compile Include="ConsoleEncoding.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' != 'true'" >
+    <Compile Include="CancelKeyPress.Unix.cs" />
+    <Compile Include="NonStandardConfiguration.Unix.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.cs">
+      <Link>Interop\Unix\System.Native\Interop.Fcntl.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">


### PR DESCRIPTION
If stdout/stderr is configured as a non-blocking file descriptor, Console.Write{Line} may fail if the descriptor is full and would block.  With this commit, we instead poll in that case waiting for the ability to write and then retry.

Port of https://github.com/dotnet/corefx/pull/23539 to release/2.0 branch.