### PR TITLE
Add help method for SGEN.

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -340,8 +340,18 @@ namespace Microsoft.XmlSerializer.Generator
 
         private void WriteHelp()
         {
-            //TBD
-            Console.WriteLine("In Development");
+            Console.Out.WriteLine(SR.Format(SR.HelpDescription));
+            Console.Out.WriteLine(SR.Format(SR.HelpUsage, this.GetType().Assembly.GetName().Name));
+            Console.Out.WriteLine(SR.Format(SR.HelpDevOptions));
+            Console.Out.WriteLine(SR.Format(SR.HelpAssembly, "/assembly:", "/a:"));
+            Console.Out.WriteLine(SR.Format(SR.HelpType, "/type:", "/t:"));
+            Console.Out.WriteLine(SR.Format(SR.HelpProxy, "/proxytypes", "/p"));
+            Console.Out.WriteLine(SR.Format(SR.HelpDebug, "/debug", "/d"));
+            Console.Out.WriteLine(SR.Format(SR.HelpForce, "/force", "/f"));
+            Console.Out.WriteLine(SR.Format(SR.HelpOut, "/out:", "/o:"));
+
+            Console.Out.WriteLine(SR.Format(SR.HelpMiscOptions));
+            Console.Out.WriteLine(SR.Format(SR.HelpHelp, "/?", "/help"));
         }
 
         private static string FormatMessage(bool warning, string message)

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -346,7 +346,6 @@ namespace Microsoft.XmlSerializer.Generator
             Console.Out.WriteLine(SR.Format(SR.HelpAssembly, "/assembly:", "/a:"));
             Console.Out.WriteLine(SR.Format(SR.HelpType, "/type:", "/t:"));
             Console.Out.WriteLine(SR.Format(SR.HelpProxy, "/proxytypes", "/p"));
-            Console.Out.WriteLine(SR.Format(SR.HelpDebug, "/debug", "/d"));
             Console.Out.WriteLine(SR.Format(SR.HelpForce, "/force", "/f"));
             Console.Out.WriteLine(SR.Format(SR.HelpOut, "/out:", "/o:"));
 

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -334,7 +334,7 @@ namespace Microsoft.XmlSerializer.Generator
         private void WriteHeader()
         {
             // do not localize Copyright header
-            Console.WriteLine(String.Format(CultureInfo.CurrentCulture, "[Microsoft (R) .NET Framework, Version {0}]", ThisAssembly.InformationalVersion));
+            Console.WriteLine(String.Format(CultureInfo.CurrentCulture, "[Microsoft (R) .NET Core Xml Serialization Generation Utility, Version {0}]", ThisAssembly.InformationalVersion));
             Console.WriteLine("Copyright (C) Microsoft Corporation. All rights reserved.");
         }
 

--- a/src/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/System.Private.Xml/src/Resources/Strings.resx
@@ -3424,10 +3424,6 @@ Usage: dotnet {0} [[/assembly:&lt;assembly name&gt;] | [&lt;assembly file locati
     <value>     {0}       Generate code for serialization/deserialization of the
                   specified type from the input assembly. Short form is '{1}'.</value>
   </data>
-  <data name="HelpDebug" xml:space="preserve">
-    <value>     {0}       Generate image which can be used under a debugger.
-                  Short form is '{1}'.</value>
-  </data>
   <data name="HelpForce" xml:space="preserve">
     <value>     {0}       Forces overwrite of a previously generated assembly.
                   Short form is '{1}'.</value>

--- a/src/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/System.Private.Xml/src/Resources/Strings.resx
@@ -3402,4 +3402,51 @@
   <data name="FailLoadAssemblyUnderPregenMode" xml:space="preserve">
     <value>"Fail to load assembly {0} or {0} doesn't exist under PreGen Mode.</value>
   </data>
+  <data name="HelpDescription" xml:space="preserve">
+    <value>Generates serialization code for use with XmlSerializer.
+The utility allows developers to pre-generate code for serialization
+building and deploying the assemblies with the application.
+    </value>
+  </data>
+  <data name="HelpUsage" xml:space="preserve">
+    <value>
+Usage: dotnet {0} [[/assembly:&lt;assembly name&gt;] | [&lt;assembly file location&gt;]]
+      [/type:] [/debug].
+    </value>
+  </data>
+  <data name="HelpDevOptions" xml:space="preserve">
+    <value>  Developer options:</value>
+  </data>
+  <data name="HelpAssembly" xml:space="preserve">
+    <value>     {0}   Assembly location or display name. Short form is '{1}'.</value>
+  </data>
+  <data name="HelpType" xml:space="preserve">
+    <value>     {0}       Generate code for serialization/deserialization of the
+                  specified type from the input assembly. Short form is '{1}'.</value>
+  </data>
+  <data name="HelpDebug" xml:space="preserve">
+    <value>     {0}       Generate image which can be used under a debugger.
+                  Short form is '{1}'.</value>
+  </data>
+  <data name="HelpForce" xml:space="preserve">
+    <value>     {0}       Forces overwrite of a previously generated assembly.
+                  Short form is '{1}'.</value>
+  </data>
+  <data name="HelpProxy" xml:space="preserve">
+    <value>     {0}  Generate serialization code only for proxy classes and web
+                  method parameters. Short form is '{1}'.</value>
+  </data>
+  <data name="HelpOut" xml:space="preserve">
+    <value>     {0}        Output directory name (default: target assembly location).
+                  Short form is '{1}'.</value>
+  </data>
+  <data name="HelpMiscOptions" xml:space="preserve">
+    <value>  Miscellaneous options:</value>
+  </data>
+  <data name="HelpHelp" xml:space="preserve">
+    <value>     {0} or {1}  Show this message</value>
+  </data>
+  <data name="MoreHelp" xml:space="preserve">
+    <value>If you would like more help, please type "sgen {0}".</value>
+  </data>
 </root>


### PR DESCRIPTION
Fix #23375

@shmao @zhenlan @mconnew 

The generated help information is like:
```
Generates serialization code for use with XmlSerializer.
The utility allows developers to pre-generate code for serialization
building and deploying the assemblies with the application.


Usage: dotnet dotnet-Microsoft.XmlSerializer.Generator [[/assembly:<assembly name>] | [<assembly file location>]]
      [/type:] [/debug].

  Developer options:
     /assembly:   Assembly location or display name. Short form is '/a:'.
     /type:       Generate code for serialization/deserialization of the
                  specified type from the input assembly. Short form is '/t:'.
     /proxytypes  Generate serialization code only for proxy classes and web
                  method parameters. Short form is '/p'.
     /debug       Generate image which can be used under a debugger.
                  Short form is '/d'.
     /force       Forces overwrite of a previously generated assembly.
                  Short form is '/f'.
     /out:        Output directory name (default: target assembly location).
                  Short form is '/o:'.
  Miscellaneous options:
     /? or /help  Show this message
```