### PR TITLE
Expose/add tests for Memory-based Stream overloads in coreclr/corert

### DIFF
--- a/src/Common/tests/System/IO/DelegateStream.cs
+++ b/src/Common/tests/System/IO/DelegateStream.cs
@@ -52,16 +52,12 @@ namespace System.IO
             _positionSetFunc = positionSetFunc ?? (_ => { throw new NotSupportedException(); });
             _positionGetFunc = positionGetFunc ?? (() => { throw new NotSupportedException(); });
 
-            if (readAsyncFunc != null && readFunc == null)
-                throw new InvalidOperationException("If reads are supported, must provide a synchronous read implementation");
             _readFunc = readFunc;
             _readAsyncFunc = readAsyncFunc ?? ((buffer, offset, count, token) => base.ReadAsync(buffer, offset, count, token));
 
             _seekFunc = seekFunc ?? ((_, __) => { throw new NotSupportedException(); });
             _setLengthFunc = setLengthFunc ?? (_ => { throw new NotSupportedException(); });
 
-            if (writeAsyncFunc != null && writeFunc == null)
-                throw new InvalidOperationException("If writes are supported, must provide a synchronous write implementation");
             _writeFunc = writeFunc;
             _writeAsyncFunc = writeAsyncFunc ?? ((buffer, offset, count, token) => base.WriteAsync(buffer, offset, count, token));
         }

--- a/src/System.IO.FileSystem/tests/FileStream/ReadWriteSpan.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ReadWriteSpan.netcoreapp.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Tests
@@ -123,6 +125,119 @@ namespace System.IO.Tests
                 Assert.Equal(TestBuffer, buffer);
             }
         }
