### PR TITLE
SslStream Correct current size calculations

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -181,7 +181,7 @@ internal static partial class Interop
             return stateOk;
         }
 
-        internal static int Encrypt(SafeSslHandle context, byte[] input, int offset, int count, ref byte[] output, out Ssl.SslErrorCode errorCode)
+        internal static int Encrypt(SafeSslHandle context, byte[] input, int offset, int count, byte[] output, out Ssl.SslErrorCode errorCode)
         {
             Debug.Assert(input != null);
             Debug.Assert(offset >= 0);
@@ -221,10 +221,7 @@ internal static partial class Interop
             {
                 int capacityNeeded = Crypto.BioCtrlPending(context.OutputBio);
 
-                if (output == null || output.Length < capacityNeeded)
-                {
-                    output = new byte[capacityNeeded];
-                }
+                Debug.Assert(output != null && output.Length >= capacityNeeded);
 
                 retVal = BioRead(context.OutputBio, output, capacityNeeded);
             }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -220,7 +220,7 @@ internal static partial class Interop
             else
             {
                 int capacityNeeded = Crypto.BioCtrlPending(context.OutputBio);
-
+                capacityNeeded = Math.Min(capacityNeeded, output.Length);
                 Debug.Assert(output != null && output.Length >= capacityNeeded);
 
                 retVal = BioRead(context.OutputBio, output, capacityNeeded);

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -390,13 +390,9 @@ namespace System.Net.Security
             }
         }
 
-        internal int HeaderSize
-        {
-            get
-            {
-                return Context.HeaderSize;
-            }
-        }
+        internal int HeaderSize => Context.HeaderSize;
+
+        internal int FrameOverhead => Context.FrameOverhead;
 
         internal int MaxDataSize
         {
@@ -479,10 +475,10 @@ namespace System.Net.Security
             }
         }
 
-        internal SecurityStatusPal EncryptData(byte[] buffer, int offset, int count, ref byte[] outBuffer, out int outSize)
+        internal SecurityStatusPal EncryptData(byte[] buffer, int offset, int count, byte[] outBuffer, out int outSize)
         {
             CheckThrow(true);
-            return Context.Encrypt(buffer, offset, count, ref outBuffer, out outSize);
+            return Context.Encrypt(buffer, offset, count, outBuffer, out outSize);
         }
 
         internal SecurityStatusPal DecryptData(byte[] buffer, ref int offset, ref int count)

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -8,8 +8,8 @@ using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
 
-using PAL_TlsHandshakeState=Interop.AppleCrypto.PAL_TlsHandshakeState;
-using PAL_TlsIo=Interop.AppleCrypto.PAL_TlsIo;
+using PAL_TlsHandshakeState = Interop.AppleCrypto.PAL_TlsHandshakeState;
+using PAL_TlsIo = Interop.AppleCrypto.PAL_TlsIo;
 
 namespace System.Net.Security
 {
@@ -81,7 +81,7 @@ namespace System.Net.Security
             int size,
             int headerSize,
             int trailerSize,
-            ref byte[] output,
+            byte[] output,
             out int resultSize)
         {
             resultSize = 0;
@@ -107,15 +107,8 @@ namespace System.Net.Security
                                 Interop.AppleCrypto.CreateExceptionForOSStatus((int)status));
                         }
 
-                        if (sslContext.BytesReadyForConnection <= output?.Length)
-                        {
-                            resultSize = sslContext.ReadPendingWrites(output, 0, output.Length);
-                        }
-                        else
-                        {
-                            output = sslContext.ReadPendingWrites();
-                            resultSize = output.Length;
-                        }
+                        Debug.Assert(output?.Length >= sslContext.BytesReadyForConnection);
+                        resultSize = sslContext.ReadPendingWrites(output, 0, output.Length);
 
                         switch (status)
                         {

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -53,15 +53,15 @@ namespace System.Net.Security
             return new SafeFreeSslCredentials(certificate, protocols, policy);
         }
 
