### PR TITLE
Expose and add tests for span-based Guid methods

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -1298,6 +1298,7 @@ namespace System
     {
         public static readonly System.Guid Empty;
         public Guid(byte[] b) { throw null; }
+        public Guid(ReadOnlySpan<byte> b) { throw null; }
         public Guid(int a, short b, short c, byte d, byte e, byte f, byte g, byte h, byte i, byte j, byte k) { throw null; }
         public Guid(int a, short b, short c, byte[] d) { throw null; }
         public Guid(string g) { throw null; }
@@ -1314,9 +1315,11 @@ namespace System
         public static System.Guid Parse(string input) { throw null; }
         public static System.Guid ParseExact(string input, string format) { throw null; }
         public byte[] ToByteArray() { throw null; }
+        public bool TryWriteBytes(Span<byte> destination) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
+        public bool TryFormat(Span<char> destination, out int charsWritten, string format) { throw null; }
         public static bool TryParse(string input, out System.Guid result) { throw null; }
         public static bool TryParseExact(string input, string format, out System.Guid result) { throw null; }
     }

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -184,6 +184,7 @@
     <Compile Include="System\DecimalTests.netcoreapp.cs" />
     <Compile Include="System\EnumTests.netcoreapp.cs" />
     <Compile Include="System\GCTests.netcoreapp.cs" />
+    <Compile Include="System\GuidTests.netcoreapp.cs" />
     <Compile Include="System\Int16Tests.netcoreapp.cs" />
     <Compile Include="System\Int32Tests.netcoreapp.cs" />
     <Compile Include="System\Int64Tests.netcoreapp.cs" />

--- a/src/System.Runtime/tests/System/GuidTests.cs
+++ b/src/System.Runtime/tests/System/GuidTests.cs
@@ -348,14 +348,14 @@ namespace System.Tests
 
         public static IEnumerable<object[]> ToString_TestData()
         {
-            yield return new object[] { s_testGuid, "N", "a8a110d5fc4943c5bf46802db8f843ff" };
-            yield return new object[] { s_testGuid, "D", "a8a110d5-fc49-43c5-bf46-802db8f843ff" };
-            yield return new object[] { s_testGuid, "B", "{a8a110d5-fc49-43c5-bf46-802db8f843ff}" };
-            yield return new object[] { s_testGuid, "P", "(a8a110d5-fc49-43c5-bf46-802db8f843ff)" };
-            yield return new object[] { s_testGuid, "X", "{0xa8a110d5,0xfc49,0x43c5,{0xbf,0x46,0x80,0x2d,0xb8,0xf8,0x43,0xff}}" };
+            yield return new object[] { s_testGuid, "N", "a8a110d5fc4943c5bf46802db8f843ff"};
+            yield return new object[] { s_testGuid, "D", "a8a110d5-fc49-43c5-bf46-802db8f843ff"};
+            yield return new object[] { s_testGuid, "B", "{a8a110d5-fc49-43c5-bf46-802db8f843ff}"};
+            yield return new object[] { s_testGuid, "P", "(a8a110d5-fc49-43c5-bf46-802db8f843ff)"};
+            yield return new object[] { s_testGuid, "X", "{0xa8a110d5,0xfc49,0x43c5,{0xbf,0x46,0x80,0x2d,0xb8,0xf8,0x43,0xff}}"};
 
-            yield return new object[] { s_testGuid, null, "a8a110d5-fc49-43c5-bf46-802db8f843ff" };
-            yield return new object[] { s_testGuid, "", "a8a110d5-fc49-43c5-bf46-802db8f843ff" };
+            yield return new object[] { s_testGuid, null, "a8a110d5-fc49-43c5-bf46-802db8f843ff"};
+            yield return new object[] { s_testGuid, "", "a8a110d5-fc49-43c5-bf46-802db8f843ff"};
         }
 
         [Theory]
@@ -372,11 +372,12 @@ namespace System.Tests
             Assert.Equal(expected, formattable.ToString(format, null));
         }
 
-        [Fact]
-        public static void ToString_InvalidFormat_ThrowsFormatException()
+        [Theory]
+        [InlineData("Y")]
+        [InlineData("XX")]
+        public static void ToString_InvalidFormat_ThrowsFormatException(string format)
         {
-            Assert.Throws<FormatException>(() => s_testGuid.ToString("Y")); // Invalid format
-            Assert.Throws<FormatException>(() => s_testGuid.ToString("XX")); // Invalid format
+            Assert.Throws<FormatException>(() => s_testGuid.ToString(format));
         }
 
         public static IEnumerable<object[]> GuidStrings_Valid_TestData()

