### PR TITLE
Disable default proxy test on Desktop

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -41,6 +41,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(23702, TargetFrameworkMonikers.NetFramework)]
         [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]


### PR DESCRIPTION
HttpClient test `ProxyExplicitlyProvided_DefaultCredentials_Ignored` has
started failing on Desktop due to build system changes. Disabling for
now.

#23702