### PR TITLE
Ported a missing SqlParameter constructor

### DIFF
--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -675,6 +675,7 @@ namespace System.Data.SqlClient
         public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size) { }
         public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size, string sourceColumn) { }
         public SqlParameter(string parameterName, object value) { }
+        public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size, System.Data.ParameterDirection direction, bool isNullable, byte precision, byte scale, string sourceColumn, System.Data.DataRowVersion sourceVersion, object value) { }
         public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size, System.Data.ParameterDirection direction, byte precision, byte scale, string sourceColumn, System.Data.DataRowVersion sourceVersion, bool sourceColumnNullMapping, object value, string xmlSchemaCollectionDatabase, string xmlSchemaCollectionOwningSchema, string xmlSchemaCollectionName) { }
         object ICloneable.Clone() { throw null; }
         public System.Data.SqlTypes.SqlCompareOptions CompareInfo { get { throw null; } set { } }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -121,16 +121,12 @@ namespace System.Data.SqlClient
             string sourceColumn,
             DataRowVersion sourceVersion,
             object value
-        ) : this()
+        ) : this(parameterName, dbType, size, sourceColumn)
         {
-            this.ParameterName = parameterName;
-            this.SqlDbType = dbType;
-            this.Size = size;
             this.Direction = direction;
             this.IsNullable = isNullable;
             this.Precision = precision;
             this.Scale = scale;
-            this.SourceColumn = sourceColumn;
             this.SourceVersion = sourceVersion;
             this.Value = value;
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -112,6 +112,31 @@ namespace System.Data.SqlClient
 
         public SqlParameter(
             string parameterName,
+            SqlDbType dbType,
+            int size,
+            ParameterDirection direction,
+            bool isNullable,
+            byte precision,
+            byte scale,
+            string sourceColumn,
+            DataRowVersion sourceVersion,
+            object value
+        ) : this()
+        {
+            this.ParameterName = parameterName;
+            this.SqlDbType = dbType;
+            this.Size = size;
+            this.Direction = direction;
+            this.IsNullable = isNullable;
+            this.Precision = precision;
+            this.Scale = scale;
+            this.SourceColumn = sourceColumn;
+            this.SourceVersion = sourceVersion;
+            this.Value = value;
+        }
+
+        public SqlParameter(
+            string parameterName,
             SqlDbType dbType, 
             int size,
             ParameterDirection direction,

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
@@ -98,6 +98,20 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         }
 
         [CheckConnStrSetupFact]
+        public static void Test_SqlParameter_Constructor()
+        {
+            using (var conn = new SqlConnection(s_connString))
+            {
+                conn.Open();
+                var cmd = new SqlCommand("select @input as 'test'", conn);
+                var sqlParameter = new SqlParameter("@input", SqlDbType.Int, 1, ParameterDirection.Input, false, 1, 0, "test", DataRowVersion.Current, MyEnum.A);
+                cmd.Parameters.Add(sqlParameter);
+                object value = cmd.ExecuteScalar();
+                Assert.Equal((MyEnum)value, MyEnum.A);
+            }
+        }
+
+        [CheckConnStrSetupFact]
         public static void Test_WithEnumValue_ShouldInferToUnderlyingType()
         {
             using (var conn = new SqlConnection(s_connString))


### PR DESCRIPTION
I've added a missing SqlParameter constructor per discussion on #17126. This is a direct port of the constructor located [here](https://msdn.microsoft.com/en-us/library/5a10hy4y(v=vs.110).aspx?cs-save-lang=1&cs-lang=csharp#code-snippet-2) from reference source located [here](https://github.com/dotnet/corefx/blob/master/src/shims/ApiCompatBaseline.netcoreapp.netfx461.txt). I tried to mirror my work off the similar PR #19544.

@danmosemsft had originally suggested that I attempt to port the rest of SqlParameter's missing items as well, but since this is my first attempt at open source contribution I'm going to start small. (Plus, some of that work looked a bit out of my league.)

I'm happy to make any changes or additions as necessary - please let me know!
