### PR TITLE
Disable sockets test always failing on Desktop

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/Accept.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Accept.cs
@@ -176,6 +176,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [ActiveIssue(22808, TargetFrameworkMonikers.NetFramework)]
         [ActiveIssue(17209, TestPlatforms.AnyUnix)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]


### PR DESCRIPTION
System.Net.Sockets.Tests.AcceptTask
Accept_WithTargetSocket_ReuseAfterDisconnect_Success

"System.InvalidOperationException : acceptSocket: The socket must not be
bound or connected."

#22808