### PR TITLE
Log Windows ProductType

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -49,9 +49,9 @@ namespace System
 
         public static string GetDistroVersionString()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return "";
+                return "OSX Version=" + s_osxProductVersion.ToString();
             }
 
             DistroInfo v = ParseOsReleaseFile();

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -59,6 +59,7 @@ namespace System
             }
         }
 
+        public static bool IsWindows => true;
         public static bool IsWindows7 => GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;
         public static bool IsWindows8x => GetWindowsVersion() == 6 && (GetWindowsMinorVersion() == 2 || GetWindowsMinorVersion() == 3);
 

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -49,8 +49,7 @@ namespace System
         {
             get
             {
-                int productType;
-                Assert.True(GetProductInfo(Environment.OSVersion.Version.Major, Environment.OSVersion.Version.Minor, 0, 0, out productType));
+                int productType = GetWindowsProductType();
                 if ((productType == PRODUCT_IOTUAPCOMMERCIAL) ||
                     (productType == PRODUCT_IOTUAP))
                 {
@@ -60,7 +59,6 @@ namespace System
             }
         }
 
-        public static bool IsWindows => true;
         public static bool IsWindows7 => GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;
         public static bool IsWindows8x => GetWindowsVersion() == 6 && (GetWindowsMinorVersion() == 2 || GetWindowsMinorVersion() == 3);
 
@@ -118,7 +116,7 @@ namespace System
             return null;
         }
 
-        public static string GetDistroVersionString() { return ""; }
+        public static string GetDistroVersionString() { return "ProductType=" + GetWindowsProductType(); }
 
         private static int s_isWinRT = -1;
 
@@ -212,30 +210,26 @@ namespace System
             }
         }
 
+        private static int GetWindowsProductType()
+        {
+            Assert.True(GetProductInfo(Environment.OSVersion.Version.Major, Environment.OSVersion.Version.Minor, 0, 0, out int productType));
+            return productType;
+        }
+
         private static int GetWindowsMinorVersion()
         {
-            if (IsWindows)
-            {
-                RTL_OSVERSIONINFOEX osvi = new RTL_OSVERSIONINFOEX();
-                osvi.dwOSVersionInfoSize = (uint)Marshal.SizeOf(osvi);
-                Assert.Equal(0, RtlGetVersion(out osvi));
-                return (int)osvi.dwMinorVersion;
-            }
-
-            return -1;
+            RTL_OSVERSIONINFOEX osvi = new RTL_OSVERSIONINFOEX();
+            osvi.dwOSVersionInfoSize = (uint)Marshal.SizeOf(osvi);
+            Assert.Equal(0, RtlGetVersion(out osvi));
+            return (int)osvi.dwMinorVersion;
         }
 
         private static int GetWindowsBuildNumber()
         {
-            if (IsWindows)
-            {
-                RTL_OSVERSIONINFOEX osvi = new RTL_OSVERSIONINFOEX();
-                osvi.dwOSVersionInfoSize = (uint)Marshal.SizeOf(osvi);
-                Assert.Equal(0, RtlGetVersion(out osvi));
-                return (int)osvi.dwBuildNumber;
-            }
-
-            return -1;
+            RTL_OSVERSIONINFOEX osvi = new RTL_OSVERSIONINFOEX();
+            osvi.dwOSVersionInfoSize = (uint)Marshal.SizeOf(osvi);
+            Assert.Equal(0, RtlGetVersion(out osvi));
+            return (int)osvi.dwBuildNumber;
         }
 
         private const uint TokenElevation = 20;


### PR DESCRIPTION
Log result of GetProductType() on Windows so I can see how to selectively disable tests on Server Core.
Log OSX product version also.

Inline IsWindows.

https://github.com/dotnet/corefx/issues/22656