### PR TITLE
Use linker from ILLink.Tasks

### DIFF
--- a/external/ILLink/ILLink.depproj
+++ b/external/ILLink/ILLink.depproj
@@ -9,7 +9,7 @@
     <NugetRuntimeIdentifier>$(ToolRuntimeRID)</NugetRuntimeIdentifier>
     <RidSpecificAssets>true</RidSpecificAssets>
     <ILLinkTasksPackageId>ILLink.Tasks</ILLinkTasksPackageId>
-    <ILLinkTasksPackageVersion>0.1.4-preview-737646</ILLinkTasksPackageVersion>
+    <ILLinkTasksPackageVersion>0.1.4-preview-981901</ILLinkTasksPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="$(ILLinkTasksPackageId)">
@@ -20,7 +20,7 @@
   <Target Name="IncludeToolsFiles"
           AfterTargets="ResolveNuGetPackages">
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(PackagesDir)\$(ILLinkTasksPackageId)\$(ILLinkTasksPackageVersion)\tools\netcoreapp2.0\*.*">
+      <ReferenceCopyLocalPaths Include="$(PackagesDir)\$(ILLinkTasksPackageId)\$(ILLinkTasksPackageVersion)\tools\net46\*.*">
         <NuGetPackageId>$(ILLinkTasksPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(ILLinkTasksPackageVersion)</NuGetPackageVersion>
       </ReferenceCopyLocalPaths>

--- a/external/ILLink/ILLink.depproj
+++ b/external/ILLink/ILLink.depproj
@@ -8,21 +8,22 @@
     <EnableBinPlacing>false</EnableBinPlacing>
     <NugetRuntimeIdentifier>$(ToolRuntimeRID)</NugetRuntimeIdentifier>
     <RidSpecificAssets>true</RidSpecificAssets>
+    <ILLinkTasksPackageId>ILLink.Tasks</ILLinkTasksPackageId>
+    <ILLinkTasksPackageVersion>0.1.4-preview-737646</ILLinkTasksPackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.ILLink">
-      <Version>0.1.9-preview</Version>
-      <IncludeAssets>Analyzers;Build;ContentFiles;Native;Runtime</IncludeAssets>
+    <PackageReference Include="$(ILLinkTasksPackageId)">
+      <Version>$(ILLinkTasksPackageVersion)</Version>
     </PackageReference>
-    <Content Include="illink.runtimeconfig.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <Target Name="IncludeAllFiles"
+  <Target Name="IncludeToolsFiles"
           AfterTargets="ResolveNuGetPackages">
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="%(ReferenceCopyLocalPaths.RootDir)%(ReferenceCopyLocalPaths.Directory)\*.*" />
+      <ReferenceCopyLocalPaths Include="$(PackagesDir)\$(ILLinkTasksPackageId)\$(ILLinkTasksPackageVersion)\tools\netcoreapp2.0\*.*">
+        <NuGetPackageId>$(ILLinkTasksPackageId)</NuGetPackageId>
+        <NuGetPackageVersion>$(ILLinkTasksPackageVersion)</NuGetPackageVersion>
+      </ReferenceCopyLocalPaths>
     </ItemGroup>
   </Target>
 </Project>

--- a/external/ILLink/ILLink.depproj
+++ b/external/ILLink/ILLink.depproj
@@ -8,7 +8,7 @@
     <EnableBinPlacing>false</EnableBinPlacing>
     <NugetRuntimeIdentifier>$(ToolRuntimeRID)</NugetRuntimeIdentifier>
     <RidSpecificAssets>true</RidSpecificAssets>
-    <ILLinkTasksPackageId>ILLink.Tasks</ILLinkTasksPackageId>
+    <ILLinkTasksPackageId>illink.tasks</ILLinkTasksPackageId>
     <ILLinkTasksPackageVersion>0.1.4-preview-981901</ILLinkTasksPackageVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -20,9 +20,17 @@
   <Target Name="IncludeToolsFiles"
           AfterTargets="ResolveNuGetPackages">
     <ItemGroup>
+      <ReferenceCopyLocalPaths Include="$(PackagesDir)\$(ILLinkTasksPackageId)\$(ILLinkTasksPackageVersion)\tools\netcoreapp2.0\*.*">
+        <NuGetPackageId>$(ILLinkTasksPackageId)</NuGetPackageId>
+        <NuGetPackageVersion>$(ILLinkTasksPackageVersion)</NuGetPackageVersion>
+        <SubFolder>/netcoreapp2.0/</SubFolder>
+      </ReferenceCopyLocalPaths>
+    </ItemGroup>
+    <ItemGroup>
       <ReferenceCopyLocalPaths Include="$(PackagesDir)\$(ILLinkTasksPackageId)\$(ILLinkTasksPackageVersion)\tools\net46\*.*">
         <NuGetPackageId>$(ILLinkTasksPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(ILLinkTasksPackageVersion)</NuGetPackageVersion>
+        <SubFolder>/net46/</SubFolder>
       </ReferenceCopyLocalPaths>
     </ItemGroup>
   </Target>

--- a/illink.targets
+++ b/illink.targets
@@ -10,7 +10,7 @@
 
   <!-- Inputs and outputs of ILLinkTrimAssembly -->
   <PropertyGroup>
-    <ILLinkToolPath Condition="'$(ILLinkToolPath)' == ''">$(ToolsDir)ILLink/illink.dll</ILLinkToolPath>
+    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == ''">$(ToolsDir)ILLink/ILLink.Tasks.dll</ILLinkTasksPath>
     <ILLinkTrimAssemblyPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</ILLinkTrimAssemblyPath>
     <ILLinkTrimAssemblySymbols>$(IntermediateOutputPath)$(TargetName).pdb</ILLinkTrimAssemblySymbols>
     <ILLinkTrimInputPath>$(IntermediateOutputPath)PreTrim/</ILLinkTrimInputPath>
@@ -55,6 +55,7 @@
        Examines the "input assembly" for IL that is unreachable from public API and trims that,
        rewriting the assembly to an "output assembly"
   -->
+  <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksPath)" />
   <Target Name="ILLinkTrimAssembly" Condition="'$(ILLinkTrimAssembly)' == 'true'" DependsOnTargets="EnsureBuildToolsRuntime">
     <ItemGroup>
       <!-- currently only directories are supported by ILLink. -->
@@ -66,7 +67,7 @@
            Currently this must be passed as name and directory.
            Directory of this assembly *must* occur before directory of references. -->
       <ILLinkArgs>$(ILLinkArgs) -r $(TargetName)</ILLinkArgs>
-      <ILLinkArgs>$(ILLinkArgs) -d $(ILLinkTrimInputPath)</ILLinkArgs>
+      <!--ILLinkArgs>$(ILLinkArgs) -d $(ILLinkTrimInputPath)</ILLinkArgs-->
       <!-- directories to examine for assembly dependencies -->
       <ILLinkArgs>$(ILLinkArgs) @(_ILLinkReferenceDirectory->'-d %(Identity)', ' ')</ILLinkArgs>
       <!-- don't trim anything that's defined in core assemblies -->
@@ -74,7 +75,7 @@
       <ILLinkArgs>$(ILLinkArgs) -p skip netstandard</ILLinkArgs>
       <!-- keep type-forward assemblies (facades) -->
       <ILLinkArgs>$(ILLinkArgs) -t</ILLinkArgs>
-      <ILLinkArgs>$(ILLinkArgs) -out $(ILLinkTrimOutputPath)</ILLinkArgs>
+      <!--ILLinkArgs>$(ILLinkArgs) -out $(ILLinkTrimOutputPath)</ILLinkArgs-->
       <ILLinkArgs Condition="'$(ILLinkTrimXml)' != ''">$(ILLinkArgs) -x $(ILLinkTrimXml)</ILLinkArgs>
       <ILLinkArgs Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimAssemblySymbols)')">$(ILLinkArgs) -b true</ILLinkArgs>
       <!-- keep types and members required by Debugger-related attributes -->