+
+        [Fact]
+        public void DisposedStream_ReadWriteAsync_Throws()
+        {
+            var fs = CreateFileStream(GetTestFilePath(), FileMode.Create);
+            fs.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => { fs.ReadAsync(new Memory<byte>(new byte[1])); });
+            Assert.Throws<ObjectDisposedException>(() => { fs.WriteAsync(new ReadOnlyMemory<byte>(new byte[1])); });
+        }
+
+        [Fact]
+        public async Task EmptyFile_ReadAsync_Succeeds()
+        {
+            using (var fs = CreateFileStream(GetTestFilePath(), FileMode.Create))
+            {
+                // use a recognizable pattern
+                var buffer = (byte[])TestBuffer.Clone();
+
+                Assert.Equal(0, await fs.ReadAsync(Memory<byte>.Empty));
+                Assert.Equal(0, await fs.ReadAsync(new Memory<byte>(buffer, 0, 1)));
+                Assert.Equal(TestBuffer, buffer);
+
+                Assert.Equal(0, await fs.ReadAsync(new Memory<byte>(buffer, 0, buffer.Length)));
+                Assert.Equal(TestBuffer, buffer);
+
+                Assert.Equal(0, await fs.ReadAsync(new Memory<byte>(buffer, buffer.Length - 1, 1)));
+                Assert.Equal(TestBuffer, buffer);
+
+                Assert.Equal(0, await fs.ReadAsync(new Memory<byte>(buffer, buffer.Length / 2, buffer.Length - buffer.Length / 2)));
+                Assert.Equal(TestBuffer, buffer);
+            }
+        }
+
+        [Fact]
+        public async Task NonEmptyFile_ReadAsync_GetsExpectedData()
+        {
+            string fileName = GetTestFilePath();
+            File.WriteAllBytes(fileName, TestBuffer);
+
+            using (var fs = CreateFileStream(fileName, FileMode.Open))
+            {
+                var buffer = new byte[TestBuffer.Length];
+                Assert.Equal(TestBuffer.Length, await fs.ReadAsync(new Memory<byte>(buffer, 0, buffer.Length)));
+                Assert.Equal(TestBuffer, buffer);
+
+                // Larger than needed buffer, read into beginning, rest remains untouched
+                fs.Position = 0;
+                buffer = new byte[TestBuffer.Length * 2];
+                Assert.Equal(TestBuffer.Length, await fs.ReadAsync(new Memory<byte>(buffer)));
+                Assert.Equal(TestBuffer, buffer.Take(TestBuffer.Length));
+                Assert.Equal(new byte[buffer.Length - TestBuffer.Length], buffer.Skip(TestBuffer.Length));
+
+                // Larger than needed buffer, read into middle, beginning and end remain untouched
+                fs.Position = 0;
+                buffer = new byte[TestBuffer.Length * 2];
+                Assert.Equal(TestBuffer.Length, await fs.ReadAsync(new Memory<byte>(buffer, 2, buffer.Length - 2)));
+                Assert.Equal(TestBuffer, buffer.Skip(2).Take(TestBuffer.Length));
+                Assert.Equal(new byte[2], buffer.Take(2));
+                Assert.Equal(new byte[buffer.Length - TestBuffer.Length - 2], buffer.Skip(2 + TestBuffer.Length));
+            }
+        }
+
+        [Fact]
+        public void ReadOnly_WriteAsync_Throws()
+        {
+            string fileName = GetTestFilePath();
+            File.WriteAllBytes(fileName, TestBuffer);
+
+            using (var fs = CreateFileStream(fileName, FileMode.Open, FileAccess.Read))
+            {
+                Assert.Throws<NotSupportedException>(() => { fs.WriteAsync(new ReadOnlyMemory<byte>(new byte[1])); });
+                fs.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => { fs.WriteAsync(new ReadOnlyMemory<byte>(new byte[1])); }); // Disposed checking happens first
+            }
+        }
+
+        [Fact]
+        public void WriteOnly_ReadAsync_Throws()
+        {
+            using (var fs = CreateFileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+                Assert.Throws<NotSupportedException>(() => { fs.ReadAsync(new Memory<byte>(new byte[1])); });
+                fs.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => { fs.ReadAsync(new Memory<byte>(new byte[1])); });// Disposed checking happens first
+            }
+        }
+
+        [Fact]
+        public async Task EmptyWriteAsync_NoDataWritten()
+        {
+            using (var fs = CreateFileStream(GetTestFilePath(), FileMode.Create))
+            {
+                await fs.WriteAsync(Memory<byte>.Empty);
+                Assert.Equal(0, fs.Length);
+                Assert.Equal(0, fs.Position);
+            }
+        }
+
+        [Fact]
+        public async Task NonEmptyWriteAsync_WritesExpectedData()
+        {
+            using (var fs = CreateFileStream(GetTestFilePath(), FileMode.Create))
+            {
+                await fs.WriteAsync(new Memory<byte>(TestBuffer));
+                Assert.Equal(TestBuffer.Length, fs.Length);
+                Assert.Equal(TestBuffer.Length, fs.Position);
+
+                fs.Position = 0;
+                var buffer = new byte[TestBuffer.Length];
+                Assert.Equal(TestBuffer.Length, await fs.ReadAsync(new Memory<byte>(buffer)));
+                Assert.Equal(TestBuffer, buffer);
+            }
+        }
     }
 
     public class Sync_FileStream_ReadWrite_Span : FileStream_ReadWrite_Span
@@ -160,6 +275,25 @@ namespace System.IO.Tests
                 Assert.True(fs.ReadArrayInvoked);
             }
         }
