### PR TITLE
System.Private.Xml: Avoid unnecessary string[] allocation

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Core/XsdValidatingReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XsdValidatingReader.cs
@@ -247,7 +247,7 @@ namespace System.Xml
                     string prefix = _validator.GetDefaultAttributePrefix(_cachedNode.Namespace);
                     if (prefix != null && prefix.Length != 0)
                     {
-                        return string.Concat(prefix + ":" + _cachedNode.LocalName);
+                        return prefix + ":" + _cachedNode.LocalName;
                     }
                     return _cachedNode.LocalName;
                 }


### PR DESCRIPTION
Previously this was concatenating a string and then passing the result to `String.Concat(params string[])`, resulting in an unnecessary `string[]` allocation (of length 1).

cc: @krwq, @pjanotti