### PR TITLE
Enable SqlDataReader.GetValue() and GetSqlValue() for UDT types.

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -2350,23 +2350,7 @@ namespace System.Data.SqlClient
             else if (_typeSystem != SqlConnectionString.TypeSystem.SQLServer2000)
             {
                 // TypeSystem.SQLServer2005
-
-                if (metaData.type == SqlDbType.Udt)
-                {
-                    var connection = _connection;
-                    if (connection != null)
-                    {
-                        throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
-                    }
-                    else
-                    {
-                        throw ADP.DataReaderClosed();
-                    }
-                }
-                else
-                {
-                    return data.SqlValue;
-                }
+                return data.SqlValue;
             }
             else
             {
@@ -2536,23 +2520,7 @@ namespace System.Data.SqlClient
             else if (_typeSystem != SqlConnectionString.TypeSystem.SQLServer2000)
             {
                 // TypeSystem.SQLServer2005
-
-                if (metaData.type != SqlDbType.Udt)
-                {
-                    return data.Value;
-                }
-                else
-                {
-                    var connection = _connection;
-                    if (connection != null)
-                    {
-                        throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
-                    }
-                    else
-                    {
-                        throw ADP.DataReaderClosed();
-                    }
-                }
+                return data.Value;
             }
             else
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -2349,7 +2349,7 @@ namespace System.Data.SqlClient
             }
             else if (_typeSystem != SqlConnectionString.TypeSystem.SQLServer2000)
             {
-                // TypeSystem.SQLServer2005
+                // TypeSystem.SQLServer2005 and above
                 return data.SqlValue;
             }
             else
@@ -2519,7 +2519,7 @@ namespace System.Data.SqlClient
             }
             else if (_typeSystem != SqlConnectionString.TypeSystem.SQLServer2000)
             {
-                // TypeSystem.SQLServer2005
+                // TypeSystem.SQLServer2005 and above
                 return data.Value;
             }
             else

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UdtTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UdtTest.cs
@@ -40,6 +40,28 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         }
 
         [CheckConnStrSetupFact]
+        public static void GetValueTest()
+        {
+            using (SqlConnection conn = new SqlConnection(DataTestUtility.TcpConnStr))
+            using (SqlCommand cmd = new SqlCommand("select hierarchyid::Parse('/1/') as col0", conn))
+            {
+                conn.Open();
+                using (SqlDataReader reader = cmd.ExecuteReader())
+                {
+                    Assert.True(reader.Read());
+
+                    object udtValue = reader.GetValue(0);
+                    Assert.True(udtValue != null, "Received null value from GetValue().");
+                    DataTestUtility.AssertEqualsWithDescription(typeof(byte[]), udtValue.GetType(), "Unexpected UDT type from GetValue()");
+
+                    object udtSqlValue = reader.GetSqlValue(0);
+                    Assert.True(udtSqlValue != null, "Received null value from GetSqlValue().");
+                    DataTestUtility.AssertEqualsWithDescription(typeof(SqlBinary), udtSqlValue.GetType(), "Unexpected UDT type from GetSqlValue()");
+                }
+            }
+        }
+
+        [CheckConnStrSetupFact]
         public static void TestUdtSqlParameterThrowsPlatformNotSupportedException()
         {
             using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))


### PR DESCRIPTION
Currently the UDT data is just returned as bytes.