### PR TITLE
Fix LargeArrayBuilder.CopyTo returning incorrect end-of-copy position

### DIFF
--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -234,7 +234,7 @@ namespace System.Collections.Generic
             T[] buffer = GetBuffer(row);
             int copied = CopyToCore(buffer, column);
 
-            if(count == 0)
+            if (count == 0)
             {
                 return new CopyPosition(row, column + copied).Normalize(buffer.Length);
             }

--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -197,9 +197,10 @@ namespace System.Collections.Generic
         /// <returns>The position in this builder that was copied up to.</returns>
         public CopyPosition CopyTo(CopyPosition position, T[] array, int arrayIndex, int count)
         {
+            Debug.Assert(array != null);
             Debug.Assert(arrayIndex >= 0);
             Debug.Assert(count > 0 && count <= Count);
-            Debug.Assert(array?.Length - arrayIndex >= count);
+            Debug.Assert(array.Length - arrayIndex >= count);
 
             // Go through each buffer, which contains one 'row' of items.
             // The index in each buffer is referred to as the 'column'.
@@ -235,14 +236,10 @@ namespace System.Collections.Generic
 
                 // Copy until we satisfy `count` or reach the end of the current buffer.
                 int copyCount = Math.Min(sourceBuffer.Length - sourceIndex, count);
+                Array.Copy(sourceBuffer, sourceIndex, array, arrayIndex, copyCount);
 
-                if (copyCount > 0)
-                {
-                    Array.Copy(sourceBuffer, sourceIndex, array, arrayIndex, copyCount);
-
-                    arrayIndex += copyCount;
-                    count -= copyCount;
-                }
+                arrayIndex += copyCount;
+                count -= copyCount;
 
                 return copyCount;
             }

--- a/src/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
@@ -149,8 +149,11 @@ namespace System.Collections.Generic
                 count -= reservedCount;
             }
 
-            // Finish copying after the final marker.
-            _builder.CopyTo(position, array, arrayIndex, count);
+            if (count > 0)
+            {
+                // Finish copying after the final marker.
+                _builder.CopyTo(position, array, arrayIndex, count);
+            }
         }
 
         /// <summary>

--- a/src/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
@@ -113,9 +113,10 @@ namespace System.Collections.Generic
         /// <param name="count">The number of items to copy.</param>
         public void CopyTo(T[] array, int arrayIndex, int count)
         {
+            Debug.Assert(array != null);
             Debug.Assert(arrayIndex >= 0);
             Debug.Assert(count >= 0 && count <= Count);
-            Debug.Assert(array?.Length - arrayIndex >= count);
+            Debug.Assert(array.Length - arrayIndex >= count);
 
             int copied = 0;
             var position = CopyPosition.Start;

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -428,14 +428,14 @@ namespace System.Linq.Tests
         {
             // See https://github.com/dotnet/corefx/issues/23680
 
-            var concats = arrays[0];
+            IEnumerable<int> concats = arrays[0];
 
             for (int i = 1; i < arrays.Length; i++)
             {
                 concats = concats.Concat(arrays[i]);
             }
 
-            var results = concats.ToArray();
+            int[] results = concats.ToArray();
 
             for (int i = 0; i < results.Length; i++)
             {
@@ -445,7 +445,31 @@ namespace System.Linq.Tests
 
         private static IEnumerable<object[]> GetToArrayDataSources()
         {
-            // Case of small arrays (same LAB row)
+            // Marker at the end
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new TestEnumerable<int>(new int[] { 0 }),
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new TestEnumerable<int>(new int[] { 2 }),
+                    new int[] { 3 },
+                }
+            };
+
+            // Marker at beginning
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new int[] { 0 },
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new TestEnumerable<int>(new int[] { 2 }),
+                    new TestEnumerable<int>(new int[] { 3 }),
+                }
+            };
+
+            // Marker in middle
             yield return new object[]
             {
                 new IEnumerable<int>[]
@@ -456,7 +480,18 @@ namespace System.Linq.Tests
                 }
             };
 
-            // Case of large arrays (many LAB rows)
+            // Non-marker in middle
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new int[] { 0 },
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new int[] { 2 },
+                }
+            };
+
+            // Big arrays (marker in middle)
             yield return new object[]
             {
                 new IEnumerable<int>[]
@@ -467,15 +502,14 @@ namespace System.Linq.Tests
                 }
             };
 
-            // Marker at the end
+            // Big arrays (non-marker in middle)
             yield return new object[]
             {
                 new IEnumerable<int>[]
                 {
-                    new TestEnumerable<int>(new int[] { 0 }),
-                    new TestEnumerable<int>(new int[] { 1 }),
-                    new TestEnumerable<int>(new int[] { 2 }),
-                    new int[] { 3 },
+                    Enumerable.Range(0, 100).ToArray(),
+                    new TestEnumerable<int>(Enumerable.Range(100, 100).ToArray()),
+                    Enumerable.Range(200, 100).ToArray(),
                 }
             };
 

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -421,5 +421,18 @@ namespace System.Linq.Tests
                 Assert.Equal(0xf00, en.Current);
             }
         }
