### PR TITLE
System.Web.HttpUtility Refactoring

### DIFF
--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -303,7 +303,7 @@ namespace System.Web
 
         public static string JavaScriptStringEncode(string value)
         {
-            return JavaScriptStringEncode(value, false);
+            return HttpEncoder.JavaScriptStringEncode(value);
         }
 
         public static string JavaScriptStringEncode(string value, bool addDoubleQuotes)

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -284,7 +284,7 @@ namespace System.Web
          )]
         public static string UrlEncodeUnicode(string str)
         {
-            return HttpEncoder.UrlEncodeUnicode(str, ignoreAscii: false);
+            return HttpEncoder.UrlEncodeUnicode(str);
         }
 
         public static string UrlDecode(string str, Encoding e)

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -58,9 +58,8 @@ namespace System.Web
                 {
                     sb.AppendFormat("{0}={1}&", keys[i], UrlEncode(this[keys[i]]));
                 }
-                if (sb.Length > 0)
-                    sb.Length--;
-                return sb.ToString();
+
+                return sb.ToString(0, sb.Length - 1);
             }
         }
 

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -247,7 +247,7 @@ namespace System.Web
                 return null;
             }
 
-            var bytes = e.GetBytes(str);
+            byte[] bytes = e.GetBytes(str);
             return HttpEncoder.UrlEncode(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
         }
 
@@ -286,7 +286,7 @@ namespace System.Web
 
         public static string JavaScriptStringEncode(string value, bool addDoubleQuotes)
         {
-            var encoded = HttpEncoder.JavaScriptStringEncode(value);
+            string encoded = HttpEncoder.JavaScriptStringEncode(value);
             return addDoubleQuotes ? "\"" + encoded + "\"" : encoded;
         }
     }

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -179,7 +179,6 @@ namespace System.Web
             return UrlEncode(str, Encoding.UTF8);
         }
 
