### PR TITLE
Make BigInteger ctor opt path for == int.MinValue reachable.

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -356,23 +356,32 @@ namespace System.Numerics
                     while (len >= 0 && val[len] == 0) len--;
                     len++;
 
-                    if (len == 1 && unchecked((int)(val[0])) > 0)
+                    if (len == 1)
                     {
-                        if (val[0] == 1 /* abs(-1) */)
+                        switch (val[0])
                         {
-                            this = s_bnMinusOneInt;
-                        }
-                        else if (val[0] == kuMaskHighBit) // abs(Int32.MinValue)
-                        {
-                            this = s_bnMinInt;
-                        }
-                        else
-                        {
-                            _sign = (-1) * ((int)val[0]);
-                            _bits = null;
+                            case 1: // abs(-1)
+                                this = s_bnMinusOneInt;
+                                return;
+
+                            case kuMaskHighBit: // abs(Int32.MinValue)
+                                this = s_bnMinInt;
+                                return;
+
+                            default:
+                                if (unchecked((int)val[0]) > 0)
+                                {
+                                    _sign = (-1) * ((int)val[0]);
+                                    _bits = null;
+                                    AssertValid();
+                                    return;
+                                }
+
+                                break;
                         }
                     }
-                    else if (len != val.Length)
+
+                    if (len != val.Length)
                     {
                         _sign = -1;
                         _bits = new uint[len];

--- a/src/System.Runtime.Numerics/tests/BigInteger/ctor.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/ctor.cs
@@ -891,6 +891,10 @@ namespace System.Numerics.Tests
             // ctor(byte[]): array is UInt32.MaxValue + 1
             VerifyCtorByteArray(new byte[] { 0, 0, 0, 0, 1 }, (UInt64)UInt32.MaxValue + 1);
 
+            // ctor(byte[]): array is Int32.MinValue with overlong representation.
+            VerifyCtorByteArray(new byte[] {0, 0, 0, 0x80, 0xFF});
+            Assert.Equal(new BigInteger(new byte[] { 0, 0, 0, 0x80, 0xFF, 0xFF, 0xFF }), int.MinValue);
+
             // ctor(byte[]): array is UInt64.MaxValue
             VerifyCtorByteArray(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0 }, UInt64.MaxValue);
 


### PR DESCRIPTION
The `BigInteger(ReadOnlySpan<byte> value)` ctor contains an optimised path for value being larger than 4 bytes and the result being equal to `int.MinValue`.

However this path is inside a test that precludes that value, so can never be reached.

Restructure so that the path is reachable.