### PR TITLE
System.Drawing - Fix and simplify PathGradientBrush.Blend and GdipSaveImageToFile_delegate PInvoke code

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
@@ -250,44 +250,25 @@ namespace System.Drawing.Drawing2D
 
                 int count = retval;
 
-                IntPtr factors = IntPtr.Zero;
-                IntPtr positions = IntPtr.Zero;
+                var factors = new float[count];
+                var positions = new float[count];
 
-                try
+                // Retrieve horizontal blend factors
+
+                status = SafeNativeMethods.Gdip.GdipGetPathGradientBlend(new HandleRef(this, NativeBrush), factors, positions, count);
+
+                if (status != SafeNativeMethods.Gdip.Ok)
                 {
-                    int size = checked(4 * count);
-                    factors = Marshal.AllocHGlobal(size);
-                    positions = Marshal.AllocHGlobal(size);
-
-                    // Retrieve horizontal blend factors
-
-                    status = SafeNativeMethods.Gdip.GdipGetPathGradientBlend(new HandleRef(this, NativeBrush), factors, positions, count);
-
-                    if (status != SafeNativeMethods.Gdip.Ok)
-                    {
-                        throw SafeNativeMethods.Gdip.StatusException(status);
-                    }
-
-                    // Return the result in a managed array
-
-                    Blend blend = new Blend(count);
-
-                    Marshal.Copy(factors, blend.Factors, 0, count);
-                    Marshal.Copy(positions, blend.Positions, 0, count);
-
-                    return blend;
+                    throw SafeNativeMethods.Gdip.StatusException(status);
                 }
-                finally
-                {
-                    if (factors != IntPtr.Zero)
-                    {
-                        Marshal.FreeHGlobal(factors);
-                    }
-                    if (positions != IntPtr.Zero)
-                    {
-                        Marshal.FreeHGlobal(positions);
-                    }
-                }
+
+                // Return the result in a managed array
+
+                Blend blend = new Blend(count);
+                blend.Factors = factors;
+                blend.Positions = positions;
+
+                return blend;
             }
             set
             {

--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
@@ -572,7 +572,7 @@ namespace System.Drawing
             private static FunctionWrapper<GdipDisposeImage_delegate> GdipDisposeImage_ptr;
             internal static int IntGdipDisposeImage(HandleRef image) => GdipDisposeImage_ptr.Delegate(image);
 
-            private delegate int GdipSaveImageToFile_delegate(HandleRef image, string filename, ref Guid classId, HandleRef encoderParams);
+            private delegate int GdipSaveImageToFile_delegate(HandleRef image, [MarshalAs(UnmanagedType.LPWStr)] string filename, ref Guid classId, HandleRef encoderParams);
             private static FunctionWrapper<GdipSaveImageToFile_delegate> GdipSaveImageToFile_ptr;
             internal static int GdipSaveImageToFile(HandleRef image, string filename, ref Guid classId, HandleRef encoderParams) => GdipSaveImageToFile_ptr.Delegate(image, filename, ref classId, encoderParams);
 

--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -709,9 +709,9 @@ namespace System.Drawing
             private static FunctionWrapper<GdipGetPathGradientBlendCount_delegate> GdipGetPathGradientBlendCount_ptr;
             internal static int GdipGetPathGradientBlendCount(HandleRef brush, out int count) => GdipGetPathGradientBlendCount_ptr.Delegate(brush, out count);
 
-            private delegate int GdipGetPathGradientBlend_delegate(HandleRef brush, IntPtr blend, IntPtr positions, int count);
+            private delegate int GdipGetPathGradientBlend_delegate(HandleRef brush, float[] blend, float[] positions, int count);
             private static FunctionWrapper<GdipGetPathGradientBlend_delegate> GdipGetPathGradientBlend_ptr;
-            internal static int GdipGetPathGradientBlend(HandleRef brush, IntPtr blend, IntPtr positions, int count) => GdipGetPathGradientBlend_ptr.Delegate(brush, blend, positions, count);
+            internal static int GdipGetPathGradientBlend(HandleRef brush, float[] blend, float[] positions, int count) => GdipGetPathGradientBlend_ptr.Delegate(brush, blend, positions, count);
 
             private delegate int GdipSetPathGradientBlend_delegate(HandleRef brush, HandleRef blend, HandleRef positions, int count);
             private static FunctionWrapper<GdipSetPathGradientBlend_delegate> GdipSetPathGradientBlend_ptr;


### PR DESCRIPTION
Fixes/cleans up some of the P/Invoke code in System.Drawing, as a result of bugs that surfaced when porting Mono's test to netfx.

* PathGradientBrush: Let the runtime marshal the `float` arrays instead of manually reading unmanaged memory
* `GdipSaveImageToFile_delegate`: Marshal `filename` as `LPWStr`