+
+        [Fact]
+        public async Task CallMemoryReadWriteAsyncOnDerivedFileStream_ArrayMethodsUsed()
+        {
+            using (var fs = (DerivedFileStream)CreateFileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite))
+            {
+                Assert.False(fs.WriteAsyncArrayInvoked);
+                Assert.False(fs.ReadAsyncArrayInvoked);
+
+                await fs.WriteAsync(new ReadOnlyMemory<byte>(new byte[1]));
+                Assert.True(fs.WriteAsyncArrayInvoked);
+                Assert.False(fs.ReadAsyncArrayInvoked);
+
+                fs.Position = 0;
+                await fs.ReadAsync(new Memory<byte>(new byte[1]));
+                Assert.True(fs.WriteAsyncArrayInvoked);
+                Assert.True(fs.ReadAsyncArrayInvoked);
+            }
+        }
     }
 
     public sealed class Async_DerivedFileStream_ReadWrite_Span : Async_FileStream_ReadWrite_Span
@@ -171,6 +305,7 @@ namespace System.IO.Tests
     internal sealed class DerivedFileStream : FileStream
     {
         public bool ReadArrayInvoked = false, WriteArrayInvoked = false;
+        public bool ReadAsyncArrayInvoked = false, WriteAsyncArrayInvoked = false;
 
         public DerivedFileStream(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options) :
             base(path, mode, access, share, bufferSize, options)
@@ -187,6 +322,18 @@ namespace System.IO.Tests
         {
             WriteArrayInvoked = true;
             base.Write(array, offset, count);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ReadAsyncArrayInvoked = true;
+            return base.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            WriteAsyncArrayInvoked = true;
+            return base.WriteAsync(buffer, offset, count, cancellationToken);
         }
     }
 }

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsReadWrite.netcoreapp.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsReadWrite.netcoreapp.cs
@@ -11,4 +11,12 @@ namespace System.IO.Tests
         public override void Write(UnmanagedMemoryStream stream, byte[] array, int offset, int count) =>
             stream.Write(new Span<byte>(array, offset, count));
     }
+
+    public sealed class MemoryUmsReadWriteTests : UmsReadWriteTests
+    {
+        public override int Read(UnmanagedMemoryStream stream, byte[] array, int offset, int count) =>
+            stream.ReadAsync(new Memory<byte>(array, offset, count)).GetAwaiter().GetResult();
+        public override void Write(UnmanagedMemoryStream stream, byte[] array, int offset, int count) =>
+            stream.WriteAsync(new Memory<byte>(array, offset, count)).GetAwaiter().GetResult();
+    }
 }

