### PR TITLE
Fix library packages overlapping with framework packages

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01929-04
+2.0.0-prerelease-01931-01

--- a/external/runtime/Configurations.props
+++ b/external/runtime/Configurations.props
@@ -4,6 +4,8 @@
     <BuildConfigurations>
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
+      netcoreapp2.0-Windows_NT;
+      netcoreapp2.0-Unix;
       uap;
       uapaot;
       mono;

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <NugetRuntimeIdentifier>$(PackageRID)</NugetRuntimeIdentifier>
     <RidSpecificAssets>true</RidSpecificAssets>
+    <CoreClrPackageVersion Condition="'$(TargetGroup)' == 'netcoreapp2.0'">2.0.0</CoreClrPackageVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <!-- Temporarily Override restore moniker since NETNative's targeting pack still uses uap10.1 moniker -->

--- a/src/System.Buffers/pkg/System.Buffers.pkgproj
+++ b/src/System.Buffers/pkg/System.Buffers.pkgproj
@@ -7,11 +7,18 @@
     </ProjectReference>
     <ProjectReference Include="..\src\System.Buffers.csproj" />
 
-    <InboxOnTargetFramework Include="netcoreapp2.0" />
-    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
     <!-- this package is part of the implementation closure of NETStandard.Library
          therefore it cannot reference NETStandard.Library -->
     <SuppressMetaPackage Include="NETStandard.Library" />
+
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Buffers/src/Configurations.props
+++ b/src/System.Buffers/src/Configurations.props
@@ -4,13 +4,15 @@
     <PackageConfigurations>
       netstandard1.1;
       netstandard;
+      netcoreapp2.0-Windows_NT;
+      netcoreapp2.0-Unix;
+      uap-Windows_NT;
+      uapaot-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
-      uap-Windows_NT;
-      uapaot-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Collections.Immutable/pkg/System.Collections.Immutable.pkgproj
+++ b/src/System.Collections.Immutable/pkg/System.Collections.Immutable.pkgproj
@@ -9,8 +9,15 @@
     <ProjectReference Include="..\src\System.Collections.Immutable.csproj">
       <SupportedFramework>net45;netcore45;netcoreapp1.0;wp8;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <InboxOnTargetFramework Include="netcoreapp2.0" />
-    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
+
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.csproj
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.csproj
@@ -3,7 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{C4D6F1F4-DC7E-4756-9A88-171A8B1F1E26}</ProjectGuid>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+    <!-- Must match version supported by frameworks which support 4.2.* inbox.
+         Can be removed when API is added and this assembly is versioned to 4.3.* -->
+    <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.2.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.csproj
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <ProjectGuid>{D58E8D2B-3331-4660-8DFB-512D66F8EC63}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+    <!-- Must match version supported by frameworks which support 4.3.* inbox.
+         Can be removed when API is added and this assembly is versioned to 4.4.* -->
+    <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.3.0.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />

--- a/src/System.Diagnostics.DiagnosticSource/pkg/System.Diagnostics.DiagnosticSource.pkgproj
+++ b/src/System.Diagnostics.DiagnosticSource/pkg/System.Diagnostics.DiagnosticSource.pkgproj
@@ -9,10 +9,18 @@
     <ProjectReference Include="..\src\System.Diagnostics.DiagnosticSource.csproj">
       <SupportedFramework>net46;net45;netcore45;netcoreapp1.0;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <InboxOnTargetFramework Include="netcoreapp2.0" />
     <!-- this package is part of the implementation closure of NETStandard.Library
          therefore it cannot reference NETStandard.Library -->
     <SuppressMetaPackage Include="NETStandard.Library" />
+    
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Ports/ref/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/ref/System.IO.Ports.csproj
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <ProjectGuid>{75DE4259-43BB-4067-9F30-3AC920D51AEC}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+    <!-- Must match version supported by frameworks which support 4.0.* inbox.
+         Can be removed when API is added and this assembly is versioned to 4.1.* -->
+    <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.0.1.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />

