### PR TITLE
XmlJsonWriter: Avoid unnecessary allocations

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
@@ -23,14 +23,45 @@ namespace System.Runtime.Serialization.Json
         private const char WHITESPACE = ' ';
         private const char CARRIAGE_RETURN = '\r';
         private const char NEWLINE = '\n';
-        private const char BACKSPACE = '\b';
-        private const char FORM_FEED = '\f';
-        private const char HORIZONTAL_TABULATION = '\t';
         private const string xmlNamespace = "http://www.w3.org/XML/1998/namespace";
         private const string xmlnsNamespace = "http://www.w3.org/2000/xmlns/";
 
         // This array was part of a perf improvement for escaping characters < WHITESPACE.
-        private static readonly string[] s_escapedJsonStringTable = CreateEscapedJsonStringTable();
+        private static readonly string[] s_escapedJsonStringTable =
+        {
+            "\\u0000",
+            "\\u0001",
+            "\\u0002",
+            "\\u0003",
+            "\\u0004",
+            "\\u0005",
+            "\\u0006",
+            "\\u0007",
+            "\\b",
+            "\\t",
+            "\\n",
+            "\\u000b",
+            "\\f",
+            "\\r",
+            "\\u000e",
+            "\\u000f",
+            "\\u0010",
+            "\\u0011",
+            "\\u0012",
+            "\\u0013",
+            "\\u0014",
+            "\\u0015",
+            "\\u0016",
+            "\\u0017",
+            "\\u0018",
+            "\\u0019",
+            "\\u001a",
+            "\\u001b",
+            "\\u001c",
+            "\\u001d",
+            "\\u001e",
+            "\\u001f"
+        };
 
         private static BinHexEncoding s_binHexEncoding;
 
@@ -70,20 +101,6 @@ namespace System.Runtime.Serialization.Json
                 _indentChars = indentChars;
             }
             InitializeWriter();
-        }
-
-        private static string[] CreateEscapedJsonStringTable()
-        {
-            var table = new string[WHITESPACE];
-            for (int ch = 0; ch < WHITESPACE; ch++)
-            {
-                char abbrev;
-                table[ch] = TryEscapeControlCharacter((char)ch, out abbrev) ?
-                    string.Concat(BACK_SLASH, abbrev) :
-                    string.Format(CultureInfo.InvariantCulture, "\\u{0:x4}", ch);
-            }
-            
-            return table;
         }
 
         private enum JsonDataType
@@ -1416,33 +1433,6 @@ namespace System.Runtime.Serialization.Json
                     _nodeWriter.WriteChars(chars + i, j - i);
                 }
             }
-        }
-
-        private static bool TryEscapeControlCharacter(char ch, out char abbrev)
-        {
-            switch (ch)
-            {
-                case BACKSPACE:
-                    abbrev = 'b';
-                    break;
-                case FORM_FEED:
-                    abbrev = 'f';
-                    break;
-                case NEWLINE:
-                    abbrev = 'n';
-                    break;
-                case CARRIAGE_RETURN:
-                    abbrev = 'r';
-                    break;
-                case HORIZONTAL_TABULATION:
-                    abbrev = 't';
-                    break;
-                default:
-                    abbrev = ' ';
-                    return false;
-            }
-
-            return true;
         }
 
         private void WriteIndent()

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -246,7 +246,7 @@ public static partial class DataContractJsonSerializerTests
             new { value = "\u000B", baseline = "\\u000b" }, // LINE TABULATION
             new { value = "\u000C", baseline = "\\f" }, // FORM FEED (FF)
             new { value = "\u000D", baseline = "\\r" }, // CARRIAGE RETURN (CR)
-            new { value = "\u000E", baseline = "\\u000e" }, // SHIFT IN
+            new { value = "\u000E", baseline = "\\u000e" },
             new { value = "\u000F", baseline = "\\u000f" }, // SHIFT IN
             new { value = "\u0010", baseline = "\\u0010" },
             new { value = "\u0011", baseline = "\\u0011" },

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -232,17 +232,41 @@ public static partial class DataContractJsonSerializerTests
 
         var testStrings = new[]
         {
-            new { value = "\u0008", baseline = "\\b" }, // BACKSPACE
-            new { value = "\u000C", baseline = "\\f" }, // FORM FEED (FF)
-            new { value = "\u000A", baseline = "\\n" }, // LINE FEED (LF)
-            new { value = "\u000D", baseline = "\\r" }, // CARRIAGE RETURN (CR)
-            new { value = "\u0009", baseline = "\\t" }, // HORIZONTAL TABULATION
-            new { value = "\u0022", baseline = "\\\"" }, // QUOTATION MARK
-            new { value = "\u005C", baseline = "\\\\" }, // REVERSE SOLIDUS
             new { value = "\u0000", baseline = "\\u0000" }, // NULL
+            new { value = "\u0001", baseline = "\\u0001" },
+            new { value = "\u0002", baseline = "\\u0002" },
+            new { value = "\u0003", baseline = "\\u0003" },
+            new { value = "\u0004", baseline = "\\u0004" },
+            new { value = "\u0005", baseline = "\\u0005" },
+            new { value = "\u0006", baseline = "\\u0006" },
+            new { value = "\u0007", baseline = "\\u0007" },
+            new { value = "\u0008", baseline = "\\b" }, // BACKSPACE
+            new { value = "\u0009", baseline = "\\t" }, // HORIZONTAL TABULATION
+            new { value = "\u000A", baseline = "\\n" }, // LINE FEED (LF)
             new { value = "\u000B", baseline = "\\u000b" }, // LINE TABULATION
+            new { value = "\u000C", baseline = "\\f" }, // FORM FEED (FF)
+            new { value = "\u000D", baseline = "\\r" }, // CARRIAGE RETURN (CR)
+            new { value = "\u000E", baseline = "\\u000e" }, // SHIFT IN
             new { value = "\u000F", baseline = "\\u000f" }, // SHIFT IN
+            new { value = "\u0010", baseline = "\\u0010" },
+            new { value = "\u0011", baseline = "\\u0011" },
+            new { value = "\u0012", baseline = "\\u0012" },
+            new { value = "\u0013", baseline = "\\u0013" },
+            new { value = "\u0014", baseline = "\\u0014" },
+            new { value = "\u0015", baseline = "\\u0015" },
+            new { value = "\u0016", baseline = "\\u0016" },
+            new { value = "\u0017", baseline = "\\u0017" },
+            new { value = "\u0018", baseline = "\\u0018" },
+            new { value = "\u0019", baseline = "\\u0019" },
+            new { value = "\u001A", baseline = "\\u001a" },
+            new { value = "\u001B", baseline = "\\u001b" },
+            new { value = "\u001C", baseline = "\\u001c" },
+            new { value = "\u001D", baseline = "\\u001d" },
+            new { value = "\u001E", baseline = "\\u001e" },
+            new { value = "\u001F", baseline = "\\u001f" },
+            new { value = "\u0022", baseline = "\\\"" }, // QUOTATION MARK
             new { value = "\u0027", baseline = "'" },
+            new { value = "\u005C", baseline = "\\\\" }, // REVERSE SOLIDUS
         };
 
         foreach (var pair in testStrings)


### PR DESCRIPTION
While it only runs once to initialize a readonly static field, `CreateEscapedJsonStringTable` was allocating a lot of unnecessary garbage. For each char in the table, either 2 box allocations for the `string.Concat(object, object)` call, or 1 box allocation plus `string.Format` overhead. These unnecessary allocations can be avoided by just pre-generating the table.

I've manually verified in a one-off test that the pre-generated table is the same as before.

cc: @shmao, @zhenlan