### PR TITLE
Respect UseProxy better in ManagedHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.IO;
-using System.Net;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,9 +21,11 @@ namespace System.Net.Http
         public HttpProxyConnectionHandler(HttpConnectionSettings settings, HttpMessageHandler innerHandler)
         {
             Debug.Assert(innerHandler != null);
+            Debug.Assert(settings._useProxy);
+            Debug.Assert(settings._proxy != null || s_proxyFromEnvironment.Value != null);
 
             _innerHandler = innerHandler;
-            _proxy = (settings._useProxy && settings._proxy != null) ? settings._proxy : new PassthroughWebProxy(s_proxyFromEnvironment.Value);
+            _proxy = settings._proxy ?? new PassthroughWebProxy(s_proxyFromEnvironment.Value);
             _defaultCredentials = settings._defaultProxyCredentials;
             _connectionPools = new HttpConnectionPools(settings._maxConnectionsPerServer);
         }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
@@ -263,8 +263,8 @@ namespace System.Net.Http
         {
             HttpMessageHandler handler = new HttpConnectionHandler(_settings);
 
-            if ((_settings._useProxy && _settings._proxy != null) ||
-                HttpProxyConnectionHandler.EnvironmentProxyConfigured)
+            if (_settings._useProxy &&
+                (_settings._proxy != null || HttpProxyConnectionHandler.EnvironmentProxyConfigured))
             {
                 handler = new HttpProxyConnectionHandler(_settings, handler);
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Net.Test.Common;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -75,12 +76,23 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)] // proxies set via the http_proxy environment variable are specific to Unix
-        public void ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed(bool useProxy)
         {
-            int port;
-            Task<LoopbackGetRequestHttpProxy.ProxyResult> proxyTask = LoopbackGetRequestHttpProxy.StartAsync(out port, requireAuth: true, expectCreds: true);
+            bool envVarsSupported = ManagedHandlerTestHelpers.IsEnabled || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            if (!envVarsSupported)
+            {
+                return;
+            }
+
+            int port = 0;
+            Task<LoopbackGetRequestHttpProxy.ProxyResult> proxyTask = null;
+            if (useProxy)
+            {
+                proxyTask = LoopbackGetRequestHttpProxy.StartAsync(out port, requireAuth: true, expectCreds: true);
+            }
 
             const string ExpectedUsername = "rightusername";
             const string ExpectedPassword = "rightpassword";
@@ -90,13 +102,14 @@ namespace System.Net.Http.Functional.Tests
             // test in another process.
             var psi = new ProcessStartInfo();
             psi.Environment.Add("http_proxy", $"http://localhost:{port}");
-            RemoteInvoke(() =>
+            RemoteInvoke(useProxyString =>
             {
                 using (var handler = new HttpClientHandler())
                 using (var client = new HttpClient(handler))
                 {
                     var creds = new NetworkCredential(ExpectedUsername, ExpectedPassword);
                     handler.DefaultProxyCredentials = creds;
+                    handler.UseProxy = bool.Parse(useProxyString);
 
                     Task<HttpResponseMessage> responseTask = client.GetAsync(Configuration.Http.RemoteEchoServer);
                     Task<string> responseStringTask = responseTask.ContinueWith(t =>
@@ -108,9 +121,12 @@ namespace System.Net.Http.Functional.Tests
                     TestHelper.VerifyResponseBody(responseStringTask.Result, responseTask.Result.Content.Headers.ContentMD5, false, null);
                 }
                 return SuccessExitCode;
-            }, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
+            }, useProxy.ToString(), new RemoteInvokeOptions { StartInfo = psi }).Dispose();
 
-            Assert.Equal($"{ExpectedUsername}:{ExpectedPassword}", proxyTask.Result.AuthenticationHeaderValue);
+            if (useProxy)
+            {
+                Assert.Equal($"{ExpectedUsername}:{ExpectedPassword}", proxyTask.Result.AuthenticationHeaderValue);
+            }
         }
 
         // The purpose of this test is mainly to validate the .NET Framework OOB System.Net.Http implementation


### PR DESCRIPTION
To match CurlHandler, we should only be using environment variable-based proxy configuration if UseProxy is true, but we're currently using it regardless.  This commit fixes that and adds a test for it.
cc: @geoffkizer, @wfurt 