### PR TITLE
Re-enable XmlSerializer.Generator tests

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-02007-01
+2.0.0-prerelease-02012-02

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -69,6 +69,7 @@
           SkipUnchangedFiles="true"
           UseHardlinksIfPossible="true" />
 
+    <Exec Command="chmod +x $(TestHostRootPath)dotnet" Condition="'$(RunningOnUnix)' == 'true'"/>
   </Target>
 
   <Target Name="OverrideRuntime"

--- a/referenceFromRuntime.targets
+++ b/referenceFromRuntime.targets
@@ -6,6 +6,7 @@
     <ItemGroup>
       <!-- tests can use anything from the RuntimePath -->
       <ReferencePath Include="@(ReferenceFromRuntime->'$(RuntimePath)%(Identity).dll')" />
+      <ReferenceCopyLocalPaths Condition="'%(ReferenceFromRuntime.Private)' == 'true'" Include="@(ReferenceFromRuntime->'$(RuntimePath)%(Identity).dll')" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.XmlSerializer.Generator/tests/Configurations.props
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Configurations.props
@@ -5,7 +5,6 @@
       netstandard;
       uap;
       netcoreapp;
-      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/tests/Configurations.props
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netstandard;
       uap;
+      netcoreapp;
       netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -32,6 +32,8 @@
   </ItemGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="dotnet-Microsoft.XmlSerializer.Generator">
+      <!-- Copy this to our test output directory and run from there.
+           This is required so that we can stage the application with a custom runtimeconfig that lets it run on the test shared framework. -->
       <Private>true</Private>
     </ReferenceFromRuntime>
   </ItemGroup>
@@ -39,9 +41,8 @@
     <PropertyGroup>
       <SerializerName>$(AssemblyName).XmlSerializers</SerializerName>
     </PropertyGroup>
-    <Copy SourceFiles="$(ToolsDir)\csc.runtimeconfig.json" DestinationFiles="$(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json" />
     <Message Text="Running Serialization Tool" Importance="normal" />
-    <Exec ContinueOnError="true" Command="$(ToolsDir)\dotnetcli\dotnet $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)Microsoft.XmlSerializer.Generator.Tests.dll /force /casesensitive"  />
+    <Exec ContinueOnError="true" Command="$(TestHostRootPath)\dotnet $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)Microsoft.XmlSerializer.Generator.Tests.dll /force /casesensitive"  />
     <Warning Condition="Exists('$(OutputPath)$(SerializerName).cs') != 'true'" Text="Fail to generate $(OutputPath)$(SerializerName).cs"/>
     <Csc Condition="Exists('$(OutputPath)$(SerializerName).cs') == 'true'" ContinueOnError="true" 
          OutputAssembly="$(OutputPath)$(SerializerName).dll" 

--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -6,7 +6,7 @@
     <DefineConstants>$(DefineConstants);XMLSERIALIZERGENERATORTESTS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <SkipTestsOnPlatform Condition="'$(TargetGroup)' == 'uap' OR '$(TargetsUnix)' == 'true'">true</SkipTestsOnPlatform>
+    <SkipTestsOnPlatform Condition="'$(TargetGroup)' == 'uap'">true</SkipTestsOnPlatform>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <!-- We're building netcoreap, run on the test CLI
@@ -26,8 +26,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
   <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
     <Compile Include=".\SGenTests.cs" />
     <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\Utils.cs" />
@@ -58,14 +56,28 @@
     <Message Text="Running Serialization Tool" Importance="normal" />
     <Exec Command="$(GeneratorCliPath)dotnet $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)Microsoft.XmlSerializer.Generator.Tests.dll /force /casesensitive"  />
     <Warning Condition="Exists('$(OutputPath)$(SerializerName).cs') != 'true'" Text="Fail to generate $(OutputPath)$(SerializerName).cs"/>
-    <Csc Condition="Exists('$(OutputPath)$(SerializerName).cs') == 'true'" ContinueOnError="true" 
+    <Csc Condition="Exists('$(OutputPath)$(SerializerName).cs') == 'true' AND '$(MSBuildRuntimeType)' != 'core'" ContinueOnError="true" 
          OutputAssembly="$(OutputPath)$(SerializerName).dll" 
          References="@(ReferencePath);@(IntermediateAssembly)" 
          EmitDebugInformation="$(DebugSymbols)"  
+         DebugType="$(DebugType)" 
          Sources="$(OutputPath)$(SerializerName).cs" 
          TargetType="Library" 
          ToolExe="$(CscToolExe)" 
          ToolPath="$(CscToolPath)" 
+         DisabledWarnings="$(NoWarn), 219" 
+         UseSharedCompilation="true" />
+    <!-- when building on core CSC requires the OverrideToolHost parameter, but this is not supported by desktop csc -->
+    <Csc Condition="Exists('$(OutputPath)$(SerializerName).cs') == 'true' AND '$(MSBuildRuntimeType)' == 'core'" ContinueOnError="true" 
+         OutputAssembly="$(OutputPath)$(SerializerName).dll" 
+         References="@(ReferencePath);@(IntermediateAssembly)" 
+         EmitDebugInformation="$(DebugSymbols)"  
+         DebugType="$(DebugType)" 
+         Sources="$(OutputPath)$(SerializerName).cs" 
+         TargetType="Library" 
+         ToolExe="$(CscToolExe)" 
+         ToolPath="$(CscToolPath)" 
+         OverrideToolHost="$(OverrideToolHost)" 
          DisabledWarnings="$(NoWarn), 219" 
          UseSharedCompilation="true" />
     <Warning Condition="Exists('$(OutputPath)$(SerializerName).dll') != 'true'" Text="Fail to generate $(OutputPath)$(SerializerName).dll"/>

