### PR TITLE
TextReader/Writer Span overloads and tests

### DIFF
--- a/src/System.IO/tests/StreamReader/StreamReaderTests.cs
+++ b/src/System.IO/tests/StreamReader/StreamReaderTests.cs
@@ -40,33 +40,7 @@ namespace System.IO.Tests
 
         protected Tuple<char[], StreamReader> GetCharArrayStream()
         {
-            var chArr = new char[]{
-                char.MinValue
-                ,char.MaxValue
-                ,'\t'
-                ,' '
-                ,'$'
-                ,'@'
-                ,'#'
-                ,'\0'
-                ,'\v'
-                ,'\''
-                ,'\u3190'
-                ,'\uC3A0'
-                ,'A'
-                ,'5'
-                ,'\r'
-                ,'\uFE70'
-                ,'-'
-                ,';'
-                ,'\r'
-                ,'\n'
-                ,'T'
-                ,'3'
-                ,'\n'
-                ,'K'
-                ,'\u00E6'
-            };
+            var chArr = TestDataProvider.CharData;
             var ms = CreateStream();
             var sw = new StreamWriter(ms);
 

--- a/src/System.IO/tests/StreamWriter/StreamWriter.WriteTests.cs
+++ b/src/System.IO/tests/StreamWriter/StreamWriter.WriteTests.cs
@@ -20,7 +20,7 @@ namespace System.IO.Tests
         [Fact]
         public void WriteChars()
         {
-            char[] chArr = setupArray();
+            char[] chArr = TestDataProvider.CharData;
 
             // [] Write a wide variety of characters and read them back
 
@@ -40,30 +40,6 @@ namespace System.IO.Tests
             }
         }
 
