### PR TITLE
Improve StreamWriter

### DIFF
--- a/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
@@ -192,7 +192,7 @@ namespace System.IO
                     {
                         CheckAsyncTaskInProgress();
 
-                        Flush(true, true);
+                        Flush(flushStream: true, flushEncoder: true);
                     }
                 }
             }
@@ -235,7 +235,7 @@ namespace System.IO
         {
             CheckAsyncTaskInProgress();
 
-            Flush(true, true);
+            Flush(flushStream: true, flushEncoder: true);
         }
 
         private void Flush(bool flushStream, bool flushEncoder)
@@ -335,7 +335,7 @@ namespace System.IO
                 _autoFlush = value;
                 if (value)
                 {
-                    Flush(true, false);
+                    Flush(flushStream: true, flushEncoder: false);
                 }
             }
         }
@@ -366,14 +366,14 @@ namespace System.IO
 
             if (_charPos == _charLen)
             {
-                Flush(false, false);
+                Flush(flushStream: false, flushEncoder: false);
             }
 
             CharBuffer[_charPos] = value;
             _charPos++;
             if (_autoFlush)
             {
-                Flush(true, false);
+                Flush(flushStream: true, flushEncoder: false);
             }
         }
 
@@ -399,7 +399,7 @@ namespace System.IO
                     if (charPos == charLen)
                     {
                         _charPos = charPos;
-                        Flush(false, false);
+                        Flush(flushStream: false, flushEncoder: false);
                         charPos = 0;
                     }
 
@@ -419,7 +419,7 @@ namespace System.IO
                 {
                     if (_charPos == _charLen)
                     {
-                        Flush(false, false);
+                        Flush(flushStream: false, flushEncoder: false);
                     }
 
                     int n = _charLen - _charPos;
@@ -438,7 +438,7 @@ namespace System.IO
 
             if (_autoFlush)
             {
-                Flush(true, false);
+                Flush(flushStream: true, flushEncoder: false);
             }
         }
 
@@ -474,7 +474,7 @@ namespace System.IO
                     if (charPos == charLen)
                     {
                         _charPos = charPos;
-                        Flush(false, false);
+                        Flush(flushStream: false, flushEncoder: false);
                         charPos = 0;
                     }
 
@@ -492,7 +492,7 @@ namespace System.IO
                 {
                     if (_charPos == _charLen)
                     {
-                        Flush(false, false);
+                        Flush(flushStream: false, flushEncoder: false);
                     }
 
                     int n = _charLen - _charPos;
@@ -511,7 +511,7 @@ namespace System.IO
 
             if (_autoFlush)
             {
-                Flush(true, false);
+                Flush(flushStream: true, flushEncoder: false);
             }
         }
 
@@ -535,7 +535,7 @@ namespace System.IO
                     if (charPos == charLen)
                     {
                         _charPos = charPos;
-                        Flush(false, false);
+                        Flush(flushStream: false, flushEncoder: false);
                         charPos = 0;
                     }
 
@@ -554,7 +554,7 @@ namespace System.IO
                 {
                     if (_charPos == _charLen)
                     {
-                        Flush(false, false);
+                        Flush(flushStream: false, flushEncoder: false);
                     }
 
                     int n = _charLen - _charPos;
@@ -573,7 +573,7 @@ namespace System.IO
 
             if (_autoFlush)
             {
-                Flush(true, false);
+                Flush(flushStream: true, flushEncoder: false);
             }
         }
 
@@ -597,7 +597,7 @@ namespace System.IO
             {
                 if (_charPos == _charLen)
                 {
-                    Flush(false, false);
+                    Flush(flushStream: false, flushEncoder: false);
                 }
 
                 int n = _charLen - _charPos;
@@ -618,7 +618,7 @@ namespace System.IO
             {
                 if (_charPos == _charLen)
                 {
-                    Flush(false, false);
+                    Flush(flushStream: false, flushEncoder: false);
                 }
 
                 charBuffer[_charPos] = coreNewLine[i];
@@ -627,7 +627,7 @@ namespace System.IO
 
             if (_autoFlush)
             {
-                Flush(true, false);
+                Flush(flushStream: true, flushEncoder: false);
             }
         }
 

--- a/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
@@ -304,8 +304,8 @@ namespace System.IO
             // Services guys have some perf tests where flushing needlessly hurts.
             if (flushStream)
             {
-                _stream.Flush();
                 ReturnCharBuffer();
+                _stream.Flush();
             }
         }
 
@@ -1111,8 +1111,8 @@ namespace System.IO
             // Services guys have some perf tests where flushing needlessly hurts.
             if (flushStream)
             {
-                await stream.FlushAsync().ConfigureAwait(false);
                 _this.ReturnCharBuffer();
+                await stream.FlushAsync().ConfigureAwait(false);
             }
         }
         #endregion


### PR DESCRIPTION
Fixes #23874

Summary of main changes

Use ArrayPool in StreamWriter
* Rents **char** buffer on first `Write` or `WriteAsync` to backing buffer.
* Rents **byte** buffer on first `Flush` or `FlushAsync` (can happen during `Write`s).
* Returns **char** and **byte** buffer on `Stream` flush (doesn't always happen during `Flush` i.e. a mid `Write` flush. (Return once enforced using `Interlocked.Exchange`)

Faster small Writes
* Changed to using local vars for counts rather than class vars, for better register use

Sync-Fast Paths
* FlushAsync methods now have non-statemachine fast-paths when completing sync

Code depue
* Merged `Write(char[], int, int)` and `Write(char[])` to `WriteInternal(char[], int, int)`
* Merged `Write(string)`/`Writeline(string)` main functionality to `WriteInternal(string)`

No Copy Write/WriteAsync
* It buffers and writes chunks to the stream in `bufferSize` **char** arrays (as before)
* If **char** buffer is empty and the remaining chars to write is above the `DontCopyOnWriteThreshold` (512 bytes); it encodes directly to the byte array rather than via the **char** buffer, in up to `bufferSize` chunks, leaving the remaining in the **char** array (i.e. less than `DontCopyOnWriteThreshold`). For large arrays and `string`s; when there is data in the buffer, this will occur second time in loop etc.

For the blocking `Write(char[])`/`Write(string)`/`Flush`s specifically:
* Below the `RentFromPoolThreshold` (64 bytes) it uses `stackalloc` rather than renting a **byte** buffer.

Effects
* Small writes are faster <= 4 bytes
* Medium writes a little slower (4 - 512 bytes) due to addition of lazy array pool acquisition, fast release
* Large writes faster as no extra copy prior to transform
* Allocations from creating and using `StreamWriter` from 5432 bytes, to 264 bytes

Contributes to https://github.com/dotnet/corefx/issues/5598 /cc @stephentoub 
Fixes https://github.com/dotnet/corefx/issues/8376 /cc @GSPP @ianhays 
