### PR TITLE
Fix build break

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
+++ b/src/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
@@ -91,6 +91,9 @@
     <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SHA512SignatureDescription.cs" />
     <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SHA384SignatureDescription.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\System.Security.Permissions\src\System.Security.Permissions.csproj"/>
+  </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.NonGeneric" />


### PR DESCRIPTION
Fix build break reported in issue https://github.com/dotnet/corefx/issues/23912. 

I could reproduce this consistently after `git clean -fxd .` in my `VS 2015 Developer Command prompt` on a `Windows 10` box. Fix was to simply add a project reference to` System.Security.Permissions` from `System.Security.Cryptography.Xml`. 

Admittedly, I'm not totally sure why there is the `ref` and `src` references. I just adopted the convention I saw in existing project files. 

Does seem odd that this wasn't caught by CI.