### PR TITLE
Avoid downgrading to netstandard reference assembly

### DIFF
--- a/src/System.Memory/ref/Configurations.props
+++ b/src/System.Memory/ref/Configurations.props
@@ -1,12 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageConfigurations>
+    <BuildConfigurations>
       netstandard1.1;
       netstandard;
-    </PackageConfigurations>
-    <BuildConfigurations>
-      $(PackageConfigurations);
       netcoreapp;
       uap;
     </BuildConfigurations>


### PR DESCRIPTION
Similar to 75962dae7f338445b57d7d276d018774e1dd2e46 but for the reference assembly.

The reference assembly for System.Memory on netcoreapp2.1 is significantly
different since types have been pushed down into System.Runtime.  We need to
make sure that is used on netcoreapp2.1 to avoid any type conflicts.

/cc @weshaggard @ahsonkhan 