-        private static char[] setupArray()
-        {
-            return new char[]{
-            char.MinValue
-            ,char.MaxValue
-            ,'\t'
-            ,' '
-            ,'$'
-            ,'@'
-            ,'#'
-            ,'\0'
-            ,'\v'
-            ,'\''
-            ,'\u3190'
-            ,'\uC3A0'
-            ,'A'
-            ,'5'
-            ,'\uFE70' 
-            ,'-'
-            ,';'
-            ,'\u00E6'
-        };
-        }
-
         [Fact]
         public void NullArray()
         {
@@ -78,7 +54,7 @@ namespace System.IO.Tests
         [Fact]
         public void NegativeOffset()
         {
-            char[] chArr = setupArray();
+            char[] chArr = TestDataProvider.CharData;
 
             // [] Exception if offset is negative
             Stream ms = CreateStream();
@@ -91,7 +67,7 @@ namespace System.IO.Tests
         [Fact]
         public void NegativeCount()
         {
-            char[] chArr = setupArray();
+            char[] chArr = TestDataProvider.CharData;
 
             // [] Exception if count is negative
             Stream ms = CreateStream();
@@ -104,7 +80,7 @@ namespace System.IO.Tests
         [Fact]
         public void WriteCustomLenghtStrings()
         {
-            char[] chArr = setupArray();
+            char[] chArr = TestDataProvider.CharData;
 
             // [] Write some custom length strings
             Stream ms = CreateStream();
@@ -127,7 +103,7 @@ namespace System.IO.Tests
         [Fact]
         public void WriteToStreamWriter()
         {
-            char[] chArr = setupArray();
+            char[] chArr = TestDataProvider.CharData;
             // [] Just construct a streamwriter and write to it    
             //-------------------------------------------------             
             Stream ms = CreateStream();
@@ -149,7 +125,7 @@ namespace System.IO.Tests
         [Fact]
         public void TestWritingPastEndOfArray()
         {
-            char[] chArr = setupArray();
+            char[] chArr = TestDataProvider.CharData;
             Stream ms = CreateStream();
             StreamWriter sw = new StreamWriter(ms);
 
@@ -160,7 +136,7 @@ namespace System.IO.Tests
         [Fact]
         public void VerifyWrittenString()
         {
-            char[] chArr = setupArray();
+            char[] chArr = TestDataProvider.CharData;
             // [] Write string with wide selection of characters and read it back        
 
             StringBuilder sb = new StringBuilder(40);

--- a/src/System.IO/tests/StringWriter/StringWriterTests.cs
+++ b/src/System.IO/tests/StringWriter/StringWriterTests.cs
@@ -17,33 +17,9 @@ namespace System.IO.Tests
         static int[] iArrLargeValues = new int[] { int.MaxValue, int.MaxValue - 1, int.MaxValue / 2, int.MaxValue / 10, int.MaxValue / 100 };
         static int[] iArrValidValues = new int[] { 10000, 100000, int.MaxValue / 2000, int.MaxValue / 5000, short.MaxValue };
 
-        private static char[] getCharArray()
-        {
-            return new char[]{
-            char.MinValue
-            ,char.MaxValue
-            ,'\t'
-            ,' '
-            ,'$'
-            ,'@'
-            ,'#'
-            ,'\0'
-            ,'\v'
-            ,'\''
-            ,'\u3190'
-            ,'\uC3A0'
-            ,'A'
-            ,'5'
-            ,'\uFE70' 
-            ,'-'
-            ,';'
-            ,'\u00E6'
-        };
-        }
-
         private static StringBuilder getSb()
         {
-            var chArr = getCharArray();
+            var chArr = TestDataProvider.CharData;
             var sb = new StringBuilder(40);
             for (int i = 0; i < chArr.Length; i++)
                 sb.Append(chArr[i]);
@@ -88,7 +64,7 @@ namespace System.IO.Tests
         [Fact]
         public static void WriteArray()
         {
-            var chArr = getCharArray();
+            var chArr = TestDataProvider.CharData;
             StringBuilder sb = getSb();
             StringWriter sw = new StringWriter(sb);
 
@@ -125,7 +101,7 @@ namespace System.IO.Tests
         [Fact]
         public static void CantWriteIndexLargeValues()
         {
-            var chArr = getCharArray();
+            var chArr = TestDataProvider.CharData;
             for (int i = 0; i < iArrLargeValues.Length; i++)
             {
                 StringWriter sw = new StringWriter();
@@ -136,7 +112,7 @@ namespace System.IO.Tests
         [Fact]
         public static void CantWriteCountLargeValues()
         {
-            var chArr = getCharArray();
+            var chArr = TestDataProvider.CharData;
             for (int i = 0; i < iArrLargeValues.Length; i++)
             {
                 StringWriter sw = new StringWriter();
@@ -150,7 +126,7 @@ namespace System.IO.Tests
             StringWriter sw = new StringWriter();
             StringReader sr;
 
-            var chArr = getCharArray();
+            var chArr = TestDataProvider.CharData;
 
             sw.Write(chArr, 2, 5);
 

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -59,6 +59,13 @@
     <Compile Include="$(CommonTestPath)\System\IO\WrappedMemoryStream.cs">
       <Link>Common\System\IO\WrappedMemoryStream.cs</Link>
     </Compile>
+    <Compile Include="TestDataProvider\TestDataProvider.cs" />
+    <Compile Include="TextReader\CharArrayTextReader.cs" />
+    <Compile Include="TextReader\TextReaderTests.cs" />
+    <Compile Include="TextReader\TextReaderTests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
+    <Compile Include="TextWriter\CharArrayTextWriter.cs" />
+    <Compile Include="TextWriter\TextWriterTests.cs" />
+    <Compile Include="TextWriter\TextWriterTests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />

--- a/src/System.IO/tests/TestDataProvider/TestDataProvider.cs
+++ b/src/System.IO/tests/TestDataProvider/TestDataProvider.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.IO.Tests
+{
+    public static class TestDataProvider
+    {
+        private static readonly char[] s_charData;
+        private static readonly char[] s_smallData;
+        private static readonly char[] s_largeData;
+
+        public static object FirstObject { get; } = (object)1;
+        public static object SecondObject { get; } = (object)"[second object]";
+        public static object ThirdObject { get; } = (object)"<third object>";
+        public static object[] MultipleObjects { get; } = new object[] { FirstObject, SecondObject, ThirdObject };
+
+        public static string FormatStringOneObject { get; } = "Object is {0}";
+        public static string FormatStringTwoObjects { get; } = $"Object are '{0}', {SecondObject}";
+        public static string FormatStringThreeObjects { get; } = $"Objects are {0}, {SecondObject}, {ThirdObject}";
+        public static string FormatStringMultipleObjects { get; } = "Multiple Objects are: {0}, {1}, {2}";
+
+        static TestDataProvider()
+        {
+            s_charData = new char[]
+            {
+                char.MinValue,
+                char.MaxValue,
+                '\t',
+                ' ',
+                '$',
+                '@',
+                '#',
+                '\0',
+                '\v',
+                '\'',
+                '\u3190',
+                '\uC3A0',
+                'A',
+                '5',
+                '\r',
+                '\uFE70',
+                '-',
+                ';',
+                '\r',
+                '\n',
+                'T',
+                '3',
+                '\n',
+                'K',
+                '\u00E6'
+            };
+
+            s_smallData = "HELLO".ToCharArray();
+
+            var data = new List<char>();
+            for (int count = 0; count < 1000; ++count)
+            {
+                data.AddRange(s_smallData);
+            }
+            s_largeData = data.ToArray();
+        }
+
+        public static char[] CharData => s_charData;
+
+        public static char[] SmallData => s_smallData;
+
+        public static char[] LargeData => s_largeData;
+    }
+}

--- a/src/System.IO/tests/TextReader/CharArrayTextReader.cs
+++ b/src/System.IO/tests/TextReader/CharArrayTextReader.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Tests
+{
+    public class CharArrayTextReader : TextReader
+    {
+        private readonly char[] _charBuffer;
+        private int _charPos = 0;
+
+        public bool EndOfStream => _charPos >= _charBuffer.Length;
+
+        public CharArrayTextReader(char[] data)
+        {
+            _charBuffer = data;
+        }
+
+        public override int Peek()
+        {
+            if (_charPos == _charBuffer.Length)
+            {
+                return -1;
+            }
+            return _charBuffer[_charPos];
+        }
+
+        public override int Read()
+        {
+            if (_charPos == _charBuffer.Length)
+            {
+                return -1;
+            }
+            return _charBuffer[_charPos++];
+        }
+    }
+}

--- a/src/System.IO/tests/TextReader/TextReaderTests.cs
+++ b/src/System.IO/tests/TextReader/TextReaderTests.cs
@@ -1,0 +1,248 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public partial class TextReaderTests
+    {
+        protected (char[] chArr, CharArrayTextReader textReader) GetCharArray()
+        {
+            CharArrayTextReader tr = new CharArrayTextReader(TestDataProvider.CharData);
+            return (TestDataProvider.CharData, tr);
+        }
+
+        [Fact]
+        public void EndOfStream()
+        {
+            using (CharArrayTextReader tr = new CharArrayTextReader(TestDataProvider.SmallData))
+            {
+                var result = tr.ReadToEnd();
+
+                Assert.Equal("HELLO", result);
+
+                Assert.True(tr.EndOfStream, "End of TextReader was not true after ReadToEnd");
+            }
+        }
+
+        [Fact]
+        public void NotEndOfStream()
+        {
+            using (CharArrayTextReader tr = new CharArrayTextReader(TestDataProvider.SmallData))
+            {
+                char[] charBuff = new char[3];
+                var result = tr.Read(charBuff, 0, 3);
+
+                Assert.Equal(3, result);
+
+                Assert.Equal("HEL", new string(charBuff));
+
+                Assert.False(tr.EndOfStream, "End of TextReader was true after ReadToEnd");
+            }
+        }
+
+        [Fact]
+        public async Task ReadToEndAsync()
+        {
+            using (CharArrayTextReader tr = new CharArrayTextReader(TestDataProvider.LargeData))
+            {
+                var result = await tr.ReadToEndAsync();
+
+                Assert.Equal(5000, result.Length);
+            }
+        }
+
+        [Fact]
+        public void TestRead()
+        {
+            (char[] chArr, CharArrayTextReader textReader) baseInfo = GetCharArray();
+            using (CharArrayTextReader tr = baseInfo.textReader)
+            {
+                for (int count = 0; count < baseInfo.chArr.Length; ++count)
+                {
+                    int tmp = tr.Read();
+                    Assert.Equal((int)baseInfo.chArr[count], tmp);
+                }
+            }
+        }
+
+        [Fact]
+        public void ArgumentNullOnNullArray()
+        {
+            (char[] chArr, CharArrayTextReader textReader) baseInfo = GetCharArray();
+            using (CharArrayTextReader tr = baseInfo.textReader)
+            {
+                Assert.Throws<ArgumentNullException>(() => tr.Read(null, 0, 0));
+            }
+        }
+
+        [Fact]
+        public void ArgumentOutOfRangeOnInvalidOffset()
+        {
+            using (CharArrayTextReader tr = GetCharArray().textReader)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => tr.Read(new char[0], -1, 0));
+            }
+        }
+
+        [Fact]
+        public void ArgumentOutOfRangeOnNegativCount()
+        {
+            using (CharArrayTextReader tr = GetCharArray().textReader)
+            {
+                AssertExtensions.Throws<ArgumentException>(null, () => tr.Read(new char[0], 0, 1));
+            }
+        }
+
+        [Fact]
+        public void ArgumentExceptionOffsetAndCount()
+        {
+            using (CharArrayTextReader tr = GetCharArray().textReader)
+            {
+                AssertExtensions.Throws<ArgumentException>(null, () => tr.Read(new char[0], 2, 0));
+            }
+        }
+
+        [Fact]
+        public void EmptyInput()
+        {
+            using (CharArrayTextReader tr = new CharArrayTextReader(new char[] { }))
+            {
+                char[] buffer = new char[10];
+                int read = tr.Read(buffer, 0, 1);
+                Assert.Equal(0, read);
+            }
+        }
+
+        [Fact]
+        public void ReadCharArr()
+        {
+            (char[] chArr, CharArrayTextReader textReader) baseInfo = GetCharArray();
+            using (CharArrayTextReader tr = baseInfo.textReader)
+            {
+                char[] chArr = new char[baseInfo.chArr.Length];
+
+                var read = tr.Read(chArr, 0, chArr.Length);
+                Assert.Equal(chArr.Length, read);
+
+                for (int count = 0; count < baseInfo.chArr.Length; ++count)
+                {
+                    Assert.Equal(baseInfo.chArr[count], chArr[count]);
+                }
+            }
+        }
+
+        [Fact]
+        public void ReadBlockCharArr()
+        {
+            (char[] chArr, CharArrayTextReader textReader) baseInfo = GetCharArray();
+            using (CharArrayTextReader tr = baseInfo.textReader)
+            {
+                char[] chArr = new char[baseInfo.chArr.Length];
+
+                var read = tr.ReadBlock(chArr, 0, chArr.Length);
+                Assert.Equal(chArr.Length, read);
+
+                for (int count = 0; count < baseInfo.chArr.Length; ++count)
+                {
+                    Assert.Equal(baseInfo.chArr[count], chArr[count]);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadBlockAsyncCharArr()
+        {
+            (char[] chArr, CharArrayTextReader textReader) baseInfo = GetCharArray();
+            using (CharArrayTextReader tr = baseInfo.textReader)
+            {
+                char[] chArr = new char[baseInfo.chArr.Length];
+
+                var read = await tr.ReadBlockAsync(chArr, 0, chArr.Length);
+                Assert.Equal(chArr.Length, read);
+
+                for (int count = 0; count < baseInfo.chArr.Length; ++count)
+                {
+                    Assert.Equal(baseInfo.chArr[count], chArr[count]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ReadAsync()
+        {
+            (char[] chArr, CharArrayTextReader textReader) baseInfo = GetCharArray();
+            using (CharArrayTextReader tr = baseInfo.textReader)
+            {
+                char[] chArr = new char[baseInfo.chArr.Length];
+
+                var read = await tr.ReadAsync(chArr, 4, 3);
+                Assert.Equal(read, 3);
+
+                for (int count = 0; count < 3; ++count)
+                {
+                    Assert.Equal(baseInfo.chArr[count], chArr[count + 4]);
+                }
+            }
+        }
+
+        [Fact]
+        public void ReadLines()
+        {
+            (char[] chArr, CharArrayTextReader textReader) baseInfo = GetCharArray();
+            using (CharArrayTextReader tr = baseInfo.textReader)
+            {
+                string valueString = new string(baseInfo.chArr);
+
+                var data = tr.ReadLine();
+                Assert.Equal(valueString.Substring(0, valueString.IndexOf('\r')), data);
+
+                data = tr.ReadLine();
+                Assert.Equal(valueString.Substring(valueString.IndexOf('\r') + 1, 3), data);
+
+                data = tr.ReadLine();
+                Assert.Equal(valueString.Substring(valueString.IndexOf('\n') + 1, 2), data);
+
+                data = tr.ReadLine();
+                Assert.Equal((valueString.Substring(valueString.LastIndexOf('\n') + 1)), data);
+            }
+        }
+
+        [Fact]
+        public void ReadLines2()
+        {
+            (char[] chArr, CharArrayTextReader textReader) baseInfo = GetCharArray();
+            using (CharArrayTextReader tr = baseInfo.textReader)
+            {
+                string valueString = new string(baseInfo.chArr);
+
+                char[] temp = new char[10];
+                tr.Read(temp, 0, 1);
+                var data = tr.ReadLine();
+
+                Assert.Equal(valueString.Substring(1, valueString.IndexOf('\r') - 1), data);
+            }
+        }
+
+        [Fact]
+        public async Task ReadLineAsyncContinuousNewLinesAndTabs()
+        {
+            char[] newLineTabData = new char[] { '\n', '\n', '\r', '\r', '\n' };
+            using (CharArrayTextReader tr = new CharArrayTextReader(newLineTabData))
+            {
+                for (int count = 0; count < 4; ++count)
+                {
+                    var data = await tr.ReadLineAsync();
+                    Assert.Equal(string.Empty, data);
+                }
+
+                var eol = await tr.ReadLineAsync();
+                Assert.Null(eol);
+            }
+        }
+    }
+}

--- a/src/System.IO/tests/TextReader/TextReaderTests.netcoreapp.cs
+++ b/src/System.IO/tests/TextReader/TextReaderTests.netcoreapp.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public partial class TextReaderTests
+    {
+        [Fact]
+        public void ReadSpan()
+        {
+            (char[] chArr, CharArrayTextReader textReader) baseInfo = GetCharArray();
+            using (CharArrayTextReader tr = baseInfo.textReader)
+            {
+                char[] chArr = new char[baseInfo.chArr.Length];
+                var chSpan = new Span<char>(chArr, 0, baseInfo.chArr.Length);
+
+                var read = tr.Read(chSpan);
+                Assert.Equal(chArr.Length, read);
+
+                for (int i = 0; i < baseInfo.chArr.Length; i++)
+                {
+                    Assert.Equal(baseInfo.chArr[i], chArr[i]);
+                }
+            }
+        }
+
+        [Fact]
+        public void ReadBlockSpan()
+        {
+            (char[] chArr, CharArrayTextReader textReader) baseInfo = GetCharArray();
+            using (CharArrayTextReader tr = baseInfo.textReader)
+            {
+                char[] chArr = new char[baseInfo.chArr.Length];
+                var chSpan = new Span<char>(chArr, 0, baseInfo.chArr.Length);
+
+                var read = tr.ReadBlock(chSpan);
+                Assert.Equal(chArr.Length, read);
+
+                for (int i = 0; i < baseInfo.chArr.Length; i++)
+                {
+                    Assert.Equal(baseInfo.chArr[i], chArr[i]);
+                }
+            }
+        }
+    }
+}

--- a/src/System.IO/tests/TextWriter/CharArrayTextWriter.cs
+++ b/src/System.IO/tests/TextWriter/CharArrayTextWriter.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace System.IO.Tests
+{
+    public class CharArrayTextWriter : TextWriter
+    {
+        private StringBuilder _sb;
+
+        public override Encoding Encoding => Encoding.Unicode;
+
+        public CharArrayTextWriter()
+        {
+            _sb = new StringBuilder();
+        }
+
+        public override void Write(char value)
+        {
+            _sb.Append(value);
+        }
+
+        public string Text => _sb.ToString();
+
+        public void Clear() => _sb.Clear();
+    }
+}

--- a/src/System.IO/tests/TextWriter/TextWriterTests.cs
+++ b/src/System.IO/tests/TextWriter/TextWriterTests.cs
@@ -1,0 +1,543 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public partial class TextWriterTests
+    {
+        protected static CharArrayTextWriter NewTextWriter => new CharArrayTextWriter() { NewLine = "---" };
+
+        #region Write Overloads
+
+        [Fact]
+        public void WriteCharTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                for (int count = 0; count < TestDataProvider.CharData.Length; ++count)
+                {
+                    tw.Write(TestDataProvider.CharData[count]);
+                }
+                Assert.Equal(new string(TestDataProvider.CharData), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteCharArrayTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(TestDataProvider.CharData);
+                Assert.Equal(new string(TestDataProvider.CharData), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteCharArrayIndexCountTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(TestDataProvider.CharData, 3, 5);
+                Assert.Equal(new string(TestDataProvider.CharData, 3, 5), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteBoolTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(true);
+                Assert.Equal("True", tw.Text);
+
+                tw.Clear();
+                tw.Write(false);
+                Assert.Equal("False", tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteIntTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(int.MinValue);
+                Assert.Equal(int.MinValue.ToString(), tw.Text);
+
+                tw.Clear();
+                tw.Write(int.MaxValue);
+                Assert.Equal(int.MaxValue.ToString(), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteUIntTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(uint.MinValue);
+                Assert.Equal(uint.MinValue.ToString(), tw.Text);
+
+                tw.Clear();
+                tw.Write(uint.MaxValue);
+                Assert.Equal(uint.MaxValue.ToString(), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLongTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(long.MinValue);
+                Assert.Equal(long.MinValue.ToString(), tw.Text);
+
+                tw.Clear();
+                tw.Write(long.MaxValue);
+                Assert.Equal(long.MaxValue.ToString(), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteULongTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(ulong.MinValue);
+                Assert.Equal(ulong.MinValue.ToString(), tw.Text);
+
+                tw.Clear();
+                tw.Write(ulong.MaxValue);
+                Assert.Equal(ulong.MaxValue.ToString(), tw.Text);
+
+            }
+        }
+
+        [Fact]
+        public void WriteFloatTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(float.MinValue);
+                Assert.Equal(float.MinValue.ToString(), tw.Text);
+
+                tw.Clear();
+                tw.Write(float.MaxValue);
+                Assert.Equal(float.MaxValue.ToString(), tw.Text);
+
+                tw.Clear();
+                tw.Write(float.NaN);
+                Assert.Equal(float.NaN.ToString(), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteDoubleTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(double.MinValue);
+                Assert.Equal(double.MinValue.ToString(), tw.Text);
+                tw.Clear();
+
+                tw.Write(double.MaxValue);
+                Assert.Equal(double.MaxValue.ToString(), tw.Text);
+                tw.Clear();
+
+                tw.Write(double.NaN);
+                Assert.Equal(double.NaN.ToString(), tw.Text);
+                tw.Clear();
+            }
+        }
+
+        [Fact]
+        public void WriteDecimalTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(decimal.MinValue);
+                Assert.Equal(decimal.MinValue.ToString(), tw.Text);
+
+                tw.Clear();
+                tw.Write(decimal.MaxValue);
+                Assert.Equal(decimal.MaxValue.ToString(), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteStringTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(new string(TestDataProvider.CharData));
+                Assert.Equal(new string(TestDataProvider.CharData), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteObjectTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(TestDataProvider.FirstObject);
+                Assert.Equal(TestDataProvider.FirstObject.ToString(), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteStringObjectTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(TestDataProvider.FormatStringOneObject, TestDataProvider.FirstObject);
+                Assert.Equal(string.Format(TestDataProvider.FormatStringOneObject, TestDataProvider.FirstObject), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteStringTwoObjectsTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(TestDataProvider.FormatStringTwoObjects, TestDataProvider.FirstObject, TestDataProvider.SecondObject);
+                Assert.Equal(string.Format(TestDataProvider.FormatStringTwoObjects, TestDataProvider.FirstObject, TestDataProvider.SecondObject), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteStringThreeObjectsTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(TestDataProvider.FormatStringThreeObjects, TestDataProvider.FirstObject, TestDataProvider.SecondObject, TestDataProvider.ThirdObject);
+                Assert.Equal(string.Format(TestDataProvider.FormatStringThreeObjects, TestDataProvider.FirstObject, TestDataProvider.SecondObject, TestDataProvider.ThirdObject), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteStringMultipleObjectsTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.Write(TestDataProvider.FormatStringMultipleObjects, TestDataProvider.MultipleObjects);
+                Assert.Equal(string.Format(TestDataProvider.FormatStringMultipleObjects, TestDataProvider.MultipleObjects), tw.Text);
+            }
+        }
+
+        #endregion
+
+        #region WriteLine Overloads
+
+        [Fact]
+        public void WriteLineTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine();
+                Assert.Equal(tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineCharTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                for (int count = 0; count < TestDataProvider.CharData.Length; ++count)
+                {
+                    tw.WriteLine(TestDataProvider.CharData[count]);
+                }
+                Assert.Equal(string.Join(tw.NewLine, TestDataProvider.CharData.Select(ch => ch.ToString()).ToArray()) + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineCharArrayTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(TestDataProvider.CharData);
+                Assert.Equal(new string(TestDataProvider.CharData) + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineCharArrayIndexCountTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(TestDataProvider.CharData, 3, 5);
+                Assert.Equal(new string(TestDataProvider.CharData, 3, 5) + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineBoolTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(true);
+                Assert.Equal("True" + tw.NewLine, tw.Text);
+
+                tw.Clear();
+                tw.WriteLine(false);
+                Assert.Equal("False" + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineIntTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(int.MinValue);
+                Assert.Equal(int.MinValue.ToString() + tw.NewLine, tw.Text);
+
+                tw.Clear();
+                tw.WriteLine(int.MaxValue);
+                Assert.Equal(int.MaxValue.ToString() + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineUIntTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(uint.MinValue);
+                Assert.Equal(uint.MinValue.ToString() + tw.NewLine, tw.Text);
+
+                tw.Clear();
+                tw.WriteLine(uint.MaxValue);
+                Assert.Equal(uint.MaxValue.ToString() + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineLongTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(long.MinValue);
+                Assert.Equal(long.MinValue.ToString() + tw.NewLine, tw.Text);
+
+                tw.Clear();
+                tw.WriteLine(long.MaxValue);
+                Assert.Equal(long.MaxValue.ToString() + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineULongTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(ulong.MinValue);
+                Assert.Equal(ulong.MinValue.ToString() + tw.NewLine, tw.Text);
+
+                tw.Clear();
+                tw.WriteLine(ulong.MaxValue);
+                Assert.Equal(ulong.MaxValue.ToString() + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineFloatTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(float.MinValue);
+                Assert.Equal(float.MinValue.ToString() + tw.NewLine, tw.Text);
+
+                tw.Clear();
+                tw.WriteLine(float.MaxValue);
+                Assert.Equal(float.MaxValue.ToString() + tw.NewLine, tw.Text);
+
+                tw.Clear();
+                tw.WriteLine(float.NaN);
+                Assert.Equal(float.NaN.ToString() + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineDoubleTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(double.MinValue);
+                Assert.Equal(double.MinValue.ToString() + tw.NewLine, tw.Text);
+                tw.Clear();
+
+                tw.WriteLine(double.MaxValue);
+                Assert.Equal(double.MaxValue.ToString() + tw.NewLine, tw.Text);
+                tw.Clear();
+
+                tw.WriteLine(double.NaN);
+                Assert.Equal(double.NaN.ToString() + tw.NewLine, tw.Text);
+                tw.Clear();
+            }
+        }
+
+        [Fact]
+        public void WriteLineDecimalTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(decimal.MinValue);
+                Assert.Equal(decimal.MinValue.ToString() + tw.NewLine, tw.Text);
+
+                tw.Clear();
+                tw.WriteLine(decimal.MaxValue);
+                Assert.Equal(decimal.MaxValue.ToString() + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineStringTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(new string(TestDataProvider.CharData));
+                Assert.Equal(new string(TestDataProvider.CharData) + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineObjectTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(TestDataProvider.FirstObject);
+                Assert.Equal(TestDataProvider.FirstObject.ToString() + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineStringObjectTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(TestDataProvider.FormatStringOneObject, TestDataProvider.FirstObject);
+                Assert.Equal(string.Format(TestDataProvider.FormatStringOneObject + tw.NewLine, TestDataProvider.FirstObject), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineStringTwoObjectsTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(TestDataProvider.FormatStringTwoObjects, TestDataProvider.FirstObject, TestDataProvider.SecondObject);
+                Assert.Equal(string.Format(TestDataProvider.FormatStringTwoObjects + tw.NewLine, TestDataProvider.FirstObject, TestDataProvider.SecondObject), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineStringThreeObjectsTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(TestDataProvider.FormatStringThreeObjects, TestDataProvider.FirstObject, TestDataProvider.SecondObject, TestDataProvider.ThirdObject);
+                Assert.Equal(string.Format(TestDataProvider.FormatStringThreeObjects + tw.NewLine, TestDataProvider.FirstObject, TestDataProvider.SecondObject, TestDataProvider.ThirdObject), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineStringMultipleObjectsTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                tw.WriteLine(TestDataProvider.FormatStringMultipleObjects, TestDataProvider.MultipleObjects);
+                Assert.Equal(string.Format(TestDataProvider.FormatStringMultipleObjects + tw.NewLine, TestDataProvider.MultipleObjects), tw.Text);
+            }
+        }
+
+        #endregion
+
+        #region Write Async Overloads
+
+        [Fact]
+        public async void WriteAsyncCharTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                await tw.WriteAsync('a');
+                Assert.Equal("a", tw.Text);
+            }
+        }
+
+        [Fact]
+        public async void WriteAsyncStringTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                var toWrite = new string(TestDataProvider.CharData);
+                await tw.WriteAsync(toWrite);
+                Assert.Equal(toWrite, tw.Text);
+            }
+        }
+
+        [Fact]
+        public async void WriteAsyncCharArrayIndexCountTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                await tw.WriteAsync(TestDataProvider.CharData, 3, 5);
+                Assert.Equal(new string(TestDataProvider.CharData, 3, 5), tw.Text);
+            }
+        }
+
+        #endregion
+
+        #region WriteLineAsync Overloads
+
+        [Fact]
+        public async void WriteLineAsyncTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                await tw.WriteLineAsync();
+                Assert.Equal(tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public async void WriteLineAsyncCharTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                await tw.WriteLineAsync('a');
+                Assert.Equal("a" + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public async void WriteLineAsyncStringTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                var toWrite = new string(TestDataProvider.CharData);
+                await tw.WriteLineAsync(toWrite);
+                Assert.Equal(toWrite + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public async void WriteLineAsyncCharArrayIndexCount()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                await tw.WriteLineAsync(TestDataProvider.CharData, 3, 5);
+                Assert.Equal(new string(TestDataProvider.CharData, 3, 5) + tw.NewLine, tw.Text);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
+++ b/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public partial class TextWriterTests
+    {
+        [Fact]
+        public void WriteCharSpanTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                var rs = new ReadOnlySpan<char>(TestDataProvider.CharData, 4, 6);
+                tw.Write(rs);
+                Assert.Equal(new string(rs), tw.Text);
+            }
+        }
+
+        [Fact]
+        public void WriteLineCharSpanTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                var rs = new ReadOnlySpan<char>(TestDataProvider.CharData, 4, 6);
+                tw.WriteLine(rs);
+                Assert.Equal(new string(rs) + tw.NewLine, tw.Text);
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1469,8 +1469,10 @@ namespace System.IO
         public virtual int Peek() { throw null; }
         public virtual int Read() { throw null; }
         public virtual int Read(char[] buffer, int index, int count) { throw null; }
+        public virtual int Read(Span<char> destination) { throw null; }
         public virtual System.Threading.Tasks.Task<int> ReadAsync(char[] buffer, int index, int count) { throw null; }
         public virtual int ReadBlock(char[] buffer, int index, int count) { throw null; }
+        public virtual int ReadBlock(Span<char> destination) { throw null; }
         public virtual System.Threading.Tasks.Task<int> ReadBlockAsync(char[] buffer, int index, int count) { throw null; }
         public virtual string ReadLine() { throw null; }
         public virtual System.Threading.Tasks.Task<string> ReadLineAsync() { throw null; }
@@ -1512,6 +1514,7 @@ namespace System.IO
         public virtual void Write(uint value) { }
         [System.CLSCompliantAttribute(false)]
         public virtual void Write(ulong value) { }
+        public virtual void Write(ReadOnlySpan<char> source) { }
         public virtual System.Threading.Tasks.Task WriteAsync(char value) { throw null; }
         public System.Threading.Tasks.Task WriteAsync(char[] buffer) { throw null; }
         public virtual System.Threading.Tasks.Task WriteAsync(char[] buffer, int index, int count) { throw null; }
@@ -1536,6 +1539,7 @@ namespace System.IO
         public virtual void WriteLine(uint value) { }
         [System.CLSCompliantAttribute(false)]
         public virtual void WriteLine(ulong value) { }
+        public virtual void WriteLine(ReadOnlySpan<char> source) { }
         public virtual System.Threading.Tasks.Task WriteLineAsync() { throw null; }
         public virtual System.Threading.Tasks.Task WriteLineAsync(char value) { throw null; }
         public System.Threading.Tasks.Task WriteLineAsync(char[] buffer) { throw null; }

--- a/src/System.Runtime.Extensions/src/Resources/Strings.resx
+++ b/src/System.Runtime.Extensions/src/Resources/Strings.resx
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -366,5 +425,8 @@
   </data>
   <data name="PlatformNotSupported_AppDomain_ResMon" xml:space="preserve">
     <value>AppDomain resource monitoring is not supported on this platform.</value>
+  </data>
+  <data name="IO_InvalidReadLength" xml:space="preserve">
+    <value>The read operation returned an invalid length.</value>
   </data>
 </root>

--- a/src/System.Runtime.Extensions/src/System/IO/TextReader.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/TextReader.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
+using System.Buffers;
 
 namespace System.IO
 {
@@ -100,6 +101,30 @@ namespace System.IO
             return n;
         }
 
+        // Reads a span of characters. This method will read up to
+        // count characters from this TextReader into the
+        // span of characters Returns the actual number of characters read.
+        //
+        public virtual int Read(Span<char> destination)
+        {
+            char[] buffer = ArrayPool<char>.Shared.Rent(destination.Length);
+
+            try
+            {
+                int numRead = Read(buffer, 0, destination.Length);
+                if ((uint)numRead > destination.Length)
+                {
+                    throw new IOException(SR.IO_InvalidReadLength);
+                }
+                new Span<char>(buffer, 0, numRead).CopyTo(destination);
+                return numRead;
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(buffer);
+            }
+        }
+
         // Reads all characters from the current position to the end of the 
         // TextReader, and returns them as one string.
         public virtual string ReadToEnd()
@@ -125,6 +150,29 @@ namespace System.IO
                 n += (i = Read(buffer, index + n, count - n));
             } while (i > 0 && n < count);
             return n;
+        }
+
+        // Blocking version of read for span of characters.  Returns only when count
+        // characters have been read or the end of the file was reached.
+        //
+        public virtual int ReadBlock(Span<char> destination)
+        {
+            char[] buffer = ArrayPool<char>.Shared.Rent(destination.Length);
+
+            try
+            {
+                int numRead = ReadBlock(buffer, 0, destination.Length);
+                if ((uint)numRead > destination.Length)
+                {
+                    throw new IOException(SR.IO_InvalidReadLength);
+                }
+                new Span<char>(buffer, 0, numRead).CopyTo(destination);
+                return numRead;
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(buffer);
+            }
         }
 
         // Reads a line. A line is defined as a sequence of characters followed by

--- a/src/System.Runtime.Extensions/src/System/IO/TextWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/TextWriter.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Globalization;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
+using System.Buffers;
 
 namespace System.IO
 {
@@ -159,6 +160,23 @@ namespace System.IO
             }
 
             for (int i = 0; i < count; i++) Write(buffer[index + i]);
+        }
+
+        // Writes a span of characters to the text stream.
+        //
+        public virtual void Write(ReadOnlySpan<char> source)
+        {
+            char[] buffer = ArrayPool<char>.Shared.Rent(source.Length);
+
+            try
+            {
+                source.CopyTo(new Span<char>(buffer));
+                Write(buffer, 0, source.Length);
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(buffer);
+            }
         }
 
         // Writes the text representation of a boolean to the text stream. This
@@ -326,6 +344,21 @@ namespace System.IO
         {
             Write(buffer, index, count);
             WriteLine();
+        }
+
+        public virtual void WriteLine(ReadOnlySpan<char> source)
+        {
+            char[] buffer = ArrayPool<char>.Shared.Rent(source.Length);
+
+            try
+            {
+                source.CopyTo(new Span<char>(buffer));
+                WriteLine(buffer, 0, source.Length);
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(buffer);
+            }
         }
 
         // Writes the text representation of a boolean followed by a line


### PR DESCRIPTION
@stephentoub , @ianhays , @JeremyKuhne 

Appreciate your review feedback on the changes in this PR.

In this PR,
1. New Span / ReadonlySpan overloads as mentioned in #22406. The buffer based overloads will be done when buffer is available.
2. Added TextReader and TextWriter tests as per comment [here](https://github.com/dotnet/corefx/issues/22406#issuecomment-325443936).

Contributes to #22406.

Thanks,
Mandar