@@ -95,12 +96,12 @@
           DestinationFolder="$(ILLinkTrimInputPath)"
           Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimAssemblySymbols)')"
     />
-
-    <PropertyGroup>
-      <ILLinkCmd>$(OverrideToolHost) "$(ILLinkToolPath)"</ILLinkCmd>
-    </PropertyGroup>
-
-    <Exec Command="$(ILLinkCmd) $(ILLinkArgs)" />
+    
+    <ILLink AssemblyPaths="$(ILLinkTrimInputAssembly)"
+            RootAssemblyNames=""
+            OutputDirectory="$(ILLinkTrimOutputPath)"
+            ExtraArgs="$(ILLinkArgs)" />
+    
   </Target>
 
   <!-- ILLink reporting.

--- a/illink.targets
+++ b/illink.targets
@@ -57,25 +57,13 @@
   -->
   <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksPath)" />
   <Target Name="ILLinkTrimAssembly" Condition="'$(ILLinkTrimAssembly)' == 'true'" DependsOnTargets="EnsureBuildToolsRuntime">
-    <ItemGroup>
-      <!-- currently only directories are supported by ILLink. -->
-      <_ILLinkReferenceDirectory Include="%(ReferencePath.RootDir)%(ReferencePath.Directory)" />
-    </ItemGroup>
-
     <PropertyGroup>