--- a/src/System.IO/tests/MemoryStream/MemoryStreamTests.netcoreapp.cs
+++ b/src/System.IO/tests/MemoryStream/MemoryStreamTests.netcoreapp.cs
@@ -4,6 +4,8 @@
 
 using Xunit;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.IO.Tests
 {
@@ -64,33 +66,114 @@ namespace System.IO.Tests
         public void DerivedMemoryStream_ReadWriteSpanCalled_ReadWriteArrayUsed()
         {
             var s = new ReadWriteOverridingMemoryStream();
-            Assert.False(s.WriteInvoked);
-            Assert.False(s.ReadInvoked);
+            Assert.False(s.WriteArrayInvoked);
+            Assert.False(s.ReadArrayInvoked);
 
             s.Write((ReadOnlySpan<byte>)new byte[1]);
-            Assert.True(s.WriteInvoked);
-            Assert.False(s.ReadInvoked);
+            Assert.True(s.WriteArrayInvoked);
+            Assert.False(s.ReadArrayInvoked);
 
             s.Position = 0;
             s.Read((Span<byte>)new byte[1]);
-            Assert.True(s.WriteInvoked);
-            Assert.True(s.ReadInvoked);
+            Assert.True(s.WriteArrayInvoked);
+            Assert.True(s.ReadArrayInvoked);
+        }
+
+        [Fact]
+        public async Task WriteAsyncReadOnlyMemory_DataWrittenAndPositionUpdated_Success()
+        {
+            const int Iters = 100;
+            var rand = new Random();
+            byte[] data = Enumerable.Range(0, (Iters * (Iters + 1)) / 2).Select(_ => (byte)rand.Next(256)).ToArray();
+            var s = new MemoryStream();
+
+            int expectedPos = 0;
+            for (int i = 0; i <= Iters; i++)
+            {
+                await s.WriteAsync(new ReadOnlyMemory<byte>(data, expectedPos, i));
+                expectedPos += i;
+                Assert.Equal(expectedPos, s.Position);
+            }
+
+            Assert.Equal(data, s.ToArray());
+        }
+
+        [Fact]
+        public async Task ReadAsyncMemory_DataReadAndPositionUpdated_Success()
+        {
+            const int Iters = 100;
+            var rand = new Random();
+            byte[] data = Enumerable.Range(0, (Iters * (Iters + 1)) / 2).Select(_ => (byte)rand.Next(256)).ToArray();
+            var s = new MemoryStream(data);
+
+            int expectedPos = 0;
+            for (int i = 0; i <= Iters; i++)
+            {
+                var toRead = new Memory<byte>(new byte[i * 3]); // enough room to read the data and have some offset and have slack at the end
+
+                // Do the read and validate we read the expected number of bytes
+                Assert.Equal(i, await s.ReadAsync(toRead.Slice(i, i)));
+
+                // The contents prior to and after the read should be empty.
+                Assert.Equal<byte>(new byte[i], toRead.Slice(0, i).ToArray());
+                Assert.Equal<byte>(new byte[i], toRead.Slice(i * 2, i).ToArray());
+
+                // And the data read should match what was expected.
+                Assert.Equal(new Span<byte>(data, expectedPos, i).ToArray(), toRead.Slice(i, i).ToArray());
+
+                // Updated position should match
+                expectedPos += i;
+                Assert.Equal(expectedPos, s.Position);
+            }
+
+            // A final read should be empty
+            Assert.Equal(0, await s.ReadAsync(new Memory<byte>(new byte[1])));
+        }
+
+        [Fact]
+        public async Task DerivedMemoryStream_ReadWriteAsyncMemoryCalled_ReadWriteAsyncArrayUsed()
+        {
+            var s = new ReadWriteOverridingMemoryStream();
+            Assert.False(s.WriteArrayInvoked);
+            Assert.False(s.ReadArrayInvoked);
+
+            await s.WriteAsync((ReadOnlyMemory<byte>)new byte[1]);
+            Assert.True(s.WriteArrayInvoked);
+            Assert.False(s.ReadArrayInvoked);
+
+            s.Position = 0;
+            await s.ReadAsync((Memory<byte>)new byte[1]);
+            Assert.True(s.WriteArrayInvoked);
+            Assert.True(s.ReadArrayInvoked);
         }
 
         private class ReadWriteOverridingMemoryStream : MemoryStream
         {
-            public bool ReadInvoked, WriteInvoked;
+            public bool ReadArrayInvoked, WriteArrayInvoked;
+            public bool ReadAsyncArrayInvoked, WriteAsyncArrayInvoked;
 
             public override int Read(byte[] buffer, int offset, int count)
             {
-                ReadInvoked = true;
+                ReadArrayInvoked = true;
                 return base.Read(buffer, offset, count);
             }
 
             public override void Write(byte[] buffer, int offset, int count)
             {
-                WriteInvoked = true;
+                WriteArrayInvoked = true;
                 base.Write(buffer, offset, count);
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                ReadAsyncArrayInvoked = true;
+                return base.ReadAsync(buffer, offset, count, cancellationToken);
+            }
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                WriteAsyncArrayInvoked = true;
+                return base.WriteAsync(buffer, offset, count, cancellationToken);
             }
         }
     }

--- a/src/System.IO/tests/Stream/Stream.ReadWriteSpan.netcoreapp.cs
+++ b/src/System.IO/tests/Stream/Stream.ReadWriteSpan.netcoreapp.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Tests
@@ -57,6 +61,223 @@ namespace System.IO.Tests
             s.Write(span.Slice(2, 3));
             Assert.True(writeInvoked);
             writeInvoked = false;
