### PR TITLE
Re-enable SystemFonts test on Linux.

### DIFF
--- a/src/System.Drawing.Common/tests/SystemFontsTests.cs
+++ b/src/System.Drawing.Common/tests/SystemFontsTests.cs
@@ -19,7 +19,6 @@ namespace System.Drawing.Tests
             yield return new object[] { (Func<Font>)(() => SystemFonts.StatusFont) };
         }
 
-        [ActiveIssue(23690, TestPlatforms.Linux)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(SystemFonts_TestData))]
         public void SystemFont_Get_ReturnsExpected(Func<Font> getFont)


### PR DESCRIPTION
#23690 should be fixed now, so I'm going to try re-enabling this test.