--- a/src/System.Runtime/tests/System/GuidTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/GuidTests.netcoreapp.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Xunit;
+
+namespace System.Tests
+{
+    public static partial class GuidTests
+    {
+        [Theory]
+        [MemberData(nameof(Ctor_ByteArray_TestData))]
+        public static void Ctor_ReadOnlySpan(byte[] b, Guid expected)
+        {
+            Assert.Equal(expected, new Guid(new ReadOnlySpan<byte>(b)));
+        }
+
+        [Theory]
+        [InlineData(15)]
+        [InlineData(17)]
+        public static void CtorSpan_InvalidLengthByteArray_ThrowsArgumentException(int length)
+        {
+            AssertExtensions.Throws<ArgumentException>("b", null, () => new Guid(new ReadOnlySpan<byte>(new byte[length])));
+        }
+
+        [Theory]
+        [MemberData(nameof(Ctor_ByteArray_TestData))]
+        public static void TryWriteBytes(byte[] b, Guid guid)
+        {
+            var bytes = new byte[16];
+            Assert.True(guid.TryWriteBytes(new Span<byte>(bytes)));
+            Assert.Equal(b, bytes);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(15)]
+        public static void TryWriteBytes_ReturnsFalse(int length)
+        {
+            Assert.False(s_testGuid.TryWriteBytes(new Span<byte>(new byte[length])));
+        }
+
+        [Theory]
+        [InlineData("Y")]
+        [InlineData("XX")]
+        public static void TryFormat_InvalidFormat_ThrowsFormatException(string format)
+        {
+            Assert.Throws<FormatException>(() => s_testGuid.TryFormat(new Span<char>(), out int charsWritten, format));
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public static void TryFormat_ReturnsTrue(Guid guid, string format, string expected)
+        {
+            Assert.True(guid.TryFormat(new Span<char>(new char[guid.ToString(format).Length]), out int charsWritten, format));
+            Assert.Equal(guid.ToString(format).Length, charsWritten);
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public static void TryFormat_ReturnsFalse_WhenSpanTooSmall(Guid guid, string format, string expected)
+        {
+            Assert.False(guid.TryFormat(new Span<char>(new char[guid.ToString(format).Length - 1]), out int charsWritten, format));
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public static void TryFormat_CharsWritten_EqualsZero_WhenSpanTooSmall(Guid guid, string format, string expected)
+        {
+            Assert.False(guid.TryFormat(new Span<char>(new char[guid.ToString(format).Length - 1]), out int charsWritten, format));
+            Assert.Equal(0, charsWritten);
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public static void TryFormat_Valid(Guid guid, string format, string expected)
+        {
+            char[] chars = new char[guid.ToString(format).Length];
+            Assert.True(guid.TryFormat(new Span<char>(chars), out int charsWritten, format));
+            Assert.Equal(chars, expected.ToCharArray());
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/GuidTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/GuidTests.netcoreapp.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 using Xunit;
 
 namespace System.Tests
@@ -28,7 +25,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_ByteArray_TestData))]
-        public static void TryWriteBytes(byte[] b, Guid guid)
+        public static void TryWriteBytes_ValidLength_ReturnsTrue(byte[] b, Guid guid)
         {
             var bytes = new byte[16];
             Assert.True(guid.TryWriteBytes(new Span<byte>(bytes)));
@@ -38,7 +35,7 @@ namespace System.Tests
         [Theory]
         [InlineData(0)]
         [InlineData(15)]
-        public static void TryWriteBytes_ReturnsFalse(int length)
+        public static void TryWriteBytes_LengthTooShort_ReturnsFalse(int length)
         {
             Assert.False(s_testGuid.TryWriteBytes(new Span<byte>(new byte[length])));
         }
@@ -53,17 +50,10 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public static void TryFormat_ReturnsTrue(Guid guid, string format, string expected)
-        {
-            Assert.True(guid.TryFormat(new Span<char>(new char[guid.ToString(format).Length]), out int charsWritten, format));
-            Assert.Equal(guid.ToString(format).Length, charsWritten);
-        }
-
-        [Theory]
-        [MemberData(nameof(ToString_TestData))]
-        public static void TryFormat_ReturnsFalse_WhenSpanTooSmall(Guid guid, string format, string expected)
+        public static void TryFormat_LengthTooSmall_ReturnsFalse(Guid guid, string format, string expected)
         {
             Assert.False(guid.TryFormat(new Span<char>(new char[guid.ToString(format).Length - 1]), out int charsWritten, format));
+            Assert.Equal(0, charsWritten);
         }
 
         [Theory]
@@ -76,7 +66,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public static void TryFormat_Valid(Guid guid, string format, string expected)
+        public static void TryFormat_ValidLength_ReturnsTrue(Guid guid, string format, string expected)
         {
             char[] chars = new char[guid.ToString(format).Length];
             Assert.True(guid.TryFormat(new Span<char>(chars), out int charsWritten, format));


### PR DESCRIPTION
Added tests for span-based Guid methods (ctor, TryWriteBytes, and TryFormat), largely based on existing tests for ctor, ToByteArray, and ToString. 
Exposed new span-based methods in the contract. 

Depends on https://github.com/dotnet/coreclr/pull/13323