### PR TITLE
Adding log message containing actual number of compares for Span API tests

### DIFF
--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.T.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.T.cs
@@ -80,7 +80,8 @@ namespace System.SpanTests
                 foreach (TInt elem in a)
                 {
                     int numCompares = log.CountCompares(elem.Value, 9999);
-                    Assert.True(numCompares == 1);
+                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
+                    Assert.True(numCompares == 1, message);
                 }
             }
         }

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.T.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.T.cs
@@ -80,8 +80,7 @@ namespace System.SpanTests
                 foreach (TInt elem in a)
                 {
                     int numCompares = log.CountCompares(elem.Value, 9999);
-                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
-                    Assert.True(numCompares == 1, message);
+                    Assert.True(numCompares == 1, $"Expected {numCompares} == 1 for element {elem.Value}.");
                 }
             }
         }

--- a/src/System.Memory/tests/ReadOnlySpan/SequenceEqual.T.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/SequenceEqual.T.cs
@@ -64,8 +64,7 @@ namespace System.SpanTests
                 foreach (TInt elem in first)
                 {
                     int numCompares = log.CountCompares(elem.Value, elem.Value);
-                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
-                    Assert.True(numCompares == 1, message);
+                    Assert.True(numCompares == 1, $"Expected {numCompares} == 1 for element {elem.Value}.");
                 }
             }
         }

--- a/src/System.Memory/tests/ReadOnlySpan/SequenceEqual.T.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/SequenceEqual.T.cs
@@ -64,7 +64,8 @@ namespace System.SpanTests
                 foreach (TInt elem in first)
                 {
                     int numCompares = log.CountCompares(elem.Value, elem.Value);
-                    Assert.True(numCompares == 1);
+                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
+                    Assert.True(numCompares == 1, message);
                 }
             }
         }

--- a/src/System.Memory/tests/ReadOnlySpan/StartsWith.T.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/StartsWith.T.cs
@@ -85,8 +85,7 @@ namespace System.SpanTests
                 foreach (TInt elem in first)
                 {
                     int numCompares = log.CountCompares(elem.Value, elem.Value);
-                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
-                    Assert.True(numCompares == 1, message);
+                    Assert.True(numCompares == 1, $"Expected {numCompares} == 1 for element {elem.Value}.");
                 }
             }
         }

--- a/src/System.Memory/tests/ReadOnlySpan/StartsWith.T.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/StartsWith.T.cs
@@ -85,7 +85,8 @@ namespace System.SpanTests
                 foreach (TInt elem in first)
                 {
                     int numCompares = log.CountCompares(elem.Value, elem.Value);
-                    Assert.True(numCompares == 1);
+                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
+                    Assert.True(numCompares == 1, message);
                 }
             }
         }

--- a/src/System.Memory/tests/Span/IndexOf.T.cs
+++ b/src/System.Memory/tests/Span/IndexOf.T.cs
@@ -80,7 +80,8 @@ namespace System.SpanTests
                 foreach (TInt elem in a)
                 {
                     int numCompares = log.CountCompares(elem.Value, 9999);
-                    Assert.True(numCompares == 1);
+                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
+                    Assert.True(numCompares == 1, message);
                 }
             }
         }

--- a/src/System.Memory/tests/Span/IndexOf.T.cs
+++ b/src/System.Memory/tests/Span/IndexOf.T.cs
@@ -80,8 +80,7 @@ namespace System.SpanTests
                 foreach (TInt elem in a)
                 {
                     int numCompares = log.CountCompares(elem.Value, 9999);
-                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
-                    Assert.True(numCompares == 1, message);
+                    Assert.True(numCompares == 1, $"Expected {numCompares} == 1 for element {elem.Value}.");
                 }
             }
         }

--- a/src/System.Memory/tests/Span/SequenceEqual.T.cs
+++ b/src/System.Memory/tests/Span/SequenceEqual.T.cs
@@ -64,8 +64,7 @@ namespace System.SpanTests
                 foreach (TInt elem in first)
                 {
                     int numCompares = log.CountCompares(elem.Value, elem.Value);
-                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
-                    Assert.True(numCompares == 1, message);
+                    Assert.True(numCompares == 1, $"Expected {numCompares} == 1 for element {elem.Value}.");
                 }
             }
         }

--- a/src/System.Memory/tests/Span/SequenceEqual.T.cs
+++ b/src/System.Memory/tests/Span/SequenceEqual.T.cs
@@ -64,7 +64,8 @@ namespace System.SpanTests
                 foreach (TInt elem in first)
                 {
                     int numCompares = log.CountCompares(elem.Value, elem.Value);
-                    Assert.True(numCompares == 1);
+                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
+                    Assert.True(numCompares == 1, message);
                 }
             }
         }

--- a/src/System.Memory/tests/Span/StartsWith.T.cs
+++ b/src/System.Memory/tests/Span/StartsWith.T.cs
@@ -85,8 +85,7 @@ namespace System.SpanTests
                 foreach (TInt elem in first)
                 {
                     int numCompares = log.CountCompares(elem.Value, elem.Value);
-                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
-                    Assert.True(numCompares == 1, message);
+                    Assert.True(numCompares == 1, $"Expected {numCompares} == 1 for element {elem.Value}.");
                 }
             }
         }

--- a/src/System.Memory/tests/Span/StartsWith.T.cs
+++ b/src/System.Memory/tests/Span/StartsWith.T.cs
@@ -85,7 +85,8 @@ namespace System.SpanTests
                 foreach (TInt elem in first)
                 {
                     int numCompares = log.CountCompares(elem.Value, elem.Value);
-                    Assert.True(numCompares == 1);
+                    string message = string.Format("Expected number of compares is 1. Actual number of compares is {0}. Element value used to compare is {1}.", numCompares, elem.Value);
+                    Assert.True(numCompares == 1, message);
                 }
             }
         }


### PR DESCRIPTION
This will help us get more info about intermittent failures like:
https://github.com/dotnet/corefx/issues/23430


cc @AtsushiKan, @shiftylogic 