+        }
+
+        [Fact]
+        public async Task ReadAsyncMemory_WrapsArray_DelegatesToReadAsyncArray_Success()
+        {
+            bool readInvoked = false;
+            var s = new DelegateStream(
+                canReadFunc: () => true,
+                readAsyncFunc: (array, offset, count, cancellationToken) =>
+                {
+                    readInvoked = true;
+                    Assert.NotNull(array);
+                    Assert.Equal(5, offset);
+                    Assert.Equal(20, count);
+
+                    for (int i = 0; i < 10; i++)
+                    {
+                        array[offset + i] = (byte)i;
+                    }
+                    return Task.FromResult(10);
+                });
+
+            Memory<byte> totalMemory = new byte[30];
+            Memory<byte> targetMemory = totalMemory.Slice(5, 20);
+
+            Assert.Equal(10, await s.ReadAsync(targetMemory));
+            Assert.True(readInvoked);
+            for (int i = 0; i < 10; i++)
+                Assert.Equal(i, targetMemory.Span[i]);
+            for (int i = 10; i < 20; i++)
+                Assert.Equal(0, targetMemory.Span[i]);
+            readInvoked = false;
+        }
+
+        [Fact]
+        public async Task ReadAsyncMemory_WrapsNative_DelegatesToReadAsyncArrayWithPool_Success()
+        {
+            bool readInvoked = false;
+            var s = new DelegateStream(
+                canReadFunc: () => true,
+                readAsyncFunc: (array, offset, count, cancellationToken) =>
+                {
+                    readInvoked = true;
+                    Assert.NotNull(array);
+                    Assert.Equal(0, offset);
+                    Assert.Equal(20, count);
+
+                    for (int i = 0; i < 10; i++)
+                    {
+                        array[offset + i] = (byte)i;
+                    }
+                    return Task.FromResult(10);
+                });
+
+            using (var totalNativeMemory = new NativeOwnedMemory(30))
+            {
+                Memory<byte> totalMemory = totalNativeMemory.AsMemory;
+                Memory<byte> targetMemory = totalMemory.Slice(5, 20);
+
+                Assert.Equal(10, await s.ReadAsync(targetMemory));
+                Assert.True(readInvoked);
+                for (int i = 0; i < 10; i++)
+                    Assert.Equal(i, targetMemory.Span[i]);
+                readInvoked = false;
+            }
+        }
+
+        [Fact]
+        public async Task WriteAsyncMemory_WrapsArray_DelegatesToWrite_Success()
+        {
+            bool writeInvoked = false;
+            var s = new DelegateStream(
+                canWriteFunc: () => true,
+                writeAsyncFunc: (array, offset, count, cancellationToken) =>
+                {
+                    writeInvoked = true;
+                    Assert.NotNull(array);
+                    Assert.Equal(2, offset);
+                    Assert.Equal(3, count);
+
+                    for (int i = 0; i < count; i++)
+                        Assert.Equal(i, array[offset + i]);
+
+                    return Task.CompletedTask;
+                });
+
+            Memory<byte> memory = new byte[10];
+            memory.Span[3] = 1;
+            memory.Span[4] = 2;
+            await s.WriteAsync(memory.Slice(2, 3));
+            Assert.True(writeInvoked);
+            writeInvoked = false;
+        }
+
+        [Fact]
+        public async Task WriteAsyncMemory_WrapsNative_DelegatesToWrite_Success()
+        {
+            bool writeInvoked = false;
+            var s = new DelegateStream(
+                canWriteFunc: () => true,
+                writeAsyncFunc: (array, offset, count, cancellationToken) =>
+                {
+                    writeInvoked = true;
+                    Assert.NotNull(array);
+                    Assert.Equal(0, offset);
+                    Assert.Equal(3, count);
+
+                    for (int i = 0; i < count; i++)
+                        Assert.Equal(i, array[i]);
+
+                    return Task.CompletedTask;
+                });
+
+            using (var nativeMemory = new NativeOwnedMemory(10))
+            {
+                Memory<byte> memory = nativeMemory.AsMemory;
+                memory.Span[2] = 0;
+                memory.Span[3] = 1;
+                memory.Span[4] = 2;
+                await s.WriteAsync(memory.Slice(2, 3));
+                Assert.True(writeInvoked);
+                writeInvoked = false;
+            }
+        }
+
+        private sealed class NativeOwnedMemory : OwnedMemory<byte>
+        {
+            private readonly int _length;
+            private IntPtr _ptr;
+            private int _retainedCount;
+            private bool _disposed;
+
+            public NativeOwnedMemory(int length)
+            {
+                _length = length;
+                _ptr = Marshal.AllocHGlobal(length);
+            }
+
+            public override bool IsDisposed
+            {
+                get
+                {
+                    lock (this)
+                    {
+                        return _disposed && _retainedCount == 0;
+                    }
+                }
+            }
+
+            public override int Length => _length;
+
+            protected override bool IsRetained
+            {
+                get
+                {
+                    lock (this)
+                    {
+                        return _retainedCount > 0;
+                    }
+                }
+            }
+
+            public override unsafe Span<byte> AsSpan() => new Span<byte>((void*)_ptr, _length);
+
+            public override unsafe MemoryHandle Pin() => new MemoryHandle(this, (void*)_ptr);
+
+            public override bool Release()
+            {
+                lock (this)
+                {
+                    if (_retainedCount > 0)
+                    {
+                        _retainedCount--;
+                        if (_retainedCount == 0)
+                        {
+                            if (_disposed)
+                            {
+                                Marshal.FreeHGlobal(_ptr);
+                                _ptr = IntPtr.Zero;
+                            }
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            public override void Retain()
+            {
+                lock (this)
+                {
+                    if (_retainedCount == 0 && _disposed)
+                    {
+                        throw new Exception();
+                    }
+                    _retainedCount++;
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                lock (this)
+                {
+                    _disposed = true;
+                    if (_retainedCount == 0)
+                    {
+                        Marshal.FreeHGlobal(_ptr);
+                        _ptr = IntPtr.Zero;
+                    }
+                }
+            }
+
+            protected override bool TryGetArray(out ArraySegment<byte> arraySegment)
+            {
+                arraySegment = default(ArraySegment<byte>);
+                return false;
+            }
         }
     }
 }

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>System.IO</RootNamespace>
     <AssemblyName>System.IO.Tests</AssemblyName>
     <ProjectGuid>{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}</ProjectGuid>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -5091,6 +5091,7 @@ namespace System.IO
         public virtual int Read(System.Span<byte> destination) { throw null; }
         public System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count) { throw null; }
         public virtual System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.ValueTask<int> ReadAsync(Memory<byte> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual int ReadByte() { throw null; }
         public abstract long Seek(long offset, System.IO.SeekOrigin origin);
         public abstract void SetLength(long value);
@@ -5099,6 +5100,7 @@ namespace System.IO
         public virtual void Write(System.ReadOnlySpan<byte> source) { }
         public System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count) { throw null; }
         public virtual System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task WriteAsync(ReadOnlyMemory<byte> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual void WriteByte(byte value) { }
     }
     public partial class FileStream : System.IO.Stream


### PR DESCRIPTION
Depends on:
https://github.com/dotnet/coreclr/pull/13769
https://github.com/dotnet/corert/pull/4443
https://github.com/dotnet/corefx/pull/23701

Closes https://github.com/dotnet/corefx/issues/22381
Closes https://github.com/dotnet/corefx/issues/22388
Closes https://github.com/dotnet/corefx/issues/22389
Closes https://github.com/dotnet/corefx/issues/22386

cc: @JeremyKuhne, @pjanotti, @KrzysztofCwalina, @ahsonkhan 