### PR TITLE
Disable brittle WebSockets.Client test

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/KeepAliveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/KeepAliveTest.cs
@@ -16,6 +16,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public KeepAliveTest(ITestOutputHelper output) : base(output) { }
 
+        [ActiveIssue(23204, TargetFrameworkMonikers.Uap)]
         [ConditionalFact(nameof(WebSocketsSupported))]
         [OuterLoop] // involves long delay
         public async Task KeepAlive_LongDelayBetweenSendReceives_Succeeds()


### PR DESCRIPTION
System.Net.WebSockets.Client.Tests.KeepAliveTest/KeepAlive_LongDelayBetweenSendReceives_Succeeds

"System.Net.WebSockets.WebSocketException : The WebSocket is in an
invalid state ('Aborted') for this operation. Valid states are: 'Open,
CloseReceived, CloseSent, Closed'"

#23204