### PR TITLE
Remove dead path from BigInteger ctor

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -314,7 +314,6 @@ namespace System.Numerics
             {
                 int unalignedBytes = byteCount % 4;
                 int dwordCount = byteCount / 4 + (unalignedBytes == 0 ? 0 : 1);
-                bool isZero = true;
                 uint[] val = new uint[dwordCount];
 
                 // Copy all dwords, except but don't do the last one if it's not a full four bytes
@@ -324,7 +323,6 @@ namespace System.Numerics
                     for (int byteInDword = 0; byteInDword < 4; byteInDword++)
                     {
                         byte curByteValue = value[curByte];
-                        if (curByteValue != 0x00) isZero = false;
                         val[curDword] = (val[curDword] << 8) | curByteValue;
                         curByte--;
                     }
@@ -338,16 +336,11 @@ namespace System.Numerics
                     for (curByte = byteCount - 1; curByte >= byteCount - unalignedBytes; curByte--)
                     {
                         byte curByteValue = value[curByte];
-                        if (curByteValue != 0x00) isZero = false;
                         val[curDword] = (val[curDword] << 8) | curByteValue;
                     }
                 }
 
-                if (isZero)
-                {
-                    this = s_bnZeroInt;
-                }
-                else if (isNegative)
+                if (isNegative)
                 {
                     NumericsHelpers.DangerousMakeTwosComplement(val); // Mutates val
 


### PR DESCRIPTION
If a `BigInteger` is created from a byte array of more than 4 bytes, and all of them are zero, then a path is taken assign the zero constant to the constructed struct.

However, as trailing zero bytes are skipped, no all-zero sequence will be treated as being larger than zero bytes, so the path can never be hit.

Remove it.