### PR TITLE
Fix Socket Shutdown_TCP_CLOSED_Success test

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/Shutdown.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Shutdown.cs
@@ -42,6 +42,7 @@ namespace System.Net.Sockets.Tests
                         var client = (Socket)args.UserToken;
                         if (args.BytesTransferred == 0)
                         {
+                            client.Shutdown(SocketShutdown.Send);
                             client.Dispose();
                             break;
                         }


### PR DESCRIPTION
This test has been failing at times with an exception being generated
from the client socket due to the loopback server terminating the
connection with RST instead of FIN.

The problem is that the server socket needs to use Shutdown() before
Dispose() to ensure a clean FIN after the data gets sent back to the
client.

Fixes #13539