### PR TITLE
ConcurrentDictionary: Reduced branching during GrowTable()

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1780,14 +1780,14 @@ namespace System.Collections.Concurrent
 
                 // Add more locks
                 if (_growLockArray && tables._locks.Length < MaxLockNumber)
+                {
+                    newLocks = new object[tables._locks.Length * 2];
+                    Array.Copy(tables._locks, 0, newLocks, 0, tables._locks.Length);
+                    for (int i = tables._locks.Length; i < newLocks.Length; i++)
                     {
-                        newLocks = new object[tables._locks.Length * 2];
-                        Array.Copy(tables._locks, 0, newLocks, 0, tables._locks.Length);
-                        for (int i = tables._locks.Length; i < newLocks.Length; i++)
-                        {
-                            newLocks[i] = new object();
-                        }
+                        newLocks[i] = new object();
                     }
+                }
 
                 Node[] newBuckets = new Node[newLength];
                 int[] newCountPerLock = new int[newLocks.Length];


### PR DESCRIPTION
Oh well, just some micro optimization for the GrowTable() method. I essentially got rid of one branch without touching the semantics of the method.

I think [line 1766 in the new code](https://github.com/dotnet/corefx/compare/master...dnickless:ConcDictGrow1?expand=1#diff-f1285172a2a161542ccf657778f0852cR1766) can be removed, too, in order to micro optimize things even further if thou so wisheth. This would result in a slightly bigger newLength than MaxArrayLength (214643507**3** vs 214643507**1** to be precise) if that's acceptable. But that line will really just be called once per instance anyway and only in the case that the dictionary is really maxed out in bucket size...