--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -37,7 +37,9 @@
       <Private>true</Private>
     </ReferenceFromRuntime>
   </ItemGroup>
-  <Target Name="GenerateSerializationAssembly" AfterTargets="Build" Condition=" '$(SkipTestsOnPlatform)' != 'true' " >
+  <!-- This target runs before binplacing as it needs to provide a test assembly to binplace, and depends on CopyFilesToOutputDirectory
+       so that the Generator app dll and runtimeconfig will be copied to the OutputPath -->
+  <Target Name="GenerateSerializationAssembly" DependsOnTargets="CopyFilesToOutputDirectory" BeforeTargets="GetBinPlaceItems" Condition=" '$(SkipTestsOnPlatform)' != 'true' " >
     <PropertyGroup>
       <SerializerName>$(AssemblyName).XmlSerializers</SerializerName>
     </PropertyGroup>
@@ -55,6 +57,11 @@
          DisabledWarnings="$(NoWarn), 219" 
          UseSharedCompilation="true" />
     <Warning Condition="Exists('$(OutputPath)$(SerializerName).dll') != 'true'" Text="Fail to generate $(OutputPath)$(SerializerName).dll"/>
+
+    <ItemGroup>
+      <!-- Include the Serializer in ReferenceCopyLocalPaths so that it will be binplaced -->
+      <ReferenceCopyLocalPaths Include="$(OutputPath)$(SerializerName).dll" />
+    </ItemGroup>
   </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -22,7 +22,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include=".\AlwaysPassTest.cs" />
-    <Content Include="dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json">
+    <!-- We're running the Generator on the test shared framework, which uses a fake shared framework version.
+         Reuse the same runtimeconfig that the tests use -->
+    <Content Include="$(XunitRuntimeConfig)">
+      <!-- Rename it to match the Generator application name -->
+      <Link>dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -27,7 +27,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="dotnet-Microsoft.XmlSerializer.Generator" />
+    <ReferenceFromRuntime Include="dotnet-Microsoft.XmlSerializer.Generator">
+      <Private>true</Private>
+    </ReferenceFromRuntime>
   </ItemGroup>
   <Target Name="GenerateSerializationAssembly" AfterTargets="Build" Condition=" '$(SkipTestsOnPlatform)' != 'true' " >
     <PropertyGroup>

--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -8,10 +8,24 @@
   <PropertyGroup>
     <SkipTestsOnPlatform Condition="'$(TargetGroup)' == 'uap' OR '$(TargetsUnix)' == 'true'">true</SkipTestsOnPlatform>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <!-- We're building netcoreap, run on the test CLI
+         Reuse the same runtimeconfig that the tests use. -->
+     <GeneratorRuntimeConfig>$(ToolsDir)xunit.console.netcore.runtimeconfig.json</GeneratorRuntimeConfig>
+     <GeneratorCliPath>$(TestHostRootPath)</GeneratorCliPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' != 'netcoreapp'">
+    <!-- We're building some non-netcoreapp target, run on the Tools CLI.
+         Reuse the same runtimeconfig used by CSC. -->
+     <GeneratorRuntimeConfig>$(ToolsDir)csc.runtimeconfig.json</GeneratorRuntimeConfig>
+     <GeneratorCliPath>$(ToolsDir)dotnetcli/</GeneratorCliPath>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
   <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
@@ -22,9 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include=".\AlwaysPassTest.cs" />
-    <!-- We're running the Generator on the test shared framework, which uses a fake shared framework version.
-         Reuse the same runtimeconfig that the tests use -->
-    <Content Include="$(XunitRuntimeConfig)">
+    <Content Include="$(GeneratorRuntimeConfig)">
       <!-- Rename it to match the Generator application name -->
       <Link>dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -44,7 +56,7 @@
       <SerializerName>$(AssemblyName).XmlSerializers</SerializerName>
     </PropertyGroup>
     <Message Text="Running Serialization Tool" Importance="normal" />
-    <Exec ContinueOnError="true" Command="$(TestHostRootPath)\dotnet $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)Microsoft.XmlSerializer.Generator.Tests.dll /force /casesensitive"  />
+    <Exec Command="$(GeneratorCliPath)dotnet $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)Microsoft.XmlSerializer.Generator.Tests.dll /force /casesensitive"  />
     <Warning Condition="Exists('$(OutputPath)$(SerializerName).cs') != 'true'" Text="Fail to generate $(OutputPath)$(SerializerName).cs"/>
     <Csc Condition="Exists('$(OutputPath)$(SerializerName).cs') == 'true'" ContinueOnError="true" 
          OutputAssembly="$(OutputPath)$(SerializerName).dll" 

--- a/src/Microsoft.XmlSerializer.Generator/tests/dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json
+++ b/src/Microsoft.XmlSerializer.Generator/tests/dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json
@@ -1,8 +1,0 @@
-{
-  "runtimeOptions": {
-    "framework": {
-      "name": "Microsoft.NETCore.App",
-      "version": "9.9.9"
-    }
-  }
-}

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -32,13 +32,7 @@ public static partial class XmlSerializerTests
             method.Invoke(null, new object[] { 1 });
 #endif
 #if XMLSERIALIZERGENERATORTESTS
-            string path = Path.GetDirectoryName(typeof(XmlSerializerTests).Assembly.Location);
-            string serializername = typeof(TypeWithDateTimeStringProperty).Assembly.GetName().Name + ".XmlSerializers.dll";
-            string serializerPath = Path.Combine(path, serializername);
-            if (File.Exists(serializerPath))
-            {
-                method.Invoke(null, new object[] { 3 });
-            }
+            method.Invoke(null, new object[] { 3 });
 #endif
         }
     }


### PR DESCRIPTION
Please see individual commits.

In a nutshell this re-enables the tests and ensures they run on the test framework rather than the tool framework.