### PR TITLE
Disable RO-filesystem tests on RH69

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -202,12 +202,15 @@ namespace System.IO.Tests
             Assert.False(Directory.Exists(testDir));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), "IsNotRedHat69")]
+        [Fact]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
         [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         public void Unix_NotFoundDirectory_ReadOnlyVolume()
         {
+            if (PlatformDetection.IsRedHat69)
+                return; // [ActiveIssue(https://github.com/dotnet/corefx/issues/21920)]
+
             ReadOnly_FileSystemHelper(readOnlyDirectory =>
             {
                 Assert.Throws<DirectoryNotFoundException>(() => Delete(Path.Combine(readOnlyDirectory, "DoesNotExist")));

--- a/src/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/System.IO.FileSystem/tests/File/Delete.cs
@@ -123,7 +123,7 @@ namespace System.IO.Tests
             Delete(Path.Combine(TestDirectory, GetTestFileName(), "C"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), "IsNotRedHat69")]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
         [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
@@ -135,7 +135,7 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), "IsNotRedHat69")]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
         [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]

--- a/src/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/System.IO.FileSystem/tests/File/Delete.cs
@@ -123,24 +123,30 @@ namespace System.IO.Tests
             Delete(Path.Combine(TestDirectory, GetTestFileName(), "C"));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), "IsNotRedHat69")]
+        [Fact]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
         [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         public void Unix_NonExistentPath_ReadOnlyVolume()
         {
+            if (PlatformDetection.IsRedHat69)
+                return; // [ActiveIssue(https://github.com/dotnet/corefx/issues/21920)]
+
             ReadOnly_FileSystemHelper(readOnlyDirectory =>
             {
                 Delete(Path.Combine(readOnlyDirectory, "DoesNotExist"));
             });
         }
 
-        [ConditionalFact(typeof(PlatformDetection), "IsNotRedHat69")]
+        [Fact]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
         [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         public void Unix_ExistingDirectory_ReadOnlyVolume()
         {
+            if (PlatformDetection.IsRedHat69)
+                return; // [ActiveIssue(https://github.com/dotnet/corefx/issues/21920)]
+
             ReadOnly_FileSystemHelper(readOnlyDirectory =>
             {
                 Assert.Throws<IOException>(() => Delete(Path.Combine(readOnlyDirectory, "subdir")));


### PR DESCRIPTION
Tracked by https://github.com/dotnet/corefx/issues/21920

For some reason mounting a directory (not even read only) is failing on RH69.