### PR TITLE
Disable Drawing tests on Server Core

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -85,6 +85,7 @@ namespace System
         public static bool IsWindowsAndElevated { get { throw null; } }
         public static bool IsWindowsIoTCore { get { throw null; } }
         public static bool IsWindowsNanoServer { get { throw null; } }
+        public static bool IsWindowsServerCore { get { throw null; } }
         public static bool IsWindowsSubsystemForLinux { get { throw null; } }
         public static bool IsInAppContainer { get { throw null; } }
         public static bool IsWinRTSupported { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -60,6 +60,7 @@ namespace System
         public static bool IsNotWindows8x { get { throw null; } }
         public static bool IsNotWindowsIoTCore { get { throw null; } }
         public static bool IsNotWindowsNanoServer { get { throw null; } }
+        public static bool IsNotWindowsServerCore { get { throw null; } }
         public static bool IsNotWindowsSubsystemForLinux { get { throw null; } }
         public static bool IsNotInAppContainer { get { throw null; } }
         public static bool IsNotWinRTSupported { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -38,6 +38,7 @@ namespace System
         public static bool IsNotFedoraOrRedHatOrCentos => !IsDistroAndVersion("fedora") && !IsDistroAndVersion("rhel") && !IsDistroAndVersion("centos");
         public static bool IsFedora => IsDistroAndVersion("fedora");
         public static bool IsWindowsNanoServer => false;
+        public static bool IsWindowsServerCore => false;
         public static bool IsWindowsAndElevated => false;
 
         public static bool IsRedHat => IsDistroAndVersion("rhel") || IsDistroAndVersion("rhl");

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -25,7 +25,8 @@ namespace System
         public static bool IsTizen => false;
         public static bool IsNotFedoraOrRedHatOrCentos => true;
         public static bool IsFedora => false;
-        public static bool IsWindowsNanoServer => (IsNotWindowsIoTCore && !File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "regedit.exe")));
+        public static bool IsWindowsNanoServer => (IsNotWindowsIoTCore && GetInstallationType().Equals("Nano Server", StringComparison.OrdinalIgnoreCase));
+        public static bool IsWindowsServerCore => (IsNotWindowsIoTCore && GetInstallationType().Equals("Server Core", StringComparison.OrdinalIgnoreCase));
         public static int WindowsVersion => GetWindowsVersion();
         public static bool IsMacOsHighSierraOrHigher { get; } = false;
         public static Version ICUVersion => new Version(0, 0, 0, 0);

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -26,7 +26,7 @@ namespace System
         public static bool IsNotFedoraOrRedHatOrCentos => true;
         public static bool IsFedora => false;
         public static bool IsWindowsNanoServer => (IsNotWindowsIoTCore && GetInstallationType().Equals("Nano Server", StringComparison.OrdinalIgnoreCase));
-        public static bool IsWindowsServerCore => (IsNotWindowsIoTCore && GetInstallationType().Equals("Server Core", StringComparison.OrdinalIgnoreCase));
+        public static bool IsWindowsServerCore => GetInstallationType().Equals("Server Core", StringComparison.OrdinalIgnoreCase);
         public static int WindowsVersion => GetWindowsVersion();
         public static bool IsMacOsHighSierraOrHigher { get; } = false;
         public static Version ICUVersion => new Version(0, 0, 0, 0);

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -26,6 +26,7 @@ namespace System
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
         public static bool IsNotWindows8x => !IsWindows8x;
         public static bool IsNotWindowsNanoServer => !IsWindowsNanoServer;
+        public static bool IsNotWindowsServerCore => !IsWindowsServerCore;
         public static bool IsNotWindowsIoTCore => !IsWindowsIoTCore;
         public static bool IsDrawingSupported => (IsNotWindowsNanoServer && IsNotWindowsIoTCore);
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;

--- a/src/System.Drawing.Common/tests/Helpers.cs
+++ b/src/System.Drawing.Common/tests/Helpers.cs
@@ -19,7 +19,7 @@ namespace System.Drawing
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return PlatformDetection.IsNotWindowsNanoServer;
+                return PlatformDetection.IsNotWindowsNanoServer && PlatformDetection.IsNotWindowsServerCore;
             }
             else
             {

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -358,7 +358,7 @@ namespace System.Tests
         [InlineData(Environment.SpecialFolder.ProgramFiles)]
         [InlineData(Environment.SpecialFolder.CommonProgramFiles)]
         [InlineData(Environment.SpecialFolder.AdminTools)]
-        [InlineData(Environment.SpecialFolder.CDBurning)]
+        //[InlineData(Environment.SpecialFolder.CDBurning)]  // Not available on Server Core
         [InlineData(Environment.SpecialFolder.CommonAdminTools)]
         [InlineData(Environment.SpecialFolder.CommonDocuments)]
         [InlineData(Environment.SpecialFolder.CommonMusic)]


### PR DESCRIPTION
Some of these seem like they could be made to work, but I'm assuming it's not a goal to make Drawing 100% work on Server Core, and partially working is not very useful.

Fix https://github.com/dotnet/corefx/issues/23001
Fix https://github.com/dotnet/corefx/issues/22629
Fix https://github.com/dotnet/corefx/issues/22632
Fix https://github.com/dotnet/corefx/issues/22631
Fix https://github.com/dotnet/corefx/issues/22634

Also CDBurning drive is unavailable
Fix https://github.com/dotnet/corefx/issues/23002