--- a/src/System.Memory/pkg/System.Memory.pkgproj
+++ b/src/System.Memory/pkg/System.Memory.pkgproj
@@ -7,8 +7,15 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Memory.csproj" />
-    <InboxOnTargetFramework Include="netcoreapp2.1" />
-    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
+    
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Memory/src/Configurations.props
+++ b/src/System.Memory/src/Configurations.props
@@ -1,12 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageConfigurations>
+    <BuildConfigurations>
       netstandard1.0;
       netstandard;
-    </PackageConfigurations>
-    <BuildConfigurations>
-      $(PackageConfigurations);
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
       uap-Windows_NT;

--- a/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
+++ b/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
@@ -15,14 +15,21 @@
     <ProjectReference Include="..\src\System.Numerics.Vectors.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <InboxOnTargetFramework Include="netcoreapp2.0" />
-    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
+
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.DispatchProxy/pkg/System.Reflection.DispatchProxy.pkgproj
+++ b/src/System.Reflection.DispatchProxy/pkg/System.Reflection.DispatchProxy.pkgproj
@@ -13,17 +13,21 @@
     <HarvestIncludePaths Include="ref/netstandard1.3;lib/netstandard1.3" />
   </ItemGroup>
   <ItemGroup>
-    <InboxOnTargetFramework Include="netcoreapp2.0" />
-    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>runtimes/aot/lib/$(UAPvNextTFM)</TargetPath>
-    </File>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
+
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.DispatchProxy/src/Configurations.props
+++ b/src/System.Reflection.DispatchProxy/src/Configurations.props
@@ -4,12 +4,13 @@
     <PackageConfigurations>
       netfx;
       netstandard;
+      netcoreapp2.0;
+      uapaot-Windows_NT;
+      uap-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
-      uapaot-Windows_NT;
       netcoreapp;
-      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.pkgproj
+++ b/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.pkgproj
@@ -13,8 +13,15 @@
       <TargetFramework>portable-net45+win8</TargetFramework>
       <Version>1.1.37</Version>
     </FilePackageDependency>
-    <InboxOnTargetFramework Include="netcoreapp2.0" />
-    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
+    
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.TypeExtensions/ref/System.Reflection.TypeExtensions.csproj
+++ b/src/System.Reflection.TypeExtensions/ref/System.Reflection.TypeExtensions.csproj
@@ -3,6 +3,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{C303A051-8D54-4460-8BFD-DE10F0473BDB}</ProjectGuid>
+    <!-- Must match version supported by frameworks which support 4.1.* inbox.
+         Can be removed when API is added and this assembly is versioned to 4.2.* -->
+    <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.1.2.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />

--- a/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
@@ -7,8 +7,15 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
-    <InboxOnTargetFramework Include="netcoreapp2.1" />
-    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
+
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/Configurations.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/Configurations.props
@@ -1,12 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageConfigurations>
+    <BuildConfigurations>
       netstandard1.0;
       netstandard;
-    </PackageConfigurations>
-    <BuildConfigurations>
-      $(PackageConfigurations);
       netcoreapp;
     </BuildConfigurations>  
   </PropertyGroup>

--- a/src/System.Security.AccessControl/ref/System.Security.AccessControl.csproj
+++ b/src/System.Security.AccessControl/ref/System.Security.AccessControl.csproj
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <ProjectGuid>{F80C478C-48EE-46A5-89C4-EE0CFB23A14F}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+    <!-- Must match version supported by frameworks which support 4.1.* inbox.
+         Can be removed when API is added and this assembly is versioned to 4.2.* -->
+    <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.1.1.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.csproj
@@ -6,6 +6,9 @@
     <ProjectGuid>{9FD12550-3A7C-49D3-9A1E-C4B7410989DD}</ProjectGuid>
     <DefineConstants Condition="'$(TargetGroup)' == 'uap' Or '$(TargeGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_HASHDATA</DefineConstants>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx' OR '$(TargetGroup)' == 'net462' OR '$(TargetGroup)' == 'net47'">true</IsPartialFacadeAssembly>
