### PR TITLE
Rollback UDT changes to SqlDataReader.GetValue() and GetSqlValue(), since they are expected to throw PlatformNotSupportedExceptions with UDTs.

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -2350,7 +2350,23 @@ namespace System.Data.SqlClient
             else if (_typeSystem != SqlConnectionString.TypeSystem.SQLServer2000)
             {
                 // TypeSystem.SQLServer2005 and above
-                return data.SqlValue;
+
+                if (metaData.type == SqlDbType.Udt)
+                {
+                    var connection = _connection;
+                    if (connection != null)
+                    {
+                        throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
+                    }
+                    else
+                    {
+                        throw ADP.DataReaderClosed();
+                    }
+                }
+                else
+                {
+                    return data.SqlValue;
+                }
             }
             else
             {
@@ -2520,7 +2536,23 @@ namespace System.Data.SqlClient
             else if (_typeSystem != SqlConnectionString.TypeSystem.SQLServer2000)
             {
                 // TypeSystem.SQLServer2005 and above
-                return data.Value;
+
+                if (metaData.type != SqlDbType.Udt)
+                {
+                    return data.Value;
+                }
+                else
+                {
+                    var connection = _connection;
+                    if (connection != null)
+                    {
+                        throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
+                    }
+                    else
+                    {
+                        throw ADP.DataReaderClosed();
+                    }
+                }
             }
             else
             {

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UdtTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UdtTest.cs
@@ -50,13 +50,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 {
                     Assert.True(reader.Read());
 
-                    object udtValue = reader.GetValue(0);
-                    Assert.True(udtValue != null, "Received null value from GetValue().");
-                    DataTestUtility.AssertEqualsWithDescription(typeof(byte[]), udtValue.GetType(), "Unexpected UDT type from GetValue()");
+                    Assert.Throws<PlatformNotSupportedException>(() => reader.GetValue(0));
 
-                    object udtSqlValue = reader.GetSqlValue(0);
-                    Assert.True(udtSqlValue != null, "Received null value from GetSqlValue().");
-                    DataTestUtility.AssertEqualsWithDescription(typeof(SqlBinary), udtSqlValue.GetType(), "Unexpected UDT type from GetSqlValue()");
+                    Assert.Throws<PlatformNotSupportedException>(() => reader.GetSqlValue(0));
                 }
             }
         }


### PR DESCRIPTION
Rolls back changes from this commit: https://github.com/dotnet/corefx/commit/2b790aa855ef28c84711f4c8f8fc9e630548b207

Also adds a UDT test to verify the PlatformNotSupportedExceptions