### PR TITLE
Disable unreliable Http diagnostics logging test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -258,6 +258,7 @@ namespace System.Net.Http.Functional.Tests
             }).Dispose();
         }
 
+        [ActiveIssue(23209)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendAsync_ExpectedDiagnosticCancelledLogging()


### PR DESCRIPTION
The Http test, SendAsync_ExpectedDiagnosticCancelledLogging, has been
failing at times.

I am going to disable this test until it can be made more robust. It is
not a reliable test because cancellation cannot be guaranteed to occur
with a certain time especially on a busy machine.

#23209