### PR TITLE
Enable S.R.CS.Unsafe and System.Memory tests for UAP

### DIFF
--- a/src/System.Memory/tests/Configurations.props
+++ b/src/System.Memory/tests/Configurations.props
@@ -2,8 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp;
-      netfx;
+      netstandard;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Memory/tests/Memory/Span.cs
+++ b/src/System.Memory/tests/Memory/Span.cs
@@ -41,6 +41,7 @@ namespace System.MemoryTests
             owner.AsMemory.Span.Validate(91, -92, 93, 94, -95);
         }
 
+        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void SpanFromCtorArrayObject()
         {

--- a/src/System.Memory/tests/Memory/Span.cs
+++ b/src/System.Memory/tests/Memory/Span.cs
@@ -41,7 +41,7 @@ namespace System.MemoryTests
             owner.AsMemory.Span.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void SpanFromCtorArrayObject()
         {

--- a/src/System.Memory/tests/ReadOnlyMemory/CtorArray.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/CtorArray.cs
@@ -41,6 +41,7 @@ namespace System.MemoryTests
             memory.Validate(91, -92, 93, 94, -95);
         }
 
+        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorArrayObject()
         {
@@ -92,6 +93,7 @@ namespace System.MemoryTests
             memory.Validate(42, -1);
         }
 
+        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorVariantArrayType()
         {

--- a/src/System.Memory/tests/ReadOnlyMemory/CtorArray.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/CtorArray.cs
@@ -41,7 +41,7 @@ namespace System.MemoryTests
             memory.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorArrayObject()
         {
@@ -93,7 +93,7 @@ namespace System.MemoryTests
             memory.Validate(42, -1);
         }
 
-        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorVariantArrayType()
         {

--- a/src/System.Memory/tests/ReadOnlyMemory/Span.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Span.cs
@@ -41,6 +41,7 @@ namespace System.MemoryTests
             ((ReadOnlyMemory<long>)owner.AsMemory).Span.Validate(91, -92, 93, 94, -95);
         }
 
+        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void SpanFromCtorArrayObject()
         {

--- a/src/System.Memory/tests/ReadOnlyMemory/Span.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Span.cs
@@ -41,7 +41,7 @@ namespace System.MemoryTests
             ((ReadOnlyMemory<long>)owner.AsMemory).Span.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void SpanFromCtorArrayObject()
         {

--- a/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
@@ -9,16 +9,25 @@ namespace System.SpanTests
     public static partial class ReadOnlySpanTests
     {
         [Fact]
-        public static void ArrayAsReadOnlySpan()
+        public static void IntArrayAsReadOnlySpan()
         {
             int[] a = { 19, -17 };
             ReadOnlySpan<int> spanInt = a.AsReadOnlySpan();
             spanInt.Validate(19, -17);
+        }
 
+        [Fact]
+        public static void LongArrayAsReadOnlySpan()
+        {
             long[] b = { 1, -3, 7, -15, 31 };
             ReadOnlySpan<long> spanLong = b.AsReadOnlySpan();
             spanLong.Validate(1, -3, 7, -15, 31);
+        }
 
+        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [Fact]
+        public static void ObjectArrayAsReadOnlySpan()
+        {
             object o1 = new object();
             object o2 = new object();
             object[] c = { o1, o2 };
@@ -43,18 +52,27 @@ namespace System.SpanTests
         }
 
         [Fact]
-        public static void ArraySegmentAsSpan()
+        public static void IntArraySegmentAsSpan()
         {
             int[] a = { 19, -17 };
             ArraySegment<int> segmentInt = new ArraySegment<int>(a, 1, 1);
             ReadOnlySpan<int> spanInt = segmentInt.AsReadOnlySpan();
             spanInt.Validate(-17);
+        }
 
+        [Fact]
+        public static void LongArraySegmentAsSpan()
+        {
             long[] b = { 1, -3, 7, -15, 31 };
             ArraySegment<long> segmentLong = new ArraySegment<long>(b, 1, 3);
             ReadOnlySpan<long> spanLong = segmentLong.AsReadOnlySpan();
             spanLong.Validate(-3, 7, -15);
+        }
 
+        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [Fact]
+        public static void ObjectArraySegmentAsSpan()
+        {
             object o1 = new object();
             object o2 = new object();
             object o3 = new object();

--- a/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
@@ -24,7 +24,7 @@ namespace System.SpanTests
             spanLong.Validate(1, -3, 7, -15, 31);
         }
 
-        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void ObjectArrayAsReadOnlySpan()
         {
@@ -69,7 +69,7 @@ namespace System.SpanTests
             spanLong.Validate(-3, 7, -15);
         }
 
-        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void ObjectArraySegmentAsSpan()
         {

--- a/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
@@ -41,6 +41,7 @@ namespace System.SpanTests
             span.Validate(91, -92, 93, 94, -95);
         }
 
+        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorArray3()
         {
@@ -92,6 +93,7 @@ namespace System.SpanTests
             span.Validate(42, -1);
         }
 
+        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorVariantArrayType()
         {

--- a/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
@@ -41,7 +41,7 @@ namespace System.SpanTests
             span.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorArray3()
         {
@@ -93,7 +93,7 @@ namespace System.SpanTests
             span.Validate(42, -1);
         }
 
-        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorVariantArrayType()
         {

--- a/src/System.Memory/tests/Span/AsSpan.cs
+++ b/src/System.Memory/tests/Span/AsSpan.cs
@@ -24,7 +24,7 @@ namespace System.SpanTests
             spanLong.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void ObjectArrayAsSpan()
         {
@@ -61,7 +61,7 @@ namespace System.SpanTests
             spanLong.Validate(-92, 93, 94);
         }
 
-        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void ObjectArraySegmentAsSpan()
         {

--- a/src/System.Memory/tests/Span/AsSpan.cs
+++ b/src/System.Memory/tests/Span/AsSpan.cs
@@ -9,16 +9,25 @@ namespace System.SpanTests
     public static partial class SpanTests
     {
         [Fact]
-        public static void ArrayAsSpan()
+        public static void IntArrayAsSpan()
         {
             int[] a = { 91, 92, -93, 94 };
             Span<int> spanInt = a.AsSpan();
             spanInt.Validate(91, 92, -93, 94);
+        }
 
+        [Fact]
+        public static void LongArrayAsSpan()
+        {
             long[] b = { 91, -92, 93, 94, -95 };
             Span<long> spanLong = b.AsSpan();
             spanLong.Validate(91, -92, 93, 94, -95);
+        }
 
+        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [Fact]
+        public static void ObjectArrayAsSpan()
+        {
             object o1 = new object();
             object o2 = new object();
             object[] c = { o1, o2 };
@@ -35,18 +44,27 @@ namespace System.SpanTests
         }
 
         [Fact]
-        public static void ArraySegmentAsSpan()
+        public static void IntArraySegmentAsSpan()
         {
             int[] a = { 91, 92, -93, 94 };
             ArraySegment<int> segmentInt = new ArraySegment<int>(a, 1, 2);
             Span<int> spanInt = segmentInt.AsSpan();
             spanInt.Validate(92, -93);
+        }
 
+        [Fact]
+        public static void LongArraySegmentAsSpan()
+        {
             long[] b = { 91, -92, 93, 94, -95 };
             ArraySegment<long> segmentLong = new ArraySegment<long>(b, 1, 3);
             Span<long> spanLong = segmentLong.AsSpan();
             spanLong.Validate(-92, 93, 94);
+        }
 
+        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [Fact]
+        public static void ObjectArraySegmentAsSpan()
+        {
             object o1 = new object();
             object o2 = new object();
             object o3 = new object();

--- a/src/System.Memory/tests/Span/CtorArray.cs
+++ b/src/System.Memory/tests/Span/CtorArray.cs
@@ -40,6 +40,7 @@ namespace System.SpanTests
             span.Validate(91, -92, 93, 94, -95);
         }
 
+        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorArray3()
         {

--- a/src/System.Memory/tests/Span/CtorArray.cs
+++ b/src/System.Memory/tests/Span/CtorArray.cs
@@ -40,7 +40,7 @@ namespace System.SpanTests
             span.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(20884, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorArray3()
         {

--- a/src/System.Memory/tests/TestHelpers.cs
+++ b/src/System.Memory/tests/TestHelpers.cs
@@ -23,7 +23,7 @@ namespace System
                 Assert.Same(expected[i], actual);
             }
 
-            object ignore;
+            T ignore;
             AssertThrows<IndexOutOfRangeException, T>(span, (_span) => ignore = _span[expected.Length]);
         }
 
@@ -79,7 +79,7 @@ namespace System
                 Assert.Same(expected[i], actual);
             }
 
-            object ignore;
+            T ignore;
             AssertThrows<IndexOutOfRangeException, T>(span, (_span) => ignore = _span[expected.Length]);
         }
 

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/Configurations.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/Configurations.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp;
+      netstandard;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
@@ -587,6 +587,7 @@ namespace System.Runtime.CompilerServices
             Assert.Equal(0x12, r3);
         }
 
+        [ActiveIssue(23953, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void RefAreSame()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/23406

**The Span tests fail for uapaot when we try to access the elements of a Span of a reference type like string using the provided indexer:**
```C#
public static void TestingSpanReferenceTypeForUAPAOT()
{
    ReadOnlySpan<byte> span1 = new byte[] { 1 };
    byte temp1 = span1[0];  // successful

    ReadOnlySpan<string> span2 = new string[] { "1" };
    string temp2 = span2[0];    // fails with IndexOutOfRangeException
}
```
```xml
<test name="System.SpanTests.ReadOnlySpanTests.TestingSpanReferenceTypeForUAPAOT" type="System.SpanTests.ReadOnlySpanTests" method="TestingSpanReferenceTypeForUAPAOT" time="0.0000441" result="Fail">
    <failure exception-type="System.IndexOutOfRangeException">
        <message><![CDATA[System.IndexOutOfRangeException : Index was outside the bounds of the array.]]></message>
        <stack-trace><![CDATA[   at Internal.Runtime.CompilerHelpers.ThrowHelpers.ThrowIndexOutOfRangeException() in f:\dd\ndp\fxcore\CoreRT\src\System.Private.CoreLib\src\Internal\Runtime\CompilerHelpers\ThrowHelpers.cs:line 25
            at System.SpanTests.ReadOnlySpanTests.TestingSpanReferenceTypeForUAPAOT(ReadOnlySpan$1<Byte> span1) in D:\GitHub\Fork\corefx\src\System.Memory\tests\ReadOnlySpan\CtorArray.cs:line 66
            at _$ILCT$.$ILT$ReflectionDynamicInvoke$.InvokeRetV(Object thisPtr, IntPtr methodToCall, ArgSetupState argSetupState, Boolean targetIsThisCall)
            at System.InvokeUtils.CalliIntrinsics.Call(IntPtr dynamicInvokeHelperMethod, Object thisPtr, IntPtr methodToCall, ArgSetupState argSetupState, Boolean isTargetThisCall)
            at System.InvokeUtils.CallDynamicInvokeMethod(Object thisPtr, IntPtr methodToCall, Object thisPtrDynamicInvokeMethod, IntPtr dynamicInvokeHelperMethod, IntPtr dynamicInvokeHelperGenericDictionary, Object targetMethodOrDelegate, Object[] parameters, BinderBundle binderBundle, Boolean wrapInTargetInvocationException, Boolean invokeMethodHelperIsThisCall, Boolean methodToCallIsThisCall, Boolean parametersNeedCopyBack, ArgSetupState argSetupState, Object[] parametersOld, Object[] nullableCopyBackObjectsOld, Int32 curIndexOld, Object targetMethodOrDelegateOld, BinderBundle binderBundleOld, Object[] customBinderProvidedParametersOld, Object result, Exception e, Int32 i) in CallDynamicInvokeMethod:line 16707566
        ]]></stack-trace>
    </failure>
```

**The Unsafe.RefAreSame test fails on uapaot:**
```C#
public static void RefAreSame()
{
    long[] a = new long[2];
    Assert.True(Unsafe.AreSame(ref a[0], ref a[0])); // successful
    Assert.False(Unsafe.AreSame(ref a[0], ref a[1])); // fails
}
```

```xml
<test name="System.Runtime.CompilerServices.UnsafeTests.RefAreSame" type="System.Runtime.CompilerServices.UnsafeTests" method="RefAreSame" time="0.0003107" result="Fail">
    <failure exception-type="Xunit.Sdk.FalseException">
        <message><![CDATA[Assert.False() Failure\r\nExpected: False\r\nActual:   True]]></message>
        <stack-trace><![CDATA[   at System.Runtime.CompilerServices.UnsafeTests.RefAreSame(Int64[] a) in D:\GitHub\Fork\corefx\src\System.Runtime.CompilerServices.Unsafe\tests\UnsafeTests.cs:line 593
            at _$ILCT$.$ILT$ReflectionDynamicInvoke$.InvokeRetV(Object thisPtr, IntPtr methodToCall, ArgSetupState argSetupState, Boolean targetIsThisCall)
            at System.InvokeUtils.CalliIntrinsics.Call(IntPtr dynamicInvokeHelperMethod, Object thisPtr, IntPtr methodToCall, ArgSetupState argSetupState, Boolean isTargetThisCall)
            at System.InvokeUtils.CallDynamicInvokeMethod(Object thisPtr, IntPtr methodToCall, Object thisPtrDynamicInvokeMethod, IntPtr dynamicInvokeHelperMethod, IntPtr dynamicInvokeHelperGenericDictionary, Object targetMethodOrDelegate, Object[] parameters, BinderBundle binderBundle, Boolean wrapInTargetInvocationException, Boolean invokeMethodHelperIsThisCall, Boolean methodToCallIsThisCall, Boolean parametersNeedCopyBack, ArgSetupState argSetupState, Object[] parametersOld, Object[] nullableCopyBackObjectsOld, Int32 curIndexOld, Object targetMethodOrDelegateOld, BinderBundle binderBundleOld, Object[] customBinderProvidedParametersOld, Object result, Exception e, Int32 i) in CallDynamicInvokeMethod:line 16707566
        ]]></stack-trace>
    </failure>
```

I am not sure why Span\<reference type\> indexer (`ref T this[int index]`) and Unsafe.AreSame\<T\>(ref T left, ref T right) are failing on uapaot. Any ideas?

cc @jkotas, @safern, @danmosemsft 