-      <!-- Root public entry points in this assembly.
-           Currently this must be passed as name and directory.
-           Directory of this assembly *must* occur before directory of references. -->
-      <ILLinkArgs>$(ILLinkArgs) -r $(TargetName)</ILLinkArgs>
-      <!--ILLinkArgs>$(ILLinkArgs) -d $(ILLinkTrimInputPath)</ILLinkArgs-->
-      <!-- directories to examine for assembly dependencies -->
-      <ILLinkArgs>$(ILLinkArgs) @(_ILLinkReferenceDirectory->'-d %(Identity)', ' ')</ILLinkArgs>
+      <ILLinkArgs>$(ILLinkArgs)-r $(TargetName)</ILLinkArgs>
       <!-- don't trim anything that's defined in core assemblies -->
       <ILLinkArgs>$(ILLinkArgs) -c skip</ILLinkArgs>
       <ILLinkArgs>$(ILLinkArgs) -p skip netstandard</ILLinkArgs>
       <!-- keep type-forward assemblies (facades) -->
       <ILLinkArgs>$(ILLinkArgs) -t</ILLinkArgs>
-      <!--ILLinkArgs>$(ILLinkArgs) -out $(ILLinkTrimOutputPath)</ILLinkArgs-->
       <ILLinkArgs Condition="'$(ILLinkTrimXml)' != ''">$(ILLinkArgs) -x $(ILLinkTrimXml)</ILLinkArgs>
       <ILLinkArgs Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimAssemblySymbols)')">$(ILLinkArgs) -b true</ILLinkArgs>
       <!-- keep types and members required by Debugger-related attributes -->
@@ -96,12 +84,12 @@
           DestinationFolder="$(ILLinkTrimInputPath)"
           Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimAssemblySymbols)')"
     />
-    
-    <ILLink AssemblyPaths="$(ILLinkTrimInputAssembly)"
+
+    <ILLink AssemblyPaths="$(ILLinkTrimInputAssembly);@(ReferencePath)"
             RootAssemblyNames=""
             OutputDirectory="$(ILLinkTrimOutputPath)"
             ExtraArgs="$(ILLinkArgs)" />
-    
+
   </Target>
 
   <!-- ILLink reporting.

--- a/illink.targets
+++ b/illink.targets
@@ -10,7 +10,8 @@
 
   <!-- Inputs and outputs of ILLinkTrimAssembly -->
   <PropertyGroup>
-    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == ''">$(ToolsDir)ILLink/ILLink.Tasks.dll</ILLinkTasksPath>
+    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' And '$(RunningOnCore)' == 'true'">$(ToolsDir)ILLink/netcoreapp2.0/ILLink.Tasks.dll</ILLinkTasksPath>
+    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' And '$(RunningOnCore)' != 'true'">$(ToolsDir)ILLink/net46/ILLink.Tasks.dll</ILLinkTasksPath>
     <ILLinkTrimAssemblyPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</ILLinkTrimAssemblyPath>
     <ILLinkTrimAssemblySymbols>$(IntermediateOutputPath)$(TargetName).pdb</ILLinkTrimAssemblySymbols>
     <ILLinkTrimInputPath>$(IntermediateOutputPath)PreTrim/</ILLinkTrimInputPath>


### PR DESCRIPTION
This tasks package contains the newest version of the linker, which comes with an msbuild task. The corefx targets have been updated to use the new msbuild task instead of running illink in a new process.