### PR TITLE
Expose {ReadOnly}Memory from System.Runtime

### DIFF
--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -7,6 +7,8 @@
 
 // Types moved down into System.Runtime.Handles
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.CriticalHandle))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandle))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandleType))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.SafeHandle))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reflection.Missing))]
 
@@ -392,31 +394,6 @@ namespace System.Runtime.InteropServices
         public ErrorWrapper(int errorCode) { }
         public ErrorWrapper(object errorCode) { }
         public int ErrorCode { get { throw null; } }
-    }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct GCHandle
-    {
-        public bool IsAllocated { get { throw null; } }
-        public object Target {get { throw null; } set { } }
-        public System.IntPtr AddrOfPinnedObject() { throw null; }
-        public static System.Runtime.InteropServices.GCHandle Alloc(object value) { throw null; }
-        public static System.Runtime.InteropServices.GCHandle Alloc(object value, System.Runtime.InteropServices.GCHandleType type) { throw null; }
-        public override bool Equals(object o) { throw null; }
-        public void Free() { }
-        public static System.Runtime.InteropServices.GCHandle FromIntPtr(System.IntPtr value) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static bool operator ==(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { throw null; }
-        public static explicit operator System.Runtime.InteropServices.GCHandle(System.IntPtr value) { throw null; }
-        public static explicit operator System.IntPtr(System.Runtime.InteropServices.GCHandle value) { throw null; }
-        public static bool operator !=(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { throw null; }
-        public static System.IntPtr ToIntPtr(System.Runtime.InteropServices.GCHandle value) { throw null; }
-    }
-    public enum GCHandleType
-    {
-        Normal = 2,
-        Pinned = 3,
-        Weak = 0,
-        WeakTrackResurrection = 1,
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(5149), Inherited = false)]
     public sealed partial class GuidAttribute : System.Attribute

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -1630,6 +1630,29 @@ namespace System
         public MemberAccessException(string message, System.Exception inner) { }
         protected MemberAccessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
+    public struct Memory<T>
+    {
+        public static Memory<T> Empty { get { throw null; } }
+        public Memory(T[] array) { throw null;}
+        public Memory(T[] array, int start, int length) { throw null;}
+        internal Memory(Buffers.OwnedMemory<T> owner, int index, int length) { throw null;}
+        public bool IsEmpty { get { throw null; } }
+        public int Length { get { throw null; } }
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(Memory<T> other) { throw null; }
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static implicit operator Memory<T>(T[] array) { throw null; }
+        public static implicit operator Memory<T>(ArraySegment<T> arraySegment) { throw null; }
+        public static implicit operator ReadOnlyMemory<T>(Memory<T> memory) { throw null; }
+        public Memory<T> Slice(int start) { throw null; }
+        public Memory<T> Slice(int start, int length) { throw null; }
+        public Span<T> Span { get { throw null; } }
+        public unsafe Buffers.MemoryHandle Retain(bool pin = false) { throw null; }
+        public T[] ToArray() { throw null; }
+        public bool TryGetArray(out ArraySegment<T> arraySegment) { throw null; }
+    }
     public partial class MethodAccessException : System.MemberAccessException
     {
         public MethodAccessException() { }
@@ -1830,6 +1853,29 @@ namespace System
         public RankException(string message) { }
         public RankException(string message, System.Exception innerException) { }
         protected RankException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+    public struct ReadOnlyMemory<T>
+    {
+        public static ReadOnlyMemory<T> Empty { get { throw null; } }
+        public ReadOnlyMemory(T[] array) { throw null;}
+        public ReadOnlyMemory(T[] array, int start, int length) { throw null;}
+        internal ReadOnlyMemory(Buffers.OwnedMemory<T> owner, int index, int length) { throw null;}
+        public bool IsEmpty { get { throw null; } }
+        public int Length { get { throw null; } }
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(ReadOnlyMemory<T> other) { throw null; }
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static implicit operator ReadOnlyMemory<T>(T[] array) { throw null; }
+        public static implicit operator ReadOnlyMemory<T>(ArraySegment<T> arraySegment) { throw null; }
+        public ReadOnlyMemory<T> Slice(int start) { throw null; }
+        public ReadOnlyMemory<T> Slice(int start, int length) { throw null; }
+        public ReadOnlySpan<T> Span { get { throw null; } }
+        public unsafe Buffers.MemoryHandle Retain(bool pin = false) { throw null; }
+        public T[] ToArray() { throw null; }
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public bool DangerousTryGetArray(out ArraySegment<T> arraySegment) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ReadOnlySpan<T>
@@ -3759,6 +3805,38 @@ namespace System.Runtime.CompilerServices
             [System.Security.SecurityCriticalAttribute]
             public void UnsafeOnCompleted(System.Action continuation) { }
         }
+    }
+}
+namespace System.Buffers
+{
+    public unsafe struct MemoryHandle : IDisposable 
+    {
+        [System.CLSCompliantAttribute(false)]
+        public MemoryHandle(IRetainable owner, void* pinnedPointer = null,  System.Runtime.InteropServices.GCHandle handle = default(System.Runtime.InteropServices.GCHandle))  { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public void* PinnedPointer { get { throw null; } }
+        public void Dispose()  { throw null; }
+    }
+
+    public interface IRetainable 
+    {
+        bool Release();
+        void Retain();
+    }
+    
+    public abstract class OwnedMemory<T> : IDisposable, IRetainable 
+    {
+        public Memory<T> AsMemory { get { throw null; } }
+        public abstract bool IsDisposed { get; }
+        protected abstract bool IsRetained { get; }
+        public abstract int Length { get; }
+        public abstract Span<T> AsSpan();
+        public void Dispose() { throw null; }
+        protected abstract void Dispose(bool disposing);
+        public abstract MemoryHandle Pin();
+        public abstract bool Release();
+        public abstract void Retain();
+        protected internal abstract bool TryGetArray(out ArraySegment<T> arraySegment);
     }
 }
 namespace System.Collections

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -6809,6 +6809,31 @@ namespace System.Runtime.InteropServices
         public FieldOffsetAttribute(int offset) { }
         public int Value { get { throw null; } }
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct GCHandle
+    {
+        public bool IsAllocated { get { throw null; } }
+        public object Target {get { throw null; } set { } }
+        public System.IntPtr AddrOfPinnedObject() { throw null; }
+        public static System.Runtime.InteropServices.GCHandle Alloc(object value) { throw null; }
+        public static System.Runtime.InteropServices.GCHandle Alloc(object value, System.Runtime.InteropServices.GCHandleType type) { throw null; }
+        public override bool Equals(object o) { throw null; }
+        public void Free() { }
+        public static System.Runtime.InteropServices.GCHandle FromIntPtr(System.IntPtr value) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { throw null; }
+        public static explicit operator System.Runtime.InteropServices.GCHandle(System.IntPtr value) { throw null; }
+        public static explicit operator System.IntPtr(System.Runtime.InteropServices.GCHandle value) { throw null; }
+        public static bool operator !=(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { throw null; }
+        public static System.IntPtr ToIntPtr(System.Runtime.InteropServices.GCHandle value) { throw null; }
+    }
+    public enum GCHandleType
+    {
+        Normal = 2,
+        Pinned = 3,
+        Weak = 0,
+        WeakTrackResurrection = 1,
+    }
     public enum LayoutKind
     {
         Auto = 3,

--- a/src/System.Runtime/src/System.Runtime.Forwards.cs
+++ b/src/System.Runtime/src/System.Runtime.Forwards.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandle))]
-[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandleType))]

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -16,7 +16,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="System.Runtime.Forwards.cs" />
     <Compile Include="System\Action.cs" />
     <Compile Include="System\Collections\Generic\ISet.cs" />
     <Compile Include="System\Function.cs" />


### PR DESCRIPTION
Part of https://github.com/dotnet/corefxlab/issues/1711

Adding the following types:
- Memory\<T\>
- ReadOnlyMemory\<T\>
- OwnedMemory\<T\>
- MemoryHandle
- IRetainable

Order of changes:
1) Add to mscorlib (https://github.com/dotnet/coreclr/pull/13583).
2) After the type has been added to mscorlib, add impl (for portable) and type forwarders to System.Memory (https://github.com/dotnet/corefx/pull/23701) and System.Runtime (this PR) here in corefx.
3) Remove impl from corefxlab and update uses/references in Pipelines/Buffers.Experimental.
4) Other changes/additions like review/add APIs from MemoryExtensions

cc @shiftylogic, @KrzysztofCwalina, @davidfowl, @jkotas, @stephentoub, @AtsushiKan, @ericstj 