### PR TITLE
Added NaN and -NaN comparison.

### DIFF
--- a/src/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/System.Runtime/tests/System/DoubleTests.cs
@@ -205,6 +205,7 @@ namespace System.Tests
         [InlineData((double)789, (double)-789, false)]
         [InlineData((double)789, (double)0, false)]
         [InlineData(double.NaN, double.NaN, true)]
+        [InlineData(double.NaN, -double.NaN, true)]
         [InlineData((double)789, (float)789, false)]
         [InlineData((double)789, "789", false)]
         public static void Equals(double d1, object value, bool expected)

--- a/src/System.Runtime/tests/System/SingleTests.cs
+++ b/src/System.Runtime/tests/System/SingleTests.cs
@@ -211,6 +211,7 @@ namespace System.Tests
         [InlineData((float)789, (float)-789, false)]
         [InlineData((float)789, (float)0, false)]
         [InlineData(float.NaN, float.NaN, true)]
+        [InlineData(float.NaN, -float.NaN, true)]
         [InlineData((float)789, (double)789, false)]
         [InlineData((float)789, "789", false)]
         public static void Equals(float f1, object value, bool expected)


### PR DESCRIPTION
NaNs should have same hash code. The two exposed NaNs are NaN and -NaN. So we need to ensure these two NaNs have the same hash code.

**NOTE: Do not merge this PR until https://github.com/dotnet/coreclr/pull/13781 included in corefx.**

Fix #23792