### PR TITLE
Fix check for in_pktinfo and ip_mreqn

### DIFF
--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -43,7 +43,7 @@ check_c_source_compiles(
     #include <${SOCKET_INCLUDES}>
     int main()
     {
-        struct in_pktinfo;
+        struct in_pktinfo pktinfo;
         return 0;
     }
     "
@@ -54,7 +54,7 @@ check_c_source_compiles(
     #include <${SOCKET_INCLUDES}>
     int main()
     {
-        struct ip_mreqn;
+        struct ip_mreqn mreqn;
         return 0;
     }
     "


### PR DESCRIPTION
This change fixes the check for in_pktinfo and ip_mreqn. It was broken and was
always succeeding even on platforms where these structs were not present. The reason was that the statements worked as forward declarations instead of usage of the structs.