-
         public static string UrlPathEncode(string str)
         {
             return HttpEncoder.UrlPathEncode(str);

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -271,12 +271,12 @@ namespace System.Web
             if (str == null)
                 return null;
             var bytes = e.GetBytes(str);
-            return HttpEncoder.UrlEncode(bytes, 0, bytes.Length, false /* alwaysCreateNewReturnValue */);
+            return HttpEncoder.UrlEncode(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
         }
 
         public static byte[] UrlEncodeToBytes(byte[] bytes, int offset, int count)
         {
-            return HttpEncoder.UrlEncode(bytes, offset, count, true /* alwaysCreateNewReturnValue */);
+            return HttpEncoder.UrlEncode(bytes, offset, count, alwaysCreateNewReturnValue: true);
         }
 
         [Obsolete(
@@ -284,7 +284,7 @@ namespace System.Web
          )]
         public static string UrlEncodeUnicode(string str)
         {
-            return HttpEncoder.UrlEncodeUnicode(str, false /* ignoreAscii */);
+            return HttpEncoder.UrlEncodeUnicode(str, ignoreAscii: false);
         }
 
         public static string UrlDecode(string str, Encoding e)

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -51,7 +51,10 @@ namespace System.Web
             {
                 int count = Count;
                 if (count == 0)
+                {
                     return "";
+                }
+
                 StringBuilder sb = new StringBuilder();
                 string[] keys = AllKeys;
                 for (int i = 0; i < count; i++)
@@ -148,10 +151,7 @@ namespace System.Web
 
         public static string HtmlEncode(object value)
         {
-            if (value == null)
-                return null;
-
-            return HtmlEncode(Convert.ToString(value, CultureInfo.CurrentCulture));
+            return value == null ? null : HtmlEncode(Convert.ToString(value, CultureInfo.CurrentCulture));
         }
 
 
@@ -174,9 +174,7 @@ namespace System.Web
 
         public static string UrlEncode(string str)
         {
-            if (str == null)
-                return null;
-            return UrlEncode(str, Encoding.UTF8);
+            return str == null ? null : UrlEncode(str, Encoding.UTF8);
         }
 
         public static string UrlPathEncode(string str)
@@ -186,37 +184,27 @@ namespace System.Web
 
         public static string UrlEncode(string str, Encoding e)
         {
-            if (str == null)
-                return null;
-            return Encoding.ASCII.GetString(UrlEncodeToBytes(str, e));
+            return str == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(str, e));
         }
 
         public static string UrlEncode(byte[] bytes)
         {
-            if (bytes == null)
-                return null;
-            return Encoding.ASCII.GetString(UrlEncodeToBytes(bytes));
+            return bytes == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(bytes));
         }
 
         public static string UrlEncode(byte[] bytes, int offset, int count)
         {
-            if (bytes == null)
-                return null;
-            return Encoding.ASCII.GetString(UrlEncodeToBytes(bytes, offset, count));
+            return bytes == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(bytes, offset, count));
         }
 
         public static byte[] UrlEncodeToBytes(string str)
         {
-            if (str == null)
-                return null;
-            return UrlEncodeToBytes(str, Encoding.UTF8);
+            return str == null ? null : UrlEncodeToBytes(str, Encoding.UTF8);
         }
 
         public static byte[] UrlEncodeToBytes(byte[] bytes)
         {
-            if (bytes == null)
-                return null;
-            return UrlEncodeToBytes(bytes, 0, bytes.Length);
+            return bytes == null ? null : UrlEncodeToBytes(bytes, 0, bytes.Length);
         }
 
         [Obsolete(
@@ -224,50 +212,41 @@ namespace System.Web
          )]
         public static byte[] UrlEncodeUnicodeToBytes(string str)
         {
-            if (str == null)
-                return null;
-            return Encoding.ASCII.GetBytes(UrlEncodeUnicode(str));
+            return str == null ? null : Encoding.ASCII.GetBytes(UrlEncodeUnicode(str));
         }
 
         public static string UrlDecode(string str)
         {
-            if (str == null)
-                return null;
-            return UrlDecode(str, Encoding.UTF8);
+            return str == null ? null : UrlDecode(str, Encoding.UTF8);
         }
 
         public static string UrlDecode(byte[] bytes, Encoding e)
         {
-            if (bytes == null)
-                return null;
-            return UrlDecode(bytes, 0, bytes.Length, e);
+            return bytes == null ? null : UrlDecode(bytes, 0, bytes.Length, e);
         }
 
         public static byte[] UrlDecodeToBytes(string str)
         {
-            if (str == null)
-                return null;
-            return UrlDecodeToBytes(str, Encoding.UTF8);
+            return str == null ? null : UrlDecodeToBytes(str, Encoding.UTF8);
         }
 
         public static byte[] UrlDecodeToBytes(string str, Encoding e)
         {
-            if (str == null)
-                return null;
-            return UrlDecodeToBytes(e.GetBytes(str));
+            return str == null ? null : UrlDecodeToBytes(e.GetBytes(str));
         }
 
         public static byte[] UrlDecodeToBytes(byte[] bytes)
         {
-            if (bytes == null)
-                return null;
-            return UrlDecodeToBytes(bytes, 0, bytes.Length);
+            return bytes == null ? null : UrlDecodeToBytes(bytes, 0, bytes.Length);
         }
 
         public static byte[] UrlEncodeToBytes(string str, Encoding e)
         {
             if (str == null)
+            {
                 return null;
+            }
+
             var bytes = e.GetBytes(str);
             return HttpEncoder.UrlEncode(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
         }

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -66,10 +66,7 @@ namespace System.Web
             }
         }
 
-        public static NameValueCollection ParseQueryString(string query)
-        {
-            return ParseQueryString(query, Encoding.UTF8);
-        }
+        public static NameValueCollection ParseQueryString(string query) => ParseQueryString(query, Encoding.UTF8);
 
         public static NameValueCollection ParseQueryString(string query, Encoding encoding)
         {
@@ -131,114 +128,50 @@ namespace System.Web
             return result;
         }
 
-        public static string HtmlDecode(string s)
-        {
-            return HttpEncoder.HtmlDecode(s);
-        }
+        public static string HtmlDecode(string s) => HttpEncoder.HtmlDecode(s);
 
+        public static void HtmlDecode(string s, TextWriter output) => HttpEncoder.HtmlDecode(s, output);
 
-        public static void HtmlDecode(string s, TextWriter output)
-        {
-            HttpEncoder.HtmlDecode(s, output);
-        }
+        public static string HtmlEncode(string s) => HttpEncoder.HtmlEncode(s);
 
+        public static string HtmlEncode(object value) =>
+            value == null ? null : HtmlEncode(Convert.ToString(value, CultureInfo.CurrentCulture));
 
-        public static string HtmlEncode(string s)
-        {
-            return HttpEncoder.HtmlEncode(s);
-        }
+        public static void HtmlEncode(string s, TextWriter output) => HttpEncoder.HtmlEncode(s, output);
 
+        public static string HtmlAttributeEncode(string s) => HttpEncoder.HtmlAttributeEncode(s);
 
