### PR TITLE
release/2.0: Fix IPv6 address parsing when last number is too long

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/IPv6AddressHelper.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPv6AddressHelper.cs
@@ -242,9 +242,12 @@ namespace System
 
             if (sequenceLength != 0)
             {
+                if (sequenceLength > 4)
+                {
+                    return false;
+                }
+
                 ++sequenceCount;
-                lastSequence = i - sequenceLength;
-                sequenceLength = 0;
             }
 
             // these sequence counts are -1 because it is implied in end-of-sequence
@@ -252,7 +255,6 @@ namespace System
             const int ExpectedSequenceCount = 8;
             return
                 !expectingNumber &&
-                (sequenceLength <= 4) &&
                 (haveCompressor ? (sequenceCount < ExpectedSequenceCount) : (sequenceCount == ExpectedSequenceCount)) &&
                 !needsClosingBracket;
         }

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -313,6 +313,14 @@ namespace System.Net.Primitives.Functional.Tests
         [InlineData("::%1a")] // alphanumeric scope
         [InlineData("[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:443/")] // errneous ending slash after ignored port
         [InlineData("::1234%0x12")] // invalid scope ID
+        [InlineData("e3fff:ffff:ffff:ffff:ffff:ffff:ffff:abcd")] // 1st number too long
+        [InlineData("3fff:effff:ffff:ffff:ffff:ffff:ffff:abcd")] // 2nd number too long
+        [InlineData("3fff:ffff:effff:ffff:ffff:ffff:ffff:abcd")] // 3rd number too long
+        [InlineData("3fff:ffff:ffff:effff:ffff:ffff:ffff:abcd")] // 4th number too long
+        [InlineData("3fff:ffff:ffff:ffff:effff:ffff:ffff:abcd")] // 5th number too long
+        [InlineData("3fff:ffff:ffff:ffff:ffff:effff:ffff:abcd")] // 6th number too long
+        [InlineData("3fff:ffff:ffff:ffff:ffff:ffff:effff:abcd")] // 7th number too long
+        [InlineData("3fff:ffff:ffff:ffff:ffff:ffff:ffff:eabcd")] // 8th number too long
         public void ParseIPv6_InvalidAddress_ThrowsFormatException(string invalidAddress)
         {
             ParseInvalidAddress(invalidAddress, hasInnerSocketException: true);


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/23712 to release/2.0 (just the relevant commits).