### PR TITLE
System.Drawing - Simplify Pen.get_DashPattern P/Invoke code

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -1171,9 +1171,9 @@ namespace System.Drawing
             private static FunctionWrapper<GdipGetPenDashCount_delegate> GdipGetPenDashCount_ptr;
             internal static int GdipGetPenDashCount(HandleRef pen, out int dashcount) => GdipGetPenDashCount_ptr.Delegate(pen, out dashcount);
 
-            private delegate int GdipGetPenDashArray_delegate(HandleRef pen, IntPtr memorydash, int count);
+            private delegate int GdipGetPenDashArray_delegate(HandleRef pen, float[] memorydash, int count);
             private static FunctionWrapper<GdipGetPenDashArray_delegate> GdipGetPenDashArray_ptr;
-            internal static int GdipGetPenDashArray(HandleRef pen, IntPtr memorydash, int count) => GdipGetPenDashArray_ptr.Delegate(pen, memorydash, count);
+            internal static int GdipGetPenDashArray(HandleRef pen, float[] memorydash, int count) => GdipGetPenDashArray_ptr.Delegate(pen, memorydash, count);
 
             private delegate int GdipGetPenCompoundCount_delegate(HandleRef pen, out int count);
             private static FunctionWrapper<GdipGetPenCompoundCount_delegate> GdipGetPenCompoundCount_ptr;

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -742,7 +742,7 @@ namespace System.Drawing
                 }
                 else if (DashStyle == DashStyle.Solid && !this.dashStyleWasChanged)
                 {
-                    // Most likely we're replicating an existing System.Drawing bug here, it doesn't make much sense t�
+                    // Most likely we're replicating an existing System.Drawing bug here, it doesn't make much sense tó
                     // ask for a dash pattern when using a solid dash.
                     throw new OutOfMemoryException();
                 }

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -740,7 +740,7 @@ namespace System.Drawing
                 }
                 else
                 {
-                    pattern = new float[0];
+                    throw new OutOfMemoryException();
                 }
                 return pattern;
             }

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -28,7 +28,7 @@ namespace System.Drawing
         private bool _immutable;
 
         // Tracks whether the dash style has been changed to something else than Solid during the lifetime of this object.
-        private bool dashStyleWasChanged;
+        private bool _dashStyleWasOrIsNotSolid;
 
         /// <summary>
         /// Creates a Pen from a native GDI+ object.
@@ -675,7 +675,7 @@ namespace System.Drawing
 
                 if (value != DashStyle.Solid)
                 {
-                    this.dashStyleWasChanged = true;
+                    this._dashStyleWasOrIsNotSolid = true;
                 }
             }
         }
@@ -740,9 +740,9 @@ namespace System.Drawing
                     status = SafeNativeMethods.Gdip.GdipGetPenDashArray(new HandleRef(this, NativePen), pattern, count);
                     SafeNativeMethods.Gdip.CheckStatus(status);
                 }
-                else if (DashStyle == DashStyle.Solid && !this.dashStyleWasChanged)
+                else if (DashStyle == DashStyle.Solid && !this._dashStyleWasOrIsNotSolid)
                 {
-                    // Most likely we're replicating an existing System.Drawing bug here, it doesn't make much sense tó
+                    // Most likely we're replicating an existing System.Drawing bug here, it doesn't make much sense to
                     // ask for a dash pattern when using a solid dash.
                     throw new OutOfMemoryException();
                 }


### PR DESCRIPTION
Let the runtime marshal the `float` arrays instead of manually processing unmanaged memory.
Fixes libgdiplus compatibility.