-        public static string HtmlEncode(object value)
-        {
-            return value == null ? null : HtmlEncode(Convert.ToString(value, CultureInfo.CurrentCulture));
-        }
+        public static void HtmlAttributeEncode(string s, TextWriter output) => HttpEncoder.HtmlAttributeEncode(s, output);
 
+        public static string UrlEncode(string str) => str == null ? null : UrlEncode(str, Encoding.UTF8);
 
-        public static void HtmlEncode(string s, TextWriter output)
-        {
-            HttpEncoder.HtmlEncode(s, output);
-        }
+        public static string UrlPathEncode(string str) => HttpEncoder.UrlPathEncode(str);
 
+        public static string UrlEncode(string str, Encoding e) =>
+            str == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(str, e));
 
-        public static string HtmlAttributeEncode(string s)
-        {
-            return HttpEncoder.HtmlAttributeEncode(s);
-        }
+        public static string UrlEncode(byte[] bytes) => bytes == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(bytes));
 
+        public static string UrlEncode(byte[] bytes, int offset, int count) => bytes == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(bytes, offset, count));
 
-        public static void HtmlAttributeEncode(string s, TextWriter output)
-        {
-            HttpEncoder.HtmlAttributeEncode(s, output);
-        }
+        public static byte[] UrlEncodeToBytes(string str) => str == null ? null : UrlEncodeToBytes(str, Encoding.UTF8);
 
-        public static string UrlEncode(string str)
-        {
-            return str == null ? null : UrlEncode(str, Encoding.UTF8);
-        }
-
-        public static string UrlPathEncode(string str)
-        {
-            return HttpEncoder.UrlPathEncode(str);
-        }
-
-        public static string UrlEncode(string str, Encoding e)
-        {
-            return str == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(str, e));
-        }
-
-        public static string UrlEncode(byte[] bytes)
-        {
-            return bytes == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(bytes));
-        }
-
-        public static string UrlEncode(byte[] bytes, int offset, int count)
-        {
-            return bytes == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(bytes, offset, count));
-        }
-
-        public static byte[] UrlEncodeToBytes(string str)
-        {
-            return str == null ? null : UrlEncodeToBytes(str, Encoding.UTF8);
-        }
-
-        public static byte[] UrlEncodeToBytes(byte[] bytes)
-        {
-            return bytes == null ? null : UrlEncodeToBytes(bytes, 0, bytes.Length);
-        }
+        public static byte[] UrlEncodeToBytes(byte[] bytes) => bytes == null ? null : UrlEncodeToBytes(bytes, 0, bytes.Length);
 
         [Obsolete(
              "This method produces non-standards-compliant output and has interoperability issues. The preferred alternative is UrlEncodeToBytes(String)."
          )]
-        public static byte[] UrlEncodeUnicodeToBytes(string str)
-        {
-            return str == null ? null : Encoding.ASCII.GetBytes(UrlEncodeUnicode(str));
-        }
+        public static byte[] UrlEncodeUnicodeToBytes(string str) => str == null ? null : Encoding.ASCII.GetBytes(UrlEncodeUnicode(str));
 
-        public static string UrlDecode(string str)
-        {
-            return str == null ? null : UrlDecode(str, Encoding.UTF8);
-        }
+        public static string UrlDecode(string str) => str == null ? null : UrlDecode(str, Encoding.UTF8);
 
-        public static string UrlDecode(byte[] bytes, Encoding e)
-        {
-            return bytes == null ? null : UrlDecode(bytes, 0, bytes.Length, e);
-        }
+        public static string UrlDecode(byte[] bytes, Encoding e) => bytes == null ? null : UrlDecode(bytes, 0, bytes.Length, e);
 
-        public static byte[] UrlDecodeToBytes(string str)
-        {
-            return str == null ? null : UrlDecodeToBytes(str, Encoding.UTF8);
-        }
+        public static byte[] UrlDecodeToBytes(string str) => str == null ? null : UrlDecodeToBytes(str, Encoding.UTF8);
 
-        public static byte[] UrlDecodeToBytes(string str, Encoding e)
-        {
-            return str == null ? null : UrlDecodeToBytes(e.GetBytes(str));
-        }
+        public static byte[] UrlDecodeToBytes(string str, Encoding e) => str == null ? null : UrlDecodeToBytes(e.GetBytes(str));
 
