### PR TITLE
Port WebRequest.DefaultWebProxy: Set doesn't work without a previous Get

### DIFF
--- a/src/System.Net.Requests/src/System/Net/WebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/WebRequest.cs
@@ -573,6 +573,7 @@ namespace System.Net
                 lock (s_internalSyncObject)
                 {
                     s_DefaultWebProxy = value;
+                    s_DefaultWebProxyInitialized = true;
                 }
             }
         }

--- a/src/System.Net.Requests/tests/WebRequestTest.cs
+++ b/src/System.Net.Requests/tests/WebRequestTest.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Net.Tests
 {
-    public class WebRequestTest
+    public class WebRequestTest : RemoteExecutorTestBase
     {
         static WebRequestTest()
         {
@@ -27,6 +28,20 @@ namespace System.Net.Tests
             Assert.NotNull(initialDefaultWebProxy);
 
             Assert.Null(initialDefaultWebProxyCredentials);
+        }
+        
+        [Fact]
+        public void DefaultWebProxy_SetThenGet_ValuesMatch()
+        {
+            RemoteInvoke(() =>
+            {
+                IWebProxy p = new WebProxy();
+
+                WebRequest.DefaultWebProxy = p;
+                Assert.Same(p, WebRequest.DefaultWebProxy);
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/22798 to 2.0

This impeded port work by Azure Backup. It seems a safe change, worth porting in case it impacts other porters.

Fixes https://github.com/dotnet/corefx/pull/23885