+
+        [Fact]
+        public void CollectionInterleavedWithLazyEnumerables_ToArray_Regression()
+        {
+            var results = new TestEnumerable<int>(new[] { 1 })
+                .Concat(new[] { 2 })
+                .Concat(new TestEnumerable<int>(new[] { 3 }))
+                // Do not omit this ToArray()! There was a previous bug where the ToArray() implementation
+                // was incorrect, while iterating with foreach produced the correct results.
+                .ToArray();
+
+            Assert.Equal(new[] { 1, 2, 3 }, results);
+        }
     }
 }

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -478,6 +478,32 @@ namespace System.Linq.Tests
                     new int[] { 3 },
                 }
             };
+
+            // Interleaved (first marker)
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new int[] { 0 },
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new int[] { 2 },
+                    new TestEnumerable<int>(new int[] { 3 }),
+                    new int[] { 4 },
+                }
+            };
+
+            // Interleaved (first non-marker)
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new TestEnumerable<int>(new int[] { 0 }),
+                    new int[] { 1 },
+                    new TestEnumerable<int>(new int[] { 2 }),
+                    new int[] { 3 },
+                    new TestEnumerable<int>(new int[] { 4 }),
+                }
+            };
         }
     }
 }

--- a/src/System.Linq/tests/SelectManyTests.cs
+++ b/src/System.Linq/tests/SelectManyTests.cs
@@ -527,6 +527,32 @@ namespace System.Linq.Tests
                     new int[] { 3 },
                 }
             };
+
+            // Interleaved (first marker)
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new int[] { 0 },
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new int[] { 2 },
+                    new TestEnumerable<int>(new int[] { 3 }),
+                    new int[] { 4 },
+                }
+            };
+
+            // Interleaved (first non-marker)
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new TestEnumerable<int>(new int[] { 0 }),
+                    new int[] { 1 },
+                    new TestEnumerable<int>(new int[] { 2 }),
+                    new int[] { 3 },
+                    new TestEnumerable<int>(new int[] { 4 }),
+                }
+            };
         }
     }
 }

--- a/src/System.Linq/tests/SelectManyTests.cs
+++ b/src/System.Linq/tests/SelectManyTests.cs
@@ -484,7 +484,7 @@ namespace System.Linq.Tests
         {
             // See https://github.com/dotnet/corefx/issues/23680
 
-            var results = arrays.SelectMany(ar => ar).ToArray();
+            int[] results = arrays.SelectMany(ar => ar).ToArray();
 
             for (int i = 0; i < results.Length; i++)
             {
@@ -494,7 +494,31 @@ namespace System.Linq.Tests
 
         private static IEnumerable<object[]> GetToArrayDataSources()
         {
-            // Case of small arrays (same LAB row)
+            // Marker at the end
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new TestEnumerable<int>(new int[] { 0 }),
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new TestEnumerable<int>(new int[] { 2 }),
+                    new int[] { 3 },
+                }
+            };
+
+            // Marker at beginning
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new int[] { 0 },
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new TestEnumerable<int>(new int[] { 2 }),
+                    new TestEnumerable<int>(new int[] { 3 }),
+                }
+            };
+
+            // Marker in middle
             yield return new object[]
             {
                 new IEnumerable<int>[]
@@ -505,7 +529,18 @@ namespace System.Linq.Tests
                 }
             };
 
-            // Case of large arrays (many LAB rows)
+            // Non-marker in middle
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new int[] { 0 },
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new int[] { 2 },
+                }
+            };
+
+            // Big arrays (marker in middle)
             yield return new object[]
             {
                 new IEnumerable<int>[]
@@ -516,15 +551,14 @@ namespace System.Linq.Tests
                 }
             };
 
-            // Marker at the end
+            // Big arrays (non-marker in middle)
             yield return new object[]
             {
                 new IEnumerable<int>[]
                 {
-                    new TestEnumerable<int>(new int[] { 0 }),
-                    new TestEnumerable<int>(new int[] { 1 }),
-                    new TestEnumerable<int>(new int[] { 2 }),
-                    new int[] { 3 },
+                    Enumerable.Range(0, 100).ToArray(),
+                    new TestEnumerable<int>(Enumerable.Range(100, 100).ToArray()),
+                    Enumerable.Range(200, 100).ToArray(),
                 }
             };
 

--- a/src/System.Linq/tests/SelectManyTests.cs
+++ b/src/System.Linq/tests/SelectManyTests.cs
@@ -477,5 +477,19 @@ namespace System.Linq.Tests
             IEnumerable<int> iterator = counts.SelectMany(c => Enumerable.Range(1, c));
             Assert.Throws<OverflowException>(() => iterator.Count());
         }
+
+        [Fact]
+        public void CollectionInterleavedWithLazyEnumerables_ToArray_Regression()
+        {
+            var results = new[] { 4, 5, 6 }
+                .SelectMany(i => i == 5 ?
+                    (IEnumerable<int>)new List<int>() { i } :
+                    new TestEnumerable<int>(new int[] { i }))
+                // Do not omit this ToArray()! There was a previous bug where the ToArray() implementation
+                // was incorrect, while iterating with foreach produced the correct results.
+                .ToArray();
+
+            Assert.Equal(new[] { 4, 5, 6 }, results);
+        }
     }
 }


### PR DESCRIPTION
Fixes #23680
Replaces #23730

cc @stephentoub @VSadov @jamesqo 