### PR TITLE
Re-enable retrying checkout

### DIFF
--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -10,7 +10,7 @@ def submittedHelixJson = null
 
 simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
     stage ('Checkout source') {
-        checkout scm
+        checkoutRepo()
     }
 
     def logFolder = getLogFolder()

--- a/buildpipeline/osx.groovy
+++ b/buildpipeline/osx.groovy
@@ -10,7 +10,7 @@ def submittedHelixJson = null
 
 simpleNode('OSX10.12','latest') {
     stage ('Checkout source') {
-        checkout scm
+        checkoutRepo()
     }
 
     def logFolder = getLogFolder()

--- a/buildpipeline/windows.groovy
+++ b/buildpipeline/windows.groovy
@@ -12,7 +12,7 @@ def submitToHelix = (params.TGroup == 'netcoreapp' || params.TGroup == 'uap')
 
 simpleNode('Windows_NT','latest') {
     stage ('Checkout source') {
-        checkout scm
+        checkoutRepo()
     }
 
     def logFolder = getLogFolder()


### PR DESCRIPTION
Patching the Windows OS seems to have resolved the checkout hangs.  It appeared to have been hanging in some Windows filesystem code.  It also may have been because of git performance issues in 2.11+ when fetching large numbers of refs, which was resolved by a recent change to only fetch the ref relevant to the current PR.