### PR TITLE
Fix LargeArrayBuilder.CopyTo returning incorrect end-of-copy position

### DIFF
--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -200,7 +200,7 @@ namespace System.Collections.Generic
                 arrayIndex += toCopy;
             }
         }
-        
+
         /// <summary>
         /// Copies the contents of this builder to the specified array.
         /// </summary>
@@ -232,7 +232,13 @@ namespace System.Collections.Generic
             int column = position.Column;
 
             T[] buffer = GetBuffer(row);
-            int copied = CopyToCore(buffer, column);
+            Debug.Assert(buffer.Length > column);
+
+            int copied = Math.Min(buffer.Length - column, count);
+            Array.Copy(buffer, column, array, arrayIndex, copied);
+
+            arrayIndex += copied;
+            count -= copied;
 
             if (count == 0)
             {
@@ -242,24 +248,16 @@ namespace System.Collections.Generic
             do
             {
                 buffer = GetBuffer(++row);
-                copied = CopyToCore(buffer, 0);
+                Debug.Assert(buffer.Length > 0);
+
+                copied = Math.Min(buffer.Length, count);
+                Array.Copy(buffer, 0, array, arrayIndex, copied);
+
+                arrayIndex += copied;
+                count -= copied;
             } while (count > 0);
 
             return new CopyPosition(row, copied).Normalize(buffer.Length);
-
-            int CopyToCore(T[] sourceBuffer, int sourceIndex)
-            {
-                Debug.Assert(sourceBuffer.Length > sourceIndex);
-
-                // Copy until we satisfy `count` or reach the end of the current buffer.
-                int copyCount = Math.Min(sourceBuffer.Length - sourceIndex, count);
-                Array.Copy(sourceBuffer, sourceIndex, array, arrayIndex, copyCount);
-
-                arrayIndex += copyCount;
-                count -= copyCount;
-
-                return copyCount;
-            }
         }
 
         /// <summary>

--- a/src/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
@@ -113,9 +113,10 @@ namespace System.Collections.Generic
         /// <param name="count">The number of items to copy.</param>
         public void CopyTo(T[] array, int arrayIndex, int count)
         {
+            Debug.Assert(array != null);
             Debug.Assert(arrayIndex >= 0);
             Debug.Assert(count >= 0 && count <= Count);
-            Debug.Assert(array?.Length - arrayIndex >= count);
+            Debug.Assert(array.Length - arrayIndex >= count);
 
             int copied = 0;
             var position = CopyPosition.Start;
@@ -149,8 +150,11 @@ namespace System.Collections.Generic
                 count -= reservedCount;
             }
 
-            // Finish copying after the final marker.
-            _builder.CopyTo(position, array, arrayIndex, count);
+            if (count > 0)
+            {
+                // Finish copying after the final marker.
+                _builder.CopyTo(position, array, arrayIndex, count);
+            }
         }
 
         /// <summary>

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -421,5 +421,123 @@ namespace System.Linq.Tests
                 Assert.Equal(0xf00, en.Current);
             }
         }
+
+        [Theory]
+        [MemberData(nameof(GetToArrayDataSources))]
+        public void CollectionInterleavedWithLazyEnumerables_ToArray(IEnumerable<int>[] arrays)
+        {
+            // See https://github.com/dotnet/corefx/issues/23680
+
+            IEnumerable<int> concats = arrays[0];
+
+            for (int i = 1; i < arrays.Length; i++)
+            {
+                concats = concats.Concat(arrays[i]);
+            }
+
+            int[] results = concats.ToArray();
+
+            for (int i = 0; i < results.Length; i++)
+            {
+                Assert.Equal(i, results[i]);
+            }
+        }
+
+        private static IEnumerable<object[]> GetToArrayDataSources()
+        {
+            // Marker at the end
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new TestEnumerable<int>(new int[] { 0 }),
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new TestEnumerable<int>(new int[] { 2 }),
+                    new int[] { 3 },
+                }
+            };
+
+            // Marker at beginning
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new int[] { 0 },
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new TestEnumerable<int>(new int[] { 2 }),
+                    new TestEnumerable<int>(new int[] { 3 }),
+                }
+            };
+
+            // Marker in middle
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new TestEnumerable<int>(new int[] { 0 }),
+                    new int[] { 1 },
+                    new TestEnumerable<int>(new int[] { 2 }),
+                }
+            };
+
+            // Non-marker in middle
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new int[] { 0 },
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new int[] { 2 },
+                }
+            };
+
+            // Big arrays (marker in middle)
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new TestEnumerable<int>(Enumerable.Range(0, 100).ToArray()),
+                    Enumerable.Range(100, 100).ToArray(),
+                    new TestEnumerable<int>(Enumerable.Range(200, 100).ToArray()),
+                }
+            };
+
+            // Big arrays (non-marker in middle)
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    Enumerable.Range(0, 100).ToArray(),
+                    new TestEnumerable<int>(Enumerable.Range(100, 100).ToArray()),
+                    Enumerable.Range(200, 100).ToArray(),
+                }
+            };
+
+            // Interleaved (first marker)
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new int[] { 0 },
+                    new TestEnumerable<int>(new int[] { 1 }),
+                    new int[] { 2 },
+                    new TestEnumerable<int>(new int[] { 3 }),
+                    new int[] { 4 },
+                }
+            };
+
+            // Interleaved (first non-marker)
+            yield return new object[]
+            {
+                new IEnumerable<int>[]
+                {
+                    new TestEnumerable<int>(new int[] { 0 }),
+                    new int[] { 1 },
+                    new TestEnumerable<int>(new int[] { 2 }),
+                    new int[] { 3 },
+                    new TestEnumerable<int>(new int[] { 4 }),
+                }
+            };
+        }
     }
 }


### PR DESCRIPTION
Porting #23817 to release 2.0 branch.
Fixes #23680