-        public static byte[] UrlDecodeToBytes(byte[] bytes)
-        {
-            return bytes == null ? null : UrlDecodeToBytes(bytes, 0, bytes.Length);
-        }
+        public static byte[] UrlDecodeToBytes(byte[] bytes) => bytes == null ? null : UrlDecodeToBytes(bytes, 0, bytes.Length);
 
         public static byte[] UrlEncodeToBytes(string str, Encoding e)
         {
@@ -251,38 +184,21 @@ namespace System.Web
             return HttpEncoder.UrlEncode(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
         }
 
-        public static byte[] UrlEncodeToBytes(byte[] bytes, int offset, int count)
-        {
-            return HttpEncoder.UrlEncode(bytes, offset, count, alwaysCreateNewReturnValue: true);
-        }
+        public static byte[] UrlEncodeToBytes(byte[] bytes, int offset, int count) => HttpEncoder.UrlEncode(bytes, offset, count, alwaysCreateNewReturnValue: true);
 
         [Obsolete(
              "This method produces non-standards-compliant output and has interoperability issues. The preferred alternative is UrlEncode(String)."
          )]
-        public static string UrlEncodeUnicode(string str)
-        {
-            return HttpEncoder.UrlEncodeUnicode(str);
-        }
+        public static string UrlEncodeUnicode(string str) => HttpEncoder.UrlEncodeUnicode(str);
 
-        public static string UrlDecode(string str, Encoding e)
-        {
-            return HttpEncoder.UrlDecode(str, e);
-        }
+        public static string UrlDecode(string str, Encoding e) => HttpEncoder.UrlDecode(str, e);
 
-        public static string UrlDecode(byte[] bytes, int offset, int count, Encoding e)
-        {
-            return HttpEncoder.UrlDecode(bytes, offset, count, e);
-        }
+        public static string UrlDecode(byte[] bytes, int offset, int count, Encoding e) =>
+            HttpEncoder.UrlDecode(bytes, offset, count, e);
 
-        public static byte[] UrlDecodeToBytes(byte[] bytes, int offset, int count)
-        {
-            return HttpEncoder.UrlDecode(bytes, offset, count);
-        }
+        public static byte[] UrlDecodeToBytes(byte[] bytes, int offset, int count) => HttpEncoder.UrlDecode(bytes, offset, count);
 
-        public static string JavaScriptStringEncode(string value)
-        {
-            return HttpEncoder.JavaScriptStringEncode(value);
-        }
+        public static string JavaScriptStringEncode(string value) => HttpEncoder.JavaScriptStringEncode(value);
 
         public static string JavaScriptStringEncode(string value, bool addDoubleQuotes)
         {

--- a/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -263,7 +263,7 @@ namespace System.Web
         {
             if (bytes == null)
                 return null;
-            return UrlDecodeToBytes(bytes, 0, bytes != null ? bytes.Length : 0);
+            return UrlDecodeToBytes(bytes, 0, bytes.Length);
         }
 
         public static byte[] UrlEncodeToBytes(string str, Encoding e)

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -119,34 +119,31 @@ namespace System.Web.Util
 
         internal static string HtmlDecode(string value)
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                return value;
-            }
-
-            return WebUtility.HtmlDecode(value);
+            return string.IsNullOrEmpty(value) ? value : WebUtility.HtmlDecode(value);
         }
 
         internal static void HtmlDecode(string value, TextWriter output)
         {
             if (output == null)
+            {
                 throw new ArgumentNullException(nameof(output));
+            }
+
             output.Write(WebUtility.HtmlDecode(value));
         }
 
         internal static string HtmlEncode(string value)
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                return value;
-            }
-            return WebUtility.HtmlEncode(value);
+            return string.IsNullOrEmpty(value) ? value : WebUtility.HtmlEncode(value);
         }
 
         internal static void HtmlEncode(string value, TextWriter output)
         {
             if (output == null)
+            {
                 throw new ArgumentNullException(nameof(output));
+            }
+
             output.Write(WebUtility.HtmlEncode(value));
         }
 
@@ -462,9 +459,13 @@ namespace System.Web.Util
                 char ch = (char)bytes[offset + i];
 
                 if (ch == ' ')
+                {
                     cSpaces++;
+                }
                 else if (!HttpEncoderUtility.IsUrlSafeChar(ch))
+                {
                     cUnsafe++;
+                }
             }
 
             // nothing to expand?
@@ -529,12 +530,16 @@ namespace System.Web.Util
             for (int i = 0; i < count; i++)
             {
                 if (IsNonAsciiByte(bytes[offset + i]))
+                {
                     cNonAscii++;
+                }
             }
 
             // nothing to expand?
             if (cNonAscii == 0)
+            {
                 return bytes;
+            }
 
             // expand not 'safe' characters into %XX, spaces to +s
             byte[] expandedBytes = new byte[count + cNonAscii * 2];
