### PR TITLE
Disable RecursiveDelete_DeepNesting for desktop

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -253,6 +253,7 @@ namespace System.IO.Tests
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
         [OuterLoop("This test is very slow.")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop does not have the fix for #22596")]
         public void RecursiveDelete_DeepNesting()
         {
             // Create a 2000 level deep directory and recursively delete from the root.


### PR DESCRIPTION
It does not have the fix we made for https://github.com/dotnet/corefx/issues/22956
Fixes https://github.com/dotnet/corefx/issues/22953