### PR TITLE
[System.Drawing] Add unit tests based on Mono's test suite

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -73,6 +73,7 @@ namespace System
         public static bool IsNotRedHat { get { throw null; } }
         public static bool IsRedHat69 { get { throw null; } }
         public static bool IsNotRedHat69 { get { throw null; } }
+        public static bool IsRedHat73 { get { throw null; } }
         public static bool IsUap { get { throw null; } }
         public static Version ICUVersion { get { return null; } }
         public static bool IsUbuntu { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -49,6 +49,7 @@ namespace System
         public static bool IsNotRedHat => !IsRedHat;
         public static bool IsRedHat69 => IsDistroAndVersion("rhel", "6.9") || IsDistroAndVersion("rhl", "6.9");
         public static bool IsNotRedHat69 => !IsRedHat69;
+        public static bool IsRedHat73 => IsDistroAndVersion("rhel", "7.3") || IsDistroAndVersion("rhl", "7.3");
 
         public static Version OSXKernelVersion { get; } = GetOSXKernelVersion();
 

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -37,6 +37,7 @@ namespace System
         public static bool IsNotRedHat => true;
         public static bool IsRedHat69 => false;
         public static bool IsNotRedHat69 => true;
+        public static bool IsRedHat73 => false;
 
         public static bool IsWindows10Version1607OrGreater => 
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;

--- a/src/System.Drawing.Common/tests/Helpers.cs
+++ b/src/System.Drawing.Common/tests/Helpers.cs
@@ -15,9 +15,52 @@ namespace System.Drawing
         public const string GdiplusIsAvailable = nameof(Helpers) + "." + nameof(GetGdiplusIsAvailable);
         public const string RecentGdiplusIsAvailable = nameof(Helpers) + "." + nameof(GetRecentGdiPlusIsAvailable);
         public const string RecentGdiplusIsAvailable2 = nameof(Helpers) + "." + nameof(GetRecentGdiPlusIsAvailable2);
+        public const string GdiplusIsAvailableOnWindows = nameof(Helpers) + "." + nameof(GetGdiPlusIsAvailableOnWindows);
         public const string GdiPlusIsAvailableNotRedhat73 = nameof(Helpers) + "." + nameof(GetGdiPlusIsAvailableNotRedhat73);
         public const string GdiPlusIsAvailableNotWindows7 = nameof(Helpers) + "." + nameof(GetGdiPlusIsAvailableNotWindows7);
         public const string AnyInstalledPrinters = nameof(Helpers) + "." + nameof(IsAnyInstalledPrinters);
+
+        public static bool GetRecentGdiPlusIsAvailable()
+        {
+            // CentOS 7, RHEL 7 and Ubuntu 14.04 are running outdated versions of libgdiplus
+            if (PlatformDetection.IsCentos7 || PlatformDetection.IsRedHat || PlatformDetection.IsUbuntu1404)
+            {
+                return false;
+            }
+            
+            return GetGdiplusIsAvailable();
+        }
+
+        public static bool GetRecentGdiPlusIsAvailable2()
+        {
+            // CentOS 7, RHEL 7 and Ubuntu 14.04, as well as Fedora 25 and OpenSUSE 4.22 are running outdated versions of libgdiplus
+            if (PlatformDetection.IsCentos7 || PlatformDetection.IsRedHat || PlatformDetection.IsUbuntu1404 || PlatformDetection.IsFedora || PlatformDetection.IsOpenSUSE)
+            {
+                return false;
+            }
+
+            return GetGdiplusIsAvailable();
+        }
+
+        public static bool GetGdiPlusIsAvailableOnWindows()
+        {
+            if (!PlatformDetection.IsWindows)
+            {
+                return false;
+            }
+
+            return GetGdiplusIsAvailable();
+        }
+
+        public static bool GetGdiPlusIsAvailableNotRedhat73()
+        {
+            if (PlatformDetection.IsRedHat)
+            {
+                return false;
+            }
+
+            return GetGdiplusIsAvailable();
+        }
 
         public static bool GetGdiplusIsAvailable()
         {

--- a/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -37,6 +37,40 @@
     <Compile Include="mono\System.Drawing\GraphicsTests.cs" />
     <Compile Include="mono\System.Imaging\MetafileTest.cs" />
     <Compile Include="mono\System.Drawing\BitmapTests.cs" />
+    <Compile Include="mono\System.Drawing.Drawing2D\GraphicsPathIteratorTest.cs" />
+    <Compile Include="mono\System.Drawing.Drawing2D\GraphicsPathTest.cs" />
+    <Compile Include="mono\System.Drawing.Drawing2D\LinearGradientBrushTest.cs" />
+    <Compile Include="mono\System.Drawing.Drawing2D\PathDataTest.cs" />
+    <Compile Include="mono\System.Drawing.Drawing2D\PathGradientBrushTest.cs" />
+    <Compile Include="mono\System.Drawing.Drawing2D\TestBlend.cs" />
+    <Compile Include="mono\System.Drawing.Drawing2D\TestColorBlend.cs" />
+    <Compile Include="mono\System.Drawing.Drawing2D\TestHatchBrush.cs" />
+    <Compile Include="mono\System.Drawing.Drawing2D\TestMatrix.cs" />
+    <Compile Include="mono\System.Drawing.Imaging\EmfPlusRecordTypeTest.cs" />
+    <Compile Include="mono\System.Drawing.Imaging\FrameDimensionTest.cs" />
+    <Compile Include="mono\System.Drawing.Imaging\TestColorMatrix.cs" />
+    <Compile Include="mono\System.Drawing.Imaging\TestImageAttributes.cs" />
+    <Compile Include="mono\System.Drawing.Imaging\TestImageCodecInfo.cs" />
+    <Compile Include="mono\System.Drawing.Printing\PrintingServicesUnixTest.cs" />
+    <Compile Include="mono\System.Drawing\ColorTranslator.cs" />
+    <Compile Include="mono\System.Drawing\FontFamilyTest.cs" />
+    <Compile Include="mono\System.Drawing\PenTest.cs" />
+    <Compile Include="mono\System.Drawing\RegionDataTest.cs" />
+    <Compile Include="mono\System.Drawing\RegionNonRectTest.cs" />
+    <Compile Include="mono\System.Drawing\SolidBrushTest.cs" />
+    <Compile Include="mono\System.Drawing\SystemFontsTest.cs" />
+    <Compile Include="mono\System.Drawing\SystemIconsTest.cs" />
+    <Compile Include="mono\System.Drawing\TestBitmap.cs" />
+    <Compile Include="mono\System.Drawing\TestBrushes.cs" />
+    <Compile Include="mono\System.Drawing\TestFont.cs" />
+    <Compile Include="mono\System.Drawing\TestIcon.cs" />
+    <Compile Include="mono\System.Drawing\TestImage.cs" />
+    <Compile Include="mono\System.Drawing\TestPens.cs" />
+    <Compile Include="mono\System.Drawing\TestRegion.cs" />
+    <Compile Include="mono\System.Drawing\TestStringFormat.cs" />
+    <Compile Include="mono\System.Drawing\TestSystemBrushes.cs" />
+    <Compile Include="mono\System.Drawing\TestSystemPens.cs" />
+    <Compile Include="mono\System.Drawing\TextureBrushTest.cs" />
     <Compile Include="PenTests.cs" />
     <Compile Include="PensTests.cs" />
     <Compile Include="Imaging\BitmapDataTests.cs" />
@@ -107,6 +141,9 @@
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="mono\resources\" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/GraphicsPathIteratorTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/GraphicsPathIteratorTest.cs
@@ -1,0 +1,172 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.Drawing2D.GraphicPathIterator unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing.Drawing2D
+{
+
+    public class GraphicsPathIteratorTest
+    {
+
+        private PointF[] pts_2f = new PointF[2] { new PointF(1, 2), new PointF(20, 30) };
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Ctor_Null()
+        {
+            using (GraphicsPathIterator gpi = new GraphicsPathIterator(null))
+            {
+                Assert.Equal(0, gpi.Count);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void NextMarker_Null()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (GraphicsPathIterator gpi = new GraphicsPathIterator(gp))
+                {
+                    Assert.Equal(0, gpi.NextMarker(null));
+                }
+            }
+        }
+
+        [ActiveIssue(20844)]
+        public void NextSubpath_Null()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (GraphicsPathIterator gpi = new GraphicsPathIterator(gp))
+                {
+                    bool closed;
+                    Assert.Equal(0, gpi.NextSubpath(null, out closed));
+                    Assert.True(closed);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CopyData_NullPoints()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (GraphicsPathIterator gpi = new GraphicsPathIterator(gp))
+                {
+                    PointF[] points = null;
+                    byte[] types = new byte[1];
+                    Assert.Throws<NullReferenceException>(() => gpi.CopyData(ref points, ref types, 0, 1));
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CopyData_NullTypes()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (GraphicsPathIterator gpi = new GraphicsPathIterator(gp))
+                {
+                    PointF[] points = new PointF[1];
+                    byte[] types = null;
+                    Assert.Throws<NullReferenceException>(() => gpi.CopyData(ref points, ref types, 0, 1));
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CopyData_DifferentSize()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (GraphicsPathIterator gpi = new GraphicsPathIterator(gp))
+                {
+                    PointF[] points = new PointF[1];
+                    byte[] types = new byte[2];
+                    Assert.Throws<ArgumentException>(() => gpi.CopyData(ref points, ref types, 0, 1));
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Enumerate_NullPoints()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (GraphicsPathIterator gpi = new GraphicsPathIterator(gp))
+                {
+                    PointF[] points = null;
+                    byte[] types = new byte[2];
+                    Assert.Throws<NullReferenceException>(() => gpi.Enumerate(ref points, ref types));
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Enumerate_NullTypes()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (GraphicsPathIterator gpi = new GraphicsPathIterator(gp))
+                {
+                    PointF[] points = new PointF[1];
+                    byte[] types = null;
+                    Assert.Throws<NullReferenceException>(() => gpi.Enumerate(ref points, ref types));
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Enumerate_DifferentSize()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (GraphicsPathIterator gpi = new GraphicsPathIterator(gp))
+                {
+                    PointF[] points = new PointF[1];
+                    byte[] types = new byte[2];
+                    Assert.Throws<ArgumentException>(() => gpi.Enumerate(ref points, ref types));
+                }
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/GraphicsPathTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/GraphicsPathTest.cs
@@ -1,0 +1,2821 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.GraphicsPath unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006-2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using SC = System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing.Drawing2D
+{
+
+    public class GraphicsPathTest
+    {
+
+        private const float Pi4 = (float)(Math.PI / 4);
+        // let's tolerate a few differences
+        private const int Precision = 3;
+        private const int LowPrecision = 1;
+
+        private void CheckEmpty(string prefix, GraphicsPath gp)
+        {
+            Assert.Equal(0, gp.PathData.Points.Length);
+            Assert.Equal(0, gp.PathData.Types.Length);
+            Assert.Equal(0, gp.PointCount);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_InvalidFillMode()
+        {
+            GraphicsPath gp = new GraphicsPath((FillMode)Int32.MinValue);
+            Assert.Equal(Int32.MinValue, (int)gp.FillMode);
+            CheckEmpty("InvalidFillMode.", gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Point_Null_Byte()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath((Point[])null, new byte[1]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Point_Byte_Null()
+        {
+            Assert.Throws<NullReferenceException>(() => new GraphicsPath(new Point[1], null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Point_Byte_LengthMismatch()
+        {
+            Assert.Throws<ArgumentException>(() => new GraphicsPath(new Point[1], new byte[2]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_PointF_Null_Byte()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath((PointF[])null, new byte[1]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_PointF_Byte_Null()
+        {
+            Assert.Throws<NullReferenceException>(() => new GraphicsPath(new PointF[1], null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_PointF_Byte_LengthMismatch()
+        {
+            Assert.Throws<ArgumentException>(() => new GraphicsPath(new PointF[2], new byte[1]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GraphicsPath_Empty()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Equal(FillMode.Alternate, gp.FillMode);
+            CheckEmpty("Empty.", gp);
+
+            GraphicsPath clone = (GraphicsPath)gp.Clone();
+            Assert.Equal(FillMode.Alternate, gp.FillMode);
+            CheckEmpty("Clone.", gp);
+
+            gp.Reverse();
+            CheckEmpty("Reverse.", gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GraphicsPath_Empty_PathPoints()
+        {
+            Assert.Throws<ArgumentException>(() => Assert.Null(new GraphicsPath().PathPoints));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GraphicsPath_Empty_PathTypes()
+        {
+            Assert.Throws<ArgumentException>(() => Assert.Null(new GraphicsPath().PathTypes));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GraphicsPath_SamePoint()
+        {
+            Point[] points = new Point[] {
+                new Point (1, 1),
+                new Point (1, 1),
+                new Point (1, 1),
+                new Point (1, 1),
+                new Point (1, 1),
+                new Point (1, 1),
+            };
+            byte[] types = new byte[6] { 0, 1, 1, 1, 1, 1 };
+            using (GraphicsPath gp = new GraphicsPath(points, types))
+            {
+                Assert.Equal(6, gp.PointCount);
+            }
+            types[0] = 1;
+            using (GraphicsPath gp = new GraphicsPath(points, types))
+            {
+                Assert.Equal(6, gp.PointCount);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GraphicsPath_SamePointF()
+        {
+            PointF[] points = new PointF[] {
+                new PointF (1f, 1f),
+                new PointF (1f, 1f),
+                new PointF (1f, 1f),
+                new PointF (1f, 1f),
+                new PointF (1f, 1f),
+                new PointF (1f, 1f),
+            };
+            byte[] types = new byte[6] { 0, 1, 1, 1, 1, 1 };
+            using (GraphicsPath gp = new GraphicsPath(points, types))
+            {
+                Assert.Equal(6, gp.PointCount);
+            }
+            types[0] = 1;
+            using (GraphicsPath gp = new GraphicsPath(points, types))
+            {
+                Assert.Equal(6, gp.PointCount);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void FillMode_Invalid()
+        {
+            // constructor accept an invalid FillMode
+            GraphicsPath gp = new GraphicsPath((FillMode)Int32.MaxValue);
+            Assert.Equal(Int32.MaxValue, (int)gp.FillMode);
+            // but you can't set the FillMode property to an invalid value );-)
+            Assert.Throws<SC.InvalidEnumArgumentException>(() => gp.FillMode = (FillMode)Int32.MaxValue);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void PathData_CannotChange()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new Rectangle(1, 1, 2, 2));
+
+            Assert.Equal(1f, gp.PathData.Points[0].X);
+            Assert.Equal(1f, gp.PathData.Points[0].Y);
+
+            // now try to change the first point
+            gp.PathData.Points[0] = new Point(0, 0);
+            // the changes isn't reflected in the property
+            Assert.Equal(1f, gp.PathData.Points[0].X);
+            Assert.Equal(1f, gp.PathData.Points[0].Y);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void PathPoints_CannotChange()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new Rectangle(1, 1, 2, 2));
+
+            Assert.Equal(1f, gp.PathPoints[0].X);
+            Assert.Equal(1f, gp.PathPoints[0].Y);
+
+            // now try to change the first point
+            gp.PathPoints[0] = new Point(0, 0);
+            // the changes isn't reflected in the property
+            Assert.Equal(1f, gp.PathPoints[0].X);
+            Assert.Equal(1f, gp.PathPoints[0].Y);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void PathTypes_CannotChange()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new Rectangle(1, 1, 2, 2));
+
+            Assert.Equal(0, gp.PathTypes[0]);
+
+            // now try to change the first type
+            gp.PathTypes[0] = 1;
+            // the changes isn't reflected in the property
+            Assert.Equal(0, gp.PathTypes[0]);
+        }
+
+        private void CheckArc(GraphicsPath path)
+        {
+            Assert.Equal(4, path.PathPoints.Length);
+            Assert.Equal(4, path.PathTypes.Length);
+            Assert.Equal(4, path.PathData.Points.Length);
+
+            // GetBounds (well GdipGetPathWorldBounds) isn't implemented
+            RectangleF rect = path.GetBounds();
+            Assert.Equal(2.99962401f, rect.X, Precision);
+            Assert.Equal(2.01370716f, rect.Y, Precision);
+            Assert.Equal(0f, rect.Width, Precision);
+            Assert.Equal(0.0137047768f, rect.Height);
+
+            Assert.Equal(2.99990582f, path.PathData.Points[0].X, Precision);
+            Assert.Equal(2.01370716f, path.PathPoints[0].Y, Precision);
+            Assert.Equal(0, path.PathData.Types[0]);
+            Assert.Equal(2.99984312f, path.PathData.Points[1].X, Precision);
+            Assert.Equal(2.018276f, path.PathPoints[1].Y, Precision);
+            Assert.Equal(3, path.PathTypes[1]);
+            Assert.Equal(2.99974918f, path.PathData.Points[2].X, Precision);
+            Assert.Equal(2.02284455f, path.PathPoints[2].Y, Precision);
+            Assert.Equal(3, path.PathData.Types[2]);
+            Assert.Equal(2.999624f, path.PathData.Points[3].X, Precision);
+            Assert.Equal(2.027412f, path.PathPoints[3].Y, Precision);
+            Assert.Equal(3, path.PathTypes[3]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddArc_Rectangle()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddArc(new Rectangle(1, 1, 2, 2), Pi4, Pi4);
+            CheckArc(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddArc_RectangleF()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddArc(new RectangleF(1f, 1f, 2f, 2f), Pi4, Pi4);
+            CheckArc(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddArc_Int()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddArc(1, 1, 2, 2, Pi4, Pi4);
+            CheckArc(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddArc_Float()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddArc(1f, 1f, 2f, 2f, Pi4, Pi4);
+            CheckArc(gp);
+        }
+
+        private void CheckBezier(GraphicsPath path)
+        {
+            Assert.Equal(4, path.PointCount);
+            Assert.Equal(4, path.PathPoints.Length);
+            Assert.Equal(4, path.PathTypes.Length);
+            Assert.Equal(4, path.PathData.Points.Length);
+
+            // GetBounds (well GdipGetPathWorldBounds) isn't implemented
+            RectangleF rect = path.GetBounds();
+            Assert.Equal(1f, rect.X);
+            Assert.Equal(1f, rect.Y);
+            Assert.Equal(3f, rect.Width);
+            Assert.Equal(3f, rect.Height);
+
+            Assert.Equal(1f, path.PathData.Points[0].X);
+            Assert.Equal(1f, path.PathPoints[0].Y);
+            Assert.Equal(0, path.PathData.Types[0]);
+            Assert.Equal(2f, path.PathData.Points[1].X);
+            Assert.Equal(2f, path.PathPoints[1].Y);
+            Assert.Equal(3, path.PathTypes[1]);
+            Assert.Equal(3f, path.PathData.Points[2].X);
+            Assert.Equal(3f, path.PathPoints[2].Y);
+            Assert.Equal(3, path.PathData.Types[2]);
+            Assert.Equal(4f, path.PathData.Points[3].X);
+            Assert.Equal(4f, path.PathPoints[3].Y);
+            Assert.Equal(3, path.PathTypes[3]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBezier_Point()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddBezier(new Point(1, 1), new Point(2, 2), new Point(3, 3), new Point(4, 4));
+            CheckBezier(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBezier_PointF()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddBezier(new PointF(1f, 1f), new PointF(2f, 2f), new PointF(3f, 3f), new PointF(4f, 4f));
+            CheckBezier(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBezier_Int()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddBezier(1, 1, 2, 2, 3, 3, 4, 4);
+            CheckBezier(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBezier_Float()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddBezier(1f, 1f, 2f, 2f, 3f, 3f, 4f, 4f);
+            CheckBezier(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBezier_SamePoint()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddBezier(1, 1, 1, 1, 1, 1, 1, 1);
+            // all points are present
+            Assert.Equal(4, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(3, gp.PathTypes[1]);
+            Assert.Equal(3, gp.PathTypes[2]);
+            Assert.Equal(3, gp.PathTypes[3]);
+
+            gp.AddBezier(new Point(1, 1), new Point(1, 1), new Point(1, 1), new Point(1, 1));
+            // the first point (move to) can be compressed (i.e. removed)
+            Assert.Equal(7, gp.PointCount);
+            Assert.Equal(3, gp.PathTypes[4]);
+            Assert.Equal(3, gp.PathTypes[5]);
+            Assert.Equal(3, gp.PathTypes[6]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBezier_SamePointF()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddBezier(new PointF(1f, 1f), new PointF(1f, 1f), new PointF(1f, 1f), new PointF(1f, 1f));
+            // all points are present
+            Assert.Equal(4, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(3, gp.PathTypes[1]);
+            Assert.Equal(3, gp.PathTypes[2]);
+            Assert.Equal(3, gp.PathTypes[3]);
+
+            gp.AddBezier(new PointF(1f, 1f), new PointF(1f, 1f), new PointF(1f, 1f), new PointF(1f, 1f));
+            // the first point (move to) can be compressed (i.e. removed)
+            Assert.Equal(7, gp.PointCount);
+            Assert.Equal(3, gp.PathTypes[4]);
+            Assert.Equal(3, gp.PathTypes[5]);
+            Assert.Equal(3, gp.PathTypes[6]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBeziers_Point_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().AddBeziers((Point[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBeziers_3_Points()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddBeziers(new Point[3] { new Point(1, 1), new Point(2, 2), new Point(3, 3) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBeziers_Point()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddBeziers(new Point[4] { new Point(1, 1), new Point(2, 2), new Point(3, 3), new Point(4, 4) });
+            CheckBezier(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBeziers_PointF_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().AddBeziers((PointF[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBeziers_3_PointFs()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddBeziers(new PointF[3] { new PointF(1f, 1f), new PointF(2f, 2f), new PointF(3f, 3f) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBeziers_PointF()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddBeziers(new PointF[4] { new PointF(1f, 1f), new PointF(2f, 2f), new PointF(3f, 3f), new PointF(4f, 4f) });
+            CheckBezier(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBeziers_SamePoint()
+        {
+            Point[] points = new Point[4] { new Point(1, 1), new Point(1, 1), new Point(1, 1), new Point(1, 1) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddBeziers(points);
+            // all points are present
+            Assert.Equal(4, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(3, gp.PathTypes[1]);
+            Assert.Equal(3, gp.PathTypes[2]);
+            Assert.Equal(3, gp.PathTypes[3]);
+
+            gp.AddBeziers(points);
+            // the first point (move to) can be compressed (i.e. removed)
+            Assert.Equal(7, gp.PointCount);
+            Assert.Equal(3, gp.PathTypes[4]);
+            Assert.Equal(3, gp.PathTypes[5]);
+            Assert.Equal(3, gp.PathTypes[6]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddBeziers_SamePointF()
+        {
+            PointF[] points = new PointF[4] { new PointF(1f, 1f), new PointF(1f, 1f), new PointF(1f, 1f), new PointF(1f, 1f) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddBeziers(points);
+            // all points are present
+            Assert.Equal(4, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(3, gp.PathTypes[1]);
+            Assert.Equal(3, gp.PathTypes[2]);
+            Assert.Equal(3, gp.PathTypes[3]);
+
+            gp.AddBeziers(points);
+            // the first point (move to) can be compressed (i.e. removed)
+            Assert.Equal(7, gp.PointCount);
+            Assert.Equal(3, gp.PathTypes[4]);
+            Assert.Equal(3, gp.PathTypes[5]);
+            Assert.Equal(3, gp.PathTypes[6]);
+        }
+
+        private void CheckEllipse(GraphicsPath path)
+        {
+            Assert.Equal(13, path.PathPoints.Length);
+            Assert.Equal(13, path.PathTypes.Length);
+            Assert.Equal(13, path.PathData.Points.Length);
+
+            // GetBounds (well GdipGetPathWorldBounds) isn't implemented
+            RectangleF rect = path.GetBounds();
+            Assert.Equal(1f, rect.X);
+            Assert.Equal(1f, rect.Y);
+            Assert.Equal(2f, rect.Width);
+            Assert.Equal(2f, rect.Height);
+
+            Assert.Equal(0, path.PathData.Types[0]);
+            for (int i = 1; i < 12; i++)
+                Assert.Equal(3, path.PathTypes[i]);
+            Assert.Equal(131, path.PathData.Types[12]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddEllipse_Rectangle()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddEllipse(new Rectangle(1, 1, 2, 2));
+            CheckEllipse(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddEllipse_RectangleF()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddEllipse(new RectangleF(1f, 1f, 2f, 2f));
+            CheckEllipse(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddEllipse_Int()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddEllipse(1, 1, 2, 2);
+            CheckEllipse(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddEllipse_Float()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddEllipse(1f, 1f, 2f, 2f);
+            CheckEllipse(gp);
+        }
+
+        private void CheckLine(GraphicsPath path)
+        {
+            Assert.Equal(2, path.PathPoints.Length);
+            Assert.Equal(2, path.PathTypes.Length);
+            Assert.Equal(2, path.PathData.Points.Length);
+
+            // GetBounds (well GdipGetPathWorldBounds) isn't implemented
+            RectangleF rect = path.GetBounds();
+            Assert.Equal(1f, rect.X);
+            Assert.Equal(1f, rect.Y);
+            Assert.Equal(1f, rect.Width);
+            Assert.Equal(1f, rect.Height);
+
+            Assert.Equal(1f, path.PathData.Points[0].X);
+            Assert.Equal(1f, path.PathPoints[0].Y);
+            Assert.Equal(0, path.PathData.Types[0]);
+            Assert.Equal(2f, path.PathData.Points[1].X);
+            Assert.Equal(2f, path.PathPoints[1].Y);
+            Assert.Equal(1, path.PathTypes[1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLine_Point()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLine(new Point(1, 1), new Point(2, 2));
+            CheckLine(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLine_PointF()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLine(new PointF(1f, 1f), new PointF(2f, 2f));
+            CheckLine(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLine_Int()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLine(1, 1, 2, 2);
+            CheckLine(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLine_Float()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLine(1f, 1f, 2f, 2f);
+            CheckLine(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLine_SamePoint()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLine(new Point(1, 1), new Point(1, 1));
+            Assert.Equal(2, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+
+            gp.AddLine(new Point(1, 1), new Point(1, 1));
+            // 3 not 4 points, the first point (only) is compressed
+            Assert.Equal(3, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+
+            gp.AddLine(new Point(1, 1), new Point(1, 1));
+            // 4 not 5 (or 6) points, the first point (only) is compressed
+            Assert.Equal(4, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+            Assert.Equal(1, gp.PathTypes[3]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLine_SamePointF()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLine(new PointF(49.2f, 157f), new PointF(49.2f, 157f));
+            Assert.Equal(2, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+
+            gp.AddLine(new PointF(49.2f, 157f), new PointF(49.2f, 157f));
+            // 3 not 4 points, the first point (only) is compressed
+            Assert.Equal(3, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLine_SamePointsF()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLine(new PointF(49.2f, 157f), new PointF(75.6f, 196f));
+            gp.AddLine(new PointF(75.6f, 196f), new PointF(102f, 209f));
+            Assert.Equal(3, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+
+            gp.AddLine(new PointF(102f, 209f), new PointF(75.6f, 196f));
+            Assert.Equal(4, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+            Assert.Equal(1, gp.PathTypes[3]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLines_Point_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().AddLines((Point[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLines_Point_0()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddLines(new Point[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLines_Point_1()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLines(new Point[1] { new Point(1, 1) });
+            // Special case - a line with a single point is valid
+            Assert.Equal(1, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLines_Point()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLines(new Point[2] { new Point(1, 1), new Point(2, 2) });
+            CheckLine(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLines_PointF_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().AddLines((PointF[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLines_PointF_0()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddLines(new PointF[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLines_PointF_1()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLines(new PointF[1] { new PointF(1f, 1f) });
+            // Special case - a line with a single point is valid
+            Assert.Equal(1, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLines_PointF()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLines(new PointF[2] { new PointF(1f, 1f), new PointF(2f, 2f) });
+            CheckLine(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLines_SamePoint()
+        {
+            Point[] points = new Point[] { new Point(1, 1), new Point(1, 1) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLines(points);
+            Assert.Equal(2, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+
+            gp.AddLines(points);
+            // 3 not 4 points, the first point (only) is compressed
+            Assert.Equal(3, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+
+            gp.AddLines(points);
+            // 4 not 5 (or 6) points, the first point (only) is compressed
+            Assert.Equal(4, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+            Assert.Equal(1, gp.PathTypes[3]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddLines_SamePointF()
+        {
+            PointF[] points = new PointF[] { new PointF(49.2f, 157f), new PointF(49.2f, 157f), new PointF(49.2f, 157f), new PointF(49.2f, 157f) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddLines(points);
+            // all identical points are added
+            Assert.Equal(4, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+            Assert.Equal(1, gp.PathTypes[3]);
+
+            gp.AddLines(points);
+            // only the first new point is compressed
+            Assert.Equal(7, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+            Assert.Equal(1, gp.PathTypes[3]);
+            Assert.Equal(1, gp.PathTypes[4]);
+            Assert.Equal(1, gp.PathTypes[5]);
+            Assert.Equal(1, gp.PathTypes[6]);
+        }
+
+        private void CheckPie(GraphicsPath path)
+        {
+            // the number of points generated for a Pie isn't the same between Mono and MS
+#if false
+			Assert.Equal (5, path.PathPoints.Length);
+			Assert.Equal (5, path.PathTypes.Length);
+			Assert.Equal (5, path.PathData.Points.Length);
+
+			// GetBounds (well GdipGetPathWorldBounds) isn't implemented
+			RectangleF rect = path.GetBounds ();
+			Assert.Equal (2f, rect.X);
+			Assert.Equal (2f, rect.Y);
+			Assert.Equal (0.9999058f, rect.Width);
+			Assert.Equal (0.0274119377f, rect.Height);
+
+			Assert.Equal (2f, path.PathData.Points[0].X);
+			Assert.Equal (2f, path.PathPoints[0].Y);
+			Assert.Equal (0, path.PathData.Types[0]);
+			Assert.Equal (2.99990582f, path.PathData.Points[1].X);
+			Assert.Equal (2.01370716f, path.PathPoints[1].Y);
+			Assert.Equal (1, path.PathTypes[1]);
+			Assert.Equal (2.99984312f, path.PathData.Points[2].X);
+			Assert.Equal (2.018276f, path.PathPoints[2].Y);
+			Assert.Equal (3, path.PathData.Types[2]);
+			Assert.Equal (2.99974918f, path.PathData.Points[3].X);
+			Assert.Equal (2.02284455f, path.PathPoints[3].Y);
+			Assert.Equal (3, path.PathData.Types[3]);
+			Assert.Equal (2.999624f, path.PathData.Points[4].X);
+			Assert.Equal (2.027412f, path.PathPoints[4].Y);
+			Assert.Equal (131, path.PathTypes[4]);
+#endif
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPie_Rect()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPie(new Rectangle(1, 1, 2, 2), Pi4, Pi4);
+            CheckPie(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPie_Int()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPie(1, 1, 2, 2, Pi4, Pi4);
+            CheckPie(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPie_Float()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPie(1f, 1f, 2f, 2f, Pi4, Pi4);
+            CheckPie(gp);
+        }
+
+        private void CheckPolygon(GraphicsPath path)
+        {
+            // an extra point is generated by Mono (libgdiplus)
+#if false
+			Assert.Equal (3, path.PathPoints.Length);
+			Assert.Equal (3, path.PathTypes.Length);
+			Assert.Equal (3, path.PathData.Points.Length);
+#endif
+            // GetBounds (well GdipGetPathWorldBounds) isn't implemented
+            RectangleF rect = path.GetBounds();
+            Assert.Equal(1f, rect.X);
+            Assert.Equal(1f, rect.Y);
+            Assert.Equal(2f, rect.Width);
+            Assert.Equal(2f, rect.Height);
+
+            Assert.Equal(1f, path.PathData.Points[0].X);
+            Assert.Equal(1f, path.PathPoints[0].Y);
+            Assert.Equal(0, path.PathData.Types[0]);
+            Assert.Equal(2f, path.PathData.Points[1].X);
+            Assert.Equal(2f, path.PathPoints[1].Y);
+            Assert.Equal(1, path.PathTypes[1]);
+            Assert.Equal(3f, path.PathData.Points[2].X);
+            Assert.Equal(3f, path.PathPoints[2].Y);
+            // the extra point change the type of the last point
+#if false
+			Assert.Equal (129, path.PathData.Types[2]);
+#endif
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_Point_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().AddPolygon((Point[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_Point_Empty()
+        {
+            Assert.Throws<ArgumentException>(() => new GraphicsPath().AddPolygon(new Point[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_Point_1()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddPolygon(new Point[1] { new Point(1, 1) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_Point_2()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddPolygon(new Point[2] { new Point(1, 1), new Point(2, 2) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_Point_3()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPolygon(new Point[3] { new Point(1, 1), new Point(2, 2), new Point(3, 3) });
+            CheckPolygon(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_PointF_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().AddPolygon((PointF[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_PointF_Empty()
+        {
+            Assert.Throws<ArgumentException>(() => new GraphicsPath().AddPolygon(new PointF[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_PointF_1()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddPolygon(new PointF[1] { new PointF(1f, 1f) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_PointF_2()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddPolygon(new PointF[2] { new PointF(1f, 1f), new PointF(2f, 2f) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_PointF_3()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPolygon(new PointF[3] { new PointF(1f, 1f), new PointF(2f, 2f), new PointF(3f, 3f) });
+            CheckPolygon(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_SamePoint()
+        {
+            Point[] points = new Point[3] { new Point(1, 1), new Point(1, 1), new Point(1, 1) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPolygon(points);
+            // all identical points are added
+            Assert.Equal(3, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(129, gp.PathTypes[2]);
+
+            gp.AddPolygon(points);
+            // all identical points are added (again)
+            Assert.Equal(6, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[3]);
+            Assert.Equal(1, gp.PathTypes[4]);
+            Assert.Equal(129, gp.PathTypes[5]);
+
+            gp.AddLines(points);
+            // all identical points are added as a line (because previous point is closed)
+            Assert.Equal(9, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[6]);
+            Assert.Equal(1, gp.PathTypes[7]);
+            Assert.Equal(1, gp.PathTypes[8]);
+
+            gp.AddPolygon(points);
+            // all identical points are added (again)
+            Assert.Equal(12, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[9]);
+            Assert.Equal(1, gp.PathTypes[10]);
+            Assert.Equal(129, gp.PathTypes[11]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPolygon_SamePointF()
+        {
+            PointF[] points = new PointF[3] { new PointF(1f, 1f), new PointF(1f, 1f), new PointF(1f, 1f) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPolygon(points);
+            // all identical points are added
+            Assert.Equal(3, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(129, gp.PathTypes[2]);
+
+            gp.AddPolygon(points);
+            // all identical points are added (again)
+            Assert.Equal(6, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[3]);
+            Assert.Equal(1, gp.PathTypes[4]);
+            Assert.Equal(129, gp.PathTypes[5]);
+
+            gp.AddLines(points);
+            // all identical points are added as a line (because previous point is closed)
+            Assert.Equal(9, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[6]);
+            Assert.Equal(1, gp.PathTypes[7]);
+            Assert.Equal(1, gp.PathTypes[8]);
+
+            gp.AddPolygon(points);
+            // all identical points are added (again)
+            Assert.Equal(12, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[9]);
+            Assert.Equal(1, gp.PathTypes[10]);
+            Assert.Equal(129, gp.PathTypes[11]);
+        }
+
+        private void CheckRectangle(GraphicsPath path, int count)
+        {
+            Assert.Equal(count, path.PathPoints.Length);
+            Assert.Equal(count, path.PathTypes.Length);
+            Assert.Equal(count, path.PathData.Points.Length);
+
+            // GetBounds (well GdipGetPathWorldBounds) isn't implemented
+            RectangleF rect = path.GetBounds();
+            Assert.Equal(1f, rect.X);
+            Assert.Equal(1f, rect.Y);
+            Assert.Equal(2f, rect.Width);
+            Assert.Equal(2f, rect.Height);
+
+            // check first four points (first rectangle)
+            Assert.Equal(1f, path.PathData.Points[0].X);
+            Assert.Equal(1f, path.PathPoints[0].Y);
+            Assert.Equal(0, path.PathData.Types[0]);
+            Assert.Equal(3f, path.PathData.Points[1].X);
+            Assert.Equal(1f, path.PathPoints[1].Y);
+            Assert.Equal(1, path.PathTypes[1]);
+            Assert.Equal(3f, path.PathData.Points[2].X);
+            Assert.Equal(3f, path.PathPoints[2].Y);
+            Assert.Equal(1, path.PathData.Types[2]);
+            Assert.Equal(1f, path.PathData.Points[3].X);
+            Assert.Equal(3f, path.PathPoints[3].Y);
+            Assert.Equal(129, path.PathTypes[3]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangle_Int()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new Rectangle(1, 1, 2, 2));
+            CheckRectangle(gp, 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangle_Float()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new RectangleF(1f, 1f, 2f, 2f));
+            CheckRectangle(gp, 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangle_SamePoint()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new Rectangle(1, 1, 0, 0));
+            Assert.Equal(0, gp.PointCount);
+
+            gp.AddRectangle(new Rectangle(1, 1, 1, 1));
+            Assert.Equal(4, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+            Assert.Equal(129, gp.PathTypes[3]);
+            PointF end = gp.PathPoints[3];
+
+            // add rectangle at the last path point
+            gp.AddRectangle(new Rectangle((int)end.X, (int)end.Y, 1, 1));
+            // no compression (different type)
+            Assert.Equal(8, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+            Assert.Equal(129, gp.PathTypes[3]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangle_SamePointF()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new RectangleF(1f, 1f, 0f, 0f));
+            Assert.Equal(0, gp.PointCount);
+
+            gp.AddRectangle(new RectangleF(1f, 1f, 1f, 1f));
+            Assert.Equal(4, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+            Assert.Equal(129, gp.PathTypes[3]);
+            PointF end = gp.PathPoints[3];
+
+            // add rectangle at the last path point
+            gp.AddRectangle(new RectangleF(end.X, end.Y, 1f, 1f));
+            // no compression (different type)
+            Assert.Equal(8, gp.PointCount);
+            Assert.Equal(0, gp.PathTypes[0]);
+            Assert.Equal(1, gp.PathTypes[1]);
+            Assert.Equal(1, gp.PathTypes[2]);
+            Assert.Equal(129, gp.PathTypes[3]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangles_Int_Null()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentNullException>(() => gp.AddRectangles((Rectangle[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangles_Int_Empty()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddRectangles(new Rectangle[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangles_Int()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangles(new Rectangle[1] { new Rectangle(1, 1, 2, 2) });
+            CheckRectangle(gp, 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangles_Float_Null()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentNullException>(() => gp.AddRectangles((RectangleF[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangles_Float_Empty()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddRectangles(new RectangleF[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangles_Float()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangles(new RectangleF[1] { new RectangleF(1f, 1f, 2f, 2f) });
+            CheckRectangle(gp, 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangles_Two()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangles(new RectangleF[2] {
+                new RectangleF (1f, 1f, 2f, 2f),
+                new RectangleF (2f, 2f, 1f, 1f) });
+            RectangleF rect = gp.GetBounds();
+            Assert.Equal(1f, rect.X);
+            Assert.Equal(1f, rect.Y);
+            Assert.Equal(2f, rect.Width);
+            Assert.Equal(2f, rect.Height);
+            // second rectangle is completely within the first one
+            CheckRectangle(gp, 8);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddRectangles_SamePoint()
+        {
+            Rectangle r1 = new Rectangle(1, 1, 0, 0);
+            Rectangle r2 = new Rectangle(1, 1, 1, 1);
+            Rectangle r3 = new Rectangle(1, 2, 1, 1);
+
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangles(new Rectangle[] { r1, r2, r3 });
+            Assert.Equal(8, gp.PointCount);
+            // first rect is ignore, then all other 2x4 (8) points are present, no compression
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPath_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().AddPath(null, false));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddPath()
+        {
+            GraphicsPath gpr = new GraphicsPath();
+            gpr.AddRectangle(new Rectangle(1, 1, 2, 2));
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPath(gpr, true);
+            CheckRectangle(gp, 4);
+        }
+
+        private void AssertEqualWithTolerance(float expected, float actual, float tolerance)
+        {
+            var difference = Math.Abs(expected - actual);
+            Assert.True(difference < tolerance);
+        }
+
+        private void CheckClosedCurve(GraphicsPath path)
+        {
+            Assert.Equal(10, path.PathPoints.Length);
+            Assert.Equal(10, path.PathTypes.Length);
+            Assert.Equal(10, path.PathData.Points.Length);
+
+            // GetBounds (well GdipGetPathWorldBounds) isn't very precise with curves
+            RectangleF rect = path.GetBounds();
+            AssertEqualWithTolerance(0.8333333f, rect.X, 0.2f);
+            AssertEqualWithTolerance(0.8333333f, rect.Y, 0.2f);
+            AssertEqualWithTolerance(2.33333278f, rect.Width, 0.4f);
+            AssertEqualWithTolerance(2.33333278f, rect.Height, 0.4f);
+
+            Assert.Equal(0, path.PathData.Types[0]);
+            for (int i = 1; i < 9; i++)
+                Assert.Equal(3, path.PathTypes[i]);
+            Assert.Equal(131, path.PathData.Types[9]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_Point_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().AddClosedCurve((Point[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_Point_0()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddClosedCurve(new Point[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_Point_1()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddClosedCurve(new Point[1] { new Point(1, 1) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_Point_2()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddClosedCurve(new Point[2] { new Point(1, 1), new Point(2, 2) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_Point_3()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddClosedCurve(new Point[3] { new Point(1, 1), new Point(2, 2), new Point(3, 3) });
+            CheckClosedCurve(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_PointF_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().AddClosedCurve((PointF[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_PointF_0()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddClosedCurve(new PointF[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_PointF_1()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddClosedCurve(new PointF[1] { new PointF(1f, 1f) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_PointF_2()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddClosedCurve(new PointF[2] { new PointF(1f, 1f), new PointF(2f, 2f) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_PointF_3()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddClosedCurve(new PointF[3] { new PointF(1f, 1f), new PointF(2f, 2f), new PointF(3f, 3f) });
+            CheckClosedCurve(gp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_SamePoint()
+        {
+            Point[] points = new Point[3] { new Point(1, 1), new Point(1, 1), new Point(1, 1) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddClosedCurve(points);
+            Assert.Equal(10, gp.PointCount);
+            gp.AddClosedCurve(points);
+            Assert.Equal(20, gp.PointCount);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddClosedCurve_SamePointF()
+        {
+            PointF[] points = new PointF[3] { new PointF(1f, 1f), new PointF(1f, 1f), new PointF(1f, 1f) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddClosedCurve(points);
+            Assert.Equal(10, gp.PointCount);
+            gp.AddClosedCurve(points);
+            Assert.Equal(20, gp.PointCount);
+        }
+
+        private void CheckCurve(GraphicsPath path)
+        {
+            Assert.Equal(4, path.PathPoints.Length);
+            Assert.Equal(4, path.PathTypes.Length);
+            Assert.Equal(4, path.PathData.Points.Length);
+
+            // GetBounds (well GdipGetPathWorldBounds) isn't implemented
+            RectangleF rect = path.GetBounds();
+            Assert.Equal(1.0f, rect.X);
+            Assert.Equal(1.0f, rect.Y);
+            Assert.Equal(1.0f, rect.Width);
+            Assert.Equal(1.0f, rect.Height);
+
+            Assert.Equal(1f, path.PathData.Points[0].X);
+            Assert.Equal(1f, path.PathPoints[0].Y);
+            Assert.Equal(0, path.PathData.Types[0]);
+            // Mono has wrong? results
+#if false
+			Assert.Equal (1.16666663f, path.PathData.Points[1].X);
+			Assert.Equal (1.16666663f, path.PathPoints[1].Y);
+#endif
+            Assert.Equal(3, path.PathTypes[1]);
+            // Mono has wrong? results
+#if false
+			Assert.Equal (1.83333325f, path.PathData.Points[2].X);
+			Assert.Equal (1.83333325f, path.PathPoints[2].Y);
+#endif
+            Assert.Equal(3, path.PathData.Types[2]);
+            Assert.Equal(2f, path.PathData.Points[3].X);
+            Assert.Equal(2f, path.PathPoints[3].Y);
+            Assert.Equal(3, path.PathTypes[3]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_Point_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().AddCurve((Point[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_Point_0()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddCurve(new Point[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_Point_1()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddCurve(new Point[1] { new Point(1, 1) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_Point_2()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddCurve(new Point[2] { new Point(1, 1), new Point(2, 2) });
+            CheckCurve(gp);
+            // note: GdipAddPathCurveI allows adding a "curve" with only 2 points (a.k.a. a line );-)
+            gp.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_Point_2_Tension()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddCurve(new Point[2] { new Point(1, 1), new Point(2, 2) }, 1.0f);
+            CheckCurve(gp);
+            // note: GdipAddPathCurve2I allows adding a "curve" with only 2 points (a.k.a. a line );-)
+            gp.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve3_Point_2()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddCurve(new Point[2] { new Point(1, 1), new Point(2, 2) }, 0, 2, 0.5f));
+            // adding only two points isn't supported by GdipAddCurve3I
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_PointF_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().AddCurve((PointF[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_PointF_0()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddCurve(new PointF[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_PointF_1()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddCurve(new PointF[1] { new PointF(1f, 1f) }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_PointF_2()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddCurve(new PointF[2] { new PointF(1f, 1f), new PointF(2f, 2f) });
+            CheckCurve(gp);
+            // note: GdipAddPathCurve allows adding a "curve" with only 2 points (a.k.a. a line );-)
+            gp.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_PoinFt_2_Tension()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddCurve(new PointF[2] { new PointF(1f, 1f), new PointF(2f, 2f) }, 1.0f);
+            CheckCurve(gp);
+            // note: GdipAddPathCurve2 allows adding a "curve" with only 2 points (a.k.a. a line );-)
+            gp.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve3_PointF_2()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddCurve(new PointF[2] { new PointF(1f, 1f), new PointF(2f, 2f) }, 0, 2, 0.5f));
+            // adding only two points isn't supported by GdipAddCurve3
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_LargeTension()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddCurve(new PointF[3] { new PointF(1f, 1f), new PointF(0f, 20f), new PointF(20f, 0f) }, 0, 2, Single.MaxValue);
+            Assert.Equal(7, gp.PointCount);
+            gp.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_ZeroSegments()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddCurve(new PointF[2] { new PointF(1f, 1f), new PointF(2f, 2f) }, 0, 0, 0.5f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_NegativeSegments()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddCurve(new PointF[2] { new PointF(1f, 1f), new PointF(2f, 2f) }, 0, -1, 0.5f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_OffsetTooLarge()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddCurve(new PointF[3] { new PointF(1f, 1f), new PointF(0f, 20f), new PointF(20f, 0f) }, 1, 2, 0.5f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_Offset()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddCurve(new PointF[4] { new PointF(1f, 1f), new PointF(0f, 20f), new PointF(20f, 0f), new PointF(0f, 10f) }, 1, 2, 0.5f);
+            Assert.Equal(7, gp.PointCount);
+            gp.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_SamePoint()
+        {
+            Point[] points = new Point[2] { new Point(1, 1), new Point(1, 1) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddCurve(points);
+            Assert.Equal(4, gp.PointCount);
+            gp.AddCurve(points);
+            Assert.Equal(7, gp.PointCount);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddCurve_SamePointF()
+        {
+            PointF[] points = new PointF[2] { new PointF(1f, 1f), new PointF(1f, 1f) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddCurve(points);
+            Assert.Equal(4, gp.PointCount);
+            gp.AddCurve(points);
+            Assert.Equal(7, gp.PointCount);
+        }
+
+        [ActiveIssue(20844)]
+        public void AddCurve()
+        {
+            PointF[] points = new PointF[] {
+                new PointF (37f, 185f),
+                new PointF (99f, 185f),
+                new PointF (161f, 159f),
+                new PointF (223f, 185f),
+                new PointF (285f, 54f),
+            };
+            int[] count = { 4, 7, 10, 13 };
+
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                for (int i = 0; i < points.Length - 1; i++)
+                {
+                    gp.AddCurve(points, i, 1, 0.5f);
+                    // all non-curves points are compressed expect the first one (positioning)
+                    Assert.Equal(count[i], gp.PointCount);
+                }
+
+                Assert.Equal(0, gp.PathData.Types[0]);
+                Assert.Equal(37f, gp.PathData.Points[0].X, Precision);
+                Assert.Equal(185f, gp.PathData.Points[1].Y, Precision);
+                Assert.Equal(3, gp.PathData.Types[1]);
+                Assert.Equal(47.3334f, gp.PathData.Points[1].X, Precision);
+                Assert.Equal(185f, gp.PathData.Points[1].Y, 3);
+                Assert.Equal(3, gp.PathData.Types[2]);
+                Assert.Equal(78.33333f, gp.PathData.Points[2].X, Precision);
+                Assert.Equal(189.3333f, gp.PathData.Points[2].Y, Precision);
+                Assert.Equal(3, gp.PathData.Types[3]);
+                Assert.Equal(99f, gp.PathData.Points[3].X, Precision);
+                Assert.Equal(185f, gp.PathData.Points[3].Y, Precision);
+                Assert.Equal(3, gp.PathData.Types[4]);
+                Assert.Equal(119.6667f, gp.PathData.Points[4].X, Precision);
+                Assert.Equal(180.6667f, gp.PathData.Points[4].Y, Precision);
+                Assert.Equal(3, gp.PathData.Types[5]);
+                Assert.Equal(140.3333f, gp.PathData.Points[5].X, Precision);
+                Assert.Equal(159f, gp.PathData.Points[5].Y, Precision);
+                Assert.Equal(3, gp.PathData.Types[6]);
+                Assert.Equal(161f, gp.PathData.Points[6].X, Precision);
+                Assert.Equal(159f, gp.PathData.Points[6].Y, Precision);
+                Assert.Equal(3, gp.PathData.Types[7]);
+                Assert.Equal(181.6667f, gp.PathData.Points[7].X, Precision);
+                Assert.Equal(159f, gp.PathData.Points[7].Y, Precision);
+                Assert.Equal(3, gp.PathData.Types[8]);
+                Assert.Equal(202.3333f, gp.PathData.Points[8].X, Precision);
+                Assert.Equal(202.5f, gp.PathData.Points[8].Y, Precision);
+                Assert.Equal(3, gp.PathData.Types[9]);
+                Assert.Equal(223f, gp.PathData.Points[9].X, Precision);
+                Assert.Equal(185f, gp.PathData.Points[9].Y, Precision);
+                Assert.Equal(3, gp.PathData.Types[10]);
+                Assert.Equal(243.6667f, gp.PathData.Points[10].X, Precision);
+                Assert.Equal(167.5f, gp.PathData.Points[10].Y, Precision);
+                Assert.Equal(3, gp.PathData.Types[11]);
+                Assert.Equal(274.6667f, gp.PathData.Points[11].X, Precision);
+                Assert.Equal(75.83334f, gp.PathData.Points[11].Y, Precision);
+                Assert.Equal(3, gp.PathData.Types[12]);
+                Assert.Equal(285f, gp.PathData.Points[12].X, Precision);
+                Assert.Equal(54f, gp.PathData.Points[12].Y, Precision);
+            }
+        }
+
+        private FontFamily GetFontFamily()
+        {
+            try
+            {
+                return FontFamily.GenericMonospace;
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(false, "GenericMonospace FontFamily couldn't be found");
+                return null;
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddString_NullString()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            FontFamily ff = GetFontFamily();
+            Assert.Throws<NullReferenceException>(() => gp.AddString(null, ff, 0, 10, new Point(10, 10), StringFormat.GenericDefault));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddString_EmptyString()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            FontFamily ff = GetFontFamily();
+            gp.AddString(String.Empty, ff, 0, 10, new Point(10, 10), StringFormat.GenericDefault);
+            Assert.Equal(0, gp.PointCount);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddString_NullFontFamily()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Assert.Throws<ArgumentException>(() => gp.AddString("mono", null, 0, 10, new Point(10, 10), StringFormat.GenericDefault));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void AddString_NegativeSize()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            FontFamily ff = GetFontFamily();
+            gp.AddString("mono", ff, 0, -10, new Point(10, 10), StringFormat.GenericDefault);
+            Assert.True(gp.PointCount > 0);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetBounds_Empty_Empty()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            RectangleF rect = gp.GetBounds();
+            Assert.Equal(0.0f, rect.X);
+            Assert.Equal(0.0f, rect.Y);
+            Assert.Equal(0.0f, rect.Width);
+            Assert.Equal(0.0f, rect.Height);
+        }
+
+        private void CheckRectangleBounds(RectangleF rect)
+        {
+            Assert.Equal(1.0f, rect.X);
+            Assert.Equal(1.0f, rect.Y);
+            Assert.Equal(2.0f, rect.Width);
+            Assert.Equal(2.0f, rect.Height);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetBounds_Empty_Rectangle()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new Rectangle(1, 1, 2, 2));
+            CheckRectangleBounds(gp.GetBounds());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetBounds_Null_Rectangle()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new Rectangle(1, 1, 2, 2));
+            CheckRectangleBounds(gp.GetBounds(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetBounds_MatrixEmpty_Rectangle()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new Rectangle(1, 1, 2, 2));
+            CheckRectangleBounds(gp.GetBounds(new Matrix()));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetBounds_NullNull_Rectangle()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new Rectangle(1, 1, 2, 2));
+            CheckRectangleBounds(gp.GetBounds(null, null));
+        }
+
+        private void CheckPieBounds(RectangleF rect)
+        {
+            Assert.Equal(60.0f, rect.X, 1);
+            Assert.Equal(60.0f, rect.Y, 1);
+            Assert.Equal(43.3f, rect.Width, 1);
+            Assert.Equal(48.3f, rect.Height, 1);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetBounds_Empty_Pie()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPie(10, 10, 100, 100, 30, 45);
+            CheckPieBounds(gp.GetBounds());
+            gp.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetBounds_Null_Pie()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPie(10, 10, 100, 100, 30, 45);
+            CheckPieBounds(gp.GetBounds(null));
+            gp.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetBounds_MatrixEmpty_Pie()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPie(10, 10, 100, 100, 30, 45);
+            CheckPieBounds(gp.GetBounds(new Matrix()));
+            gp.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetBounds_NullNull_Pie()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddPie(10, 10, 100, 100, 30, 45);
+            CheckPieBounds(gp.GetBounds(null, null));
+            gp.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetBounds_Empty_ClosedCurve()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddClosedCurve(new Point[4] { new Point (20, 100), new Point (70, 10),
+                new Point (130, 200), new Point (180, 100) });
+#if false
+			// so far from reality that it's totally useless
+			Assert.Equal (1.666666f, rect.X, 0.00001);
+			Assert.Equal (-6.66666f, rect.Y, 1);
+			Assert.Equal (196.6666f, rect.Width, 1);
+			Assert.Equal (221.6666f, rect.Height, 1);
+#endif
+            gp.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().Transform(null));
+        }
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Empty()
+        {
+            // no points in path and no exception
+            new GraphicsPath().Transform(new Matrix());
+        }
+
+        private void ComparePaths(GraphicsPath expected, GraphicsPath actual)
+        {
+            Assert.Equal(expected.PointCount, actual.PointCount);
+            for (int i = 0; i < expected.PointCount; i++)
+            {
+                Assert.Equal(expected.PathPoints[i], actual.PathPoints[i]);
+                Assert.Equal(expected.PathTypes[i], actual.PathTypes[i]);
+            }
+        }
+
+        private void CompareFlats(GraphicsPath flat, GraphicsPath original)
+        {
+            Assert.True(flat.PointCount >= original.PointCount);
+            for (int i = 0; i < flat.PointCount; i++)
+            {
+                Assert.True(flat.PathTypes[i] != 3);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_Empty()
+        {
+            GraphicsPath path = new GraphicsPath();
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            // this is a no-op as there's nothing in the path
+            path.Flatten();
+            ComparePaths(path, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_Null()
+        {
+            GraphicsPath path = new GraphicsPath();
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            // this is a no-op as there's nothing in the path
+            // an no matrix to apply
+            path.Flatten(null);
+            ComparePaths(path, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_NullFloat()
+        {
+            GraphicsPath path = new GraphicsPath();
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            // this is a no-op as there's nothing in the path
+            // an no matrix to apply
+            path.Flatten(null, 1f);
+            ComparePaths(path, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_Arc()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddArc(0f, 0f, 100f, 100f, 30, 30);
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            path.Flatten();
+            CompareFlats(path, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_Bezier()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddBezier(0, 0, 100, 100, 30, 30, 60, 60);
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            path.Flatten();
+            CompareFlats(path, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_ClosedCurve()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddClosedCurve(new Point[4] {
+                new Point (0, 0), new Point (40, 20),
+                new Point (20, 40), new Point (40, 40)
+                });
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            path.Flatten();
+            CompareFlats(path, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_Curve()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddCurve(new Point[4] {
+                new Point (0, 0), new Point (40, 20),
+                new Point (20, 40), new Point (40, 40)
+                });
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            path.Flatten();
+            CompareFlats(path, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_Ellipse()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddEllipse(10f, 10f, 100f, 100f);
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            path.Flatten();
+            CompareFlats(path, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_Line()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(10f, 10f, 100f, 100f);
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            path.Flatten();
+            ComparePaths(path, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_Pie()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddPie(0, 0, 100, 100, 30, 30);
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            path.Flatten();
+            CompareFlats(path, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_Polygon()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddPolygon(new Point[4] {
+                new Point (0, 0), new Point (10, 10),
+                new Point (20, 20), new Point (40, 40)
+                });
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            path.Flatten();
+            ComparePaths(path, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Flatten_Rectangle()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddRectangle(new Rectangle(0, 0, 100, 100));
+            GraphicsPath clone = (GraphicsPath)path.Clone();
+            path.Flatten();
+            ComparePaths(path, clone);
+        }
+
+        private void CheckWrap(GraphicsPath path)
+        {
+            Assert.Equal(3, path.PointCount);
+
+            PointF[] pts = path.PathPoints;
+            Assert.Equal(0, pts[0].X, Precision);
+            Assert.Equal(0, pts[0].Y, Precision);
+            Assert.Equal(0, pts[1].X, Precision);
+            Assert.Equal(0, pts[1].Y, Precision);
+            Assert.Equal(0, pts[2].X, Precision);
+            Assert.Equal(0, pts[2].Y, Precision);
+
+            byte[] types = path.PathTypes;
+            Assert.Equal(0, types[0]);
+            Assert.Equal(1, types[1]);
+            Assert.Equal(129, types[2]);
+        }
+
+        private void CheckWrapNaN(GraphicsPath path, bool closed)
+        {
+            Assert.Equal(3, path.PointCount);
+
+            PointF[] pts = path.PathPoints;
+            Assert.Equal(Single.NaN, pts[0].X);
+            Assert.Equal(Single.NaN, pts[0].Y);
+            Assert.Equal(Single.NaN, pts[1].X);
+            Assert.Equal(Single.NaN, pts[1].Y);
+            Assert.Equal(Single.NaN, pts[2].X);
+            Assert.Equal(Single.NaN, pts[2].Y);
+
+            byte[] types = path.PathTypes;
+            Assert.Equal(0, types[0]);
+            Assert.Equal(1, types[1]);
+            Assert.Equal(closed ? 129 : 1, types[2]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Warp_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().Warp(null, new RectangleF()));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Warp_NoPoints()
+        {
+            Assert.Throws<ArgumentException>(() => new GraphicsPath().Warp(new PointF[0], new RectangleF()));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Wrap_NoPoint()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                Assert.Equal(0, gp.PointCount);
+
+                PointF[] pts = new PointF[1] { new PointF(0, 0) };
+                RectangleF r = new RectangleF(10, 20, 30, 40);
+                gp.Warp(pts, r, new Matrix());
+                Assert.Equal(0, gp.PointCount);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Warp_Invalid()
+        {
+            PointF[] pts = new PointF[1] { new PointF(0, 0) };
+            GraphicsPath path = new GraphicsPath();
+            path.AddPolygon(new Point[3] { new Point(5, 5), new Point(15, 5), new Point(10, 15) });
+            RectangleF r = new RectangleF(10, 20, 30, 40);
+            path.Warp(pts, r, new Matrix(), (WarpMode)Int32.MinValue);
+            Assert.Equal(0, path.PointCount);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetMarkers_EmptyPath()
+        {
+            new GraphicsPath().SetMarkers();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ClearMarkers_EmptyPath()
+        {
+            new GraphicsPath().ClearMarkers();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CloseFigure_EmptyPath()
+        {
+            new GraphicsPath().CloseFigure();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CloseAllFigures_EmptyPath()
+        {
+            new GraphicsPath().CloseAllFigures();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddArc()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddArc(10, 10, 100, 100, 90, 180);
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(1, types[2]);
+            // check last types
+            Assert.Equal(3, types[path.PointCount - 3]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddBezier()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddBezier(10, 10, 100, 100, 20, 20, 200, 200);
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(1, types[2]);
+            // check last types
+            Assert.Equal(3, types[path.PointCount - 3]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddBeziers()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddBeziers(new Point[7] { new Point (10, 10),
+                new Point (20, 10), new Point (20, 20), new Point (30, 20),
+                new Point (40, 40), new Point (50, 40), new Point (50, 50)
+            });
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(1, types[2]);
+            // check last types
+            Assert.Equal(3, types[path.PointCount - 3]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddClosedCurve()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddClosedCurve(new Point[3] { new Point(1, 1), new Point(2, 2), new Point(3, 3) });
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(0, types[2]);
+            // check last types
+            Assert.Equal(131, types[path.PointCount - 3]);
+            Assert.Equal(0, types[path.PointCount - 2]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddCurve()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddCurve(new Point[3] { new Point(1, 1), new Point(2, 2), new Point(3, 3) });
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(1, types[2]);
+            // check last types
+            Assert.Equal(3, types[path.PointCount - 3]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddEllipse()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddEllipse(10, 10, 100, 100);
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(0, types[2]);
+            // check last types
+            Assert.Equal(131, types[path.PointCount - 3]);
+            Assert.Equal(0, types[path.PointCount - 2]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddLine()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddLine(5, 5, 10, 10);
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(1, types[2]);
+            // check last types
+            Assert.Equal(1, types[path.PointCount - 3]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddLines()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddLines(new Point[4] { new Point(10, 10), new Point(20, 10), new Point(20, 20), new Point(30, 20) });
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(1, types[2]);
+            // check last types
+            Assert.Equal(1, types[path.PointCount - 3]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddPath_Connect()
+        {
+            GraphicsPath inner = new GraphicsPath();
+            inner.AddArc(10, 10, 100, 100, 90, 180);
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddPath(inner, true);
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(1, types[2]);
+            // check last types
+            Assert.Equal(3, types[path.PointCount - 3]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddPath_NoConnect()
+        {
+            GraphicsPath inner = new GraphicsPath();
+            inner.AddArc(10, 10, 100, 100, 90, 180);
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddPath(inner, false);
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(0, types[2]);
+            // check last types
+            Assert.Equal(3, types[path.PointCount - 3]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddPie()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddPie(10, 10, 10, 10, 90, 180);
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(0, types[2]);
+            // check last types
+            // libgdiplus draws pie by ending with a line (not a curve) section
+            Assert.True((types[path.PointCount - 3] & 128) == 128);
+            Assert.Equal(0, types[path.PointCount - 2]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddPolygon()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddPolygon(new Point[3] { new Point(1, 1), new Point(2, 2), new Point(3, 3) });
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(0, types[2]);
+            // check last types
+            Assert.Equal(129, types[path.PointCount - 3]);
+            Assert.Equal(0, types[path.PointCount - 2]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddRectangle()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddRectangle(new RectangleF(10, 10, 20, 20));
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(0, types[2]);
+            // check last types
+            Assert.Equal(129, types[path.PointCount - 3]);
+            Assert.Equal(0, types[path.PointCount - 2]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartClose_AddRectangles()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddLine(1, 1, 2, 2);
+            path.AddRectangles(new RectangleF[2] {
+                new RectangleF (10, 10, 20, 20),
+                new RectangleF (20, 20, 10, 10) });
+            path.AddLine(10, 10, 20, 20);
+            byte[] types = path.PathTypes;
+            // check first types
+            Assert.Equal(0, types[0]);
+            Assert.Equal(0, types[2]);
+            // check last types
+            Assert.Equal(129, types[path.PointCount - 3]);
+            Assert.Equal(0, types[path.PointCount - 2]);
+            Assert.Equal(1, types[path.PointCount - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Widen_Pen_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().Widen(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Widen_Pen_Null_Matrix()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().Widen(null, new Matrix()));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Widen_NoPoint()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                Assert.Equal(0, gp.PointCount);
+                Pen pen = new Pen(Color.Blue);
+                gp.Widen(pen);
+                Assert.Equal(0, gp.PointCount);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Widen_SinglePoint()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(new Point[1] { new Point(1, 1) });
+                // Special case - a line with a single point is valid
+                Assert.Equal(1, gp.PointCount);
+                Assert.Throws<OutOfMemoryException>(() => gp.Widen(Pens.Red));
+                // oops );-)
+            }
+        }
+
+        private void CheckWiden3(GraphicsPath path)
+        {
+            PointF[] pts = path.PathPoints;
+            Assert.Equal(4.2, pts[0].X, LowPrecision);
+            Assert.Equal(4.5, pts[0].Y, LowPrecision);
+            Assert.Equal(15.8, pts[1].X, LowPrecision);
+            Assert.Equal(4.5, pts[1].Y, LowPrecision);
+            Assert.Equal(10.0, pts[2].X, LowPrecision);
+            Assert.Equal(16.1, pts[2].Y, LowPrecision);
+            Assert.Equal(10.4, pts[3].X, LowPrecision);
+            Assert.Equal(14.8, pts[3].Y, LowPrecision);
+            Assert.Equal(9.6, pts[4].X, LowPrecision);
+            Assert.Equal(14.8, pts[4].Y, LowPrecision);
+            Assert.Equal(14.6, pts[5].X, LowPrecision);
+            Assert.Equal(4.8, pts[5].Y, LowPrecision);
+            Assert.Equal(15.0, pts[6].X, LowPrecision);
+            Assert.Equal(5.5, pts[6].Y, LowPrecision);
+            Assert.Equal(5.0, pts[7].X, LowPrecision);
+            Assert.Equal(5.5, pts[7].Y, LowPrecision);
+            Assert.Equal(5.4, pts[8].X, LowPrecision);
+            Assert.Equal(4.8, pts[8].Y, LowPrecision);
+
+            byte[] types = path.PathTypes;
+            Assert.Equal(0, types[0]);
+            Assert.Equal(1, types[1]);
+            Assert.Equal(129, types[2]);
+            Assert.Equal(0, types[3]);
+            Assert.Equal(1, types[4]);
+            Assert.Equal(1, types[5]);
+            Assert.Equal(1, types[6]);
+            Assert.Equal(1, types[7]);
+            Assert.Equal(129, types[8]);
+        }
+
+        private void CheckWidenedBounds(string message, GraphicsPath gp, Matrix m)
+        {
+            RectangleF bounds = gp.GetBounds(m);
+            Assert.Equal(0.5f, bounds.X, Precision);
+            Assert.Equal(0.5f, bounds.Y, Precision);
+            Assert.Equal(3.0f, bounds.Width, Precision);
+            Assert.Equal(3.0f, bounds.Height, Precision);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOutlineVisible_IntNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().IsOutlineVisible(1, 1, null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOutlineVisible_FloatNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().IsOutlineVisible(1.0f, 1.0f, null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOutlineVisible_PointNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().IsOutlineVisible(new Point(), null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOutlineVisible_PointFNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath().IsOutlineVisible(new PointF(), null));
+        }
+
+        private void IsOutlineVisible_Line(Graphics graphics)
+        {
+            Pen p2 = new Pen(Color.Red, 3.0f);
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLine(10, 1, 14, 1);
+                Assert.True(gp.IsOutlineVisible(10, 1, Pens.Red, graphics));
+                Assert.True(gp.IsOutlineVisible(10, 2, p2, graphics));
+                Assert.False(gp.IsOutlineVisible(10, 2, Pens.Red, graphics));
+
+                Assert.True(gp.IsOutlineVisible(11.0f, 1.0f, Pens.Red, graphics));
+                Assert.True(gp.IsOutlineVisible(11.0f, 1.0f, p2, graphics));
+                Assert.False(gp.IsOutlineVisible(11.0f, 2.0f, Pens.Red, graphics));
+
+                Point pt = new Point(12, 2);
+                Assert.False(gp.IsOutlineVisible(pt, Pens.Red, graphics));
+                Assert.True(gp.IsOutlineVisible(pt, p2, graphics));
+                pt.Y = 1;
+                Assert.True(gp.IsOutlineVisible(pt, Pens.Red, graphics));
+
+                PointF pf = new PointF(13.0f, 2.0f);
+                Assert.False(gp.IsOutlineVisible(pf, Pens.Red, graphics));
+                Assert.True(gp.IsOutlineVisible(pf, p2, graphics));
+                pf.Y = 1;
+                Assert.True(gp.IsOutlineVisible(pf, Pens.Red, graphics));
+            }
+            p2.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOutlineVisible_Line_WithoutGraphics()
+        {
+            IsOutlineVisible_Line(null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOutlineVisible_Line_WithGraphics_Inside()
+        {
+            using (Bitmap bitmap = new Bitmap(20, 20))
+            {
+                using (Graphics g = Graphics.FromImage(bitmap))
+                {
+                    IsOutlineVisible_Line(g);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOutlineVisible_Line_WithGraphics_Outside()
+        {
+            using (Bitmap bitmap = new Bitmap(5, 5))
+            {
+                using (Graphics g = Graphics.FromImage(bitmap))
+                {
+                    IsOutlineVisible_Line(g);
+                }
+                // graphics "seems" ignored as the line is outside the bitmap!
+            }
+        }
+
+        // docs ways the point is in world coordinates and that the graphics transform 
+        // should be applied
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOutlineVisible_Line_WithGraphics_Transform()
+        {
+            using (Bitmap bitmap = new Bitmap(20, 20))
+            {
+                using (Graphics g = Graphics.FromImage(bitmap))
+                {
+                    g.Transform = new Matrix(2, 0, 0, 2, 50, -50);
+                    IsOutlineVisible_Line(g);
+                }
+                // graphics still "seems" ignored (Transform)
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOutlineVisible_Line_WithGraphics_PageUnit()
+        {
+            using (Bitmap bitmap = new Bitmap(20, 20))
+            {
+                using (Graphics g = Graphics.FromImage(bitmap))
+                {
+                    g.PageUnit = GraphicsUnit.Millimeter;
+                    IsOutlineVisible_Line(g);
+                }
+                // graphics still "seems" ignored (PageUnit)
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOutlineVisible_Line_WithGraphics_PageScale()
+        {
+            using (Bitmap bitmap = new Bitmap(20, 20))
+            {
+                using (Graphics g = Graphics.FromImage(bitmap))
+                {
+                    g.PageScale = 2.0f;
+                    IsOutlineVisible_Line(g);
+                }
+                // graphics still "seems" ignored (PageScale)
+            }
+        }
+
+        private void IsOutlineVisible_Rectangle(Graphics graphics)
+        {
+            Pen p2 = new Pen(Color.Red, 3.0f);
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddRectangle(new Rectangle(10, 10, 20, 20));
+                Assert.True(gp.IsOutlineVisible(10, 10, Pens.Red, graphics));
+                Assert.True(gp.IsOutlineVisible(10, 11, p2, graphics));
+                Assert.False(gp.IsOutlineVisible(11, 11, Pens.Red, graphics));
+
+                Assert.True(gp.IsOutlineVisible(11.0f, 10.0f, Pens.Red, graphics));
+                Assert.True(gp.IsOutlineVisible(11.0f, 11.0f, p2, graphics));
+                Assert.False(gp.IsOutlineVisible(11.0f, 11.0f, Pens.Red, graphics));
+
+                Point pt = new Point(15, 10);
+                Assert.True(gp.IsOutlineVisible(pt, Pens.Red, graphics));
+                Assert.True(gp.IsOutlineVisible(pt, p2, graphics));
+                pt.Y = 15;
+                Assert.False(gp.IsOutlineVisible(pt, Pens.Red, graphics));
+
+                PointF pf = new PointF(29.0f, 29.0f);
+                Assert.False(gp.IsOutlineVisible(pf, Pens.Red, graphics));
+                Assert.True(gp.IsOutlineVisible(pf, p2, graphics));
+                pf.Y = 31.0f;
+                Assert.True(gp.IsOutlineVisible(pf, p2, graphics));
+            }
+            p2.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOutlineVisible_Rectangle_WithoutGraphics()
+        {
+            IsOutlineVisible_Rectangle(null);
+        }
+
+        private void IsVisible_Rectangle(Graphics graphics)
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddRectangle(new Rectangle(10, 10, 20, 20));
+                Assert.False(gp.IsVisible(9, 9, graphics));
+                Assert.True(gp.IsVisible(10, 10, graphics));
+                Assert.True(gp.IsVisible(20, 20, graphics));
+                Assert.True(gp.IsVisible(29, 29, graphics));
+                Assert.False(gp.IsVisible(30, 29, graphics));
+                Assert.False(gp.IsVisible(29, 30, graphics));
+                Assert.False(gp.IsVisible(30, 30, graphics));
+
+                Assert.False(gp.IsVisible(9.4f, 9.4f, graphics));
+                Assert.True(gp.IsVisible(9.5f, 9.5f, graphics));
+                Assert.True(gp.IsVisible(10f, 10f, graphics));
+                Assert.True(gp.IsVisible(20f, 20f, graphics));
+                // the next diff is too close, so this fails with libgdiplus/cairo
+                //Assert.True (gp.IsVisible (29.4f, 29.4f, graphics));
+                Assert.False(gp.IsVisible(29.5f, 29.5f, graphics));
+                Assert.False(gp.IsVisible(29.5f, 29.4f, graphics));
+                Assert.False(gp.IsVisible(29.4f, 29.5f, graphics));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_Rectangle_WithoutGraphics()
+        {
+            IsVisible_Rectangle(null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_Rectangle_WithGraphics()
+        {
+            using (Bitmap bitmap = new Bitmap(40, 40))
+            {
+                using (Graphics g = Graphics.FromImage(bitmap))
+                {
+                    IsVisible_Rectangle(g);
+                }
+            }
+        }
+
+        // bug #325502 has shown that ellipse didn't work with earlier code
+        private void IsVisible_Ellipse(Graphics graphics)
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddEllipse(new Rectangle(10, 10, 20, 20));
+                Assert.False(gp.IsVisible(10, 10, graphics));
+                Assert.True(gp.IsVisible(20, 20, graphics));
+                Assert.False(gp.IsVisible(29, 29, graphics));
+
+                Assert.False(gp.IsVisible(10f, 10f, graphics));
+                Assert.True(gp.IsVisible(20f, 20f, graphics));
+                Assert.False(gp.IsVisible(29.4f, 29.4f, graphics));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_Ellipse_WithoutGraphics()
+        {
+            IsVisible_Ellipse(null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_Ellipse_WithGraphics()
+        {
+            using (Bitmap bitmap = new Bitmap(40, 40))
+            {
+                using (Graphics g = Graphics.FromImage(bitmap))
+                {
+                    IsVisible_Ellipse(g);
+                }
+            }
+        }
+
+        // Reverse simple test cases
+
+        private void Reverse(GraphicsPath gp)
+        {
+            PointF[] bp = gp.PathPoints;
+            byte[] bt = gp.PathTypes;
+
+            gp.Reverse();
+            PointF[] ap = gp.PathPoints;
+            byte[] at = gp.PathTypes;
+
+            int count = gp.PointCount;
+            Assert.Equal(bp.Length, count);
+            for (int i = 0; i < count; i++)
+            {
+                Assert.Equal(bp[i], ap[count - i - 1]);
+                Assert.Equal(bt[i], at[i]);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Arc()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddArc(1f, 1f, 2f, 2f, Pi4, Pi4);
+                Reverse(gp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Bezier()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddBezier(1, 2, 3, 4, 5, 6, 7, 8);
+                Reverse(gp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Beziers()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                Point[] beziers = new Point[] { new Point (1,2), new Point (3,4), new Point (5,6),
+                    new Point (7,8), new Point (9,10), new Point (11,12), new Point (13,14) };
+                gp.AddBeziers(beziers);
+                Reverse(gp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_ClosedCurve()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                Point[] beziers = new Point[] { new Point (1,2), new Point (3,4), new Point (5,6),
+                    new Point (7,8), new Point (9,10), new Point (11,12), new Point (13,14) };
+                gp.AddClosedCurve(beziers);
+                Reverse(gp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Curve()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                Point[] beziers = new Point[] { new Point (1,2), new Point (3,4), new Point (5,6),
+                    new Point (7,8), new Point (9,10), new Point (11,12), new Point (13,14) };
+                gp.AddCurve(beziers);
+                Reverse(gp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Ellipse()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddEllipse(1, 2, 3, 4);
+                Reverse(gp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Line()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLine(1, 2, 3, 4);
+                Reverse(gp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Line_Closed()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLine(1, 2, 3, 4);
+                gp.CloseFigure();
+                Reverse(gp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Lines()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                Point[] points = new Point[] { new Point (1,2), new Point (3,4), new Point (5,6),
+                    new Point (7,8), new Point (9,10), new Point (11,12), new Point (13,14) };
+                gp.AddLines(points);
+                Reverse(gp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Polygon()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                Point[] points = new Point[] { new Point (1,2), new Point (3,4), new Point (5,6),
+                    new Point (7,8), new Point (9,10), new Point (11,12), new Point (13,14) };
+                gp.AddPolygon(points);
+                Reverse(gp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Rectangle()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddRectangle(new Rectangle(1, 2, 3, 4));
+                Reverse(gp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Rectangles()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                Rectangle[] rects = new Rectangle[] { new Rectangle(1, 2, 3, 4), new Rectangle(5, 6, 7, 8) };
+                gp.AddRectangles(rects);
+                Reverse(gp);
+            }
+        }
+
+        // Reverse complex test cases
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Path()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                GraphicsPath path = new GraphicsPath();
+                path.AddArc(1f, 1f, 2f, 2f, Pi4, Pi4);
+                path.AddLine(1, 2, 3, 4);
+                gp.AddPath(path, true);
+                PointF[] bp = gp.PathPoints;
+                byte[] expected = new byte[] { 0, 1, 1, 3, 3, 3 };
+
+                gp.Reverse();
+                PointF[] ap = gp.PathPoints;
+                byte[] at = gp.PathTypes;
+
+                int count = gp.PointCount;
+                Assert.Equal(bp.Length, count);
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.Equal(bp[i], ap[count - i - 1]);
+                    Assert.Equal(expected[i], at[i]);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Path_2()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddEllipse(50, 51, 50, 100);
+                gp.AddRectangle(new Rectangle(200, 201, 60, 61));
+                PointF[] bp = gp.PathPoints;
+                byte[] expected = new byte[] { 0, 1, 1, 129, 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 131 };
+
+                gp.Reverse();
+                PointF[] ap = gp.PathPoints;
+                byte[] at = gp.PathTypes;
+
+                int count = gp.PointCount;
+                Assert.Equal(bp.Length, count);
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.Equal(bp[i], ap[count - i - 1]);
+                    Assert.Equal(expected[i], at[i]);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Marker()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddRectangle(new Rectangle(200, 201, 60, 61));
+                gp.SetMarkers();
+                PointF[] bp = gp.PathPoints;
+                byte[] expected = new byte[] { 0, 1, 1, 129 };
+
+                gp.Reverse();
+                PointF[] ap = gp.PathPoints;
+                byte[] at = gp.PathTypes;
+
+                int count = gp.PointCount;
+                Assert.Equal(bp.Length, count);
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.Equal(bp[i], ap[count - i - 1]);
+                    Assert.Equal(expected[i], at[i]);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Subpath_Marker()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLine(0, 1, 2, 3);
+                gp.SetMarkers();
+                gp.CloseFigure();
+                gp.AddBezier(5, 6, 7, 8, 9, 10, 11, 12);
+                gp.CloseFigure();
+                PointF[] bp = gp.PathPoints;
+                byte[] expected = new byte[] { 0, 3, 3, 163, 0, 129 };
+
+                gp.Reverse();
+                PointF[] ap = gp.PathPoints;
+                byte[] at = gp.PathTypes;
+
+                int count = gp.PointCount;
+                Assert.Equal(bp.Length, count);
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.Equal(bp[i], ap[count - i - 1]);
+                    Assert.Equal(expected[i], at[i]);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reverse_Subpath_Marker_2()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLine(0, 1, 2, 3);
+                gp.SetMarkers();
+                gp.StartFigure();
+                gp.AddLine(20, 21, 22, 23);
+                gp.AddBezier(5, 6, 7, 8, 9, 10, 11, 12);
+                PointF[] bp = gp.PathPoints;
+                byte[] expected = new byte[] { 0, 3, 3, 3, 1, 33, 0, 1 };
+
+                gp.Reverse();
+                PointF[] ap = gp.PathPoints;
+                byte[] at = gp.PathTypes;
+
+                int count = gp.PointCount;
+                Assert.Equal(bp.Length, count);
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.Equal(bp[i], ap[count - i - 1]);
+                    Assert.Equal(expected[i], at[i]);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void bug413461()
+        {
+            int dX = 520;
+            int dY = 320;
+            Point[] expected_points = new Point[] {
+                new Point(dX-64, dY-24),//start
+				new Point(dX-59, dY-34),//focal point 1
+				new Point(dX-52, dY-54),//focal point 2
+				new Point(dX-18, dY-66),//top
+				new Point(dX-34, dY-47),//focal point 1
+				new Point(dX-43, dY-27),//focal point 2
+				new Point(dX-44, dY-8),//end
+				};
+            byte[] expected_types = new byte[] {
+                (byte)PathPointType.Start,
+                (byte)PathPointType.Bezier,
+                (byte)PathPointType.Bezier,
+                (byte)PathPointType.Bezier,
+                (byte)PathPointType.Bezier,
+                (byte)PathPointType.Bezier,
+                (byte)PathPointType.Bezier };
+            using (GraphicsPath path = new GraphicsPath(expected_points, expected_types))
+            {
+                Assert.Equal(7, path.PointCount);
+                byte[] actual_types = path.PathTypes;
+                Assert.Equal(expected_types[0], actual_types[0]);
+                Assert.Equal(expected_types[1], actual_types[1]);
+                Assert.Equal(expected_types[2], actual_types[2]);
+                Assert.Equal(expected_types[3], actual_types[3]);
+                Assert.Equal(expected_types[4], actual_types[4]);
+                Assert.Equal(expected_types[5], actual_types[5]);
+                // path is filled like closed but this does not show on the type
+                Assert.Equal(expected_types[6], actual_types[6]);
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/LinearGradientBrushTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/LinearGradientBrushTest.cs
@@ -1,0 +1,862 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.Drawing2D.LinearGradientBrush unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006, 2008 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing.Drawing2D
+{
+
+    public class LinearGradientBrushTest
+    {
+
+        private Point pt1;
+        private Point pt2;
+        private Color c1;
+        private Color c2;
+        private LinearGradientBrush default_brush;
+        private Matrix empty_matrix;
+        private RectangleF rect;
+
+        public LinearGradientBrushTest()
+        {
+            pt1 = new Point(0, 0);
+            pt2 = new Point(32, 32);
+            c1 = Color.Blue;
+            c2 = Color.Red;
+            default_brush = new LinearGradientBrush(pt1, pt2, c1, c2);
+            empty_matrix = new Matrix();
+            rect = new RectangleF(0, 0, 32, 32);
+        }
+
+        private void CheckDefaultRectangle(string msg, RectangleF rect)
+        {
+            Assert.Equal(pt1.X, rect.X);
+            Assert.Equal(pt1.Y, rect.Y);
+            Assert.Equal(pt2.X, rect.Width);
+            Assert.Equal(pt2.Y, rect.Height);
+        }
+
+        private void CheckDefaultMatrix(Matrix matrix)
+        {
+            float[] elements = matrix.Elements;
+            Assert.Equal(1.0f, elements[0], 1);
+            Assert.Equal(1.0f, elements[1], 1);
+            Assert.Equal(-1.0f, elements[2], 1);
+            Assert.Equal(1.0f, elements[3], 1);
+            Assert.Equal(16.0f, elements[4], 1);
+            Assert.Equal(-16.0f, elements[5], 1);
+        }
+
+        private void CheckBrushAt45(LinearGradientBrush lgb)
+        {
+            CheckDefaultRectangle("4", lgb.Rectangle);
+            Assert.Equal(1, lgb.Blend.Factors.Length);
+            Assert.Equal(1, lgb.Blend.Factors[0]);
+            Assert.Equal(1, lgb.Blend.Positions.Length);
+            // lgb.Blend.Positions [0] is always small (e-39) but never quite the same
+            Assert.False(lgb.GammaCorrection);
+            Assert.Equal(2, lgb.LinearColors.Length);
+            Assert.NotNull(lgb.Transform);
+            CheckDefaultMatrix(lgb.Transform);
+        }
+
+        private void CheckMatrixAndRect(PointF pt1, PointF pt2, float[] testVals)
+        {
+            Matrix m;
+            RectangleF rect;
+
+            using (LinearGradientBrush b = new LinearGradientBrush(pt1, pt2, Color.Black, Color.White))
+            {
+                m = b.Transform;
+                rect = b.Rectangle;
+            }
+
+            Assert.Equal(testVals[0], m.Elements[0], 3);
+            Assert.Equal(testVals[1], m.Elements[1], 3);
+            Assert.Equal(testVals[2], m.Elements[2], 3);
+            Assert.Equal(testVals[3], m.Elements[3], 3);
+            Assert.Equal(testVals[4], m.Elements[4], 3);
+            Assert.Equal(testVals[5], m.Elements[5], 3);
+
+            Assert.Equal(testVals[6], rect.X, 3);
+            Assert.Equal(testVals[7], rect.Y, 3);
+            Assert.Equal(testVals[8], rect.Width, 3);
+            Assert.Equal(testVals[9], rect.Height, 3);
+        }
+
+        private void CheckMatrixForScalableAngle(RectangleF rect, float angle, float[] testVals)
+        {
+            Matrix m;
+
+            using (LinearGradientBrush b = new LinearGradientBrush(rect, Color.Firebrick, Color.Lavender, angle, true))
+            {
+                m = b.Transform;
+            }
+
+            Assert.Equal(testVals[0], m.Elements[0], 3);
+            Assert.Equal(testVals[1], m.Elements[1], 3);
+            Assert.Equal(testVals[2], m.Elements[2], 3);
+            Assert.Equal(testVals[3], m.Elements[3], 3);
+            Assert.Equal(testVals[4], m.Elements[4], 3);
+            Assert.Equal(testVals[5], m.Elements[5], 3);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Point_Point_Color_Color()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(pt1, pt2, c1, c2);
+            CheckBrushAt45(lgb);
+
+            Assert.Equal(WrapMode.Tile, lgb.WrapMode);
+            lgb.WrapMode = WrapMode.TileFlipX;
+            Assert.Equal(WrapMode.TileFlipX, lgb.WrapMode);
+            lgb.WrapMode = WrapMode.TileFlipY;
+            Assert.Equal(WrapMode.TileFlipY, lgb.WrapMode);
+            lgb.WrapMode = WrapMode.TileFlipXY;
+            Assert.Equal(WrapMode.TileFlipXY, lgb.WrapMode);
+            // can't set WrapMode.Clamp
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Point_Point_Color_Color_1()
+        {
+            PointF pt1 = new Point(100, 200);
+            PointF pt2 = new Point(200, 200);
+            CheckMatrixAndRect(pt1, pt2, new float[] { 1, 0, 0, 1, 0, 0, 100, 150, 100, 100 });
+
+            pt1 = new Point(100, 200);
+            pt2 = new Point(0, 200);
+            CheckMatrixAndRect(pt1, pt2, new float[] { -1, 0, 0, -1, 100, 400, 0, 150, 100, 100 });
+
+            pt1 = new Point(100, 200);
+            pt2 = new Point(100, 300);
+            CheckMatrixAndRect(pt1, pt2, new float[] { 0, 1, -1, 0, 350, 150, 50, 200, 100, 100 });
+
+            pt1 = new Point(100, 200);
+            pt2 = new Point(100, 100);
+            CheckMatrixAndRect(pt1, pt2, new float[] { 0, -1, 1, 0, -50, 250, 50, 100, 100, 100 });
+
+            pt1 = new Point(100, 100);
+            pt2 = new Point(150, 225);
+            CheckMatrixAndRect(pt1, pt2, new float[] { 1, 2.5f, -0.6896552f, 0.2758622f, 112.069f, -194.8276f, 100, 100, 50, 125 });
+
+            pt1 = new Point(100, 100);
+            pt2 = new Point(55, 200);
+            CheckMatrixAndRect(pt1, pt2, new float[] { -1, 2.222222f, -0.7484408f, -0.3367983f, 267.2661f, 28.29753f, 55, 100, 45, 100 });
+
+            pt1 = new Point(100, 100);
+            pt2 = new Point(150, 60);
+            CheckMatrixAndRect(pt1, pt2, new float[] { 1, -0.8000001f, 0.9756095f, 1.219512f, -78.04876f, 82.43903f, 100, 60, 50, 40 });
+
+            pt1 = new Point(100, 100);
+            pt2 = new Point(27, 59);
+            CheckMatrixAndRect(pt1, pt2, new float[] { -1, -0.5616435f, 0.8539224f, -1.520399f, 59.11317f, 236.0361f, 27, 59, 73, 41 });
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RectangleF_Color_Color_Single_0()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 0f);
+            CheckDefaultRectangle("Original", lgb.Rectangle);
+            Assert.Equal(1, lgb.Blend.Factors.Length);
+            Assert.Equal(1, lgb.Blend.Factors[0]);
+            Assert.Equal(1, lgb.Blend.Positions.Length);
+            // lgb.Blend.Positions [0] is always small (e-39) but never quite the same
+            Assert.False(lgb.GammaCorrection);
+            Assert.Equal(c1.ToArgb(), lgb.LinearColors[0].ToArgb());
+            Assert.Equal(c2.ToArgb(), lgb.LinearColors[1].ToArgb());
+            Assert.Equal(rect, lgb.Rectangle);
+            Assert.True(lgb.Transform.IsIdentity);
+            Assert.Equal(WrapMode.Tile, lgb.WrapMode);
+
+            Matrix matrix = new Matrix(2, -1, 1, 2, 10, 10);
+            lgb.Transform = matrix;
+            Assert.Equal(matrix, lgb.Transform);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RectangleF_Color_Color_Single_22_5()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 22.5f);
+            CheckDefaultRectangle("Original", lgb.Rectangle);
+            float[] elements = lgb.Transform.Elements;
+            Assert.Equal(1.207107, elements[0], 4);
+            Assert.Equal(0.5, elements[1], 4);
+            Assert.Equal(-0.5, elements[2], 4);
+            Assert.Equal(1.207107, elements[3], 4);
+            Assert.Equal(4.686291, elements[4], 4);
+            Assert.Equal(-11.313709, elements[5], 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RectangleF_Color_Color_Single_45()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 45f);
+            CheckBrushAt45(lgb);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RectangleF_Color_Color_Single_90()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 90f);
+            CheckDefaultRectangle("Original", lgb.Rectangle);
+            float[] elements = lgb.Transform.Elements;
+            Assert.Equal(0, elements[0], 4);
+            Assert.Equal(1, elements[1], 4);
+            Assert.Equal(-1, elements[2], 4);
+            Assert.Equal(0, elements[3], 4);
+            Assert.Equal(32, elements[4], 4);
+            Assert.Equal(0, elements[5], 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RectangleF_Color_Color_Single_135()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 135f);
+            CheckDefaultRectangle("Original", lgb.Rectangle);
+            float[] elements = lgb.Transform.Elements;
+            Assert.Equal(-1, elements[0], 4);
+            Assert.Equal(1, elements[1], 4);
+            Assert.Equal(-1, elements[2], 4);
+            Assert.Equal(-1, elements[3], 4);
+            Assert.Equal(48, elements[4], 4);
+            Assert.Equal(16, elements[5], 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RectangleF_Color_Color_Single_180()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 180f);
+            CheckDefaultRectangle("Original", lgb.Rectangle);
+            float[] elements = lgb.Transform.Elements;
+            Assert.Equal(-1, elements[0], 4);
+            Assert.Equal(0, elements[1], 4);
+            Assert.Equal(0, elements[2], 4);
+            Assert.Equal(-1, elements[3], 4);
+            Assert.Equal(32, elements[4], 4);
+            Assert.Equal(32, elements[5], 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RectangleF_Color_Color_Single_270()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 270f);
+            CheckDefaultRectangle("Original", lgb.Rectangle);
+            float[] elements = lgb.Transform.Elements;
+            Assert.Equal(0, elements[0], 4);
+            Assert.Equal(-1, elements[1], 4);
+            Assert.Equal(1, elements[2], 4);
+            Assert.Equal(0, elements[3], 4);
+            Assert.Equal(0, elements[4], 4);
+            Assert.Equal(32, elements[5], 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RectangleF_Color_Color_Single_315()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 315f);
+            CheckDefaultRectangle("Original", lgb.Rectangle);
+            float[] elements = lgb.Transform.Elements;
+            Assert.Equal(1, elements[0], 4);
+            Assert.Equal(-1, elements[1], 4);
+            Assert.Equal(1, elements[2], 4);
+            Assert.Equal(1, elements[3], 4);
+            Assert.Equal(-16, elements[4], 4);
+            Assert.Equal(16, elements[5], 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RectangleF_Color_Color_Single_360()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 360f);
+            CheckDefaultRectangle("Original", lgb.Rectangle);
+            float[] elements = lgb.Transform.Elements;
+            // just like 0'
+            Assert.Equal(1, elements[0], 4);
+            Assert.Equal(0, elements[1], 4);
+            Assert.Equal(0, elements[2], 4);
+            Assert.Equal(1, elements[3], 4);
+            Assert.Equal(0, elements[4], 4);
+            Assert.Equal(0, elements[5], 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RectangleF_Color_Color_Single_540()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 540f);
+            CheckDefaultRectangle("Original", lgb.Rectangle);
+            float[] elements = lgb.Transform.Elements;
+            // just like 180'
+            Assert.Equal(-1, elements[0], 4);
+            Assert.Equal(0, elements[1], 4);
+            Assert.Equal(0, elements[2], 4);
+            Assert.Equal(-1, elements[3], 4);
+            Assert.Equal(32, elements[4], 4);
+            Assert.Equal(32, elements[5], 4);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InterpolationColors_Colors_InvalidBlend()
+        {
+            // default Blend doesn't allow getting this property
+            Assert.Throws<ArgumentException>(() => { var x = default_brush.InterpolationColors.Colors; });
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InterpolationColors_Positions_InvalidBlend()
+        {
+            // default Blend doesn't allow getting this property
+            Assert.Throws<ArgumentException>(() => { var x = default_brush.InterpolationColors.Positions; });
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LinearColors_Empty()
+        {
+            Assert.Throws<IndexOutOfRangeException>(() => default_brush.LinearColors = new Color[0]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LinearColors_One()
+        {
+            Assert.Throws<IndexOutOfRangeException>(() => default_brush.LinearColors = new Color[1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LinearColors_Two()
+        {
+            Assert.Equal(Color.FromArgb(255, 0, 0, 255), default_brush.LinearColors[0]);
+            Assert.Equal(Color.FromArgb(255, 255, 0, 0), default_brush.LinearColors[1]);
+
+            LinearGradientBrush lgb = new LinearGradientBrush(pt1, pt2, c1, c2);
+            lgb.LinearColors = new Color[2] { Color.Black, Color.White };
+            // not the same, the alpha is changed to 255 so they can't compare
+            Assert.Equal(Color.FromArgb(255, 0, 0, 0), lgb.LinearColors[0]);
+            Assert.Equal(Color.FromArgb(255, 255, 255, 255), lgb.LinearColors[1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LinearColors_Three()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(pt1, pt2, c1, c2);
+            lgb.LinearColors = new Color[3] { Color.Red, Color.Green, Color.Blue };
+            // not the same, the alpha is changed to 255 so they can't compare
+            Assert.Equal(Color.FromArgb(255, 255, 0, 0), lgb.LinearColors[0]);
+            Assert.Equal(Color.FromArgb(255, 0, 128, 0), lgb.LinearColors[1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Rectangle()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 0f);
+            CheckDefaultRectangle("Original", lgb.Rectangle);
+            lgb.MultiplyTransform(new Matrix(2, 0, 0, 2, 2, 2));
+            CheckDefaultRectangle("Multiply", lgb.Rectangle);
+            lgb.ResetTransform();
+            CheckDefaultRectangle("Reset", lgb.Rectangle);
+            lgb.RotateTransform(90);
+            CheckDefaultRectangle("Rotate", lgb.Rectangle);
+            lgb.ScaleTransform(4, 0.25f);
+            CheckDefaultRectangle("Scale", lgb.Rectangle);
+            lgb.TranslateTransform(-10, -20);
+            CheckDefaultRectangle("Translate", lgb.Rectangle);
+
+            lgb.SetBlendTriangularShape(0.5f);
+            CheckDefaultRectangle("SetBlendTriangularShape", lgb.Rectangle);
+            lgb.SetSigmaBellShape(0.5f);
+            CheckDefaultRectangle("SetSigmaBellShape", lgb.Rectangle);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => default_brush.Transform = null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Empty()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(pt1, pt2, c1, c2);
+            lgb.Transform = new Matrix();
+            Assert.True(lgb.Transform.IsIdentity);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_NonInvertible()
+        {
+            Assert.Throws<ArgumentException>(() => default_brush.Transform = new Matrix(123, 24, 82, 16, 47, 30));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void WrapMode_AllValid()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(pt1, pt2, c1, c2);
+            lgb.WrapMode = WrapMode.Tile;
+            Assert.Equal(WrapMode.Tile, lgb.WrapMode);
+            lgb.WrapMode = WrapMode.TileFlipX;
+            Assert.Equal(WrapMode.TileFlipX, lgb.WrapMode);
+            lgb.WrapMode = WrapMode.TileFlipY;
+            Assert.Equal(WrapMode.TileFlipY, lgb.WrapMode);
+            lgb.WrapMode = WrapMode.TileFlipXY;
+            Assert.Equal(WrapMode.TileFlipXY, lgb.WrapMode);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void WrapMode_Clamp()
+        {
+            Assert.Throws<ArgumentException>(() => default_brush.WrapMode = WrapMode.Clamp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void WrapMode_Invalid()
+        {
+            Assert.Throws<InvalidEnumArgumentException>(() => default_brush.WrapMode = (WrapMode)Int32.MinValue);
+        }
+
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Clone()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 0f);
+            LinearGradientBrush clone = (LinearGradientBrush)lgb.Clone();
+            Assert.Equal(lgb.Blend.Factors.Length, clone.Blend.Factors.Length);
+            Assert.Equal(lgb.Blend.Positions.Length, clone.Blend.Positions.Length);
+            Assert.Equal(lgb.GammaCorrection, clone.GammaCorrection);
+            Assert.Equal(lgb.LinearColors.Length, clone.LinearColors.Length);
+            Assert.Equal(lgb.LinearColors.Length, clone.LinearColors.Length);
+            Assert.Equal(lgb.Rectangle, clone.Rectangle);
+            Assert.Equal(lgb.Transform, clone.Transform);
+            Assert.Equal(lgb.WrapMode, clone.WrapMode);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform1_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => default_brush.MultiplyTransform(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform2_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => default_brush.MultiplyTransform(null, MatrixOrder.Append));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform2_Invalid()
+        {
+            default_brush.MultiplyTransform(empty_matrix, (MatrixOrder)Int32.MinValue);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform_NonInvertible()
+        {
+            Matrix noninvertible = new Matrix(123, 24, 82, 16, 47, 30);
+            Assert.Throws<ArgumentException>(() => default_brush.MultiplyTransform(noninvertible));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ResetTransform()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(pt1, pt2, c1, c2);
+            Assert.False(lgb.Transform.IsIdentity);
+            lgb.ResetTransform();
+            Assert.True(lgb.Transform.IsIdentity);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RotateTransform()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 0f);
+            lgb.RotateTransform(90);
+            float[] elements = lgb.Transform.Elements;
+            Assert.Equal(0, elements[0], 1);
+            Assert.Equal(1, elements[1], 1);
+            Assert.Equal(-1, elements[2], 1);
+            Assert.Equal(0, elements[3], 1);
+            Assert.Equal(0, elements[4], 1);
+            Assert.Equal(0, elements[5], 1);
+
+            lgb.RotateTransform(270);
+            Assert.True(lgb.Transform.IsIdentity);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RotateTransform_InvalidOrder()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(pt1, pt2, c1, c2);
+            Assert.Throws<ArgumentException>(() => lgb.RotateTransform(720, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 0f);
+            lgb.ScaleTransform(2, 4);
+            float[] elements = lgb.Transform.Elements;
+            Assert.Equal(2, elements[0], 1);
+            Assert.Equal(0, elements[1], 1);
+            Assert.Equal(0, elements[2], 1);
+            Assert.Equal(4, elements[3], 1);
+            Assert.Equal(0, elements[4], 1);
+            Assert.Equal(0, elements[5], 1);
+
+            lgb.ScaleTransform(0.5f, 0.25f);
+            Assert.True(lgb.Transform.IsIdentity);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform_45()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 45f);
+            lgb.ScaleTransform(3, 3);
+            float[] elements = lgb.Transform.Elements;
+            Assert.Equal(3, elements[0], 1);
+            Assert.Equal(3, elements[1], 1);
+            Assert.Equal(-3, elements[2], 1);
+            Assert.Equal(3, elements[3], 1);
+            Assert.Equal(16, elements[4], 1);
+            Assert.Equal(-16, elements[5], 1);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform_MaxMin()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 0f);
+            lgb.ScaleTransform(Single.MaxValue, Single.MinValue);
+            float[] elements = lgb.Transform.Elements;
+            Assert.Equal(Single.MaxValue, elements[0]);
+            Assert.Equal(0, elements[1], 1);
+            Assert.Equal(0, elements[2], 1);
+            Assert.Equal(Single.MinValue, elements[3]);
+            Assert.Equal(0, elements[4], 1);
+            Assert.Equal(0, elements[5], 1);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform_InvalidOrder()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(pt1, pt2, c1, c2);
+            Assert.Throws<ArgumentException>(() => lgb.ScaleTransform(1, 1, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_Focus()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 0f);
+            // max valid
+            lgb.SetBlendTriangularShape(1);
+            Assert.True(lgb.Transform.IsIdentity);
+            // min valid
+            lgb.SetBlendTriangularShape(0);
+            Assert.True(lgb.Transform.IsIdentity);
+            // middle
+            lgb.SetBlendTriangularShape(0.5f);
+            Assert.True(lgb.Transform.IsIdentity);
+            // no impact on matrix
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_Scale()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 0f);
+            // max valid
+            lgb.SetBlendTriangularShape(0, 1);
+            Assert.True(lgb.Transform.IsIdentity);
+            // min valid
+            lgb.SetBlendTriangularShape(1, 0);
+            Assert.True(lgb.Transform.IsIdentity);
+            // middle
+            lgb.SetBlendTriangularShape(0.5f, 0.5f);
+            Assert.True(lgb.Transform.IsIdentity);
+            // no impact on matrix
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_FocusTooSmall()
+        {
+            Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape(-1));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_FocusTooBig()
+        {
+            Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape(1.01f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_ScaleTooSmall()
+        {
+            Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape(1, -1));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_ScaleTooBig()
+        {
+            Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape(1, 1.01f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_Focus()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 0f);
+            // max valid
+            lgb.SetSigmaBellShape(1);
+            Assert.True(lgb.Transform.IsIdentity);
+            // min valid
+            lgb.SetSigmaBellShape(0);
+            Assert.True(lgb.Transform.IsIdentity);
+            // middle
+            lgb.SetSigmaBellShape(0.5f);
+            Assert.True(lgb.Transform.IsIdentity);
+            // no impact on matrix
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_Scale()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 0f);
+            // max valid
+            lgb.SetSigmaBellShape(0, 1);
+            Assert.True(lgb.Transform.IsIdentity);
+            // min valid
+            lgb.SetSigmaBellShape(1, 0);
+            Assert.True(lgb.Transform.IsIdentity);
+            // middle
+            lgb.SetSigmaBellShape(0.5f, 0.5f);
+            Assert.True(lgb.Transform.IsIdentity);
+            // no impact on matrix
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_FocusTooSmall()
+        {
+            Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape(-1));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_FocusTooBig()
+        {
+            Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape(1.01f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_ScaleTooSmall()
+        {
+            Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape(1, -1));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_ScaleTooBig()
+        {
+            Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape(1, 1.01f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TranslateTransform()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 0f);
+            lgb.TranslateTransform(1, 1);
+            float[] elements = lgb.Transform.Elements;
+            Assert.Equal(1, elements[0], 1);
+            Assert.Equal(0, elements[1], 1);
+            Assert.Equal(0, elements[2], 1);
+            Assert.Equal(1, elements[3], 1);
+            Assert.Equal(1, elements[4], 1);
+            Assert.Equal(1, elements[5], 1);
+
+            lgb.TranslateTransform(-1, -1);
+            // strangely lgb.Transform.IsIdentity is false
+            elements = lgb.Transform.Elements;
+            Assert.Equal(1, elements[0], 1);
+            Assert.Equal(0, elements[1], 1);
+            Assert.Equal(0, elements[2], 1);
+            Assert.Equal(1, elements[3], 1);
+            Assert.Equal(0, elements[4], 1);
+            Assert.Equal(0, elements[5], 1);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TranslateTransform_InvalidOrder()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(pt1, pt2, c1, c2);
+            Assert.Throws<ArgumentException>(() => lgb.TranslateTransform(1, 1, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Operations()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 45f);
+            Matrix clone = lgb.Transform.Clone();
+            Matrix mul = clone.Clone();
+
+            clone.Multiply(mul, MatrixOrder.Append);
+            lgb.MultiplyTransform(mul, MatrixOrder.Append);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Multiply(mul, MatrixOrder.Prepend);
+            lgb.MultiplyTransform(mul, MatrixOrder.Prepend);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Rotate(45, MatrixOrder.Append);
+            lgb.RotateTransform(45, MatrixOrder.Append);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Rotate(45, MatrixOrder.Prepend);
+            lgb.RotateTransform(45, MatrixOrder.Prepend);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Scale(0.25f, 2, MatrixOrder.Append);
+            lgb.ScaleTransform(0.25f, 2, MatrixOrder.Append);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Scale(0.25f, 2, MatrixOrder.Prepend);
+            lgb.ScaleTransform(0.25f, 2, MatrixOrder.Prepend);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Translate(10, 20, MatrixOrder.Append);
+            lgb.TranslateTransform(10, 20, MatrixOrder.Append);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Translate(30, 40, MatrixOrder.Prepend);
+            lgb.TranslateTransform(30, 40, MatrixOrder.Prepend);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Reset();
+            lgb.ResetTransform();
+            Assert.Equal(lgb.Transform, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Operations_OnScalableAngle()
+        {
+            LinearGradientBrush lgb = new LinearGradientBrush(rect, c1, c2, 360f, true);
+            Matrix clone = lgb.Transform.Clone();
+            Matrix mul = clone.Clone();
+            Matrix m = new Matrix();
+            m.Scale(2, 1);
+            m.Translate(rect.Width, rect.Height);
+            m.Rotate(30f);
+
+            clone.Multiply(mul, MatrixOrder.Append);
+            lgb.MultiplyTransform(mul, MatrixOrder.Append);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Multiply(mul, MatrixOrder.Prepend);
+            lgb.MultiplyTransform(mul, MatrixOrder.Prepend);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Rotate(45, MatrixOrder.Append);
+            lgb.RotateTransform(45, MatrixOrder.Append);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Rotate(45, MatrixOrder.Prepend);
+            lgb.RotateTransform(45, MatrixOrder.Prepend);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Scale(0.25f, 2, MatrixOrder.Append);
+            lgb.ScaleTransform(0.25f, 2, MatrixOrder.Append);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Scale(0.25f, 2, MatrixOrder.Prepend);
+            lgb.ScaleTransform(0.25f, 2, MatrixOrder.Prepend);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Translate(10, 20, MatrixOrder.Append);
+            lgb.TranslateTransform(10, 20, MatrixOrder.Append);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Translate(30, 40, MatrixOrder.Prepend);
+            lgb.TranslateTransform(30, 40, MatrixOrder.Prepend);
+            Assert.Equal(lgb.Transform, clone);
+
+            clone.Reset();
+            lgb.ResetTransform();
+            Assert.Equal(lgb.Transform, clone);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Rectangle_Angle_Scalable()
+        {
+            CheckMatrixForScalableAngle(new RectangleF(0, 0, 10, 10), 15, new float[] { 1.183013f, 0.3169873f, -0.3169873f, 1.183012f, 0.6698728f, -2.5f });
+
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 50), 15, new float[] { 1.183012f, 0.176104f, -0.5705772f, 1.183012f, 34.77311f, -28.76387f });
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 50), 75, new float[] { 0.3169872f, 0.6572293f, -2.129423f, 0.3169873f, 232.2269f, 8.763878f });
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 50), 95, new float[] { -0.09442029f, 0.599571f, -1.942611f, -0.09442017f, 247.2034f, 48.05788f });
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 50), 150, new float[] { -1.183013f, 0.3794515f, -1.229423f, -1.183013f, 268.2269f, 157.0972f });
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 50), 215, new float[] { -1.140856f, -0.4437979f, 1.437905f, -1.140856f, 38.34229f, 215.2576f });
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 50), 300, new float[] { 0.6830127f, -0.6572294f, 2.129422f, 0.6830124f, -157.2269f, 76.23613f });
+
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 150), 15, new float[] { 1.183012f, 0.5283121f, -0.1901924f, 1.183012f, 11.95002f, -64.33012f });
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 150), 75, new float[] { 0.3169872f, 1.971688f, -0.7098077f, 0.3169872f, 147.05f, -55.66987f });
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 150), 95, new float[] { -0.09442029f, 1.798713f, -0.6475369f, -0.09442022f, 169.499f, 12.84323f });
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 150), 150, new float[] { -1.183013f, 1.138354f, -0.4098077f, -1.183013f, 219.05f, 209.3301f });
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 150), 215, new float[] { -1.140856f, -1.331394f, 0.4793016f, -1.140856f, 95.85849f, 388.8701f });
+            CheckMatrixForScalableAngle(new RectangleF(30, 60, 90, 150), 300, new float[] { 0.6830127f, -1.971688f, 0.7098075f, 0.6830125f, -72.04998f, 190.6699f });
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LinearColors_Null()
+        {
+            Assert.Throws<NullReferenceException>(() => default_brush.LinearColors = null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InterpolationColors_Null()
+        {
+            Assert.Throws<ArgumentException>(() => default_brush.InterpolationColors = null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Blend_Null()
+        {
+            Assert.Throws<NullReferenceException>(() => default_brush.Blend = null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ZeroWidthRectangle()
+        {
+            Rectangle r = new Rectangle(10, 10, 0, 10);
+            Assert.Equal(0, r.Width);
+            Assert.Throws<ArgumentException>(() => new LinearGradientBrush(r, Color.Red, Color.Blue, LinearGradientMode.Vertical));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ZeroHeightRectangleF()
+        {
+            RectangleF r = new RectangleF(10.0f, 10.0f, 10.0f, 0.0f);
+            Assert.Equal(0.0f, r.Height);
+            Assert.Throws<ArgumentException>(() => new LinearGradientBrush(r, Color.Red, Color.Blue, LinearGradientMode.Vertical));
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/PathDataTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/PathDataTest.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.Drawing2D.PathData unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing.Drawing2D
+{
+
+    public class PathDataTest
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void PathData_Empty()
+        {
+            PathData data = new PathData();
+            Assert.Null(data.Points);
+            Assert.Null(data.Types);
+
+            data.Points = new PointF[0];
+            data.Types = new byte[0];
+            Assert.Equal(0, data.Points.Length);
+            Assert.Equal(0, data.Types.Length);
+
+            data.Points = null;
+            data.Types = null;
+            Assert.Null(data.Points);
+            Assert.Null(data.Types);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void PathData_LengthMismatch()
+        {
+            PathData data = new PathData();
+            data.Points = new PointF[2];
+            data.Types = new byte[1];
+            Assert.Equal(2, data.Points.Length);
+            Assert.Equal(1, data.Types.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void PathData_UnclonedProperties()
+        {
+            PathData data = new PathData();
+            data.Points = new PointF[1] { new PointF(1f, 1f) };
+            data.Types = new byte[1] { 1 };
+            Assert.Equal(1f, data.Points[0].X);
+            Assert.Equal(1f, data.Points[0].Y);
+            Assert.Equal(1, data.Types[0]);
+
+            data.Points[0] = new PointF(0f, 0f);
+            Assert.Equal(0f, data.Points[0].X);
+            Assert.Equal(0f, data.Points[0].Y);
+
+            data.Types[0] = 0;
+            Assert.Equal(0, data.Types[0]);
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/PathGradientBrushTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/PathGradientBrushTest.cs
@@ -1,0 +1,919 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.Drawing2D.PathGradientBrush unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing.Drawing2D
+{
+
+    public class PathGradientBrushTest
+    {
+
+        private Point[] pts_2i;
+        private PointF[] pts_2f;
+        private Matrix empty_matrix;
+
+        private void CheckDefaultRectangle(string message, RectangleF rect)
+        {
+            Assert.Equal(1f, rect.X);
+            Assert.Equal(2f, rect.Y);
+            Assert.Equal(19f, rect.Width);
+            Assert.Equal(28f, rect.Height);
+        }
+
+        private void CheckDefaults(PathGradientBrush pgb)
+        {
+            Assert.Equal(1, pgb.Blend.Factors.Length);
+            Assert.Equal(1f, pgb.Blend.Factors[0]);
+            Assert.Equal(1, pgb.Blend.Positions.Length);
+            Assert.Equal(0f, pgb.Blend.Positions[0]);
+            Assert.Equal(10.5f, pgb.CenterPoint.X);
+            Assert.Equal(16f, pgb.CenterPoint.Y);
+            Assert.True(pgb.FocusScales.IsEmpty);
+            Assert.Equal(1, pgb.InterpolationColors.Colors.Length);
+            Assert.Equal(0, pgb.InterpolationColors.Colors[0].ToArgb());
+            Assert.Equal(1, pgb.InterpolationColors.Positions.Length);
+            Assert.Equal(0f, pgb.InterpolationColors.Positions[0]);
+            CheckDefaultRectangle(String.Empty, pgb.Rectangle);
+            Assert.Equal(1, pgb.SurroundColors.Length);
+            Assert.Equal(-1, pgb.SurroundColors[0].ToArgb());
+            Assert.True(pgb.Transform.IsIdentity);
+        }
+
+        private void CheckPointsDefaults(PathGradientBrush pgb)
+        {
+            CheckDefaults(pgb);
+            Assert.Equal(-16777216, pgb.CenterColor.ToArgb());
+        }
+
+        private void CheckPathDefaults(PathGradientBrush pgb)
+        {
+            CheckDefaults(pgb);
+            Assert.Equal(-1, pgb.CenterColor.ToArgb());
+        }
+
+        public PathGradientBrushTest()
+        {
+            pts_2i = new Point[2] { new Point(1, 2), new Point(20, 30) };
+            pts_2f = new PointF[2] { new PointF(1, 2), new PointF(20, 30) };
+            empty_matrix = new Matrix();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_GraphicsPath_Null()
+        {
+            GraphicsPath gp = null;
+            Assert.Throws<ArgumentNullException>(() => new PathGradientBrush(gp));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_GraphicsPath_Empty()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush(gp));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_GraphicsPath_SinglePoint()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(new Point[1] { new Point(1, 1) });
+                // Special case - a line with a single point is valid
+                Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush(gp));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconsistent between Deskop & Core")]
+        public void Constructor_GraphicsPath_Line()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (PathGradientBrush pgb = new PathGradientBrush(gp))
+                {
+                    CheckPathDefaults(pgb);
+                    Assert.Equal(WrapMode.Clamp, pgb.WrapMode);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Point_Null()
+        {
+            Point[] pts = null;
+            Assert.Throws<ArgumentNullException>(() => new PathGradientBrush(pts));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Point_Empty()
+        {
+            Point[] pts = new Point[0];
+            Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush(pts));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Point_One()
+        {
+            Point[] pts = new Point[1] { new Point(1, 1) };
+            Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush(pts));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconsistent between Desktop & CoreFX")]
+        public void Constructor_Point_Two()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2i))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.Clamp, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconsistent between Desktop & CoreFX")]
+        public void Constructor_Point_WrapMode_Clamp()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2i, WrapMode.Clamp))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.Clamp, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconsistent between Desktop & CoreFX")]
+        public void Constructor_Point_WrapMode_Tile()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2i, WrapMode.Tile))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.Tile, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconsistent between Desktop & Core")]
+        public void Constructor_Point_WrapMode_TileFlipX()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2i, WrapMode.TileFlipX))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.TileFlipX, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconsistent between Desktop & Core")]
+        public void Constructor_Point_WrapMode_TileFlipY()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2i, WrapMode.TileFlipY))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.TileFlipY, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconstent between Desktop & CoreFX")]
+        public void Constructor_Point_WrapMode_TileFlipXY()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2i, WrapMode.TileFlipXY))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.TileFlipXY, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_PointF_Null()
+        {
+            PointF[] pts = null;
+            Assert.Throws<ArgumentNullException>(() => new PathGradientBrush(pts));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_PointF_Empty()
+        {
+            PointF[] pts = new PointF[0];
+            Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush(pts));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_PointF_One()
+        {
+            PointF[] pts = new PointF[1] { new PointF(1, 1) };
+            Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush(pts));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconsistent between Desktop & CoreFX")]
+        public void Constructor_PointF_Two()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.Clamp, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void Constructor_PointF_WrapMode_Invalid()
+        {
+            Assert.Throws<InvalidEnumArgumentException>(() => new PathGradientBrush(pts_2f, (WrapMode)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void Constructor_PointF_WrapMode_Clamp()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.Clamp, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconsistent between Desktop & CoreFX")]
+        public void Constructor_PointF_WrapMode_Tile()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Tile))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.Tile, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconsistent between Desktop & CoreFX")]
+        public void Constructor_PointF_WrapMode_TileFlipX()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.TileFlipX))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.TileFlipX, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconsistent between Desktop & CoreFX")]
+        public void Constructor_PointF_WrapMode_TileFlipY()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.TileFlipY))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.TileFlipY, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Inconsistent between Desktop & CoreFX")]
+        public void Constructor_PointF_WrapMode_TileFlipXY()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.TileFlipXY))
+            {
+                CheckPointsDefaults(pgb);
+                Assert.Equal(WrapMode.TileFlipXY, pgb.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Blend()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.TileFlipXY))
+            {
+                // change not accepted - but no exception is thrown
+                pgb.Blend.Factors = new float[0];
+                Assert.Equal(1, pgb.Blend.Factors.Length);
+                pgb.Blend.Factors = new float[2];
+                Assert.Equal(1, pgb.Blend.Factors.Length);
+
+                // change not accepted - but no exception is thrown
+                pgb.Blend.Positions = new float[0];
+                Assert.Equal(1, pgb.Blend.Positions.Length);
+                pgb.Blend.Positions = new float[2];
+                Assert.Equal(1, pgb.Blend.Positions.Length);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FocusScales()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.TileFlipXY))
+            {
+                PointF fs = new PointF(Single.MaxValue, Single.MinValue);
+                pgb.FocusScales = fs;
+                Assert.Equal(Single.MaxValue, pgb.FocusScales.X);
+                Assert.Equal(Single.MinValue, pgb.FocusScales.Y);
+
+                fs.X = Single.NaN;
+                fs.Y = Single.NegativeInfinity;
+                pgb.FocusScales = fs;
+                Assert.Equal(Single.NaN, pgb.FocusScales.X);
+                Assert.Equal(Single.NegativeInfinity, pgb.FocusScales.Y);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CenterColor()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.TileFlipXY))
+            {
+                pgb.CenterColor = Color.Black;
+                Assert.Equal(Color.Black.ToArgb(), pgb.CenterColor.ToArgb());
+                pgb.CenterColor = Color.Transparent;
+                Assert.Equal(Color.Transparent.ToArgb(), pgb.CenterColor.ToArgb());
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CenterPoint()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.TileFlipXY))
+            {
+                PointF cp = new PointF(Single.MaxValue, Single.MinValue);
+                pgb.CenterPoint = cp;
+                Assert.Equal(Single.MaxValue, pgb.CenterPoint.X);
+                Assert.Equal(Single.MinValue, pgb.CenterPoint.Y);
+
+                cp.X = Single.NaN;
+                cp.Y = Single.NegativeInfinity;
+                pgb.CenterPoint = cp;
+                Assert.Equal(Single.NaN, pgb.CenterPoint.X);
+                Assert.Equal(Single.NegativeInfinity, pgb.CenterPoint.Y);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InterpolationColors()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.TileFlipXY))
+            {
+                // change not accepted - but no exception is thrown
+                pgb.InterpolationColors.Colors = new Color[0];
+                Assert.Equal(1, pgb.InterpolationColors.Colors.Length);
+                pgb.InterpolationColors.Colors = new Color[2];
+                Assert.Equal(1, pgb.InterpolationColors.Colors.Length);
+
+                // change not accepted - but no exception is thrown
+                pgb.InterpolationColors.Positions = new float[0];
+                Assert.Equal(1, pgb.InterpolationColors.Positions.Length);
+                pgb.InterpolationColors.Positions = new float[2];
+                Assert.Equal(1, pgb.InterpolationColors.Positions.Length);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Rectangle()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.TileFlipXY))
+            {
+                CheckDefaultRectangle("Original", pgb.Rectangle);
+                pgb.MultiplyTransform(new Matrix(2, 0, 0, 2, 2, 2));
+                CheckDefaultRectangle("Multiply", pgb.Rectangle);
+                pgb.ResetTransform();
+                CheckDefaultRectangle("Reset", pgb.Rectangle);
+                pgb.RotateTransform(90);
+                CheckDefaultRectangle("Rotate", pgb.Rectangle);
+                pgb.ScaleTransform(4, 0.25f);
+                CheckDefaultRectangle("Scale", pgb.Rectangle);
+                pgb.TranslateTransform(-10, -20);
+                CheckDefaultRectangle("Translate", pgb.Rectangle);
+
+                pgb.SetBlendTriangularShape(0.5f);
+                CheckDefaultRectangle("SetBlendTriangularShape", pgb.Rectangle);
+                pgb.SetSigmaBellShape(0.5f);
+                CheckDefaultRectangle("SetSigmaBellShape", pgb.Rectangle);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SurroundColors_Empty()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.TileFlipXY))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.SurroundColors = new Color[0]);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SurroundColors_2PointF()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.TileFlipXY))
+            {
+                // default values
+                Assert.Equal(1, pgb.SurroundColors.Length);
+                Assert.Equal(-1, pgb.SurroundColors[0].ToArgb());
+
+                // default can't be changed
+                pgb.SurroundColors[0] = Color.Gold;
+                Assert.Equal(-1, pgb.SurroundColors[0].ToArgb());
+
+                // 2 empty color isn't valid, change isn't accepted
+                pgb.SurroundColors = new Color[2];
+                Assert.Equal(1, pgb.SurroundColors.Length);
+
+                pgb.SurroundColors = new Color[2] { Color.Black, Color.White };
+                Assert.Equal(2, pgb.SurroundColors.Length);
+                Assert.Equal(-16777216, pgb.SurroundColors[0].ToArgb());
+                Assert.Equal(-1, pgb.SurroundColors[1].ToArgb());
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SurroundColors_3PointsF()
+        {
+            PointF[] points = new PointF[3] { new PointF(5, 50), new PointF(10, 100), new PointF(20, 75) };
+            using (PathGradientBrush pgb = new PathGradientBrush(points))
+            {
+                // 3 empty color isn't valid, change isn't accepted
+                pgb.SurroundColors = new Color[3] { Color.Empty, Color.Empty, Color.Empty };
+                Assert.Equal(1, pgb.SurroundColors.Length);
+
+                pgb.SurroundColors = new Color[3] { Color.Red, Color.Green, Color.Blue };
+                // change not accepted - but no exception is thrown
+                Assert.Equal(3, pgb.SurroundColors.Length);
+                Assert.Equal(-65536, pgb.SurroundColors[0].ToArgb());
+                Assert.Equal(-16744448, pgb.SurroundColors[1].ToArgb());
+                Assert.Equal(-16776961, pgb.SurroundColors[2].ToArgb());
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new PathGradientBrush(pts_2f, WrapMode.Clamp).Transform = null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Empty()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                pgb.Transform = new Matrix();
+                Assert.True(pgb.Transform.IsIdentity);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_NonInvertible()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.Transform = new Matrix(123, 24, 82, 16, 47, 30));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void WrapMode_All()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                foreach (WrapMode wm in Enum.GetValues(typeof(WrapMode)))
+                {
+                    pgb.WrapMode = wm;
+                    Assert.Equal(wm, pgb.WrapMode);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void WrapMode_Invalid()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.WrapMode = (WrapMode)Int32.MinValue);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void Clone()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (PathGradientBrush pgb = new PathGradientBrush(gp))
+                {
+                    using (PathGradientBrush clone = (PathGradientBrush)pgb.Clone())
+                    {
+                        CheckPathDefaults(clone);
+                        Assert.Equal(WrapMode.Clamp, clone.WrapMode);
+                    }
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform1_Null()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentNullException>(() => pgb.MultiplyTransform(null));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform2_Null()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentNullException>(() => pgb.MultiplyTransform(null, MatrixOrder.Append));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform2_Invalid()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                pgb.MultiplyTransform(empty_matrix, (MatrixOrder)Int32.MinValue);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform_NonInvertible()
+        {
+            using (Matrix noninvertible = new Matrix(123, 24, 82, 16, 47, 30))
+            {
+                using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+                {
+                    Assert.Throws<ArgumentException>(() => pgb.MultiplyTransform(noninvertible));
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ResetTransform()
+        {
+            using (Matrix m = new Matrix(2, 0, 0, 2, 10, -10))
+            {
+                using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+                {
+                    pgb.Transform = m;
+                    Assert.False(pgb.Transform.IsIdentity);
+                    pgb.ResetTransform();
+                    Assert.True(pgb.Transform.IsIdentity);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RotateTransform()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                pgb.RotateTransform(90);
+                float[] elements = pgb.Transform.Elements;
+                Assert.Equal(0, elements[0], 1);
+                Assert.Equal(1, elements[1], 1);
+                Assert.Equal(-1, elements[2], 1);
+                Assert.Equal(0, elements[3], 1);
+                Assert.Equal(0, elements[4], 1);
+                Assert.Equal(0, elements[5], 1);
+
+                pgb.RotateTransform(270);
+                Assert.True(pgb.Transform.IsIdentity);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RotateTransform_InvalidOrder()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.RotateTransform(720, (MatrixOrder)Int32.MinValue));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                pgb.ScaleTransform(2, 4);
+                float[] elements = pgb.Transform.Elements;
+                Assert.Equal(2, elements[0], 1);
+                Assert.Equal(0, elements[1], 1);
+                Assert.Equal(0, elements[2], 1);
+                Assert.Equal(4, elements[3], 1);
+                Assert.Equal(0, elements[4], 1);
+                Assert.Equal(0, elements[5], 1);
+
+                pgb.ScaleTransform(0.5f, 0.25f);
+                Assert.True(pgb.Transform.IsIdentity);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform_MaxMin()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                pgb.ScaleTransform(Single.MaxValue, Single.MinValue);
+                float[] elements = pgb.Transform.Elements;
+                Assert.Equal(Single.MaxValue, elements[0]);
+                Assert.Equal(0, elements[1], 1);
+                Assert.Equal(0, elements[2], 1);
+                Assert.Equal(Single.MinValue, elements[3]);
+                Assert.Equal(0, elements[4], 1);
+                Assert.Equal(0, elements[5], 1);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform_InvalidOrder()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.ScaleTransform(1, 1, (MatrixOrder)Int32.MinValue));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_Focus()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                // max valid
+                pgb.SetBlendTriangularShape(1);
+                Assert.True(pgb.Transform.IsIdentity);
+                // min valid
+                pgb.SetBlendTriangularShape(0);
+                Assert.True(pgb.Transform.IsIdentity);
+                // middle
+                pgb.SetBlendTriangularShape(0.5f);
+                Assert.True(pgb.Transform.IsIdentity);
+                // no impact on matrix
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_Scale()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                // max valid
+                pgb.SetBlendTriangularShape(0, 1);
+                Assert.True(pgb.Transform.IsIdentity);
+                // min valid
+                pgb.SetBlendTriangularShape(1, 0);
+                Assert.True(pgb.Transform.IsIdentity);
+                // middle
+                pgb.SetBlendTriangularShape(0.5f, 0.5f);
+                Assert.True(pgb.Transform.IsIdentity);
+                // no impact on matrix
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_FocusTooSmall()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape(-1));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_FocusTooBig()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape(1.01f));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_ScaleTooSmall()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape(1, -1));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetBlendTriangularShape_ScaleTooBig()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape(1, 1.01f));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_Focus()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                // max valid
+                pgb.SetSigmaBellShape(1);
+                Assert.True(pgb.Transform.IsIdentity);
+                // min valid
+                pgb.SetSigmaBellShape(0);
+                Assert.True(pgb.Transform.IsIdentity);
+                // middle
+                pgb.SetSigmaBellShape(0.5f);
+                Assert.True(pgb.Transform.IsIdentity);
+                // no impact on matrix
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_Scale()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                // max valid
+                pgb.SetSigmaBellShape(0, 1);
+                Assert.True(pgb.Transform.IsIdentity);
+                // min valid
+                pgb.SetSigmaBellShape(1, 0);
+                Assert.True(pgb.Transform.IsIdentity);
+                // middle
+                pgb.SetSigmaBellShape(0.5f, 0.5f);
+                Assert.True(pgb.Transform.IsIdentity);
+                // no impact on matrix
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_FocusTooSmall()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape(-1));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_FocusTooBig()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape(1.01f));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_ScaleTooSmall()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape(1, -1));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetSigmaBellShape_ScaleTooBig()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape(1, 1.01f));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TranslateTransform()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                pgb.TranslateTransform(1, 1);
+                float[] elements = pgb.Transform.Elements;
+                Assert.Equal(1, elements[0], 1);
+                Assert.Equal(0, elements[1], 1);
+                Assert.Equal(0, elements[2], 1);
+                Assert.Equal(1, elements[3], 1);
+                Assert.Equal(1, elements[4], 1);
+                Assert.Equal(1, elements[5], 1);
+
+                pgb.TranslateTransform(-1, -1);
+                // strangely lgb.Transform.IsIdentity is false
+                elements = pgb.Transform.Elements;
+                Assert.Equal(1, elements[0], 1);
+                Assert.Equal(0, elements[1], 1);
+                Assert.Equal(0, elements[2], 1);
+                Assert.Equal(1, elements[3], 1);
+                Assert.Equal(0, elements[4], 1);
+                Assert.Equal(0, elements[5], 1);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TranslateTransform_InvalidOrder()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Assert.Throws<ArgumentException>(() => pgb.TranslateTransform(1, 1, (MatrixOrder)Int32.MinValue));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Operations()
+        {
+            using (PathGradientBrush pgb = new PathGradientBrush(pts_2f, WrapMode.Clamp))
+            {
+                Matrix clone = pgb.Transform.Clone();
+                Matrix mul = clone.Clone();
+
+                clone.Multiply(mul, MatrixOrder.Append);
+                pgb.MultiplyTransform(mul, MatrixOrder.Append);
+                Assert.Equal(pgb.Transform, clone);
+
+                clone.Multiply(mul, MatrixOrder.Prepend);
+                pgb.MultiplyTransform(mul, MatrixOrder.Prepend);
+                Assert.Equal(pgb.Transform, clone);
+
+                clone.Rotate(45, MatrixOrder.Append);
+                pgb.RotateTransform(45, MatrixOrder.Append);
+                Assert.Equal(pgb.Transform, clone);
+
+                clone.Rotate(45, MatrixOrder.Prepend);
+                pgb.RotateTransform(45, MatrixOrder.Prepend);
+                Assert.Equal(pgb.Transform, clone);
+
+                clone.Scale(0.25f, 2, MatrixOrder.Append);
+                pgb.ScaleTransform(0.25f, 2, MatrixOrder.Append);
+                Assert.Equal(pgb.Transform, clone);
+
+                clone.Scale(0.25f, 2, MatrixOrder.Prepend);
+                pgb.ScaleTransform(0.25f, 2, MatrixOrder.Prepend);
+                Assert.Equal(pgb.Transform, clone);
+
+                clone.Translate(10, 20, MatrixOrder.Append);
+                pgb.TranslateTransform(10, 20, MatrixOrder.Append);
+                Assert.Equal(pgb.Transform, clone);
+
+                clone.Translate(30, 40, MatrixOrder.Prepend);
+                pgb.TranslateTransform(30, 40, MatrixOrder.Prepend);
+                Assert.Equal(pgb.Transform, clone);
+
+                clone.Reset();
+                pgb.ResetTransform();
+                Assert.Equal(pgb.Transform, clone);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Blend_Null()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (PathGradientBrush pgb = new PathGradientBrush(gp))
+                {
+                    Assert.Throws<NullReferenceException>(() => pgb.Blend = null);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InterpolationColors_Null()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (PathGradientBrush pgb = new PathGradientBrush(gp))
+                {
+                    Assert.Throws<NullReferenceException>(() => pgb.InterpolationColors = null);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SurroundColors_Null()
+        {
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                gp.AddLines(pts_2f);
+                using (PathGradientBrush pgb = new PathGradientBrush(gp))
+                {
+                    Assert.Throws<NullReferenceException>(() => pgb.SurroundColors = null);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/TestBlend.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/TestBlend.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Tests for System.Drawing.Drawing2D.Blend.cs
+//
+// Author:
+//   Ravindra (rkumar@novell.com)
+//
+// Copyright (C) 2004 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using Xunit;
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+
+namespace MonoTests.System.Drawing.Drawing2D
+{
+    public class BlendTest
+    {
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestConstructors()
+        {
+            Blend blend0 = new Blend();
+
+            Assert.Equal(1, blend0.Factors.Length);
+            Assert.Equal(1, blend0.Positions.Length);
+
+            Blend blend1 = new Blend(1);
+
+            Assert.Equal(1, blend1.Factors.Length);
+            Assert.Equal(1, blend1.Positions.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestProperties()
+        {
+            Blend blend0 = new Blend();
+
+            Assert.Equal(0, blend0.Factors[0]);
+            Assert.Equal(0, blend0.Positions[0]);
+
+            Blend blend1 = new Blend(1);
+            float[] positions = { 0.0F, 0.5F, 1.0F };
+            float[] factors = { 0.0F, 0.5F, 1.0F };
+            blend1.Factors = factors;
+            blend1.Positions = positions;
+
+            Assert.Equal(factors[0], blend1.Factors[0]);
+            Assert.Equal(factors[1], blend1.Factors[1]);
+            Assert.Equal(factors[2], blend1.Factors[2]);
+            Assert.Equal(positions[0], blend1.Positions[0]);
+            Assert.Equal(positions[1], blend1.Positions[1]);
+            Assert.Equal(positions[2], blend1.Positions[2]);
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/TestColorBlend.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/TestColorBlend.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Tests for System.Drawing.Drawing2D.ColorBlend.cs
+//
+// Authors:
+//	Ravindra (rkumar@novell.com)
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2004,2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using Xunit;
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+
+namespace MonoTests.System.Drawing.Drawing2D
+{
+    public class ColorBlendTest
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestConstructors()
+        {
+            ColorBlend cb1 = new ColorBlend(1);
+            Assert.Equal(1, cb1.Colors.Length);
+            Assert.Equal(1, cb1.Positions.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestProperties()
+        {
+            ColorBlend cb1 = new ColorBlend(1);
+            float[] positions = { 0.0F, 0.5F, 1.0F };
+            Color[] colors = { Color.Red, Color.White, Color.Black };
+            cb1.Colors = colors;
+            cb1.Positions = positions;
+
+            // size match
+            Assert.Equal(colors[0], cb1.Colors[0]);
+            Assert.Equal(colors[1], cb1.Colors[1]);
+            Assert.Equal(colors[2], cb1.Colors[2]);
+            Assert.Equal(positions[0], cb1.Positions[0]);
+            Assert.Equal(positions[1], cb1.Positions[1]);
+            Assert.Equal(positions[2], cb1.Positions[2]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ColorBlend_Empty()
+        {
+            ColorBlend cb = new ColorBlend();
+            Assert.Equal(1, cb.Colors.Length);
+            Assert.True(cb.Colors[0].IsEmpty);
+            Assert.Equal(1, cb.Positions.Length);
+            Assert.Equal(0f, cb.Positions[0]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ColorBlend_Zero()
+        {
+            ColorBlend cb = new ColorBlend(0);
+            Assert.Equal(0, cb.Colors.Length);
+            Assert.Equal(0, cb.Positions.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MismatchSizes()
+        {
+            ColorBlend cb = new ColorBlend();
+
+            cb.Colors = new Color[16];
+            Assert.Equal(16, cb.Colors.Length);
+
+            cb.Positions = new float[1];
+            Assert.Equal(1, cb.Positions.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ColorBlend_Negative()
+        {
+            Assert.Throws<OverflowException>(() => new ColorBlend(-1));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ColorBlend_Lots()
+        {
+            ColorBlend cb = new ColorBlend(1000);
+            Assert.Equal(1000, cb.Colors.Length);
+            Assert.Equal(1000, cb.Positions.Length);
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/TestHatchBrush.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/TestHatchBrush.cs
@@ -1,0 +1,633 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.Drawing2D.TestHatchBrush.cs 
+//
+// Author:
+//	Ravindra (rkumar@novell.com)
+//
+// Copyright (C) 2004,2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+using System.IO;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing.Drawing2D
+{
+    public class HatchBrushTest
+    {
+        Graphics gr;
+        Bitmap bmp;
+        Font font;
+        Color bgColor;  // background color
+        Color fgColor;  // foreground color
+        int currentTop; // the location for next drawing operation
+        int spacing;    // space between two consecutive drawing operations
+        int fontSize;   // text size
+        int textStart;  // text starting location
+        int lineStart;  // line starting location
+        int length;     // length of the line
+        int penWidth;   // width of the Pen used to draw lines
+
+
+        public HatchBrushTest()
+        {
+            fontSize = 16;
+            textStart = 10;
+            lineStart = 200;
+            length = 400;
+            penWidth = 50;
+            currentTop = 0;
+            spacing = 50;
+
+            bgColor = Color.Yellow;
+            fgColor = Color.Red;
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestProperties()
+        {
+            HatchBrush hbr = new HatchBrush(HatchStyle.SolidDiamond, fgColor);
+
+            Assert.Equal(hbr.HatchStyle, HatchStyle.SolidDiamond);
+            Assert.Equal(hbr.ForegroundColor.ToArgb(), fgColor.ToArgb());
+            Assert.Equal(hbr.BackgroundColor.ToArgb(), Color.Black.ToArgb());
+
+            hbr = new HatchBrush(HatchStyle.Cross, fgColor, bgColor);
+
+            Assert.Equal(hbr.HatchStyle, HatchStyle.Cross);
+            Assert.Equal(hbr.ForegroundColor.ToArgb(), fgColor.ToArgb());
+            Assert.Equal(hbr.BackgroundColor.ToArgb(), bgColor.ToArgb());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestClone()
+        {
+            HatchBrush hbr = new HatchBrush(HatchStyle.Cross, fgColor, bgColor);
+
+            HatchBrush clone = (HatchBrush)hbr.Clone();
+
+            Assert.Equal(hbr.HatchStyle, clone.HatchStyle);
+            Assert.Equal(hbr.ForegroundColor, clone.ForegroundColor);
+            Assert.Equal(hbr.BackgroundColor, clone.BackgroundColor);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDrawing()
+        {
+            // create a bitmap with big enough dimensions 
+            // to accomodate all the tests
+            bmp = new Bitmap(700, 6000); // width, height
+            gr = Graphics.FromImage(bmp);
+            try
+            {
+                font = new Font(new FontFamily("Arial"), fontSize);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(false, "Arial FontFamily couldn't be found");
+            }
+
+            // make the background white
+            gr.Clear(Color.White);
+
+            // draw figures using hatch brush constructed
+            // using different constructors
+            Constructors();
+
+            // draw figures using different hatchstyles
+            HatchStyles();
+
+            // save the drawing
+            string file = "TestHatchBrush" + getOutSufix() + ".png";
+            bmp.Save(file, ImageFormat.Png);
+            File.Delete(file);
+        }
+
+        private void Constructors()
+        {
+            int top = currentTop;
+            SolidBrush br = new SolidBrush(Color.Black);
+
+            top += spacing;
+
+            gr.DrawString("Test Constructors", font, br, textStart, top);
+
+            // #1
+            top += spacing;
+            gr.DrawString("Test #1 Horizontal, BackgroundColor=Black, ForegroundColor=White", font, br, textStart, top);
+
+            top += spacing;
+            Pen pen = new Pen(new HatchBrush(HatchStyle.Horizontal, Color.White), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #2
+            top += spacing;
+            gr.DrawString("Test #2 Vertical, BackgroundColor=Blue, ForegroundColor=Red", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Vertical, Color.Red, Color.Blue), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            currentTop = top;
+        }
+
+        private void HatchStyles()
+        {
+            int top = currentTop;
+            HatchBrush hbr;
+            Pen pen;
+            SolidBrush br = new SolidBrush(Color.Black);
+
+            top += spacing;
+
+            gr.DrawString("Test HatchStyles", font, br, textStart, top);
+
+            // #1
+            top += spacing;
+            gr.DrawString("Test #1 Horizontal", font, br, textStart, top);
+
+            top += spacing;
+            hbr = new HatchBrush(HatchStyle.Horizontal, fgColor, bgColor);
+            pen = new Pen(hbr, penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #2
+            top += spacing;
+            gr.DrawString("Test #2 Min", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.Min, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #3
+            top += spacing;
+            gr.DrawString("Test #3 DarkHorizontal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.DarkHorizontal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #4
+            top += spacing;
+            gr.DrawString("Test #4 LightHorizontal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.LightHorizontal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #5
+            top += spacing;
+            gr.DrawString("Test #5 NarrowHorizontal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.NarrowHorizontal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #6
+            top += spacing;
+            gr.DrawString("Test #6 Vertical", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.Vertical, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #7
+            top += spacing;
+            gr.DrawString("Test #7 DarkVertical", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.DarkVertical, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #8
+            top += spacing;
+            gr.DrawString("Test #8 LightVertical", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.LightVertical, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #9
+            top += spacing;
+            gr.DrawString("Test #9 NarrowVertical", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.NarrowVertical, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #10
+            top += spacing;
+            gr.DrawString("Test #10 Cross", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.Cross, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #11
+            top += spacing;
+            gr.DrawString("Test #11 LargeGrid", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.LargeGrid, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #12
+            top += spacing;
+            gr.DrawString("Test #12 SmallGrid", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.SmallGrid, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #13
+            top += spacing;
+            gr.DrawString("Test #13 DottedGrid", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.DottedGrid, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #14
+            top += spacing;
+            gr.DrawString("Test #14 DiagonalCross", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.DiagonalCross, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #15
+            top += spacing;
+            gr.DrawString("Test #15 BackwardDiagonal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.BackwardDiagonal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #16
+            top += spacing;
+            gr.DrawString("Test #16 ForwardDiagonal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.ForwardDiagonal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #17
+            top += spacing;
+            gr.DrawString("Test #17 LightDownwardDiagonal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.LightDownwardDiagonal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #18
+            top += spacing;
+            gr.DrawString("Test #18 DarkDownwardDiagonal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.DarkDownwardDiagonal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #19
+            top += spacing;
+            gr.DrawString("Test #19 WideDownwardDiagonal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.WideDownwardDiagonal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #20
+            top += spacing;
+            gr.DrawString("Test #20 LightUpwardDiagonal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.LightUpwardDiagonal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #21
+            top += spacing;
+            gr.DrawString("Test #21 DarkUpwardDiagonal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.DarkUpwardDiagonal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #22
+            top += spacing;
+            gr.DrawString("Test #22 WideUpwardDiagonal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.WideUpwardDiagonal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #23
+            top += spacing;
+            gr.DrawString("Test #23 DashedHorizontal", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.DashedHorizontal, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #24
+            top += spacing;
+            gr.DrawString("Test #24 DashedVertical", font, br, textStart, top);
+
+            top += spacing;
+            hbr = new HatchBrush(HatchStyle.DashedVertical, fgColor, bgColor);
+            gr.FillRectangle(hbr, lineStart, top, length, penWidth);
+
+            // #25
+            top += spacing;
+            gr.DrawString("Test #25 DashedDownwardDiagonal", font, br, textStart, top);
+
+            top += spacing;
+            hbr = new HatchBrush(HatchStyle.DashedDownwardDiagonal, fgColor, bgColor);
+            gr.FillRectangle(hbr, lineStart, top, length, penWidth);
+
+            // #26
+            top += spacing;
+            gr.DrawString("Test #26 DashedUpwardDiagonal", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.DashedUpwardDiagonal, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #27
+            top += spacing;
+            gr.DrawString("Test #27 05Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent05, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #28
+            top += spacing;
+            gr.DrawString("Test #28 10Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent10, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #29
+            top += spacing;
+            gr.DrawString("Test #29 20Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent20, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #30
+            top += spacing;
+            gr.DrawString("Test #30 25Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent25, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #31
+            top += spacing;
+            gr.DrawString("Test #31 30Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent30, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #32
+            top += spacing;
+            gr.DrawString("Test #32 40Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent40, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #33
+            top += spacing;
+            gr.DrawString("Test #33 50Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent50, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #34
+            top += spacing;
+            gr.DrawString("Test #34 60Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent60, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #35
+            top += spacing;
+            gr.DrawString("Test #35 70Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent70, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #36
+            top += spacing;
+            gr.DrawString("Test #36 75Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent75, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #37
+            top += spacing;
+            gr.DrawString("Test #37 80Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent80, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #38
+            top += spacing;
+            gr.DrawString("Test #38 90Percent", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Percent90, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #39
+            top += spacing;
+            gr.DrawString("Test #39 SmallConfetti", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.SmallConfetti, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #40
+            top += spacing;
+            gr.DrawString("Test #40 LargeConfetti", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.LargeConfetti, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #41
+            top += spacing;
+            gr.DrawString("Test #41 ZigZag", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.ZigZag, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #42
+            top += spacing;
+            gr.DrawString("Test #42 Wave", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Wave, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #43
+            top += spacing;
+            gr.DrawString("Test #43 HorizontalBrick", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.HorizontalBrick, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #44
+            top += spacing;
+            gr.DrawString("Test #44 DiagonalBrick", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.DiagonalBrick, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #45
+            top += spacing;
+            gr.DrawString("Test #45 Weave", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Weave, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #46
+            top += spacing;
+            gr.DrawString("Test #46 Plaid", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Plaid, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #47
+            top += spacing;
+            gr.DrawString("Test #47 Divot", font, br, textStart, top);
+
+            top += spacing;
+            pen = new Pen(new HatchBrush(HatchStyle.Divot, fgColor, bgColor), penWidth);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #48
+            top += spacing;
+            gr.DrawString("Test #48 SmallCheckerBoard", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.SmallCheckerBoard, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #49
+            top += spacing;
+            gr.DrawString("Test #49 LargeCheckerBoard", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.LargeCheckerBoard, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #50
+            top += spacing;
+            gr.DrawString("Test #50 OutlinedDiamond", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.OutlinedDiamond, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #51
+            top += spacing;
+            gr.DrawString("Test #51 SolidDiamond", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.SolidDiamond, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #52
+            top += spacing;
+            gr.DrawString("Test #52 DottedDiamond", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.DottedDiamond, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #53
+            top += spacing;
+            gr.DrawString("Test #53 Shingle", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.Shingle, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #54
+            top += spacing;
+            gr.DrawString("Test #54 Trellis", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.Trellis, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            // #55
+            top += spacing;
+            gr.DrawString("Test #55 Sphere", font, br, textStart, top);
+
+            top += spacing;
+            pen.Brush = new HatchBrush(HatchStyle.Sphere, fgColor, bgColor);
+            gr.DrawLine(pen, lineStart, top, lineStart + length, top);
+
+            currentTop = top;
+        }
+
+        internal string getOutSufix()
+        {
+            string s;
+
+            int p = (int)Environment.OSVersion.Platform;
+            if ((p == 4) || (p == 128) || (p == 6))
+                s = "-unix";
+            else
+                s = "-windows";
+
+            if (Type.GetType("Mono.Runtime", false) == null)
+                s += "-msnet";
+            else
+                s += "-mono";
+
+            return s;
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/TestMatrix.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Drawing2D/TestMatrix.cs
@@ -1,0 +1,651 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Tests for System.Drawing.Drawing2D.Matrix.cs
+//
+// Authors:
+//	Jordi Mas i Hernandez <jordi@ximian.com>
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2005-2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using Xunit;
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+
+namespace MonoTests.System.Drawing.Drawing2D
+{
+    public class MatrixTest
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Default()
+        {
+            Matrix matrix = new Matrix();
+            Assert.Equal(6, matrix.Elements.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_SixFloats()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            Assert.Equal(6, matrix.Elements.Length);
+            Assert.Equal(10, matrix.Elements[0]);
+            Assert.Equal(20, matrix.Elements[1]);
+            Assert.Equal(30, matrix.Elements[2]);
+            Assert.Equal(40, matrix.Elements[3]);
+            Assert.Equal(50, matrix.Elements[4]);
+            Assert.Equal(60, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Float()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            Assert.Equal(6, matrix.Elements.Length);
+            Assert.Equal(10, matrix.Elements[0]);
+            Assert.Equal(20, matrix.Elements[1]);
+            Assert.Equal(30, matrix.Elements[2]);
+            Assert.Equal(40, matrix.Elements[3]);
+            Assert.Equal(50, matrix.Elements[4]);
+            Assert.Equal(60, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Int_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Matrix(default(Rectangle), null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Int_Empty()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix(default(Rectangle), new Point[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Int_4Point()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix(default(Rectangle), new Point[4]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Rect_Point()
+        {
+            Rectangle r = new Rectangle(100, 200, 300, 400);
+            Matrix m = new Matrix(r, new Point[3] { new Point(10, 20), new Point(30, 40), new Point(50, 60) });
+            float[] elements = m.Elements;
+            Assert.Equal(0.06666666, elements[0], 5);
+            Assert.Equal(0.06666666, elements[1], 5);
+            Assert.Equal(0.09999999, elements[2], 5);
+            Assert.Equal(0.09999999, elements[3], 5);
+            Assert.Equal(-16.6666679, elements[4], 5);
+            Assert.Equal(-6.666667, elements[5], 5);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Float_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Matrix(default(RectangleF), null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Float_Empty()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix(default(RectangleF), new PointF[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Float_2PointF()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix(default(RectangleF), new PointF[2]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RectF_PointF()
+        {
+            RectangleF r = new RectangleF(100, 200, 300, 400);
+            Matrix m = new Matrix(r, new PointF[3] { new PointF(10, 20), new PointF(30, 40), new PointF(50, 60) });
+            float[] elements = m.Elements;
+            Assert.Equal(0.06666666, elements[0], 5);
+            Assert.Equal(0.06666666, elements[1], 5);
+            Assert.Equal(0.09999999, elements[2], 5);
+            Assert.Equal(0.09999999, elements[3], 5);
+            Assert.Equal(-16.6666679, elements[4], 5);
+            Assert.Equal(-6.666667, elements[5], 5);
+        }
+
+        // Properties
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Invertible()
+        {
+            Matrix matrix = new Matrix(123, 24, 82, 16, 47, 30);
+            Assert.Equal(false, matrix.IsInvertible);
+
+            matrix = new Matrix(156, 46, 0, 0, 106, 19);
+            Assert.Equal(false, matrix.IsInvertible);
+
+            matrix = new Matrix(146, 66, 158, 104, 42, 150);
+            Assert.Equal(true, matrix.IsInvertible);
+
+            matrix = new Matrix(119, 140, 145, 74, 102, 58);
+            Assert.Equal(true, matrix.IsInvertible);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsIdentity()
+        {
+            Matrix identity = new Matrix();
+            Matrix matrix = new Matrix(123, 24, 82, 16, 47, 30);
+            Assert.Equal(false, matrix.IsIdentity);
+            Assert.True(!identity.Equals(matrix));
+
+            matrix = new Matrix(1, 0, 0, 1, 0, 0);
+            Assert.Equal(true, matrix.IsIdentity);
+            Assert.True(identity.Equals(matrix));
+
+            // so what's the required precision ?
+
+            matrix = new Matrix(1.1f, 0.1f, -0.1f, 0.9f, 0, 0);
+            Assert.True(!matrix.IsIdentity);
+            Assert.True(!identity.Equals(matrix));
+
+            matrix = new Matrix(1.01f, 0.01f, -0.01f, 0.99f, 0, 0);
+            Assert.True(!matrix.IsIdentity);
+            Assert.True(!identity.Equals(matrix));
+
+            matrix = new Matrix(1.001f, 0.001f, -0.001f, 0.999f, 0, 0);
+            Assert.True(!matrix.IsIdentity);
+            Assert.True(!identity.Equals(matrix));
+
+            matrix = new Matrix(1.0001f, 0.0001f, -0.0001f, 0.9999f, 0, 0);
+            Assert.True(matrix.IsIdentity);
+            // note: NOT equal
+            Assert.True(!identity.Equals(matrix));
+
+            matrix = new Matrix(1.0009f, 0.0009f, -0.0009f, 0.99995f, 0, 0);
+            Assert.True(!matrix.IsIdentity);
+            Assert.True(!identity.Equals(matrix));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOffsetX()
+        {
+            Matrix matrix = new Matrix(123, 24, 82, 16, 47, 30);
+            Assert.Equal(47, matrix.OffsetX);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsOffsetY()
+        {
+            Matrix matrix = new Matrix(123, 24, 82, 16, 47, 30);
+            Assert.Equal(30, matrix.OffsetY);
+        }
+
+        // Elements Property is checked implicity in other test
+
+        //
+        // Methods
+        //
+
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Clone()
+        {
+            Matrix matsrc = new Matrix(10, 20, 30, 40, 50, 60);
+            Matrix matrix = matsrc.Clone();
+
+            Assert.Equal(6, matrix.Elements.Length);
+            Assert.Equal(10, matrix.Elements[0]);
+            Assert.Equal(20, matrix.Elements[1]);
+            Assert.Equal(30, matrix.Elements[2]);
+            Assert.Equal(40, matrix.Elements[3]);
+            Assert.Equal(50, matrix.Elements[4]);
+            Assert.Equal(60, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void HashCode()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            Matrix clone = matrix.Clone();
+            Assert.True(matrix.GetHashCode() != clone.GetHashCode());
+
+            Matrix matrix2 = new Matrix(10, 20, 30, 40, 50, 60);
+            Assert.True(matrix.GetHashCode() != matrix2.GetHashCode());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Reset()
+        {
+            Matrix matrix = new Matrix(51, 52, 53, 54, 55, 56);
+            matrix.Reset();
+
+            Assert.Equal(6, matrix.Elements.Length);
+            Assert.Equal(1, matrix.Elements[0]);
+            Assert.Equal(0, matrix.Elements[1]);
+            Assert.Equal(0, matrix.Elements[2]);
+            Assert.Equal(1, matrix.Elements[3]);
+            Assert.Equal(0, matrix.Elements[4]);
+            Assert.Equal(0, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Rotate()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            matrix.Rotate(180);
+
+            Assert.Equal(-10.0f, matrix.Elements[0], 4);
+            Assert.Equal(-20, matrix.Elements[1], 4);
+            Assert.Equal(-30.0000019f, matrix.Elements[2], 4);
+            Assert.Equal(-40.0000038f, matrix.Elements[3], 4);
+            Assert.Equal(50, matrix.Elements[4]);
+            Assert.Equal(60, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Rotate_45_135()
+        {
+            Matrix matrix = new Matrix();
+            Assert.True(matrix.IsIdentity);
+
+            matrix.Rotate(45);
+            Assert.True(!matrix.IsIdentity);
+            float[] elements = matrix.Elements;
+            Assert.Equal(0.707106769f, elements[0], 4);
+            Assert.Equal(0.707106769f, elements[1], 4);
+            Assert.Equal(-0.707106829f, elements[2], 4);
+            Assert.Equal(0.707106769f, elements[3], 4);
+            Assert.Equal(0, elements[4], 3);
+            Assert.Equal(0, elements[5], 3);
+
+            matrix.Rotate(135);
+            Assert.True(!matrix.IsIdentity);
+            elements = matrix.Elements;
+            Assert.Equal(-1, elements[0], 4);
+            Assert.Equal(0, elements[1], 4);
+            Assert.Equal(0, elements[2], 4);
+            Assert.Equal(-1, elements[3], 4);
+            Assert.Equal(0, elements[4]);
+            Assert.Equal(0, elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Rotate_90_270_Matrix()
+        {
+            Matrix matrix = new Matrix();
+            Assert.True(matrix.IsIdentity);
+
+            matrix.Rotate(90);
+            Assert.True(!matrix.IsIdentity);
+            float[] elements = matrix.Elements;
+            Assert.Equal(0, elements[0], 4);
+            Assert.Equal(1, elements[1], 4);
+            Assert.Equal(-1, elements[2], 4);
+            Assert.Equal(0, elements[3], 4);
+            Assert.Equal(0, elements[4]);
+            Assert.Equal(0, elements[5]);
+
+            matrix.Rotate(270);
+            // this isn't a perfect 1, 0, 0, 1, 0, 0 matrix - but close enough
+            Assert.True(matrix.IsIdentity);
+            Assert.True(!new Matrix().Equals(matrix));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Rotate_InvalidOrder()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix().Rotate(180, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RotateAt()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            matrix.RotateAt(180, new PointF(10, 10));
+
+            Assert.Equal(-10, matrix.Elements[0], 2);
+            Assert.Equal(-20, matrix.Elements[1], 2);
+            Assert.Equal(-30, matrix.Elements[2], 2);
+            Assert.Equal(-40, matrix.Elements[3], 2);
+            Assert.Equal(850, matrix.Elements[4], 2);
+            Assert.Equal(1260, matrix.Elements[5], 2);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RotateAt_InvalidOrder()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix().RotateAt(180, new PointF(10, 10), (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Multiply_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Matrix(10, 20, 30, 40, 50, 60).Multiply(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Multiply()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            matrix.Multiply(new Matrix(10, 20, 30, 40, 50, 60));
+
+            Assert.Equal(700, matrix.Elements[0]);
+            Assert.Equal(1000, matrix.Elements[1]);
+            Assert.Equal(1500, matrix.Elements[2]);
+            Assert.Equal(2200, matrix.Elements[3]);
+            Assert.Equal(2350, matrix.Elements[4]);
+            Assert.Equal(3460, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Multiply_Null_Order()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Matrix(10, 20, 30, 40, 50, 60).Multiply(null, MatrixOrder.Append));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Multiply_Append()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            matrix.Multiply(new Matrix(10, 20, 30, 40, 50, 60), MatrixOrder.Append);
+
+            Assert.Equal(700, matrix.Elements[0]);
+            Assert.Equal(1000, matrix.Elements[1]);
+            Assert.Equal(1500, matrix.Elements[2]);
+            Assert.Equal(2200, matrix.Elements[3]);
+            Assert.Equal(2350, matrix.Elements[4]);
+            Assert.Equal(3460, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Multiply_Prepend()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            matrix.Multiply(new Matrix(10, 20, 30, 40, 50, 60), MatrixOrder.Prepend);
+
+            Assert.Equal(700, matrix.Elements[0]);
+            Assert.Equal(1000, matrix.Elements[1]);
+            Assert.Equal(1500, matrix.Elements[2]);
+            Assert.Equal(2200, matrix.Elements[3]);
+            Assert.Equal(2350, matrix.Elements[4]);
+            Assert.Equal(3460, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Multiply_InvalidOrder()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            Assert.Throws<ArgumentException>(() => matrix.Multiply(new Matrix(10, 20, 30, 40, 50, 60), (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Equals()
+        {
+            Matrix mat1 = new Matrix(10, 20, 30, 40, 50, 60);
+            Matrix mat2 = new Matrix(10, 20, 30, 40, 50, 60);
+            Matrix mat3 = new Matrix(10, 20, 30, 40, 50, 10);
+
+            Assert.Equal(true, mat1.Equals(mat2));
+            Assert.Equal(false, mat2.Equals(mat3));
+            Assert.Equal(false, mat1.Equals(mat3));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Invert()
+        {
+            Matrix matrix = new Matrix(1, 2, 3, 4, 5, 6);
+            matrix.Invert();
+
+            Assert.Equal(-2, matrix.Elements[0]);
+            Assert.Equal(1, matrix.Elements[1]);
+            Assert.Equal(1.5, matrix.Elements[2]);
+            Assert.Equal(-0.5, matrix.Elements[3]);
+            Assert.Equal(1, matrix.Elements[4]);
+            Assert.Equal(-2, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Invert_Translation()
+        {
+            Matrix matrix = new Matrix(1, 0, 0, 1, 8, 8);
+            matrix.Invert();
+
+            float[] elements = matrix.Elements;
+            Assert.Equal(1, elements[0]);
+            Assert.Equal(0, elements[1]);
+            Assert.Equal(0, elements[2]);
+            Assert.Equal(1, elements[3]);
+            Assert.Equal(-8, elements[4]);
+            Assert.Equal(-8, elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Invert_Identity()
+        {
+            Matrix matrix = new Matrix();
+            Assert.True(matrix.IsIdentity);
+            Assert.True(matrix.IsInvertible);
+            matrix.Invert();
+            Assert.True(matrix.IsIdentity);
+            Assert.True(matrix.IsInvertible);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Scale()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            matrix.Scale(2, 4);
+
+            Assert.Equal(20, matrix.Elements[0]);
+            Assert.Equal(40, matrix.Elements[1]);
+            Assert.Equal(120, matrix.Elements[2]);
+            Assert.Equal(160, matrix.Elements[3]);
+            Assert.Equal(50, matrix.Elements[4]);
+            Assert.Equal(60, matrix.Elements[5]);
+
+            matrix.Scale(0.5f, 0.25f);
+
+            Assert.Equal(10, matrix.Elements[0]);
+            Assert.Equal(20, matrix.Elements[1]);
+            Assert.Equal(30, matrix.Elements[2]);
+            Assert.Equal(40, matrix.Elements[3]);
+            Assert.Equal(50, matrix.Elements[4]);
+            Assert.Equal(60, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Scale_Negative()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            matrix.Scale(-2, -4);
+
+            Assert.Equal(-20, matrix.Elements[0]);
+            Assert.Equal(-40, matrix.Elements[1]);
+            Assert.Equal(-120, matrix.Elements[2]);
+            Assert.Equal(-160, matrix.Elements[3]);
+            Assert.Equal(50, matrix.Elements[4]);
+            Assert.Equal(60, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Scale_InvalidOrder()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix().Scale(2, 1, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Shear()
+        {
+            Matrix matrix = new Matrix(10, 20, 30, 40, 50, 60);
+            matrix.Shear(2, 4);
+
+            Assert.Equal(130, matrix.Elements[0]);
+            Assert.Equal(180, matrix.Elements[1]);
+            Assert.Equal(50, matrix.Elements[2]);
+            Assert.Equal(80, matrix.Elements[3]);
+            Assert.Equal(50, matrix.Elements[4]);
+            Assert.Equal(60, matrix.Elements[5]);
+
+            matrix = new Matrix(5, 3, 9, 2, 2, 1);
+            matrix.Shear(10, 20);
+
+            Assert.Equal(185, matrix.Elements[0]);
+            Assert.Equal(43, matrix.Elements[1]);
+            Assert.Equal(59, matrix.Elements[2]);
+            Assert.Equal(32, matrix.Elements[3]);
+            Assert.Equal(2, matrix.Elements[4]);
+            Assert.Equal(1, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Shear_InvalidOrder()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix().Shear(-1, 1, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TransformPoints()
+        {
+            Matrix matrix = new Matrix(2, 4, 6, 8, 10, 12);
+            PointF[] pointsF = new PointF[] { new PointF(2, 4), new PointF(4, 8) };
+            matrix.TransformPoints(pointsF);
+
+            Assert.Equal(38, pointsF[0].X);
+            Assert.Equal(52, pointsF[0].Y);
+            Assert.Equal(66, pointsF[1].X);
+            Assert.Equal(92, pointsF[1].Y);
+
+            Point[] points = new Point[] { new Point(2, 4), new Point(4, 8) };
+            matrix.TransformPoints(points);
+            Assert.Equal(38, pointsF[0].X);
+            Assert.Equal(52, pointsF[0].Y);
+            Assert.Equal(66, pointsF[1].X);
+            Assert.Equal(92, pointsF[1].Y);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TransformPoints_Point_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Matrix().TransformPoints((Point[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TransformPoints_PointF_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Matrix().TransformPoints((PointF[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TransformPoints_Point_Empty()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix().TransformPoints(new Point[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TransformPoints_PointF_Empty()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix().TransformPoints(new PointF[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TransformVectors()
+        {
+            Matrix matrix = new Matrix(2, 4, 6, 8, 10, 12);
+            PointF[] pointsF = new PointF[] { new PointF(2, 4), new PointF(4, 8) };
+            matrix.TransformVectors(pointsF);
+
+            Assert.Equal(28, pointsF[0].X);
+            Assert.Equal(40, pointsF[0].Y);
+            Assert.Equal(56, pointsF[1].X);
+            Assert.Equal(80, pointsF[1].Y);
+
+            Point[] points = new Point[] { new Point(2, 4), new Point(4, 8) };
+            matrix.TransformVectors(points);
+            Assert.Equal(28, pointsF[0].X);
+            Assert.Equal(40, pointsF[0].Y);
+            Assert.Equal(56, pointsF[1].X);
+            Assert.Equal(80, pointsF[1].Y);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TransformVectors_Point_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Matrix().TransformVectors((Point[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TransformVectors_PointF_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Matrix().TransformVectors((PointF[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TransformVectors_Point_Empty()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix().TransformVectors(new Point[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TransformVectors_PointF_Empty()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix().TransformVectors(new PointF[0]));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Translate()
+        {
+            Matrix matrix = new Matrix(2, 4, 6, 8, 10, 12);
+            matrix.Translate(5, 10);
+
+            Assert.Equal(2, matrix.Elements[0]);
+            Assert.Equal(4, matrix.Elements[1]);
+            Assert.Equal(6, matrix.Elements[2]);
+            Assert.Equal(8, matrix.Elements[3]);
+            Assert.Equal(80, matrix.Elements[4]);
+            Assert.Equal(112, matrix.Elements[5]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Translate_InvalidOrder()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix().Translate(-1, 1, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void VectorTransformPoints_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Matrix().VectorTransformPoints((Point[])null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void VectorTransformPoints_Empty()
+        {
+            Assert.Throws<ArgumentException>(() => new Matrix().VectorTransformPoints(new Point[0]));
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/EmfPlusRecordTypeTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/EmfPlusRecordTypeTest.cs
@@ -1,0 +1,311 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// EmfPlusRecordType class unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing.Imaging
+{
+
+    public class EmfPlusRecordTypeTest
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void EmfRecords()
+        {
+            Assert.Equal(1, (int)EmfPlusRecordType.EmfMin);
+            Assert.Equal(1, (int)EmfPlusRecordType.EmfHeader);
+            Assert.Equal(2, (int)EmfPlusRecordType.EmfPolyBezier);
+            Assert.Equal(3, (int)EmfPlusRecordType.EmfPolygon);
+            Assert.Equal(4, (int)EmfPlusRecordType.EmfPolyline);
+            Assert.Equal(5, (int)EmfPlusRecordType.EmfPolyBezierTo);
+            Assert.Equal(6, (int)EmfPlusRecordType.EmfPolyLineTo);
+            Assert.Equal(7, (int)EmfPlusRecordType.EmfPolyPolyline);
+            Assert.Equal(8, (int)EmfPlusRecordType.EmfPolyPolygon);
+            Assert.Equal(9, (int)EmfPlusRecordType.EmfSetWindowExtEx);
+            Assert.Equal(10, (int)EmfPlusRecordType.EmfSetWindowOrgEx);
+            Assert.Equal(11, (int)EmfPlusRecordType.EmfSetViewportExtEx);
+            Assert.Equal(12, (int)EmfPlusRecordType.EmfSetViewportOrgEx);
+            Assert.Equal(13, (int)EmfPlusRecordType.EmfSetBrushOrgEx);
+            Assert.Equal(14, (int)EmfPlusRecordType.EmfEof);
+            Assert.Equal(15, (int)EmfPlusRecordType.EmfSetPixelV);
+            Assert.Equal(16, (int)EmfPlusRecordType.EmfSetMapperFlags);
+            Assert.Equal(17, (int)EmfPlusRecordType.EmfSetMapMode);
+            Assert.Equal(18, (int)EmfPlusRecordType.EmfSetBkMode);
+            Assert.Equal(19, (int)EmfPlusRecordType.EmfSetPolyFillMode);
+            Assert.Equal(20, (int)EmfPlusRecordType.EmfSetROP2);
+            Assert.Equal(21, (int)EmfPlusRecordType.EmfSetStretchBltMode);
+            Assert.Equal(22, (int)EmfPlusRecordType.EmfSetTextAlign);
+            Assert.Equal(23, (int)EmfPlusRecordType.EmfSetColorAdjustment);
+            Assert.Equal(24, (int)EmfPlusRecordType.EmfSetTextColor);
+            Assert.Equal(25, (int)EmfPlusRecordType.EmfSetBkColor);
+            Assert.Equal(26, (int)EmfPlusRecordType.EmfOffsetClipRgn);
+            Assert.Equal(27, (int)EmfPlusRecordType.EmfMoveToEx);
+            Assert.Equal(28, (int)EmfPlusRecordType.EmfSetMetaRgn);
+            Assert.Equal(29, (int)EmfPlusRecordType.EmfExcludeClipRect);
+            Assert.Equal(30, (int)EmfPlusRecordType.EmfIntersectClipRect);
+            Assert.Equal(31, (int)EmfPlusRecordType.EmfScaleViewportExtEx);
+            Assert.Equal(32, (int)EmfPlusRecordType.EmfScaleWindowExtEx);
+            Assert.Equal(33, (int)EmfPlusRecordType.EmfSaveDC);
+            Assert.Equal(34, (int)EmfPlusRecordType.EmfRestoreDC);
+            Assert.Equal(35, (int)EmfPlusRecordType.EmfSetWorldTransform);
+            Assert.Equal(36, (int)EmfPlusRecordType.EmfModifyWorldTransform);
+            Assert.Equal(37, (int)EmfPlusRecordType.EmfSelectObject);
+            Assert.Equal(38, (int)EmfPlusRecordType.EmfCreatePen);
+            Assert.Equal(39, (int)EmfPlusRecordType.EmfCreateBrushIndirect);
+            Assert.Equal(40, (int)EmfPlusRecordType.EmfDeleteObject);
+            Assert.Equal(41, (int)EmfPlusRecordType.EmfAngleArc);
+            Assert.Equal(42, (int)EmfPlusRecordType.EmfEllipse);
+            Assert.Equal(43, (int)EmfPlusRecordType.EmfRectangle);
+            Assert.Equal(44, (int)EmfPlusRecordType.EmfRoundRect);
+            Assert.Equal(45, (int)EmfPlusRecordType.EmfRoundArc);
+            Assert.Equal(46, (int)EmfPlusRecordType.EmfChord);
+            Assert.Equal(47, (int)EmfPlusRecordType.EmfPie);
+            Assert.Equal(48, (int)EmfPlusRecordType.EmfSelectPalette);
+            Assert.Equal(49, (int)EmfPlusRecordType.EmfCreatePalette);
+            Assert.Equal(50, (int)EmfPlusRecordType.EmfSetPaletteEntries);
+            Assert.Equal(51, (int)EmfPlusRecordType.EmfResizePalette);
+            Assert.Equal(52, (int)EmfPlusRecordType.EmfRealizePalette);
+            Assert.Equal(53, (int)EmfPlusRecordType.EmfExtFloodFill);
+            Assert.Equal(54, (int)EmfPlusRecordType.EmfLineTo);
+            Assert.Equal(55, (int)EmfPlusRecordType.EmfArcTo);
+            Assert.Equal(56, (int)EmfPlusRecordType.EmfPolyDraw);
+            Assert.Equal(57, (int)EmfPlusRecordType.EmfSetArcDirection);
+            Assert.Equal(58, (int)EmfPlusRecordType.EmfSetMiterLimit);
+            Assert.Equal(59, (int)EmfPlusRecordType.EmfBeginPath);
+            Assert.Equal(60, (int)EmfPlusRecordType.EmfEndPath);
+            Assert.Equal(61, (int)EmfPlusRecordType.EmfCloseFigure);
+            Assert.Equal(62, (int)EmfPlusRecordType.EmfFillPath);
+            Assert.Equal(63, (int)EmfPlusRecordType.EmfStrokeAndFillPath);
+            Assert.Equal(64, (int)EmfPlusRecordType.EmfStrokePath);
+            Assert.Equal(65, (int)EmfPlusRecordType.EmfFlattenPath);
+            Assert.Equal(66, (int)EmfPlusRecordType.EmfWidenPath);
+            Assert.Equal(67, (int)EmfPlusRecordType.EmfSelectClipPath);
+            Assert.Equal(68, (int)EmfPlusRecordType.EmfAbortPath);
+            Assert.Equal(69, (int)EmfPlusRecordType.EmfReserved069);
+            Assert.Equal(70, (int)EmfPlusRecordType.EmfGdiComment);
+            Assert.Equal(71, (int)EmfPlusRecordType.EmfFillRgn);
+            Assert.Equal(72, (int)EmfPlusRecordType.EmfFrameRgn);
+            Assert.Equal(73, (int)EmfPlusRecordType.EmfInvertRgn);
+            Assert.Equal(74, (int)EmfPlusRecordType.EmfPaintRgn);
+            Assert.Equal(75, (int)EmfPlusRecordType.EmfExtSelectClipRgn);
+            Assert.Equal(76, (int)EmfPlusRecordType.EmfBitBlt);
+            Assert.Equal(77, (int)EmfPlusRecordType.EmfStretchBlt);
+            Assert.Equal(78, (int)EmfPlusRecordType.EmfMaskBlt);
+            Assert.Equal(79, (int)EmfPlusRecordType.EmfPlgBlt);
+            Assert.Equal(80, (int)EmfPlusRecordType.EmfSetDIBitsToDevice);
+            Assert.Equal(81, (int)EmfPlusRecordType.EmfStretchDIBits);
+            Assert.Equal(82, (int)EmfPlusRecordType.EmfExtCreateFontIndirect);
+            Assert.Equal(83, (int)EmfPlusRecordType.EmfExtTextOutA);
+            Assert.Equal(84, (int)EmfPlusRecordType.EmfExtTextOutW);
+            Assert.Equal(85, (int)EmfPlusRecordType.EmfPolyBezier16);
+            Assert.Equal(86, (int)EmfPlusRecordType.EmfPolygon16);
+            Assert.Equal(87, (int)EmfPlusRecordType.EmfPolyline16);
+            Assert.Equal(88, (int)EmfPlusRecordType.EmfPolyBezierTo16);
+            Assert.Equal(89, (int)EmfPlusRecordType.EmfPolylineTo16);
+            Assert.Equal(90, (int)EmfPlusRecordType.EmfPolyPolyline16);
+            Assert.Equal(91, (int)EmfPlusRecordType.EmfPolyPolygon16);
+            Assert.Equal(92, (int)EmfPlusRecordType.EmfPolyDraw16);
+            Assert.Equal(93, (int)EmfPlusRecordType.EmfCreateMonoBrush);
+            Assert.Equal(94, (int)EmfPlusRecordType.EmfCreateDibPatternBrushPt);
+            Assert.Equal(95, (int)EmfPlusRecordType.EmfExtCreatePen);
+            Assert.Equal(96, (int)EmfPlusRecordType.EmfPolyTextOutA);
+            Assert.Equal(97, (int)EmfPlusRecordType.EmfPolyTextOutW);
+            Assert.Equal(98, (int)EmfPlusRecordType.EmfSetIcmMode);
+            Assert.Equal(99, (int)EmfPlusRecordType.EmfCreateColorSpace);
+            Assert.Equal(100, (int)EmfPlusRecordType.EmfSetColorSpace);
+            Assert.Equal(101, (int)EmfPlusRecordType.EmfDeleteColorSpace);
+            Assert.Equal(102, (int)EmfPlusRecordType.EmfGlsRecord);
+            Assert.Equal(103, (int)EmfPlusRecordType.EmfGlsBoundedRecord);
+            Assert.Equal(104, (int)EmfPlusRecordType.EmfPixelFormat);
+            Assert.Equal(105, (int)EmfPlusRecordType.EmfDrawEscape);
+            Assert.Equal(106, (int)EmfPlusRecordType.EmfExtEscape);
+            Assert.Equal(107, (int)EmfPlusRecordType.EmfStartDoc);
+            Assert.Equal(108, (int)EmfPlusRecordType.EmfSmallTextOut);
+            Assert.Equal(109, (int)EmfPlusRecordType.EmfForceUfiMapping);
+            Assert.Equal(110, (int)EmfPlusRecordType.EmfNamedEscpae);
+            Assert.Equal(111, (int)EmfPlusRecordType.EmfColorCorrectPalette);
+            Assert.Equal(112, (int)EmfPlusRecordType.EmfSetIcmProfileA);
+            Assert.Equal(113, (int)EmfPlusRecordType.EmfSetIcmProfileW);
+            Assert.Equal(114, (int)EmfPlusRecordType.EmfAlphaBlend);
+            Assert.Equal(115, (int)EmfPlusRecordType.EmfSetLayout);
+            Assert.Equal(116, (int)EmfPlusRecordType.EmfTransparentBlt);
+            Assert.Equal(117, (int)EmfPlusRecordType.EmfReserved117);
+            Assert.Equal(118, (int)EmfPlusRecordType.EmfGradientFill);
+            Assert.Equal(119, (int)EmfPlusRecordType.EmfSetLinkedUfis);
+            Assert.Equal(120, (int)EmfPlusRecordType.EmfSetTextJustification);
+            Assert.Equal(121, (int)EmfPlusRecordType.EmfColorMatchToTargetW);
+            Assert.Equal(122, (int)EmfPlusRecordType.EmfCreateColorSpaceW);
+            Assert.Equal(122, (int)EmfPlusRecordType.EmfMax);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void EmfPlusRecords()
+        {
+            Assert.Equal(16384, (int)EmfPlusRecordType.EmfPlusRecordBase);
+            Assert.Equal(16384, (int)EmfPlusRecordType.Invalid);
+            Assert.Equal(16385, (int)EmfPlusRecordType.Min);
+            Assert.Equal(16385, (int)EmfPlusRecordType.Header);
+            Assert.Equal(16386, (int)EmfPlusRecordType.EndOfFile);
+            Assert.Equal(16387, (int)EmfPlusRecordType.Comment);
+            Assert.Equal(16388, (int)EmfPlusRecordType.GetDC);
+            Assert.Equal(16389, (int)EmfPlusRecordType.MultiFormatStart);
+            Assert.Equal(16390, (int)EmfPlusRecordType.MultiFormatSection);
+            Assert.Equal(16391, (int)EmfPlusRecordType.MultiFormatEnd);
+            Assert.Equal(16392, (int)EmfPlusRecordType.Object);
+            Assert.Equal(16393, (int)EmfPlusRecordType.Clear);
+            Assert.Equal(16394, (int)EmfPlusRecordType.FillRects);
+            Assert.Equal(16395, (int)EmfPlusRecordType.DrawRects);
+            Assert.Equal(16396, (int)EmfPlusRecordType.FillPolygon);
+            Assert.Equal(16397, (int)EmfPlusRecordType.DrawLines);
+            Assert.Equal(16398, (int)EmfPlusRecordType.FillEllipse);
+            Assert.Equal(16399, (int)EmfPlusRecordType.DrawEllipse);
+            Assert.Equal(16400, (int)EmfPlusRecordType.FillPie);
+            Assert.Equal(16401, (int)EmfPlusRecordType.DrawPie);
+            Assert.Equal(16402, (int)EmfPlusRecordType.DrawArc);
+            Assert.Equal(16403, (int)EmfPlusRecordType.FillRegion);
+            Assert.Equal(16404, (int)EmfPlusRecordType.FillPath);
+            Assert.Equal(16405, (int)EmfPlusRecordType.DrawPath);
+            Assert.Equal(16406, (int)EmfPlusRecordType.FillClosedCurve);
+            Assert.Equal(16407, (int)EmfPlusRecordType.DrawClosedCurve);
+            Assert.Equal(16408, (int)EmfPlusRecordType.DrawCurve);
+            Assert.Equal(16409, (int)EmfPlusRecordType.DrawBeziers);
+            Assert.Equal(16410, (int)EmfPlusRecordType.DrawImage);
+            Assert.Equal(16411, (int)EmfPlusRecordType.DrawImagePoints);
+            Assert.Equal(16412, (int)EmfPlusRecordType.DrawString);
+            Assert.Equal(16413, (int)EmfPlusRecordType.SetRenderingOrigin);
+            Assert.Equal(16414, (int)EmfPlusRecordType.SetAntiAliasMode);
+            Assert.Equal(16415, (int)EmfPlusRecordType.SetTextRenderingHint);
+            Assert.Equal(16416, (int)EmfPlusRecordType.SetTextContrast);
+            Assert.Equal(16417, (int)EmfPlusRecordType.SetInterpolationMode);
+            Assert.Equal(16418, (int)EmfPlusRecordType.SetPixelOffsetMode);
+            Assert.Equal(16419, (int)EmfPlusRecordType.SetCompositingMode);
+            Assert.Equal(16420, (int)EmfPlusRecordType.SetCompositingQuality);
+            Assert.Equal(16421, (int)EmfPlusRecordType.Save);
+            Assert.Equal(16422, (int)EmfPlusRecordType.Restore);
+            Assert.Equal(16423, (int)EmfPlusRecordType.BeginContainer);
+            Assert.Equal(16424, (int)EmfPlusRecordType.BeginContainerNoParams);
+            Assert.Equal(16425, (int)EmfPlusRecordType.EndContainer);
+            Assert.Equal(16426, (int)EmfPlusRecordType.SetWorldTransform);
+            Assert.Equal(16427, (int)EmfPlusRecordType.ResetWorldTransform);
+            Assert.Equal(16428, (int)EmfPlusRecordType.MultiplyWorldTransform);
+            Assert.Equal(16429, (int)EmfPlusRecordType.TranslateWorldTransform);
+            Assert.Equal(16430, (int)EmfPlusRecordType.ScaleWorldTransform);
+            Assert.Equal(16431, (int)EmfPlusRecordType.RotateWorldTransform);
+            Assert.Equal(16432, (int)EmfPlusRecordType.SetPageTransform);
+            Assert.Equal(16433, (int)EmfPlusRecordType.ResetClip);
+            Assert.Equal(16434, (int)EmfPlusRecordType.SetClipRect);
+            Assert.Equal(16435, (int)EmfPlusRecordType.SetClipPath);
+            Assert.Equal(16436, (int)EmfPlusRecordType.SetClipRegion);
+            Assert.Equal(16437, (int)EmfPlusRecordType.OffsetClip);
+            Assert.Equal(16438, (int)EmfPlusRecordType.DrawDriverString);
+            Assert.Equal(16438, (int)EmfPlusRecordType.Max);
+            Assert.Equal(16439, (int)EmfPlusRecordType.Total);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void WmfRecords()
+        {
+            Assert.Equal(65536, (int)EmfPlusRecordType.WmfRecordBase);
+            Assert.Equal(65566, (int)EmfPlusRecordType.WmfSaveDC);
+            Assert.Equal(65589, (int)EmfPlusRecordType.WmfRealizePalette);
+            Assert.Equal(65591, (int)EmfPlusRecordType.WmfSetPalEntries);
+            Assert.Equal(65783, (int)EmfPlusRecordType.WmfCreatePalette);
+            Assert.Equal(65794, (int)EmfPlusRecordType.WmfSetBkMode);
+            Assert.Equal(65795, (int)EmfPlusRecordType.WmfSetMapMode);
+            Assert.Equal(65796, (int)EmfPlusRecordType.WmfSetROP2);
+            Assert.Equal(65797, (int)EmfPlusRecordType.WmfSetRelAbs);
+            Assert.Equal(65798, (int)EmfPlusRecordType.WmfSetPolyFillMode);
+            Assert.Equal(65799, (int)EmfPlusRecordType.WmfSetStretchBltMode);
+            Assert.Equal(65800, (int)EmfPlusRecordType.WmfSetTextCharExtra);
+            Assert.Equal(65831, (int)EmfPlusRecordType.WmfRestoreDC);
+            Assert.Equal(65834, (int)EmfPlusRecordType.WmfInvertRegion);
+            Assert.Equal(65835, (int)EmfPlusRecordType.WmfPaintRegion);
+            Assert.Equal(65836, (int)EmfPlusRecordType.WmfSelectClipRegion);
+            Assert.Equal(65837, (int)EmfPlusRecordType.WmfSelectObject);
+            Assert.Equal(65838, (int)EmfPlusRecordType.WmfSetTextAlign);
+            Assert.Equal(65849, (int)EmfPlusRecordType.WmfResizePalette);
+            Assert.Equal(65858, (int)EmfPlusRecordType.WmfDibCreatePatternBrush);
+            Assert.Equal(65865, (int)EmfPlusRecordType.WmfSetLayout);
+            Assert.Equal(66032, (int)EmfPlusRecordType.WmfDeleteObject);
+            Assert.Equal(66041, (int)EmfPlusRecordType.WmfCreatePatternBrush);
+            Assert.Equal(66049, (int)EmfPlusRecordType.WmfSetBkColor);
+            Assert.Equal(66057, (int)EmfPlusRecordType.WmfSetTextColor);
+            Assert.Equal(66058, (int)EmfPlusRecordType.WmfSetTextJustification);
+            Assert.Equal(66059, (int)EmfPlusRecordType.WmfSetWindowOrg);
+            Assert.Equal(66060, (int)EmfPlusRecordType.WmfSetWindowExt);
+            Assert.Equal(66061, (int)EmfPlusRecordType.WmfSetViewportOrg);
+            Assert.Equal(66062, (int)EmfPlusRecordType.WmfSetViewportExt);
+            Assert.Equal(66063, (int)EmfPlusRecordType.WmfOffsetWindowOrg);
+            Assert.Equal(66065, (int)EmfPlusRecordType.WmfOffsetViewportOrg);
+            Assert.Equal(66067, (int)EmfPlusRecordType.WmfLineTo);
+            Assert.Equal(66068, (int)EmfPlusRecordType.WmfMoveTo);
+            Assert.Equal(66080, (int)EmfPlusRecordType.WmfOffsetCilpRgn);
+            Assert.Equal(66088, (int)EmfPlusRecordType.WmfFillRegion);
+            Assert.Equal(66097, (int)EmfPlusRecordType.WmfSetMapperFlags);
+            Assert.Equal(66100, (int)EmfPlusRecordType.WmfSelectPalette);
+            Assert.Equal(66298, (int)EmfPlusRecordType.WmfCreatePenIndirect);
+            Assert.Equal(66299, (int)EmfPlusRecordType.WmfCreateFontIndirect);
+            Assert.Equal(66300, (int)EmfPlusRecordType.WmfCreateBrushIndirect);
+            Assert.Equal(66340, (int)EmfPlusRecordType.WmfPolygon);
+            Assert.Equal(66341, (int)EmfPlusRecordType.WmfPolyline);
+            Assert.Equal(66576, (int)EmfPlusRecordType.WmfScaleWindowExt);
+            Assert.Equal(66578, (int)EmfPlusRecordType.WmfScaleViewportExt);
+            Assert.Equal(66581, (int)EmfPlusRecordType.WmfExcludeClipRect);
+            Assert.Equal(66582, (int)EmfPlusRecordType.WmfIntersectClipRect);
+            Assert.Equal(66584, (int)EmfPlusRecordType.WmfEllipse);
+            Assert.Equal(66585, (int)EmfPlusRecordType.WmfFloodFill);
+            Assert.Equal(66587, (int)EmfPlusRecordType.WmfRectangle);
+            Assert.Equal(66591, (int)EmfPlusRecordType.WmfSetPixel);
+            Assert.Equal(66601, (int)EmfPlusRecordType.WmfFrameRegion);
+            Assert.Equal(66614, (int)EmfPlusRecordType.WmfAnimatePalette);
+            Assert.Equal(66849, (int)EmfPlusRecordType.WmfTextOut);
+            Assert.Equal(66872, (int)EmfPlusRecordType.WmfPolyPolygon);
+            Assert.Equal(66888, (int)EmfPlusRecordType.WmfExtFloodFill);
+            Assert.Equal(67100, (int)EmfPlusRecordType.WmfRoundRect);
+            Assert.Equal(67101, (int)EmfPlusRecordType.WmfPatBlt);
+            Assert.Equal(67110, (int)EmfPlusRecordType.WmfEscape);
+            Assert.Equal(67327, (int)EmfPlusRecordType.WmfCreateRegion);
+            Assert.Equal(67607, (int)EmfPlusRecordType.WmfArc);
+            Assert.Equal(67610, (int)EmfPlusRecordType.WmfPie);
+            Assert.Equal(67632, (int)EmfPlusRecordType.WmfChord);
+            Assert.Equal(67874, (int)EmfPlusRecordType.WmfBitBlt);
+            Assert.Equal(67904, (int)EmfPlusRecordType.WmfDibBitBlt);
+            Assert.Equal(68146, (int)EmfPlusRecordType.WmfExtTextOut);
+            Assert.Equal(68387, (int)EmfPlusRecordType.WmfStretchBlt);
+            Assert.Equal(68417, (int)EmfPlusRecordType.WmfDibStretchBlt);
+            Assert.Equal(68915, (int)EmfPlusRecordType.WmfSetDibToDev);
+            Assert.Equal(69443, (int)EmfPlusRecordType.WmfStretchDib);
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/FrameDimensionTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/FrameDimensionTest.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2008 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing.Imaging
+{
+
+    public class FrameDimensionTest
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Empty()
+        {
+            FrameDimension fd = new FrameDimension(Guid.Empty);
+            Assert.Equal("00000000-0000-0000-0000-000000000000", fd.Guid.ToString());
+            Assert.Equal(Guid.Empty.GetHashCode(), fd.GetHashCode());
+            Assert.Equal("[FrameDimension: 00000000-0000-0000-0000-000000000000]", fd.ToString());
+
+            Assert.True(fd.Equals(new FrameDimension(Guid.Empty)));
+            Assert.False(fd.Equals(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void WellKnownValues()
+        {
+            Assert.Equal("7462dc86-6180-4c7e-8e3f-ee7333a7a483", FrameDimension.Page.Guid.ToString());
+            Assert.Equal("Page", FrameDimension.Page.ToString());
+            Assert.True(Object.ReferenceEquals(FrameDimension.Page, FrameDimension.Page));
+
+            Assert.Equal("84236f7b-3bd3-428f-8dab-4ea1439ca315", FrameDimension.Resolution.Guid.ToString());
+            Assert.Equal("Resolution", FrameDimension.Resolution.ToString());
+            Assert.True(Object.ReferenceEquals(FrameDimension.Resolution, FrameDimension.Resolution));
+
+            Assert.Equal("6aedbd6d-3fb5-418a-83a6-7f45229dc872", FrameDimension.Time.Guid.ToString());
+            Assert.Equal("Time", FrameDimension.Time.ToString());
+            Assert.True(Object.ReferenceEquals(FrameDimension.Time, FrameDimension.Time));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Equals()
+        {
+            FrameDimension fd = new FrameDimension(new Guid("7462dc86-6180-4c7e-8e3f-ee7333a7a483"));
+            // equals
+            Assert.True(fd.Equals(FrameDimension.Page));
+            // but ToString differs!
+            Assert.Equal("[FrameDimension: 7462dc86-6180-4c7e-8e3f-ee7333a7a483]", fd.ToString());
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/TestColorMatrix.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/TestColorMatrix.cs
@@ -1,0 +1,290 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Copyright (C) 2005-2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//
+// Authors:
+//   Jordi Mas i Hernandez (jordi@ximian.com)
+//   Sebastien Pouliot  <sebastien@ximian.com>
+//
+
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing.Imaging
+{
+
+    public class ColorMatrixTest
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Null()
+        {
+            Assert.Throws<NullReferenceException>(() => new ColorMatrix(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_TooSmallArraySize()
+        {
+            Assert.Throws<IndexOutOfRangeException>(() => new ColorMatrix(new float[][] { }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_TooWideArraySize()
+        {
+            Assert.Throws<IndexOutOfRangeException>(() => new ColorMatrix(new float[][] {
+                new float[] { 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f }
+            }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_TooTallArraySize()
+        {
+            Assert.Throws<IndexOutOfRangeException>(() => new ColorMatrix(new float[][] {
+                new float[] { 0.0f },
+                new float[] { 1.0f },
+                new float[] { 2.0f },
+                new float[] { 3.0f },
+                new float[] { 4.0f },
+                new float[] { 5.0f }
+            }));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_TooBigArraySize()
+        {
+            ColorMatrix cm = new ColorMatrix(new float[][] {
+                new float[] { 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f },
+                new float[] { 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f },
+                new float[] { 2.0f, 2.1f, 2.2f, 2.3f, 2.4f, 2.5f },
+                new float[] { 3.0f, 3.1f, 3.2f, 3.3f, 3.4f, 3.5f },
+                new float[] { 4.0f, 4.1f, 4.2f, 4.3f, 4.4f, 4.5f },
+                new float[] { 5.0f, 5.1f, 5.2f, 5.3f, 5.4f, 5.5f }
+            });
+
+            Assert.Equal(0.0f, cm.Matrix00);
+            Assert.Equal(0.1f, cm.Matrix01);
+            Assert.Equal(0.2f, cm.Matrix02);
+            Assert.Equal(0.3f, cm.Matrix03);
+            Assert.Equal(0.4f, cm.Matrix04);
+            Assert.Equal(1.0f, cm.Matrix10);
+            Assert.Equal(1.1f, cm.Matrix11);
+            Assert.Equal(1.2f, cm.Matrix12);
+            Assert.Equal(1.3f, cm.Matrix13);
+            Assert.Equal(1.4f, cm.Matrix14);
+            Assert.Equal(2.0f, cm.Matrix20);
+            Assert.Equal(2.1f, cm.Matrix21);
+            Assert.Equal(2.2f, cm.Matrix22);
+            Assert.Equal(2.3f, cm.Matrix23);
+            Assert.Equal(2.4f, cm.Matrix24);
+            Assert.Equal(3.0f, cm.Matrix30);
+            Assert.Equal(3.1f, cm.Matrix31);
+            Assert.Equal(3.2f, cm.Matrix32);
+            Assert.Equal(3.3f, cm.Matrix33);
+            Assert.Equal(3.4f, cm.Matrix34);
+            Assert.Equal(4.0f, cm.Matrix40);
+            Assert.Equal(4.1f, cm.Matrix41);
+            Assert.Equal(4.2f, cm.Matrix42);
+            Assert.Equal(4.3f, cm.Matrix43);
+            Assert.Equal(4.4f, cm.Matrix44);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TooBigItems()
+        {
+            ColorMatrix cm = new ColorMatrix(new float[][] {
+                new float[] { 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f },
+                new float[] { 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f },
+                new float[] { 2.0f, 2.1f, 2.2f, 2.3f, 2.4f, 2.5f },
+                new float[] { 3.0f, 3.1f, 3.2f, 3.3f, 3.4f, 3.5f },
+                new float[] { 4.0f, 4.1f, 4.2f, 4.3f, 4.4f, 4.5f },
+                new float[] { 5.0f, 5.1f, 5.2f, 5.3f, 5.4f, 5.5f }
+            });
+            Assert.Throws<IndexOutOfRangeException>(() => { var x = cm[5, 5]; });
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DefaultConstructor()
+        {
+            ColorMatrix cm = new ColorMatrix();
+
+            Assert.Equal(1, cm.Matrix00);
+            Assert.Equal(1, cm.Matrix11);
+            Assert.Equal(1, cm.Matrix22);
+            Assert.Equal(1, cm.Matrix33);
+            Assert.Equal(1, cm.Matrix44);
+            Assert.Equal(0, cm.Matrix01);
+            Assert.Equal(0, cm.Matrix02);
+            Assert.Equal(0, cm.Matrix03);
+            Assert.Equal(0, cm.Matrix04);
+            Assert.Equal(0, cm.Matrix10);
+            Assert.Equal(0, cm.Matrix12);
+            Assert.Equal(0, cm.Matrix13);
+            Assert.Equal(0, cm.Matrix14);
+            Assert.Equal(0, cm.Matrix20);
+            Assert.Equal(0, cm.Matrix21);
+            Assert.Equal(0, cm.Matrix23);
+            Assert.Equal(0, cm.Matrix24);
+            Assert.Equal(0, cm.Matrix30);
+            Assert.Equal(0, cm.Matrix31);
+            Assert.Equal(0, cm.Matrix32);
+            Assert.Equal(0, cm.Matrix34);
+            Assert.Equal(0, cm.Matrix40);
+            Assert.Equal(0, cm.Matrix41);
+            Assert.Equal(0, cm.Matrix42);
+            Assert.Equal(0, cm.Matrix43);
+            Assert.Equal(100, Marshal.SizeOf(cm));
+            Assert.Equal(100, Marshal.SizeOf(typeof(ColorMatrix)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ConstructorArrayAndMethods()
+        {
+            ColorMatrix cm = new ColorMatrix(new float[][] {
+                new float[] {0.393f, 0.349f, 0.272f, 0, 0},
+                new float[] {0.769f, 0.686f, 0.534f, 0, 0},
+                new float[] {0.189f, 0.168f, 0.131f, 0, 0},
+                new float[] {     0,      0,      0, 1, 0},
+                new float[] {     0,      0,      0, 0, 1}
+            });
+
+            Assert.Equal(0.393f, cm.Matrix00);
+            Assert.Equal(0.349f, cm.Matrix01);
+            Assert.Equal(0.272f, cm.Matrix02);
+            Assert.Equal(0, cm.Matrix03);
+            Assert.Equal(0, cm.Matrix04);
+
+            Assert.Equal(0.769f, cm.Matrix10);
+            Assert.Equal(0.686f, cm.Matrix11);
+            Assert.Equal(0.534f, cm.Matrix12);
+            Assert.Equal(0, cm.Matrix13);
+            Assert.Equal(0, cm.Matrix14);
+
+            Assert.Equal(0.189f, cm.Matrix20);
+            Assert.Equal(0.168f, cm.Matrix21);
+            Assert.Equal(0.131f, cm.Matrix22);
+            Assert.Equal(0, cm.Matrix23);
+            Assert.Equal(0, cm.Matrix24);
+
+            Assert.Equal(0, cm.Matrix30);
+            Assert.Equal(0, cm.Matrix31);
+            Assert.Equal(0, cm.Matrix32);
+            Assert.Equal(1, cm.Matrix33);
+            Assert.Equal(0, cm.Matrix34);
+
+            Assert.Equal(0, cm.Matrix40);
+            Assert.Equal(0, cm.Matrix41);
+            Assert.Equal(0, cm.Matrix42);
+            Assert.Equal(0, cm.Matrix43);
+            Assert.Equal(1, cm.Matrix44);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IndexerProperty()
+        {
+            ColorMatrix cm = new ColorMatrix(new float[][] {
+                new float[]     {1, 0,  0,  0,  0},
+                new float[]     {0.5f,  1,  0,  0,  0},
+                new float[]     {0, 0.1f,   1.5f,   0,  0},
+                new float[]     {0.5f,  3,  0.5f,   1,  0},
+                new float[]     {0, 0,  0,  0,  0}
+            });
+
+            Assert.Equal(1, cm[0, 0]);
+            Assert.Equal(0, cm[0, 1]);
+            Assert.Equal(0, cm[0, 2]);
+            Assert.Equal(0, cm[0, 3]);
+            Assert.Equal(0, cm[0, 4]);
+
+            Assert.Equal(0.5f, cm[1, 0]);
+            Assert.Equal(1, cm[1, 1]);
+            Assert.Equal(0, cm[1, 2]);
+            Assert.Equal(0, cm[1, 3]);
+            Assert.Equal(0, cm[1, 4]);
+
+            Assert.Equal(0, cm[2, 0]);
+            Assert.Equal(0.1f, cm[2, 1]);
+            Assert.Equal(1.5f, cm[2, 2]);
+            Assert.Equal(0, cm[2, 3]);
+            Assert.Equal(0, cm[2, 4]);
+
+            Assert.Equal(0.5f, cm[3, 0]);
+            Assert.Equal(3, cm[3, 1]);
+            Assert.Equal(0.5f, cm[3, 2]);
+            Assert.Equal(1, cm[3, 3]);
+            Assert.Equal(0, cm[3, 4]);
+
+            Assert.Equal(0, cm[4, 0]);
+            Assert.Equal(0, cm[4, 1]);
+            Assert.Equal(0, cm[4, 2]);
+            Assert.Equal(0, cm[4, 3]);
+            Assert.Equal(0, cm[4, 4]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IndividualProperties()
+        {
+            ColorMatrix cm = new ColorMatrix(new float[][] {
+                new float[]     {1, 0,  0,  0,  0},
+                new float[]     {0.5f,  1,  0,  0,  0},
+                new float[]     {0, 0.1f,   1.5f,   0,  0},
+                new float[]     {0.5f,  3,  0.5f,   1,  0},
+                new float[]     {0, 0,  0,  0,  0}
+            });
+
+            Assert.Equal(1, cm.Matrix00);
+            Assert.Equal(0, cm.Matrix01);
+            Assert.Equal(0, cm.Matrix02);
+            Assert.Equal(0, cm.Matrix03);
+            Assert.Equal(0, cm.Matrix04);
+
+            Assert.Equal(0.5f, cm.Matrix10);
+            Assert.Equal(1, cm.Matrix11);
+            Assert.Equal(0, cm.Matrix12);
+            Assert.Equal(0, cm.Matrix13);
+            Assert.Equal(0, cm.Matrix14);
+
+            Assert.Equal(0, cm.Matrix20);
+            Assert.Equal(0.1f, cm.Matrix21);
+            Assert.Equal(1.5f, cm.Matrix22);
+            Assert.Equal(0, cm.Matrix23);
+            Assert.Equal(0, cm.Matrix24);
+
+            Assert.Equal(0.5f, cm.Matrix30);
+            Assert.Equal(3, cm.Matrix31);
+            Assert.Equal(0.5f, cm.Matrix32);
+            Assert.Equal(1, cm.Matrix33);
+            Assert.Equal(0, cm.Matrix34);
+
+            Assert.Equal(0, cm.Matrix40);
+            Assert.Equal(0, cm.Matrix41);
+            Assert.Equal(0, cm.Matrix42);
+            Assert.Equal(0, cm.Matrix43);
+            Assert.Equal(0, cm.Matrix44);
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/TestImageAttributes.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/TestImageAttributes.cs
@@ -1,0 +1,482 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Copyright (C) 2005-2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//
+// Authors:
+//	Jordi Mas i Hernandez (jordi@ximian.com)
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+
+using System;
+using System.IO;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing.Imaging
+{
+
+    public class ImageAttributesTest
+    {
+
+        static ColorMatrix global_color_matrix = new ColorMatrix(new float[][] {
+            new float[]     {2, 0,  0,  0,  0}, //R
+			new float[]     {0, 1,  0,  0,  0}, //G
+			new float[]     {0, 0,  1,  0,  0}, //B
+			new float[]     {0, 0,  0,  1,  0}, //A
+			new float[]     {0.2f,  0,  0,  0,  0}, //Translation
+		});
+
+        static ColorMatrix global_gray_matrix = new ColorMatrix(new float[][] {
+            new float[]     {1, 0,  0,  0,  0}, //R
+			new float[]     {0, 2,  0,  0,  0}, //G
+			new float[]     {0, 0,  3,  0,  0}, //B
+			new float[]     {0, 0,  0,  1,  0}, //A
+			new float[]     {0.5f,  0,  0,  0,  0}, //Translation
+		});
+
+        private static Color ProcessColorMatrix(Color color, ColorMatrix colorMatrix)
+        {
+            using (Bitmap bmp = new Bitmap(64, 64))
+            {
+                using (Graphics gr = Graphics.FromImage(bmp))
+                {
+                    ImageAttributes imageAttr = new ImageAttributes();
+                    bmp.SetPixel(0, 0, color);
+                    imageAttr.SetColorMatrix(colorMatrix);
+                    gr.DrawImage(bmp, new Rectangle(0, 0, 64, 64), 0, 0, 64, 64, GraphicsUnit.Pixel, imageAttr);
+                    return bmp.GetPixel(0, 0);
+                }
+            }
+        }
+
+
+        // Text Color Matrix processing
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ColorMatrix1()
+        {
+            Color clr_src, clr_rslt;
+
+            ColorMatrix cm = new ColorMatrix(new float[][] {
+                new float[]     {2, 0,  0,  0,  0}, //R
+				new float[]     {0, 1,  0,  0,  0}, //G
+				new float[]     {0, 0,  1,  0,  0}, //B
+				new float[]     {0, 0,  0,  1,  0}, //A
+				new float[]     {0.2f,  0,  0,  0,  0}, //Translation
+			  });
+
+            clr_src = Color.FromArgb(255, 100, 20, 50);
+            clr_rslt = ProcessColorMatrix(clr_src, cm);
+
+            Assert.Equal(Color.FromArgb(255, 251, 20, 50), clr_rslt);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ColorMatrix2()
+        {
+            Color clr_src, clr_rslt;
+
+            ColorMatrix cm = new ColorMatrix(new float[][] {
+                new float[]     {1, 0,  0,  0,  0}, //R
+				new float[]     {0, 1,  0,  0,  0}, //G
+				new float[]     {0, 0,  1.5f,   0,  0}, //B
+				new float[]     {0, 0,  0.5f,   1,  0}, //A
+				new float[]     {0, 0,  0,  0,  0}, //Translation
+			  });
+
+            clr_src = Color.FromArgb(255, 100, 40, 25);
+            clr_rslt = ProcessColorMatrix(clr_src, cm);
+            Assert.Equal(Color.FromArgb(255, 100, 40, 165), clr_rslt);
+        }
+
+        private void Bug80323(Color c)
+        {
+            string fileName = String.Format("80323-{0}.png", c.ToArgb().ToString("X"));
+
+            // test case from bug #80323
+            ColorMatrix cm = new ColorMatrix(new float[][] {
+                new float[]     {1, 0,  0,  0,  0}, //R
+				new float[]     {0, 1,  0,  0,  0}, //G
+				new float[]     {0, 0,  1,  0,  0}, //B
+				new float[]     {0, 0,  0,  0.5f,   0}, //A
+				new float[]     {0, 0,  0,  0,  1}, //Translation
+			  });
+
+            using (SolidBrush sb = new SolidBrush(c))
+            {
+                using (Bitmap bmp = new Bitmap(100, 100))
+                {
+                    using (Graphics gr = Graphics.FromImage(bmp))
+                    {
+                        gr.FillRectangle(Brushes.White, 0, 0, 100, 100);
+                        gr.FillEllipse(sb, 0, 0, 100, 100);
+                    }
+                    using (Bitmap b = new Bitmap(200, 100))
+                    {
+                        using (Graphics g = Graphics.FromImage(b))
+                        {
+                            g.FillRectangle(Brushes.White, 0, 0, 200, 100);
+
+                            ImageAttributes ia = new ImageAttributes();
+                            ia.SetColorMatrix(cm);
+                            g.DrawImage(bmp, new Rectangle(0, 0, 100, 100), 0, 0, 100, 100, GraphicsUnit.Pixel, null);
+                            g.DrawImage(bmp, new Rectangle(100, 0, 100, 100), 0, 0, 100, 100, GraphicsUnit.Pixel, ia);
+                        }
+                        b.Save(fileName);
+                        Assert.Equal(Color.FromArgb(255, 255, 155, 155), b.GetPixel(50, 50));
+                        Assert.Equal(Color.FromArgb(255, 255, 205, 205), b.GetPixel(150, 50));
+                    }
+                }
+            }
+
+            File.Delete(fileName);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ColorMatrix_80323_UsingAlpha()
+        {
+            Bug80323(Color.FromArgb(100, 255, 0, 0));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ColorMatrix_80323_WithoutAlpha()
+        {
+            // this color is identical, once drawn over the bitmap, to Color.FromArgb (100, 255, 0, 0)
+            Bug80323(Color.FromArgb(255, 255, 155, 155));
+        }
+
+
+
+        private static Color ProcessColorMatrices(Color color, ColorMatrix colorMatrix, ColorMatrix grayMatrix, ColorMatrixFlag flags, ColorAdjustType type)
+        {
+            using (Bitmap bmp = new Bitmap(64, 64))
+            {
+                using (Graphics gr = Graphics.FromImage(bmp))
+                {
+                    ImageAttributes imageAttr = new ImageAttributes();
+                    bmp.SetPixel(0, 0, color);
+                    imageAttr.SetColorMatrices(colorMatrix, grayMatrix, flags, type);
+                    gr.DrawImage(bmp, new Rectangle(0, 0, 64, 64), 0, 0, 64, 64, GraphicsUnit.Pixel, imageAttr);
+                    return bmp.GetPixel(0, 0);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_Null()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(null));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_Default()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.Default);
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Brush);
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Default);
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Pen);
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Text);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_Default_Any()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Any));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_Default_Count()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Count));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_AltGrays()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.AltGrays));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_AltGrays_Any()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Any));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_AltGrays_Bitmap()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Bitmap));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_AltGrays_Brush()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Brush));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_AltGrays_Count()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Count));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_AltGrays_Default()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Default));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_AltGrays_Pen()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Pen));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_AltGrays_Text()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Text));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_SkipGrays()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.SkipGrays);
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Bitmap);
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Brush);
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Default);
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Pen);
+                ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Text);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_SkipGrays_Any()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Any));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_SkipGrays_Count()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Count));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_InvalidFlag()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, (ColorMatrixFlag)Int32.MinValue));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrix_InvalidType()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrix(global_color_matrix, ColorMatrixFlag.Default, (ColorAdjustType)Int32.MinValue));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrices_Null_ColorMatrix()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrices(null, global_color_matrix));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrices_ColorMatrix_Null()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                ia.SetColorMatrices(global_color_matrix, null);
+                ia.SetColorMatrices(global_color_matrix, null, ColorMatrixFlag.Default);
+                ia.SetColorMatrices(global_color_matrix, null, ColorMatrixFlag.SkipGrays);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrices_ColorMatrix_Null_AltGrays()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrices(global_color_matrix, null, ColorMatrixFlag.AltGrays));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrices_ColorMatrix_ColorMatrix()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                ia.SetColorMatrices(global_color_matrix, global_color_matrix);
+                ia.SetColorMatrices(global_color_matrix, global_color_matrix, ColorMatrixFlag.Default);
+                ia.SetColorMatrices(global_color_matrix, global_color_matrix, ColorMatrixFlag.SkipGrays);
+                ia.SetColorMatrices(global_color_matrix, global_color_matrix, ColorMatrixFlag.AltGrays);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrices_Gray()
+        {
+            Color c = ProcessColorMatrices(Color.Gray, global_color_matrix, global_gray_matrix, ColorMatrixFlag.Default, ColorAdjustType.Default);
+            Assert.Equal(0xFFFF8080, (uint)c.ToArgb());
+
+            c = ProcessColorMatrices(Color.Gray, global_color_matrix, global_gray_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Default);
+            Assert.Equal(0xFF808080, (uint)c.ToArgb());
+
+            c = ProcessColorMatrices(Color.Gray, global_color_matrix, global_gray_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Default);
+            Assert.Equal(0xFFFFFFFF, (uint)c.ToArgb());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrices_Color()
+        {
+            Color c = ProcessColorMatrices(Color.MidnightBlue, global_color_matrix, global_gray_matrix, ColorMatrixFlag.Default, ColorAdjustType.Default);
+            Assert.Equal(0xFF651970, (uint)c.ToArgb());
+
+            c = ProcessColorMatrices(Color.MidnightBlue, global_color_matrix, global_gray_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Default);
+            Assert.Equal(0xFF651970, (uint)c.ToArgb());
+
+            c = ProcessColorMatrices(Color.MidnightBlue, global_color_matrix, global_gray_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Default);
+            Assert.Equal(0xFF651970, (uint)c.ToArgb());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrices_InvalidFlags()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrices(global_color_matrix, global_color_matrix, (ColorMatrixFlag)Int32.MinValue));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetColorMatrices_InvalidType()
+        {
+            using (ImageAttributes ia = new ImageAttributes())
+            {
+                Assert.Throws<ArgumentException>(() => ia.SetColorMatrices(global_color_matrix, global_color_matrix, ColorMatrixFlag.Default, (ColorAdjustType)Int32.MinValue));
+            }
+        }
+
+        private void Alpha(string prefix, int n, float a)
+        {
+            ColorMatrix cm = new ColorMatrix(new float[][] {
+                new float[]     {1, 0,  0,  0,  0}, //R
+				new float[]     {0, 1,  0,  0,  0}, //G
+				new float[]     {0, 0,  1,  0,  0}, //B
+				new float[]     {0, 0,  0,  a,  0}, //A
+				new float[]     {0, 0,  0,  0,  1}, //Translation
+			  });
+
+            using (Bitmap bmp = new Bitmap(1, 4))
+            {
+                bmp.SetPixel(0, 0, Color.White);
+                bmp.SetPixel(0, 1, Color.Red);
+                bmp.SetPixel(0, 2, Color.Lime);
+                bmp.SetPixel(0, 3, Color.Blue);
+                using (Bitmap b = new Bitmap(1, 4))
+                {
+                    using (Graphics g = Graphics.FromImage(b))
+                    {
+                        ImageAttributes ia = new ImageAttributes();
+                        ia.SetColorMatrix(cm);
+                        g.FillRectangle(Brushes.White, new Rectangle(0, 0, 1, 4));
+                        g.DrawImage(bmp, new Rectangle(0, 0, 1, 4), 0, 0, 1, 4, GraphicsUnit.Pixel, ia);
+                        Assert.Equal(Color.FromArgb(255, 255, 255, 255), b.GetPixel(0, 0));
+                        int val = 255 - n;
+                        Assert.Equal(Color.FromArgb(255, 255, val, val), b.GetPixel(0, 1));
+                        Assert.Equal(Color.FromArgb(255, val, 255, val), b.GetPixel(0, 2));
+                        Assert.Equal(Color.FromArgb(255, val, val, 255), b.GetPixel(0, 3));
+                    }
+                }
+            }
+        }
+
+        [ActiveIssue(20844)]
+        public void ColorMatrixAlpha()
+        {
+            for (int i = 0; i < 256; i++)
+            {
+                Alpha(i.ToString(), i, (float)i / 255);
+                // generally color matrix are specified with values between [0..1]
+                Alpha("small-" + i.ToString(), i, (float)i / 255);
+                // but GDI+ also accept value > 1
+                Alpha("big-" + i.ToString(), i, 256 - i);
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/TestImageCodecInfo.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/TestImageCodecInfo.cs
@@ -1,0 +1,279 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// ImageCodecInfo class testing unit
+//
+// Authors:
+// 	Jordi Mas i Hernàndez (jordi@ximian.com)
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// (C) 2004 Ximian, Inc.  http://www.ximian.com
+// Copyright (C) 2004-2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using Xunit;
+using System.Collections;
+using System.Security.Permissions;
+using System.Text.RegularExpressions;
+
+namespace MonoTests.System.Drawing.Imaging
+{
+
+    public class ImageCodecInfoTest
+    {
+
+        Hashtable decoders;
+        Hashtable encoders;
+
+        ImageCodecInfo GetEncoder(Guid clsid)
+        {
+            return (ImageCodecInfo)encoders[clsid];
+        }
+
+        ImageCodecInfo GetDecoder(Guid clsid)
+        {
+            return (ImageCodecInfo)decoders[clsid];
+        }
+
+        public ImageCodecInfoTest()
+        {
+            decoders = new Hashtable();
+            encoders = new Hashtable();
+
+            foreach (ImageCodecInfo decoder in ImageCodecInfo.GetImageDecoders())
+                decoders[decoder.Clsid] = decoder;
+
+            foreach (ImageCodecInfo encoder in ImageCodecInfo.GetImageEncoders())
+                encoders[encoder.Clsid] = encoder;
+        }
+
+        static void Check(ImageCodecInfo e, ImageCodecInfo d, Guid FormatID, string CodecName, string DllName,
+            string FilenameExtension, ImageCodecFlags Flags, string FormatDescription,
+            string MimeType, int Version, int signatureLength, string mask, string pattern, string pattern2)
+        {
+            Regex extRegex = new Regex(@"^(\*\.\w+(;(\*\.\w+))*;)?" +
+                Regex.Escape(FilenameExtension) + @"(;\*\.\w+(;(\*\.\w+))*)?$",
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+            if (e != null)
+            {
+                Assert.Equal(FormatID, e.FormatID);
+                Assert.True(e.CodecName.IndexOf(CodecName) >= 0,
+                    "Encoder.CodecName contains " + CodecName);
+                Assert.Equal(DllName, e.DllName);
+                Assert.True(extRegex.IsMatch(e.FilenameExtension),
+                    "Encoder.FilenameExtension is a right list with " + FilenameExtension);
+                Assert.Equal(Flags, e.Flags);
+                Assert.True(e.FormatDescription.IndexOf(FormatDescription) >= 0,
+                    "Encoder.FormatDescription contains " + FormatDescription);
+                Assert.True(e.MimeType.IndexOf(MimeType) >= 0,
+                    "Encoder.MimeType contains " + MimeType);
+
+                Assert.Equal(signatureLength, e.SignatureMasks.Length);
+                for (int i = 0; i < signatureLength; i++)
+                {
+                    Assert.Equal(mask, BitConverter.ToString(e.SignatureMasks[i]));
+                }
+                Assert.Equal(signatureLength, e.SignaturePatterns.Length);
+                Assert.Equal(pattern, BitConverter.ToString(e.SignaturePatterns[0]));
+                if (pattern2 != null)
+                    Assert.Equal(pattern2, BitConverter.ToString(e.SignaturePatterns[1]));
+            }
+            if (d != null)
+            {
+                Assert.Equal(FormatID, d.FormatID);
+                Assert.True(d.CodecName.IndexOf(CodecName) >= 0,
+                    "Decoder.CodecName contains " + CodecName);
+                Assert.Equal(DllName, d.DllName);
+                Assert.True(extRegex.IsMatch(d.FilenameExtension),
+                    "Decoder.FilenameExtension is a right list with " + FilenameExtension);
+                Assert.Equal(Flags, d.Flags);
+                Assert.True(d.FormatDescription.IndexOf(FormatDescription) >= 0,
+                    "Decoder.FormatDescription contains " + FormatDescription);
+                Assert.True(d.MimeType.IndexOf(MimeType) >= 0,
+                    "Decoder.MimeType contains " + MimeType);
+
+                Assert.Equal(signatureLength, d.SignatureMasks.Length);
+                for (int i = 0; i < signatureLength; i++)
+                {
+                    Assert.Equal(mask, BitConverter.ToString(d.SignatureMasks[i]));
+                }
+                Assert.Equal(signatureLength, d.SignaturePatterns.Length);
+                Assert.Equal(pattern, BitConverter.ToString(d.SignaturePatterns[0]));
+                if (pattern2 != null)
+                    Assert.Equal(pattern2, BitConverter.ToString(d.SignaturePatterns[1]));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Decoders()
+        {
+            Assert.Equal(8, decoders.Count);
+            foreach (DictionaryEntry de in decoders)
+            {
+                string guid = de.Key.ToString();
+                switch (guid)
+                {
+                    case "557cf402-1a04-11d3-9a73-0000f81ef32e": // GIF
+                    case "557cf403-1a04-11d3-9a73-0000f81ef32e": // EMF
+                    case "557cf400-1a04-11d3-9a73-0000f81ef32e": // BMP/DIB/RLE
+                    case "557cf401-1a04-11d3-9a73-0000f81ef32e": // JPG,JPEG,JPE,JFIF
+                    case "557cf406-1a04-11d3-9a73-0000f81ef32e": // PNG
+                    case "557cf407-1a04-11d3-9a73-0000f81ef32e": // ICO
+                    case "557cf404-1a04-11d3-9a73-0000f81ef32e": // WMF
+                    case "557cf405-1a04-11d3-9a73-0000f81ef32e": // TIF,TIFF
+                        break;
+                    default:
+                        Assert.True(false, "Unknown decoder " + guid);
+                        break;
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Encoders()
+        {
+            Assert.Equal(5, encoders.Count);
+            foreach (DictionaryEntry de in encoders)
+            {
+                string guid = de.Key.ToString();
+                switch (guid)
+                {
+                    case "557cf402-1a04-11d3-9a73-0000f81ef32e": // GIF
+                    case "557cf400-1a04-11d3-9a73-0000f81ef32e": // BMP/DIB/RLE
+                    case "557cf401-1a04-11d3-9a73-0000f81ef32e": // JPG,JPEG,JPE,JFIF
+                    case "557cf406-1a04-11d3-9a73-0000f81ef32e": // PNG
+                    case "557cf405-1a04-11d3-9a73-0000f81ef32e": // TIF,TIFF
+                        break;
+                    default:
+                        Assert.True(false, "Unknown encoder " + guid);
+                        break;
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BMPCodec()
+        {
+            Guid g = new Guid("557cf400-1a04-11d3-9a73-0000f81ef32e");
+            Check(GetEncoder(g), GetDecoder(g), ImageFormat.Bmp.Guid,
+                "BMP", null, "*.BMP",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "BMP", "image/bmp", 1, 1, "FF-FF", "42-4D", null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GifCodec()
+        {
+            Guid g = new Guid("557cf402-1a04-11d3-9a73-0000f81ef32e");
+            Check(GetEncoder(g), GetDecoder(g), ImageFormat.Gif.Guid,
+                "GIF", null, "*.GIF",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "GIF", "image/gif", 1, 2, "FF-FF-FF-FF-FF-FF", "47-49-46-38-39-61", "47-49-46-38-37-61");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void JpegCodec()
+        {
+            Guid g = new Guid("557cf401-1a04-11d3-9a73-0000f81ef32e");
+            Check(GetEncoder(g), GetDecoder(g), ImageFormat.Jpeg.Guid,
+                "JPEG", null, "*.JPG",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "JPEG", "image/jpeg", 1, 1, "FF-FF", "FF-D8", null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void PngCodec()
+        {
+            Guid g = new Guid("557cf406-1a04-11d3-9a73-0000f81ef32e");
+            Check(GetEncoder(g), GetDecoder(g), ImageFormat.Png.Guid,
+                "PNG", null, "*.PNG",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "PNG", "image/png", 1, 1, "FF-FF-FF-FF-FF-FF-FF-FF", "89-50-4E-47-0D-0A-1A-0A", null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TiffCodec()
+        {
+            Guid g = new Guid("557cf405-1a04-11d3-9a73-0000f81ef32e");
+            Check(GetEncoder(g), GetDecoder(g), ImageFormat.Tiff.Guid,
+                "TIFF", null, "*.TIF;*.TIFF",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "TIFF", "image/tiff", 1, 2, "FF-FF", "49-49", "4D-4D");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IconCodec_Encoder()
+        {
+            Guid g = new Guid("557cf407-1a04-11d3-9a73-0000f81ef32e");
+            Assert.Null(GetEncoder(g));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IconCodec_Decoder()
+        {
+            Guid g = new Guid("557cf407-1a04-11d3-9a73-0000f81ef32e");
+            Check(null, GetDecoder(g), ImageFormat.Icon.Guid,
+                "ICO", null, "*.ICO",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "ICO", "image/x-icon", 1, 1, "FF-FF-FF-FF", "00-00-01-00", null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void EmfCodec_Encoder()
+        {
+            Guid g = new Guid("557cf403-1a04-11d3-9a73-0000f81ef32e");
+            Assert.Null(GetEncoder(g));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void EmfCodec_Decoder()
+        {
+            Guid g = new Guid("557cf403-1a04-11d3-9a73-0000f81ef32e");
+            Check(null, GetDecoder(g), ImageFormat.Emf.Guid,
+                "EMF", null, "*.EMF",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "EMF", "image/x-emf", 1, 1, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF",
+                "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-20-45-4D-46", null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void WmfCodec_Encoder()
+        {
+            Guid g = new Guid("557cf404-1a04-11d3-9a73-0000f81ef32e");
+            Assert.Null(GetEncoder(g));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void WmfCodec_Decoder()
+        {
+            Guid g = new Guid("557cf404-1a04-11d3-9a73-0000f81ef32e");
+            Check(null, GetDecoder(g), ImageFormat.Wmf.Guid,
+                "WMF", null, "*.WMF",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "WMF", "image/x-wmf", 1, 1, "FF-FF-FF-FF", "D7-CD-C6-9A", null);
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Printing/PrintingServicesUnixTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Printing/PrintingServicesUnixTest.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// PrintingServicesUnix class unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Printing;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace MonoTests.System.Drawing.Printing
+{
+
+    public class PrintingServicesUnixTest
+    {
+        #region Novell Bug #602934
+
+        #region CUPS methods and structs
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct CUPS_DEST
+        {
+            public string Name;
+            public string Instance;
+            public int IsDefault;
+            public int NumOptions;
+            public IntPtr Options;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct CUPS_OPTION
+        {
+            public string Name;
+            public string Value;
+        }
+
+        readonly IntPtr CUPS_HTTP_DEFAULT = IntPtr.Zero;
+
+        [DllImport("libcups")]
+        static extern IntPtr cupsGetNamedDest(IntPtr http, string name, string instance);
+
+        [DllImport("libcups")]
+        static extern void cupsFreeDests(int num_dests, IntPtr dests);
+
+        [DllImport("libcups")]
+        static extern void cupsFreeDests(int num_dests, ref CUPS_DEST dests);
+
+        #endregion
+
+        Dictionary<string, string> GetOptionsOfFirstPrinterThroughCups()
+        {
+            var options = new Dictionary<string, string>();
+
+            var destPtr = cupsGetNamedDest(CUPS_HTTP_DEFAULT, PrinterSettings.InstalledPrinters[0], null);
+            var dest = (CUPS_DEST)Marshal.PtrToStructure(destPtr, typeof(CUPS_DEST));
+            var optionPtr = dest.Options;
+            int cupsOptionSize = Marshal.SizeOf(typeof(CUPS_OPTION));
+            for (int i = 0; i < dest.NumOptions; i++)
+            {
+                var cupsOption = (CUPS_OPTION)Marshal.PtrToStructure(optionPtr, typeof(CUPS_OPTION));
+                options.Add(cupsOption.Name, cupsOption.Value);
+                optionPtr = (IntPtr)((long)optionPtr + cupsOptionSize);
+            }
+            cupsFreeDests(1, destPtr);
+            return options;
+        }
+
+        [ActiveIssue(20844)]
+        public void Bug602934_PrinterSettingsReturnActualValues()
+        {
+            if (PrinterSettings.InstalledPrinters.Count < 1)
+                Assert.True(false, "Need at least one printer installed.");
+
+            var options = GetOptionsOfFirstPrinterThroughCups();
+
+            var settings = new PrinterSettings() { PrinterName = PrinterSettings.InstalledPrinters[0] };
+            Assert.Equal(options["PageSize"], settings.DefaultPageSettings.PaperSize.PaperName);
+            if (options.ContainsKey("Resolution"))
+                Assert.Equal(options["Resolution"], string.Format("{0}dpi", settings.DefaultPageSettings.PrinterResolution.X));
+        }
+
+        #endregion
+
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/ColorTranslator.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/ColorTranslator.cs
@@ -1,0 +1,231 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// ColorTranslator class testing unit
+//
+// Copyright (C) 2006-2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class ColorTranslatorTest
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromHtml_Null()
+        {
+            Assert.Equal(0, ColorTranslator.FromHtml(null).ToArgb());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromHtml_Empty()
+        {
+            Assert.Equal(0, ColorTranslator.FromHtml(String.Empty).ToArgb());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromHtml_KnownValues()
+        {
+            Assert.Equal(SystemColors.Control, ColorTranslator.FromHtml("buttonface"));
+            Assert.Equal(SystemColors.ActiveCaptionText, ColorTranslator.FromHtml("CAPTIONTEXT"));
+            Assert.Equal(SystemColors.ControlDarkDark, ColorTranslator.FromHtml("threedDARKshadow"));
+            Assert.Equal(SystemColors.Desktop, ColorTranslator.FromHtml("background"));
+            Assert.Equal(SystemColors.ControlText, ColorTranslator.FromHtml("ButtonText"));
+            Assert.Equal(SystemColors.Info, ColorTranslator.FromHtml("infobackground"));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromHtml_Int()
+        {
+            Assert.Equal(-1, ColorTranslator.FromHtml("-1").ToArgb());
+            Assert.Equal(0, ColorTranslator.FromHtml("0").ToArgb());
+            Assert.Equal(1, ColorTranslator.FromHtml("1").ToArgb());
+        }
+
+        [ActiveIssue(20844, TestPlatforms.Any)]
+        public void FromHtml_PoundInt()
+        {
+            Assert.Equal(0, ColorTranslator.FromHtml("#0").ToArgb());
+            Assert.Equal(1, ColorTranslator.FromHtml("#1").ToArgb());
+            Assert.Equal(255, ColorTranslator.FromHtml("#FF").ToArgb());
+            Assert.Equal(-15654349, ColorTranslator.FromHtml("#123").ToArgb());
+            Assert.Equal(-1, ColorTranslator.FromHtml("#FFF").ToArgb());
+            Assert.Equal(65535, ColorTranslator.FromHtml("#FFFF").ToArgb());
+            Assert.Equal(-15584170, ColorTranslator.FromHtml("#123456").ToArgb());
+            Assert.Equal(-1, ColorTranslator.FromHtml("#FFFFFF").ToArgb());
+            Assert.Equal(305419896, ColorTranslator.FromHtml("#12345678").ToArgb());
+            Assert.Equal(-1, ColorTranslator.FromHtml("#FFFFFFFF").ToArgb());
+
+            Assert.Equal(Color.White, ColorTranslator.FromHtml("#FFFFFF"));
+            Assert.Equal(Color.White, ColorTranslator.FromHtml("0xFFFFFF"));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromHtml_PoundNegative()
+        {
+            Assert.Throws<Exception>(() => ColorTranslator.FromHtml("#-1"));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromHtml_PoundTooLarge()
+        {
+            Assert.Throws<Exception>(() => ColorTranslator.FromHtml("#100000000"));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromHtml_Unknown()
+        {
+            Assert.Throws<Exception>(() => ColorTranslator.FromHtml("unknown-color-test"));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromHtml()
+        {
+            Color[] colors = new Color[] {
+Color.Aqua, Color.Black, Color.Blue, Color.Fuchsia, Color.Gray,
+Color.Green, Color.Lime, Color.Maroon, Color.Navy, Color.Olive,
+Color.Purple, Color.Red, Color.Silver, Color.Teal, Color.White,
+Color.Yellow,
+
+SystemColors.ActiveBorder, SystemColors.ActiveCaption,
+SystemColors.Control, 
+//SystemColors.ControlLightLight,
+SystemColors.ActiveCaptionText, SystemColors.GrayText,
+//SystemColors.InactiveBorder, SystemColors.InactiveCaption,
+SystemColors.InfoText, SystemColors.Menu,
+SystemColors.ControlDarkDark, 
+//SystemColors.ControlText, SystemColors.ControlDark,
+SystemColors.Window,
+SystemColors.AppWorkspace, SystemColors.Desktop,
+//SystemColors.ControlDark,
+SystemColors.ControlText,
+SystemColors.Highlight, SystemColors.HighlightText,
+//SystemColors.InactiveCaptionText,
+SystemColors.Info,
+SystemColors.MenuText, SystemColors.ScrollBar,
+//SystemColors.ControlLight, SystemColors.ControlLightLight
+			};
+            string[] htmlColors = new string[] {
+"Aqua", "Black", "Blue", "Fuchsia", "Gray", "Green",
+"Lime", "Maroon", "Navy", "Olive", "Purple", "Red",
+"Silver", "Teal", "White", "Yellow",
+
+"activeborder", "activecaption", "buttonface",
+//"buhighlight",
+"captiontext", "graytext",
+//"iborder", "Icaption", 
+"infotext", "menu", "threeddarkshadow",
+//"thrface", "Threedshadow",
+"window", "appworkspace",
+"background", 
+//"bshadow",
+"buttontext", "highlight",
+"highlighttext",
+//"icaptiontext",
+"infobackground",
+"menutext", "scrollbar", 
+//"thhighlight", "thlightshadow"
+			};
+
+            for (int i = 0; i < colors.Length; i++)
+                Assert.Equal(colors[i], ColorTranslator.FromHtml(htmlColors[i]));
+        }
+
+        [Fact] // 340917
+        public void FromHtml_LightGrey()
+        {
+            Assert.Equal(Color.LightGray, ColorTranslator.FromHtml(ColorTranslator.ToHtml(Color.LightGray)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromOle()
+        {
+            Assert.Equal(Color.FromArgb(0x10, 0x20, 0x30), ColorTranslator.FromOle(0x302010));
+            Assert.Equal(Color.FromArgb(0xbb, 0x20, 0x30), ColorTranslator.FromOle(unchecked((int)0xee3020bb)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromWin32()
+        {
+            Assert.Equal(Color.FromArgb(0x10, 0x20, 0x30), ColorTranslator.FromWin32(0x302010));
+            Assert.Equal(Color.FromArgb(0xbb, 0x20, 0x30), ColorTranslator.FromWin32(unchecked((int)0xee3020bb)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ToHtml()
+        {
+            string[] htmlColors = new string[] {
+"activeborder", "activecaption", "captiontext", "appworkspace", "buttonface",
+"buttonshadow", "threeddarkshadow", "buttonface", "buttonhighlight", "buttontext",
+"background", "graytext", "highlight", "highlighttext", "highlight", "inactiveborder",
+"inactivecaption", "inactivecaptiontext", "infobackground", "infotext", "menu",
+"menutext", "scrollbar", "window", "windowframe", "windowtext",
+
+"Transparent", "AliceBlue", "AntiqueWhite", "Aqua", "Aquamarine", "Azure", "Beige",
+"Bisque", "Black", "BlanchedAlmond", "Blue", "BlueViolet", "Brown", "BurlyWood",
+"CadetBlue", "Chartreuse", "Chocolate", "Coral", "CornflowerBlue", "Cornsilk",
+"Crimson", "Cyan", "DarkBlue", "DarkCyan", "DarkGoldenrod", "DarkGray", "DarkGreen",
+"DarkKhaki", "DarkMagenta", "DarkOliveGreen", "DarkOrange", "DarkOrchid", "DarkRed",
+"DarkSalmon", "DarkSeaGreen", "DarkSlateBlue", "DarkSlateGray", "DarkTurquoise", "DarkViolet",
+"DeepPink", "DeepSkyBlue", "DimGray", "DodgerBlue", "Firebrick", "FloralWhite", "ForestGreen",
+"Fuchsia", "Gainsboro", "GhostWhite", "Gold", "Goldenrod", "Gray", "Green", "GreenYellow",
+"Honeydew", "HotPink", "IndianRed", "Indigo", "Ivory", "Khaki", "Lavender", "LavenderBlush",
+"LawnGreen", "LemonChiffon", "LightBlue", "LightCoral", "LightCyan", "LightGoldenrodYellow",
+"LightGrey", "LightGreen", "LightPink", "LightSalmon", "LightSeaGreen", "LightSkyBlue",
+"LightSlateGray", "LightSteelBlue", "LightYellow", "Lime", "LimeGreen", "Linen", "Magenta",
+"Maroon", "MediumAquamarine", "MediumBlue", "MediumOrchid", "MediumPurple", "MediumSeaGreen",
+"MediumSlateBlue", "MediumSpringGreen", "MediumTurquoise", "MediumVioletRed", "MidnightBlue",
+"MintCream", "MistyRose", "Moccasin", "NavajoWhite", "Navy", "OldLace", "Olive", "OliveDrab",
+"Orange", "OrangeRed", "Orchid", "PaleGoldenrod", "PaleGreen", "PaleTurquoise", "PaleVioletRed",
+"PapayaWhip", "PeachPuff", "Peru", "Pink", "Plum", "PowderBlue", "Purple", "Red", "RosyBrown",
+"RoyalBlue", "SaddleBrown", "Salmon", "SandyBrown", "SeaGreen", "SeaShell", "Sienna", "Silver",
+"SkyBlue", "SlateBlue", "SlateGray", "Snow", "SpringGreen", "SteelBlue", "Tan", "Teal",
+"Thistle", "Tomato", "Turquoise", "Violet", "Wheat", "White", "WhiteSmoke", "Yellow", "YellowGreen",
+                                            };
+
+            for (KnownColor i = KnownColor.ActiveBorder; i <= KnownColor.YellowGreen; i++)
+                Assert.Equal(htmlColors[(int)i - 1], ColorTranslator.ToHtml(Color.FromKnownColor(i)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ToOle()
+        {
+            Assert.Equal(0x302010, ColorTranslator.ToOle(Color.FromArgb(0x10, 0x20, 0x30)));
+            Assert.Equal(unchecked((int)0x3020bb), ColorTranslator.ToOle(Color.FromArgb(0xee, 0xbb, 0x20, 0x30)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ToWin32()
+        {
+            Assert.Equal(0x302010, ColorTranslator.ToWin32(Color.FromArgb(0x10, 0x20, 0x30)));
+            Assert.Equal(unchecked((int)0x3020bb), ColorTranslator.ToWin32(Color.FromArgb(0xee, 0xbb, 0x20, 0x30)));
+        }
+
+    }
+}
+

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/FontFamilyTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/FontFamilyTest.cs
@@ -1,0 +1,200 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.FontFamily unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Text;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class FontFamilyTest
+    {
+
+        private Bitmap bitmap;
+        private Graphics graphic;
+        private string name;
+
+        public FontFamilyTest()
+        {
+            bitmap = new Bitmap(10, 10);
+            graphic = Graphics.FromImage(bitmap);
+            using (FontFamily ff = new FontFamily(GenericFontFamilies.Monospace))
+            {
+                name = ff.Name;
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FontFamily_String_Null()
+        {
+            Assert.Throws<ArgumentException>(() => new FontFamily(null));
+        }
+
+        private void CheckMono(FontFamily ff)
+        {
+            Assert.True(ff.Equals(FontFamily.GenericMonospace));
+            // note: Mono has this behaviour on both 1.1 and 2.0 profiles
+            Assert.Equal(ff.Name.GetHashCode(), ff.GetHashCode());
+        }
+
+        [ActiveIssue(20884)]
+        public void FontFamily_String()
+        {
+            FontFamily ff = new FontFamily(name);
+            CheckMono(ff);
+            FontStyle style = FontStyle.Bold;
+            Assert.Equal(ff.Name, ff.GetName(0));
+            Assert.True((ff.GetCellAscent(style) > 0));
+            Assert.True((ff.GetCellDescent(style) > 0));
+            Assert.True((ff.GetEmHeight(style) > 0));
+            Assert.True((ff.GetLineSpacing(style) > 0));
+            Assert.True(ff.IsStyleAvailable(style));
+        }
+
+        [ActiveIssue(20884, TestPlatforms.Any)]
+        public void FontFamily_String_FontCollection_Null()
+        {
+            FontFamily ff = new FontFamily(name, null);
+            CheckMono(ff);
+        }
+
+        [ActiveIssue(20884, TestPlatforms.Any)]
+        public void FontFamily_String_InstalledFontCollection()
+        {
+            FontFamily ff = new FontFamily(name, new InstalledFontCollection());
+            CheckMono(ff);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FontFamily_String_PrivateFontCollection()
+        {
+            Assert.Throws<ArgumentException>(() => new FontFamily(name, new PrivateFontCollection()));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FontFamily_Monospace()
+        {
+            FontFamily ff = new FontFamily(GenericFontFamilies.Monospace);
+            CheckMono(ff);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FontFamily_SansSerif()
+        {
+            FontFamily ff = new FontFamily(GenericFontFamilies.SansSerif);
+            Assert.True(ff.Equals(FontFamily.GenericSansSerif));
+            // note: Mono has this behaviour on both 1.1 and 2.0 profiles
+            Assert.Equal(ff.Name.GetHashCode(), ff.GetHashCode());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FontFamily_Serif()
+        {
+            FontFamily ff = new FontFamily(GenericFontFamilies.Serif);
+            Assert.True(ff.Equals(FontFamily.GenericSerif));
+            // note: Mono has this behaviour on both 1.1 and 2.0 profiles
+            Assert.Equal(ff.Name.GetHashCode(), ff.GetHashCode());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FontFamily_Invalid()
+        {
+            FontFamily ff = new FontFamily((GenericFontFamilies)Int32.MinValue);
+            // default to Monospace
+            Assert.True(ff.Equals(FontFamily.GenericMonospace));
+            CheckMono(ff);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GenericMonospace()
+        {
+            FontFamily ff = FontFamily.GenericMonospace;
+            string ts = ff.ToString();
+            Assert.Equal('[', ts[0]);
+            Assert.True((ts.IndexOf(name) >= 0));
+            Assert.Equal(']', ts[ts.Length - 1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GenericSansSerif()
+        {
+            FontFamily ff = FontFamily.GenericSansSerif;
+            string name = ff.Name;
+            ff.Dispose();
+            Assert.Equal(name, FontFamily.GenericSansSerif.Name);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GenericSerif()
+        {
+            FontFamily ff = FontFamily.GenericSerif;
+            string name = ff.Name;
+            ff.Dispose();
+            Assert.Equal(name, FontFamily.GenericSerif.Name);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetFamilies_Null()
+        {
+#pragma warning disable 618
+            Assert.Throws<ArgumentNullException>(() => FontFamily.GetFamilies(null));
+#pragma warning restore 618
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetFamilies()
+        {
+#pragma warning disable 618
+            FontFamily[] ffc = FontFamily.GetFamilies(graphic);
+            Assert.Equal(ffc.Length, FontFamily.Families.Length);
+#pragma warning restore 618
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_Double()
+        {
+            FontFamily ff = FontFamily.GenericSerif;
+            ff.Dispose();
+            ff.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_UseAfter()
+        {
+            FontFamily ff = FontFamily.GenericMonospace;
+            ff.Dispose();
+            Assert.Throws<ArgumentException>(() => { var x = ff.Name; });
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/PenTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/PenTest.cs
@@ -1,0 +1,799 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.Pen unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using SC = System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class PenTest
+    {
+
+        private Pen default_pen;
+        private CustomLineCap custom_line_cap;
+
+        public PenTest()
+        {
+            default_pen = new Pen(Color.Empty);
+            custom_line_cap = new CustomLineCap(new GraphicsPath(), new GraphicsPath());
+        }
+
+        private void Check(Pen p)
+        {
+            Assert.Equal(PenAlignment.Center, p.Alignment);
+            Assert.Equal(typeof(SolidBrush), p.Brush.GetType());
+            Assert.Equal(Color.Red.ToArgb(), (p.Brush as SolidBrush).Color.ToArgb());
+            Assert.Equal(Color.Red.ToArgb(), p.Color.ToArgb());
+            Assert.Equal(0, p.CompoundArray.Length);
+            Assert.Equal(DashCap.Flat, p.DashCap);
+            Assert.Equal(0, p.DashOffset);
+            Assert.Equal(DashStyle.Solid, p.DashStyle);
+            Assert.Equal(LineCap.Flat, p.EndCap);
+            Assert.Equal(LineJoin.Miter, p.LineJoin);
+            Assert.Equal(10, p.MiterLimit);
+            Assert.Equal(PenType.SolidColor, p.PenType);
+            Assert.Equal(LineCap.Flat, p.StartCap);
+            Assert.True(p.Transform.IsIdentity);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Color()
+        {
+            using (Pen p = new Pen(Color.Red))
+            {
+                Assert.Equal(1, p.Width);
+                Check(p);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Color_Float()
+        {
+            using (Pen p = new Pen(Color.Red, 2.5f))
+            {
+                Assert.Equal(2.5f, p.Width);
+                Check(p);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Color_Float_Zero()
+        {
+            using (Pen p = new Pen(Color.Red, 0.0f))
+            {
+                Assert.Equal(0.0f, p.Width);
+                Check(p);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Color_Float_Negative()
+        {
+            using (Pen p = new Pen(Color.Red, -2))
+            {
+                Assert.Equal(-2, p.Width);
+                Check(p);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Color_Float_MaxValue()
+        {
+            using (Pen p = new Pen(Color.Red, Single.MaxValue))
+            {
+                Assert.Equal(Single.MaxValue, p.Width);
+                Check(p);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Brush()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                Assert.Equal(1, p.Width);
+                Check(p);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Brush_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Pen((Brush)null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Brush_Float()
+        {
+            using (Pen p = new Pen(Brushes.Red, 2.5f))
+            {
+                Assert.Equal(2.5f, p.Width);
+                Check(p);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Brush_Float_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Pen((Brush)null, Single.MaxValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Brush_Float_Zero()
+        {
+            using (Pen p = new Pen(Brushes.Red, 0.0f))
+            {
+                Assert.Equal(0.0f, p.Width);
+                Check(p);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Brush_Float_Negative()
+        {
+            using (Pen p = new Pen(Brushes.Red, -2))
+            {
+                Assert.Equal(-2, p.Width);
+                Check(p);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Brush_Float_MaxValue()
+        {
+            using (Pen p = new Pen(Brushes.Red, Single.MaxValue))
+            {
+                Assert.Equal(Single.MaxValue, p.Width);
+                Check(p);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Brush_DisposeBeforeUse()
+        {
+            using (SolidBrush b = new SolidBrush(Color.Red))
+            {
+                using (Pen p = new Pen(b, 1))
+                {
+                    b.Dispose();
+                    Check(p);
+                    using (Bitmap bmp = new Bitmap(12, 12))
+                    {
+                        using (Graphics g = Graphics.FromImage(bmp))
+                        {
+                            g.DrawLine(p, 1, 1, 10, 10);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void Check2(Pen p)
+        {
+            Assert.Equal(typeof(SolidBrush), p.Brush.GetType());
+            Assert.Equal(Color.Red.ToArgb(), (p.Brush as SolidBrush).Color.ToArgb());
+            Assert.Equal(Color.Red.ToArgb(), p.Color.ToArgb());
+            Assert.Equal(0, p.CompoundArray.Length);
+            //			Assert.Equal (DashCap.Flat, p.DashCap);
+            Assert.Equal(0, p.DashOffset);
+            Assert.Equal(10, p.MiterLimit);
+            Assert.Equal(PenType.SolidColor, p.PenType);
+            Assert.True(p.Transform.IsIdentity);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Alignment()
+        {
+            using (Pen p = new Pen(Brushes.Gold, Single.NegativeInfinity))
+            {
+                foreach (PenAlignment pa in Enum.GetValues(typeof(PenAlignment)))
+                {
+                    p.Alignment = pa;
+                    Assert.Equal(pa, p.Alignment);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void Alignment_Invalid()
+        {
+            Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.Alignment = (PenAlignment)Int32.MinValue);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Brush_Dispose()
+        {
+            using (Pen p = new Pen(Brushes.Red, 2.5f))
+            {
+                // are we getting the original brush ?
+                Brush b1 = p.Brush;
+                b1.Dispose();
+                Check(p);
+                using (Pen clone = (Pen)p.Clone())
+                {
+                    Check(clone);
+                }
+                Assert.False(Object.ReferenceEquals(b1, p.Brush));
+                // nope :)
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Brush_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => default_pen.Brush = null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DashCap_Valid()
+        {
+            // note: YellowGreen is broken by a destructive test so we can't use it afterward
+            // note: this worked with nunit 2.2 because this test was executed before the destructive one
+            using (Pen p = new Pen(Brushes.Yellow, 0))
+            {
+                foreach (DashCap dc in Enum.GetValues(typeof(DashCap)))
+                {
+                    p.DashCap = dc;
+                    Assert.Equal(dc, p.DashCap);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void DashCap_Invalid()
+        {
+            Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.DashCap = (DashCap)Int32.MinValue);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DashOffset()
+        {
+            using (Pen p = new Pen(Brushes.Transparent, 32))
+            {
+                p.DashOffset = 0;
+                Assert.Equal(0, p.DashOffset);
+                p.DashOffset = Single.MaxValue;
+                Assert.Equal(Single.MaxValue, p.DashOffset);
+                p.DashOffset = Single.MinValue;
+                Assert.Equal(Single.MinValue, p.DashOffset);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DashPattern()
+        {
+            using (Pen p = new Pen(Brushes.Tomato, 1.1f))
+            {
+                Assert.Equal(DashStyle.Solid, p.DashStyle);
+                p.DashPattern = new float[1] { 1 };
+                Assert.Equal(DashStyle.Custom, p.DashStyle);
+                Assert.Equal(1, p.DashPattern.Length);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DashPattern_Empty()
+        {
+            Assert.Throws<ArgumentException>(() => default_pen.DashPattern = new float[0]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DashStyle_Valid()
+        {
+            using (Pen p = new Pen(Brushes.Silver, Single.PositiveInfinity))
+            {
+                foreach (DashStyle ds in Enum.GetValues(typeof(DashStyle)))
+                {
+                    p.DashStyle = ds;
+                    Assert.Equal(ds, p.DashStyle);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void DashStyle_Invalid()
+        {
+            Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.DashStyle = (DashStyle)Int32.MinValue);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DashStyle_Custom()
+        {
+            using (Pen p = new Pen(Brushes.Silver, Single.PositiveInfinity))
+            {
+                Assert.Equal(DashStyle.Solid, p.DashStyle);
+                // can't ask for Solid (default) -> OutOfMemoryException
+                p.DashStyle = DashStyle.Custom;
+                Assert.Equal(DashStyle.Custom, p.DashStyle);
+                Assert.Equal(1, p.DashPattern.Length);
+                Assert.Equal(1, p.DashPattern[0]);
+
+                p.DashStyle = DashStyle.Dot;
+                Assert.Equal(DashStyle.Dot, p.DashStyle);
+                Assert.Equal(2, p.DashPattern.Length);
+                Assert.Equal(1, p.DashPattern[0]);
+                Assert.Equal(1, p.DashPattern[1]);
+                p.DashStyle = DashStyle.Custom;
+                Assert.Equal(DashStyle.Custom, p.DashStyle);
+                Assert.Equal(2, p.DashPattern.Length);
+                Assert.Equal(1, p.DashPattern[0]);
+                Assert.Equal(1, p.DashPattern[1]);
+
+                p.DashStyle = DashStyle.Dash;
+                Assert.Equal(DashStyle.Dash, p.DashStyle);
+                Assert.Equal(2, p.DashPattern.Length);
+                Assert.Equal(3, p.DashPattern[0]);
+                Assert.Equal(1, p.DashPattern[1]);
+                p.DashStyle = DashStyle.Custom;
+                Assert.Equal(DashStyle.Custom, p.DashStyle);
+                Assert.Equal(2, p.DashPattern.Length);
+                Assert.Equal(3, p.DashPattern[0]);
+                Assert.Equal(1, p.DashPattern[1]);
+
+                p.DashStyle = DashStyle.DashDot;
+                Assert.Equal(DashStyle.DashDot, p.DashStyle);
+                Assert.Equal(4, p.DashPattern.Length);
+                Assert.Equal(3, p.DashPattern[0]);
+                Assert.Equal(1, p.DashPattern[1]);
+                Assert.Equal(1, p.DashPattern[2]);
+                Assert.Equal(1, p.DashPattern[3]);
+                p.DashStyle = DashStyle.Custom;
+                Assert.Equal(DashStyle.Custom, p.DashStyle);
+                Assert.Equal(4, p.DashPattern.Length);
+                Assert.Equal(3, p.DashPattern[0]);
+                Assert.Equal(1, p.DashPattern[1]);
+                Assert.Equal(1, p.DashPattern[2]);
+                Assert.Equal(1, p.DashPattern[3]);
+
+                p.DashStyle = DashStyle.DashDotDot;
+                Assert.Equal(DashStyle.DashDotDot, p.DashStyle);
+                Assert.Equal(6, p.DashPattern.Length);
+                Assert.Equal(3, p.DashPattern[0]);
+                Assert.Equal(1, p.DashPattern[1]);
+                Assert.Equal(1, p.DashPattern[2]);
+                Assert.Equal(1, p.DashPattern[3]);
+                Assert.Equal(1, p.DashPattern[2]);
+                Assert.Equal(1, p.DashPattern[3]);
+                p.DashStyle = DashStyle.Custom;
+                Assert.Equal(DashStyle.Custom, p.DashStyle);
+                Assert.Equal(6, p.DashPattern.Length);
+                Assert.Equal(3, p.DashPattern[0]);
+                Assert.Equal(1, p.DashPattern[1]);
+                Assert.Equal(1, p.DashPattern[2]);
+                Assert.Equal(1, p.DashPattern[3]);
+                Assert.Equal(1, p.DashPattern[2]);
+                Assert.Equal(1, p.DashPattern[3]);
+
+                // resetting to DashStyle.Solid doesn't throw the OutOfMemoryException
+                // on MS runtime
+                p.DashStyle = DashStyle.Solid;
+                Assert.Equal(DashStyle.Solid, p.DashStyle);
+                Assert.Equal(0, p.DashPattern.Length);
+                p.DashStyle = DashStyle.Custom;
+                Assert.Equal(DashStyle.Custom, p.DashStyle);
+                Assert.Equal(1, p.DashPattern.Length);
+                Assert.Equal(1, p.DashPattern[0]);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void EndCap_Valid()
+        {
+            using (Pen p = new Pen(Brushes.Silver, Single.PositiveInfinity))
+            {
+                foreach (LineCap lc in Enum.GetValues(typeof(LineCap)))
+                {
+                    p.EndCap = lc;
+                    Assert.Equal(lc, p.EndCap);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void EndCap_Invalid()
+        {
+            Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.EndCap = (LineCap)Int32.MinValue);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LineJoin_Valid()
+        {
+            using (Pen p = new Pen(Brushes.Chocolate, Single.NaN))
+            {
+                foreach (LineJoin lj in Enum.GetValues(typeof(LineJoin)))
+                {
+                    p.LineJoin = lj;
+                    Assert.Equal(lj, p.LineJoin);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void LineJoin_Invalid()
+        {
+            Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.LineJoin = (LineJoin)Int32.MinValue);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MiterLimit()
+        {
+            using (Pen p = new Pen(Brushes.Tan, 1))
+            {
+                p.MiterLimit = Single.MinValue;
+                Assert.Equal(1, p.MiterLimit);
+                p.MiterLimit = 0;
+                Assert.Equal(1, p.MiterLimit);
+                p.MiterLimit = Single.MaxValue;
+                Assert.Equal(Single.MaxValue, p.MiterLimit);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StartCap_Valid()
+        {
+            using (Pen p = new Pen(Brushes.Silver, Single.PositiveInfinity))
+            {
+                foreach (LineCap lc in Enum.GetValues(typeof(LineCap)))
+                {
+                    p.StartCap = lc;
+                    Assert.Equal(lc, p.StartCap);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void StartCap_Invalid()
+        {
+            Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.StartCap = (LineCap)Int32.MinValue);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => default_pen.Transform = null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_NonInvertible()
+        {
+            using (Pen p = new Pen(Brushes.Snow, Single.MaxValue))
+            {
+                Assert.Throws<ArgumentException>(() => p.Transform = new Matrix(123, 24, 82, 16, 47, 30));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Width()
+        {
+            using (Pen p = new Pen(Brushes.Tan, Single.MinValue))
+            {
+                Assert.Equal(Single.MinValue, p.Width);
+                p.Width = 0;
+                Assert.Equal(0, p.Width);
+                p.Width = Single.MaxValue;
+                Assert.Equal(Single.MaxValue, p.Width);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Clone()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                using (Pen clone = (Pen)p.Clone())
+                {
+                    Check(clone);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose()
+        {
+            Pen p = new Pen(Brushes.Red);
+            p.Dispose();
+            Assert.Throws<ArgumentException>(() => p.Alignment = PenAlignment.Center);
+            // exception but not an ObjectDisposedException
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetLineCap()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                foreach (LineCap sc in Enum.GetValues(typeof(LineCap)))
+                {
+                    foreach (LineCap ec in Enum.GetValues(typeof(LineCap)))
+                    {
+                        foreach (DashCap dc in Enum.GetValues(typeof(DashCap)))
+                        {
+                            string s = String.Format("{0}-{1}-{2}", sc, ec, dc);
+                            p.SetLineCap(sc, ec, dc);
+                            Assert.Equal(sc, p.StartCap);
+                            Assert.Equal(ec, p.EndCap);
+                            Assert.Equal(dc, p.DashCap);
+                        }
+                    }
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetLineCap_InvalidStartCap()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                p.SetLineCap((LineCap)Int32.MinValue, LineCap.Flat, DashCap.Flat);
+                // no exception :( (reported as FDBK50057)
+                Assert.Equal(Int32.MinValue, (int)p.StartCap);
+                Assert.Equal(LineCap.Flat, p.EndCap);
+                Assert.Equal(DashCap.Flat, p.DashCap);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetLineCap_InvalidEndCap()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                p.SetLineCap(LineCap.Flat, (LineCap)Int32.MinValue, DashCap.Flat);
+                // no exception :( (reported as FDBK50057)
+                Assert.Equal(LineCap.Flat, p.StartCap);
+                Assert.Equal(Int32.MinValue, (int)p.EndCap);
+                Assert.Equal(DashCap.Flat, p.DashCap);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetLineCap_InvalidDashCap()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                p.SetLineCap(LineCap.Flat, LineCap.Flat, (DashCap)Int32.MinValue);
+                Assert.Equal(LineCap.Flat, p.StartCap);
+                Assert.Equal(LineCap.Flat, p.EndCap);
+                // invalid value was reseted to Flat (reported as FDBK50057)
+                Assert.Equal(DashCap.Flat, p.DashCap);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        //[ExpectedException (typeof (ArgumentNullException))] // reported as FDBK50058
+        public void MultiplyTransform1_Null()
+        {
+            Assert.Throws<NullReferenceException>(() => default_pen.MultiplyTransform(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        //[ExpectedException (typeof (ArgumentNullException))] // reported as FDBK50058
+        public void MultiplyTransform2_Null()
+        {
+            Assert.Throws<NullReferenceException>(() => default_pen.MultiplyTransform(null, MatrixOrder.Append));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform2_InvalidMatrixOrder()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                Matrix m1 = new Matrix(2, 0.5f, 0.5f, 4, 10, 20);
+                Matrix m2 = new Matrix(1, 0, 0, 1, -50, -30);
+
+                p.Transform = m2;
+                p.MultiplyTransform(m1, (MatrixOrder)Int32.MinValue);
+                // no exception, but which order is it ?
+                Matrix invalid = p.Transform;
+
+                p.Transform = m2;
+                p.MultiplyTransform(m1, MatrixOrder.Append);
+                Assert.True(invalid.Equals(p.Transform));
+
+                p.Transform = m2;
+                p.MultiplyTransform(m1, MatrixOrder.Prepend);
+                Assert.False(invalid.Equals(p.Transform));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform_NonInvertible()
+        {
+            using (Matrix noninvertible = new Matrix(123, 24, 82, 16, 47, 30))
+            {
+                using (Pen p = new Pen(Brushes.Red))
+                {
+                    Assert.Throws<ArgumentException>(() => p.MultiplyTransform(noninvertible));
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ResetTransform()
+        {
+            using (Matrix m = new Matrix(2, 0, 0, 2, 10, -10))
+            {
+                using (Pen p = new Pen(Brushes.Red))
+                {
+                    p.Transform = m;
+                    Assert.False(p.Transform.IsIdentity);
+                    p.ResetTransform();
+                    Assert.True(p.Transform.IsIdentity);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RotateTransform()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                p.RotateTransform(90);
+                float[] elements = p.Transform.Elements;
+                Assert.Equal(0, elements[0], 1);
+                Assert.Equal(1, elements[1], 1);
+                Assert.Equal(-1, elements[2], 1);
+                Assert.Equal(0, elements[3], 1);
+                Assert.Equal(0, elements[4], 1);
+                Assert.Equal(0, elements[5], 1);
+
+                p.RotateTransform(270);
+                Assert.True(p.Transform.IsIdentity);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RotateTransform_InvalidOrder()
+        {
+            Assert.Throws<ArgumentException>(() => default_pen.RotateTransform(720, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                p.ScaleTransform(2, 4);
+                float[] elements = p.Transform.Elements;
+                Assert.Equal(2, elements[0], 1);
+                Assert.Equal(0, elements[1], 1);
+                Assert.Equal(0, elements[2], 1);
+                Assert.Equal(4, elements[3], 1);
+                Assert.Equal(0, elements[4], 1);
+                Assert.Equal(0, elements[5], 1);
+
+                p.ScaleTransform(0.5f, 0.25f);
+                Assert.True(p.Transform.IsIdentity);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform_MaxMin()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                p.ScaleTransform(Single.MaxValue, Single.MinValue);
+                float[] elements = p.Transform.Elements;
+                Assert.Equal(Single.MaxValue, elements[0]);
+                Assert.Equal(0, elements[1], 1);
+                Assert.Equal(0, elements[2], 1);
+                Assert.Equal(Single.MinValue, elements[3]);
+                Assert.Equal(0, elements[4], 1);
+                Assert.Equal(0, elements[5], 1);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform_InvalidOrder()
+        {
+            Assert.Throws<ArgumentException>(() => default_pen.ScaleTransform(1, 1, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TranslateTransform()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                p.TranslateTransform(1, 1);
+                float[] elements = p.Transform.Elements;
+                Assert.Equal(1, elements[0], 1);
+                Assert.Equal(0, elements[1], 1);
+                Assert.Equal(0, elements[2], 1);
+                Assert.Equal(1, elements[3], 1);
+                Assert.Equal(1, elements[4], 1);
+                Assert.Equal(1, elements[5], 1);
+
+                p.TranslateTransform(-1, -1);
+                elements = p.Transform.Elements;
+                Assert.Equal(1, elements[0], 1);
+                Assert.Equal(0, elements[1], 1);
+                Assert.Equal(0, elements[2], 1);
+                Assert.Equal(1, elements[3], 1);
+                Assert.Equal(0, elements[4], 1);
+                Assert.Equal(0, elements[5], 1);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TranslateTransform_InvalidOrder()
+        {
+            Assert.Throws<ArgumentException>(() => default_pen.TranslateTransform(1, 1, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Operations()
+        {
+            using (Pen p = new Pen(Brushes.Red))
+            {
+                Matrix clone = p.Transform.Clone();
+                Matrix mul = clone.Clone();
+
+                clone.Multiply(mul, MatrixOrder.Append);
+                p.MultiplyTransform(mul, MatrixOrder.Append);
+                Assert.Equal(p.Transform, clone);
+
+                clone.Multiply(mul, MatrixOrder.Prepend);
+                p.MultiplyTransform(mul, MatrixOrder.Prepend);
+                Assert.Equal(p.Transform, clone);
+
+                clone.Rotate(45, MatrixOrder.Append);
+                p.RotateTransform(45, MatrixOrder.Append);
+                Assert.Equal(p.Transform, clone);
+
+                clone.Rotate(45, MatrixOrder.Prepend);
+                p.RotateTransform(45, MatrixOrder.Prepend);
+                Assert.Equal(p.Transform, clone);
+
+                clone.Scale(0.25f, 2, MatrixOrder.Append);
+                p.ScaleTransform(0.25f, 2, MatrixOrder.Append);
+                Assert.Equal(p.Transform, clone);
+
+                clone.Scale(0.25f, 2, MatrixOrder.Prepend);
+                p.ScaleTransform(0.25f, 2, MatrixOrder.Prepend);
+                Assert.Equal(p.Transform, clone);
+
+                clone.Translate(10, 20, MatrixOrder.Append);
+                p.TranslateTransform(10, 20, MatrixOrder.Append);
+                Assert.Equal(p.Transform, clone);
+
+                clone.Translate(30, 40, MatrixOrder.Prepend);
+                p.TranslateTransform(30, 40, MatrixOrder.Prepend);
+                Assert.Equal(p.Transform, clone);
+
+                clone.Reset();
+                p.ResetTransform();
+                Assert.Equal(p.Transform, clone);
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/RegionDataTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/RegionDataTest.cs
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.RegionData unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class RegionDataTest
+    {
+
+        private Bitmap bitmap;
+        private Graphics graphic;
+        private GraphicsPath sp1;
+        private GraphicsPath sp2;
+
+        public RegionDataTest()
+        {
+            bitmap = new Bitmap(10, 10);
+            graphic = Graphics.FromImage(bitmap);
+
+            sp1 = new GraphicsPath();
+            sp1.AddPolygon(new Point[4] { new Point(0, 0), new Point(3, 0), new Point(3, 3), new Point(0, 3) });
+
+            sp2 = new GraphicsPath();
+            sp2.AddPolygon(new Point[4] { new Point(2, 2), new Point(5, 2), new Point(5, 5), new Point(2, 5) });
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RegionData_Null()
+        {
+            RegionData data = new Region().GetRegionData();
+            data.Data = null;
+            Assert.Null(data.Data);
+            Assert.Throws<NullReferenceException>(() => new Region(data));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RegionData_EmptyData()
+        {
+            RegionData data = new Region().GetRegionData();
+            data.Data = new byte[0];
+            Assert.Equal(0, data.Data.Length);
+            try
+            {
+                new Region(data);
+            }
+            catch (ExternalException)
+            {
+                // MS
+            }
+            catch (ArgumentException)
+            {
+                // Mono
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void EmptyRegion()
+        {
+            // note: an empty region is (for libgdiplus) a rectangular based region
+            Region empty = new Region();
+            RegionData data = empty.GetRegionData();
+            Assert.NotNull(data.Data);
+            Region region = new Region(data);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void PathRegion()
+        {
+            GraphicsPath path = new GraphicsPath();
+            path.AddCurve(new Point[2] { new Point(1, 1), new Point(2, 2) });
+            Region r = new Region(path);
+            RegionData data = r.GetRegionData();
+            Assert.NotNull(data.Data);
+            Region region = new Region(data);
+            Assert.True(r.GetBounds(graphic).Equals(region.GetBounds(graphic)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CombinedPathRegion()
+        {
+            // note: seems identical to PathRegion but it test another code path inside libgdiplus
+            Region r = new Region(sp1);
+            r.Xor(sp2);
+            RegionData data = r.GetRegionData();
+            Assert.NotNull(data.Data);
+            Region region = new Region(data);
+            Assert.True(r.GetBounds(graphic).Equals(region.GetBounds(graphic)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiCombinedPathRegion()
+        {
+            // note: seems identical to PathRegion but it test another code path inside libgdiplus
+            Region r1 = new Region(sp1);
+            r1.Xor(sp2);
+            Region r2 = new Region(sp2);
+            r2.Complement(sp1);
+
+            Region r = r1.Clone();
+            r.Union(r2);
+            RegionData data = r.GetRegionData();
+            Assert.NotNull(data.Data);
+            Region region = new Region(data);
+            Assert.True(r.GetBounds(graphic).Equals(region.GetBounds(graphic)));
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/RegionNonRectTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/RegionNonRectTest.cs
@@ -1,0 +1,727 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.Region non-rectangular unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing.Imaging;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    /* NOTE: General tests and rectangular region tests are located in TestRegion.cs */
+    /*       Here we exclusively tests non-rectangular (GraphicsPath based) regions. */
+
+    public class RegionNonRectTest
+    {
+
+        private Bitmap bitmap;
+        private Graphics graphic;
+        private Matrix matrix;
+        private GraphicsPath sp1, sp2, sp3, sp4;
+
+        public RegionNonRectTest()
+        {
+            bitmap = new Bitmap(10, 10);
+            graphic = Graphics.FromImage(bitmap);
+            matrix = new Matrix();
+
+            sp1 = new GraphicsPath();
+            sp1.AddPolygon(new Point[4] { new Point(0, 0), new Point(3, 0), new Point(3, 3), new Point(0, 3) });
+
+            sp2 = new GraphicsPath();
+            sp2.AddPolygon(new Point[4] { new Point(2, 2), new Point(5, 2), new Point(5, 5), new Point(2, 5) });
+
+            sp3 = new GraphicsPath();
+            sp3.AddPolygon(new Point[4] { new Point(6, 0), new Point(9, 0), new Point(9, 3), new Point(6, 3) });
+
+            sp4 = new GraphicsPath();
+            sp4.AddPolygon(new Point[4] { new Point(8, 0), new Point(11, 0), new Point(11, 3), new Point(8, 3) });
+        }
+
+        // a region with an "empty ctor" graphic path is "empty" (i.e. not infinite)
+        private void CheckEmpty(string prefix, Region region)
+        {
+            Assert.True(region.IsEmpty(graphic), prefix + "IsEmpty");
+            Assert.False(region.IsInfinite(graphic), prefix + "graphic");
+
+            RectangleF rect = region.GetBounds(graphic);
+            Assert.Equal(0f, rect.X);
+            Assert.Equal(0f, rect.Y);
+            Assert.Equal(0f, rect.Width);
+            Assert.Equal(0f, rect.Height);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Region_Ctor_GraphicsPath_Empty()
+        {
+            Region region = new Region(new GraphicsPath());
+            CheckEmpty("GraphicsPath.", region);
+
+            Region clone = region.Clone();
+            CheckEmpty("Clone.", region);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Region_Ctor_GraphicsPath()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Region region = new Region(gp);
+            CheckEmpty("GraphicsPath.", region);
+
+            Region clone = region.Clone();
+            CheckEmpty("Clone.", region);
+        }
+
+        private void CheckInfiniteBounds(GraphicsPath path)
+        {
+            RectangleF rect = path.GetBounds();
+            Assert.Equal(-4194304f, rect.X);
+            Assert.Equal(-4194304f, rect.Y);
+            Assert.Equal(8388608f, rect.Width);
+            Assert.Equal(8388608f, rect.Height);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Region_Curve_IsInfinite()
+        {
+            Point[] points = new Point[2] { new Point(-4194304, -4194304), new Point(4194304, 4194304) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddCurve(points);
+            CheckInfiniteBounds(gp);
+
+            Region region = new Region(gp);
+            Assert.False(region.IsInfinite(graphic));
+            // note: infinity isn't based on the bounds
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Curve_GetRegionScans()
+        {
+            Point[] points = new Point[2] { new Point(-4194304, -4194304), new Point(4194304, 4194304) };
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddCurve(points);
+            Region region = new Region(gp);
+            // too big, returns 0
+            Assert.Equal(0, region.GetRegionScans(matrix).Length);
+        }
+
+        private void DisplaySmallRegion(Region region, int ox, int oy, int width, int height)
+        {
+            for (int y = oy; y < height - 1; y++)
+            {
+                for (int x = ox; x < width - 1; x++)
+                {
+                    if (region.IsVisible(x, y))
+                        Console.Write("X");
+                    else
+                        Console.Write(".");
+                }
+                Console.WriteLine();
+            }
+        }
+
+        private void DisplaySmallRegion(Region region, int width, int height)
+        {
+            DisplaySmallRegion(region, -1, -1, width, height);
+        }
+
+
+        private void CompareSmallRegion(Region region, bool[] expected, int ox, int oy, int width, int height)
+        {
+            int p = 0;
+            for (int y = oy; y < height + oy; y++)
+            {
+                for (int x = ox; x < width + ox; x++)
+                {
+                    Assert.Equal(expected[p], region.IsVisible(x, y));
+                    p++;
+                }
+            }
+        }
+
+        private void CompareSmallRegion(Region region, bool[] expected, int width, int height)
+        {
+            CompareSmallRegion(region, expected, -1, -1, width, height);
+        }
+
+        private void CheckRectF(string msg, int x, int y, int w, int h, RectangleF rect)
+        {
+            Assert.Equal(x, rect.X);
+            Assert.Equal(y, rect.Y);
+            Assert.Equal(w, rect.Width);
+            Assert.Equal(h, rect.Height);
+        }
+
+        static bool[] sunion = new bool[49] {
+            false, false, false, false, false, false, false, // .......
+			false, true,  true,  true,  false, false, false, // .XXX...
+			false, true,  true,  true,  false, false, false, // .XXX...
+			false, true,  true,  true,  true,  true,  false, // .XXXXX.
+			false, false, false, true,  true,  true,  false, // ...XXX.
+			false, false, false, true,  true,  true,  false, // ...XXX.
+			false, false, false, false, false, false, false, // .......
+		};
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallUnion1()
+        {
+            Region region = new Region(sp1);
+            region.Union(sp2);
+            CompareSmallRegion(region, sunion, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(3, scans.Length);
+            CheckRectF("[0]", 0, 0, 3, 2, scans[0]);
+            CheckRectF("[1]", 0, 2, 5, 1, scans[1]);
+            CheckRectF("[2]", 2, 3, 3, 2, scans[2]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallUnion2()
+        {
+            Region region = new Region(sp2);
+            region.Union(sp1);
+            CompareSmallRegion(region, sunion, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(3, scans.Length);
+            CheckRectF("[0]", 0, 0, 3, 2, scans[0]);
+            CheckRectF("[1]", 0, 2, 5, 1, scans[1]);
+            CheckRectF("[2]", 2, 3, 3, 2, scans[2]);
+        }
+
+        static bool[] self1 = new bool[49] {
+            false, false, false, false, false, false, false, // .......
+			false, true,  true,  true,  false, false, false, // .XXX...
+			false, true,  true,  true,  false, false, false, // .XXX...
+			false, true,  true,  true,  false, false, false, // .XXX...
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+		};
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallUnion_Self1()
+        {
+            Region region = new Region(sp1);
+            region.Union(sp1);
+            CompareSmallRegion(region, self1, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(1, scans.Length);
+            CheckRectF("[0]", 0, 0, 3, 3, scans[0]);
+        }
+
+        static bool[] self2 = new bool[49] {
+            false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, true,  true,  true,  false, // ...XXX.
+			false, false, false, true,  true,  true,  false, // ...XXX.
+			false, false, false, true,  true,  true,  false, // ...XXX.
+			false, false, false, false, false, false, false, // .......
+		};
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallUnion_Self2()
+        {
+            Region region = new Region(sp2);
+            region.Union(sp2);
+            CompareSmallRegion(region, self2, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(1, scans.Length);
+            CheckRectF("[0]", 2, 2, 3, 3, scans[0]);
+        }
+
+        static bool[] sintersection = new bool[49] {
+            false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, true,  false, false, false, // ...X...
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+		};
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallIntersection1()
+        {
+            Region region = new Region(sp1);
+            region.Intersect(sp2);
+            CompareSmallRegion(region, sintersection, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(1, scans.Length);
+            CheckRectF("[0]", 2, 2, 1, 1, scans[0]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallIntersection2()
+        {
+            Region region = new Region(sp2);
+            region.Intersect(sp1);
+            CompareSmallRegion(region, sintersection, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(1, scans.Length);
+            CheckRectF("[0]", 2, 2, 1, 1, scans[0]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallIntersection_Self1()
+        {
+            Region region = new Region(sp1);
+            region.Intersect(sp1);
+            CompareSmallRegion(region, self1, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(1, scans.Length);
+            CheckRectF("[0]", 0, 0, 3, 3, scans[0]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallIntersection_Self2()
+        {
+            Region region = new Region(sp2);
+            region.Intersect(sp2);
+            CompareSmallRegion(region, self2, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(1, scans.Length);
+            CheckRectF("[0]", 2, 2, 3, 3, scans[0]);
+        }
+
+        static bool[] sexclude1 = new bool[49] {
+            false, false, false, false, false, false, false, // .......
+			false, true,  true,  true,  false, false, false, // .XXX...
+			false, true,  true,  true,  false, false, false, // .XXX...
+			false, true,  true,  false, false, false, false, // .XX....
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+		};
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallExclude1()
+        {
+            Region region = new Region(sp1);
+            region.Exclude(sp2);
+            CompareSmallRegion(region, sexclude1, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(2, scans.Length);
+            CheckRectF("[0]", 0, 0, 3, 2, scans[0]);
+            CheckRectF("[1]", 0, 2, 2, 1, scans[1]);
+        }
+
+        static bool[] sexclude2 = new bool[49] {
+            false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, true,  true,  false, // ....XX.
+			false, false, false, true,  true,  true,  false, // ...XXX.
+			false, false, false, true,  true,  true,  false, // ...XXX.
+			false, false, false, false, false, false, false, // .......
+		};
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallExclude2()
+        {
+            Region region = new Region(sp2);
+            region.Exclude(sp1);
+            CompareSmallRegion(region, sexclude2, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(2, scans.Length);
+            CheckRectF("[0]", 3, 2, 2, 1, scans[0]);
+            CheckRectF("[1]", 2, 3, 3, 2, scans[1]);
+        }
+
+        static bool[] sempty = new bool[49] {
+            false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+			false, false, false, false, false, false, false, // .......
+		};
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallExclude_Self1()
+        {
+            Region region = new Region(sp1);
+            region.Exclude(sp1);
+            CompareSmallRegion(region, sempty, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(0, scans.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallExclude_Self2()
+        {
+            Region region = new Region(sp2);
+            region.Exclude(sp2);
+            CompareSmallRegion(region, sempty, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(0, scans.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallComplement1()
+        {
+            Region region = new Region(sp1);
+            region.Complement(sp2);
+            CompareSmallRegion(region, sexclude2, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(2, scans.Length);
+            CheckRectF("[0]", 3, 2, 2, 1, scans[0]);
+            CheckRectF("[1]", 2, 3, 3, 2, scans[1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallComplement2()
+        {
+            Region region = new Region(sp2);
+            region.Complement(sp1);
+            CompareSmallRegion(region, sexclude1, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(2, scans.Length);
+            CheckRectF("[0]", 0, 0, 3, 2, scans[0]);
+            CheckRectF("[1]", 0, 2, 2, 1, scans[1]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallComplement_Self1()
+        {
+            Region region = new Region(sp1);
+            region.Complement(sp1);
+            CompareSmallRegion(region, sempty, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(0, scans.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallComplement_Self2()
+        {
+            Region region = new Region(sp2);
+            region.Complement(sp2);
+            CompareSmallRegion(region, sempty, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(0, scans.Length);
+        }
+
+        static bool[] sxor = new bool[49] {
+            false, false, false, false, false, false, false, // .......
+			false, true,  true,  true,  false, false, false, // .XXX...
+			false, true,  true,  true,  false, false, false, // .XXX...
+			false, true,  true,  false, true,  true,  false, // .XX.XX.
+			false, false, false, true,  true,  true,  false, // ...XXX.
+			false, false, false, true,  true,  true,  false, // ...XXX.
+			false, false, false, false, false, false, false, // .......
+		};
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallXor1()
+        {
+            Region region = new Region(sp1);
+            region.Xor(sp2);
+            CompareSmallRegion(region, sxor, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(4, scans.Length);
+            CheckRectF("[0]", 0, 0, 3, 2, scans[0]);
+            CheckRectF("[1]", 0, 2, 2, 1, scans[1]);
+            CheckRectF("[2]", 3, 2, 2, 1, scans[2]);
+            CheckRectF("[3]", 2, 3, 3, 2, scans[3]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallXor2()
+        {
+            Region region = new Region(sp2);
+            region.Xor(sp1);
+            CompareSmallRegion(region, sxor, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(4, scans.Length);
+            CheckRectF("[0]", 0, 0, 3, 2, scans[0]);
+            CheckRectF("[1]", 0, 2, 2, 1, scans[1]);
+            CheckRectF("[2]", 3, 2, 2, 1, scans[2]);
+            CheckRectF("[3]", 2, 3, 3, 2, scans[3]);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallXor_Self1()
+        {
+            Region region = new Region(sp1);
+            region.Xor(sp1);
+            CompareSmallRegion(region, sempty, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(0, scans.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SmallXor_Self2()
+        {
+            Region region = new Region(sp2);
+            region.Xor(sp2);
+            CompareSmallRegion(region, sempty, 7, 7);
+
+            RectangleF[] scans = region.GetRegionScans(matrix);
+            Assert.Equal(0, scans.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void NegativeXor()
+        {
+            GraphicsPath neg = new GraphicsPath();
+            // identical result (matrix) of XOR but we're using negative coordinates
+            neg.AddPolygon(new Point[4] { new Point(-2, -2), new Point(1, -2), new Point(1, 1), new Point(-2, 1) });
+
+            Region region = new Region(sp1);
+            region.Xor(neg);
+            CompareSmallRegion(region, sxor, -3, -3, 7, 7);
+        }
+
+        static bool[] ni_union = new bool[55] {
+            false, false, false, false, false, false, false, false, false, false, false, // ...........
+			false, true,  true,  true,  false, false, false, true,  true,  true,  false, // .XXX...XXX.
+			false, true,  true,  true,  false, false, false, true,  true,  true,  false, // .XXX...XXX.
+			false, true,  true,  true,  false, false, false, true,  true,  true,  false, // .XXX...XXX.
+			false, false, false, false, false, false, false, false, false, false, false, // ...........
+		};
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void UnionWithoutIntersection()
+        {
+            Region region = new Region(sp1);
+            region.Union(sp3);
+            CompareSmallRegion(region, ni_union, 11, 5);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        // libgdiplus: both region are considered inside as intersecting rectangle because
+        // part of them co-exists in the same 8x8 bitmap. Full algorithm apply but results
+        // in an empty bitmap
+        public void IntersectionWithoutIntersection()
+        {
+            Region region = new Region(sp1);
+            region.Intersect(sp3);
+            CompareSmallRegion(region, sempty, 7, 7);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        // libgdiplus: no intersection results in an empty bitmap (optimization)
+        public void IntersectionWithoutIntersection_Large()
+        {
+            Region region = new Region(sp1);
+            region.Intersect(sp4);
+            CompareSmallRegion(region, sempty, 7, 7);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        // libgdiplus: both region are considered inside as intersecting rectangle because
+        // part of them co-exists in the same 8x8 bitmap. Full algorithm apply but results
+        // as a copy of sp1
+        public void ExcludeWithoutIntersection()
+        {
+            Region region = new Region(sp1);
+            region.Exclude(sp3);
+            CompareSmallRegion(region, self1, 7, 7);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        // libgdiplus: no intersection results in a clone of sp1 (optimization)
+        public void ExcludeWithoutIntersection_Large()
+        {
+            Region region = new Region(sp1);
+            region.Exclude(sp4);
+            CompareSmallRegion(region, self1, 7, 7);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        // libgdiplus: both region are considered inside as intersecting rectangle because
+        // part of them co-exists in the same 8x8 bitmap. Full algorithm apply but results
+        // as a copy of sp1
+        public void ComplementWithoutIntersection()
+        {
+            Region region = new Region(sp3);
+            region.Complement(sp1);
+            CompareSmallRegion(region, self1, 7, 7);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        // libgdiplus: no intersection results in a clone of sp1 (optimization)
+        public void ComplementWithoutIntersection_Large()
+        {
+            Region region = new Region(sp4);
+            region.Complement(sp1);
+            CompareSmallRegion(region, self1, 7, 7);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        // libgdiplus: both region are considered inside as intersecting rectangle because
+        // part of them co-exists in the same 8x8 bitmap.
+        public void XorWithoutIntersection()
+        {
+            Region region = new Region(sp1);
+            region.Xor(sp3);
+            CompareSmallRegion(region, ni_union, 11, 5);
+        }
+
+        static bool[] ni_xor = new bool[65] {
+            false, false, false, false, false, false, false, false, false, false, false, false, false, // .............
+			false, true,  true,  true,  false, false, false, false, false, true,  true,  true,  false, // .XXX.....XXX.
+			false, true,  true,  true,  false, false, false, false, false, true,  true,  true,  false, // .XXX.....XXX.
+			false, true,  true,  true,  false, false, false, false, false, true,  true,  true,  false, // .XXX.....XXX.
+			false, false, false, false, false, false, false, false, false, false, false, false, false, // .............
+		};
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        // libgdiplus: both region aren't considered as an intersection because they do 
+        // not co-exists in the same 8x8 bitmap. In this case the xor function calls the
+        // union code (optimization).
+        public void XorWithoutIntersection_Large()
+        {
+            Region region = new Region(sp1);
+            region.Xor(sp4);
+            CompareSmallRegion(region, ni_xor, 13, 5);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsEqual()
+        {
+            Region r1 = new Region(sp1);
+            Region r2 = new Region(sp2);
+            Region r3 = new Region(sp3);
+            Region r4 = new Region(sp4);
+            // with self
+            Assert.True(r1.Equals(r1, graphic));
+            Assert.True(r2.Equals(r2, graphic));
+            Assert.True(r3.Equals(r3, graphic));
+            Assert.True(r4.Equals(r4, graphic));
+            // with a different
+            Assert.False(r1.Equals(r4, graphic));
+            Assert.False(r2.Equals(r3, graphic));
+            Assert.False(r3.Equals(r2, graphic));
+            Assert.False(r4.Equals(r1, graphic));
+            // with same (not self)
+            Region r5 = r1.Clone();
+            r1.Exclude(r4);
+            Assert.True(r1.Equals(r5, graphic));
+            Assert.True(r5.Equals(r1, graphic));
+            Assert.False(r5.Equals(r4, graphic));
+            Assert.False(r4.Equals(r5, graphic));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Translate_Int()
+        {
+            Region r1 = new Region(sp1);
+            Region r2 = new Region(sp2);
+            r2.Translate(-2, -2);
+            r1.Intersect(r2);
+            CompareSmallRegion(r1, self1, 7, 7);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Translate_Float()
+        {
+            Region r1 = new Region(sp1);
+            Region r2 = new Region(sp2);
+            r2.Translate(-2.0f, -2.0f);
+            r1.Intersect(r2);
+            CompareSmallRegion(r1, self1, 7, 7);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void EmptyPathWithInfiniteRegion()
+        {
+            GraphicsPath gp = new GraphicsPath();
+            Region region = new Region();
+            Assert.True(region.IsInfinite(graphic));
+
+            region.Union(gp);
+            Assert.True(region.IsInfinite(graphic));
+
+            region.Xor(gp);
+            Assert.True(region.IsInfinite(graphic));
+
+            region.Exclude(gp);
+            Assert.True(region.IsInfinite(graphic));
+
+            region.Intersect(gp);
+            Assert.True(region.IsEmpty(graphic));
+
+            region.MakeInfinite();
+            region.Complement(gp);
+            Assert.True(region.IsEmpty(graphic));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void EmptyRegionWithInfiniteRegion()
+        {
+            Region empty = new Region();
+            empty.MakeEmpty();
+            Assert.True(empty.IsEmpty(graphic));
+
+            Region region = new Region();
+            Assert.True(region.IsInfinite(graphic));
+
+            region.Union(empty);
+            Assert.True(region.IsInfinite(graphic));
+
+            region.Xor(empty);
+            Assert.True(region.IsInfinite(graphic));
+
+            region.Exclude(empty);
+            Assert.True(region.IsInfinite(graphic));
+
+            region.Intersect(empty);
+            Assert.True(region.IsEmpty(graphic));
+
+            region.MakeInfinite();
+            region.Complement(empty);
+            Assert.True(region.IsEmpty(graphic));
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/SolidBrushTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/SolidBrushTest.cs
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.SolidBrush unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006-2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class SolidBrushTest
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transparent()
+        {
+            SolidBrush sb = new SolidBrush(Color.Transparent);
+            Assert.Equal(Color.Transparent, sb.Color);
+            sb.Color = Color.Empty;
+            SolidBrush clone = (SolidBrush)sb.Clone();
+            sb.Dispose();
+            Assert.Equal(Color.Empty.ToArgb(), clone.Color.ToArgb());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_Color()
+        {
+            SolidBrush sb = new SolidBrush(Color.Transparent);
+            sb.Dispose();
+            Assert.Equal(Color.Transparent, sb.Color);
+            // no exception - the call probably doesn't get to gdi+
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_Clone()
+        {
+            SolidBrush sb = new SolidBrush(Color.Transparent);
+            sb.Dispose();
+            Assert.Throws<ArgumentException>(() => sb.Clone());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_Dispose()
+        {
+            SolidBrush sb = new SolidBrush(Color.Transparent);
+            sb.Dispose();
+            sb.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FillRectangle()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10))
+            {
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    SolidBrush sb = new SolidBrush(Color.Red);
+                    g.FillRectangle(sb, 0, 0, 9, 9);
+                    sb.Color = Color.Blue;
+                    g.FillRectangle(sb, 4, 4, 5, 5);
+                }
+                Assert.Equal(Color.Red.ToArgb(), bmp.GetPixel(0, 0).ToArgb());
+                Assert.Equal(Color.Blue.ToArgb(), bmp.GetPixel(8, 8).ToArgb());
+                Assert.Equal(0, bmp.GetPixel(9, 9).ToArgb());
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DrawLine()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10))
+            {
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    SolidBrush sb = new SolidBrush(Color.Red);
+                    Pen p = new Pen(sb);
+                    g.DrawLine(p, 0, 0, 9, 9);
+                    sb.Color = Color.Blue;
+                    g.DrawLine(p, 8, 8, 4, 4); // pen is still red
+                }
+                Assert.Equal(Color.Red.ToArgb(), bmp.GetPixel(0, 0).ToArgb());
+                Assert.Equal(Color.Red.ToArgb(), bmp.GetPixel(8, 8).ToArgb());
+                Assert.Equal(Color.Red.ToArgb(), bmp.GetPixel(9, 9).ToArgb()); // include end point
+            }
+            using (Bitmap bmp = new Bitmap(10, 10))
+            {
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    SolidBrush sb = new SolidBrush(Color.Red);
+                    Pen p = new Pen(sb);
+                    g.DrawLine(p, float.NaN, float.NaN, 9, 9);
+                }
+                Assert.NotEqual(Color.Red.ToArgb(), bmp.GetPixel(0, 0).ToArgb());
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Clone()
+        {
+            using (SolidBrush sb = new SolidBrush(Color.Transparent))
+            {
+                // we still get a "named" color
+                Assert.Equal(Color.Transparent, sb.Color);
+                using (SolidBrush clone = (SolidBrush)sb.Clone())
+                {
+                    // but not after cloning the brush
+                    Assert.False(Color.Transparent.Equals(clone.Color));
+                    Assert.Equal(Color.Transparent.ToArgb(), clone.Color.ToArgb());
+                }
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/SystemFontsTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/SystemFontsTest.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Tests for System.Drawing.SystemFontsTest
+//
+// Authors:
+//	Gert Driesen  <drieseng@users.sourceforge.net>
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006-2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+using System.Drawing;
+
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class SystemFontsTest
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DefaultFont()
+        {
+            Font f = SystemFonts.DefaultFont;
+            Assert.False(f.Bold);
+
+            Assert.Equal(true, f.IsSystemFont);
+            Assert.False(f.Italic);
+            Assert.Equal(8.25, f.Size, 2);
+            Assert.Equal(8.25, f.SizeInPoints, 2);
+            Assert.False(f.Strikeout);
+            Assert.False(f.Underline);
+            Assert.Equal(GraphicsUnit.Point, f.Unit);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SystemFontName()
+        {
+            Assert.Equal("CaptionFont", SystemFonts.CaptionFont.SystemFontName);
+            Assert.Equal("DefaultFont", SystemFonts.DefaultFont.SystemFontName);
+            Assert.Equal("DialogFont", SystemFonts.DialogFont.SystemFontName);
+            Assert.Equal("IconTitleFont", SystemFonts.IconTitleFont.SystemFontName);
+            Assert.Equal("MenuFont", SystemFonts.MenuFont.SystemFontName);
+            Assert.Equal("MessageBoxFont", SystemFonts.MessageBoxFont.SystemFontName);
+            Assert.Equal("SmallCaptionFont", SystemFonts.SmallCaptionFont.SystemFontName);
+            Assert.Equal("StatusFont", SystemFonts.StatusFont.SystemFontName);
+        }
+
+        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
+        public void GetFontByName()
+        {
+            Assert.Equal("CaptionFont", SystemFonts.GetFontByName("CaptionFont").SystemFontName);
+            Assert.Equal("DefaultFont", SystemFonts.GetFontByName("DefaultFont").SystemFontName);
+            Assert.Equal("DialogFont", SystemFonts.GetFontByName("DialogFont").SystemFontName);
+            Assert.Equal("IconTitleFont", SystemFonts.GetFontByName("IconTitleFont").SystemFontName);
+            Assert.Equal("MenuFont", SystemFonts.GetFontByName("MenuFont").SystemFontName);
+            Assert.Equal("MessageBoxFont", SystemFonts.GetFontByName("MessageBoxFont").SystemFontName);
+            Assert.Equal("SmallCaptionFont", SystemFonts.GetFontByName("SmallCaptionFont").SystemFontName);
+            Assert.Equal("StatusFont", SystemFonts.GetFontByName("StatusFont").SystemFontName);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetFontByName_Invalid()
+        {
+            Assert.Null(SystemFonts.GetFontByName(null));
+            Assert.Null(SystemFonts.GetFontByName(String.Empty));
+            Assert.Null(SystemFonts.GetFontByName("defaultfont"));
+            Assert.Null(SystemFonts.GetFontByName("DEFAULTFONT"));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Same()
+        {
+            Font f1 = SystemFonts.CaptionFont;
+            Font f2 = SystemFonts.CaptionFont;
+            Assert.False(Object.ReferenceEquals(f1, f2));
+            f2 = SystemFonts.GetFontByName("CaptionFont");
+            Assert.False(Object.ReferenceEquals(f1, f2));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_Instance()
+        {
+            Font f1 = SystemFonts.CaptionFont;
+            float height = f1.GetHeight(72f);
+            f1.Dispose();
+            Assert.Throws<ArgumentException>(() => f1.GetHeight(72f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_Property()
+        {
+            float height = SystemFonts.CaptionFont.GetHeight(72f);
+            SystemFonts.CaptionFont.Dispose();
+            Assert.Equal(height, SystemFonts.CaptionFont.GetHeight(72f));
+        }
+    }
+}
+

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/SystemIconsTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/SystemIconsTest.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Tests for System.Drawing.SystemIconsTest.cs 
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using Xunit;
+using System;
+using System.Drawing;
+using System.Security.Permissions;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class SystemIconsTest
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Same()
+        {
+            // SystemIcons always return the same icon
+            Assert.True(Object.ReferenceEquals(SystemIcons.Application, SystemIcons.Application));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_SystemIcons()
+        {
+            // SystemIcons icon's can't be disposed
+            SystemIcons.Application.Dispose();
+            Assert.NotNull(SystemIcons.Application.ToBitmap());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_Indirect()
+        {
+            // SystemIcons icon's can't be disposed
+            Icon app = SystemIcons.Application;
+            app.Dispose();
+            Assert.NotNull(app.ToBitmap());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Clone_Dispose()
+        {
+            // Clones of SystemIcons icon's can be disposed
+            Icon app = SystemIcons.Application;
+            Icon clone = (Icon)app.Clone();
+            clone.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => clone.ToBitmap());
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/TestBitmap.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/TestBitmap.cs
@@ -1,0 +1,1762 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Bitmap class testing unit
+//
+// Authors:
+// 	Jordi Mas i Hernàndez (jmas@softcatala.org>
+//	Jonathan Gilbert <logic@deltaq.org>
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// (C) 2004 Ximian, Inc.  http://www.ximian.com
+// Copyright (C) 2004,2006-2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security.Cryptography;
+using System.Security.Permissions;
+using System.Text;
+using System.Xml.Serialization;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class TestBitmap
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPixels()
+        {
+            // Tests GetSetPixel/SetPixel			
+            Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format32bppRgb);
+            bmp.SetPixel(0, 0, Color.FromArgb(255, 128, 128, 128));
+            Color color = bmp.GetPixel(0, 0);
+
+            Assert.Equal(Color.FromArgb(255, 128, 128, 128), color);
+
+            bmp.SetPixel(99, 99, Color.FromArgb(255, 255, 0, 155));
+            Color color2 = bmp.GetPixel(99, 99);
+            Assert.Equal(Color.FromArgb(255, 255, 0, 155), color2);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_32_32_NonIndexedWrite()
+        {
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format32bppRgb))
+            {
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                BitmapData data = bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format32bppRgb);
+                Assert.Equal(100, data.Height);
+                Assert.Equal(PixelFormat.Format32bppRgb, data.PixelFormat);
+                Assert.Equal(400, data.Stride);
+                Assert.Equal(100, data.Width);
+                bmp.UnlockBits(data);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_32_24_NonIndexedWrite()
+        {
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format32bppRgb))
+            {
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                BitmapData data = bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb);
+                Assert.Equal(100, data.Height);
+                Assert.Equal(PixelFormat.Format24bppRgb, data.PixelFormat);
+                Assert.Equal(300, data.Stride);
+                Assert.Equal(100, data.Width);
+                bmp.UnlockBits(data);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_24_24_NonIndexedWrite()
+        {
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format24bppRgb))
+            {
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                BitmapData data = bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb);
+                Assert.Equal(100, data.Height);
+                Assert.Equal(PixelFormat.Format24bppRgb, data.PixelFormat);
+                Assert.Equal(300, data.Stride);
+                Assert.Equal(100, data.Width);
+                bmp.UnlockBits(data);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_24_32_NonIndexedWrite()
+        {
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format24bppRgb))
+            {
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                BitmapData data = bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format32bppRgb);
+                Assert.Equal(100, data.Height);
+                Assert.Equal(PixelFormat.Format32bppRgb, data.PixelFormat);
+                Assert.Equal(400, data.Stride);
+                Assert.Equal(100, data.Width);
+                bmp.UnlockBits(data);
+            }
+        }
+
+        [ActiveIssue(20884)]
+        public void LockBits_IndexedWrite_NonIndexed()
+        {
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format8bppIndexed))
+            {
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                Assert.Throws<ArgumentException>(() => bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb));
+            }
+        }
+
+        [ActiveIssue(20884)]
+        public void LockBits_NonIndexedWrite_ToIndexed()
+        {
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format32bppRgb))
+            {
+                BitmapData bd = new BitmapData();
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                Assert.Throws<ArgumentException>(() => bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed, bd));
+
+                // test to see if there's a leak or not in this case
+                Assert.Equal(IntPtr.Zero, bd.Scan0);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_IndexedWrite_SameIndexedFormat()
+        {
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format8bppIndexed))
+            {
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                BitmapData data = bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed);
+                Assert.Equal(100, data.Height);
+                Assert.Equal(PixelFormat.Format8bppIndexed, data.PixelFormat);
+                Assert.Equal(100, data.Stride);
+                Assert.Equal(100, data.Width);
+                bmp.UnlockBits(data);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_ImageLockMode_Invalid()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10, PixelFormat.Format24bppRgb))
+            {
+                Rectangle r = new Rectangle(4, 4, 4, 4);
+                BitmapData data = bmp.LockBits(r, (ImageLockMode)0, PixelFormat.Format24bppRgb);
+                try
+                {
+                    Assert.Equal(4, data.Height);
+                    Assert.Equal(4, data.Width);
+                    Assert.True(data.Stride >= 12);
+                    Assert.Equal(PixelFormat.Format24bppRgb, data.PixelFormat);
+                    Assert.False(IntPtr.Zero.Equals(data.Scan0));
+                }
+                finally
+                {
+                    bmp.UnlockBits(data);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_Double()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10, PixelFormat.Format24bppRgb))
+            {
+                Rectangle r = new Rectangle(4, 4, 4, 4);
+                BitmapData data = bmp.LockBits(r, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
+                try
+                {
+                    Assert.Throws<InvalidOperationException>(() => bmp.LockBits(r, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb));
+                }
+                finally
+                {
+                    bmp.UnlockBits(data);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_Disposed()
+        {
+            Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format32bppRgb);
+            Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+            bmp.Dispose();
+            Assert.Throws<ArgumentException>(() => bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void UnlockBits_Null()
+        {
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format32bppRgb))
+            {
+                Assert.Throws<ArgumentException>(() => bmp.UnlockBits(null));
+            }
+        }
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_BitmapData_Null()
+        {
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format32bppRgb))
+            {
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                Assert.Throws<ArgumentException>(() => bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb, null));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_32_32_BitmapData()
+        {
+            BitmapData data = new BitmapData();
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format32bppRgb))
+            {
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format32bppRgb, data);
+                Assert.Equal(100, data.Height);
+                Assert.Equal(PixelFormat.Format32bppRgb, data.PixelFormat);
+                Assert.Equal(400, data.Stride);
+                Assert.Equal(100, data.Width);
+                bmp.UnlockBits(data);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_32_24_BitmapData()
+        {
+            BitmapData data = new BitmapData();
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format32bppRgb))
+            {
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb, data);
+                Assert.Equal(100, data.Height);
+                Assert.Equal(PixelFormat.Format24bppRgb, data.PixelFormat);
+                Assert.Equal(300, data.Stride);
+                Assert.Equal(100, data.Width);
+                bmp.UnlockBits(data);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_24_24_BitmapData()
+        {
+            BitmapData data = new BitmapData();
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format24bppRgb))
+            {
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb, data);
+                Assert.Equal(100, data.Height);
+                Assert.Equal(PixelFormat.Format24bppRgb, data.PixelFormat);
+                Assert.Equal(300, data.Stride);
+                Assert.Equal(100, data.Width);
+                bmp.UnlockBits(data);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBits_24_32_BitmapData()
+        {
+            BitmapData data = new BitmapData();
+            using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format24bppRgb))
+            {
+                Rectangle rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                bmp.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format32bppRgb, data);
+                Assert.Equal(100, data.Height);
+                Assert.Equal(PixelFormat.Format32bppRgb, data.PixelFormat);
+                Assert.Equal(400, data.Stride);
+                Assert.Equal(100, data.Width);
+                bmp.UnlockBits(data);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Format1bppIndexed()
+        {
+            using (Bitmap bmp = new Bitmap(1, 1, PixelFormat.Format1bppIndexed))
+            {
+                Color c = bmp.GetPixel(0, 0);
+                Assert.Equal(-16777216, c.ToArgb());
+                Assert.Throws<InvalidOperationException>(() => bmp.SetPixel(0, 0, c));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Format4bppIndexed()
+        {
+            using (Bitmap bmp = new Bitmap(1, 1, PixelFormat.Format4bppIndexed))
+            {
+                Color c = bmp.GetPixel(0, 0);
+                Assert.Equal(-16777216, c.ToArgb());
+                Assert.Throws<InvalidOperationException>(() => bmp.SetPixel(0, 0, c));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Format8bppIndexed()
+        {
+            using (Bitmap bmp = new Bitmap(1, 1, PixelFormat.Format8bppIndexed))
+            {
+                Color c = bmp.GetPixel(0, 0);
+                Assert.Equal(-16777216, c.ToArgb());
+                Assert.Throws<InvalidOperationException>(() => bmp.SetPixel(0, 0, c));
+            }
+        }
+
+        private void FormatTest(PixelFormat format)
+        {
+            bool alpha = Image.IsAlphaPixelFormat(format);
+            int size = Image.GetPixelFormatSize(format) / 8 * 2;
+            using (Bitmap bmp = new Bitmap(2, 1, format))
+            {
+                Color a = Color.FromArgb(128, 64, 32, 16);
+                Color b = Color.FromArgb(192, 96, 48, 24);
+                bmp.SetPixel(0, 0, a);
+                bmp.SetPixel(1, 0, b);
+                Color c = bmp.GetPixel(0, 0);
+                Color d = bmp.GetPixel(1, 0);
+                if (size == 4)
+                {
+                    Assert.Equal(255, c.A);
+                    Assert.Equal(66, c.R);
+                    if (format == PixelFormat.Format16bppRgb565)
+                    {
+                        Assert.Equal(32, c.G);
+                    }
+                    else
+                    {
+                        Assert.Equal(33, c.G);
+                    }
+                    Assert.Equal(16, c.B);
+
+                    Assert.Equal(255, d.A);
+                    Assert.Equal(99, d.R);
+                    if (format == PixelFormat.Format16bppRgb565)
+                    {
+                        Assert.Equal(48, d.G);
+                    }
+                    else
+                    {
+                        Assert.Equal(49, d.G);
+                    }
+                    Assert.Equal(24, d.B);
+                }
+                else if (alpha)
+                {
+                    if (format == PixelFormat.Format32bppPArgb)
+                    {
+                        Assert.Equal(a.A, c.A);
+                        // note sure why the -1
+                        Assert.Equal(a.R - 1, c.R);
+                        Assert.Equal(a.G - 1, c.G);
+                        Assert.Equal(a.B - 1, c.B);
+
+                        Assert.Equal(b.A, d.A);
+                        // note sure why the -1
+                        Assert.Equal(b.R - 1, d.R);
+                        Assert.Equal(b.G - 1, d.G);
+                        Assert.Equal(b.B - 1, d.B);
+                    }
+                    else
+                    {
+                        Assert.Equal(a, c);
+                        Assert.Equal(b, d);
+                    }
+                }
+                else
+                {
+                    Assert.Equal(Color.FromArgb(255, 64, 32, 16), c);
+                    Assert.Equal(Color.FromArgb(255, 96, 48, 24), d);
+                }
+                BitmapData bd = bmp.LockBits(new Rectangle(0, 0, 2, 1), ImageLockMode.ReadOnly, format);
+                try
+                {
+                    byte[] data = new byte[size];
+                    Marshal.Copy(bd.Scan0, data, 0, size);
+                    if (format == PixelFormat.Format32bppPArgb)
+                    {
+                        Assert.Equal(Math.Ceiling((float)c.B * c.A / 255), data[0]);
+                        Assert.Equal(Math.Ceiling((float)c.G * c.A / 255), data[1]);
+                        Assert.Equal(Math.Ceiling((float)c.R * c.A / 255), data[2]);
+                        Assert.Equal(c.A, data[3]);
+                        Assert.Equal(Math.Ceiling((float)d.B * d.A / 255), data[4]);
+                        Assert.Equal(Math.Ceiling((float)d.G * d.A / 255), data[5]);
+                        Assert.Equal(Math.Ceiling((float)d.R * d.A / 255), data[6]);
+                        Assert.Equal(d.A, data[7]);
+                    }
+                    else if (size == 4)
+                    {
+                        int n = 0;
+                        switch (format)
+                        {
+                            case PixelFormat.Format16bppRgb565:
+                                Assert.Equal(2, data[n++]);
+                                Assert.Equal(65, data[n++]);
+                                Assert.Equal(131, data[n++]);
+                                Assert.Equal(97, data[n++]);
+                                break;
+                            case PixelFormat.Format16bppArgb1555:
+                                Assert.Equal(130, data[n++]);
+                                Assert.Equal(160, data[n++]);
+                                Assert.Equal(195, data[n++]);
+                                Assert.Equal(176, data[n++]);
+                                break;
+                            case PixelFormat.Format16bppRgb555:
+                                Assert.Equal(130, data[n++]);
+                                Assert.Equal(32, data[n++]);
+                                Assert.Equal(195, data[n++]);
+                                Assert.Equal(48, data[n++]);
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        int n = 0;
+                        Assert.Equal(c.B, data[n++]);
+                        Assert.Equal(c.G, data[n++]);
+                        Assert.Equal(c.R, data[n++]);
+                        if (size % 4 == 0)
+                            Assert.Equal(c.A, data[n++]);
+                        Assert.Equal(d.B, data[n++]);
+                        Assert.Equal(d.G, data[n++]);
+                        Assert.Equal(d.R, data[n++]);
+                        if (size % 4 == 0)
+                            Assert.Equal(d.A, data[n++]);
+                    }
+                }
+                finally
+                {
+                    bmp.UnlockBits(bd);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Format32bppArgb()
+        {
+            FormatTest(PixelFormat.Format32bppArgb);
+        }
+
+        [ActiveIssue(20884)]
+        public void Format32bppRgb()
+        {
+            FormatTest(PixelFormat.Format32bppRgb);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Format24bppRgb()
+        {
+            FormatTest(PixelFormat.Format24bppRgb);
+        }
+
+        /* Get the output directory depending on the runtime and location*/
+        public static string getOutSubDir()
+        {
+            string sSub, sRslt;
+
+            if (Environment.GetEnvironmentVariable("MSNet") == null)
+                sSub = "mono/";
+            else
+                sSub = "MSNet/";
+
+            sRslt = Path.GetFullPath(sSub);
+
+            if (Directory.Exists(sRslt) == false)
+                sRslt = "Test/System.Drawing/" + sSub;
+
+            if (sRslt.Length > 0)
+                if (sRslt[sRslt.Length - 1] != '\\' && sRslt[sRslt.Length - 1] != '/')
+                    sRslt += "/";
+
+            return sRslt;
+        }
+
+        // note: this test fails when saving (for the same reason) on Mono and MS.NET
+        //[ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MakeTransparent()
+        {
+            string sInFile = Helpers.GetTestBitmapPath("maketransparent.bmp");
+            string sOutFile = getOutSubDir() + "transparent.bmp";
+
+            Bitmap bmp = new Bitmap(sInFile);
+
+            bmp.MakeTransparent();
+            bmp.Save(sOutFile);
+
+            Color color = bmp.GetPixel(1, 1);
+            Assert.Equal(Color.Black.R, color.R);
+            Assert.Equal(Color.Black.G, color.G);
+            Assert.Equal(Color.Black.B, color.B);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Clone()
+        {
+            string sInFile = Helpers.GetTestBitmapPath("almogaver24bits.bmp");
+            Rectangle rect = new Rectangle(0, 0, 50, 50);
+            Bitmap bmp = new Bitmap(sInFile);
+
+            Bitmap bmpNew = bmp.Clone(rect, PixelFormat.Format32bppArgb);
+            Color colororg0 = bmp.GetPixel(0, 0);
+            Color colororg50 = bmp.GetPixel(49, 49);
+            Color colornew0 = bmpNew.GetPixel(0, 0);
+            Color colornew50 = bmpNew.GetPixel(49, 49);
+
+            Assert.Equal(colororg0, colornew0);
+            Assert.Equal(colororg50, colornew50);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CloneImage()
+        {
+            string sInFile = Helpers.GetTestBitmapPath("almogaver24bits.bmp");
+            Bitmap bmp = new Bitmap(sInFile);
+
+            Bitmap bmpNew = (Bitmap)bmp.Clone();
+
+            Assert.Equal(bmp.Width, bmpNew.Width);
+            Assert.Equal(bmp.Height, bmpNew.Height);
+            Assert.Equal(bmp.PixelFormat, bmpNew.PixelFormat);
+
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Frames()
+        {
+            string sInFile = Helpers.GetTestBitmapPath("almogaver24bits.bmp");
+            Bitmap bmp = new Bitmap(sInFile);
+            int cnt = bmp.GetFrameCount(FrameDimension.Page);
+            int active = bmp.SelectActiveFrame(FrameDimension.Page, 0);
+
+            Assert.Equal(1, cnt);
+            Assert.Equal(0, active);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FileDoesNotExists()
+        {
+            Assert.Throws<ArgumentException>(() => new Bitmap("FileDoesNotExists.jpg"));
+        }
+
+        static string ByteArrayToString(byte[] arrInput)
+        {
+            int i;
+            StringBuilder sOutput = new StringBuilder(arrInput.Length);
+            for (i = 0; i < arrInput.Length - 1; i++)
+            {
+                sOutput.Append(arrInput[i].ToString("X2"));
+            }
+            return sOutput.ToString();
+        }
+
+
+        public string RotateBmp(Bitmap src, RotateFlipType rotate)
+        {
+            int width = 150, height = 150, index = 0;
+            byte[] pixels = new byte[width * height * 3];
+            Bitmap bmp_rotate;
+            byte[] hash;
+            Color clr;
+
+            bmp_rotate = src.Clone(new RectangleF(0, 0, width, height), PixelFormat.Format32bppArgb);
+            bmp_rotate.RotateFlip(rotate);
+
+            for (int y = 0; y < height; y++)
+            {
+                for (int x = 0; x < width; x++)
+                {
+                    clr = bmp_rotate.GetPixel(x, y);
+                    pixels[index++] = clr.R;
+                    pixels[index++] = clr.G;
+                    pixels[index++] = clr.B;
+                }
+            }
+
+            hash = MD5.Create().ComputeHash(pixels);
+            return ByteArrayToString(hash);
+        }
+        public string RotateIndexedBmp(Bitmap src, RotateFlipType type)
+        {
+            int pixels_per_byte;
+
+            switch (src.PixelFormat)
+            {
+                case PixelFormat.Format1bppIndexed:
+                    pixels_per_byte = 8;
+                    break;
+                case PixelFormat.Format4bppIndexed:
+                    pixels_per_byte = 2;
+                    break;
+                case PixelFormat.Format8bppIndexed:
+                    pixels_per_byte = 1;
+                    break;
+
+                default:
+                    throw new Exception("Cannot pass a bitmap of format " + src.PixelFormat + " to RotateIndexedBmp");
+            }
+
+            Bitmap test = src.Clone() as Bitmap;
+
+            test.RotateFlip(type);
+
+            BitmapData data = null;
+            byte[] pixel_data;
+
+            try
+            {
+                data = test.LockBits(new Rectangle(0, 0, test.Width, test.Height), ImageLockMode.ReadOnly, test.PixelFormat);
+
+                int scan_size = (data.Width + pixels_per_byte - 1) / pixels_per_byte;
+                pixel_data = new byte[data.Height * scan_size];
+
+                for (int y = 0; y < data.Height; y++)
+                {
+                    IntPtr src_ptr = (IntPtr)(y * data.Stride + data.Scan0.ToInt64());
+                    int dest_offset = y * scan_size;
+                    for (int x = 0; x < scan_size; x++)
+                        pixel_data[dest_offset + x] = Marshal.ReadByte(src_ptr, x);
+                }
+            }
+            finally
+            {
+                if (test != null)
+                {
+                    if (data != null)
+                        try
+                        { test.UnlockBits(data); }
+                        catch { }
+
+                    try
+                    { test.Dispose(); }
+                    catch { }
+                }
+            }
+
+            if (pixel_data == null)
+                return "--ERROR--";
+
+            byte[] hash = MD5.Create().ComputeHash(pixel_data);
+            return ByteArrayToString(hash);
+        }
+
+
+        /*
+			Rotate bitmap in diffent ways, and check the result
+			pixels using MD5
+		*/
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Rotate()
+        {
+            string sInFile = Helpers.GetTestBitmapPath("almogaver24bits.bmp");
+            Bitmap bmp = new Bitmap(sInFile);
+
+            Assert.Equal("312958A3C67402E1299413794988A3", RotateBmp(bmp, RotateFlipType.Rotate90FlipNone));
+            Assert.Equal("BF70D8DA4F1545AEDD77D0296B47AE", RotateBmp(bmp, RotateFlipType.Rotate180FlipNone));
+            Assert.Equal("15AD2ADBDC7090C0EC744D0F7ACE2F", RotateBmp(bmp, RotateFlipType.Rotate270FlipNone));
+            Assert.Equal("2E10FEC1F4FD64ECC51D7CE68AEB18", RotateBmp(bmp, RotateFlipType.RotateNoneFlipX));
+            Assert.Equal("E63204779B566ED01162B90B49BD9E", RotateBmp(bmp, RotateFlipType.Rotate90FlipX));
+            Assert.Equal("B1ECB17B5093E13D04FF55CFCF7763", RotateBmp(bmp, RotateFlipType.Rotate180FlipX));
+            Assert.Equal("71A173882C16755D86F4BC26532374", RotateBmp(bmp, RotateFlipType.Rotate270FlipX));
+
+        }
+
+        /*
+			Rotate 1- and 4-bit bitmaps in different ways and check the
+			resulting pixels using MD5
+		*/
+        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void Rotate1bit4bit()
+        {
+            string[] files = {
+                               Helpers.GetTestBitmapPath ("1bit.png"),
+                               Helpers.GetTestBitmapPath ("4bit.png")
+                             };
+
+            StringBuilder md5s = new StringBuilder();
+
+            foreach (string file in files)
+                using (Bitmap bmp = new Bitmap(file))
+                    foreach (RotateFlipType type in Enum.GetValues(typeof(RotateFlipType)))
+                        md5s.Append(RotateIndexedBmp(bmp, type));
+
+            using (StreamWriter writer = new StreamWriter("/tmp/md5s.txt"))
+                writer.WriteLine(md5s);
+
+            Assert.Equal(
+                "A4DAF507C92BDE10626BC7B34FEFE5" + // 1-bit RotateNoneFlipNone
+                "A4DAF507C92BDE10626BC7B34FEFE5" + // 1-bit Rotate180FlipXY
+                "C0975EAFD2FC1CC9CC7AF20B92FC9F" + // 1-bit Rotate90FlipNone
+                "C0975EAFD2FC1CC9CC7AF20B92FC9F" + // 1-bit Rotate270FlipXY
+                "64AE60858A02228F7B1B18C7812FB6" + // 1-bit Rotate180FlipNone
+                "64AE60858A02228F7B1B18C7812FB6" + // 1-bit RotateNoneFlipXY
+                "E96D3390938350F9DE2608C4364424" + // 1-bit Rotate270FlipNone
+                "E96D3390938350F9DE2608C4364424" + // 1-bit Rotate90FlipXY
+                "23947CE822C1DDE6BEA69C01F8D0D9" + // 1-bit RotateNoneFlipX
+                "23947CE822C1DDE6BEA69C01F8D0D9" + // 1-bit Rotate180FlipY
+                "BE45F685BDEBD7079AA1B2CBA46723" + // 1-bit Rotate90FlipX
+                "BE45F685BDEBD7079AA1B2CBA46723" + // 1-bit Rotate270FlipY
+                "353E937CFF31B1BF6C3DD0A031ACB5" + // 1-bit Rotate180FlipX
+                "353E937CFF31B1BF6C3DD0A031ACB5" + // 1-bit RotateNoneFlipY
+                "AEA18A770A845E25B6A8CE28DD6DCB" + // 1-bit Rotate270FlipX
+                "AEA18A770A845E25B6A8CE28DD6DCB" + // 1-bit Rotate90FlipY
+                "3CC874B571902366AACED5D619E87D" + // 4-bit RotateNoneFlipNone
+                "3CC874B571902366AACED5D619E87D" + // 4-bit Rotate180FlipXY
+                "8DE25C7E1BE4A3B535DB5D83198D83" + // 4-bit Rotate90FlipNone
+                "8DE25C7E1BE4A3B535DB5D83198D83" + // 4-bit Rotate270FlipXY
+                "27CF5E9CE70BE9EBC47FB996721B95" + // 4-bit Rotate180FlipNone
+                "27CF5E9CE70BE9EBC47FB996721B95" + // 4-bit RotateNoneFlipXY
+                "A919CCB8F97CAD7DC1F01026D11A5D" + // 4-bit Rotate270FlipNone
+                "A919CCB8F97CAD7DC1F01026D11A5D" + // 4-bit Rotate90FlipXY
+                "545876C99ACF833E69FBFFBF436034" + // 4-bit RotateNoneFlipX
+                "545876C99ACF833E69FBFFBF436034" + // 4-bit Rotate180FlipY
+                "5DB56687757CDEFC52D89C77CA9223" + // 4-bit Rotate90FlipX
+                "5DB56687757CDEFC52D89C77CA9223" + // 4-bit Rotate270FlipY
+                "05A77EDDCDF20D5B0AC0169E95D7D7" + // 4-bit Rotate180FlipX
+                "05A77EDDCDF20D5B0AC0169E95D7D7" + // 4-bit RotateNoneFlipY
+                "B6B6245796C836923ABAABDF368B29" + // 4-bit Rotate270FlipX
+                "B6B6245796C836923ABAABDF368B29",  // 4-bit Rotate90FlipY
+                md5s.ToString());
+        }
+
+        private Bitmap CreateBitmap(int width, int height, PixelFormat fmt)
+        {
+            Bitmap bmp = new Bitmap(width, height, fmt);
+            using (Graphics gr = Graphics.FromImage(bmp))
+            {
+                Color c = Color.FromArgb(255, 100, 200, 250);
+                for (int x = 1; x < 80; x++)
+                {
+                    bmp.SetPixel(x, 1, c);
+                    bmp.SetPixel(x, 2, c);
+                    bmp.SetPixel(x, 78, c);
+                    bmp.SetPixel(x, 79, c);
+                }
+                for (int y = 3; y < 78; y++)
+                {
+                    bmp.SetPixel(1, y, c);
+                    bmp.SetPixel(2, y, c);
+                    bmp.SetPixel(78, y, c);
+                    bmp.SetPixel(79, y, c);
+                }
+            }
+            return bmp;
+        }
+
+        private byte[] HashPixels(Bitmap bmp)
+        {
+            int len = bmp.Width * bmp.Height * 4;
+            int index = 0;
+            byte[] pixels = new byte[len];
+
+            for (int y = 0; y < bmp.Height; y++)
+            {
+                for (int x = 0; x < bmp.Width; x++)
+                {
+                    Color clr = bmp.GetPixel(x, y);
+                    pixels[index++] = clr.R;
+                    pixels[index++] = clr.G;
+                    pixels[index++] = clr.B;
+                }
+            }
+            return MD5.Create().ComputeHash(pixels);
+        }
+
+        private byte[] HashLock(Bitmap bmp, int width, int height, PixelFormat fmt, ImageLockMode mode)
+        {
+            int len = bmp.Width * bmp.Height * 4;
+            byte[] pixels = new byte[len];
+            BitmapData bd = bmp.LockBits(new Rectangle(0, 0, width, height), mode, fmt);
+            try
+            {
+                int index = 0;
+                int bbps = Image.GetPixelFormatSize(fmt);
+                long pos = bd.Scan0.ToInt64();
+                byte[] btv = new byte[1];
+                for (int y = 0; y < bd.Height; y++)
+                {
+                    for (int x = 0; x < bd.Width; x++)
+                    {
+
+                        /* Read the pixels*/
+                        for (int bt = 0; bt < bbps / 8; bt++, index++)
+                        {
+                            long cur = pos;
+                            cur += y * bd.Stride;
+                            cur += x * bbps / 8;
+                            cur += bt;
+                            Marshal.Copy((IntPtr)cur, btv, 0, 1);
+                            pixels[index] = btv[0];
+
+                            /* Make change of all the colours = 250 to 10*/
+                            if (btv[0] == 250)
+                            {
+                                btv[0] = 10;
+                                Marshal.Copy(btv, 0, (IntPtr)cur, 1);
+                            }
+                        }
+                    }
+                }
+
+                for (int i = index; i < len; i++)
+                    pixels[index] = 0;
+            }
+            finally
+            {
+                bmp.UnlockBits(bd);
+            }
+            return MD5.Create().ComputeHash(pixels);
+        }
+
+        /*
+			Tests the LockBitmap functions. Makes a hash of the block of pixels that it returns
+			firsts, changes them, and then using GetPixel does another check of the changes.
+			The results match the .Net framework
+		*/
+        private static byte[] DefaultBitmapHash = new byte[] { 0xD8, 0xD3, 0x68, 0x9C, 0x86, 0x7F, 0xB6, 0xA0, 0x76, 0xD6, 0x00, 0xEF, 0xFF, 0xE5, 0x8E, 0x1B };
+        private static byte[] FinalWholeBitmapHash = new byte[] { 0x5F, 0x52, 0x98, 0x37, 0xE3, 0x94, 0xE1, 0xA6, 0x06, 0x6C, 0x5B, 0xF1, 0xA9, 0xC2, 0xA9, 0x43 };
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBitmap_Format32bppArgb_Format32bppArgb_ReadWrite_Whole()
+        {
+            using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
+            {
+                Assert.Equal(DefaultBitmapHash, HashPixels(bmp));
+                byte[] expected = { 0x89, 0x6A, 0x6B, 0x35, 0x5C, 0x89, 0xD9, 0xE9, 0xF4, 0x51, 0xD5, 0x89, 0xED, 0x28, 0x68, 0x5C };
+                byte[] actual = HashLock(bmp, bmp.Width, bmp.Height, PixelFormat.Format32bppArgb, ImageLockMode.ReadWrite);
+                Assert.Equal(expected, actual);
+                Assert.Equal(FinalWholeBitmapHash, HashPixels(bmp));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBitmap_Format32bppArgb_Format32bppPArgb_ReadWrite_Whole()
+        {
+            using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
+            {
+                Assert.Equal(DefaultBitmapHash, HashPixels(bmp));
+                byte[] expected = { 0x89, 0x6A, 0x6B, 0x35, 0x5C, 0x89, 0xD9, 0xE9, 0xF4, 0x51, 0xD5, 0x89, 0xED, 0x28, 0x68, 0x5C };
+                byte[] actual = HashLock(bmp, bmp.Width, bmp.Height, PixelFormat.Format32bppPArgb, ImageLockMode.ReadWrite);
+                Assert.Equal(expected, actual);
+                Assert.Equal(FinalWholeBitmapHash, HashPixels(bmp));
+            }
+        }
+
+        [ActiveIssue(20884)]
+        public void LockBitmap_Format32bppArgb_Format32bppRgb_ReadWrite_Whole()
+        {
+            using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
+            {
+                Assert.Equal(DefaultBitmapHash, HashPixels(bmp));
+                byte[] expected = { 0xC0, 0x28, 0xB5, 0x2E, 0x86, 0x90, 0x6F, 0x37, 0x09, 0x5F, 0x49, 0xA4, 0x91, 0xDA, 0xEE, 0xB9 };
+                byte[] actual = HashLock(bmp, bmp.Width, bmp.Height, PixelFormat.Format32bppRgb, ImageLockMode.ReadWrite);
+                Assert.Equal(expected, actual);
+                Assert.Equal(FinalWholeBitmapHash, HashPixels(bmp));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBitmap_Format32bppArgb_Format24bppRgb_ReadWrite_Whole()
+        {
+            using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
+            {
+                Assert.Equal(DefaultBitmapHash, HashPixels(bmp));
+                byte[] expected = { 0xA7, 0xB2, 0x50, 0x04, 0x11, 0x12, 0x64, 0x68, 0x6B, 0x7D, 0x2F, 0x6E, 0x69, 0x24, 0xCB, 0x14 };
+                byte[] actual = HashLock(bmp, bmp.Width, bmp.Height, PixelFormat.Format24bppRgb, ImageLockMode.ReadWrite);
+                Assert.Equal(expected, actual);
+                Assert.Equal(FinalWholeBitmapHash, HashPixels(bmp));
+            }
+        }
+
+        private static byte[] FinalPartialBitmapHash = new byte[] { 0xED, 0xD8, 0xDC, 0x9B, 0x44, 0x00, 0x22, 0x9B, 0x07, 0x06, 0x4A, 0x21, 0x70, 0xA7, 0x31, 0x1D };
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBitmap_Format32bppArgb_Format32bppArgb_ReadWrite_Partial()
+        {
+            using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
+            {
+                Assert.Equal(DefaultBitmapHash, HashPixels(bmp));
+                byte[] expected = { 0x5D, 0xFF, 0x02, 0x34, 0xEB, 0x7C, 0xF7, 0x42, 0xD4, 0xB7, 0x70, 0x49, 0xB4, 0x06, 0x79, 0xBC };
+                byte[] actual = HashLock(bmp, 50, 50, PixelFormat.Format32bppArgb, ImageLockMode.ReadWrite);
+                Assert.Equal(expected, actual);
+                Assert.Equal(FinalPartialBitmapHash, HashPixels(bmp));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBitmap_Format32bppArgb_Format32bppPArgb_ReadWrite_Partial()
+        {
+            using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
+            {
+                Assert.Equal(DefaultBitmapHash, HashPixels(bmp));
+                byte[] expected = { 0x5D, 0xFF, 0x02, 0x34, 0xEB, 0x7C, 0xF7, 0x42, 0xD4, 0xB7, 0x70, 0x49, 0xB4, 0x06, 0x79, 0xBC };
+                byte[] actual = HashLock(bmp, 50, 50, PixelFormat.Format32bppPArgb, ImageLockMode.ReadWrite);
+                Assert.Equal(expected, actual);
+                Assert.Equal(FinalPartialBitmapHash, HashPixels(bmp));
+            }
+        }
+
+        [ActiveIssue(20884)]
+        public void LockBitmap_Format32bppArgb_Format32bppRgb_ReadWrite_Partial()
+        {
+            using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
+            {
+                Assert.Equal(DefaultBitmapHash, HashPixels(bmp));
+                byte[] expected = { 0x72, 0x33, 0x09, 0x67, 0x53, 0x65, 0x38, 0xF9, 0xE4, 0x58, 0xE1, 0x0A, 0xAA, 0x6A, 0xCC, 0xB8 };
+                byte[] actual = HashLock(bmp, 50, 50, PixelFormat.Format32bppRgb, ImageLockMode.ReadWrite);
+                Assert.Equal(expected, actual);
+                Assert.Equal(FinalPartialBitmapHash, HashPixels(bmp));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockBitmap_Format32bppArgb_Format24bppRgb_ReadWrite_Partial()
+        {
+            using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
+            {
+                Assert.Equal(DefaultBitmapHash, HashPixels(bmp));
+                byte[] expected = { 0x4D, 0x39, 0x21, 0x88, 0xC2, 0x17, 0x14, 0x5F, 0x89, 0x9E, 0x02, 0x75, 0xF3, 0x64, 0xD8, 0xF0 };
+                byte[] actual = HashLock(bmp, 50, 50, PixelFormat.Format24bppRgb, ImageLockMode.ReadWrite);
+                Assert.Equal(expected, actual);
+                Assert.Equal(FinalPartialBitmapHash, HashPixels(bmp));
+            }
+        }
+
+        /*
+			Tests the LockBitmap and UnlockBitmap functions, specifically the copying
+			of bitmap data in the directions indicated by the ImageLockMode.
+		*/
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LockUnlockBitmap()
+        {
+            BitmapData data;
+            int pixel_value;
+            Color pixel_colour;
+
+            Color red = Color.FromArgb(Color.Red.A, Color.Red.R, Color.Red.G, Color.Red.B);
+            Color blue = Color.FromArgb(Color.Blue.A, Color.Blue.R, Color.Blue.G, Color.Blue.B);
+
+            using (Bitmap bmp = new Bitmap(1, 1, PixelFormat.Format32bppRgb))
+            {
+                bmp.SetPixel(0, 0, red);
+                pixel_colour = bmp.GetPixel(0, 0);
+                Assert.Equal(red, pixel_colour);
+
+                data = bmp.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+                try
+                {
+                    pixel_value = Marshal.ReadByte(data.Scan0, 0);
+                    pixel_value |= Marshal.ReadByte(data.Scan0, 1) << 8;
+                    pixel_value |= Marshal.ReadByte(data.Scan0, 2) << 16;
+                    pixel_value |= Marshal.ReadByte(data.Scan0, 3) << 24;
+
+                    pixel_colour = Color.FromArgb(pixel_value);
+                    // Disregard alpha information in the test
+                    pixel_colour = Color.FromArgb(red.A, pixel_colour.R, pixel_colour.G, pixel_colour.B);
+                    Assert.Equal(red, pixel_colour);
+
+                    // write blue but we're locked in read-only...
+                    Marshal.WriteByte(data.Scan0, 0, blue.B);
+                    Marshal.WriteByte(data.Scan0, 1, blue.G);
+                    Marshal.WriteByte(data.Scan0, 2, blue.R);
+                    Marshal.WriteByte(data.Scan0, 3, blue.A);
+                }
+                finally
+                {
+                    bmp.UnlockBits(data);
+                    pixel_colour = bmp.GetPixel(0, 0);
+                    // Disregard alpha information in the test
+                    pixel_colour = Color.FromArgb(red.A, pixel_colour.R, pixel_colour.G, pixel_colour.B);
+                    // ...so we still read red after unlocking
+                    Assert.Equal(red, pixel_colour);
+                }
+
+                data = bmp.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
+                try
+                {
+                    // write blue
+                    Marshal.WriteByte(data.Scan0, 0, blue.B);
+                    Marshal.WriteByte(data.Scan0, 1, blue.G);
+                    Marshal.WriteByte(data.Scan0, 2, blue.R);
+                    Marshal.WriteByte(data.Scan0, 3, blue.A);
+                }
+                finally
+                {
+                    bmp.UnlockBits(data);
+                    pixel_colour = bmp.GetPixel(0, 0);
+                    // Disregard alpha information in the test
+                    pixel_colour = Color.FromArgb(blue.A, pixel_colour.R, pixel_colour.G, pixel_colour.B);
+                    // read blue
+                    Assert.Equal(blue, pixel_colour);
+                }
+            }
+
+            using (Bitmap bmp = new Bitmap(1, 1, PixelFormat.Format32bppArgb))
+            {
+                bmp.SetPixel(0, 0, red);
+
+                data = bmp.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
+                try
+                {
+                    byte b = Marshal.ReadByte(data.Scan0, 0);
+                    byte g = Marshal.ReadByte(data.Scan0, 1);
+                    byte r = Marshal.ReadByte(data.Scan0, 2);
+                    pixel_colour = Color.FromArgb(red.A, r, g, b);
+                    Assert.Equal(red, pixel_colour);
+                    // write blue but we're locked in read-only...
+                    Marshal.WriteByte(data.Scan0, 0, blue.B);
+                    Marshal.WriteByte(data.Scan0, 1, blue.G);
+                    Marshal.WriteByte(data.Scan0, 2, blue.R);
+                }
+                finally
+                {
+                    bmp.UnlockBits(data);
+                    // ...so we still read red after unlocking
+                    Assert.Equal(red, bmp.GetPixel(0, 0));
+                }
+
+                data = bmp.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb);
+                try
+                {
+                    // write blue
+                    Marshal.WriteByte(data.Scan0, 0, blue.B);
+                    Marshal.WriteByte(data.Scan0, 1, blue.G);
+                    Marshal.WriteByte(data.Scan0, 2, blue.R);
+                }
+                finally
+                {
+                    bmp.UnlockBits(data);
+                    // read blue
+                    Assert.Equal(blue, bmp.GetPixel(0, 0));
+                }
+            }
+        }
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DefaultFormat1()
+        {
+            using (Bitmap bmp = new Bitmap(20, 20))
+            {
+                Assert.Equal(ImageFormat.MemoryBmp, bmp.RawFormat);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void DefaultFormat2()
+        {
+            string filename = Path.GetTempFileName();
+            using (Bitmap bmp = new Bitmap(20, 20))
+            {
+                bmp.Save(filename);
+            }
+
+            using (Bitmap other = new Bitmap(filename))
+            {
+                Assert.Equal(ImageFormat.Png, other.RawFormat);
+            }
+            File.Delete(filename);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BmpDataStride1()
+        {
+            Bitmap bmp = new Bitmap(184, 184, PixelFormat.Format1bppIndexed);
+            BitmapData data = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadWrite, PixelFormat.Format1bppIndexed);
+            try
+            {
+                Assert.Equal(24, data.Stride);
+            }
+            finally
+            {
+                bmp.UnlockBits(data);
+                bmp.Dispose();
+            }
+        }
+
+        private Stream Serialize(object o)
+        {
+            MemoryStream ms = new MemoryStream();
+            IFormatter formatter = new BinaryFormatter();
+            formatter.Serialize(ms, o);
+            ms.Position = 0;
+            return ms;
+        }
+
+        private object Deserialize(Stream s)
+        {
+            return new BinaryFormatter().Deserialize(s);
+        }
+
+        [ActiveIssue(20844)]
+        public void Serialize_Icon()
+        {
+            // this cause a problem with resgen, see http://bugzilla.ximian.com/show_bug.cgi?id=80565
+            string filename = Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico");
+            using (Bitmap icon = new Bitmap(filename))
+            {
+                using (Stream s = Serialize(icon))
+                {
+                    using (Bitmap copy = (Bitmap)Deserialize(s))
+                    {
+                        Assert.Equal(icon.Height, copy.Height);
+                        Assert.Equal(icon.Width, copy.Width);
+                        Assert.Equal(icon.PixelFormat, copy.PixelFormat);
+                        Assert.True(icon.RawFormat.Equals(ImageFormat.Icon));
+                        Assert.True(copy.RawFormat.Equals(ImageFormat.Png));
+                    }
+                }
+            }
+        }
+
+        static int[] palette1 = {
+            -16777216,
+            -1,
+        };
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Format1bppIndexed_Palette()
+        {
+            using (Bitmap bmp = new Bitmap(1, 1, PixelFormat.Format1bppIndexed))
+            {
+                ColorPalette pal = bmp.Palette;
+                Assert.Equal(2, pal.Entries.Length);
+                for (int i = 0; i < pal.Entries.Length; i++)
+                {
+                    Assert.Equal(palette1[i], pal.Entries[i].ToArgb());
+                }
+                Assert.Equal(2, pal.Flags);
+            }
+        }
+
+        static int[] palette16 = {
+            -16777216,
+            -8388608,
+            -16744448,
+            -8355840,
+            -16777088,
+            -8388480,
+            -16744320,
+            -8355712,
+            -4144960,
+            -65536,
+            -16711936,
+            -256,
+            -16776961,
+            -65281,
+            -16711681,
+            -1,
+        };
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Format4bppIndexed_Palette()
+        {
+            using (Bitmap bmp = new Bitmap(1, 1, PixelFormat.Format4bppIndexed))
+            {
+                ColorPalette pal = bmp.Palette;
+                Assert.Equal(16, pal.Entries.Length);
+                for (int i = 0; i < pal.Entries.Length; i++)
+                {
+                    Assert.Equal(palette16[i], pal.Entries[i].ToArgb());
+                }
+                Assert.Equal(0, pal.Flags);
+            }
+        }
+
+        static int[] palette256 = {
+            -16777216,
+            -8388608,
+            -16744448,
+            -8355840,
+            -16777088,
+            -8388480,
+            -16744320,
+            -8355712,
+            -4144960,
+            -65536,
+            -16711936,
+            -256,
+            -16776961,
+            -65281,
+            -16711681,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            -16777216,
+            -16777165,
+            -16777114,
+            -16777063,
+            -16777012,
+            -16776961,
+            -16764160,
+            -16764109,
+            -16764058,
+            -16764007,
+            -16763956,
+            -16763905,
+            -16751104,
+            -16751053,
+            -16751002,
+            -16750951,
+            -16750900,
+            -16750849,
+            -16738048,
+            -16737997,
+            -16737946,
+            -16737895,
+            -16737844,
+            -16737793,
+            -16724992,
+            -16724941,
+            -16724890,
+            -16724839,
+            -16724788,
+            -16724737,
+            -16711936,
+            -16711885,
+            -16711834,
+            -16711783,
+            -16711732,
+            -16711681,
+            -13434880,
+            -13434829,
+            -13434778,
+            -13434727,
+            -13434676,
+            -13434625,
+            -13421824,
+            -13421773,
+            -13421722,
+            -13421671,
+            -13421620,
+            -13421569,
+            -13408768,
+            -13408717,
+            -13408666,
+            -13408615,
+            -13408564,
+            -13408513,
+            -13395712,
+            -13395661,
+            -13395610,
+            -13395559,
+            -13395508,
+            -13395457,
+            -13382656,
+            -13382605,
+            -13382554,
+            -13382503,
+            -13382452,
+            -13382401,
+            -13369600,
+            -13369549,
+            -13369498,
+            -13369447,
+            -13369396,
+            -13369345,
+            -10092544,
+            -10092493,
+            -10092442,
+            -10092391,
+            -10092340,
+            -10092289,
+            -10079488,
+            -10079437,
+            -10079386,
+            -10079335,
+            -10079284,
+            -10079233,
+            -10066432,
+            -10066381,
+            -10066330,
+            -10066279,
+            -10066228,
+            -10066177,
+            -10053376,
+            -10053325,
+            -10053274,
+            -10053223,
+            -10053172,
+            -10053121,
+            -10040320,
+            -10040269,
+            -10040218,
+            -10040167,
+            -10040116,
+            -10040065,
+            -10027264,
+            -10027213,
+            -10027162,
+            -10027111,
+            -10027060,
+            -10027009,
+            -6750208,
+            -6750157,
+            -6750106,
+            -6750055,
+            -6750004,
+            -6749953,
+            -6737152,
+            -6737101,
+            -6737050,
+            -6736999,
+            -6736948,
+            -6736897,
+            -6724096,
+            -6724045,
+            -6723994,
+            -6723943,
+            -6723892,
+            -6723841,
+            -6711040,
+            -6710989,
+            -6710938,
+            -6710887,
+            -6710836,
+            -6710785,
+            -6697984,
+            -6697933,
+            -6697882,
+            -6697831,
+            -6697780,
+            -6697729,
+            -6684928,
+            -6684877,
+            -6684826,
+            -6684775,
+            -6684724,
+            -6684673,
+            -3407872,
+            -3407821,
+            -3407770,
+            -3407719,
+            -3407668,
+            -3407617,
+            -3394816,
+            -3394765,
+            -3394714,
+            -3394663,
+            -3394612,
+            -3394561,
+            -3381760,
+            -3381709,
+            -3381658,
+            -3381607,
+            -3381556,
+            -3381505,
+            -3368704,
+            -3368653,
+            -3368602,
+            -3368551,
+            -3368500,
+            -3368449,
+            -3355648,
+            -3355597,
+            -3355546,
+            -3355495,
+            -3355444,
+            -3355393,
+            -3342592,
+            -3342541,
+            -3342490,
+            -3342439,
+            -3342388,
+            -3342337,
+            -65536,
+            -65485,
+            -65434,
+            -65383,
+            -65332,
+            -65281,
+            -52480,
+            -52429,
+            -52378,
+            -52327,
+            -52276,
+            -52225,
+            -39424,
+            -39373,
+            -39322,
+            -39271,
+            -39220,
+            -39169,
+            -26368,
+            -26317,
+            -26266,
+            -26215,
+            -26164,
+            -26113,
+            -13312,
+            -13261,
+            -13210,
+            -13159,
+            -13108,
+            -13057,
+            -256,
+            -205,
+            -154,
+            -103,
+            -52,
+            -1,
+        };
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Format8bppIndexed_Palette()
+        {
+            using (Bitmap bmp = new Bitmap(1, 1, PixelFormat.Format8bppIndexed))
+            {
+                ColorPalette pal = bmp.Palette;
+                Assert.Equal(256, pal.Entries.Length);
+                for (int i = 0; i < pal.Entries.Length; i++)
+                {
+                    Assert.Equal(palette256[i], pal.Entries[i].ToArgb());
+                }
+                Assert.Equal(4, pal.Flags);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void XmlSerialization()
+        {
+            new XmlSerializer(typeof(Bitmap));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapImageCtor()
+        {
+            Assert.Throws<NullReferenceException>(() => new Bitmap((Image)null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapImageSizeCtor()
+        {
+            Assert.Throws<ArgumentException>(() => new Bitmap((Image)null, Size.Empty));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapImageIntIntCtor()
+        {
+            Assert.Throws<ArgumentException>(() => new Bitmap((Image)null, Int32.MinValue, Int32.MaxValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapIntIntCtor()
+        {
+            Assert.Throws<ArgumentException>(() => new Bitmap(Int32.MinValue, Int32.MaxValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapIntIntGraphicCtor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Bitmap(1, 1, null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapIntIntPixelFormatCtor()
+        {
+            Assert.Throws<ArgumentException>(() => new Bitmap(Int32.MinValue, Int32.MaxValue, PixelFormat.Format1bppIndexed));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapStreamCtor()
+        {
+            AssertExtensions.Throws<ArgumentNullException, ArgumentException>("stream", null, () => new Bitmap((Stream)null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapStreamBoolCtor()
+        {
+            AssertExtensions.Throws<ArgumentNullException, ArgumentException>("stream", null, () => new Bitmap((Stream)null, true));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapStringCtor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Bitmap((string)null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapStringBoolCtor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Bitmap((string)null, false));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapTypeStringCtor1()
+        {
+            Assert.Throws<NullReferenceException>(() => new Bitmap((Type)null, "mono"));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapTypeStringCtor2()
+        {
+            Assert.Throws<ArgumentException>(() => new Bitmap(typeof(Bitmap), null));
+        }
+
+        private void SetResolution(float x, float y)
+        {
+            using (Bitmap bmp = new Bitmap(1, 1))
+            {
+                bmp.SetResolution(x, y);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetResolution_Zero()
+        {
+            Assert.Throws<ArgumentException>(() => SetResolution(0.0f, 0.0f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetResolution_Negative_X()
+        {
+            Assert.Throws<ArgumentException>(() => SetResolution(-1.0f, 1.0f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetResolution_Negative_Y()
+        {
+            Assert.Throws<ArgumentException>(() => SetResolution(1.0f, -1.0f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetResolution_MaxValue()
+        {
+            SetResolution(Single.MaxValue, Single.MaxValue);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetResolution_PositiveInfinity()
+        {
+            SetResolution(Single.PositiveInfinity, Single.PositiveInfinity);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetResolution_NaN()
+        {
+            Assert.Throws<ArgumentException>(() => SetResolution(Single.NaN, Single.NaN));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetResolution_NegativeInfinity()
+        {
+            Assert.Throws<ArgumentException>(() => SetResolution(Single.NegativeInfinity, Single.NegativeInfinity));
+        }
+    }
+
+    public class BitmapFullTrustTest
+    {
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void BitmapIntIntIntPixelFormatIntPtrCtor()
+        {
+            new Bitmap(1, 1, 1, PixelFormat.Format1bppIndexed, IntPtr.Zero);
+        }
+
+        // BitmapFromHicon## is *almost* the same as IconTest.Icon##ToBitmap except
+        // for the Flags property
+
+        private void HiconTest(string msg, Bitmap b, int size)
+        {
+            Assert.Equal(PixelFormat.Format32bppArgb, b.PixelFormat);
+            // unlike the GDI+ icon decoder the palette isn't kept
+            Assert.Equal(0, b.Palette.Entries.Length);
+            Assert.Equal(size, b.Height);
+            Assert.Equal(size, b.Width);
+            Assert.True(b.RawFormat.Equals(ImageFormat.MemoryBmp));
+            Assert.Equal(335888, b.Flags);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Hicon16()
+        {
+            IntPtr hicon;
+            int size;
+            using (Icon icon = new Icon(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico")))
+            {
+                size = icon.Width;
+                using (Bitmap bitmap = Bitmap.FromHicon(icon.Handle))
+                {
+                    HiconTest("Icon.Handle/FromHicon", bitmap, size);
+                    hicon = bitmap.GetHicon();
+                }
+            }
+            using (Bitmap bitmap2 = Bitmap.FromHicon(hicon))
+            {
+                // hicon survives bitmap and icon disposal
+                HiconTest("GetHicon/FromHicon", bitmap2, size);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Hicon32()
+        {
+            IntPtr hicon;
+            int size;
+            using (Icon icon = new Icon(Helpers.GetTestBitmapPath("32x32_one_entry_4bit.ico")))
+            {
+                size = icon.Width;
+                using (Bitmap bitmap = Bitmap.FromHicon(icon.Handle))
+                {
+                    HiconTest("Icon.Handle/FromHicon", bitmap, size);
+                    hicon = bitmap.GetHicon();
+                }
+            }
+            using (Bitmap bitmap2 = Bitmap.FromHicon(hicon))
+            {
+                // hicon survives bitmap and icon disposal
+                HiconTest("GetHicon/FromHicon", bitmap2, size);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Hicon64()
+        {
+            IntPtr hicon;
+            int size;
+            using (Icon icon = new Icon(Helpers.GetTestBitmapPath("64x64_one_entry_8bit.ico")))
+            {
+                size = icon.Width;
+                using (Bitmap bitmap = Bitmap.FromHicon(icon.Handle))
+                {
+                    HiconTest("Icon.Handle/FromHicon", bitmap, size);
+                    hicon = bitmap.GetHicon();
+                }
+            }
+            using (Bitmap bitmap2 = Bitmap.FromHicon(hicon))
+            {
+                // hicon survives bitmap and icon disposal
+                HiconTest("GetHicon/FromHicon", bitmap2, size);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Hicon96()
+        {
+            IntPtr hicon;
+            int size;
+            using (Icon icon = new Icon(Helpers.GetTestBitmapPath("96x96_one_entry_8bit.ico")))
+            {
+                size = icon.Width;
+                using (Bitmap bitmap = Bitmap.FromHicon(icon.Handle))
+                {
+                    HiconTest("Icon.Handle/FromHicon", bitmap, size);
+                    hicon = bitmap.GetHicon();
+                }
+            }
+            using (Bitmap bitmap2 = Bitmap.FromHicon(hicon))
+            {
+                // hicon survives bitmap and icon disposal
+                HiconTest("GetHicon/FromHicon", bitmap2, size);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void HBitmap()
+        {
+            IntPtr hbitmap;
+            string sInFile = Helpers.GetTestBitmapPath("almogaver24bits.bmp");
+            using (Bitmap bitmap = new Bitmap(sInFile))
+            {
+                Assert.Equal(PixelFormat.Format24bppRgb, bitmap.PixelFormat);
+                Assert.Equal(0, bitmap.Palette.Entries.Length);
+                Assert.Equal(183, bitmap.Height);
+                Assert.Equal(173, bitmap.Width);
+                Assert.Equal(73744, bitmap.Flags);
+                Assert.True(bitmap.RawFormat.Equals(ImageFormat.Bmp));
+                hbitmap = bitmap.GetHbitmap();
+            }
+            // hbitmap survives original bitmap disposal
+            using (Image image = Image.FromHbitmap(hbitmap))
+            {
+                //Assert.Equal (PixelFormat.Format32bppRgb, image.PixelFormat);
+                Assert.Equal(0, image.Palette.Entries.Length);
+                Assert.Equal(183, image.Height);
+                Assert.Equal(173, image.Width);
+                Assert.Equal(335888, image.Flags);
+                Assert.True(image.RawFormat.Equals(ImageFormat.MemoryBmp));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CreateMultipleBitmapFromSameHBITMAP()
+        {
+            IntPtr hbitmap;
+            string sInFile = Helpers.GetTestBitmapPath("almogaver24bits.bmp");
+            using (Bitmap bitmap = new Bitmap(sInFile))
+            {
+                Assert.Equal(PixelFormat.Format24bppRgb, bitmap.PixelFormat);
+                Assert.Equal(0, bitmap.Palette.Entries.Length);
+                Assert.Equal(183, bitmap.Height);
+                Assert.Equal(173, bitmap.Width);
+                Assert.Equal(73744, bitmap.Flags);
+                Assert.True(bitmap.RawFormat.Equals(ImageFormat.Bmp));
+                hbitmap = bitmap.GetHbitmap();
+            }
+            // hbitmap survives original bitmap disposal
+            using (Image image = Image.FromHbitmap(hbitmap))
+            {
+                //Assert.Equal (PixelFormat.Format32bppRgb, image.PixelFormat);
+                Assert.Equal(0, image.Palette.Entries.Length);
+                Assert.Equal(183, image.Height);
+                Assert.Equal(173, image.Width);
+                Assert.Equal(335888, image.Flags);
+                Assert.True(image.RawFormat.Equals(ImageFormat.MemoryBmp));
+            }
+            using (Image image2 = Image.FromHbitmap(hbitmap))
+            {
+                //Assert.Equal (PixelFormat.Format32bppRgb, image2.PixelFormat);
+                Assert.Equal(0, image2.Palette.Entries.Length);
+                Assert.Equal(183, image2.Height);
+                Assert.Equal(173, image2.Width);
+                Assert.Equal(335888, image2.Flags);
+                Assert.True(image2.RawFormat.Equals(ImageFormat.MemoryBmp));
+            }
+        }
+    }
+}
+

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/TestBrushes.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/TestBrushes.cs
@@ -1,0 +1,1363 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Tests for System.Drawing.Brushes.cs
+//
+// Authors:
+//	Ravindra (rkumar@novell.com)
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2004, 2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using Xunit;
+using System;
+using System.Drawing;
+using System.Security.Permissions;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class BrushesTest
+    {
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Equality()
+        {
+            Brush brush1 = Brushes.Blue;
+            Brush brush2 = Brushes.Blue;
+            Assert.True(brush1.Equals(brush2));
+            Assert.True(Object.ReferenceEquals(brush1, brush2));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Properties()
+        {
+            Brush br;
+            SolidBrush solid;
+
+            br = Brushes.Transparent;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Transparent, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Transparent as SolidBrush).Color);
+            solid.Color = Color.Transparent; // revert to correct color (for other unit tests)
+
+            br = Brushes.AliceBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.AliceBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.AliceBlue as SolidBrush).Color);
+            solid.Color = Color.AliceBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.AntiqueWhite;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.AntiqueWhite, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.AntiqueWhite as SolidBrush).Color);
+            solid.Color = Color.AntiqueWhite; // revert to correct color (for other unit tests)
+
+            br = Brushes.Aqua;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Aqua, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Aqua as SolidBrush).Color);
+            solid.Color = Color.Aqua; // revert to correct color (for other unit tests)
+
+            br = Brushes.Aquamarine;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Aquamarine, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Aquamarine as SolidBrush).Color);
+            solid.Color = Color.Aquamarine; // revert to correct color (for other unit tests)
+
+            br = Brushes.Azure;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Azure, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Azure as SolidBrush).Color);
+            solid.Color = Color.Azure; // revert to correct color (for other unit tests)
+
+            br = Brushes.Beige;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Beige, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Beige as SolidBrush).Color);
+            solid.Color = Color.Beige; // revert to correct color (for other unit tests)
+
+            br = Brushes.Bisque;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Bisque, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Bisque as SolidBrush).Color);
+            solid.Color = Color.Bisque; // revert to correct color (for other unit tests)
+
+            br = Brushes.Black;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Black, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Black as SolidBrush).Color);
+            solid.Color = Color.Black; // revert to correct color (for other unit tests)
+
+            br = Brushes.BlanchedAlmond;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.BlanchedAlmond, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.BlanchedAlmond as SolidBrush).Color);
+            solid.Color = Color.BlanchedAlmond; // revert to correct color (for other unit tests)
+
+            br = Brushes.Blue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Blue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Blue as SolidBrush).Color);
+            solid.Color = Color.Blue; // revert to correct color (for other unit tests)
+
+            br = Brushes.BlueViolet;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.BlueViolet, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.BlueViolet as SolidBrush).Color);
+            solid.Color = Color.BlueViolet; // revert to correct color (for other unit tests)
+
+            br = Brushes.Brown;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Brown, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Brown as SolidBrush).Color);
+            solid.Color = Color.Brown; // revert to correct color (for other unit tests)
+
+            br = Brushes.BurlyWood;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.BurlyWood, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.BurlyWood as SolidBrush).Color);
+            solid.Color = Color.BurlyWood; // revert to correct color (for other unit tests)
+
+            br = Brushes.CadetBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.CadetBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.CadetBlue as SolidBrush).Color);
+            solid.Color = Color.CadetBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.Chartreuse;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Chartreuse, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Chartreuse as SolidBrush).Color);
+            solid.Color = Color.Chartreuse; // revert to correct color (for other unit tests)
+
+            br = Brushes.Chocolate;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Chocolate, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Chocolate as SolidBrush).Color);
+            solid.Color = Color.Chocolate; // revert to correct color (for other unit tests)
+
+            br = Brushes.Coral;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Coral, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Coral as SolidBrush).Color);
+            solid.Color = Color.Coral; // revert to correct color (for other unit tests)
+
+            br = Brushes.CornflowerBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.CornflowerBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.CornflowerBlue as SolidBrush).Color);
+            solid.Color = Color.CornflowerBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.Cornsilk;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Cornsilk, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Cornsilk as SolidBrush).Color);
+            solid.Color = Color.Cornsilk; // revert to correct color (for other unit tests)
+
+            br = Brushes.Crimson;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Crimson, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Crimson as SolidBrush).Color);
+            solid.Color = Color.Crimson; // revert to correct color (for other unit tests)
+
+            br = Brushes.Cyan;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Cyan, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Cyan as SolidBrush).Color);
+            solid.Color = Color.Cyan; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkBlue as SolidBrush).Color);
+            solid.Color = Color.DarkBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkCyan;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkCyan, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkCyan as SolidBrush).Color);
+            solid.Color = Color.DarkCyan; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkGoldenrod;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkGoldenrod, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkGoldenrod as SolidBrush).Color);
+            solid.Color = Color.DarkGoldenrod; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkGray;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkGray, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkGray as SolidBrush).Color);
+            solid.Color = Color.DarkGray; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkGreen as SolidBrush).Color);
+            solid.Color = Color.DarkGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkKhaki;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkKhaki, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkKhaki as SolidBrush).Color);
+            solid.Color = Color.DarkKhaki; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkMagenta;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkMagenta, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkMagenta as SolidBrush).Color);
+            solid.Color = Color.DarkMagenta; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkOliveGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkOliveGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkOliveGreen as SolidBrush).Color);
+            solid.Color = Color.DarkOliveGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkOrange;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkOrange, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkOrange as SolidBrush).Color);
+            solid.Color = Color.DarkOrange; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkOrchid;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkOrchid, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkOrchid as SolidBrush).Color);
+            solid.Color = Color.DarkOrchid; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkRed;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkRed, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkRed as SolidBrush).Color);
+            solid.Color = Color.DarkRed; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkSalmon;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkSalmon, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkSalmon as SolidBrush).Color);
+            solid.Color = Color.DarkSalmon; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkSeaGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkSeaGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkSeaGreen as SolidBrush).Color);
+            solid.Color = Color.DarkSeaGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkSlateBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkSlateBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkSlateBlue as SolidBrush).Color);
+            solid.Color = Color.DarkSlateBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkSlateGray;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkSlateGray, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkSlateGray as SolidBrush).Color);
+            solid.Color = Color.DarkSlateGray; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkTurquoise;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkTurquoise, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkTurquoise as SolidBrush).Color);
+            solid.Color = Color.DarkTurquoise; // revert to correct color (for other unit tests)
+
+            br = Brushes.DarkViolet;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DarkViolet, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DarkViolet as SolidBrush).Color);
+            solid.Color = Color.DarkViolet; // revert to correct color (for other unit tests)
+
+            br = Brushes.DeepPink;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DeepPink, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DeepPink as SolidBrush).Color);
+            solid.Color = Color.DeepPink; // revert to correct color (for other unit tests)
+
+            br = Brushes.DeepSkyBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DeepSkyBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DeepSkyBlue as SolidBrush).Color);
+            solid.Color = Color.DeepSkyBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.DimGray;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DimGray, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DimGray as SolidBrush).Color);
+            solid.Color = Color.DimGray; // revert to correct color (for other unit tests)
+
+            br = Brushes.DodgerBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.DodgerBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.DodgerBlue as SolidBrush).Color);
+            solid.Color = Color.DodgerBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.Firebrick;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Firebrick, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Firebrick as SolidBrush).Color);
+            solid.Color = Color.Firebrick; // revert to correct color (for other unit tests)
+
+            br = Brushes.FloralWhite;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.FloralWhite, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.FloralWhite as SolidBrush).Color);
+            solid.Color = Color.FloralWhite; // revert to correct color (for other unit tests)
+
+            br = Brushes.ForestGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.ForestGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.ForestGreen as SolidBrush).Color);
+            solid.Color = Color.ForestGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.Fuchsia;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Fuchsia, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Fuchsia as SolidBrush).Color);
+            solid.Color = Color.Fuchsia; // revert to correct color (for other unit tests)
+
+            br = Brushes.Gainsboro;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Gainsboro, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Gainsboro as SolidBrush).Color);
+            solid.Color = Color.Gainsboro; // revert to correct color (for other unit tests)
+
+            br = Brushes.GhostWhite;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.GhostWhite, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.GhostWhite as SolidBrush).Color);
+            solid.Color = Color.GhostWhite; // revert to correct color (for other unit tests)
+
+            br = Brushes.Gold;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Gold, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Gold as SolidBrush).Color);
+            solid.Color = Color.Gold; // revert to correct color (for other unit tests)
+
+            br = Brushes.Goldenrod;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Goldenrod, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Goldenrod as SolidBrush).Color);
+            solid.Color = Color.Goldenrod; // revert to correct color (for other unit tests)
+
+            br = Brushes.Gray;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Gray, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Gray as SolidBrush).Color);
+            solid.Color = Color.Gray; // revert to correct color (for other unit tests)
+
+            br = Brushes.Green;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Green, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Green as SolidBrush).Color);
+            solid.Color = Color.Green; // revert to correct color (for other unit tests)
+
+            br = Brushes.GreenYellow;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.GreenYellow, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.GreenYellow as SolidBrush).Color);
+            solid.Color = Color.GreenYellow; // revert to correct color (for other unit tests)
+
+            br = Brushes.Honeydew;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Honeydew, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Honeydew as SolidBrush).Color);
+            solid.Color = Color.Honeydew; // revert to correct color (for other unit tests)
+
+            br = Brushes.HotPink;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.HotPink, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.HotPink as SolidBrush).Color);
+            solid.Color = Color.HotPink; // revert to correct color (for other unit tests)
+
+            br = Brushes.IndianRed;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.IndianRed, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.IndianRed as SolidBrush).Color);
+            solid.Color = Color.IndianRed; // revert to correct color (for other unit tests)
+
+            br = Brushes.Indigo;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Indigo, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Indigo as SolidBrush).Color);
+            solid.Color = Color.Indigo; // revert to correct color (for other unit tests)
+
+            br = Brushes.Ivory;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Ivory, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Ivory as SolidBrush).Color);
+            solid.Color = Color.Ivory; // revert to correct color (for other unit tests)
+
+            br = Brushes.Khaki;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Khaki, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Khaki as SolidBrush).Color);
+            solid.Color = Color.Khaki; // revert to correct color (for other unit tests)
+
+            br = Brushes.Lavender;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Lavender, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Lavender as SolidBrush).Color);
+            solid.Color = Color.Lavender; // revert to correct color (for other unit tests)
+
+            br = Brushes.LavenderBlush;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LavenderBlush, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LavenderBlush as SolidBrush).Color);
+            solid.Color = Color.LavenderBlush; // revert to correct color (for other unit tests)
+
+            br = Brushes.LawnGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LawnGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LawnGreen as SolidBrush).Color);
+            solid.Color = Color.LawnGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.LemonChiffon;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LemonChiffon, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LemonChiffon as SolidBrush).Color);
+            solid.Color = Color.LemonChiffon; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightBlue as SolidBrush).Color);
+            solid.Color = Color.LightBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightCoral;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightCoral, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightCoral as SolidBrush).Color);
+            solid.Color = Color.LightCoral; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightCyan;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightCyan, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightCyan as SolidBrush).Color);
+            solid.Color = Color.LightCyan; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightGoldenrodYellow;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightGoldenrodYellow, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightGoldenrodYellow as SolidBrush).Color);
+            solid.Color = Color.LightGoldenrodYellow; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightGreen as SolidBrush).Color);
+            solid.Color = Color.LightGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightGray;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightGray, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightGray as SolidBrush).Color);
+            solid.Color = Color.LightGray; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightPink;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightPink, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightPink as SolidBrush).Color);
+            solid.Color = Color.LightPink; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightSalmon;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightSalmon, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightSalmon as SolidBrush).Color);
+            solid.Color = Color.LightSalmon; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightSeaGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightSeaGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightSeaGreen as SolidBrush).Color);
+            solid.Color = Color.LightSeaGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightSkyBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightSkyBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightSkyBlue as SolidBrush).Color);
+            solid.Color = Color.LightSkyBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightSlateGray;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightSlateGray, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightSlateGray as SolidBrush).Color);
+            solid.Color = Color.LightSlateGray; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightSteelBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightSteelBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightSteelBlue as SolidBrush).Color);
+            solid.Color = Color.LightSteelBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.LightYellow;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LightYellow, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LightYellow as SolidBrush).Color);
+            solid.Color = Color.LightYellow; // revert to correct color (for other unit tests)
+
+            br = Brushes.Lime;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Lime, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Lime as SolidBrush).Color);
+            solid.Color = Color.Lime; // revert to correct color (for other unit tests)
+
+            br = Brushes.LimeGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.LimeGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.LimeGreen as SolidBrush).Color);
+            solid.Color = Color.LimeGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.Linen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Linen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Linen as SolidBrush).Color);
+            solid.Color = Color.Linen; // revert to correct color (for other unit tests)
+
+            br = Brushes.Magenta;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Magenta, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Magenta as SolidBrush).Color);
+            solid.Color = Color.Magenta; // revert to correct color (for other unit tests)
+
+            br = Brushes.Maroon;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Maroon, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Maroon as SolidBrush).Color);
+            solid.Color = Color.Maroon; // revert to correct color (for other unit tests)
+
+            br = Brushes.MediumAquamarine;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MediumAquamarine, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MediumAquamarine as SolidBrush).Color);
+            solid.Color = Color.MediumAquamarine; // revert to correct color (for other unit tests)
+
+            br = Brushes.MediumBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MediumBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MediumBlue as SolidBrush).Color);
+            solid.Color = Color.MediumBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.MediumOrchid;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MediumOrchid, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MediumOrchid as SolidBrush).Color);
+            solid.Color = Color.MediumOrchid; // revert to correct color (for other unit tests)
+
+            br = Brushes.MediumPurple;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MediumPurple, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MediumPurple as SolidBrush).Color);
+            solid.Color = Color.MediumPurple; // revert to correct color (for other unit tests)
+
+            br = Brushes.MediumSeaGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MediumSeaGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MediumSeaGreen as SolidBrush).Color);
+            solid.Color = Color.MediumSeaGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.MediumSlateBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MediumSlateBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MediumSlateBlue as SolidBrush).Color);
+            solid.Color = Color.MediumSlateBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.MediumSpringGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MediumSpringGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MediumSpringGreen as SolidBrush).Color);
+            solid.Color = Color.MediumSpringGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.MediumTurquoise;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MediumTurquoise, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MediumTurquoise as SolidBrush).Color);
+            solid.Color = Color.MediumTurquoise; // revert to correct color (for other unit tests)
+
+            br = Brushes.MediumVioletRed;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MediumVioletRed, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MediumVioletRed as SolidBrush).Color);
+            solid.Color = Color.MediumVioletRed; // revert to correct color (for other unit tests)
+
+            br = Brushes.MidnightBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MidnightBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MidnightBlue as SolidBrush).Color);
+            solid.Color = Color.MidnightBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.MintCream;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MintCream, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MintCream as SolidBrush).Color);
+            solid.Color = Color.MintCream; // revert to correct color (for other unit tests)
+
+            br = Brushes.MistyRose;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.MistyRose, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.MistyRose as SolidBrush).Color);
+            solid.Color = Color.MistyRose; // revert to correct color (for other unit tests)
+
+            br = Brushes.Moccasin;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Moccasin, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Moccasin as SolidBrush).Color);
+            solid.Color = Color.Moccasin; // revert to correct color (for other unit tests)
+
+            br = Brushes.NavajoWhite;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.NavajoWhite, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.NavajoWhite as SolidBrush).Color);
+            solid.Color = Color.NavajoWhite; // revert to correct color (for other unit tests)
+
+            br = Brushes.Navy;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Navy, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Navy as SolidBrush).Color);
+            solid.Color = Color.Navy; // revert to correct color (for other unit tests)
+
+            br = Brushes.OldLace;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.OldLace, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.OldLace as SolidBrush).Color);
+            solid.Color = Color.OldLace; // revert to correct color (for other unit tests)
+
+            br = Brushes.Olive;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Olive, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Olive as SolidBrush).Color);
+            solid.Color = Color.Olive; // revert to correct color (for other unit tests)
+
+            br = Brushes.OliveDrab;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.OliveDrab, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.OliveDrab as SolidBrush).Color);
+            solid.Color = Color.OliveDrab; // revert to correct color (for other unit tests)
+
+            br = Brushes.Orange;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Orange, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Orange as SolidBrush).Color);
+            solid.Color = Color.Orange; // revert to correct color (for other unit tests)
+
+            br = Brushes.OrangeRed;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.OrangeRed, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.OrangeRed as SolidBrush).Color);
+            solid.Color = Color.OrangeRed; // revert to correct color (for other unit tests)
+
+            br = Brushes.Orchid;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Orchid, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Orchid as SolidBrush).Color);
+            solid.Color = Color.Orchid; // revert to correct color (for other unit tests)
+
+            br = Brushes.PaleGoldenrod;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.PaleGoldenrod, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.PaleGoldenrod as SolidBrush).Color);
+            solid.Color = Color.PaleGoldenrod; // revert to correct color (for other unit tests)
+
+            br = Brushes.PaleGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.PaleGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.PaleGreen as SolidBrush).Color);
+            solid.Color = Color.PaleGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.PaleTurquoise;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.PaleTurquoise, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.PaleTurquoise as SolidBrush).Color);
+            solid.Color = Color.PaleTurquoise; // revert to correct color (for other unit tests)
+
+            br = Brushes.PaleVioletRed;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.PaleVioletRed, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.PaleVioletRed as SolidBrush).Color);
+            solid.Color = Color.PaleVioletRed; // revert to correct color (for other unit tests)
+
+            br = Brushes.PapayaWhip;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.PapayaWhip, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.PapayaWhip as SolidBrush).Color);
+            solid.Color = Color.PapayaWhip; // revert to correct color (for other unit tests)
+
+            br = Brushes.PeachPuff;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.PeachPuff, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.PeachPuff as SolidBrush).Color);
+            solid.Color = Color.PeachPuff; // revert to correct color (for other unit tests)
+
+            br = Brushes.Peru;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Peru, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Peru as SolidBrush).Color);
+            solid.Color = Color.Peru; // revert to correct color (for other unit tests)
+
+            br = Brushes.Pink;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Pink, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Pink as SolidBrush).Color);
+            solid.Color = Color.Pink; // revert to correct color (for other unit tests)
+
+            br = Brushes.Plum;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Plum, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Plum as SolidBrush).Color);
+            solid.Color = Color.Plum; // revert to correct color (for other unit tests)
+
+            br = Brushes.PowderBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.PowderBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.PowderBlue as SolidBrush).Color);
+            solid.Color = Color.PowderBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.Purple;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Purple, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Purple as SolidBrush).Color);
+            solid.Color = Color.Purple; // revert to correct color (for other unit tests)
+
+            br = Brushes.Red;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Red, solid.Color);
+            solid.Color = Color.White;
+            Assert.Equal(Color.White, solid.Color);
+            Assert.Equal(Color.White, (Brushes.Red as SolidBrush).Color);
+            solid.Color = Color.Red; // revert to correct color (for other unit tests)
+
+            br = Brushes.RosyBrown;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.RosyBrown, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.RosyBrown as SolidBrush).Color);
+            solid.Color = Color.RosyBrown; // revert to correct color (for other unit tests)
+
+            br = Brushes.RoyalBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.RoyalBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.RoyalBlue as SolidBrush).Color);
+            solid.Color = Color.RoyalBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.SaddleBrown;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.SaddleBrown, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.SaddleBrown as SolidBrush).Color);
+            solid.Color = Color.SaddleBrown; // revert to correct color (for other unit tests)
+
+            br = Brushes.Salmon;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Salmon, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Salmon as SolidBrush).Color);
+            solid.Color = Color.Salmon; // revert to correct color (for other unit tests)
+
+            br = Brushes.SandyBrown;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.SandyBrown, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.SandyBrown as SolidBrush).Color);
+            solid.Color = Color.SandyBrown; // revert to correct color (for other unit tests)
+
+            br = Brushes.SeaGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.SeaGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.SeaGreen as SolidBrush).Color);
+            solid.Color = Color.SeaGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.SeaShell;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.SeaShell, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.SeaShell as SolidBrush).Color);
+            solid.Color = Color.SeaShell; // revert to correct color (for other unit tests)
+
+            br = Brushes.Sienna;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Sienna, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Sienna as SolidBrush).Color);
+            solid.Color = Color.Sienna; // revert to correct color (for other unit tests)
+
+            br = Brushes.Silver;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Silver, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Silver as SolidBrush).Color);
+            solid.Color = Color.Silver; // revert to correct color (for other unit tests)
+
+            br = Brushes.SkyBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.SkyBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.SkyBlue as SolidBrush).Color);
+            solid.Color = Color.SkyBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.SlateBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.SlateBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.SlateBlue as SolidBrush).Color);
+            solid.Color = Color.SlateBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.SlateGray;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.SlateGray, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.SlateGray as SolidBrush).Color);
+            solid.Color = Color.SlateGray; // revert to correct color (for other unit tests)
+
+            br = Brushes.Snow;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Snow, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Snow as SolidBrush).Color);
+            solid.Color = Color.Snow; // revert to correct color (for other unit tests)
+
+            br = Brushes.SpringGreen;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.SpringGreen, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.SpringGreen as SolidBrush).Color);
+            solid.Color = Color.SpringGreen; // revert to correct color (for other unit tests)
+
+            br = Brushes.SteelBlue;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.SteelBlue, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.SteelBlue as SolidBrush).Color);
+            solid.Color = Color.SteelBlue; // revert to correct color (for other unit tests)
+
+            br = Brushes.Tan;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Tan, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Tan as SolidBrush).Color);
+            solid.Color = Color.Tan; // revert to correct color (for other unit tests)
+
+            br = Brushes.Teal;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Teal, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Teal as SolidBrush).Color);
+            solid.Color = Color.Teal; // revert to correct color (for other unit tests)
+
+            br = Brushes.Thistle;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Thistle, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Thistle as SolidBrush).Color);
+            solid.Color = Color.Thistle; // revert to correct color (for other unit tests)
+
+            br = Brushes.Tomato;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Tomato, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Tomato as SolidBrush).Color);
+            solid.Color = Color.Tomato; // revert to correct color (for other unit tests)
+
+            br = Brushes.Turquoise;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Turquoise, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Turquoise as SolidBrush).Color);
+            solid.Color = Color.Turquoise; // revert to correct color (for other unit tests)
+
+            br = Brushes.Violet;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Violet, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Violet as SolidBrush).Color);
+            solid.Color = Color.Violet; // revert to correct color (for other unit tests)
+
+            br = Brushes.Wheat;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Wheat, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Wheat as SolidBrush).Color);
+            solid.Color = Color.Wheat; // revert to correct color (for other unit tests)
+
+            br = Brushes.White;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.White, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.White as SolidBrush).Color);
+            solid.Color = Color.White; // revert to correct color (for other unit tests)
+
+            br = Brushes.WhiteSmoke;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.WhiteSmoke, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.WhiteSmoke as SolidBrush).Color);
+            solid.Color = Color.WhiteSmoke; // revert to correct color (for other unit tests)
+
+            br = Brushes.Yellow;
+            Assert.True((br is SolidBrush));
+            solid = (SolidBrush)br;
+            Assert.Equal(Color.Yellow, solid.Color);
+            solid.Color = Color.Red;
+            Assert.Equal(Color.Red, solid.Color);
+            Assert.Equal(Color.Red, (Brushes.Yellow as SolidBrush).Color);
+            solid.Color = Color.Yellow; // revert to correct color (for other unit tests)
+
+            /* YellowGreen is broken by "destructive" Dispose test
+			br = Brushes.YellowGreen;
+			Assert.True ((br is SolidBrush));
+			solid = (SolidBrush) br;
+			Assert.Equal (Color.YellowGreen, solid.Color);
+			solid.Color = Color.Red;
+			Assert.Equal (Color.Red, solid.Color);
+			Assert.Equal (Color.Red, (Brushes.YellowGreen as SolidBrush).Color);
+			solid.Color = Color.YellowGreen; // revert to correct color (for other unit tests)
+			*/
+        }
+    }
+}
+
+// Following code was used to generate the TestProperties method.
+/*
+using System;
+using System.Drawing;
+using System.Reflection;
+class Program {
+	static void Main ()
+	{
+		Type type = typeof (Brushes);
+		PropertyInfo[] properties = type.GetProperties ();
+		int count = 1;
+		foreach (PropertyInfo property in properties) {
+			Console.WriteLine("\n\t\t\tbr = Brushes." + property.Name + ";");
+			Console.WriteLine("\t\t\tAssert.True ((br is SolidBrush), \"P" + count + "#1\");");
+			Console.WriteLine("\t\t\tsolid = (SolidBrush) br;");
+			Console.WriteLine("\t\t\tAssert.Equal (Color." + property.Name + ", solid.Color, \"P" + count + "#2\");");
+
+			if (property.Name != "Red") {
+				Console.WriteLine("\t\t\tsolid.Color = Color.Red;");
+				Console.WriteLine("\t\t\tAssert.Equal (Color.Red, solid.Color, \"P" + count + "#3\");");
+				Console.WriteLine("\t\t\tAssert.Equal (Color.Red, (Brushes." + property.Name + " as SolidBrush).Color, \"P" + count + "#4\");");
+			} else {
+				Console.WriteLine("\t\t\tsolid.Color = Color.White;");
+				Console.WriteLine("\t\t\tAssert.Equal (Color.White, solid.Color, \"P" + count + "#3\");");
+				Console.WriteLine("\t\t\tAssert.Equal (Color.White, (Brushes." + property.Name + " as SolidBrush).Color, \"P" + count + "#4\");");
+			}
+			Console.WriteLine("\t\t\tsolid.Color = Color." + property.Name + "; // revert to correct color (for other unit tests)");
+			count++;
+		}
+	}
+}
+ */

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/TestFont.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/TestFont.cs
@@ -1,0 +1,576 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Test Font class testing unit
+//
+// Authors:
+// 	Jordi Mas i Hernandez, jordi@ximian.com
+// 	Peter Dennis Bartok, pbartok@novell.com
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// (C) 2003 Ximian, Inc.  http://www.ximian.com
+// Copyright (C) 2004-2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using Xunit;
+using System;
+using System.Drawing;
+using System.Drawing.Text;
+using System.Security;
+using System.Security.Permissions;
+using System.Runtime.InteropServices;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class FontTest
+    {
+
+        private string name;
+
+        public FontTest()
+        {
+            using (FontFamily ff = new FontFamily(GenericFontFamilies.Monospace))
+            {
+                name = ff.Name;
+            }
+        }
+
+        // Test basic Font clone, properties and contructor
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestClone()
+        {
+            Font f = new Font("Arial", 12);
+            Font f2 = (Font)f.Clone();
+
+            Assert.Equal(f.Bold, f2.Bold);
+            Assert.Equal(f.FontFamily, f2.FontFamily);
+            Assert.Equal(f.GdiCharSet, f2.GdiCharSet);
+            Assert.Equal(f.GdiVerticalFont, f2.GdiVerticalFont);
+            Assert.Equal(f.Height, f2.Height);
+            Assert.Equal(f.Italic, f2.Italic);
+            Assert.Equal(f.Name, f2.Name);
+            Assert.Equal(f.Size, f2.Size);
+            Assert.Equal(f.SizeInPoints, f2.SizeInPoints);
+            Assert.Equal(f.Strikeout, f2.Strikeout);
+            Assert.Equal(f.Style, f2.Style);
+            Assert.Equal(f.Underline, f2.Underline);
+            Assert.Equal(f.Unit, f2.Unit);
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        class LOGFONT
+        {
+            public int lfHeight;
+            public int lfWidth;
+            public int lfEscapement;
+            public int lfOrientation;
+            public int lfWeight;
+            public byte lfItalic;
+            public byte lfUnderline;
+            public byte lfStrikeOut;
+            public byte lfCharSet;
+            public byte lfOutPrecision;
+            public byte lfClipPrecision;
+            public byte lfQuality;
+            public byte lfPitchAndFamily;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+            public string lfFaceName;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        struct LOGFONT_STRUCT
+        {
+            public int lfHeight;
+            public int lfWidth;
+            public int lfEscapement;
+            public int lfOrientation;
+            public int lfWeight;
+            public byte lfItalic;
+            public byte lfUnderline;
+            public byte lfStrikeOut;
+            public byte lfCharSet;
+            public byte lfOutPrecision;
+            public byte lfClipPrecision;
+            public byte lfQuality;
+            public byte lfPitchAndFamily;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+            public string lfFaceName;
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailableOnWindows)]
+        [SecurityPermission(SecurityAction.Assert, UnmanagedCode = true)]
+        public void ToLogFont_AssertUnmanagedCode()
+        {
+            Font f = new Font("Arial", 10);
+            LOGFONT lf = new LOGFONT();
+
+            f.ToLogFont(lf);
+            Assert.Equal(400, lf.lfWeight);
+            Assert.Equal(1, lf.lfCharSet);
+            Assert.Equal(f.Name, lf.lfFaceName);
+
+            LOGFONT_STRUCT lfs = new LOGFONT_STRUCT();
+            f.ToLogFont(lfs);
+            Assert.Equal(0, lfs.lfWeight);
+            Assert.Equal(0, lfs.lfCharSet);
+            Assert.Equal(0, lfs.lfHeight);
+            Assert.Equal(0, lfs.lfWidth);
+            Assert.Equal(0, lfs.lfEscapement);
+            Assert.Equal(0, lfs.lfOrientation);
+            Assert.Equal(0, lfs.lfWeight);
+            Assert.Equal(0, lfs.lfItalic);
+            Assert.Equal(0, lfs.lfUnderline);
+            Assert.Equal(0, lfs.lfStrikeOut);
+            Assert.Equal(0, lfs.lfCharSet);
+            Assert.Equal(0, lfs.lfOutPrecision);
+            Assert.Equal(0, lfs.lfClipPrecision);
+            Assert.Equal(0, lfs.lfQuality);
+            Assert.Equal(0, lfs.lfPitchAndFamily);
+            Assert.Null(lfs.lfFaceName);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        [SecurityPermission(SecurityAction.Assert, UnmanagedCode = true)]
+        public void ToLogFont_TooSmall()
+        {
+            Font f = new Font("Arial", 10);
+            object o = new object();
+            Assert.Throws<ArgumentException>(() => f.ToLogFont(o));
+            // no PInvoke conversion exists !?!?
+        }
+
+        // This test seems to cause the test host to crash.
+        [ActiveIssue(20844)]
+        [SecurityPermission(SecurityAction.Assert, UnmanagedCode = true)]
+        public void ToLogFont_Int()
+        {
+            Font f = new Font("Arial", 10);
+            int i = 1;
+            f.ToLogFont(i);
+            Assert.Equal(1, i);
+        }
+
+        [ActiveIssue(20844)]
+        [SecurityPermission(SecurityAction.Assert, UnmanagedCode = true)]
+        public void ToLogFont_Null()
+        {
+            Font f = new Font("Arial", 10);
+            Assert.Throws<AccessViolationException>(() => f.ToLogFont(null));
+        }
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Font_StringNull_Float()
+        {
+            string family = null;
+            Font f = new Font(family, 12.5f);
+            Assert.Equal(FontFamily.GenericSansSerif, f.FontFamily);
+            Assert.Equal(f.Name, f.FontFamily.Name);
+            Assert.Equal(12.5f, f.Size);
+            Assert.Equal(12.5f, f.SizeInPoints);
+            Assert.Equal(GraphicsUnit.Point, f.Unit);
+        }
+
+        [ActiveIssue(20844)]
+        public void Font_String_Float()
+        {
+            Font f = new Font(name, 12.5f);
+            Assert.Equal(FontFamily.GenericMonospace, f.FontFamily);
+            Assert.False(f.Bold);
+            Assert.Equal(1, f.GdiCharSet);
+            Assert.False(f.GdiVerticalFont);
+            Assert.True(f.Height > 0);
+            Assert.False(f.Italic);
+            Assert.Equal(f.Name, f.FontFamily.Name);
+            Assert.Equal(12.5f, f.Size);
+            Assert.Equal(12.5f, f.SizeInPoints);
+            Assert.False(f.Strikeout);
+            Assert.False(f.Underline);
+            Assert.Equal(GraphicsUnit.Point, f.Unit);
+        }
+
+        [ActiveIssue(20844)]
+        public void Font_String_Float_FontStyle()
+        {
+            Font f = new Font(name, 12.5f, FontStyle.Bold);
+            Assert.Equal(FontFamily.GenericMonospace, f.FontFamily);
+            Assert.True(f.Bold);
+            Assert.Equal(1, f.GdiCharSet);
+            Assert.False(f.GdiVerticalFont);
+            Assert.True(f.Height > 0);
+            Assert.False(f.Italic);
+            Assert.Equal(f.Name, f.FontFamily.Name);
+            Assert.Equal(12.5f, f.Size);
+            Assert.Equal(12.5f, f.SizeInPoints);
+            Assert.False(f.Strikeout);
+            Assert.False(f.Underline);
+            Assert.Equal(GraphicsUnit.Point, f.Unit);
+        }
+
+        [ActiveIssue(20844)]
+        public void Font_String_Float_FontStyle_GraphicsUnit()
+        {
+            Font f = new Font(name, 12.5f, FontStyle.Italic, GraphicsUnit.Pixel);
+            Assert.False(f.Bold);
+            Assert.Equal(1, f.GdiCharSet);
+            Assert.False(f.GdiVerticalFont);
+            Assert.True(f.Height > 0);
+            Assert.True(f.Italic);
+            Assert.Equal(FontFamily.GenericMonospace, f.FontFamily);
+            Assert.Equal(f.Name, f.FontFamily.Name);
+            Assert.Equal(12.5f, f.Size);
+            Assert.False(f.Strikeout);
+            Assert.False(f.Underline);
+            Assert.Equal(GraphicsUnit.Pixel, f.Unit);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Font_String_Float_FontStyle_GraphicsUnit_Display()
+        {
+            Assert.Throws<ArgumentException>(() => new Font(name, 12.5f, FontStyle.Italic, GraphicsUnit.Display));
+        }
+
+        [ActiveIssue(20844)]
+        public void Font_String_Float_FontStyle_GraphicsUnit_Byte()
+        {
+            Font f = new Font(name, 12.5f, FontStyle.Strikeout, GraphicsUnit.Inch, Byte.MaxValue);
+            Assert.False(f.Bold);
+            Assert.Equal(Byte.MaxValue, f.GdiCharSet);
+            Assert.False(f.GdiVerticalFont);
+            Assert.True(f.Height > 0);
+            Assert.False(f.Italic);
+            Assert.Equal(FontFamily.GenericMonospace, f.FontFamily);
+            Assert.Equal(f.Name, f.FontFamily.Name);
+            Assert.Equal(12.5f, f.Size);
+            Assert.Equal(900f, f.SizeInPoints);
+            Assert.True(f.Strikeout);
+            Assert.False(f.Underline);
+            Assert.Equal(GraphicsUnit.Inch, f.Unit);
+        }
+
+        [ActiveIssue(20844)]
+        public void Font_String_Float_FontStyle_GraphicsUnit_Byte_Bool()
+        {
+            Font f = new Font(name, 12.5f, FontStyle.Underline, GraphicsUnit.Document, Byte.MinValue, true);
+            Assert.False(f.Bold);
+            Assert.Equal(Byte.MinValue, f.GdiCharSet);
+            Assert.True(f.GdiVerticalFont);
+            Assert.True(f.Height > 0);
+            Assert.False(f.Italic);
+            Assert.Equal(FontFamily.GenericMonospace, f.FontFamily);
+            Assert.Equal(f.Name, f.FontFamily.Name);
+            Assert.Equal(12.5f, f.Size);
+            Assert.Equal(3f, f.SizeInPoints);
+            Assert.False(f.Strikeout);
+            Assert.True(f.Underline);
+            Assert.Equal(GraphicsUnit.Document, f.Unit);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Font_FontFamilyNull_Float()
+        {
+            FontFamily ff = null;
+            Assert.Throws<ArgumentNullException>(() => new Font(ff, 12.5f));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Font_FontNull_FontStyle()
+        {
+            Font f = null;
+            Assert.Throws<NullReferenceException>(() => new Font(f, FontStyle.Bold));
+        }
+
+        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
+        public void Font_FontFamily_Float()
+        {
+            Font f = new Font(FontFamily.GenericMonospace, 12.5f);
+            Assert.Equal(FontFamily.GenericMonospace, f.FontFamily);
+            Assert.False(f.Bold);
+            Assert.Equal(1, f.GdiCharSet);
+            Assert.False(f.GdiVerticalFont);
+            Assert.True(f.Height > 0);
+            Assert.False(f.Italic);
+            Assert.Equal(f.Name, f.FontFamily.Name);
+            Assert.Equal(12.5f, f.Size);
+            Assert.Equal(12.5f, f.SizeInPoints);
+            Assert.False(f.Strikeout);
+            Assert.False(f.Underline);
+            Assert.Equal(GraphicsUnit.Point, f.Unit);
+        }
+
+        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
+        public void Font_FontFamily_Float_FontStyle()
+        {
+            Font f = new Font(FontFamily.GenericMonospace, 12.5f, FontStyle.Bold);
+            Assert.Equal(FontFamily.GenericMonospace, f.FontFamily);
+            Assert.True(f.Bold);
+            Assert.Equal(1, f.GdiCharSet);
+            Assert.False(f.GdiVerticalFont);
+            Assert.True(f.Height > 0);
+            Assert.False(f.Italic);
+            Assert.Equal(f.Name, f.FontFamily.Name);
+            Assert.Equal(12.5f, f.Size);
+            Assert.Equal(12.5f, f.SizeInPoints);
+            Assert.False(f.Strikeout);
+            Assert.False(f.Underline);
+            Assert.Equal(GraphicsUnit.Point, f.Unit);
+        }
+
+        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
+        public void Font_FontFamily_Float_FontStyle_GraphicsUnit()
+        {
+            Font f = new Font(FontFamily.GenericMonospace, 12.5f, FontStyle.Italic, GraphicsUnit.Millimeter);
+            Assert.False(f.Bold);
+            Assert.Equal(1, f.GdiCharSet);
+            Assert.False(f.GdiVerticalFont);
+            Assert.True(f.Height > 0);
+            Assert.True(f.Italic);
+            Assert.Equal(FontFamily.GenericMonospace, f.FontFamily);
+            Assert.Equal(f.Name, f.FontFamily.Name);
+            Assert.Equal(12.5f, f.Size);
+            Assert.Equal(35.43307f, f.SizeInPoints, 4);
+            Assert.False(f.Strikeout);
+            Assert.False(f.Underline);
+            Assert.Equal(GraphicsUnit.Millimeter, f.Unit);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Font_FontFamily_Float_FontStyle_GraphicsUnit_Display()
+        {
+            Assert.Throws<ArgumentException>(() => new Font(FontFamily.GenericMonospace, 12.5f, FontStyle.Italic, GraphicsUnit.Display));
+        }
+
+        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
+        public void Font_FontFamily_Float_FontStyle_GraphicsUnit_Byte()
+        {
+            Font f = new Font(FontFamily.GenericMonospace, 12.5f, FontStyle.Strikeout, GraphicsUnit.Inch, Byte.MaxValue);
+            Assert.False(f.Bold);
+            Assert.Equal(Byte.MaxValue, f.GdiCharSet);
+            Assert.False(f.GdiVerticalFont);
+            Assert.True(f.Height > 0);
+            Assert.False(f.Italic);
+            Assert.Equal(FontFamily.GenericMonospace, f.FontFamily);
+            Assert.Equal(f.Name, f.FontFamily.Name);
+            Assert.Equal(12.5f, f.Size);
+            Assert.Equal(900f, f.SizeInPoints);
+            Assert.True(f.Strikeout);
+            Assert.False(f.Underline);
+            Assert.Equal(GraphicsUnit.Inch, f.Unit);
+        }
+
+        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
+        public void Font_FontFamily_Float_FontStyle_GraphicsUnit_Byte_Bool()
+        {
+            Font f = new Font(FontFamily.GenericMonospace, 12.5f, FontStyle.Underline, GraphicsUnit.Document, Byte.MinValue, true);
+            Assert.False(f.Bold);
+            Assert.Equal(Byte.MinValue, f.GdiCharSet);
+            Assert.True(f.GdiVerticalFont);
+            Assert.True(f.Height > 0);
+            Assert.False(f.Italic);
+            Assert.Equal(FontFamily.GenericMonospace, f.FontFamily);
+            Assert.Equal(f.Name, f.FontFamily.Name);
+            Assert.Equal(12.5f, f.Size);
+            Assert.Equal(3f, f.SizeInPoints, precision: 3);
+            Assert.False(f.Strikeout);
+            Assert.True(f.Underline);
+            Assert.Equal(GraphicsUnit.Document, f.Unit);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_Double()
+        {
+            Font f = new Font(name, 12.5f);
+            f.Dispose();
+            f.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_UseAfter_Works()
+        {
+            Font f = new Font(name, 12.5f);
+            string fname = f.Name;
+            f.Dispose();
+            // most properties don't throw, everything seems to be cached
+            Assert.Equal(fname, f.Name);
+            Assert.Equal(12.5f, f.Size);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_Height()
+        {
+            Font f = new Font(name, 12.5f);
+            f.Dispose();
+            Assert.Throws<ArgumentException>(() => { var x = f.Height; });
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_ToLogFont()
+        {
+            Font f = new Font(name, 12.5f);
+            f.Dispose();
+            LOGFONT lf = new LOGFONT();
+            Assert.Throws<ArgumentException>(() => f.ToLogFont(lf));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailableOnWindows)]
+        public void Dispose_ToLogFont_LoopCharSet()
+        {
+            Font f = new Font(name, 12.5f);
+            f.Dispose();
+            LOGFONT lf = new LOGFONT();
+
+            for (int i = Byte.MinValue; i < Byte.MaxValue; i++)
+            {
+                byte b = (byte)i;
+                lf.lfHeight = b;
+                lf.lfWidth = b;
+                lf.lfEscapement = b;
+                lf.lfOrientation = b;
+                lf.lfWeight = b;
+                lf.lfItalic = b;
+                lf.lfUnderline = b;
+                lf.lfStrikeOut = b;
+                lf.lfCharSet = b;
+                lf.lfOutPrecision = b;
+                lf.lfClipPrecision = b;
+                lf.lfQuality = b;
+                lf.lfPitchAndFamily = b;
+                lf.lfFaceName = b.ToString();
+                try
+                {
+                    f.ToLogFont(lf);
+                }
+                catch (ArgumentException)
+                {
+                    Assert.Equal(b, lf.lfHeight);
+                    Assert.Equal(b, lf.lfWidth);
+                    Assert.Equal(b, lf.lfEscapement);
+                    Assert.Equal(b, lf.lfOrientation);
+                    Assert.Equal(b, lf.lfWeight);
+                    Assert.Equal(b, lf.lfItalic);
+                    Assert.Equal(b, lf.lfUnderline);
+                    Assert.Equal(b, lf.lfStrikeOut);
+                    // special case for 0
+                    Assert.Equal((i == 0) ? (byte)1 : b, lf.lfCharSet);
+                    Assert.Equal(b, lf.lfOutPrecision);
+                    Assert.Equal(b, lf.lfClipPrecision);
+                    Assert.Equal(b, lf.lfQuality);
+                    Assert.Equal(b, lf.lfPitchAndFamily);
+                    Assert.Equal(b.ToString(), lf.lfFaceName);
+                }
+                catch (Exception e)
+                {
+                    Assert.True(false, string.Format("Unexcepted exception {0} at iteration {1}", e, i));
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_ToHFont()
+        {
+            Font f = new Font(name, 12.5f);
+            f.Dispose();
+            Assert.Throws<ArgumentException>(() => f.ToHfont());
+        }
+
+        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
+        public void GetHeight_Float()
+        {
+            using (Font f = new Font(name, 12.5f))
+            {
+                Assert.Equal(0, f.GetHeight(0));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetHeight_Graphics()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10))
+            {
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    using (Font f = new Font(name, 12.5f))
+                    {
+                        float expected = f.GetHeight(g.DpiY);
+                        Assert.Equal(expected, f.GetHeight(g), 3);
+                        g.ScaleTransform(2, 4);
+                        Assert.Equal(expected, f.GetHeight(g), 3);
+                        g.PageScale = 3;
+                        Assert.Equal(expected, f.GetHeight(g), 3);
+                    }
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetHeight_Graphics_Null()
+        {
+            using (Font f = new Font(name, 12.5f))
+            {
+                Assert.Throws<ArgumentNullException>(() => f.GetHeight(null));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FontUniqueHashCode()
+        {
+            Font f1 = new Font("Arial", 14);
+            Font f2 = new Font("Arial", 12);
+            Font f3 = new Font(f1, FontStyle.Bold);
+
+            Assert.False(f1.GetHashCode() == f2.GetHashCode());
+            Assert.False(f1.GetHashCode() == f3.GetHashCode());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetHashCode_UnitDiffers_HashesNotEqual()
+        {
+            Font f1 = new Font("Arial", 8.25F, GraphicsUnit.Point);
+            Font f2 = new Font("Arial", 8.25F, GraphicsUnit.Pixel);
+
+            Assert.False(f1.GetHashCode() == f2.GetHashCode(),
+                "Hashcodes should differ if _unit member differs");
+        }
+
+        [ActiveIssue(20844)]
+        public void GetHashCode_NameDiffers_HashesNotEqual()
+        {
+            Font f1 = new Font("Arial", 8.25F, GraphicsUnit.Point);
+            Font f2 = new Font("Courier New", 8.25F, GraphicsUnit.Point);
+
+            if (f1.Name != f2.Name)
+            {
+                Assert.False(f1.GetHashCode() == f2.GetHashCode(),
+                               "Hashcodes should differ if _name member differs");
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetHashCode_StyleEqualsGdiCharSet_HashesNotEqual()
+        {
+            Font f1 = new Font("Arial", 8.25F, FontStyle.Regular, GraphicsUnit.Point, ((byte)(0)));
+            Font f2 = new Font("Arial", 8.25F, FontStyle.Bold, GraphicsUnit.Point, ((byte)(1)));
+
+            Assert.False(f1.GetHashCode() == f2.GetHashCode(),
+                "Hashcodes should differ if _style member differs");
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/TestIcon.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/TestIcon.cs
@@ -1,0 +1,666 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Icon class testing unit
+//
+// Authors:
+//	Gary Barnett <gary.barnett.mono@gmail.com>
+// 	Sanjay Gupta <gsanjay@novell.com>
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2004,2006-2008 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Reflection;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class IconTest : IDisposable
+    {
+
+        Icon icon;
+        Icon icon16, icon32, icon48, icon64, icon96;
+
+        static string filename_dll;
+
+        // static ctor are executed outside the Deny
+        static IconTest()
+        {
+            filename_dll = Assembly.GetExecutingAssembly().Location;
+        }
+
+        public IconTest()
+        {
+            String path = Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico");
+            icon = new Icon(path);
+
+            icon16 = new Icon(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico"));
+            icon32 = new Icon(Helpers.GetTestBitmapPath("32x32_one_entry_4bit.ico"));
+            icon48 = new Icon(Helpers.GetTestBitmapPath("48x48_one_entry_1bit.ico"));
+            icon64 = new Icon(Helpers.GetTestBitmapPath("64x64_one_entry_8bit.ico"));
+            icon96 = new Icon(Helpers.GetTestBitmapPath("96x96_one_entry_8bit.ico"));
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists("newIcon.ico"))
+                File.Delete("newIcon.ico");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestConstructors()
+        {
+            Assert.Equal(32, icon.Height);
+            Assert.Equal(32, icon.Width);
+
+            String path = Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico");
+            using (var fs1 = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                Icon newIcon = new Icon(fs1, 48, 48);
+                Assert.Equal(48, newIcon.Height);
+                Assert.Equal(48, newIcon.Width);
+
+                newIcon = new Icon(icon, 16, 16);
+                Assert.Equal(16, newIcon.Height);
+                Assert.Equal(16, newIcon.Width);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_IconNull_Int_Int()
+        {
+            AssertExtensions.Throws<ArgumentNullException, ArgumentException>("original", null, () => new Icon((Icon)null, 32, 32));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Icon_IntNegative_Int()
+        {
+            Icon neg = new Icon(icon, -32, 32);
+            Assert.Equal(32, neg.Height);
+            Assert.Equal(32, neg.Width);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_IconNull_Size()
+        {
+            AssertExtensions.Throws<ArgumentNullException, ArgumentException>("original", null, () => new Icon((Icon)null, new Size(32, 32)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Icon_Size_Negative()
+        {
+            Icon neg = new Icon(icon, new Size(-32, -32));
+            Assert.Equal(16, neg.Height);
+            Assert.Equal(16, neg.Width);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Icon_Int_Int_NonSquare()
+        {
+            Icon non_square = new Icon(icon, 32, 16);
+            Assert.Equal(32, non_square.Height);
+            Assert.Equal(32, non_square.Width);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Icon_GetNormalSizeFromIconWith256()
+        {
+            string filepath = Helpers.GetTestBitmapPath("256x256_seven_entries_multiple_bits.ico");
+
+            Icon orig = new Icon(filepath);
+            Assert.Equal(32, orig.Height);
+            Assert.Equal(32, orig.Width);
+
+            Icon ret = new Icon(orig, 48, 48);
+            Assert.Equal(48, ret.Height);
+            Assert.Equal(48, ret.Width);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Icon_DoesntReturn256Passing0()
+        {
+            string filepath = Helpers.GetTestBitmapPath("256x256_seven_entries_multiple_bits.ico");
+
+            Icon orig = new Icon(filepath);
+            Assert.Equal(32, orig.Height);
+            Assert.Equal(32, orig.Width);
+
+            Icon ret = new Icon(orig, 0, 0);
+            Assert.NotEqual(0, ret.Height);
+            Assert.NotEqual(0, ret.Width);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Icon_DoesntReturn256Passing1()
+        {
+            string filepath = Helpers.GetTestBitmapPath("256x256_seven_entries_multiple_bits.ico");
+
+            Icon orig = new Icon(filepath);
+            Assert.Equal(32, orig.Height);
+            Assert.Equal(32, orig.Width);
+
+            Icon ret = new Icon(orig, 1, 1);
+            Assert.NotEqual(0, ret.Height);
+            Assert.NotEqual(0, ret.Width);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_StreamNull()
+        {
+            AssertExtensions.Throws<ArgumentNullException, ArgumentException>("stream", null, () => new Icon((Stream)null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_StreamNull_Int_Int()
+        {
+            AssertExtensions.Throws<ArgumentNullException, ArgumentException>("stream", null, () => new Icon((Stream)null, 32, 32));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_StringNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Icon((string)null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_TypeNull_String()
+        {
+            Assert.Throws<NullReferenceException>(() => new Icon((Type)null, "mono.ico"));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_Type_StringNull()
+        {
+            Assert.Throws<ArgumentException>(() => new Icon(typeof(Icon), null));
+        }
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_StreamNull_Size()
+        {
+            AssertExtensions.Throws<ArgumentNullException, ArgumentException>("stream", null, () => new Icon((Stream)null, new Size(32, 32)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_StringNull_Size()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Icon((string)null, new Size(32, 32)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_StringNull_Int_Int()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Icon((string)null, 32, 32));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestProperties()
+        {
+            Assert.Equal(32, icon.Height);
+            Assert.Equal(32, icon.Width);
+            Assert.Equal(32, icon.Size.Width);
+            Assert.Equal(32, icon.Size.Height);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Clone()
+        {
+            Icon clone = (Icon)icon.Clone();
+            Assert.Equal(32, clone.Height);
+            Assert.Equal(32, clone.Width);
+            Assert.Equal(32, clone.Size.Width);
+            Assert.Equal(32, clone.Size.Height);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CloneHandleIcon()
+        {
+            Icon clone = (Icon)Icon.FromHandle(SystemIcons.Hand.Handle).Clone();
+            Assert.Equal(SystemIcons.Hand.Height, clone.Height);
+            Assert.Equal(SystemIcons.Hand.Width, clone.Width);
+            Assert.Equal(SystemIcons.Hand.Size.Width, clone.Size.Width);
+            Assert.Equal(SystemIcons.Hand.Size.Height, clone.Size.Height);
+        }
+
+        private void XPIcon(int size)
+        {
+            // note: the Icon(string,Size) or Icon(string,int,int) doesn't exists under 1.x
+            using (FileStream fs = File.OpenRead(Helpers.GetTestBitmapPath("48x48_multiple_entries_32bit.ico")))
+            {
+                using (Icon xp = new Icon(fs, size, size))
+                {
+                    Assert.Equal(size, xp.Height);
+                    Assert.Equal(size, xp.Width);
+                    Assert.Equal(size, xp.Size.Width);
+                    Assert.Equal(size, xp.Size.Height);
+
+                    Bitmap bmp = xp.ToBitmap();
+                    Assert.Equal(size, bmp.Height);
+                    Assert.Equal(size, bmp.Width);
+                    Assert.Equal(size, bmp.Size.Width);
+                    Assert.Equal(size, bmp.Size.Height);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Icon32bits_XP16()
+        {
+            XPIcon(16);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Icon32bits_XP32()
+        {
+            XPIcon(32);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Icon32bits_XP48()
+        {
+            XPIcon(48);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SelectFromUnusualSize_Small16()
+        {
+            using (FileStream fs = File.OpenRead(Helpers.GetTestBitmapPath("10x16_one_entry_32bit.ico")))
+            {
+                using (Icon xp = new Icon(fs, 16, 16))
+                {
+                    Assert.Equal(16, xp.Height);
+                    Assert.Equal(10, xp.Width);
+                    Assert.Equal(10, xp.Size.Width);
+                    Assert.Equal(16, xp.Size.Height);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SelectFromUnusualSize_Normal32()
+        {
+            using (FileStream fs = File.OpenRead(Helpers.GetTestBitmapPath("10x16_one_entry_32bit.ico")))
+            {
+                using (Icon xp = new Icon(fs, 32, 32))
+                {
+                    Assert.Equal(22, xp.Height);
+                    Assert.Equal(11, xp.Width);
+                    Assert.Equal(11, xp.Size.Width);
+                    Assert.Equal(22, xp.Size.Height);
+                }
+            }
+        }
+
+        internal static void SaveAndCompare(string msg, Icon icon, bool alpha)
+        {
+            using (MemoryStream ms = new MemoryStream())
+            {
+                icon.Save(ms);
+                ms.Position = 0;
+
+                using (Icon loaded = new Icon(ms))
+                {
+                    Assert.Equal(icon.Height, loaded.Height);
+                    Assert.Equal(icon.Width, loaded.Width);
+
+                    using (Bitmap expected = icon.ToBitmap())
+                    {
+                        using (Bitmap actual = loaded.ToBitmap())
+                        {
+                            Assert.Equal(expected.Height, actual.Height);
+                            Assert.Equal(expected.Width, actual.Width);
+
+                            for (int y = 0; y < expected.Height; y++)
+                            {
+                                for (int x = 0; x < expected.Width; x++)
+                                {
+                                    Color e = expected.GetPixel(x, y);
+                                    Color a = actual.GetPixel(x, y);
+                                    if (alpha)
+                                        Assert.Equal(e.A, a.A);
+                                    Assert.Equal(e.R, a.R);
+                                    Assert.Equal(e.G, a.G);
+                                    Assert.Equal(e.B, a.B);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Save()
+        {
+            SaveAndCompare("16", icon16, true);
+            SaveAndCompare("32", icon32, true);
+            SaveAndCompare("48", icon48, true);
+            SaveAndCompare("64", icon64, true);
+            SaveAndCompare("96", icon96, true);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)] // bug #410608
+        public void Save_256()
+        {
+            string filepath = Helpers.GetTestBitmapPath("256x256_seven_entries_multiple_bits.ico");
+
+            using (Icon icon = new Icon(filepath))
+            {
+                // bug #415809 fixed
+                SaveAndCompare("256", icon, true);
+            }
+
+            // binary comparison
+            var orig = new MemoryStream(File.ReadAllBytes(filepath));
+            var saved = new MemoryStream();
+            using (Icon icon = new Icon(filepath))
+                icon.Save(saved);
+
+            Assert.Equal(orig.ToArray(), saved.ToArray());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Save_Null()
+        {
+            Assert.Throws<NullReferenceException>(() => icon.Save(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Icon16ToBitmap()
+        {
+            using (Bitmap b = icon16.ToBitmap())
+            {
+                Assert.Equal(PixelFormat.Format32bppArgb, b.PixelFormat);
+                // unlike the GDI+ icon decoder the palette isn't kept
+                Assert.Equal(0, b.Palette.Entries.Length);
+                Assert.Equal(icon16.Height, b.Height);
+                Assert.Equal(icon16.Width, b.Width);
+                Assert.True(b.RawFormat.Equals(ImageFormat.MemoryBmp));
+                Assert.Equal(2, b.Flags);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Icon32ToBitmap()
+        {
+            using (Bitmap b = icon32.ToBitmap())
+            {
+                Assert.Equal(PixelFormat.Format32bppArgb, b.PixelFormat);
+                // unlike the GDI+ icon decoder the palette isn't kept
+                Assert.Equal(0, b.Palette.Entries.Length);
+                Assert.Equal(icon32.Height, b.Height);
+                Assert.Equal(icon32.Width, b.Width);
+                Assert.True(b.RawFormat.Equals(ImageFormat.MemoryBmp));
+                Assert.Equal(2, b.Flags);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Icon48ToBitmap()
+        {
+            using (Bitmap b = icon48.ToBitmap())
+            {
+                Assert.Equal(PixelFormat.Format32bppArgb, b.PixelFormat);
+                // unlike the GDI+ icon decoder the palette isn't kept
+                Assert.Equal(0, b.Palette.Entries.Length);
+                Assert.Equal(icon48.Height, b.Height);
+                Assert.Equal(icon48.Width, b.Width);
+                Assert.True(b.RawFormat.Equals(ImageFormat.MemoryBmp));
+                Assert.Equal(2, b.Flags);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Icon64ToBitmap()
+        {
+            using (Bitmap b = icon64.ToBitmap())
+            {
+                Assert.Equal(PixelFormat.Format32bppArgb, b.PixelFormat);
+                // unlike the GDI+ icon decoder the palette isn't kept
+                Assert.Equal(0, b.Palette.Entries.Length);
+                Assert.Equal(icon64.Height, b.Height);
+                Assert.Equal(icon64.Width, b.Width);
+                Assert.True(b.RawFormat.Equals(ImageFormat.MemoryBmp));
+                Assert.Equal(2, b.Flags);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Icon96ToBitmap()
+        {
+            using (Bitmap b = icon96.ToBitmap())
+            {
+                Assert.Equal(PixelFormat.Format32bppArgb, b.PixelFormat);
+                // unlike the GDI+ icon decoder the palette isn't kept
+                Assert.Equal(0, b.Palette.Entries.Length);
+                Assert.Equal(icon96.Height, b.Height);
+                Assert.Equal(icon96.Width, b.Width);
+                Assert.True(b.RawFormat.Equals(ImageFormat.MemoryBmp));
+                Assert.Equal(2, b.Flags);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)] // bug #415581
+        public void Icon256ToBitmap()
+        {
+            using (FileStream fs = File.OpenRead(Helpers.GetTestBitmapPath("415581.ico")))
+            {
+                Icon icon = new Icon(fs, 48, 48);
+                using (Bitmap b = icon.ToBitmap())
+                {
+                    Assert.Equal(0, b.Palette.Entries.Length);
+                    Assert.Equal(48, b.Height);
+                    Assert.Equal(48, b.Width);
+                    Assert.True(b.RawFormat.Equals(ImageFormat.MemoryBmp));
+                    Assert.Equal(2, b.Flags);
+                }
+                icon.Dispose();
+            }
+
+            using (FileStream fs = File.OpenRead(Helpers.GetTestBitmapPath("415581.ico")))
+            {
+                Icon icon = new Icon(fs, 256, 256);
+                using (Bitmap b = icon.ToBitmap())
+                {
+                    Assert.Equal(0, b.Palette.Entries.Length);
+                    Assert.Equal(48, b.Height);
+                    Assert.Equal(48, b.Width);
+                    Assert.True(b.RawFormat.Equals(ImageFormat.MemoryBmp));
+                    Assert.Equal(2, b.Flags);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Icon256ToBitmap_Request0()
+        {
+            // 415581.ico has 2 images, the 256 and 48
+            using (FileStream fs = File.OpenRead(Helpers.GetTestBitmapPath("415581.ico")))
+            {
+                Icon icon = new Icon(fs, 0, 0);
+                using (Bitmap b = icon.ToBitmap())
+                {
+                    Assert.Equal(0, b.Palette.Entries.Length);
+                    Assert.Equal(48, b.Height);
+                    Assert.Equal(48, b.Width);
+                    Assert.True(b.RawFormat.Equals(ImageFormat.MemoryBmp));
+                    Assert.Equal(2, b.Flags);
+                }
+            }
+        }
+
+        [ActiveIssue(20844)]
+        public void Only256InFile()
+        {
+            using (FileStream fs = File.OpenRead(Helpers.GetTestBitmapPath("only256.ico")))
+            {
+                Assert.Throws<Win32Exception>(() => new Icon(fs, 0, 0));
+            }
+        }
+
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ExtractAssociatedIcon_Null()
+        {
+            AssertExtensions.Throws<ArgumentNullException, ArgumentException>("filePath", null, () => Icon.ExtractAssociatedIcon(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ExtractAssociatedIcon_Empty()
+        {
+            Assert.Throws<ArgumentException>(() => Icon.ExtractAssociatedIcon(String.Empty));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ExtractAssociatedIcon_DoesNotExists()
+        {
+            Assert.Throws<FileNotFoundException>(() => Icon.ExtractAssociatedIcon("does-not-exists.png"));
+        }
+
+        private static bool RunningOnUnix
+        {
+            get
+            {
+                int p = (int)Environment.OSVersion.Platform;
+
+                return (p == 4) || (p == 6) || (p == 128);
+            }
+        }
+    }
+
+    public class IconFullTrustTest
+    {
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ExtractAssociatedIcon()
+        {
+            string filename_dll = Assembly.GetExecutingAssembly().Location;
+            Assert.NotNull(Icon.ExtractAssociatedIcon(filename_dll));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void HandleRoundtrip()
+        {
+            IntPtr handle;
+            using (Icon icon = new Icon(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico")))
+            {
+                Assert.Equal(16, icon.Height);
+                Assert.Equal(16, icon.Width);
+                handle = icon.Handle;
+                using (Icon icon2 = Icon.FromHandle(handle))
+                {
+                    Assert.Equal(16, icon2.Height);
+                    Assert.Equal(16, icon2.Width);
+                    Assert.Equal(handle, icon2.Handle);
+                    IconTest.SaveAndCompare("Handle", icon2, false);
+                }
+            }
+            // unlike other cases (HICON, HBITMAP) handle DOESN'T survives original icon disposal
+            // commented / using freed memory is risky ;-)
+            /*using (Icon icon3 = Icon.FromHandle (handle)) {
+				Assert.Equal (0, icon3.Height);
+				Assert.Equal (0, icon3.Width);
+				Assert.Equal (handle, icon3.Handle);
+			}*/
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CreateMultipleIconFromSameHandle()
+        {
+            IntPtr handle;
+            using (Icon icon = new Icon(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico")))
+            {
+                Assert.Equal(16, icon.Height);
+                Assert.Equal(16, icon.Width);
+                handle = icon.Handle;
+                using (Icon icon2 = Icon.FromHandle(handle))
+                {
+                    Assert.Equal(16, icon2.Height);
+                    Assert.Equal(16, icon2.Width);
+                    Assert.Equal(handle, icon2.Handle);
+                    IconTest.SaveAndCompare("Handle2", icon2, false);
+                }
+                using (Icon icon3 = Icon.FromHandle(handle))
+                {
+                    Assert.Equal(16, icon3.Height);
+                    Assert.Equal(16, icon3.Width);
+                    Assert.Equal(handle, icon3.Handle);
+                    IconTest.SaveAndCompare("Handle3", icon3, false);
+                }
+            }
+            // unlike other cases (HICON, HBITMAP) handle DOESN'T survives original icon disposal
+            // commented / using freed memory is risky ;-)
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void HiconRoundtrip()
+        {
+            IntPtr handle;
+            using (Icon icon = new Icon(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico")))
+            {
+                Assert.Equal(16, icon.Height);
+                Assert.Equal(16, icon.Width);
+                handle = icon.ToBitmap().GetHicon();
+            }
+            // HICON survives
+            using (Icon icon2 = Icon.FromHandle(handle))
+            {
+                Assert.Equal(16, icon2.Height);
+                Assert.Equal(16, icon2.Width);
+                Assert.Equal(handle, icon2.Handle);
+                IconTest.SaveAndCompare("HICON", icon2, false);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CreateMultipleIconFromSameHICON()
+        {
+            IntPtr handle;
+            using (Icon icon = new Icon(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico")))
+            {
+                Assert.Equal(16, icon.Height);
+                Assert.Equal(16, icon.Width);
+                handle = icon.ToBitmap().GetHicon();
+            }
+            // HICON survives
+            using (Icon icon2 = Icon.FromHandle(handle))
+            {
+                Assert.Equal(16, icon2.Height);
+                Assert.Equal(16, icon2.Width);
+                Assert.Equal(handle, icon2.Handle);
+                IconTest.SaveAndCompare("HICON2", icon2, false);
+            }
+            using (Icon icon3 = Icon.FromHandle(handle))
+            {
+                Assert.Equal(16, icon3.Height);
+                Assert.Equal(16, icon3.Width);
+                Assert.Equal(handle, icon3.Handle);
+                IconTest.SaveAndCompare("HICON", icon3, false);
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/TestImage.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/TestImage.cs
@@ -1,0 +1,361 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Image class testing unit
+//
+// Authors:
+// 	Jordi Mas i Hernàndez (jmas@softcatala.org>
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// (C) 2005 Ximian, Inc.  http://www.ximian.com
+// Copyright (C) 2005-2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Reflection;
+using System.Security.Permissions;
+using System.Xml.Serialization;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class ImageTest : IDisposable
+    {
+
+        private string fname;
+        private bool callback;
+
+        public ImageTest()
+        {
+            fname = Path.GetTempFileName();
+            callback = false;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                File.Delete(fname);
+            }
+            catch
+            {
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FileDoesNotExists()
+        {
+            Assert.Throws<FileNotFoundException>(() => Image.FromFile("FileDoesNotExists.jpg"));
+        }
+
+        private bool CallbackTrue()
+        {
+            callback = true;
+            return true;
+        }
+
+        private bool CallbackFalse()
+        {
+            callback = true;
+            return false;
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetThumbnailImage_NullCallback_Tiff()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10))
+            {
+                // according to documentation a callback is mandatory
+                Image tn = bmp.GetThumbnailImage(10, 5, null, IntPtr.Zero);
+                Assert.Equal(5, tn.Height);
+                Assert.Equal(10, tn.Width);
+                Assert.False(callback);
+                tn.Save(fname, ImageFormat.Tiff);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetThumbnailImage_Height_Zero()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10))
+            {
+                Assert.Throws<OutOfMemoryException>(() => bmp.GetThumbnailImage(5, 0, new Image.GetThumbnailImageAbort(CallbackFalse), IntPtr.Zero));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetThumbnailImage_Width_Negative()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10))
+            {
+                Assert.Throws<OutOfMemoryException>(() => bmp.GetThumbnailImage(-5, 5, new Image.GetThumbnailImageAbort(CallbackFalse), IntPtr.Zero));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetThumbnailImage_CallbackData_Invalid()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10))
+            {
+                // according to documentation IntPtr.Zero must be supplied as data
+                Image tn = bmp.GetThumbnailImage(5, 5, new Image.GetThumbnailImageAbort(CallbackFalse), (IntPtr)Int32.MaxValue);
+                Assert.Equal(5, tn.Height);
+                Assert.Equal(5, tn.Width);
+                Assert.False(callback);
+                tn.Save(fname, ImageFormat.Tiff);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetThumbnailImage_SameSize_Bmp()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10))
+            {
+                Image tn = bmp.GetThumbnailImage(10, 10, new Image.GetThumbnailImageAbort(CallbackFalse), IntPtr.Zero);
+                Assert.Equal(10, tn.Height);
+                Assert.Equal(10, tn.Width);
+                Assert.False(callback);
+                tn.Save(fname, ImageFormat.Bmp);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetThumbnailImage_Smaller_Gif()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10))
+            {
+                Image tn = bmp.GetThumbnailImage(4, 4, new Image.GetThumbnailImageAbort(CallbackTrue), IntPtr.Zero);
+                Assert.Equal(4, tn.Height);
+                Assert.Equal(4, tn.Width);
+                Assert.False(callback);
+                tn.Save(fname, ImageFormat.Gif);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetThumbnailImage_Bigger_Png()
+        {
+            using (Bitmap bmp = new Bitmap(10, 10))
+            {
+                Image tn = bmp.GetThumbnailImage(40, 40, new Image.GetThumbnailImageAbort(CallbackTrue), IntPtr.Zero);
+                Assert.Equal(40, tn.Height);
+                Assert.Equal(40, tn.Width);
+                Assert.False(callback);
+                tn.Save(fname, ImageFormat.Png);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Stream_Unlocked()
+        {
+            try
+            {
+                Image img = null;
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    using (Bitmap bmp = new Bitmap(10, 10))
+                    {
+                        bmp.Save(ms, ImageFormat.Png);
+                    }
+                    ms.Position = 0;
+                    img = Image.FromStream(ms);
+                }
+                // stream isn't available anymore
+                ((Bitmap)img).MakeTransparent(Color.Transparent);
+            }
+            catch (OutOfMemoryException)
+            {
+                int p = (int)Environment.OSVersion.Platform;
+                // libgdiplus (UNIX) doesn't lazy load the image so the
+                // stream may be freed (and this exception will never occur)
+                if ((p == 4) || (p == 128) || (p == 6))
+                    throw;
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Stream_Locked()
+        {
+            Image img = null;
+            using (MemoryStream ms = new MemoryStream())
+            {
+                using (Bitmap bmp = new Bitmap(10, 10))
+                {
+                    bmp.Save(ms, ImageFormat.Png);
+                }
+                ms.Position = 0;
+                img = Image.FromStream(ms);
+                // stream is available
+                ((Bitmap)img).MakeTransparent(Color.Transparent);
+            }
+        }
+
+        private void Wmf(Image img)
+        {
+            Assert.False(img is Bitmap);
+            Assert.True(img is Metafile);
+            // as Image
+            Assert.Equal(327683, img.Flags);
+            Assert.True(img.RawFormat.Equals(ImageFormat.Wmf));
+            Assert.Null(img.Tag);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromFile_Metafile_Wmf()
+        {
+            string filename = Helpers.GetTestBitmapPath("telescope_01.wmf");
+            using (Image img = Image.FromFile(filename))
+            {
+                Wmf(img);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromStream_Metafile_Wmf()
+        {
+            string filename = Helpers.GetTestBitmapPath("telescope_01.wmf");
+            using (FileStream fs = File.OpenRead(filename))
+            {
+                using (Image img = Image.FromStream(fs))
+                {
+                    Wmf(img);
+                }
+            }
+        }
+
+        private void Emf(Image img)
+        {
+            Assert.False(img is Bitmap);
+            Assert.True(img is Metafile);
+            // as Image
+            Assert.Equal(327683, img.Flags);
+            Assert.True(img.RawFormat.Equals(ImageFormat.Emf));
+            Assert.Null(img.Tag);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromFile_Metafile_Emf()
+        {
+            string filename = Helpers.GetTestBitmapPath("milkmateya01.emf");
+            using (Image img = Image.FromFile(filename))
+            {
+                Emf(img);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromStream_Metafile_Emf()
+        {
+            string filename = Helpers.GetTestBitmapPath("milkmateya01.emf");
+            using (FileStream fs = File.OpenRead(filename))
+            {
+                using (Image img = Image.FromStream(fs))
+                {
+                    Emf(img);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromFile_Invalid()
+        {
+            string filename = Assembly.GetExecutingAssembly().Location;
+            Assert.Throws<OutOfMemoryException>(() => Image.FromFile(filename));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromStream_Invalid()
+        {
+            string filename = Assembly.GetExecutingAssembly().Location;
+            using (FileStream fs = File.OpenRead(filename))
+            {
+                Assert.Throws<ArgumentException>(() => Image.FromStream(fs));
+            }
+        }
+
+        private Bitmap GetBitmap()
+        {
+            Bitmap bmp = new Bitmap(20, 10, PixelFormat.Format24bppRgb);
+            using (Graphics g = Graphics.FromImage(bmp))
+            {
+                Pen pen = new Pen(Color.Black, 3);
+                g.DrawRectangle(pen, 0, 0, 5, 10);
+            }
+            return bmp;
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StreamSaveLoad()
+        {
+            using (MemoryStream ms = new MemoryStream())
+            {
+                using (Bitmap bmp = GetBitmap())
+                {
+                    Assert.Equal(0, ms.Position);
+                    bmp.Save(ms, ImageFormat.Bmp);
+                    Assert.True(ms.Position > 0);
+
+                    ms.Position = ms.Length;
+                    Assert.Equal(ms.Length, ms.Position);
+
+                    Bitmap bmp2 = (Bitmap)Image.FromStream(ms);
+                    Assert.True(ms.Position > 20);
+
+                    Assert.True(bmp2.RawFormat.Equals(ImageFormat.Bmp));
+
+                    Assert.Equal(bmp.GetPixel(0, 0), bmp2.GetPixel(0, 0));
+                    Assert.Equal(bmp.GetPixel(10, 0), bmp2.GetPixel(10, 0));
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void StreamJunkSaveLoad()
+        {
+            using (MemoryStream ms = new MemoryStream())
+            {
+                // junk
+                ms.WriteByte(0xff);
+                ms.WriteByte(0xef);
+                Assert.Equal(2, ms.Position);
+
+                using (Bitmap bmp = GetBitmap())
+                {
+                    bmp.Save(ms, ImageFormat.Bmp);
+                    Assert.True(ms.Position > 2);
+                    // exception here
+                    Assert.Throws<ArgumentException>(() => Image.FromStream(ms));
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void XmlSerialization()
+        {
+            new XmlSerializer(typeof(Image));
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/TestPens.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/TestPens.cs
@@ -1,0 +1,2614 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+// Tests for System.Drawing.Pens.cs
+//
+// Author:
+//     Ravindra (rkumar@novell.com)
+//
+
+//
+// Copyright (C) 2004 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using Xunit;
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+
+namespace MonoTests.System.Drawing
+{
+    public class PensTest
+    {
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestEquals()
+        {
+            Pen pen1 = Pens.Blue;
+            Pen pen2 = Pens.Blue;
+
+            Assert.Equal(true, pen1.Equals(pen2));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestAliceBlue()
+        {
+            Pen pen = Pens.AliceBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.AliceBlue);
+
+            try
+            {
+                pen.Color = Color.AliceBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestAntiqueWhite()
+        {
+            Pen pen = Pens.AntiqueWhite;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.AntiqueWhite);
+
+            try
+            {
+                pen.Color = Color.AntiqueWhite;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestAqua()
+        {
+            Pen pen = Pens.Aqua;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Aqua);
+
+            try
+            {
+                pen.Color = Color.Aqua;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestAquamarine()
+        {
+            Pen pen = Pens.Aquamarine;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Aquamarine);
+
+            try
+            {
+                pen.Color = Color.Aquamarine;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestAzure()
+        {
+            Pen pen = Pens.Azure;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Azure);
+
+            try
+            {
+                pen.Color = Color.Azure;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestBeige()
+        {
+            Pen pen = Pens.Beige;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Beige);
+
+            try
+            {
+                pen.Color = Color.Beige;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestBisque()
+        {
+            Pen pen = Pens.Bisque;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Bisque);
+
+            try
+            {
+                pen.Color = Color.Bisque;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestBlack()
+        {
+            Pen pen = Pens.Black;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Black);
+
+            try
+            {
+                pen.Color = Color.Black;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestBlanchedAlmond()
+        {
+            Pen pen = Pens.BlanchedAlmond;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.BlanchedAlmond);
+
+            try
+            {
+                pen.Color = Color.BlanchedAlmond;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestBlue()
+        {
+            Pen pen = Pens.Blue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Blue);
+
+            try
+            {
+                pen.Color = Color.Blue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestBlueViolet()
+        {
+            Pen pen = Pens.BlueViolet;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.BlueViolet);
+
+            try
+            {
+                pen.Color = Color.BlueViolet;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestBrown()
+        {
+            Pen pen = Pens.Brown;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Brown);
+
+            try
+            {
+                pen.Color = Color.Brown;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestBurlyWood()
+        {
+            Pen pen = Pens.BurlyWood;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.BurlyWood);
+
+            try
+            {
+                pen.Color = Color.BurlyWood;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestCadetBlue()
+        {
+            Pen pen = Pens.CadetBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.CadetBlue);
+
+            try
+            {
+                pen.Color = Color.CadetBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestChartreuse()
+        {
+            Pen pen = Pens.Chartreuse;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Chartreuse);
+
+            try
+            {
+                pen.Color = Color.Chartreuse;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestChocolate()
+        {
+            Pen pen = Pens.Chocolate;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Chocolate);
+
+            try
+            {
+                pen.Color = Color.Chocolate;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestCoral()
+        {
+            Pen pen = Pens.Coral;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Coral);
+
+            try
+            {
+                pen.Color = Color.Coral;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestCornflowerBlue()
+        {
+            Pen pen = Pens.CornflowerBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.CornflowerBlue);
+
+            try
+            {
+                pen.Color = Color.CornflowerBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestCornsilk()
+        {
+            Pen pen = Pens.Cornsilk;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Cornsilk);
+
+            try
+            {
+                pen.Color = Color.Cornsilk;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestCrimson()
+        {
+            Pen pen = Pens.Crimson;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Crimson);
+
+            try
+            {
+                pen.Color = Color.Crimson;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestCyan()
+        {
+            Pen pen = Pens.Cyan;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Cyan);
+
+            try
+            {
+                pen.Color = Color.Cyan;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkBlue()
+        {
+            Pen pen = Pens.DarkBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkBlue);
+
+            try
+            {
+                pen.Color = Color.DarkBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkCyan()
+        {
+            Pen pen = Pens.DarkCyan;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkCyan);
+
+            try
+            {
+                pen.Color = Color.DarkCyan;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkGoldenrod()
+        {
+            Pen pen = Pens.DarkGoldenrod;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkGoldenrod);
+
+            try
+            {
+                pen.Color = Color.DarkGoldenrod;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkGray()
+        {
+            Pen pen = Pens.DarkGray;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkGray);
+
+            try
+            {
+                pen.Color = Color.DarkGray;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkGreen()
+        {
+            Pen pen = Pens.DarkGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkGreen);
+
+            try
+            {
+                pen.Color = Color.DarkGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkKhaki()
+        {
+            Pen pen = Pens.DarkKhaki;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkKhaki);
+
+            try
+            {
+                pen.Color = Color.DarkKhaki;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkMagenta()
+        {
+            Pen pen = Pens.DarkMagenta;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkMagenta);
+
+            try
+            {
+                pen.Color = Color.DarkMagenta;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkOliveGreen()
+        {
+            Pen pen = Pens.DarkOliveGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkOliveGreen);
+
+            try
+            {
+                pen.Color = Color.DarkOliveGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkOrange()
+        {
+            Pen pen = Pens.DarkOrange;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkOrange);
+
+            try
+            {
+                pen.Color = Color.DarkOrange;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkOrchid()
+        {
+            Pen pen = Pens.DarkOrchid;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkOrchid);
+
+            try
+            {
+                pen.Color = Color.DarkOrchid;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkRed()
+        {
+            Pen pen = Pens.DarkRed;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkRed);
+
+            try
+            {
+                pen.Color = Color.DarkRed;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkSalmon()
+        {
+            Pen pen = Pens.DarkSalmon;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkSalmon);
+
+            try
+            {
+                pen.Color = Color.DarkSalmon;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkSeaGreen()
+        {
+            Pen pen = Pens.DarkSeaGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkSeaGreen);
+
+            try
+            {
+                pen.Color = Color.DarkSeaGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkSlateBlue()
+        {
+            Pen pen = Pens.DarkSlateBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkSlateBlue);
+
+            try
+            {
+                pen.Color = Color.DarkSlateBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkSlateGray()
+        {
+            Pen pen = Pens.DarkSlateGray;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkSlateGray);
+
+            try
+            {
+                pen.Color = Color.DarkSlateGray;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkTurquoise()
+        {
+            Pen pen = Pens.DarkTurquoise;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkTurquoise);
+
+            try
+            {
+                pen.Color = Color.DarkTurquoise;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDarkViolet()
+        {
+            Pen pen = Pens.DarkViolet;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DarkViolet);
+
+            try
+            {
+                pen.Color = Color.DarkViolet;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDeepPink()
+        {
+            Pen pen = Pens.DeepPink;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DeepPink);
+
+            try
+            {
+                pen.Color = Color.DeepPink;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDeepSkyBlue()
+        {
+            Pen pen = Pens.DeepSkyBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DeepSkyBlue);
+
+            try
+            {
+                pen.Color = Color.DeepSkyBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDimGray()
+        {
+            Pen pen = Pens.DimGray;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DimGray);
+
+            try
+            {
+                pen.Color = Color.DimGray;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDodgerBlue()
+        {
+            Pen pen = Pens.DodgerBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.DodgerBlue);
+
+            try
+            {
+                pen.Color = Color.DodgerBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestFirebrick()
+        {
+            Pen pen = Pens.Firebrick;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Firebrick);
+
+            try
+            {
+                pen.Color = Color.Firebrick;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestFloralWhite()
+        {
+            Pen pen = Pens.FloralWhite;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.FloralWhite);
+
+            try
+            {
+                pen.Color = Color.FloralWhite;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestForestGreen()
+        {
+            Pen pen = Pens.ForestGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.ForestGreen);
+
+            try
+            {
+                pen.Color = Color.ForestGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestFuchsia()
+        {
+            Pen pen = Pens.Fuchsia;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Fuchsia);
+
+            try
+            {
+                pen.Color = Color.Fuchsia;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestGainsboro()
+        {
+            Pen pen = Pens.Gainsboro;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Gainsboro);
+
+            try
+            {
+                pen.Color = Color.Gainsboro;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestGhostWhite()
+        {
+            Pen pen = Pens.GhostWhite;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.GhostWhite);
+
+            try
+            {
+                pen.Color = Color.GhostWhite;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestGold()
+        {
+            Pen pen = Pens.Gold;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Gold);
+
+            try
+            {
+                pen.Color = Color.Gold;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestGoldenrod()
+        {
+            Pen pen = Pens.Goldenrod;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Goldenrod);
+
+            try
+            {
+                pen.Color = Color.Goldenrod;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestGray()
+        {
+            Pen pen = Pens.Gray;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Gray);
+
+            try
+            {
+                pen.Color = Color.Gray;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestGreen()
+        {
+            Pen pen = Pens.Green;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Green);
+
+            try
+            {
+                pen.Color = Color.Green;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestGreenYellow()
+        {
+            Pen pen = Pens.GreenYellow;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.GreenYellow);
+
+            try
+            {
+                pen.Color = Color.GreenYellow;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestHoneydew()
+        {
+            Pen pen = Pens.Honeydew;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Honeydew);
+
+            try
+            {
+                pen.Color = Color.Honeydew;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestHotPink()
+        {
+            Pen pen = Pens.HotPink;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.HotPink);
+
+            try
+            {
+                pen.Color = Color.HotPink;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestIndianRed()
+        {
+            Pen pen = Pens.IndianRed;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.IndianRed);
+
+            try
+            {
+                pen.Color = Color.IndianRed;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestIndigo()
+        {
+            Pen pen = Pens.Indigo;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Indigo);
+
+            try
+            {
+                pen.Color = Color.Indigo;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestIvory()
+        {
+            Pen pen = Pens.Ivory;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Ivory);
+
+            try
+            {
+                pen.Color = Color.Ivory;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestKhaki()
+        {
+            Pen pen = Pens.Khaki;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Khaki);
+
+            try
+            {
+                pen.Color = Color.Khaki;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLavender()
+        {
+            Pen pen = Pens.Lavender;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Lavender);
+
+            try
+            {
+                pen.Color = Color.Lavender;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLavenderBlush()
+        {
+            Pen pen = Pens.LavenderBlush;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LavenderBlush);
+
+            try
+            {
+                pen.Color = Color.LavenderBlush;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLawnGreen()
+        {
+            Pen pen = Pens.LawnGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LawnGreen);
+
+            try
+            {
+                pen.Color = Color.LawnGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLemonChiffon()
+        {
+            Pen pen = Pens.LemonChiffon;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LemonChiffon);
+
+            try
+            {
+                pen.Color = Color.LemonChiffon;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightBlue()
+        {
+            Pen pen = Pens.LightBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightBlue);
+
+            try
+            {
+                pen.Color = Color.LightBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightCoral()
+        {
+            Pen pen = Pens.LightCoral;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightCoral);
+
+            try
+            {
+                pen.Color = Color.LightCoral;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightCyan()
+        {
+            Pen pen = Pens.LightCyan;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightCyan);
+
+            try
+            {
+                pen.Color = Color.LightCyan;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightGoldenrodYellow()
+        {
+            Pen pen = Pens.LightGoldenrodYellow;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightGoldenrodYellow);
+
+            try
+            {
+                pen.Color = Color.LightGoldenrodYellow;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightGray()
+        {
+            Pen pen = Pens.LightGray;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightGray);
+
+            try
+            {
+                pen.Color = Color.LightGray;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightGreen()
+        {
+            Pen pen = Pens.LightGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightGreen);
+
+            try
+            {
+                pen.Color = Color.LightGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightPink()
+        {
+            Pen pen = Pens.LightPink;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightPink);
+
+            try
+            {
+                pen.Color = Color.LightPink;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightSalmon()
+        {
+            Pen pen = Pens.LightSalmon;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightSalmon);
+
+            try
+            {
+                pen.Color = Color.LightSalmon;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightSeaGreen()
+        {
+            Pen pen = Pens.LightSeaGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightSeaGreen);
+
+            try
+            {
+                pen.Color = Color.LightSeaGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightSkyBlue()
+        {
+            Pen pen = Pens.LightSkyBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightSkyBlue);
+
+            try
+            {
+                pen.Color = Color.LightSkyBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightSlateGray()
+        {
+            Pen pen = Pens.LightSlateGray;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightSlateGray);
+
+            try
+            {
+                pen.Color = Color.LightSlateGray;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightSteelBlue()
+        {
+            Pen pen = Pens.LightSteelBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightSteelBlue);
+
+            try
+            {
+                pen.Color = Color.LightSteelBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLightYellow()
+        {
+            Pen pen = Pens.LightYellow;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LightYellow);
+
+            try
+            {
+                pen.Color = Color.LightYellow;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLime()
+        {
+            Pen pen = Pens.Lime;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Lime);
+
+            try
+            {
+                pen.Color = Color.Lime;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLimeGreen()
+        {
+            Pen pen = Pens.LimeGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.LimeGreen);
+
+            try
+            {
+                pen.Color = Color.LimeGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestLinen()
+        {
+            Pen pen = Pens.Linen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Linen);
+
+            try
+            {
+                pen.Color = Color.Linen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMagenta()
+        {
+            Pen pen = Pens.Magenta;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Magenta);
+
+            try
+            {
+                pen.Color = Color.Magenta;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMaroon()
+        {
+            Pen pen = Pens.Maroon;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Maroon);
+
+            try
+            {
+                pen.Color = Color.Maroon;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMediumAquamarine()
+        {
+            Pen pen = Pens.MediumAquamarine;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MediumAquamarine);
+
+            try
+            {
+                pen.Color = Color.MediumAquamarine;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMediumBlue()
+        {
+            Pen pen = Pens.MediumBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MediumBlue);
+
+            try
+            {
+                pen.Color = Color.MediumBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMediumOrchid()
+        {
+            Pen pen = Pens.MediumOrchid;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MediumOrchid);
+
+            try
+            {
+                pen.Color = Color.MediumOrchid;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMediumPurple()
+        {
+            Pen pen = Pens.MediumPurple;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MediumPurple);
+
+            try
+            {
+                pen.Color = Color.MediumPurple;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMediumSeaGreen()
+        {
+            Pen pen = Pens.MediumSeaGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MediumSeaGreen);
+
+            try
+            {
+                pen.Color = Color.MediumSeaGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMediumSlateBlue()
+        {
+            Pen pen = Pens.MediumSlateBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MediumSlateBlue);
+
+            try
+            {
+                pen.Color = Color.MediumSlateBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMediumSpringGreen()
+        {
+            Pen pen = Pens.MediumSpringGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MediumSpringGreen);
+
+            try
+            {
+                pen.Color = Color.MediumSpringGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMediumTurquoise()
+        {
+            Pen pen = Pens.MediumTurquoise;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MediumTurquoise);
+
+            try
+            {
+                pen.Color = Color.MediumTurquoise;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMediumVioletRed()
+        {
+            Pen pen = Pens.MediumVioletRed;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MediumVioletRed);
+
+            try
+            {
+                pen.Color = Color.MediumVioletRed;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMidnightBlue()
+        {
+            Pen pen = Pens.MidnightBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MidnightBlue);
+
+            try
+            {
+                pen.Color = Color.MidnightBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMintCream()
+        {
+            Pen pen = Pens.MintCream;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MintCream);
+
+            try
+            {
+                pen.Color = Color.MintCream;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMistyRose()
+        {
+            Pen pen = Pens.MistyRose;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.MistyRose);
+
+            try
+            {
+                pen.Color = Color.MistyRose;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMoccasin()
+        {
+            Pen pen = Pens.Moccasin;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Moccasin);
+
+            try
+            {
+                pen.Color = Color.Moccasin;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestNavajoWhite()
+        {
+            Pen pen = Pens.NavajoWhite;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.NavajoWhite);
+
+            try
+            {
+                pen.Color = Color.NavajoWhite;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestNavy()
+        {
+            Pen pen = Pens.Navy;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Navy);
+
+            try
+            {
+                pen.Color = Color.Navy;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestOldLace()
+        {
+            Pen pen = Pens.OldLace;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.OldLace);
+
+            try
+            {
+                pen.Color = Color.OldLace;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestOlive()
+        {
+            Pen pen = Pens.Olive;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Olive);
+
+            try
+            {
+                pen.Color = Color.Olive;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestOliveDrab()
+        {
+            Pen pen = Pens.OliveDrab;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.OliveDrab);
+
+            try
+            {
+                pen.Color = Color.OliveDrab;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestOrange()
+        {
+            Pen pen = Pens.Orange;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Orange);
+
+            try
+            {
+                pen.Color = Color.Orange;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestOrangeRed()
+        {
+            Pen pen = Pens.OrangeRed;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.OrangeRed);
+
+            try
+            {
+                pen.Color = Color.OrangeRed;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestOrchid()
+        {
+            Pen pen = Pens.Orchid;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Orchid);
+
+            try
+            {
+                pen.Color = Color.Orchid;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPaleGoldenrod()
+        {
+            Pen pen = Pens.PaleGoldenrod;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.PaleGoldenrod);
+
+            try
+            {
+                pen.Color = Color.PaleGoldenrod;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPaleGreen()
+        {
+            Pen pen = Pens.PaleGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.PaleGreen);
+
+            try
+            {
+                pen.Color = Color.PaleGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPaleTurquoise()
+        {
+            Pen pen = Pens.PaleTurquoise;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.PaleTurquoise);
+
+            try
+            {
+                pen.Color = Color.PaleTurquoise;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPaleVioletRed()
+        {
+            Pen pen = Pens.PaleVioletRed;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.PaleVioletRed);
+
+            try
+            {
+                pen.Color = Color.PaleVioletRed;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPapayaWhip()
+        {
+            Pen pen = Pens.PapayaWhip;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.PapayaWhip);
+
+            try
+            {
+                pen.Color = Color.PapayaWhip;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPeachPuff()
+        {
+            Pen pen = Pens.PeachPuff;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.PeachPuff);
+
+            try
+            {
+                pen.Color = Color.PeachPuff;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPeru()
+        {
+            Pen pen = Pens.Peru;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Peru);
+
+            try
+            {
+                pen.Color = Color.Peru;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPink()
+        {
+            Pen pen = Pens.Pink;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Pink);
+
+            try
+            {
+                pen.Color = Color.Pink;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPlum()
+        {
+            Pen pen = Pens.Plum;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Plum);
+
+            try
+            {
+                pen.Color = Color.Plum;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPowderBlue()
+        {
+            Pen pen = Pens.PowderBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.PowderBlue);
+
+            try
+            {
+                pen.Color = Color.PowderBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestPurple()
+        {
+            Pen pen = Pens.Purple;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Purple);
+
+            try
+            {
+                pen.Color = Color.Purple;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestRed()
+        {
+            Pen pen = Pens.Red;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Red);
+
+            try
+            {
+                pen.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestRosyBrown()
+        {
+            Pen pen = Pens.RosyBrown;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.RosyBrown);
+
+            try
+            {
+                pen.Color = Color.RosyBrown;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestRoyalBlue()
+        {
+            Pen pen = Pens.RoyalBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.RoyalBlue);
+
+            try
+            {
+                pen.Color = Color.RoyalBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSaddleBrown()
+        {
+            Pen pen = Pens.SaddleBrown;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.SaddleBrown);
+
+            try
+            {
+                pen.Color = Color.SaddleBrown;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSalmon()
+        {
+            Pen pen = Pens.Salmon;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Salmon);
+
+            try
+            {
+                pen.Color = Color.Salmon;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSandyBrown()
+        {
+            Pen pen = Pens.SandyBrown;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.SandyBrown);
+
+            try
+            {
+                pen.Color = Color.SandyBrown;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSeaGreen()
+        {
+            Pen pen = Pens.SeaGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.SeaGreen);
+
+            try
+            {
+                pen.Color = Color.SeaGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSeaShell()
+        {
+            Pen pen = Pens.SeaShell;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.SeaShell);
+
+            try
+            {
+                pen.Color = Color.SeaShell;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSienna()
+        {
+            Pen pen = Pens.Sienna;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Sienna);
+
+            try
+            {
+                pen.Color = Color.Sienna;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSilver()
+        {
+            Pen pen = Pens.Silver;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Silver);
+
+            try
+            {
+                pen.Color = Color.Silver;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSkyBlue()
+        {
+            Pen pen = Pens.SkyBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.SkyBlue);
+
+            try
+            {
+                pen.Color = Color.SkyBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSlateBlue()
+        {
+            Pen pen = Pens.SlateBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.SlateBlue);
+
+            try
+            {
+                pen.Color = Color.SlateBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSlateGray()
+        {
+            Pen pen = Pens.SlateGray;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.SlateGray);
+
+            try
+            {
+                pen.Color = Color.SlateGray;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSnow()
+        {
+            Pen pen = Pens.Snow;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Snow);
+
+            try
+            {
+                pen.Color = Color.Snow;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSpringGreen()
+        {
+            Pen pen = Pens.SpringGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.SpringGreen);
+
+            try
+            {
+                pen.Color = Color.SpringGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestSteelBlue()
+        {
+            Pen pen = Pens.SteelBlue;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.SteelBlue);
+
+            try
+            {
+                pen.Color = Color.SteelBlue;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestTan()
+        {
+            Pen pen = Pens.Tan;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Tan);
+
+            try
+            {
+                pen.Color = Color.Tan;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestTeal()
+        {
+            Pen pen = Pens.Teal;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Teal);
+
+            try
+            {
+                pen.Color = Color.Teal;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestThistle()
+        {
+            Pen pen = Pens.Thistle;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Thistle);
+
+            try
+            {
+                pen.Color = Color.Thistle;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestTomato()
+        {
+            Pen pen = Pens.Tomato;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Tomato);
+
+            try
+            {
+                pen.Color = Color.Tomato;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestTransparent()
+        {
+            Pen pen = Pens.Transparent;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Transparent);
+
+            try
+            {
+                pen.Color = Color.Transparent;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestTurquoise()
+        {
+            Pen pen = Pens.Turquoise;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Turquoise);
+
+            try
+            {
+                pen.Color = Color.Turquoise;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestViolet()
+        {
+            Pen pen = Pens.Violet;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Violet);
+
+            try
+            {
+                pen.Color = Color.Violet;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestWheat()
+        {
+            Pen pen = Pens.Wheat;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Wheat);
+
+            try
+            {
+                pen.Color = Color.Wheat;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestWhite()
+        {
+            Pen pen = Pens.White;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.White);
+
+            try
+            {
+                pen.Color = Color.White;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestWhiteSmoke()
+        {
+            Pen pen = Pens.WhiteSmoke;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.WhiteSmoke);
+
+            try
+            {
+                pen.Color = Color.WhiteSmoke;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestYellow()
+        {
+            Pen pen = Pens.Yellow;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.Yellow);
+
+            try
+            {
+                pen.Color = Color.Yellow;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestYellowGreen()
+        {
+            Pen pen = Pens.YellowGreen;
+            Assert.Equal(pen.PenType, PenType.SolidColor);
+            Assert.Equal(pen.Color, Color.YellowGreen);
+
+            try
+            {
+                pen.Color = Color.YellowGreen;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+    }
+}
+
+// Following code was used to generate the test methods above
+//
+//Type type = typeof (Pens);
+//PropertyInfo [] properties = type.GetProperties ();
+//int count = 1;
+//foreach (PropertyInfo property in properties) {
+//	Console.WriteLine();
+//	Console.WriteLine("\t\t[Fact]");
+//	Console.WriteLine("\t\tpublic void Test" + property.Name + " ()");
+//	Console.WriteLine("\t\t{");
+//	Console.WriteLine("\t\t\tPen pen = Pens." + property.Name + ";");
+//	Console.WriteLine("\t\t\tAssertEquals (\"P" + count + "#1\", pen.PenType, PenType.SolidColor);");
+//	Console.WriteLine("\t\t\tAssertEquals (\"P" + count + "#2\", pen.Color, Color." + property.Name + ");\n");
+//
+//	Console.WriteLine("\t\t\ttry {");
+//	Console.WriteLine("\t\t\t\tpen.Color = Color." + property.Name + ";");
+//	Console.WriteLine("\t\t\t\tAssert.True(false,  (\"P" + count + "#3: must throw ArgumentException\");");
+//	Console.WriteLine("\t\t\t} catch (ArgumentException) {");
+//	Console.WriteLine("\t\t\t\tAssert.True (\"P" + count + "#3\", true);");
+//	Console.WriteLine("\t\t\t}");
+//	Console.WriteLine("\t\t}");
+//	count++;
+//}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/TestRegion.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/TestRegion.cs
@@ -1,0 +1,1564 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Region class testing unit
+//
+// Authors:
+//   Jordi Mas, jordi@ximian.com
+//   Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2004-2008 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing.Imaging;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class TestRegion
+    {
+        /* For debugging */
+        public static void DumpRegion(Region rgn)
+        {
+            Matrix matrix = new Matrix();
+            RectangleF[] rects = rgn.GetRegionScans(matrix);
+
+            for (int i = 0; i < rects.Length; i++)
+                Console.WriteLine(rects[i]);
+        }
+
+        private Bitmap bitmap;
+        private Graphics graphic;
+
+        public TestRegion()
+        {
+            bitmap = new Bitmap(10, 10);
+            graphic = Graphics.FromImage(bitmap);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestBounds()
+        {
+            Bitmap bmp = new Bitmap(600, 800);
+            Graphics dc = Graphics.FromImage(bmp);
+            Rectangle rect1, rect2;
+            Region rgn1, rgn2;
+            RectangleF bounds;
+
+            rect1 = new Rectangle(500, 30, 60, 80);
+            rect2 = new Rectangle(520, 40, 60, 80);
+            rgn1 = new Region(rect1);
+            rgn2 = new Region(rect2);
+            rgn1.Union(rgn2);
+
+            bounds = rgn1.GetBounds(dc);
+
+            Assert.Equal(500, bounds.X);
+            Assert.Equal(30, bounds.Y);
+            Assert.Equal(80, bounds.Width);
+            Assert.Equal(90, bounds.Height);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestCloneAndEquals()
+        {
+            Bitmap bmp = new Bitmap(600, 800);
+            Graphics dc = Graphics.FromImage(bmp);
+            Rectangle rect1, rect2;
+            Region rgn1, rgn2;
+            RectangleF[] rects;
+            RectangleF[] rects2;
+            Matrix matrix = new Matrix();
+
+            rect1 = new Rectangle(500, 30, 60, 80);
+            rect2 = new Rectangle(520, 40, 60, 80);
+            rgn1 = new Region(rect1);
+            rgn1.Union(rect2);
+            rgn2 = rgn1.Clone();
+
+            rects = rgn1.GetRegionScans(matrix);
+            rects2 = rgn2.GetRegionScans(matrix);
+
+            Assert.Equal(rects.Length, rects2.Length);
+
+            for (int i = 0; i < rects.Length; i++)
+            {
+
+                Assert.Equal(rects[i].X, rects[i].X);
+                Assert.Equal(rects[i].Y, rects[i].Y);
+                Assert.Equal(rects[i].Width, rects[i].Width);
+                Assert.Equal(rects[i].Height, rects[i].Height);
+            }
+
+            Assert.Equal(true, rgn1.Equals(rgn2, dc));
+        }
+
+        /*Tests infinite, empty, etc*/
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestInfiniteAndEmpty()
+        {
+            Bitmap bmp = new Bitmap(600, 800);
+            Graphics dc = Graphics.FromImage(bmp);
+            Rectangle rect1, rect2;
+            Region rgn1;
+            RectangleF[] rects;
+            Matrix matrix = new Matrix();
+
+            rect1 = new Rectangle(500, 30, 60, 80);
+            rect2 = new Rectangle(520, 40, 60, 80);
+            rgn1 = new Region(rect1);
+            rgn1.Union(rect2);
+
+            Assert.Equal(false, rgn1.IsEmpty(dc));
+            Assert.Equal(false, rgn1.IsInfinite(dc));
+
+            rgn1.MakeEmpty();
+            Assert.Equal(true, rgn1.IsEmpty(dc));
+
+            rgn1 = new Region(rect1);
+            rgn1.Union(rect2);
+            rgn1.MakeInfinite();
+            rects = rgn1.GetRegionScans(matrix);
+
+            Assert.Equal(1, rects.Length);
+            Assert.Equal(-4194304, rects[0].X);
+            Assert.Equal(-4194304, rects[0].Y);
+            Assert.Equal(8388608, rects[0].Width);
+            Assert.Equal(8388608, rects[0].Height);
+            Assert.Equal(true, rgn1.IsInfinite(dc));
+        }
+
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestUnionGroup1()
+        {
+            Bitmap bmp = new Bitmap(600, 800);
+            Graphics dc = Graphics.FromImage(bmp);
+            Matrix matrix = new Matrix();
+            Rectangle rect1, rect2, rect3, rect4;
+            Region rgn1, rgn2, rgn3, rgn4;
+            RectangleF[] rects;
+
+            rect1 = new Rectangle(500, 30, 60, 80);
+            rect2 = new Rectangle(520, 40, 60, 80);
+            rgn1 = new Region(rect1);
+            rgn2 = new Region(rect2);
+            rgn1.Union(rgn2);
+            rects = rgn1.GetRegionScans(matrix);
+
+            Assert.Equal(3, rects.Length);
+            Assert.Equal(500, rects[0].X);
+            Assert.Equal(30, rects[0].Y);
+            Assert.Equal(60, rects[0].Width);
+            Assert.Equal(10, rects[0].Height);
+
+            Assert.Equal(500, rects[1].X);
+            Assert.Equal(40, rects[1].Y);
+            Assert.Equal(80, rects[1].Width);
+            Assert.Equal(70, rects[1].Height);
+
+            Assert.Equal(520, rects[2].X);
+            Assert.Equal(110, rects[2].Y);
+            Assert.Equal(60, rects[2].Width);
+            Assert.Equal(10, rects[2].Height);
+
+            rect1 = new Rectangle(20, 180, 40, 50);
+            rect2 = new Rectangle(50, 190, 40, 50);
+            rect3 = new Rectangle(70, 210, 30, 50);
+            rgn1 = new Region(rect1);
+            rgn2 = new Region(rect2);
+            rgn3 = new Region(rect3);
+
+            rgn1.Union(rgn2);
+            rgn1.Union(rgn3);
+            rects = rgn1.GetRegionScans(matrix);
+            Assert.Equal(5, rects.Length);
+
+            Assert.Equal(20, rects[0].X);
+            Assert.Equal(180, rects[0].Y);
+            Assert.Equal(40, rects[0].Width);
+            Assert.Equal(10, rects[0].Height);
+
+            Assert.Equal(20, rects[1].X);
+            Assert.Equal(190, rects[1].Y);
+            Assert.Equal(70, rects[1].Width);
+            Assert.Equal(20, rects[1].Height);
+
+            Assert.Equal(20, rects[2].X);
+            Assert.Equal(210, rects[2].Y);
+            Assert.Equal(80, rects[2].Width);
+            Assert.Equal(20, rects[2].Height);
+
+            Assert.Equal(50, rects[3].X);
+            Assert.Equal(230, rects[3].Y);
+            Assert.Equal(50, rects[3].Width);
+            Assert.Equal(10, rects[3].Height);
+
+            Assert.Equal(70, rects[4].X);
+            Assert.Equal(240, rects[4].Y);
+            Assert.Equal(30, rects[4].Width);
+            Assert.Equal(20, rects[4].Height);
+
+            rect1 = new Rectangle(20, 330, 40, 50);
+            rect2 = new Rectangle(50, 340, 40, 50);
+            rect3 = new Rectangle(70, 360, 30, 50);
+            rect4 = new Rectangle(80, 400, 30, 10);
+            rgn1 = new Region(rect1);
+            rgn2 = new Region(rect2);
+            rgn3 = new Region(rect3);
+            rgn4 = new Region(rect4);
+
+            rgn1.Union(rgn2);
+            rgn1.Union(rgn3);
+            rgn1.Union(rgn4);
+
+            rects = rgn1.GetRegionScans(matrix);
+
+            Assert.Equal(6, rects.Length);
+
+            Assert.Equal(20, rects[0].X);
+            Assert.Equal(330, rects[0].Y);
+            Assert.Equal(40, rects[0].Width);
+            Assert.Equal(10, rects[0].Height);
+
+            Assert.Equal(20, rects[1].X);
+            Assert.Equal(340, rects[1].Y);
+            Assert.Equal(70, rects[1].Width);
+            Assert.Equal(20, rects[1].Height);
+
+            Assert.Equal(20, rects[2].X);
+            Assert.Equal(360, rects[2].Y);
+            Assert.Equal(80, rects[2].Width);
+            Assert.Equal(20, rects[2].Height);
+
+            Assert.Equal(50, rects[3].X);
+            Assert.Equal(380, rects[3].Y);
+            Assert.Equal(50, rects[3].Width);
+            Assert.Equal(10, rects[3].Height);
+
+            Assert.Equal(70, rects[4].X);
+            Assert.Equal(390, rects[4].Y);
+            Assert.Equal(30, rects[4].Width);
+            Assert.Equal(10, rects[4].Height);
+
+            Assert.Equal(70, rects[5].X);
+            Assert.Equal(400, rects[5].Y);
+            Assert.Equal(40, rects[5].Width);
+            Assert.Equal(10, rects[5].Height);
+
+            rect1 = new Rectangle(10, 20, 50, 50);
+            rect2 = new Rectangle(100, 100, 60, 60);
+            rect3 = new Rectangle(200, 200, 80, 80);
+
+            rgn1 = new Region(rect1);
+            rgn1.Union(rect2);
+            rgn1.Union(rect3);
+
+            rects = rgn1.GetRegionScans(matrix);
+
+            Assert.Equal(3, rects.Length);
+
+            Assert.Equal(10, rects[0].X);
+            Assert.Equal(20, rects[0].Y);
+            Assert.Equal(50, rects[0].Width);
+            Assert.Equal(50, rects[0].Height);
+
+            Assert.Equal(100, rects[1].X);
+            Assert.Equal(100, rects[1].Y);
+            Assert.Equal(60, rects[1].Width);
+            Assert.Equal(60, rects[1].Height);
+
+            Assert.Equal(200, rects[2].X);
+            Assert.Equal(200, rects[2].Y);
+            Assert.Equal(80, rects[2].Width);
+            Assert.Equal(80, rects[2].Height);
+        }
+
+        void AssertEqualRectangles(RectangleF rect1, RectangleF rect2, string text)
+        {
+            Assert.Equal(rect1.X, rect2.X);
+            Assert.Equal(rect1.Y, rect2.Y);
+            Assert.Equal(rect1.Width, rect2.Width);
+            Assert.Equal(rect1.Height, rect2.Height);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestUnionGroup2()
+        {
+            RectangleF[] rects;
+            Region r1 = new Region();
+            Rectangle rect2 = Rectangle.Empty;
+            Rectangle rect1 = Rectangle.Empty;
+            Rectangle rect3 = Rectangle.Empty;
+            Rectangle rect4 = Rectangle.Empty;
+
+            { // TEST1: Not intersecting rects. Union just adds them
+
+                rect1 = new Rectangle(20, 20, 20, 20);
+                rect2 = new Rectangle(20, 80, 20, 10);
+                rect3 = new Rectangle(60, 60, 30, 10);
+
+                r1 = new Region(rect1);
+                r1.Union(rect2);
+                r1.Union(rect3);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(3, rects.Length);
+                AssertEqualRectangles(new RectangleF(20, 20, 20, 20), rects[0], "TUG1Test2");
+                AssertEqualRectangles(new RectangleF(60, 60, 30, 10), rects[1], "TUG1Test3");
+                AssertEqualRectangles(new RectangleF(20, 80, 20, 10), rects[2], "TUG1Test4");
+            }
+
+            { // TEST2: Intersecting from the right
+              /*
+              *  -----------
+              *  |         |
+              *  |     |-------- |
+              *  |     |         |
+              *  |     |-------- |
+              *  |	      |
+              *  ----------|
+              *
+              */
+
+                rect1 = new Rectangle(10, 10, 100, 100);
+                rect2 = new Rectangle(40, 60, 100, 20);
+                r1 = new Region(rect1);
+                r1.Union(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(3, rects.Length);
+                AssertEqualRectangles(new RectangleF(10, 10, 100, 50), rects[0], "TUG2Test2");
+                AssertEqualRectangles(new RectangleF(10, 60, 130, 20), rects[1], "TUG2Test3");
+                AssertEqualRectangles(new RectangleF(10, 80, 100, 30), rects[2], "TUG2Test4");
+            }
+
+            { // TEST3: Intersecting from the right
+              /*
+              *  	-----------
+              *  	|         |
+              * |-------- |    |
+              * |         |    |
+              * |-------- |    |
+              *  	|	  |
+              *  	----------|
+              *
+              */
+
+                rect1 = new Rectangle(70, 10, 100, 100);
+                rect2 = new Rectangle(40, 60, 100, 20);
+
+                r1 = new Region(rect1);
+                r1.Union(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(3, rects.Length);
+                AssertEqualRectangles(new RectangleF(70, 10, 100, 50), rects[0], "TUG3Test2");
+                AssertEqualRectangles(new RectangleF(40, 60, 130, 20), rects[1], "TUG3Test3");
+                AssertEqualRectangles(new RectangleF(70, 80, 100, 30), rects[2], "TUG3Test4");
+            }
+
+            { // TEST4: Intersecting from the top
+              /*
+              *  	   -----
+              *  	   |   |
+              *  	-----------
+              *  	|  |   |  |
+              *  	|  -----  |
+              *  	|         |
+              *  	|	  |
+              *  	----------|
+              *
+              */
+
+                rect1 = new Rectangle(40, 100, 100, 100);
+                rect2 = new Rectangle(70, 80, 50, 40);
+                r1 = new Region(rect1);
+                r1.Union(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(2, rects.Length);
+                AssertEqualRectangles(new RectangleF(70, 80, 50, 20), rects[0], "TUG4Test2");
+                AssertEqualRectangles(new RectangleF(40, 100, 100, 100), rects[1], "TUG4Test3");
+            }
+
+            { // TEST5: Intersecting from the bottom
+              /*
+
+              *  	-----------
+              *  	|  	  |
+              *  	|  	  |
+              *  	|         |
+              *  	|  |   |  |
+              *  	|--|   |--|
+              *	   |   |
+              *  	   -----
+              */
+
+                rect1 = new Rectangle(40, 10, 100, 100);
+                rect2 = new Rectangle(70, 80, 50, 40);
+
+                r1 = new Region(rect1);
+                r1.Union(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(2, rects.Length);
+                AssertEqualRectangles(new RectangleF(40, 10, 100, 100), rects[0], "TUG5Test2");
+                AssertEqualRectangles(new RectangleF(70, 110, 50, 10), rects[1], "TUG5Test3");
+            }
+
+            { // TEST6: Multiple regions, two separted by zero pixels
+
+                rect1 = new Rectangle(30, 30, 80, 80);
+                rect2 = new Rectangle(45, 45, 200, 200);
+                rect3 = new Rectangle(160, 260, 10, 10);
+                rect4 = new Rectangle(170, 260, 10, 10);
+
+                r1 = new Region(rect1);
+                r1.Union(rect2);
+                r1.Union(rect3);
+                r1.Union(rect4);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(4, rects.Length);
+                AssertEqualRectangles(new RectangleF(30, 30, 80, 15), rects[0], "TUG6Test2");
+                AssertEqualRectangles(new RectangleF(30, 45, 215, 65), rects[1], "TUG6Test3");
+                AssertEqualRectangles(new RectangleF(45, 110, 200, 135), rects[2], "TUG6Test4");
+                AssertEqualRectangles(new RectangleF(160, 260, 20, 10), rects[3], "TUG6Test5");
+            }
+        }
+
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestComplementGroup1()
+        {
+            RectangleF[] rects;
+            Region r1 = new Region();
+            Region r2 = new Region();
+            Rectangle rect1 = Rectangle.Empty;
+            Rectangle rect2 = Rectangle.Empty;
+            Rectangle rect3 = Rectangle.Empty;
+            Rectangle rect4 = Rectangle.Empty;
+            Rectangle rect5 = Rectangle.Empty;
+            Rectangle rect6 = Rectangle.Empty;
+            Rectangle rect7 = Rectangle.Empty;
+
+
+            { // TEST1
+
+                rect1 = new Rectangle(20, 20, 20, 20);
+                rect2 = new Rectangle(20, 80, 20, 10);
+                rect3 = new Rectangle(60, 60, 30, 10);
+
+                r1 = new Region(rect1);
+                r2 = new Region(rect2);
+                r2.Union(rect3);
+                r1.Complement(r2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(2, rects.Length);
+                AssertEqualRectangles(new RectangleF(60, 60, 30, 10), rects[0], "TCG1Test2");
+                AssertEqualRectangles(new RectangleF(20, 80, 20, 10), rects[1], "TCG1Test3");
+            }
+
+
+            { // TEST2
+
+                rect1 = new Rectangle(10, 10, 100, 100);
+                rect2 = new Rectangle(40, 60, 100, 20);
+
+                r1 = new Region(rect1);
+                r1.Complement(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(1, rects.Length);
+                AssertEqualRectangles(new RectangleF(110, 60, 30, 20), rects[0], "TCG2Test2");
+            }
+
+            { // TEST3
+
+                rect1 = new Rectangle(70, 10, 100, 100);
+                rect2 = new Rectangle(40, 60, 100, 20);
+
+                r1 = new Region(rect1);
+                r1.Complement(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(1, rects.Length);
+                AssertEqualRectangles(new RectangleF(40, 60, 30, 20), rects[0], "TCG3Test2");
+            }
+
+            { // TEST4
+
+                rect1 = new Rectangle(40, 100, 100, 100);
+                rect2 = new Rectangle(70, 80, 50, 40);
+
+                r1 = new Region(rect1);
+                r1.Complement(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(1, rects.Length);
+                AssertEqualRectangles(new RectangleF(70, 80, 50, 20), rects[0], "TCG4Test2");
+            }
+
+            { // TEST5
+
+                rect1 = new Rectangle(40, 10, 100, 100);
+                rect2 = new Rectangle(70, 80, 50, 40);
+
+                r1 = new Region(rect1);
+                r1.Complement(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(1, rects.Length);
+                AssertEqualRectangles(new RectangleF(70, 110, 50, 10), rects[0], "TCG5Test2");
+            }
+
+            { // TEST6: Multiple regions
+
+                rect1 = new Rectangle(30, 30, 80, 80);
+                rect2 = new Rectangle(45, 45, 200, 200);
+                rect3 = new Rectangle(160, 260, 10, 10);
+                rect4 = new Rectangle(170, 260, 10, 10);
+
+                r1 = new Region(rect1);
+                r1.Complement(rect2);
+                r1.Complement(rect3);
+                r1.Complement(rect4);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(1, rects.Length);
+                AssertEqualRectangles(new RectangleF(170, 260, 10, 10), rects[0], "TCG6Test2");
+            }
+
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestComplementGroup2()
+        {
+
+            Bitmap bmp = new Bitmap(600, 800);
+            Graphics dc = Graphics.FromImage(bmp);
+            Matrix matrix = new Matrix();
+            Rectangle rect1, rect2;
+            Region rgn1, rgn2;
+            RectangleF[] rects;
+
+            rect1 = new Rectangle(20, 30, 60, 80);
+            rect2 = new Rectangle(50, 40, 60, 80);
+            rgn1 = new Region(rect1);
+            rgn2 = new Region(rect2);
+            dc.DrawRectangle(Pens.Green, rect1);
+            dc.DrawRectangle(Pens.Red, rect2);
+            rgn1.Complement(rgn2);
+            dc.FillRegion(Brushes.Blue, rgn1);
+            dc.DrawRectangles(Pens.Yellow, rgn1.GetRegionScans(matrix));
+
+            rects = rgn1.GetRegionScans(matrix);
+
+            Assert.Equal(2, rects.Length);
+
+            Assert.Equal(80, rects[0].X);
+            Assert.Equal(40, rects[0].Y);
+            Assert.Equal(30, rects[0].Width);
+            Assert.Equal(70, rects[0].Height);
+
+            Assert.Equal(50, rects[1].X);
+            Assert.Equal(110, rects[1].Y);
+            Assert.Equal(60, rects[1].Width);
+            Assert.Equal(10, rects[1].Height);
+
+        }
+
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestExcludeGroup1()
+        {
+            RectangleF[] rects;
+            Region r1 = new Region();
+            Region r2 = new Region();
+            Rectangle rect1 = Rectangle.Empty;
+            Rectangle rect2 = Rectangle.Empty;
+            Rectangle rect3 = Rectangle.Empty;
+            Rectangle rect4 = Rectangle.Empty;
+            Rectangle rect5 = Rectangle.Empty;
+            Rectangle rect6 = Rectangle.Empty;
+            Rectangle rect7 = Rectangle.Empty;
+
+
+            { // TEST1: Not intersecting rects. Exclude just adds them
+
+                rect1 = new Rectangle(20, 20, 20, 20);
+                rect2 = new Rectangle(20, 80, 20, 10);
+                rect3 = new Rectangle(60, 60, 30, 10);
+
+                r1 = new Region(rect1);
+                r2 = new Region(rect2);
+                r2.Union(rect3);
+                r1.Exclude(r2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(1, rects.Length);
+                AssertEqualRectangles(new RectangleF(20, 20, 20, 20), rects[0], "TEG1Test2");
+            }
+
+            { // TEST2: Excluding from the right
+              /*
+              *  -----------
+              *  |         |
+              *  |     |-------- |
+              *  |     |         |
+              *  |     |-------- |
+              *  |	      |
+              *  ----------|
+              *
+              */
+
+                rect1 = new Rectangle(10, 10, 100, 100);
+                rect2 = new Rectangle(40, 60, 100, 20);
+                r1 = new Region(rect1);
+                r1.Exclude(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(3, rects.Length);
+                AssertEqualRectangles(new RectangleF(10, 10, 100, 50), rects[0], "TEG2Test2");
+                AssertEqualRectangles(new RectangleF(10, 60, 30, 20), rects[1], "TEG2Test3");
+                AssertEqualRectangles(new RectangleF(10, 80, 100, 30), rects[2], "TEG2Test4");
+            }
+
+
+            { // TEST3: Intersecting from the right
+              /*
+              *  	-----------
+              *  	|         |
+              * |-------- |    |
+              * |         |    |
+              * |-------- |    |
+              *  	|	  |
+              *  	----------|
+              *
+              */
+
+                rect1 = new Rectangle(70, 10, 100, 100);
+                rect2 = new Rectangle(40, 60, 100, 20);
+
+                r1 = new Region(rect1);
+                r1.Exclude(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(3, rects.Length);
+                AssertEqualRectangles(new RectangleF(70, 10, 100, 50), rects[0], "TEG3Test2");
+                AssertEqualRectangles(new RectangleF(140, 60, 30, 20), rects[1], "TEG3Test3");
+                AssertEqualRectangles(new RectangleF(70, 80, 100, 30), rects[2], "TEG3Test4");
+            }
+
+
+            { // TEST4: Intersecting from the top
+              /*
+              *  	   -----
+              *  	   |   |
+              *  	-----------
+              *  	|  |   |  |
+              *  	|  -----  |
+              *  	|         |
+              *  	|	  |
+              *  	----------|
+              *
+              */
+
+                rect1 = new Rectangle(40, 100, 100, 100);
+                rect2 = new Rectangle(70, 80, 50, 40);
+
+                r1 = new Region(rect1);
+                r1.Exclude(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(3, rects.Length);
+                AssertEqualRectangles(new RectangleF(40, 100, 30, 20), rects[0], "TEG4Test2");
+                AssertEqualRectangles(new RectangleF(120, 100, 20, 20), rects[1], "TEG4Test3");
+                AssertEqualRectangles(new RectangleF(40, 120, 100, 80), rects[2], "TEG4Test4");
+            }
+
+
+            { // TEST5: Intersecting from the bottom
+              /*
+              *  	-----------
+              *  	|  	  |
+              *  	|         |
+              *  	|         |
+              *  	|  |   |  |
+              *  	|--|   |--|
+              *	   |   |
+              *  	   -----
+              *
+              */
+
+                rect1 = new Rectangle(40, 10, 100, 100);
+                rect2 = new Rectangle(70, 80, 50, 40);
+
+                r1 = new Region(rect1);
+                r1.Exclude(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(3, rects.Length);
+                AssertEqualRectangles(new RectangleF(40, 10, 100, 70), rects[0], "TEG5Test2");
+                AssertEqualRectangles(new RectangleF(40, 80, 30, 30), rects[1], "TEG5Test3");
+                AssertEqualRectangles(new RectangleF(120, 80, 20, 30), rects[2], "TEG5Test4");
+            }
+
+
+            { // TEST6: Multiple regions
+
+                rect1 = new Rectangle(30, 30, 80, 80);
+                rect2 = new Rectangle(45, 45, 200, 200);
+                rect3 = new Rectangle(160, 260, 10, 10);
+                rect4 = new Rectangle(170, 260, 10, 10);
+
+                r1 = new Region(rect1);
+                r1.Exclude(rect2);
+                r1.Exclude(rect3);
+                r1.Exclude(rect4);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(2, rects.Length);
+                AssertEqualRectangles(new RectangleF(30, 30, 80, 15), rects[0], "TEG6Test2");
+                AssertEqualRectangles(new RectangleF(30, 45, 15, 65), rects[1], "TEG6Test3");
+            }
+
+
+            { // TEST7: Intersecting from the top with a larger rect
+              /*
+              *    -----------------
+              *    |               |
+              *    |	-----------   |
+              *  	|  |   |  |
+              *  	|  -----  |
+              *  	|         |
+              *  	|	  |
+              *  	----------|
+              *
+              */
+
+                rect1 = new Rectangle(50, 100, 100, 100);
+                rect2 = new Rectangle(30, 70, 150, 40);
+
+                r1 = new Region(rect1);
+                r1.Exclude(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(1, rects.Length);
+                AssertEqualRectangles(new RectangleF(50, 110, 100, 90), rects[0], "TEG7Test2");
+            }
+
+            { // TEST8: Intersecting from the right with a larger rect
+              /*
+              *
+              * |--------|
+              * |	    |
+              * |	-----------
+              * | 	|         |
+              * |	|	  |
+              * |    |	  |
+              * |    |         |
+              * | 	|	  |
+              * | 	----------|
+              * |-------|
+              */
+
+                rect1 = new Rectangle(70, 60, 100, 70);
+                rect2 = new Rectangle(40, 10, 100, 150);
+
+                r1 = new Region(rect1);
+                r1.Exclude(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(1, rects.Length);
+                AssertEqualRectangles(new RectangleF(140, 60, 30, 70), rects[0], "TEG8Test2");
+
+            }
+
+            { // TEST9: Intersecting from the left with a larger rect
+              /*
+              *
+              * 		|--------|
+              * 		|	 |
+              * 	-----------      |
+              *  	|         |      |
+              * 	|	  |      |
+              *      |	  |	 |
+              *      |         |	 |
+              *  	|	  |	 |
+              *  	----------|      |
+              * 		|--------|
+              *
+              */
+
+
+                rect1 = new Rectangle(70, 60, 100, 70);
+                rect2 = new Rectangle(100, 10, 100, 150);
+
+                r1 = new Region(rect1);
+                r1.Exclude(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(1, rects.Length);
+                AssertEqualRectangles(new RectangleF(70, 60, 30, 70), rects[0], "TEG9Test2");
+            }
+
+
+            { // TEST10: Intersecting from the bottom with a larger rect
+              /*
+              * *
+              * 		|--------|
+              * 		|	 |
+              * 		|	 |
+              * 		|	 |
+              * 	  --------------------
+              *  	  |        	     |
+              * 	  |  		     |
+              *  	  |------------------|
+              */
+
+
+                rect1 = new Rectangle(20, 20, 100, 100);
+                rect2 = new Rectangle(10, 80, 140, 150);
+
+                r1 = new Region(rect1);
+                r1.Exclude(rect2);
+
+                rects = r1.GetRegionScans(new Matrix());
+                Assert.Equal(1, rects.Length);
+                AssertEqualRectangles(new RectangleF(20, 20, 100, 60), rects[0], "TEG10Test2");
+            }
+
+
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestExcludeGroup2()
+        {
+            Bitmap bmp = new Bitmap(600, 800);
+            Graphics dc = Graphics.FromImage(bmp);
+            Matrix matrix = new Matrix();
+            Rectangle rect1, rect2;
+            Region rgn1;
+            RectangleF[] rects;
+
+            rect1 = new Rectangle(130, 30, 60, 80);
+            rect2 = new Rectangle(170, 40, 60, 80);
+            rgn1 = new Region(rect1);
+            rgn1.Exclude(rect2);
+            rects = rgn1.GetRegionScans(matrix);
+
+            Assert.Equal(2, rects.Length);
+
+            Assert.Equal(130, rects[0].X);
+            Assert.Equal(30, rects[0].Y);
+            Assert.Equal(60, rects[0].Width);
+            Assert.Equal(10, rects[0].Height);
+
+            Assert.Equal(130, rects[1].X);
+            Assert.Equal(40, rects[1].Y);
+            Assert.Equal(40, rects[1].Width);
+            Assert.Equal(70, rects[1].Height);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ExcludeBug402613()
+        {
+            Region r = new Region();
+            r.MakeInfinite();
+            r.Exclude(new Rectangle(387, 292, 189, 133));
+            r.Exclude(new Rectangle(387, 66, 189, 133));
+            Assert.True(r.IsVisible(new Rectangle(66, 292, 189, 133)));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestIntersect()
+        {
+
+
+            Bitmap bmp = new Bitmap(600, 800);
+            Graphics dc = Graphics.FromImage(bmp);
+            Matrix matrix = new Matrix();
+            RectangleF[] rects;
+            RectangleF rect3, rect4;
+            Region rgn3, rgn4;
+
+            /* Two simple areas */
+            Rectangle rect1 = new Rectangle(260, 30, 60, 80);
+            Rectangle rect2 = new Rectangle(290, 40, 60, 80);
+            Region rgn1 = new Region(rect1);
+            Region rgn2 = new Region(rect2);
+            rgn1.Intersect(rgn2);
+
+            rects = rgn1.GetRegionScans(matrix);
+            Assert.Equal(1, rects.Length);
+
+            Assert.Equal(290, rects[0].X);
+            Assert.Equal(40, rects[0].Y);
+            Assert.Equal(30, rects[0].Width);
+            Assert.Equal(70, rects[0].Height);
+
+            /* No intersect */
+            rect1 = new Rectangle(20, 330, 40, 50);
+            rect2 = new Rectangle(50, 340, 40, 50);
+            rect3 = new Rectangle(70, 360, 30, 50);
+            rect4 = new Rectangle(80, 400, 30, 10);
+            rgn1 = new Region(rect1);
+            rgn2 = new Region(rect2);
+            rgn3 = new Region(rect3);
+            rgn4 = new Region(rect4);
+
+            rgn1.Intersect(rgn2);
+            rgn1.Intersect(rgn3);
+            rgn1.Intersect(rgn4);
+            rects = rgn1.GetRegionScans(matrix);
+            Assert.Equal(0, rects.Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestXor()
+        {
+            Bitmap bmp = new Bitmap(600, 800);
+            Graphics dc = Graphics.FromImage(bmp);
+            Matrix matrix = new Matrix();
+            RectangleF[] rects;
+
+            Rectangle rect1 = new Rectangle(380, 30, 60, 80);
+            Rectangle rect2 = new Rectangle(410, 40, 60, 80);
+            Region rgn1 = new Region(rect1);
+            Region rgn2 = new Region(rect2);
+            rgn1.Xor(rgn2);
+
+
+            rects = rgn1.GetRegionScans(matrix);
+
+            Assert.Equal(4, rects.Length);
+
+            Assert.Equal(380, rects[0].X);
+            Assert.Equal(30, rects[0].Y);
+            Assert.Equal(60, rects[0].Width);
+            Assert.Equal(10, rects[0].Height);
+
+            Assert.Equal(380, rects[1].X);
+            Assert.Equal(40, rects[1].Y);
+            Assert.Equal(30, rects[1].Width);
+            Assert.Equal(70, rects[1].Height);
+
+            Assert.Equal(440, rects[2].X);
+            Assert.Equal(40, rects[2].Y);
+            Assert.Equal(30, rects[2].Width);
+            Assert.Equal(70, rects[2].Height);
+
+            Assert.Equal(410, rects[3].X);
+            Assert.Equal(110, rects[3].Y);
+            Assert.Equal(60, rects[3].Width);
+            Assert.Equal(10, rects[3].Height);
+        }
+
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestIsVisible()
+        {
+            Bitmap bmp = new Bitmap(600, 800);
+            Graphics dc = Graphics.FromImage(bmp);
+            Rectangle rect1, rect2;
+            Region rgn1, rgn2;
+            Matrix matrix = new Matrix();
+
+            rect1 = new Rectangle(500, 30, 60, 80);
+            rect2 = new Rectangle(520, 40, 60, 80);
+
+            rgn1 = new Region(new RectangleF(0, 0, 10, 10));
+            Assert.Equal(false, rgn1.IsVisible(0, 0, 0, 1));
+
+            rgn1 = new Region(rect1);
+            Assert.Equal(false, rgn1.IsVisible(500, 29));
+            Assert.Equal(true, rgn1.IsVisible(500, 30));
+            Assert.Equal(true, rgn1.IsVisible(rect1));
+            Assert.Equal(true, rgn1.IsVisible(rect2));
+            Assert.Equal(false, rgn1.IsVisible(new Rectangle(50, 50, 2, 5)));
+
+            Rectangle r = new Rectangle(1, 1, 2, 1);
+            rgn2 = new Region(r);
+            Assert.Equal(true, rgn2.IsVisible(r));
+            Assert.Equal(true, rgn2.IsVisible(new Rectangle(1, 1, 2, 2)));
+            Assert.Equal(true, rgn2.IsVisible(new Rectangle(1, 1, 10, 10)));
+            Assert.Equal(true, rgn2.IsVisible(new Rectangle(1, 1, 1, 1)));
+            Assert.Equal(false, rgn2.IsVisible(new Rectangle(2, 2, 1, 1)));
+            Assert.Equal(false, rgn2.IsVisible(new Rectangle(0, 0, 1, 1)));
+            Assert.Equal(false, rgn2.IsVisible(new Rectangle(3, 3, 1, 1)));
+
+            Assert.Equal(false, rgn2.IsVisible(0, 0));
+            Assert.Equal(false, rgn2.IsVisible(1, 0));
+            Assert.Equal(false, rgn2.IsVisible(2, 0));
+            Assert.Equal(false, rgn2.IsVisible(3, 0));
+            Assert.Equal(false, rgn2.IsVisible(0, 1));
+            Assert.Equal(true, rgn2.IsVisible(1, 1));
+            Assert.Equal(true, rgn2.IsVisible(2, 1));
+            Assert.Equal(false, rgn2.IsVisible(3, 1));
+            Assert.Equal(false, rgn2.IsVisible(0, 2));
+            Assert.Equal(false, rgn2.IsVisible(1, 2));
+            Assert.Equal(false, rgn2.IsVisible(2, 2));
+            Assert.Equal(false, rgn2.IsVisible(3, 2));
+
+
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestTranslate()
+        {
+            Region rgn1 = new Region(new RectangleF(10, 10, 120, 120));
+            rgn1.Translate(30, 20);
+            Matrix matrix = new Matrix();
+
+            RectangleF[] rects = rgn1.GetRegionScans(matrix);
+
+            Assert.Equal(1, rects.Length);
+
+            Assert.Equal(40, rects[0].X);
+            Assert.Equal(30, rects[0].Y);
+            Assert.Equal(120, rects[0].Width);
+            Assert.Equal(120, rects[0].Height);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_GraphicsPath_Null()
+        {
+            GraphicsPath gp = null;
+            Assert.Throws<ArgumentNullException>(() => new Region(gp));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Constructor_RegionData_Null()
+        {
+            RegionData rd = null;
+            Assert.Throws<ArgumentNullException>(() => new Region(rd));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Union_GraphicsPath_Null()
+        {
+            GraphicsPath gp = null;
+            Assert.Throws<ArgumentNullException>(() => new Region().Union(gp));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Union_Region_Null()
+        {
+            Region r = null;
+            Assert.Throws<ArgumentNullException>(() => new Region().Union(r));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Union_Region_Infinite()
+        {
+            // default ctor creates an infinite region
+            Region r = new Region();
+            CheckEmpty("default .ctor", r);
+            // union-ing to infinity doesn't change the results
+            r.Union(new Rectangle(10, 10, 100, 100));
+            CheckEmpty("U infinity", r);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Intersect_GraphicsPath_Null()
+        {
+            GraphicsPath gp = null;
+            Assert.Throws<ArgumentNullException>(() => new Region().Intersect(gp));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Intersect_Region_Null()
+        {
+            Region r = null;
+            Assert.Throws<ArgumentNullException>(() => new Region().Intersect(r));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Complement_GraphicsPath_Null()
+        {
+            GraphicsPath gp = null;
+            Assert.Throws<ArgumentNullException>(() => new Region().Complement(gp));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Complement_Region_Null()
+        {
+            Region r = null;
+            Assert.Throws<ArgumentNullException>(() => new Region().Complement(r));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Exclude_GraphicsPath_Null()
+        {
+            GraphicsPath gp = null;
+            Assert.Throws<ArgumentNullException>(() => new Region().Exclude(gp));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Exclude_Region_Null()
+        {
+            Region r = null;
+            Assert.Throws<ArgumentNullException>(() => new Region().Exclude(r));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Xor_GraphicsPath_Null()
+        {
+            GraphicsPath gp = null;
+            Assert.Throws<ArgumentNullException>(() => new Region().Xor(gp));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Xor_Region_Null()
+        {
+            Region r = null;
+            Assert.Throws<ArgumentNullException>(() => new Region().Xor(r));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetBounds_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Region().GetBounds(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_IntIntNull()
+        {
+            Assert.True(new Region().IsVisible(0, 0, null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_IntIntIntIntNull()
+        {
+            Assert.False(new Region().IsVisible(0, 0, 0, 0, null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_PointNull()
+        {
+            Point p = new Point();
+            Assert.True(new Region().IsVisible(p, null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_PointFNull()
+        {
+            PointF p = new PointF();
+            Assert.True(new Region().IsVisible(p, null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_RectangleNull()
+        {
+            Rectangle r = new Rectangle();
+            Assert.False(new Region().IsVisible(r, null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_RectangleFNull()
+        {
+            RectangleF r = new RectangleF();
+            Assert.False(new Region().IsVisible(r, null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_SingleSingleNull()
+        {
+            Assert.True(new Region().IsVisible(0f, 0f, null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsVisible_SingleSingleSingleSingleNull()
+        {
+            Assert.False(new Region().IsVisible(0f, 0f, 0f, 0f, null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsEmpty_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Region().IsEmpty(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void IsInfinite_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Region().IsInfinite(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Equals_NullGraphics()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Region().Equals(null, Graphics.FromImage(new Bitmap(10, 10))));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Equals_RegionNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Region().Equals(new Region(), null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetRegionScans_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Region().GetRegionScans(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Region().Transform(null));
+        }
+
+        // an "empty ctor" Region is infinite
+        private void CheckEmpty(string prefix, Region region)
+        {
+            Assert.False(region.IsEmpty(graphic));
+            Assert.True(region.IsInfinite(graphic));
+
+            RectangleF rect = region.GetBounds(graphic);
+            Assert.Equal(-4194304f, rect.X);
+            Assert.Equal(-4194304f, rect.Y);
+            Assert.Equal(8388608f, rect.Width);
+            Assert.Equal(8388608f, rect.Height);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Region_Empty()
+        {
+            Region region = new Region();
+            CheckEmpty("Empty.", region);
+
+            Region clone = region.Clone();
+            CheckEmpty("Clone.", region);
+
+            RegionData data = region.GetRegionData();
+            Region r2 = new Region(data);
+            CheckEmpty("RegionData.", region);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Rectangle_GetRegionScans()
+        {
+            Matrix matrix = new Matrix();
+            GraphicsPath gp = new GraphicsPath();
+            gp.AddRectangle(new Rectangle(10, 10, 10, 10));
+            Region region = new Region(gp);
+            Assert.Equal(1, region.GetRegionScans(matrix).Length);
+
+            gp.AddRectangle(new Rectangle(20, 20, 20, 20));
+            region = new Region(gp);
+            Assert.Equal(2, region.GetRegionScans(matrix).Length);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InfinityExclude()
+        {
+            using (Region r = new Region())
+            {
+                Assert.True(r.IsInfinite(graphic));
+                r.Exclude(new Rectangle(5, 5, 10, 10));
+                Assert.False(r.IsInfinite(graphic));
+                RectangleF bounds = r.GetBounds(graphic);
+                Assert.Equal(-4194304, bounds.X);
+                Assert.Equal(-4194304, bounds.Y);
+                Assert.Equal(8388608, bounds.Width);
+                Assert.Equal(8388608, bounds.Height);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InfinityIntersect()
+        {
+            using (Region r = new Region())
+            {
+                Assert.True(r.IsInfinite(graphic));
+                r.Intersect(new Rectangle(-10, -10, 20, 20));
+                Assert.False(r.IsInfinite(graphic));
+                RectangleF bounds = r.GetBounds(graphic);
+                Assert.Equal(-10, bounds.X);
+                Assert.Equal(-10, bounds.Y);
+                Assert.Equal(20, bounds.Width);
+                Assert.Equal(20, bounds.Height);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InfinityIntersectTranslate()
+        {
+            using (Region r = new Region())
+            {
+                Assert.True(r.IsInfinite(graphic));
+                r.Intersect(new Rectangle(-10, -10, 20, 20));
+                r.Translate(10, 10);
+                RectangleF bounds = r.GetBounds(graphic);
+                Assert.Equal(0, bounds.X);
+                Assert.Equal(0, bounds.Y);
+                Assert.Equal(20, bounds.Width);
+                Assert.Equal(20, bounds.Height);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InfinityIntersectScale()
+        {
+            using (Region r = new Region())
+            {
+                Assert.True(r.IsInfinite(graphic));
+                r.Intersect(new Rectangle(-10, -10, 20, 20));
+                using (Matrix m = new Matrix())
+                {
+                    m.Scale(2, 0.5f);
+                    r.Transform(m);
+                }
+                RectangleF bounds = r.GetBounds(graphic);
+                Assert.Equal(-20, bounds.X);
+                Assert.Equal(-5, bounds.Y);
+                Assert.Equal(40, bounds.Width);
+                Assert.Equal(10, bounds.Height);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InfinityIntersectTransform()
+        {
+            using (Region r = new Region())
+            {
+                Assert.True(r.IsInfinite(graphic));
+                r.Intersect(new Rectangle(-10, -10, 20, 20));
+                using (Matrix m = new Matrix(2, 0, 0, 0.5f, 10, 10))
+                {
+                    r.Transform(m);
+                }
+                RectangleF bounds = r.GetBounds(graphic);
+                Assert.Equal(-10, bounds.X);
+                Assert.Equal(5, bounds.Y);
+                Assert.Equal(40, bounds.Width);
+                Assert.Equal(10, bounds.Height);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InfinityTranslate()
+        {
+            using (Region r = new Region())
+            {
+                Assert.True(r.IsInfinite(graphic));
+                r.Translate(10, 10);
+                Assert.True(r.IsInfinite(graphic));
+                CheckEmpty("InfinityTranslate", r);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InfinityScaleUp()
+        {
+            using (Region r = new Region())
+            {
+                Assert.True(r.IsInfinite(graphic));
+                using (Matrix m = new Matrix())
+                {
+                    m.Scale(2, 2);
+                    r.Transform(m);
+                }
+                Assert.True(r.IsInfinite(graphic));
+                CheckEmpty("InfinityScaleUp", r);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InfinityScaleDown()
+        {
+            using (Region r = new Region())
+            {
+                Assert.True(r.IsInfinite(graphic));
+                using (Matrix m = new Matrix())
+                {
+                    m.Scale(0.5f, 0.5f);
+                    r.Transform(m);
+                }
+                Assert.True(r.IsInfinite(graphic));
+                CheckEmpty("InfinityScaleDown", r);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void InfinityRotate()
+        {
+            using (Region r = new Region())
+            {
+                Assert.True(r.IsInfinite(graphic));
+                using (Matrix m = new Matrix())
+                {
+                    m.Rotate(45);
+                    r.Transform(m);
+                }
+                Assert.True(r.IsInfinite(graphic));
+                CheckEmpty("InfinityRotate", r);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Intersect_383878()
+        {
+            using (Region clipRegion = new Region())
+            {
+                clipRegion.MakeInfinite();
+
+                Rectangle smaller = new Rectangle(5, 5, -10, -10);
+
+                clipRegion.Intersect(smaller);
+                Assert.False(clipRegion.IsEmpty(graphic));
+                Assert.False(clipRegion.IsInfinite(graphic));
+
+                RectangleF[] rects = clipRegion.GetRegionScans(new Matrix());
+                Assert.Equal(1, rects.Length);
+                Assert.Equal(new RectangleF(-5, -5, 10, 10), rects[0]);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Complement_383878()
+        {
+            using (Region clipRegion = new Region())
+            {
+                clipRegion.MakeInfinite();
+
+                Rectangle smaller = new Rectangle(5, 5, -10, -10);
+                Rectangle bigger = new Rectangle(-5, -5, 12, 12);
+
+                clipRegion.Intersect(smaller);
+                clipRegion.Complement(bigger);
+
+                Assert.False(clipRegion.IsEmpty(graphic));
+                Assert.False(clipRegion.IsInfinite(graphic));
+
+                RectangleF[] rects = clipRegion.GetRegionScans(new Matrix());
+                Assert.Equal(2, rects.Length);
+                Assert.Equal(new RectangleF(5, -5, 2, 10), rects[0]);
+                Assert.Equal(new RectangleF(-5, 5, 12, 2), rects[1]);
+            }
+        }
+    }
+
+    // the test cases in this fixture aren't restricted wrt running unmanaged code
+    public class RegionTestUnmanaged
+    {
+        private Bitmap bitmap;
+        private Graphics graphic;
+
+        public RegionTestUnmanaged()
+        {
+            bitmap = new Bitmap(10, 10);
+            graphic = Graphics.FromImage(bitmap);
+        }
+
+        // Note: Test cases calling GetHrng will leak memory unless ReleaseHrgn
+        // (which only exists in 2.0) is called.
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetHrgn_Infinite_MakeEmpty()
+        {
+            Region r = new Region();
+            Assert.False(r.IsEmpty(graphic));
+            Assert.True(r.IsInfinite(graphic));
+            Assert.Equal(IntPtr.Zero, r.GetHrgn(graphic));
+
+            r.MakeEmpty();
+            Assert.True(r.IsEmpty(graphic));
+            Assert.False(r.IsInfinite(graphic));
+            IntPtr h = r.GetHrgn(graphic);
+            Assert.False(h == IntPtr.Zero);
+            r.ReleaseHrgn(h);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetHrgn_Empty_MakeInfinite()
+        {
+            Region r = new Region(new GraphicsPath());
+            Assert.True(r.IsEmpty(graphic));
+            Assert.False(r.IsInfinite(graphic));
+            IntPtr h = r.GetHrgn(graphic);
+            Assert.False(h == IntPtr.Zero);
+
+            r.MakeInfinite();
+            Assert.False(r.IsEmpty(graphic));
+            Assert.True(r.IsInfinite(graphic));
+            Assert.Equal(IntPtr.Zero, r.GetHrgn(graphic));
+            r.ReleaseHrgn(h);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetHrgn_TwiceFromSameRegionInstance()
+        {
+            Region r = new Region(new GraphicsPath());
+            IntPtr h1 = r.GetHrgn(graphic);
+            IntPtr h2 = r.GetHrgn(graphic);
+            Assert.False(h1 == h2);
+            r.ReleaseHrgn(h1);
+            r.ReleaseHrgn(h2);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GetHrgn_FromHrgn()
+        {
+            Region r1 = new Region(new GraphicsPath());
+            IntPtr h1 = r1.GetHrgn(graphic);
+            Assert.False(h1 == IntPtr.Zero);
+
+            Region r2 = Region.FromHrgn(h1);
+            IntPtr h2 = r2.GetHrgn(graphic);
+            Assert.False(h2 == IntPtr.Zero);
+            Assert.False(h1 == h2);
+            r1.ReleaseHrgn(h1);
+            r2.ReleaseHrgn(h2);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void FromHrgn_Zero()
+        {
+            Assert.Throws<ArgumentException>(() => Region.FromHrgn(IntPtr.Zero));
+        }
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ReleaseHrng_Zero()
+        {
+            Region r = new Region(new GraphicsPath());
+            Assert.Throws<ArgumentNullException>(() => r.ReleaseHrgn(IntPtr.Zero));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ReleaseHrng()
+        {
+            Region r = new Region(new GraphicsPath());
+            IntPtr ptr = r.GetHrgn(graphic);
+            Assert.False(IntPtr.Zero == ptr);
+            r.ReleaseHrgn(ptr);
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/TestStringFormat.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/TestStringFormat.cs
@@ -1,0 +1,387 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// StringFormat class testing unit
+//
+// Authors:
+// 	 Jordi Mas i Hernàndez (jordi@ximian.com)
+//	 Sebastien Pouliot  <sebastien@ximian.com>
+//
+// (C) 2004 Ximian, Inc.  http://www.ximian.com
+// Copyright (C) 2004-2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Text;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+    public class StringFormatTest
+    {
+
+        private void CheckDefaults(StringFormat sf)
+        {
+            Assert.Equal(StringAlignment.Near, sf.Alignment);
+            Assert.Equal(0, sf.DigitSubstitutionLanguage);
+            Assert.Equal(StringDigitSubstitute.User, sf.DigitSubstitutionMethod);
+            Assert.Equal((StringFormatFlags)0, sf.FormatFlags);
+            Assert.Equal(HotkeyPrefix.None, sf.HotkeyPrefix);
+            Assert.Equal(StringAlignment.Near, sf.LineAlignment);
+            Assert.Equal(StringTrimming.Character, sf.Trimming);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Default()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                CheckDefaults(sf);
+                Assert.Equal("[StringFormat, FormatFlags=0]", sf.ToString());
+                // check setters validations
+                sf.FormatFlags = (StringFormatFlags)Int32.MinValue;
+                Assert.Equal((StringFormatFlags)Int32.MinValue, sf.FormatFlags);
+                Assert.Equal("[StringFormat, FormatFlags=-2147483648]", sf.ToString());
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Default_Dispose()
+        {
+            StringFormat sf = new StringFormat();
+            sf.Dispose();
+            Assert.Throws<ArgumentException>(() => sf.ToString());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ctor_StringFormat_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new StringFormat(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ctor_StringFormat()
+        {
+            using (StringFormat sf = new StringFormat(StringFormat.GenericTypographic))
+            {
+                CheckTypographic(sf);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ctor_StringFormatFlags()
+        {
+            using (StringFormat sf = new StringFormat((StringFormatFlags)Int32.MinValue))
+            {
+                Assert.Equal((StringFormatFlags)Int32.MinValue, sf.FormatFlags);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ctor_StringFormatFlags_Int32()
+        {
+            using (StringFormat sf = new StringFormat((StringFormatFlags)Int32.MinValue, Int32.MinValue))
+            {
+                Assert.Equal(0, sf.DigitSubstitutionLanguage);
+                Assert.Equal((StringFormatFlags)Int32.MinValue, sf.FormatFlags);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GenericDefault()
+        {
+            CheckDefaults(StringFormat.GenericDefault);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GenericDefault_Dispose()
+        {
+            StringFormat.GenericDefault.Dispose();
+            CheckDefaults(StringFormat.GenericDefault);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GenericDefault_Local_Dispose()
+        {
+            StringFormat sf = StringFormat.GenericDefault;
+            sf.Dispose(); // can't be cached
+            Assert.Throws<ArgumentException>(() => CheckDefaults(sf));
+        }
+
+        private void CheckTypographic(StringFormat sf)
+        {
+            Assert.Equal(StringAlignment.Near, sf.Alignment);
+            Assert.Equal(0, sf.DigitSubstitutionLanguage);
+            Assert.Equal(StringDigitSubstitute.User, sf.DigitSubstitutionMethod);
+            Assert.Equal(StringFormatFlags.FitBlackBox | StringFormatFlags.LineLimit | StringFormatFlags.NoClip, sf.FormatFlags);
+            Assert.Equal(HotkeyPrefix.None, sf.HotkeyPrefix);
+            Assert.Equal(StringAlignment.Near, sf.LineAlignment);
+            Assert.Equal(StringTrimming.None, sf.Trimming);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GenericTypographic()
+        {
+            StringFormat sf = StringFormat.GenericTypographic;
+            CheckTypographic(sf);
+            Assert.Equal("[StringFormat, FormatFlags=FitBlackBox, LineLimit, NoClip]", sf.ToString());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GenericTypographic_Dispose()
+        {
+            StringFormat.GenericTypographic.Dispose();
+            CheckTypographic(StringFormat.GenericTypographic);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void GenericTypographic_Local_Dispose()
+        {
+            StringFormat sf = StringFormat.GenericTypographic;
+            sf.Dispose(); // can't be cached
+            Assert.Throws<ArgumentException>(() => CheckTypographic(sf));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Alignment_All()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                foreach (StringAlignment sa in Enum.GetValues(typeof(StringAlignment)))
+                {
+                    sf.Alignment = sa;
+                    Assert.Equal(sa, sf.Alignment);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void Alignment_Invalid()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                Assert.Throws<InvalidEnumArgumentException>(() => sf.Alignment = (StringAlignment)Int32.MinValue);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void HotkeyPrefix_All()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                foreach (HotkeyPrefix hp in Enum.GetValues(typeof(HotkeyPrefix)))
+                {
+                    sf.HotkeyPrefix = hp;
+                    Assert.Equal(hp, sf.HotkeyPrefix);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void HotkeyPrefix_Invalid()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                Assert.Throws<InvalidEnumArgumentException>(() => sf.HotkeyPrefix = (HotkeyPrefix)Int32.MinValue);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void LineAlignment_All()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                foreach (StringAlignment sa in Enum.GetValues(typeof(StringAlignment)))
+                {
+                    sf.LineAlignment = sa;
+                    Assert.Equal(sa, sf.LineAlignment);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void LineAlignment_Invalid()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                Assert.Throws<InvalidEnumArgumentException>(() => sf.LineAlignment = (StringAlignment)Int32.MinValue);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Trimming_All()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                foreach (StringTrimming st in Enum.GetValues(typeof(StringTrimming)))
+                {
+                    sf.Trimming = st;
+                    Assert.Equal(st, sf.Trimming);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void Trimming_Invalid()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                Assert.Throws<InvalidEnumArgumentException>(() => sf.Trimming = (StringTrimming)Int32.MinValue);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Clone()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                using (StringFormat clone = (StringFormat)sf.Clone())
+                {
+                    CheckDefaults(clone);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Clone_Complex()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                CharacterRange[] ranges = new CharacterRange[2];
+                ranges[0].First = 1;
+                ranges[0].Length = 2;
+                ranges[1].First = 3;
+                ranges[1].Length = 4;
+                sf.SetMeasurableCharacterRanges(ranges);
+
+                float[] stops = new float[2];
+                stops[0] = 6.0f;
+                stops[1] = 7.0f;
+                sf.SetTabStops(5.0f, stops);
+
+                using (StringFormat clone = (StringFormat)sf.Clone())
+                {
+                    CheckDefaults(clone);
+
+                    float first;
+                    float[] cloned_stops = clone.GetTabStops(out first);
+                    Assert.Equal(5.0f, first);
+                    Assert.Equal(6.0f, cloned_stops[0]);
+                    Assert.Equal(7.0f, cloned_stops[1]);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestFormatFlags()
+        {
+            using (StringFormat smf = new StringFormat())
+            {
+                smf.FormatFlags = StringFormatFlags.DisplayFormatControl;
+                Assert.Equal(StringFormatFlags.DisplayFormatControl, smf.FormatFlags);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TabsStops()
+        {
+            using (StringFormat smf = new StringFormat())
+            {
+                float firstTabOffset;
+                float[] tabsSrc = { 100, 200, 300, 400 };
+                float[] tabStops;
+
+                smf.SetTabStops(200, tabsSrc);
+                tabStops = smf.GetTabStops(out firstTabOffset);
+
+                Assert.Equal(200, firstTabOffset);
+                Assert.Equal(tabsSrc.Length, tabStops.Length);
+                Assert.Equal(tabsSrc[0], tabStops[0]);
+                Assert.Equal(tabsSrc[1], tabStops[1]);
+                Assert.Equal(tabsSrc[2], tabStops[2]);
+                Assert.Equal(tabsSrc[3], tabStops[3]);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetTabStops_Null()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                Assert.Throws<NullReferenceException>(() => sf.SetTabStops(Single.NaN, null));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetDigitSubstitution()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                sf.SetDigitSubstitution(Int32.MinValue, (StringDigitSubstitute)Int32.MinValue);
+                Assert.Equal(0, sf.DigitSubstitutionLanguage);
+                Assert.Equal((StringDigitSubstitute)Int32.MinValue, sf.DigitSubstitutionMethod);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetMeasurableCharacterRanges_Null()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                Assert.Throws<NullReferenceException>(() => sf.SetMeasurableCharacterRanges(null));
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetMeasurableCharacterRanges_Empty()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                CharacterRange[] range = new CharacterRange[0];
+                sf.SetMeasurableCharacterRanges(range);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetMeasurableCharacterRanges_Max()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                CharacterRange[] range = new CharacterRange[32];
+                sf.SetMeasurableCharacterRanges(range);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void SetMeasurableCharacterRanges_TooBig()
+        {
+            using (StringFormat sf = new StringFormat())
+            {
+                CharacterRange[] range = new CharacterRange[33];
+                Assert.Throws<OverflowException>(() => sf.SetMeasurableCharacterRanges(range));
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/TestSystemBrushes.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/TestSystemBrushes.cs
@@ -1,0 +1,913 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+// Tests for System.Drawing.SystemBrushes.cs
+//
+// Author: Ravindra (rkumar@novell.com)
+//
+
+//
+// Copyright (C) 2004 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using Xunit;
+using System;
+using System.Drawing;
+using System.Security.Permissions;
+
+namespace MonoTests.System.Drawing
+{
+    public class SystemBrushesTest
+    {
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestActiveBorder()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.ActiveBorder;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.ActiveBorder, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.ActiveBorder;
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestActiveCaption()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.ActiveCaption;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.ActiveCaption, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.ActiveCaption;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestActiveCaptionText()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.ActiveCaptionText;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.ActiveCaptionText, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.ActiveCaptionText;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestAppWorkspace()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.AppWorkspace;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.AppWorkspace, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.AppWorkspace;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControl()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.Control;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.Control, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.Control;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControlDark()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.ControlDark;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.ControlDark, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.ControlDark;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControlDarkDark()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.ControlDarkDark;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.ControlDarkDark, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.ControlDarkDark;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControlLight()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.ControlLight;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.ControlLight, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.ControlLight;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControlLightLight()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.ControlLightLight;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.ControlLightLight, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.ControlLightLight;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControlText()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.ControlText;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.ControlText, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.ControlText;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestDesktop()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.Desktop;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.Desktop, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.Desktop;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestHighlight()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.Highlight;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.Highlight, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.Highlight;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestHighlightText()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.HighlightText;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.HighlightText, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.HighlightText;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestHotTrack()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.HotTrack;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.HotTrack, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.HotTrack;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestInactiveBorder()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.InactiveBorder;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.InactiveBorder, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.InactiveBorder;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestInactiveCaption()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.InactiveCaption;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.InactiveCaption, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.InactiveCaption;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestInfo()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.Info;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.Info, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.Info;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMenu()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.Menu;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.Menu, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.Menu;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestScrollBar()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.ScrollBar;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.ScrollBar, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.ScrollBar;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestWindow()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.Window;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.Window, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.Window;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestWindowText()
+        {
+            SolidBrush brush;
+            brush = (SolidBrush)SystemBrushes.WindowText;
+            Assert.True(brush.Color.IsSystemColor);
+            Assert.Equal(SystemColors.WindowText, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.WindowText;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestFromSystemColor()
+        {
+            SolidBrush brush;
+
+            brush = (SolidBrush)SystemBrushes.FromSystemColor(SystemColors.Menu);
+            Assert.Equal(SystemColors.Menu, brush.Color);
+
+            try
+            {
+                brush.Color = Color.Red;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Color = SystemColors.Menu;
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+            try
+            {
+                brush.Dispose();
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+
+
+            try
+            {
+                brush = (SolidBrush)SystemBrushes.FromSystemColor(Color.Red);
+                Assert.True(false);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is ArgumentException);
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/TestSystemPens.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/TestSystemPens.cs
@@ -1,0 +1,397 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+// Tests for System.Drawing.SystemPens.cs
+//
+// Author: 
+//     Ravindra (rkumar@novell.com)
+//
+
+//
+// Copyright (C) 2004 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using Xunit;
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Security.Permissions;
+
+namespace MonoTests.System.Drawing
+{
+    public class SystemPensTest
+    {
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestActiveCaptionText()
+        {
+            Pen pen;
+            pen = SystemPens.ActiveCaptionText;
+            CheckProperties(pen, "P1", SystemColors.ActiveCaptionText);
+            CheckMethods(pen, "M1");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControl()
+        {
+            Pen pen;
+            pen = SystemPens.Control;
+            CheckProperties(pen, "P2", SystemColors.Control);
+            CheckMethods(pen, "M2");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControlDark()
+        {
+            Pen pen;
+            pen = SystemPens.ControlDark;
+            CheckProperties(pen, "P3", SystemColors.ControlDark);
+            CheckMethods(pen, "M3");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControlDarkDark()
+        {
+            Pen pen;
+            pen = SystemPens.ControlDarkDark;
+            CheckProperties(pen, "P4", SystemColors.ControlDarkDark);
+            CheckMethods(pen, "M4");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControlLight()
+        {
+            Pen pen;
+            pen = SystemPens.ControlLight;
+            CheckProperties(pen, "P5", SystemColors.ControlLight);
+            CheckMethods(pen, "M5");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControlLightLight()
+        {
+            Pen pen;
+            pen = SystemPens.ControlLightLight;
+            CheckProperties(pen, "P6", SystemColors.ControlLightLight);
+            CheckMethods(pen, "M6");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestControlText()
+        {
+            Pen pen;
+            pen = SystemPens.ControlText;
+            CheckProperties(pen, "P7", SystemColors.ControlText);
+            CheckMethods(pen, "M7");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestGrayText()
+        {
+            Pen pen;
+            pen = SystemPens.GrayText;
+            CheckProperties(pen, "P8", SystemColors.GrayText);
+            CheckMethods(pen, "M8");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestHighlight()
+        {
+            Pen pen;
+            pen = SystemPens.Highlight;
+            CheckProperties(pen, "P9", SystemColors.Highlight);
+            CheckMethods(pen, "M9");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestHighlightText()
+        {
+            Pen pen;
+            pen = SystemPens.HighlightText;
+            CheckProperties(pen, "P10", SystemColors.HighlightText);
+            CheckMethods(pen, "M10");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestInactiveCaptionText()
+        {
+            Pen pen;
+            pen = SystemPens.InactiveCaptionText;
+            CheckProperties(pen, "P11", SystemColors.InactiveCaptionText);
+            CheckMethods(pen, "M11");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestInfoText()
+        {
+            Pen pen;
+            pen = SystemPens.InfoText;
+            CheckProperties(pen, "P12", SystemColors.InfoText);
+            CheckMethods(pen, "M12");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestMenuText()
+        {
+            Pen pen;
+            pen = SystemPens.MenuText;
+            CheckProperties(pen, "P13", SystemColors.MenuText);
+            CheckMethods(pen, "M13");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestWindowFrame()
+        {
+            Pen pen;
+            pen = SystemPens.WindowFrame;
+            CheckProperties(pen, "P14", SystemColors.WindowFrame);
+            CheckMethods(pen, "M14");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestWindowText()
+        {
+            Pen pen;
+            pen = SystemPens.WindowText;
+            CheckProperties(pen, "P15", SystemColors.WindowText);
+            CheckMethods(pen, "M15");
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TestFromSystemColor()
+        {
+            Pen pen;
+
+            pen = SystemPens.FromSystemColor(SystemColors.MenuText);
+            CheckProperties(pen, "P16", SystemColors.MenuText);
+            CheckMethods(pen, "M16");
+
+            try
+            {
+                pen = SystemPens.FromSystemColor(Color.Red);
+                Assert.True(false);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true);
+            }
+        }
+
+        // helper test functions
+        void CheckProperties(Pen pen, String tag, Color sysColor)
+        {
+            // Try modifying properties of a SystemPen.
+            // ArgumentException must be thrown.
+
+            Assert.True(pen.Color.IsSystemColor, tag + "#1");
+            Assert.Equal(sysColor, pen.Color);
+
+            try
+            {
+                pen.Alignment = PenAlignment.Center;
+                Assert.True(false, tag + "#2: must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#2");
+            }
+
+            try
+            {
+                pen.Brush = new SolidBrush(Color.Red);
+                Assert.True(false, tag + "#3: must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#3");
+            }
+
+            try
+            {
+                pen.Color = Color.Red;
+                Assert.True(false, tag + "#4: must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#4");
+            }
+
+            try
+            {
+                pen.Color = sysColor;
+                Assert.True(false, tag + "#5" + ": must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#5");
+            }
+            /*
+                        try {
+                            // NotImplemented
+                            pen.CompoundArray = new float[2];
+                            Assert.True(false,  (tag + "#6: must throw ArgumentException");
+                        } catch (ArgumentException) {
+                            Assert.True (true, tag + "#6");
+                        }
+
+                        try {
+                            // NotImplemented
+                            pen.CustomEndCap = null;
+                            Assert.True(false,  (tag + "#7: must throw ArgumentException");
+                        } catch (ArgumentException) {
+                            Assert.True (true, tag + "#7");
+                        }
+
+                        try {
+                            // NotImplemented
+                            pen.CustomStartCap = null;
+                            Assert.True(false,  (tag + "#8: must throw ArgumentException");
+                        } catch (ArgumentException) {
+                            Assert.True (true, tag + "#8");
+                        }
+
+                        try {
+                            // NotImplemented
+                            pen.DashCap = DashCap.Flat;
+                            Assert.True(false,  (tag + "#9: must throw ArgumentException");
+                        } catch (ArgumentException) {
+                            Assert.True (true, tag + "#9");
+                        }
+            */
+            try
+            {
+                pen.DashOffset = 5.5F;
+                Assert.True(false, tag + "#10: must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#10");
+            }
+
+            try
+            {
+                pen.DashPattern = null;
+                Assert.True(false, tag + "#11: must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#11");
+            }
+
+            try
+            {
+                pen.DashStyle = DashStyle.Dot; // hangs!prob
+                Assert.True(false, tag + "#12: must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#12");
+            }
+            /*
+                        try {
+                            // NotImplemented
+                            pen.EndCap = LineCap.Round;
+                            Assert.True(false,  (tag + "#13: must throw ArgumentException");
+                        } catch (ArgumentException) {
+                            Assert.True (true, tag + "#13");
+                        }
+            */
+            try
+            {
+                pen.LineJoin = LineJoin.Round;
+                Assert.True(false, tag + "#14: must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#14");
+            }
+
+            try
+            {
+                pen.MiterLimit = 0.1f;
+                Assert.True(false, tag + "#15: must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#15");
+            }
+            /*
+                        try {
+                            // NotImplemented
+                            pen.StartCap = LineCap.Square;
+                            Assert.True(false,  (tag + "#16: must throw ArgumentException");
+                        } catch (ArgumentException) {
+                            Assert.True (true, tag + "#16");
+                        }
+            */
+            try
+            {
+                pen.Transform = new Matrix(); //Matrix hangs!problem
+                Assert.True(false, tag + "#17: must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#17");
+            }
+
+            try
+            {
+                pen.Width = 0.5F;
+                Assert.True(false, tag + "#18: must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#18");
+            }
+        }
+
+        void CheckMethods(Pen pen, String tag)
+        {
+            // Try modifying a SystemPen by calling methods.
+            // ArgumentException must be thrown in some cases.
+            /*
+                        try {
+                            // NotImplemented
+                            pen.SetLineCap (LineCap.Flat, LineCap.Round, DashCap.Triangle);
+                            Assert.True(false,  (tag + "#1: must throw ArgumentException");
+                        } catch (ArgumentException) {
+                            Assert.True (tag + "#1", true);
+                        }
+            */
+            pen.ResetTransform();
+            pen.RotateTransform(90);
+            pen.ScaleTransform(2, 1);
+            pen.TranslateTransform(10, 20);
+            pen.MultiplyTransform(new Matrix());
+            pen.Clone();
+
+            try
+            {
+                pen.Dispose();
+                Assert.True(false, tag + "#8: must throw ArgumentException");
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(true, tag + "#8");
+            }
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/TextureBrushTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/TextureBrushTest.cs
@@ -1,0 +1,495 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// System.Drawing.TextureBrush unit tests
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Copyright (C) 2006-2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Security.Permissions;
+using Xunit;
+
+namespace MonoTests.System.Drawing
+{
+
+    public class TextureBrushTest
+    {
+
+        private Image image;
+        private Rectangle rect;
+        private RectangleF rectf;
+        private ImageAttributes attr;
+        private Bitmap bmp;
+
+        public TextureBrushTest()
+        {
+            image = new Bitmap(10, 10);
+            rect = new Rectangle(0, 0, 10, 10);
+            rectf = new RectangleF(0, 0, 10, 10);
+            attr = new ImageAttributes();
+            bmp = new Bitmap(50, 50);
+        }
+
+        private void Common(TextureBrush t, WrapMode wm)
+        {
+            using (Image img = t.Image)
+            {
+                Assert.NotNull(img);
+            }
+            Assert.False(Object.ReferenceEquals(image, t.Image));
+            Assert.True(t.Transform.IsIdentity);
+            Assert.Equal(wm, t.WrapMode);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImage_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TextureBrush(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImage()
+        {
+            TextureBrush t = new TextureBrush(image);
+            Common(t, WrapMode.Tile);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImage_Null_WrapMode()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TextureBrush(null, WrapMode.Clamp));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageWrapMode()
+        {
+            foreach (WrapMode wm in Enum.GetValues(typeof(WrapMode)))
+            {
+                TextureBrush t = new TextureBrush(image, wm);
+                Common(t, wm);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void CtorImageWrapMode_Invalid()
+        {
+            Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush(image, (WrapMode)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImage_Null_Rectangle()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TextureBrush(null, rect));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageRectangle_Empty()
+        {
+            Assert.Throws<OutOfMemoryException>(() => new TextureBrush(image, new Rectangle()));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageRectangle()
+        {
+            TextureBrush t = new TextureBrush(image, rect);
+            Common(t, WrapMode.Tile);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImage_Null_RectangleF()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TextureBrush(null, rectf));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageRectangleF_Empty()
+        {
+            Assert.Throws<OutOfMemoryException>(() => new TextureBrush(image, new RectangleF()));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageRectangleF()
+        {
+            TextureBrush t = new TextureBrush(image, rectf);
+            Common(t, WrapMode.Tile);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImage_Null_RectangleAttributes()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TextureBrush(null, rect, attr));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageRectangle_Empty_Attributes()
+        {
+            Assert.Throws<OutOfMemoryException>(() => new TextureBrush(image, new Rectangle(), attr));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageRectangleAttributes_Null()
+        {
+            TextureBrush t = new TextureBrush(image, rect, null);
+            Common(t, WrapMode.Tile);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageRectangleAttributes()
+        {
+            TextureBrush t = new TextureBrush(image, rect, attr);
+            Common(t, WrapMode.Clamp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImage_Null_RectangleFAttributes()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TextureBrush(null, rectf, attr));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageRectangleF_Empty_Attributes()
+        {
+            Assert.Throws<OutOfMemoryException>(() => new TextureBrush(image, new RectangleF()));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageRectangleFAttributes_Null()
+        {
+            TextureBrush t = new TextureBrush(image, rectf, null);
+            Common(t, WrapMode.Tile);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageRectangleFAttributes()
+        {
+            TextureBrush t = new TextureBrush(image, rectf, attr);
+            Common(t, WrapMode.Clamp);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageWrapModeRectangle()
+        {
+            foreach (WrapMode wm in Enum.GetValues(typeof(WrapMode)))
+            {
+                TextureBrush t = new TextureBrush(image, wm, rect);
+                Common(t, wm);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void CtorImageWrapMode_Invalid_Rectangle()
+        {
+            Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush(image, (WrapMode)Int32.MinValue, rect));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void CtorImageWrapModeRectangleF()
+        {
+            foreach (WrapMode wm in Enum.GetValues(typeof(WrapMode)))
+            {
+                TextureBrush t = new TextureBrush(image, wm, rectf);
+                Common(t, wm);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void CtorImageWrapMode_Invalid_RectangleF()
+        {
+            Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush(image, (WrapMode)Int32.MinValue, rectf));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TextureBush_RectangleInsideBitmap()
+        {
+            Rectangle r = new Rectangle(10, 10, 40, 40);
+            Assert.True(r.Y + r.Height <= bmp.Height);
+            Assert.True(r.X + r.Width <= bmp.Width);
+            TextureBrush b = new TextureBrush(bmp, r);
+            using (Image img = b.Image)
+            {
+                Assert.Equal(r.Height, img.Height);
+                Assert.Equal(r.Width, img.Width);
+            }
+            Assert.True(b.Transform.IsIdentity);
+            Assert.Equal(WrapMode.Tile, b.WrapMode);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TextureBush_RectangleOutsideBitmap()
+        {
+            Rectangle r = new Rectangle(50, 50, 50, 50);
+            Assert.False(r.Y + r.Height <= bmp.Height);
+            Assert.False(r.X + r.Width <= bmp.Width);
+            Assert.Throws<OutOfMemoryException>(() => new TextureBrush(bmp, r));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TextureBrush(image).Transform = null);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Transform()
+        {
+            Matrix m = new Matrix();
+            TextureBrush t = new TextureBrush(image);
+            t.Transform = m;
+            Assert.False(Object.ReferenceEquals(m, t.Transform));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void WrapMode_Valid()
+        {
+            foreach (WrapMode wm in Enum.GetValues(typeof(WrapMode)))
+            {
+                TextureBrush t = new TextureBrush(image);
+                t.WrapMode = wm;
+                Assert.Equal(wm, t.WrapMode);
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable, Skip = "Internal ArgumentException in System.Drawing")]
+        public void WrapMode_Invalid()
+        {
+            Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush(image).WrapMode = (WrapMode)Int32.MinValue);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Clone()
+        {
+            TextureBrush t = new TextureBrush(image);
+            TextureBrush clone = (TextureBrush)t.Clone();
+            Common(clone, t.WrapMode);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_Clone()
+        {
+            TextureBrush t = new TextureBrush(image);
+            t.Dispose();
+            Assert.Throws<ArgumentException>(() => t.Clone());
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Dispose_Dispose()
+        {
+            TextureBrush t = new TextureBrush(image);
+            t.Dispose();
+            t.Dispose();
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TextureBrush(image).MultiplyTransform(null));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform_Null_Order()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TextureBrush(image).MultiplyTransform(null, MatrixOrder.Append));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransformOrder_Invalid()
+        {
+            TextureBrush t = new TextureBrush(image);
+            t.MultiplyTransform(new Matrix(), (MatrixOrder)Int32.MinValue);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void MultiplyTransform_NonInvertible()
+        {
+            TextureBrush t = new TextureBrush(image);
+            Matrix noninvertible = new Matrix(123, 24, 82, 16, 47, 30);
+            Assert.Throws<ArgumentException>(() => t.MultiplyTransform(noninvertible));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ResetTransform()
+        {
+            TextureBrush t = new TextureBrush(image);
+            t.RotateTransform(90);
+            Assert.False(t.Transform.IsIdentity);
+            t.ResetTransform();
+            Assert.True(t.Transform.IsIdentity);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RotateTransform()
+        {
+            TextureBrush t = new TextureBrush(image);
+            t.RotateTransform(90);
+            float[] elements = t.Transform.Elements;
+            Assert.Equal(0, elements[0], 1);
+            Assert.Equal(1, elements[1], 1);
+            Assert.Equal(-1, elements[2], 1);
+            Assert.Equal(0, elements[3], 1);
+            Assert.Equal(0, elements[4], 1);
+            Assert.Equal(0, elements[5], 1);
+
+            t.RotateTransform(270);
+            Assert.True(t.Transform.IsIdentity);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void RotateTransform_InvalidOrder()
+        {
+            TextureBrush t = new TextureBrush(image);
+            Assert.Throws<ArgumentException>(() => t.RotateTransform(720, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform()
+        {
+            TextureBrush t = new TextureBrush(image);
+            t.ScaleTransform(2, 4);
+            float[] elements = t.Transform.Elements;
+            Assert.Equal(2, elements[0], 1);
+            Assert.Equal(0, elements[1], 1);
+            Assert.Equal(0, elements[2], 1);
+            Assert.Equal(4, elements[3], 1);
+            Assert.Equal(0, elements[4], 1);
+            Assert.Equal(0, elements[5], 1);
+
+            t.ScaleTransform(0.5f, 0.25f);
+            Assert.True(t.Transform.IsIdentity);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform_MaxMin()
+        {
+            TextureBrush t = new TextureBrush(image);
+            t.ScaleTransform(Single.MaxValue, Single.MinValue);
+            float[] elements = t.Transform.Elements;
+            Assert.Equal(Single.MaxValue, elements[0]);
+            Assert.Equal(0, elements[1], 1);
+            Assert.Equal(0, elements[2], 1);
+            Assert.Equal(Single.MinValue, elements[3]);
+            Assert.Equal(0, elements[4], 1);
+            Assert.Equal(0, elements[5], 1);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void ScaleTransform_InvalidOrder()
+        {
+            TextureBrush t = new TextureBrush(image);
+            Assert.Throws<ArgumentException>(() => t.ScaleTransform(1, 1, (MatrixOrder)Int32.MinValue));
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TranslateTransform()
+        {
+            TextureBrush t = new TextureBrush(image);
+            t.TranslateTransform(1, 1);
+            float[] elements = t.Transform.Elements;
+            Assert.Equal(1, elements[0], 1);
+            Assert.Equal(0, elements[1], 1);
+            Assert.Equal(0, elements[2], 1);
+            Assert.Equal(1, elements[3], 1);
+            Assert.Equal(1, elements[4], 1);
+            Assert.Equal(1, elements[5], 1);
+
+            t.TranslateTransform(-1, -1);
+            elements = t.Transform.Elements;
+            Assert.Equal(1, elements[0], 1);
+            Assert.Equal(0, elements[1], 1);
+            Assert.Equal(0, elements[2], 1);
+            Assert.Equal(1, elements[3], 1);
+            Assert.Equal(0, elements[4], 1);
+            Assert.Equal(0, elements[5], 1);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void TranslateTransform_InvalidOrder()
+        {
+            TextureBrush t = new TextureBrush(image);
+            Assert.Throws<ArgumentException>(() => t.TranslateTransform(1, 1, (MatrixOrder)Int32.MinValue));
+        }
+
+        private void Alpha_81828(WrapMode mode, bool equals)
+        {
+            using (Bitmap bm = new Bitmap(2, 1))
+            {
+                using (Graphics g = Graphics.FromImage(bm))
+                {
+                    Color t = Color.FromArgb(128, Color.White);
+                    g.Clear(Color.Green);
+                    g.FillRectangle(new SolidBrush(t), 0, 0, 1, 1);
+                    using (Bitmap bm_for_brush = new Bitmap(1, 1))
+                    {
+                        bm_for_brush.SetPixel(0, 0, t);
+                        using (TextureBrush tb = new TextureBrush(bm_for_brush, mode))
+                        {
+                            g.FillRectangle(tb, 1, 0, 1, 1);
+                        }
+                    }
+                    Color c1 = bm.GetPixel(0, 0);
+                    Color c2 = bm.GetPixel(1, 0);
+                    if (equals)
+                        Assert.Equal(c1, c2);
+                    else
+                        Assert.Equal(-16744448, c2.ToArgb());
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Alpha_81828_Clamp()
+        {
+            Alpha_81828(WrapMode.Clamp, false);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Alpha_81828_Tile()
+        {
+            Alpha_81828(WrapMode.Tile, true);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Alpha_81828_TileFlipX()
+        {
+            Alpha_81828(WrapMode.TileFlipX, true);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Alpha_81828_TileFlipY()
+        {
+            Alpha_81828(WrapMode.TileFlipY, true);
+        }
+
+        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        public void Alpha_81828_TileFlipXY()
+        {
+            Alpha_81828(WrapMode.TileFlipXY, true);
+        }
+    }
+}


### PR DESCRIPTION
When consolidating the Unix and Windows codebase for System.Drawing, I noticed some gaps in code coverage. For example, the various `Graphics.*Clip*` methods and properties did not have any coverage.

As a result, I tried to port the Mono test suite for System.Drawing to corefx. This PR is the result of that.

The tests uncovered a couple of bugs in the current implementation of System.Drawing:
-  The getter for `PathGradientBrush.Blend` returned inconsistent results across calls due to invalid P/Invoke code -  https://github.com/dotnet/corefx/commit/3a6f13043b6790449cc2c0b1d4c44b3c7e15bc9b
- The P/Invoke declaration for `GdipSaveImageToFile_delegate` was missing a `MarshalAs` attribute for the `filename` parameter, causing the filenames to be passed in ANSI format to a function which expected Unicode, resulting in unexpected filenames.
- The `InvalidEnumArgumentException` exception class exists in both `System.Drawing` and `System.ComponentModel`