@@ -644,7 +649,9 @@ namespace System.Web.Util
             // recurse in case there is a query string
             int i = value.IndexOf('?');
             if (i >= 0)
+            {
                 return UrlPathEncodeImpl(value.Substring(0, i)) + value.Substring(i);
+            }
 
             // encode DBCS characters and spaces only
             return HttpEncoderUtility.UrlEncodeSpaces(UrlEncodeNonAscii(value, Encoding.UTF8));
@@ -653,7 +660,10 @@ namespace System.Web.Util
         private static bool ValidateUrlEncodingParameters(byte[] bytes, int offset, int count)
         {
             if (bytes == null && count == 0)
+            {
                 return false;
+            }
+
             if (bytes == null)
             {
                 throw new ArgumentNullException(nameof(bytes));
@@ -707,7 +717,9 @@ namespace System.Web.Util
             internal void AddChar(char ch)
             {
                 if (_numBytes > 0)
+                {
                     FlushBytes();
+                }
 
                 _charBuffer[_numChars++] = ch;
             }
@@ -724,7 +736,9 @@ namespace System.Web.Util
                 */
                 {
                     if (_byteBuffer == null)
+                    {
                         _byteBuffer = new byte[_bufferSize];
+                    }
 
                     _byteBuffer[_numBytes++] = b;
                 }
@@ -733,12 +747,11 @@ namespace System.Web.Util
             internal string GetString()
             {
                 if (_numBytes > 0)
+                {
                     FlushBytes();
+                }
 
-                if (_numChars > 0)
-                    return new string(_charBuffer, 0, _numChars);
-                else
-                    return string.Empty;
+                return _numChars > 0 ? new string(_charBuffer, 0, _numChars) : "";
             }
         }
     }

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -570,7 +570,7 @@ namespace System.Web.Util
         }
 
         [Obsolete("This method produces non-standards-compliant output and has interoperability issues. The preferred alternative is UrlEncode(*).")]
