### PR TITLE
Xml schema dependency removal for AOT compilers

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Core/XmlValidatingReaderImpl.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlValidatingReaderImpl.cs
@@ -57,7 +57,7 @@ namespace System.Xml
                 {
                     _eventHandler(_reader, new ValidationEventArgs((XmlSchemaException)exception, severity));
                 }
-                else if (_reader.ValidationType != ValidationType.None && severity == XmlSeverityType.Error)
+                else if (_reader._validationType != ValidationType.None && severity == XmlSeverityType.Error)
                 {
                     throw exception;
                 }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -115,6 +115,10 @@ namespace System.Xml.Serialization
         public virtual XmlSerializer GetSerializer(Type type) { throw new NotSupportedException(); }
     }
 
+    // This enum is intentionally kept outside of the XmlSerializer class since if it would be a subclass
+    // of XmlSerializer, then any access to this enum would be treated by AOT compilers as access to the XmlSerializer
+    // as well, which has a large static ctor which brings in a lot of code. So keeping the enum separate
+    // makes sure that using just the enum itself doesn't bring in the whole of serialization code base.
 #if FEATURE_SERIALIZATION_UAPAOT
     public enum SerializationMode
 #else

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -115,24 +115,24 @@ namespace System.Xml.Serialization
         public virtual XmlSerializer GetSerializer(Type type) { throw new NotSupportedException(); }
     }
 
+#if FEATURE_SERIALIZATION_UAPAOT
+    public enum SerializationMode
+#else
+    internal enum SerializationMode
+#endif
+    {
+        CodeGenOnly,
+        ReflectionOnly,
+        ReflectionAsBackup,
+        PreGenOnly
+    }
+
     /// <include file='doc\XmlSerializer.uex' path='docs/doc[@for="XmlSerializer"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
     public class XmlSerializer
     {
-#if FEATURE_SERIALIZATION_UAPAOT
-        public enum SerializationMode
-#else
-        internal enum SerializationMode
-#endif
-        {
-            CodeGenOnly,
-            ReflectionOnly,
-            ReflectionAsBackup,
-            PreGenOnly
-        }
-
 #if FEATURE_SERIALIZATION_UAPAOT
         public static SerializationMode Mode { get; set; } = SerializationMode.ReflectionAsBackup;
 #else


### PR DESCRIPTION
This changes fixes a size issue in AOT compiled code which uses XmlReader. Using XmlReader for just reading XML without validation still pulls in all of the XmlSchema code. This makes the AOT compilation slow (it's more than 400KB of IL) and the resulting app is larger (.NET Native X86 measures the difference at more than 800KB of native code).
The change relies on an assumption, that apps which don't need validation will not call the XmlReaderSettings.ValidationType setter. As such it can be reduced away and the change then ties all the dependencies needed for validation to that setter. So if the setter itself is not called XmlSchema is not pulled in.
Verified that the change does reduce the app size and that XmlSchema is not in final app anymore.