### PR TITLE
Enable disabled HttpClientEKUTests on ManagedHandler

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -44,12 +44,11 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    // TODO #23139: Tests on this class fail when the associated condition is enabled.
-    //public sealed class ManagedHandler_HttpClientEKUTest : HttpClientEKUTest, IDisposable
-    //{
-    //    public ManagedHandler_HttpClientEKUTest() => ManagedHandlerTestHelpers.SetEnvVar();
-    //    public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
-    //}
+    public sealed class ManagedHandler_HttpClientEKUTest : HttpClientEKUTest, IDisposable
+    {
+        public ManagedHandler_HttpClientEKUTest() => ManagedHandlerTestHelpers.SetEnvVar();
+        public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
+    }
 
     public sealed class ManagedHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test : HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test, IDisposable
     {


### PR DESCRIPTION
They appear to all be passing now.
Closes https://github.com/dotnet/corefx/issues/23128