### PR TITLE
Disable broken HttpWebRequest timeout test

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -279,6 +279,7 @@ namespace System.Net.Tests
             Assert.Equal(int.MaxValue, request.Timeout);
         }
 
+        [ActiveIssue(22627)]
         [Fact]
         public async Task Timeout_SetTenMillisecondsOnLoopback_ThrowsWebException()
         {


### PR DESCRIPTION
The HttpWebRequest test,
Timeout_SetTenMillisecondsOnLoopback_ThrowsWebException, doesn't work
reliably. It's trying to test timeouts on requests but doesn't actually
create stable conditions with the loopback server (i.e. to make it slow
to respond).

#22627