+    <!-- Must match version supported by frameworks which support 4.3.* inbox.
+         Can be removed when API is added and this assembly is versioned to 4.4.* -->
+    <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.3.1.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />

--- a/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.csproj
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <ProjectGuid>{25A02E40-D12C-4184-B599-E4F954D142DB}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+    <!-- Must match version supported by frameworks which support 4.1.* inbox.
+         Can be removed when API is added and this assembly is versioned to 4.2.* -->
+    <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.1.1.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />

--- a/src/System.Text.Encoding.CodePages/pkg/System.Text.Encoding.CodePages.pkgproj
+++ b/src/System.Text.Encoding.CodePages/pkg/System.Text.Encoding.CodePages.pkgproj
@@ -10,15 +10,21 @@
     <HarvestIncludePaths Include="ref/netstandard1.3;runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
   </ItemGroup>
   <ItemGroup>
-    <InboxOnTargetFramework Include="$(UAPvNextTFM)">
-      <PackageTargetRuntime>win</PackageTargetRuntime>
-    </InboxOnTargetFramework>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
+
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Tasks.Dataflow/pkg/System.Threading.Tasks.Dataflow.pkgproj
+++ b/src/System.Threading.Tasks.Dataflow/pkg/System.Threading.Tasks.Dataflow.pkgproj
@@ -9,8 +9,15 @@
     <ProjectReference Include="..\src\System.Threading.Tasks.Dataflow.csproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <InboxOnTargetFramework Include="netcoreapp2.0" />
-    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
+
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Tasks.Extensions/pkg/System.Threading.Tasks.Extensions.pkgproj
+++ b/src/System.Threading.Tasks.Extensions/pkg/System.Threading.Tasks.Extensions.pkgproj
@@ -9,7 +9,15 @@
     <ProjectReference Include="..\src\System.Threading.Tasks.Extensions.csproj">
       <SupportedFramework>net45;netcore45;netcoreapp1.0;wpa81;wp8;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <InboxOnTargetFramework Include="netcoreapp2.0" />
+
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
 
     <!-- this package is part of the implementation closure of NETStandard.Library
          therefore it cannot reference NETStandard.Library -->

--- a/src/System.ValueTuple/ref/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/ref/System.ValueTuple.csproj
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <ProjectGuid>{11AE73F7-3532-47B9-8FF6-B4F22D76456D}</ProjectGuid>
     <RootNamespace>System</RootNamespace>
+    <!-- Must match version supported by frameworks which support 4.0.* inbox.
+         Can be removed when API is added and this assembly is versioned to 4.1.* -->
+    <AssemblyVersion Condition="'$(TargetGroup)' != 'netfx'">4.0.3.0</AssemblyVersion>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />


### PR DESCRIPTION
Many library packages overlap with assemblies we include in our framework packages.

In the first release we handled this by preventing the library package from applying any
assets.

This becomes problematic if the reference assembly needs to version, and especially
if the library wants to add API.  The new version will be greater than what was previously
shipped inbox, and we wouldn't want to restrict the new version just to future TFMs.

To address this problem I've made a couple fixes:
1. For packages which are shipping brand new API that's not present in desktop, we'll
omit any placeholders and allow conflict resolution to decide if the library package
or framework package should be used (based on version).  In some cases this required
bringing some configurations into the package so that it could always be "up to date".

2. For packages which are just exposing API in desktop, and thus already tied/anchored
to netstandard versions, we'll freeze the reference assembly version for the non-desktop
builds.  This ensures that the reference assembly will never move past the version that's
inbox in the framework package.

Update BuildToolsVersion to 2.0.0-prerelease-01931-01

Fixes #23656 