### PR TITLE
Fix connection pool & connection pool group fragmentation

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionFactory.cs
@@ -395,15 +395,14 @@ namespace System.Data.ProviderBase
                     }
                 }
 
-
-                DbConnectionPoolGroup newConnectionPoolGroup = new DbConnectionPoolGroup(connectionOptions, key, poolOptions);
-                newConnectionPoolGroup.ProviderInfo = CreateConnectionPoolGroupProviderInfo(connectionOptions);
-
                 lock (this)
                 {
                     connectionPoolGroups = _connectionPoolGroups;
                     if (!connectionPoolGroups.TryGetValue(key, out connectionPoolGroup))
                     {
+                        DbConnectionPoolGroup newConnectionPoolGroup = new DbConnectionPoolGroup(connectionOptions, key, poolOptions);
+                        newConnectionPoolGroup.ProviderInfo = CreateConnectionPoolGroupProviderInfo(connectionOptions);
+
                         // build new dictionary with space for new connection string
                         Dictionary<DbConnectionPoolKey, DbConnectionPoolGroup> newConnectionPoolGroups = new Dictionary<DbConnectionPoolKey, DbConnectionPoolGroup>(1 + connectionPoolGroups.Count);
                         foreach (KeyValuePair<DbConnectionPoolKey, DbConnectionPoolGroup> entry in connectionPoolGroups)

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -8,7 +8,6 @@
 using System.Collections.Concurrent;
 using System.Data.Common;
 using System.Diagnostics;
-using System.Threading;
 
 namespace System.Data.ProviderBase
 {

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -215,6 +215,10 @@ namespace System.Data.ProviderBase
                                 {
                                     // else pool entry has been disabled so don't create new pools
                                     Debug.Assert(PoolGroupStateDisabled == _state, "state should be disabled");
+
+                                    // don't need to call connectionFactory.QueuePoolForRelease(newPool) because		
+                                    // pool callbacks were delayed and no risk of connections being created		
+                                    newPool.Shutdown();
                                 }
                             }
                             else

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -208,7 +208,6 @@ namespace System.Data.ProviderBase
                                     bool addResult = _poolCollection.TryAdd(currentIdentity, newPool);
                                     Debug.Assert(addResult, "No other pool with current identity should exist at this point");
                                     pool = newPool;
-                                    newPool = null;
                                 }
                                 else
                                 {


### PR DESCRIPTION
This is fix for https://github.com/dotnet/corefx/issues/23626
This issue is fixed by moving code part for the connection pool creation to synchronized (lock) block so that only one thread can create connection pool, and adds it to pool group.
It will prevent the extra empty pool creation, which will save memory and CPU resource consumption.
Addition unit test is not added since existing unit tests utilize the code spot this fix is applied on.