### PR TITLE
Fix behavior of Dns.GetHost* with empty string

### DIFF
--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
@@ -141,6 +141,12 @@ namespace System.Net
 
         public static unsafe IPHostEntry GetHostByName(string hostName)
         {
+            if (hostName == "")
+            {
+                // To match documented behavior on Windows, if an empty string is passed in, use the local host's name.
+                hostName = Dns.GetHostName();
+            }
+
             Interop.Sys.HostEntry entry;
             int err = Interop.Sys.GetHostByName(hostName, &entry);
             if (err != 0)
@@ -167,6 +173,12 @@ namespace System.Net
 
         public static unsafe SocketError TryGetAddrInfo(string name, out IPHostEntry hostinfo, out int nativeErrorCode)
         {
+            if (name == "")
+            {
+                // To match documented behavior on Windows, if an empty string is passed in, use the local host's name.
+                name = Dns.GetHostName();
+            }
+
             Interop.Sys.HostEntry entry;
             int result = Interop.Sys.GetHostEntryForName(name, &entry);
             if (result != 0)

--- a/src/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -101,5 +101,19 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal(1, entry.AddressList.Length);
             Assert.Equal(IPAddress.IPv6Loopback, entry.AddressList[0]);
         }
+
+        [Fact]
+        public void DnsObsoleteGetHostByName_EmptyString_ReturnsHostName()
+        {
+            IPHostEntry entry = Dns.GetHostByName("");
+            Assert.Contains(Dns.GetHostName(), entry.HostName);
+        }
+
+        [Fact]
+        public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
+        {
+            IPHostEntry entry = Dns.EndGetHostByName(Dns.BeginGetHostByName("", null, null));
+            Assert.Contains(Dns.GetHostName(), entry.HostName);
+        }
     }
 }

--- a/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -20,10 +20,20 @@ namespace System.Net.NameResolution.Tests
             TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(localIPAddress));
         }
 
-        [Fact]
-        public void Dns_GetHostEntryAsync_HostString_Ok()
+        [Theory]
+        [InlineData("")]
+        [InlineData(TestSettings.LocalHost)]
+        public void Dns_GetHostEntry_HostString_Ok(string hostName)
         {
-            TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(TestSettings.LocalHost));
+            TestGetHostEntryAsync(() => Task.FromResult(Dns.GetHostEntry(hostName)));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(TestSettings.LocalHost)]
+        public void Dns_GetHostEntryAsync_HostString_Ok(string hostName)
+        {
+            TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(hostName));
         }
 
         [Fact]

--- a/src/System.Net.NameResolution/tests/PalTests/Fakes/DnsFake.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/Fakes/DnsFake.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net
+{
+    internal static class Dns
+    {
+        public static string GetHostName() => string.Empty;
+    }
+}

--- a/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
+++ b/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <Compile Include="NameResolutionPalTests.cs" />
     <Compile Include="Fakes\DebugThreadTracking.cs" />
+    <Compile Include="Fakes\DnsFake.cs" />
     <Compile Include="Fakes\IPAddressFakeExtensions.cs" />
     <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.cs</Link>


### PR DESCRIPTION
On Windows, passing an empty string to gethostbyname/GetAddrInfoW results in the host's information being used; that behavior then bubble's up through (and is documented for) the Dns.GetHost* APIs in .NET.  On Unix, the native functions being used don't provide that same behavior, instead returning an error.

This just special-cases empty string in the Unix implementation.

cc: @geoffkizer, @Priya91, @wfurt 