### PR TITLE
Add /casesensitive parameter so the command works on linux when the path contains capital letter

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -11,7 +11,7 @@
     <Delete Condition="Exists('$(SerializerPdbImmediatePath)') == 'true'" Files="$(SerializerPdbImmediatePath)" />
     <Delete Condition="Exists('$(SerializerCsImmediatePath)') == 'true'"  Files="$(SerializerCsImmediatePath)" />
     <Message Text="Running Serialization Tool" Importance="normal" />
-    <Exec Command="dotnet Microsoft.XmlSerializer.Generator $(IntermediateOutputPath)$(AssemblyName).dll /force /casesensitive" ContinueOnError="true"/>
+    <Exec Command="dotnet Microsoft.XmlSerializer.Generator $(IntermediateOutputPath)$(AssemblyName).dll /force" ContinueOnError="true"/>
     <Warning Condition="Exists('$(SerializerCsImmediatePath)') != 'true'" Text="$(SGenWarningText)" />
     <Csc Condition="Exists('$(SerializerCsImmediatePath)') == 'true'" ContinueOnError="true" OutputAssembly="$(SerializerDllImmediatePath)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(SerializerCsImmediatePath)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)"/>
     <Warning Condition="Exists('$(SerializerDllImmediatePath)') != 'true' And Exists('$(SerializerCsImmediatePath)') == 'true'" Text="$(SGenWarningText)"/>

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -11,7 +11,7 @@
     <Delete Condition="Exists('$(SerializerPdbImmediatePath)') == 'true'" Files="$(SerializerPdbImmediatePath)" />
     <Delete Condition="Exists('$(SerializerCsImmediatePath)') == 'true'"  Files="$(SerializerCsImmediatePath)" />
     <Message Text="Running Serialization Tool" Importance="normal" />
-    <Exec Command="dotnet Microsoft.XmlSerializer.Generator $(IntermediateOutputPath)$(AssemblyName).dll /force" ContinueOnError="true"/>
+    <Exec Command="dotnet Microsoft.XmlSerializer.Generator $(IntermediateOutputPath)$(AssemblyName).dll /force /casesensitive" ContinueOnError="true"/>
     <Warning Condition="Exists('$(SerializerCsImmediatePath)') != 'true'" Text="$(SGenWarningText)" />
     <Csc Condition="Exists('$(SerializerCsImmediatePath)') == 'true'" ContinueOnError="true" OutputAssembly="$(SerializerDllImmediatePath)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(SerializerCsImmediatePath)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)"/>
     <Warning Condition="Exists('$(SerializerDllImmediatePath)') != 'true' And Exists('$(SerializerCsImmediatePath)') == 'true'" Text="$(SGenWarningText)"/>

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -82,6 +82,7 @@ namespace Microsoft.XmlSerializer.Generator
                         {
                             errs.Add(SR.Format(SR.ErrInvalidArgument, "/assembly", arg));
                         }
+
                         assembly = value;
                     }
                     else

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -28,18 +28,9 @@ namespace Microsoft.XmlSerializer.Generator
             var errs = new ArrayList();
             bool force = false;
             bool proxyOnly = false;
-            bool caseSensitive = false;
 
             try
             {
-                if (args.Length > 0)
-                {
-                    if (args.Any(s => s.IndexOf("casesensitive", StringComparison.OrdinalIgnoreCase) >= 0))
-                    {
-                        caseSensitive = true;
-                    }
-                }
-
                 for (int i = 0; i < args.Length; i++)
                 {
                     string arg = args[i];
@@ -55,10 +46,8 @@ namespace Microsoft.XmlSerializer.Generator
                         }
                     }
 
-                    if (!caseSensitive)
-                    {
-                        arg = arg.ToLower(CultureInfo.InvariantCulture);
-                    }
+                    string originalArg = arg;
+                    arg = arg.ToLower(CultureInfo.InvariantCulture);
 
                     if (ArgumentMatch(arg, "?") || ArgumentMatch(arg, "help"))
                     {
@@ -87,9 +76,13 @@ namespace Microsoft.XmlSerializer.Generator
                     {
                         types.Add(value);
                     }
-                    else if (ArgumentMatch(arg, "casesensitive"))
+                    else if (ArgumentMatch(arg, "assembly"))
                     {
-                        continue;
+                        if (assembly != null)
+                        {
+                            errs.Add(SR.Format(SR.ErrInvalidArgument, "/assembly", arg));
+                        }
+                        assembly = value;
                     }
                     else
                     {
@@ -100,7 +93,7 @@ namespace Microsoft.XmlSerializer.Generator
                                 errs.Add(SR.Format(SR.ErrInvalidArgument, "/assembly", arg));
                             }
 
-                            assembly = arg;
+                            assembly = originalArg;
                         }
                         else
                         {

--- a/src/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
+++ b/src/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.XmlSerializer.Generator.Tests
         public static void SgenCommandTest()
         {
             string codefile = "Microsoft.XmlSerializer.Generator.Tests.XmlSerializers.cs";
-            int n = Sgen.Main(new string[] { "Microsoft.XmlSerializer.Generator.Tests.dll", "/force", "/casesensitive" });
+            int n = Sgen.Main(new string[] { "Microsoft.XmlSerializer.Generator.Tests.dll", "/force"});
             Assert.Equal(0, n);
             Assert.True(File.Exists(codefile), string.Format("Fail to generate {0}.", codefile));
         }


### PR DESCRIPTION
On linux, the output folder Debug contains "D", without adding /casesitive, it will try to reach folder debug, which doesn't exist.

@shmao @zhenlan @mconnew 