-        internal static string UrlEncodeUnicode(string value, bool ignoreAscii)
+        internal static string UrlEncodeUnicode(string value)
         {
             if (value == null)
             {
@@ -586,7 +586,7 @@ namespace System.Web.Util
 
                 if ((ch & 0xff80) == 0)
                 {  // 7 bit?
-                    if (ignoreAscii || HttpEncoderUtility.IsUrlSafeChar(ch))
+                    if (HttpEncoderUtility.IsUrlSafeChar(ch))
                     {
                         sb.Append(ch);
                     }

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -528,11 +528,6 @@ namespace System.Web.Util
 
         private static byte[] UrlEncodeNonAscii(byte[] bytes, int offset, int count)
         {
-            if (!ValidateUrlEncodingParameters(bytes, offset, count))
-            {
-                return null;
-            }
-
             int cNonAscii = 0;
 
             // count them first

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -478,7 +478,7 @@ namespace System.Web.Util
                 }
                 else
                 {
-                    var subarray = new byte[count];
+                    byte[] subarray = new byte[count];
                     Buffer.BlockCopy(bytes, offset, subarray, 0, count);
                     return subarray;
                 }

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -517,10 +517,8 @@ namespace System.Web.Util
         //  Helper to encode the non-ASCII url characters only
         private static string UrlEncodeNonAscii(string str, Encoding e)
         {
-            if (string.IsNullOrEmpty(str))
-                return str;
-            if (e == null)
-                e = Encoding.UTF8;
+            Debug.Assert(!string.IsNullOrEmpty(str));
+            Debug.Assert(e != null);
             byte[] bytes = e.GetBytes(str);
             byte[] encodedBytes = UrlEncodeNonAscii(bytes, 0, bytes.Length);
             return Encoding.ASCII.GetString(encodedBytes);

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -211,41 +211,38 @@ namespace System.Web.Util
 
                     startIndex = i + 1;
                     count = 0;
-                }
 
-                switch (c)
-                {
-                    case '\r':
-                        b.Append("\\r");
-                        break;
-                    case '\t':
-                        b.Append("\\t");
-                        break;
-                    case '\"':
-                        b.Append("\\\"");
-                        break;
-                    case '\\':
-                        b.Append("\\\\");
-                        break;
-                    case '\n':
-                        b.Append("\\n");
-                        break;
-                    case '\b':
-                        b.Append("\\b");
-                        break;
-                    case '\f':
-                        b.Append("\\f");
-                        break;
-                    default:
-                        if (CharRequiresJavaScriptEncoding(c))
-                        {
+                    switch (c)
+                    {
+                        case '\r':
+                            b.Append("\\r");
+                            break;
+                        case '\t':
+                            b.Append("\\t");
+                            break;
+                        case '\"':
+                            b.Append("\\\"");
+                            break;
+                        case '\\':
+                            b.Append("\\\\");
+                            break;
+                        case '\n':
+                            b.Append("\\n");
+                            break;
+                        case '\b':
+                            b.Append("\\b");
+                            break;
+                        case '\f':
+                            b.Append("\\f");
+                            break;
+                        default:
                             AppendCharAsUnicodeJavaScript(b, c);
-                        }
-                        else
-                        {
-                            count++;
-                        }
-                        break;
+                            break;
+                    }
+                }
+                else
+                {
+                    count++;
                 }
             }
 

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -522,11 +522,11 @@ namespace System.Web.Util
             if (e == null)
                 e = Encoding.UTF8;
             byte[] bytes = e.GetBytes(str);
-            byte[] encodedBytes = UrlEncodeNonAscii(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
+            byte[] encodedBytes = UrlEncodeNonAscii(bytes, 0, bytes.Length);
             return Encoding.ASCII.GetString(encodedBytes);
         }
 
-        private static byte[] UrlEncodeNonAscii(byte[] bytes, int offset, int count, bool alwaysCreateNewReturnValue)
+        private static byte[] UrlEncodeNonAscii(byte[] bytes, int offset, int count)
         {
             if (!ValidateUrlEncodingParameters(bytes, offset, count))
             {
@@ -543,7 +543,7 @@ namespace System.Web.Util
             }
 
             // nothing to expand?
-            if (!alwaysCreateNewReturnValue && cNonAscii == 0)
+            if (cNonAscii == 0)
                 return bytes;
 
             // expand not 'safe' characters into %XX, spaces to +s

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -19,9 +19,8 @@ namespace System.Web.Util
             builder.Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
         }
 
-        private static bool CharRequiresJavaScriptEncoding(char c)
-        {
-            return c < 0x20 // control chars always have to be encoded
+        private static bool CharRequiresJavaScriptEncoding(char c) =>
+            c < 0x20 // control chars always have to be encoded
                 || c == '\"' // chars which must be encoded per JSON spec
                 || c == '\\'
                 || c == '\'' // HTML-sensitive chars encoded for safety
@@ -31,7 +30,6 @@ namespace System.Web.Util
                 || c == '\u0085' // newline chars (see Unicode 6.2, Table 5-1 [http://www.unicode.org/versions/Unicode6.2.0/ch05.pdf]) have to be encoded
                 || c == '\u2028'
                 || c == '\u2029';
-        }
 
         internal static string HtmlAttributeEncode(string value)
         {
@@ -117,10 +115,7 @@ namespace System.Web.Util
             }
         }
 
-        internal static string HtmlDecode(string value)
-        {
-            return string.IsNullOrEmpty(value) ? value : WebUtility.HtmlDecode(value);
-        }
+        internal static string HtmlDecode(string value) => string.IsNullOrEmpty(value) ? value : WebUtility.HtmlDecode(value);
 
         internal static void HtmlDecode(string value, TextWriter output)
         {
@@ -132,10 +127,7 @@ namespace System.Web.Util
             output.Write(WebUtility.HtmlDecode(value));
         }
 
-        internal static string HtmlEncode(string value)
-        {
-            return string.IsNullOrEmpty(value) ? value : WebUtility.HtmlEncode(value);
-        }
+        internal static string HtmlEncode(string value) => string.IsNullOrEmpty(value) ? value : WebUtility.HtmlEncode(value);
 
         internal static void HtmlEncode(string value, TextWriter output)
         {
@@ -173,10 +165,7 @@ namespace System.Web.Util
             return -1;
         }
 
-        private static bool IsNonAsciiByte(byte b)
-        {
-            return (b >= 0x7F || b < 0x20);
-        }
+        private static bool IsNonAsciiByte(byte b) => b >= 0x7F || b < 0x20;
 
         internal static string JavaScriptStringEncode(string value)
         {

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -522,7 +522,7 @@ namespace System.Web.Util
             if (e == null)
                 e = Encoding.UTF8;
             byte[] bytes = e.GetBytes(str);
-            byte[] encodedBytes = UrlEncodeNonAscii(bytes, 0, bytes.Length, false /* alwaysCreateNewReturnValue */);
+            byte[] encodedBytes = UrlEncodeNonAscii(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
             return Encoding.ASCII.GetString(encodedBytes);
         }
 

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoderUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoderUtility.cs
@@ -8,13 +8,14 @@ namespace System.Web.Util
 {
     internal static class HttpEncoderUtility
     {
-        public static int HexToInt(char h)
-        {
-            return (h >= '0' && h <= '9') ? h - '0' :
-                (h >= 'a' && h <= 'f') ? h - 'a' + 10 :
-                    (h >= 'A' && h <= 'F') ? h - 'A' + 10 :
-                        -1;
-        }
+        public static int HexToInt(char h) =>
+            h >= '0' && h <= '9'
+                ? h - '0'
+                : h >= 'a' && h <= 'f'
+                    ? h - 'a' + 10
+                    : h >= 'A' && h <= 'F'
+                        ? h - 'A' + 10
+                        : -1;
 
         public static char IntToHex(int n)
         {
@@ -47,14 +48,6 @@ namespace System.Web.Util
         }
 
         //  Helper to encode spaces only
-        internal static string UrlEncodeSpaces(string str)
-        {
-            if (str != null && str.IndexOf(' ') >= 0)
-            {
-                str = str.Replace(" ", "%20");
-            }
-
-            return str;
-        }
+        internal static string UrlEncodeSpaces(string str) => str != null && str.IndexOf(' ') >= 0 ? str.Replace(" ", "%20") : str;
     }
 }

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoderUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoderUtility.cs
@@ -20,7 +20,7 @@ namespace System.Web.Util
         {
             Debug.Assert(n < 0x10);
 
-            return n <= 9 ? (char)(n + (int)'0') : (char)(n - 10 + (int)'a');
+            return n <= 9 ? (char)(n + '0') : (char)(n - 10 + 'a');
         }
 
         // Set of safe chars, from RFC 1738.4 minus '+'

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoderUtility.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoderUtility.cs
@@ -20,17 +20,16 @@ namespace System.Web.Util
         {
             Debug.Assert(n < 0x10);
 
-            if (n <= 9)
-                return (char)(n + (int)'0');
-            else
-                return (char)(n - 10 + (int)'a');
+            return n <= 9 ? (char)(n + (int)'0') : (char)(n - 10 + (int)'a');
         }
 
         // Set of safe chars, from RFC 1738.4 minus '+'
         public static bool IsUrlSafeChar(char ch)
         {
             if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9'))
+            {
                 return true;
+            }
 
             switch (ch)
             {
@@ -51,7 +50,10 @@ namespace System.Web.Util
         internal static string UrlEncodeSpaces(string str)
         {
             if (str != null && str.IndexOf(' ') >= 0)
+            {
                 str = str.Replace(" ", "%20");
+            }
+
             return str;
         }
     }

--- a/src/System.Web.HttpUtility/src/System/Web/Util/UriUtil.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/UriUtil.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System.Web.Util
 {
     internal static class UriUtil
@@ -50,13 +52,11 @@ namespace System.Web.Util
                     // To retain the same string as originally given, find the authority in the original url and include
                     // everything up to that.
                     int authorityIndex = inputWithoutQueryFragment.IndexOf(authority, StringComparison.OrdinalIgnoreCase);
-                    if (authorityIndex != -1)
-                    {
-                        int schemeAndAuthorityLength = authorityIndex + authority.Length;
-                        schemeAndAuthority = inputWithoutQueryFragment.Substring(0, schemeAndAuthorityLength);
-                        path = inputWithoutQueryFragment.Substring(schemeAndAuthorityLength);
-                        return true;
-                    }
+                    Debug.Assert(authorityIndex != -1); // Otherwise authority would be null or empty.
+                    int schemeAndAuthorityLength = authorityIndex + authority.Length;
+                    schemeAndAuthority = inputWithoutQueryFragment.Substring(0, schemeAndAuthorityLength);
+                    path = inputWithoutQueryFragment.Substring(schemeAndAuthorityLength);
+                    return true;
                 }
             }
 

--- a/src/System.Web.HttpUtility/src/System/Web/Util/UriUtil.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/UriUtil.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-
 namespace System.Web.Util
 {
     internal static class UriUtil
@@ -52,11 +50,13 @@ namespace System.Web.Util
                     // To retain the same string as originally given, find the authority in the original url and include
                     // everything up to that.
                     int authorityIndex = inputWithoutQueryFragment.IndexOf(authority, StringComparison.OrdinalIgnoreCase);
-                    Debug.Assert(authorityIndex != -1); // Otherwise authority would be null or empty.
-                    int schemeAndAuthorityLength = authorityIndex + authority.Length;
-                    schemeAndAuthority = inputWithoutQueryFragment.Substring(0, schemeAndAuthorityLength);
-                    path = inputWithoutQueryFragment.Substring(schemeAndAuthorityLength);
-                    return true;
+                    if (authorityIndex != -1)
+                    {
+                        int schemeAndAuthorityLength = authorityIndex + authority.Length;
+                        schemeAndAuthority = inputWithoutQueryFragment.Substring(0, schemeAndAuthorityLength);
+                        path = inputWithoutQueryFragment.Substring(schemeAndAuthorityLength);
+                        return true;
+                    }
                 }
             }
 

--- a/src/System.Web.HttpUtility/src/System/Web/Util/Utf16StringValidator.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/Utf16StringValidator.cs
@@ -6,7 +6,7 @@ namespace System.Web.Util
 {
     internal static class Utf16StringValidator
     {
-        private const char UNICODE_REPLACEMENT_CHAR = '\uFFFD';
+        private const char UnicodeReplacementChar = '\uFFFD';
 
         internal static string ValidateString(string input)
         {
@@ -42,7 +42,7 @@ namespace System.Web.Util
                 // a high surrogate, so we'll replace it.
                 if (char.IsLowSurrogate(thisChar))
                 {
-                    chars[i] = UNICODE_REPLACEMENT_CHAR;
+                    chars[i] = UnicodeReplacementChar;
                     continue;
                 }
 
@@ -58,7 +58,7 @@ namespace System.Web.Util
 
                     // If this character is a high surrogate and it is not followed
                     // by a low surrogate, replace it.
-                    chars[i] = UNICODE_REPLACEMENT_CHAR;
+                    chars[i] = UnicodeReplacementChar;
                     continue;
                 }
 

--- a/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -748,6 +748,7 @@ namespace System.Web.Tests
         [InlineData("http://EXAMPLE.NET/défault.xxx?sdsd=sds", "http://EXAMPLE.NET/d%c3%a9fault.xxx?sdsd=sds")]
         [InlineData("file:///C/Users", "file:///C/Users")]
         [InlineData("mailto:user@example.net", "mailto:user@example.net")]
+        [InlineData("http://example\u200E.net/", "http://example%e2%80%8e.net/")]
         public void UrlPathEncode(string decoded, string encoded)
         {
             Assert.Equal(encoded, HttpUtility.UrlPathEncode(decoded));

--- a/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -349,6 +349,14 @@ namespace System.Web.Tests
             Assert.Equal("\"" + encoded + "\"", HttpUtility.JavaScriptStringEncode(decoded, true));
         }
 
+
+        [Theory]
+        [MemberData(nameof(JavaScriptStringEncodeData))]
+        public void JavaScriptStringEncode_ExplicitDontAddQuotes(string decoded, string encoded)
+        {
+            Assert.Equal(encoded, HttpUtility.JavaScriptStringEncode(decoded, false));
+        }
+
         #endregion JavaScriptStringEncode
 
         #region ParseQueryString


### PR DESCRIPTION
Some refactoring of the `HttpUtility` class.

Removal of dead code and an extra test brings coverage up to 100% lines, 98.4% branching (two branches implicit to `fixed` are left uncoverable).

* Use named arguments instead of comments.

* Remove `ignoreAscii` parameter from `UrlEncodeUnicode` method

Only ever `false`.

* Remove `alwasyCreateNewReturnValue` from `UrlEncodeNonAscii`

Always `false`.

* Remove `ValidateUrlEncodingParameters` check from `UrlEncodeNonAscii`

Cases covered can't happen as bytes comes from `Encoding.GetBytes` call and sizes are based on that.

* Remove `string.IsnullOrEmpty` and `e == null` branches from `UrlEncodeNonAscii`

Guaranteed by only caller not to be hit. Replace with assertions.

* Remove `bytes == null` branch from `UrlDecodeToBytes`

Exists in a `bytes != null` branch, so never `true`.

* Remove `sb.Length` test from `HttpQSCollection.ToString()`

In a path for which there will always be at least one value added, so always true, so just use offset & length overload of `ToString`.

* Remove check that `authorityIndex != -1`.

Cannot be `false` in the branch it is in.

* Change `JavaScriptStringEncode` call to avoid unnecessary branch.

Can just call `HttpEncoder.JavaScriptStringEncode` directly.

* Move switch for determining js escape into first `CharRequiresJavaScriptEncoding` branch.

Removes need for double-check.

* Add test for `JavaScriptStringEncode` with `false` for `addDoubleQuotes`

* Always have braces in `if`

* Remove redundant casts.

* Use explicit types.

* Use expression-body syntax

* Use PascalCase for constant.