### PR TITLE
Only truncate to IOV_MAX for stream sockets

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -1148,9 +1148,8 @@ static bool IsStreamSocket(int socket)
 {
     int type;
     socklen_t length = sizeof(int);
-    return socket != -1
-            && getsockopt(socket, SOL_SOCKET, SO_TYPE, &type, &length) == 0
-            && type == SOCK_STREAM;
+    return getsockopt(socket, SOL_SOCKET, SO_TYPE, &type, &length) == 0
+           && type == SOCK_STREAM;
 }
 
 static void ConvertMessageHeaderToMsghdr(msghdr* header, const MessageHeader& messageHeader, int socket = -1)

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -1144,13 +1144,25 @@ SystemNative_SetIPv6Address(uint8_t* socketAddress, int32_t socketAddressLen, ui
     return PAL_SUCCESS;
 }
 
-static void ConvertMessageHeaderToMsghdr(msghdr* header, const MessageHeader& messageHeader)
+static bool IsStreamSocket(int socket)
+{
+    int type;
+    socklen_t length = sizeof(int);
+    return socket != -1
+            && getsockopt(socket, SOL_SOCKET, SO_TYPE, &type, &length) == 0
+            && type == SOCK_STREAM;
+}
+
+static void ConvertMessageHeaderToMsghdr(msghdr* header, const MessageHeader& messageHeader, int socket = -1)
 {
     // sendmsg/recvmsg can return EMSGSIZE when msg_iovlen is greather than IOV_MAX.
-    // We avoid this by truncating msg_iovlen to IOV_MAX, this is ok since sendmsg is
+    // We avoid this for stream sockets by truncating msg_iovlen to IOV_MAX. This is ok since sendmsg is
     // not required to send all data and recvmsg can be called again to receive more.
     auto iovlen = static_cast<decltype(header->msg_iovlen)>(messageHeader.IOVectorCount);
-    iovlen = Min(iovlen, static_cast<decltype(iovlen)>(IOV_MAX));
+    if (iovlen > IOV_MAX && IsStreamSocket(socket))
+    {
+        iovlen = static_cast<decltype(iovlen)>(IOV_MAX);
+    }
     *header = {
         .msg_name = messageHeader.SocketAddress,
         .msg_namelen = static_cast<unsigned int>(messageHeader.SocketAddressLen),
@@ -1582,7 +1594,7 @@ extern "C" Error SystemNative_ReceiveMessage(intptr_t socket, MessageHeader* mes
     }
 
     msghdr header;
-    ConvertMessageHeaderToMsghdr(&header, *messageHeader);
+    ConvertMessageHeaderToMsghdr(&header, *messageHeader, fd);
 
     ssize_t res;
     while (CheckInterrupted(res = recvmsg(fd, &header, socketFlags)));
@@ -1625,7 +1637,7 @@ extern "C" Error SystemNative_SendMessage(intptr_t socket, MessageHeader* messag
     }
 
     msghdr header;
-    ConvertMessageHeaderToMsghdr(&header, *messageHeader);
+    ConvertMessageHeaderToMsghdr(&header, *messageHeader, fd);
 
     ssize_t res;
     while (CheckInterrupted(res = sendmsg(fd, &header, flags)));

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -253,8 +253,8 @@ namespace System.Net.Sockets
             }
             if (available == 0)
             {
-                // Always request at least one byte.
-                available = 1;
+                // Don't truncate iovecs.
+                available = int.MaxValue;
             }
 
             // Pin buffers and set up iovecs.

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -976,14 +976,8 @@ namespace System.Net.Sockets.Tests
                     int bytesReceived = socketEvent.BytesTransferred;
                     if (error == SocketError.Success)
                     {
-                        // Linux sometimes returns EMSGSIZE and sometimes fills a single segment and sets MSG_TRUNC.
-                        // The latter is unexpected, MSG_TRUNC should only be set when there is insufficient buffer space.
-                        bool truncated = (socketEvent.SocketFlags & SocketFlags.Truncated) != SocketFlags.None;
-                        if (!truncated)
-                        {
-                            // platform received message in > IOV_MAX segments
-                            Assert.Equal(segmentCount, bytesReceived);
-                        }
+                        // platform received message in > IOV_MAX segments
+                        Assert.Equal(segmentCount, bytesReceived);
                     }
                     else
                     {

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -956,6 +956,7 @@ namespace System.Net.Sockets.Tests
             sender.BindToAnonymousPort(IPAddress.Loopback);
             var receiver = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
             receiver.Connect(sender.LocalEndPoint); // only receive from sender
+            EndPoint receiverEndPoint = receiver.LocalEndPoint;
 
             Task receiveTask = Task.Run(() =>
             {
@@ -987,7 +988,7 @@ namespace System.Net.Sockets.Tests
 
             using (sender)
             {
-                sender.Connect(receiver.LocalEndPoint);
+                sender.Connect(receiverEndPoint);
                 var sendBuffer = new byte[SegmentCount];
                 for (int i = 0; i < TestSettings.UDPRedundancy; i++)
                 {

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -841,20 +841,20 @@ namespace System.Net.Sockets.Tests
             // This is handled internally for stream sockets so this error shouldn't surface.
 
             // Use more than IOV_MAX (1024 on Linux & macOS) segments.
-            const int segmentCount = 2400;
+            const int SegmentCount = 2400;
             using (var server = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 server.BindToAnonymousPort(IPAddress.Loopback);
                 server.Listen(1);
 
-                var sendBuffer = new byte[segmentCount];
+                var sendBuffer = new byte[SegmentCount];
                 Task serverProcessingTask = Task.Run(async () =>
                 {
                     using (Socket acceptSocket = await AcceptAsync(server))
                     {
-                        // send data as segmentCount (> IOV_MAX) 1-byte segments.
+                        // send data as SegmentCount (> IOV_MAX) 1-byte segments.
                         var sendSegments = new List<ArraySegment<byte>>();
-                        for (int i = 0; i < segmentCount; i++)
+                        for (int i = 0; i < SegmentCount; i++)
                         {
                             sendBuffer[i] = (byte)i;
                             sendSegments.Add(new ArraySegment<byte>(sendBuffer, i, 1));
@@ -863,7 +863,7 @@ namespace System.Net.Sockets.Tests
                         // Send blocks until all segments are sent.
                         int bytesSent = acceptSocket.Send(sendSegments, SocketFlags.None, out error);
 
-                        Assert.Equal(segmentCount, bytesSent);
+                        Assert.Equal(SegmentCount, bytesSent);
                         Assert.Equal(SocketError.Success, error);
                     }
                 });
@@ -873,9 +873,9 @@ namespace System.Net.Sockets.Tests
                     client.Connect(server.LocalEndPoint);
 
                     // receive data as 1-byte segments.
-                    var receiveBuffer = new byte[segmentCount];
+                    var receiveBuffer = new byte[SegmentCount];
                     var receiveSegments = new List<ArraySegment<byte>>();
-                    for (int i = 0; i < segmentCount; i++)
+                    for (int i = 0; i < SegmentCount; i++)
                     {
                         receiveSegments.Add(new ArraySegment<byte>(receiveBuffer, i, 1));
                     }
@@ -891,7 +891,7 @@ namespace System.Net.Sockets.Tests
 
                         Assert.NotEqual(0, bytesReceived);
                         Assert.Equal(SocketError.Success, error);
-                    } while (bytesReceivedTotal != segmentCount);
+                    } while (bytesReceivedTotal != SegmentCount);
 
                     Assert.Equal(sendBuffer, receiveBuffer);
                 }
@@ -907,28 +907,28 @@ namespace System.Net.Sockets.Tests
 
             // Use more than IOV_MAX (1024 on Linux & macOS) segments
             // and less than Ethernet MTU.
-            const int segmentCount = 1200;
+            const int SegmentCount = 1200;
             using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
                 socket.BindToAnonymousPort(IPAddress.Loopback);
                 // Use our own address as destination.
                 socket.Connect(socket.LocalEndPoint);
 
-                var sendBuffer = new byte[segmentCount];
+                var sendBuffer = new byte[SegmentCount];
                 var sendSegments = new List<ArraySegment<byte>>();
-                for (int i = 0; i < segmentCount; i++)
+                for (int i = 0; i < SegmentCount; i++)
                 {
                     sendBuffer[i] = (byte)i;
                     sendSegments.Add(new ArraySegment<byte>(sendBuffer, i, 1));
                 }
 
                 SocketError error;
-                // send data as segmentCount (> IOV_MAX) 1-byte segments.
+                // send data as SegmentCount (> IOV_MAX) 1-byte segments.
                 int bytesSent = socket.Send(sendSegments, SocketFlags.None, out error);
                 if (error == SocketError.Success)
                 {
                     // platform sent message with > IOV_MAX segments
-                    Assert.Equal(segmentCount, bytesSent);
+                    Assert.Equal(SegmentCount, bytesSent);
                 }
                 else
                 {
@@ -948,27 +948,27 @@ namespace System.Net.Sockets.Tests
 
             // Use more than IOV_MAX (1024 on Linux & macOS) segments
             // and less than Ethernet MTU.
-            const int segmentCount = 1200;
+            const int SegmentCount = 1200;
             var receiver = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
             receiver.BindToAnonymousPort(IPAddress.Loopback);
             Task receiveTask = Task.Run(() =>
             {
                 using (receiver)
                 {
-                    var receiveBuffer = new byte[segmentCount];
+                    var receiveBuffer = new byte[SegmentCount];
                     var receiveSegments = new List<ArraySegment<byte>>();
-                    for (int i = 0; i < segmentCount; i++)
+                    for (int i = 0; i < SegmentCount; i++)
                     {
                         receiveSegments.Add(new ArraySegment<byte>(receiveBuffer, i, 1));
                     }
-                    // receive data as segmentCount (> IOV_MAX) 1-byte segments.
+                    // receive data as SegmentCount (> IOV_MAX) 1-byte segments.
                     SocketError error;
                     int bytesReceived = receiver.Receive(receiveSegments, SocketFlags.None, out error);
 
                     if (error == SocketError.Success)
                     {
                         // platform received message in > IOV_MAX segments
-                        Assert.Equal(segmentCount, bytesReceived);
+                        Assert.Equal(SegmentCount, bytesReceived);
                     }
                     else
                     {
@@ -982,11 +982,11 @@ namespace System.Net.Sockets.Tests
             using (var sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
                 sender.Connect(receiver.LocalEndPoint);
-                var sendBuffer = new byte[segmentCount];
+                var sendBuffer = new byte[SegmentCount];
                 for (int i = 0; i < TestSettings.UDPRedundancy; i++)
                 {
                     int bytesSent = sender.Send(sendBuffer);
-                    Assert.Equal(segmentCount, bytesSent);
+                    Assert.Equal(SegmentCount, bytesSent);
                 }
             }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -962,18 +962,9 @@ namespace System.Net.Sockets.Tests
                         receiveSegments.Add(new ArraySegment<byte>(receiveBuffer, i, 1));
                     }
                     // receive data as segmentCount (> IOV_MAX) 1-byte segments.
-                    EventWaitHandle completed = new ManualResetEvent(false);
-                    var socketEvent = new SocketAsyncEventArgs();
-                    socketEvent.UserToken = completed;
-                    socketEvent.BufferList = receiveSegments;
-                    socketEvent.Completed += OnCompleted;
-                    if (receiver.ReceiveAsync(socketEvent))
-                    {
-                        completed.WaitOne();
-                    }
+                    SocketError error;
+                    int bytesReceived = receiver.Receive(receiveSegments, SocketFlags.None, out error);
 
-                    SocketError error = socketEvent.SocketError;
-                    int bytesReceived = socketEvent.BytesTransferred;
                     if (error == SocketError.Success)
                     {
                         // platform received message in > IOV_MAX segments
@@ -1000,12 +991,6 @@ namespace System.Net.Sockets.Tests
             }
 
             await receiveTask;
-        }
-
-        private static void OnCompleted(object sender, SocketAsyncEventArgs e)
-        {
-            EventWaitHandle handle = (EventWaitHandle)e.UserToken;
-            handle.Set();
         }
     }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -990,13 +990,19 @@ namespace System.Net.Sockets.Tests
             {
                 sender.Connect(receiverEndPoint);
                 var sendBuffer = new byte[SegmentCount];
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
+                for (int i = 0; i < 10; i++) // UDPRedundancy
                 {
                     int bytesSent = sender.Send(sendBuffer);
                     Assert.Equal(SegmentCount, bytesSent);
+                    await Task.WhenAny(receiveTask, Task.Delay(1));
+                    if (receiveTask.IsCompleted)
+                    {
+                        break;
+                    }
                 }
             }
 
+            Assert.True(receiveTask.IsCompleted);
             await receiveTask;
         }
     }

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -952,8 +952,11 @@ namespace System.Net.Sockets.Tests
             // Use more than IOV_MAX (1024 on Linux & macOS) segments
             // and less than Ethernet MTU.
             const int SegmentCount = 1200;
+            var sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            sender.BindToAnonymousPort(IPAddress.Loopback);
             var receiver = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-            receiver.BindToAnonymousPort(IPAddress.Loopback);
+            receiver.Connect(sender.LocalEndPoint); // only receive from sender
+
             Task receiveTask = Task.Run(() =>
             {
                 using (receiver)
@@ -982,7 +985,7 @@ namespace System.Net.Sockets.Tests
                 }
             });
 
-            using (var sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+            using (sender)
             {
                 sender.Connect(receiver.LocalEndPoint);
                 var sendBuffer = new byte[SegmentCount];

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -833,7 +833,10 @@ namespace System.Net.Sockets.Tests
                 Assert.Equal(e.SocketErrorCode, SocketError.InvalidArgument);
             }
         }
+    }
 
+    public class SendReceive
+    {
         [Fact]
         public void SendRecvIovMaxTcp_Success()
         {
@@ -848,9 +851,9 @@ namespace System.Net.Sockets.Tests
                 server.Listen(1);
 
                 var sendBuffer = new byte[SegmentCount];
-                Task serverProcessingTask = Task.Run(async () =>
+                Task serverProcessingTask = Task.Run(() =>
                 {
-                    using (Socket acceptSocket = await AcceptAsync(server))
+                    using (Socket acceptSocket = server.Accept())
                     {
                         // send data as SegmentCount (> IOV_MAX) 1-byte segments.
                         var sendSegments = new List<ArraySegment<byte>>();


### PR DESCRIPTION
This fixes the change in behavior for non-stream sockets introduced by https://github.com/dotnet/corefx/pull/23781.

CC @wfurt @stephentoub 