### PR TITLE
[WIP] Fix LargeArrayBuilder.CopyTo returning incorrect end-of-copy position

### DIFF
--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -47,6 +47,11 @@ namespace System.Collections.Generic
         /// </summary>
         private string DebuggerDisplay => $"[{Row}, {Column}]";
 
+        /// <summary>
+        /// If this position is at the end of the current buffer, returns the position
+        /// at the start of the next buffer. Otherwise, returns this position.
+        /// </summary>
+        /// <param name="endColumn">The length of the current buffer.</param>
         public CopyPosition Normalize(int endColumn)
         {
             Debug.Assert(Column <= endColumn);
@@ -184,7 +189,7 @@ namespace System.Collections.Generic
             for (int i = 0; count > 0; i++)
             {
                 // Find the buffer we're copying from.
-                T[] buffer = GetBuffer(index: i);
+                T[] buffer = GetBuffer(i);
 
                 // Copy until we satisfy count, or we reach the end of the buffer.
                 int toCopy = Math.Min(count, buffer.Length);
@@ -208,7 +213,7 @@ namespace System.Collections.Generic
         {
             int CopyToCore(T[] sourceBuffer, int sourceIndex)
             {
-                Debug.Assert(sourceBuffer.Length != sourceIndex);
+                Debug.Assert(sourceBuffer.Length > sourceIndex);
 
                 // Copy until we satisfy `count` or reach the end of the current buffer.
                 int copyCount = Math.Min(sourceBuffer.Length - sourceIndex, count);

--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -47,7 +47,7 @@ namespace System.Collections.Generic
         /// </summary>
         private string DebuggerDisplay => $"[{Row}, {Column}]";
 
-        public CopyPosition NormalizeEnds(int endColumn)
+        public CopyPosition Normalize(int endColumn)
         {
             Debug.Assert(Column <= endColumn);
 
@@ -247,7 +247,7 @@ namespace System.Collections.Generic
             int copied = CopyToCore(buffer, column);
             if (count == 0)
             {
-                return new CopyPosition(row, column + copied).NormalizeEnds(buffer.Length);
+                return new CopyPosition(row, column + copied).Normalize(buffer.Length);
             }
 
             do
@@ -257,7 +257,7 @@ namespace System.Collections.Generic
             }
             while (count > 0);
 
-            return new CopyPosition(row, copied).NormalizeEnds(buffer.Length);
+            return new CopyPosition(row, copied).Normalize(buffer.Length);
         }
 
         /// <summary>

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -421,5 +421,18 @@ namespace System.Linq.Tests
                 Assert.Equal(0xf00, en.Current);
             }
         }
+
+        [Fact]
+        public void CollectionInterleavedWithLazyEnumerables_ToArray_Regression()
+        {
+            var results = new TestEnumerable<int>(new[] { 1 })
+                .Concat(new[] { 2 })
+                .Concat(new TestEnumerable<int>(new[] { 3 }))
+                // Do not omit this ToArray()! There was a previous bug where the ToArray() implementation
+                // was incorrect, while iterating with foreach produced the correct results.
+                .ToArray();
+
+            Assert.Equal(new[] { 1, 2, 3 }, results);
+        }
     }
 }

--- a/src/System.Linq/tests/SelectManyTests.cs
+++ b/src/System.Linq/tests/SelectManyTests.cs
@@ -477,5 +477,19 @@ namespace System.Linq.Tests
             IEnumerable<int> iterator = counts.SelectMany(c => Enumerable.Range(1, c));
             Assert.Throws<OverflowException>(() => iterator.Count());
         }
+
+        [Fact]
+        public void CollectionInterleavedWithLazyEnumerables_ToArray_Regression()
+        {
+            var results = new[] { 4, 5, 6 }
+                .SelectMany(i => i == 5 ?
+                    (IEnumerable<int>)new List<int>() { i } :
+                    new TestEnumerable<int>(new int[] { i }))
+                // Do not omit this ToArray()! There was a previous bug where the ToArray() implementation
+                // was incorrect, while iterating with foreach produced the correct results.
+                .ToArray();
+
+            Assert.Equal(new[] { 4, 5, 6 }, results);
+        }
     }
 }


### PR DESCRIPTION
**Note:** This only affects the `LAB.CopyTo` overload that returns a `CopyPosition`. The other void overload isn't affected. The only type that uses this method is `SparseArrayBuilder` (SAB), so really only consumers of SAB are affected. Only LINQ uses SAB even though it's in Common, specifically in the functions `Concat`, `SelectMany`, `Append`, and `Prepend`. `Append` and `Prepend` weren't affected by this bug for reasons that will be explained later.

---

The job of `LAB.CopyTo` is to accept a `CopyPosition` to start copying from, and to return a `CopyPosition` representing the position copied up to. Previously, it was always returning an incorrect `CopyPosition` because of this line:

```cs
for (; count > 0; row++, column = 0)
```

The loop statement here, `row++, column = 0`, is the cause of the bug; it should not be running on the very last iteration of the loop. To give a better understanding of what it's causing, consider the following repro from @OmarTawfik:

```cs

var results = new TestEnumerable<int>(new[] { 1 })
    .Concat(new[] { 2 })
    .Concat(new TestEnumerable<int>(new[] { 3 }))
    .ToArray();

Assert.Equal(new[] { 1, 2, 3 }, results); // Actual: { 1, 2, 1 }
```

First, the SAB buffers the contents of all non-collections into a LAB, and stores references to the collections in an array (without copying the contents of those collections). It also maintains a list of "markers", which are indices at which the contents of the collections will be inserted in the future. So the above calls will create this:

```
LAB: [ [1, 3] ]
Markers: [ [ Index: 1, CollectionCount: 1 ] ]
CollectionReferences: [ [ 2 ] ]
```

Then in SAB.ToArray comes the bug. **When a marker is sandwiched between the contents of two non-collections,** this bug occurs.

- We start out with `[ 0 0 0 ]` for the output array.

- What happens in the above example is SAB.ToArray (correctly) calls LAB.CopyTo to copy the contents of the first collection, with `position = (0, 0)` and `count = 1`. Now the output array is `[ 1 0 0 ]`.
  - It receives back the position `(1, 0)` due to aforementioned bug, when it should really receive `(0, 1)`.

- Then we (correctly) reserve space for the second collection, skipping over the 2nd slot.

- Then we continue copying, starting from the position we received from the last LAB.CopyTo call.
  - Since the LAB doesn't even have 2 buffers, you would think starting the copy from `(1, 0)` (which means index 0 in the buffer at index 1) should throw an exception/raise an assert/etc. However, due to the way it's currently written, `GetBuffer(1)` returns the same as `GetBuffer(0)`, the first buffer which is `[ 1 3 ]`.
  - So then we copy 1 item starting at index 0 of `[ 1 3 ]` to the output array, resulting in `[ 1 0 1 ]`.

- Then we fill in the collections' contents, finally resulting in `[ 1 2 1 ]`.

---

This bug doesn't affect `Append` or `Prepend` because they don't use the faulty position from `CopyTo`; to put it another way, there's no way they can sandwich a marker between 2 non-collections. If we call `nonCollection.Append(item).Prepend(item).ToArray()`, we get this during the first stage above:

```
Marker | NonCollection | Marker
```

---

This PR fixes the implementation, refactors some loop logic into a `CopyToCore` method and adds regression tests.