-        public static SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, byte[] input, int offset, int size, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
+        public static SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, byte[] input, int offset, int size, int headerSize, int trailerSize, byte[] output, out int resultSize)
         {
-            return EncryptDecryptHelper(securityContext, input, offset, size, true, ref output, out resultSize);
+            return EncryptDecryptHelper(securityContext, input, offset, size, true, output, out resultSize);
         }
 
         public static SecurityStatusPal DecryptMessage(SafeDeleteContext securityContext, byte[] buffer, ref int offset, ref int count)
         {
             int resultSize;
-            SecurityStatusPal retVal = EncryptDecryptHelper(securityContext, buffer, offset, count, false, ref buffer, out resultSize);
+            SecurityStatusPal retVal = EncryptDecryptHelper(securityContext, buffer, offset, count, false, buffer, out resultSize);
             if (retVal.ErrorCode == SecurityStatusPalErrorCode.OK || 
                 retVal.ErrorCode == SecurityStatusPalErrorCode.Renegotiate)
             {
@@ -140,7 +140,7 @@ namespace System.Net.Security
             }
         }
 
-        private static SecurityStatusPal EncryptDecryptHelper(SafeDeleteContext securityContext, byte[] input, int offset, int size, bool encrypt, ref byte[] output, out int resultSize)
+        private static SecurityStatusPal EncryptDecryptHelper(SafeDeleteContext securityContext, byte[] input, int offset, int size, bool encrypt, byte[] output, out int resultSize)
         {
             resultSize = 0;
             try
@@ -150,7 +150,7 @@ namespace System.Net.Security
 
                 if (encrypt)
                 {
-                    resultSize = Interop.OpenSsl.Encrypt(scHandle, input, offset, size, ref output, out errorCode);
+                    resultSize = Interop.OpenSsl.Encrypt(scHandle, input, offset, size, output, out errorCode);
                 }
                 else
                 {

--- a/src/System.Net.Security/src/System/Net/Security/StreamSizes.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/StreamSizes.OSX.cs
@@ -21,9 +21,9 @@ namespace System.Net
 
         public StreamSizes()
         {
-            Header = 0;
+            Header = 32;
             Trailer = 0;
-            MaximumMessage = 32 * 1024;
+            MaximumMessage = 16 * 1024;
         }
     }
 }

--- a/src/System.Net.Security/src/System/Net/Security/StreamSizes.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/StreamSizes.Unix.cs
@@ -22,9 +22,9 @@ namespace System.Net
 
         public StreamSizes()
         {
-            Header = 0;
+            Header = 32;
             Trailer = 0;
-            MaximumMessage = 32 * 1024;
+            MaximumMessage = 16 * 1024;
         }
     }
 }


### PR DESCRIPTION
/cc @geoffkizer 

When attempting to remove the "ref" for the encrypt function I placed some Debug.Asserts and ran a lot fo testing. What I found is there was a lot of allocations on windows and a few on Linux.

The windows ones I tracked down to the fact that even though the header/trailer could not be any bigger than 32 bytes SChannel claimed it needed more space. So I have changed the calculation instead to use the StreamSizes that we have (from Linux/OSX they are fixed from SChannel it is retrieved from the API for that connection based on it's requirements/session ciphers etc).

This means we always now have the correct size on windows. So I could remove the allocations and the refs. I put in some Debug.Asserts to replace the code that checked the size and allocated.

Onto Linux. Currently we had zero for Headers + Trailers and just a fixed MaxMessageSize. The message size is currently set to 32k. Which the description even says is arbitrary.

As the max framesize for TLS is 16k if we set this to 32k we could need to output 16k * 2 + Overhead * 2. This means we can allocate in Linux/OSX whenever we go over the 16k boundary. As the frames are independent and it's not a Kernel call just native interop I have changed the this to 16k (reduces the buffer sizes in OpenSSL as well because it has to buffer the first completed frame).

Next I added the 32byte overhead to the header to work with the new flow of sizes above.

Last thing I fixed is the calculation of the "max data" we can send. Currently we are taking the max message size and subtracting the Head and Trailer. This is not what the API says for SChannel from my understanding and certainly isn't the logic from OpenSsl.

> The length of the SecBuffer structure that contains the message must be no greater than cbMaximumMessage, which is obtained from the QueryContextAttributes (Schannel) (SECPKG_ATTR_STREAM_SIZES) function.

However our data is the only thing that goes into that buffer there are separate buffers for the header and trailer so the max is the max.

Once this has been done I did some testing with your tool @geoffkizer and there was pretty much no difference (it's only allocations) but I could see a drop in allocations on large scale stress tests :)
