### PR TITLE
Override memory-based Read/WriteAsync APIs on System.IO streams

### DIFF
--- a/src/Common/tests/System/IO/StreamSpanExtensions.netstandard.cs
+++ b/src/Common/tests/System/IO/StreamSpanExtensions.netstandard.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 /// <summary>Extensions to enable the tests to use the span-based Read/Write methods that only exist in netcoreapp.</summary>
 internal static class StreamSpanExtensions
@@ -18,9 +20,20 @@ internal static class StreamSpanExtensions
         return bytesRead;
     }
 
-    public static void Write(this Stream stream, ReadOnlySpan<byte> source)
+    public static void Write(this Stream stream, ReadOnlySpan<byte> source) =>
+        stream.Write(source.ToArray(), 0, source.Length);
+
+    public static ValueTask<int> ReadAsync(this Stream stream, Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken))
     {
-        byte[] array = source.ToArray();
-        stream.Write(array, 0, array.Length);
+        byte[] array = new byte[destination.Length];
+        return new ValueTask<int>(stream.ReadAsync(array, 0, array.Length, cancellationToken).ContinueWith(t =>
+        {
+            int bytesRead = t.GetAwaiter().GetResult();
+            new Span<byte>(array, 0, bytesRead).CopyTo(destination.Span);
+            return bytesRead;
+        }));
     }
+
+    public static Task WriteAsync(this Stream stream, ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default(CancellationToken)) =>
+        stream.WriteAsync(source.ToArray(), 0, source.Length, cancellationToken);
 }

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -352,58 +352,73 @@ namespace System.IO.Compression
 
         public override Task<int> ReadAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
-            // We use this checking order for compat to earlier versions:
+            ValidateParameters(array, offset, count);
+            return ReadAsyncMemory(new Memory<byte>(array, offset, count), cancellationToken).AsTask();
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (GetType() != typeof(DeflateStream))
+            {
+                // Ensure that existing streams derived from DeflateStream and that override ReadAsync(byte[],...)
+                // get their existing behaviors when the newer Memory-based overload is used.
+                return base.ReadAsync(destination, cancellationToken);
+            }
+            else
+            {
+                return ReadAsyncMemory(destination, cancellationToken);
+            }
+        }
+
+        internal ValueTask<int> ReadAsyncMemory(Memory<byte> destination, CancellationToken cancellationToken)
+        {
             EnsureDecompressionMode();
             EnsureNoActiveAsyncOperation();
-            ValidateParameters(array, offset, count);
             EnsureNotDisposed();
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<int>(cancellationToken);
+                return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
             }
 
             EnsureBufferInitialized();
-            Task<int> readTask = null;
 
+            bool cleanup = true;
             AsyncOperationStarting();
             try
             {
                 // Try to read decompressed data in output buffer
-                int bytesRead = _inflater.Inflate(array, offset, count);
+                int bytesRead = _inflater.Inflate(destination.Span);
                 if (bytesRead != 0)
                 {
                     // If decompression output buffer is not empty, return immediately.
-                    return Task.FromResult(bytesRead);
+                    return new ValueTask<int>(bytesRead);
                 }
 
                 if (_inflater.Finished())
                 {
                     // end of compression stream
-                    return Task.FromResult(0);
+                    return new ValueTask<int>(0);
                 }
 
                 // If there is no data on the output buffer and we are not at
                 // the end of the stream, we need to get more data from the base stream
-                readTask = _stream.ReadAsync(_buffer, 0, _buffer.Length, cancellationToken);
-                if (readTask == null)
-                {
-                    throw new InvalidOperationException(SR.NotSupported_UnreadableStream);
-                }
-
-                return ReadAsyncCore(readTask, array, offset, count, cancellationToken);
+                ValueTask<int> readTask = _stream.ReadAsync(_buffer, cancellationToken);
+                cleanup = false;
+                return FinishReadAsyncMemory(readTask, destination, cancellationToken);
             }
             finally
             {
                 // if we haven't started any async work, decrement the counter to end the transaction
-                if (readTask == null)
+                if (cleanup)
                 {
                     AsyncOperationCompleting();
                 }
             }
         }
 
-        private async Task<int> ReadAsyncCore(Task<int> readTask, byte[] array, int offset, int count, CancellationToken cancellationToken)
+        private async ValueTask<int> FinishReadAsyncMemory(
+            ValueTask<int> readTask, Memory<byte> destination, CancellationToken cancellationToken)
         {
             try
             {
@@ -428,17 +443,13 @@ namespace System.IO.Compression
 
                     // Feed the data from base stream into decompression engine
                     _inflater.SetInput(_buffer, 0, bytesRead);
-                    bytesRead = _inflater.Inflate(array, offset, count);
+                    bytesRead = _inflater.Inflate(destination.Span);
 
                     if (bytesRead == 0 && !_inflater.Finished())
                     {
                         // We could have read in head information and didn't get any data.
                         // Read from the base stream again.
-                        readTask = _stream.ReadAsync(_buffer, 0, _buffer.Length, cancellationToken);
-                        if (readTask == null)
-                        {
-                            throw new InvalidOperationException(SR.NotSupported_UnreadableStream);
-                        }
+                        readTask = _stream.ReadAsync(_buffer, cancellationToken);
                     }
                     else
                     {
@@ -632,19 +643,36 @@ namespace System.IO.Compression
 
         public override Task WriteAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
-            // We use this checking order for compat to earlier versions:
-            EnsureCompressionMode();
-            EnsureNoActiveAsyncOperation();
             ValidateParameters(array, offset, count);
-            EnsureNotDisposed();
-
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled<int>(cancellationToken);
-
-            return WriteAsyncCore(array, offset, count, cancellationToken);
+            return WriteAsyncMemory(new ReadOnlyMemory<byte>(array, offset, count), cancellationToken);
         }
 
-        private async Task WriteAsyncCore(byte[] array, int offset, int count, CancellationToken cancellationToken)
+        public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
+        {
+            if (GetType() != typeof(DeflateStream))
+            {
+                // Ensure that existing streams derived from DeflateStream and that override WriteAsync(byte[],...)
+                // get their existing behaviors when the newer Memory-based overload is used.
+                return base.WriteAsync(source, cancellationToken);
+            }
+            else
+            {
+                return WriteAsyncMemory(source, cancellationToken);
+            }
+        }
+
+        internal Task WriteAsyncMemory(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
+        {
+            EnsureCompressionMode();
+            EnsureNoActiveAsyncOperation();
+            EnsureNotDisposed();
+
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled<int>(cancellationToken) :
+                WriteAsyncMemoryCore(source, cancellationToken);
+        }
+
+        private async Task WriteAsyncMemoryCore(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
         {
             AsyncOperationStarting();
             try
@@ -652,7 +680,7 @@ namespace System.IO.Compression
                 await WriteDeflaterOutputAsync(cancellationToken).ConfigureAwait(false);
 
                 // Pass new bytes through deflater
-                _deflater.SetInput(array, offset, count);
+                _deflater.SetInput(source);
 
                 await WriteDeflaterOutputAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
-using System.Runtime.InteropServices;
 using System.Security;
 
 using ZErrorCode = System.IO.Compression.ZLibNative.ErrorCode;
@@ -18,7 +18,7 @@ namespace System.IO.Compression
     internal sealed class Deflater : IDisposable
     {
         private ZLibNative.ZLibStreamHandle _zlibStream;
-        private GCHandle _inputBufferHandle;
+        private MemoryHandle _inputBufferHandle;
         private bool _isDisposed;
         private const int minWindowBits = -15;  // WindowBits must be between -8..-15 to write no header, 8..15 for a
         private const int maxWindowBits = 31;   // zlib header, or 24..31 for a GZip header
@@ -90,22 +90,22 @@ namespace System.IO.Compression
 
         public bool NeedsInput() => 0 == _zlibStream.AvailIn;
 
-        internal void SetInput(byte[] inputBuffer, int startIndex, int count)
+        internal unsafe void SetInput(ReadOnlyMemory<byte> inputBuffer)
         {
             Debug.Assert(NeedsInput(), "We have something left in previous input!");
-            Debug.Assert(null != inputBuffer);
-            Debug.Assert(startIndex >= 0 && count >= 0 && count + startIndex <= inputBuffer.Length);
-            Debug.Assert(!_inputBufferHandle.IsAllocated);
+            Debug.Assert(_inputBufferHandle.PinnedPointer == null);
 
-            if (0 == count)
+            if (0 == inputBuffer.Length)
+            {
                 return;
+            }
 
             lock (SyncLock)
             {
-                _inputBufferHandle = GCHandle.Alloc(inputBuffer, GCHandleType.Pinned);
+                _inputBufferHandle = inputBuffer.Retain(pin: true);
 
-                _zlibStream.NextIn = _inputBufferHandle.AddrOfPinnedObject() + startIndex;
-                _zlibStream.AvailIn = (uint)count;
+                _zlibStream.NextIn = (IntPtr)_inputBufferHandle.PinnedPointer;
+                _zlibStream.AvailIn = (uint)inputBuffer.Length;
             }
         }
 
@@ -113,7 +113,7 @@ namespace System.IO.Compression
         {
             Debug.Assert(NeedsInput(), "We have something left in previous input!");
             Debug.Assert(inputBufferPtr != null);
-            Debug.Assert(!_inputBufferHandle.IsAllocated);
+            Debug.Assert(_inputBufferHandle.PinnedPointer == null);
 
             if (count == 0)
             {
@@ -174,7 +174,10 @@ namespace System.IO.Compression
             Debug.Assert(null != outputBuffer, "Can't pass in a null output buffer!");
             Debug.Assert(outputBuffer.Length > 0, "Can't pass in an empty output buffer!");
             Debug.Assert(NeedsInput(), "We have something left in previous input!");
-            Debug.Assert(!_inputBufferHandle.IsAllocated);
+            unsafe
+            {
+                Debug.Assert(_inputBufferHandle.PinnedPointer == null);
+            }
 
             // Note: we require that NeedsInput() == true, i.e. that 0 == _zlibStream.AvailIn.
             // If there is still input left we should never be getting here; instead we
@@ -192,7 +195,10 @@ namespace System.IO.Compression
             Debug.Assert(null != outputBuffer, "Can't pass in a null output buffer!");
             Debug.Assert(outputBuffer.Length > 0, "Can't pass in an empty output buffer!");
             Debug.Assert(NeedsInput(), "We have something left in previous input!");
-            Debug.Assert(!_inputBufferHandle.IsAllocated);
+            unsafe
+            {
+                Debug.Assert(_inputBufferHandle.PinnedPointer == null);
+            }
 
             // Note: we require that NeedsInput() == true, i.e. that 0 == _zlibStream.AvailIn.
             // If there is still input left we should never be getting here; instead we
@@ -207,10 +213,7 @@ namespace System.IO.Compression
             {
                 _zlibStream.AvailIn = 0;
                 _zlibStream.NextIn = ZLibNative.ZNullPtr;
-                if (_inputBufferHandle.IsAllocated)
-                {
-                    _inputBufferHandle.Free();
-                }
+                _inputBufferHandle.Dispose();
             }
         }
 

--- a/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
@@ -120,7 +120,6 @@ namespace System.IO.Compression
                 // to this Write(ReadOnlySpan<byte>) overload being introduced.  In that case, this Write(ReadOnlySpan<byte>) overload
                 // should use the behavior of Write(byte[],int,int) overload.
                 base.Write(source);
-                return;
             }
             else
             {
@@ -159,10 +158,42 @@ namespace System.IO.Compression
             return _deflateStream.ReadAsync(array, offset, count, cancellationToken);
         }
 
+        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (GetType() != typeof(GZipStream))
+            {
+                // GZipStream is not sealed, and a derived type may have overridden ReadAsync(byte[], int, int) prior
+                // to this ReadAsync(Memory<byte>) overload being introduced.  In that case, this ReadAsync(Memory<byte>) overload
+                // should use the behavior of ReadAsync(byte[],int,int) overload.
+                return base.ReadAsync(destination, cancellationToken);
+            }
+            else
+            {
+                CheckDeflateStream();
+                return _deflateStream.ReadAsyncMemory(destination, cancellationToken);
+            }
+        }
+
         public override Task WriteAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             CheckDeflateStream();
             return _deflateStream.WriteAsync(array, offset, count, cancellationToken);
+        }
+
+        public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (GetType() != typeof(GZipStream))
+            {
+                // GZipStream is not sealed, and a derived type may have overridden WriteAsync(byte[], int, int) prior
+                // to this WriteAsync(ReadOnlyMemory<byte>) overload being introduced.  In that case, this
+                // WriteAsync(ReadOnlyMemory<byte>) overload should use the behavior of Write(byte[],int,int) overload.
+                return base.WriteAsync(source, cancellationToken);
+            }
+            else
+            {
+                CheckDeflateStream();
+                return _deflateStream.WriteAsyncMemory(source, cancellationToken);
+            }
         }
 
         public override Task FlushAsync(CancellationToken cancellationToken)

--- a/src/System.IO.Compression/src/System/IO/Compression/PositionPreservingWriteOnlyStreamWrapper.netcoreapp.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/PositionPreservingWriteOnlyStreamWrapper.netcoreapp.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace System.IO.Compression
 {
     internal sealed partial class PositionPreservingWriteOnlyStreamWrapper : Stream
@@ -10,6 +13,12 @@ namespace System.IO.Compression
         {
             _position += source.Length;
             _stream.Write(source);
+        }
+
+        public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            _position += source.Length;
+            return _stream.WriteAsync(source, cancellationToken);
         }
     }
 }

--- a/src/System.IO.Compression/tests/Configurations.props
+++ b/src/System.IO.Compression/tests/Configurations.props
@@ -6,6 +6,7 @@
       netstandard-Windows_NT;
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Compression/tests/DeflateStreamTests.netcoreapp.cs
+++ b/src/System.IO.Compression/tests/DeflateStreamTests.netcoreapp.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO.Compression.Tests
+{
+    public partial class ManualSyncMemoryStream : MemoryStream
+    {
+        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
+        {
+            ReadHit = true;
+            return base.ReadAsync(destination, cancellationToken);
+        }
+
+        public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
+        {
+            WriteHit = true;
+            return base.WriteAsync(source, cancellationToken);
+        }
+    }
+}

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -12,6 +12,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AsyncStreamTests.cs" />
     <Compile Include="DeflateStreamTests.cs" />
@@ -52,7 +54,7 @@
       <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap'">
       <Compile Include="ZipArchive\zip_netcoreappTests.cs" />
       <Compile Include="DeflateStreamTests.netcoreapp.cs" />
   </ItemGroup>

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
       <Compile Include="ZipArchive\zip_netcoreappTests.cs" />
+      <Compile Include="DeflateStreamTests.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
     <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.5-prerelease\content\**\*.*">

--- a/src/System.IO.Pipes/src/System/IO/Pipes/ConnectionCompletionSource.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/ConnectionCompletionSource.cs
@@ -12,7 +12,7 @@ namespace System.IO.Pipes
 
         // Using RunContinuationsAsynchronously for compat reasons (old API used ThreadPool.QueueUserWorkItem for continuations)
         internal ConnectionCompletionSource(NamedPipeServerStream server, CancellationToken cancellationToken)
-            : base(server._threadPoolBinding, cancellationToken, pinData: null)
+            : base(server._threadPoolBinding, cancellationToken, ReadOnlyMemory<byte>.Empty)
         {
             _serverStream = server;
         }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -81,7 +81,7 @@ namespace System.IO.Pipes
         }
 
         [SecuritySafeCritical]
-        private Task<int> ReadAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        private Task<int> ReadAsyncCore(Memory<byte> buffer, CancellationToken cancellationToken)
         {
             var completionSource = new ReadWriteCompletionSource(this, buffer, cancellationToken, isWrite: false);
 
@@ -90,7 +90,7 @@ namespace System.IO.Pipes
             int r;
             unsafe
             {
-                r = ReadFileNative(_handle, new Span<byte>(buffer, offset, count), completionSource.Overlapped, out errorCode);
+                r = ReadFileNative(_handle, buffer.Span, completionSource.Overlapped, out errorCode);
             }
 
             // ReadFile, the OS version, will return 0 on failure, but this ReadFileNative wrapper
@@ -149,7 +149,7 @@ namespace System.IO.Pipes
         }
 
         [SecuritySafeCritical]
-        private Task WriteAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        private Task WriteAsyncCore(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
             var completionSource = new ReadWriteCompletionSource(this, buffer, cancellationToken, isWrite: true);
             int errorCode = 0;
@@ -158,7 +158,7 @@ namespace System.IO.Pipes
             int r;
             unsafe
             {
-                r = WriteFileNative(_handle, new ReadOnlySpan<byte>(buffer, offset, count), completionSource.Overlapped, out errorCode);
+                r = WriteFileNative(_handle, buffer.Span, completionSource.Overlapped, out errorCode);
             }
 
             // WriteFile, the OS version, will return 0 on failure, but this WriteFileNative 

--- a/src/System.IO.Pipes/src/System/IO/Pipes/ReadWriteCompletionSource.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/ReadWriteCompletionSource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Threading;
 
 namespace System.IO.Pipes
@@ -15,11 +14,9 @@ namespace System.IO.Pipes
         private bool _isMessageComplete;
         private int _numBytes; // number of buffer read OR written
 
-        internal ReadWriteCompletionSource(PipeStream stream, byte[] buffer, CancellationToken cancellationToken, bool isWrite)
-            : base(stream._threadPoolBinding, cancellationToken, pinData: buffer)
+        internal ReadWriteCompletionSource(PipeStream stream, ReadOnlyMemory<byte> bufferToPin, CancellationToken cancellationToken, bool isWrite)
+            : base(stream._threadPoolBinding, cancellationToken, bufferToPin)
         {
-            Debug.Assert(buffer != null, "buffer is null");
-
             _pipeStream = stream;
             _isWrite = isWrite;
             _isMessageComplete = true;

--- a/src/System.IO.Pipes/tests/Configurations.props
+++ b/src/System.IO.Pipes/tests/Configurations.props
@@ -4,6 +4,8 @@
     <BuildConfigurations>
       netstandard-Unix;
       netstandard-Windows_NT;
+      netcoreapp-Unix;
+      netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Read.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Read.cs
@@ -67,8 +67,7 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
 
-        // InOut pipes can be written/read from either direction
-        public override void WriteToReadOnlyPipe_Throws_NotSupportedException() { }
+        public override bool SupportsBidirectionalReadingWriting => true;
     }
     
     [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
@@ -90,7 +89,6 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
 
-        // InOut pipes can be written/read from either direction
-        public override void WriteToReadOnlyPipe_Throws_NotSupportedException() { }
+        public override bool SupportsBidirectionalReadingWriting => true;
     }
 }

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Write.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Write.cs
@@ -68,6 +68,6 @@ namespace System.IO.Pipes.Tests
         }
 
         // InOut pipes can be written/read from either direction
-        public override void ReadOnWriteOnlyPipe_Throws_NotSupportedException() { }
+        public override bool SupportsBidirectionalReadingWriting => true;
     }
 }

--- a/src/System.IO.Pipes/tests/PipeTest.Read.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Read.cs
@@ -16,6 +16,8 @@ namespace System.IO.Pipes.Tests
     /// </summary>
     public abstract partial class PipeTest_Read : PipeTestBase
     {
+        public virtual bool SupportsBidirectionalReadingWriting => false;
+
         [Fact]
         public void ReadWithNullBuffer_Throws_ArgumentNullException()
         {
@@ -117,8 +119,13 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        public virtual void WriteToReadOnlyPipe_Throws_NotSupportedException()
+        public void WriteToReadOnlyPipe_Throws_NotSupportedException()
         {
+            if (SupportsBidirectionalReadingWriting)
+            {
+                return;
+            }
+
             using (ServerClientPair pair = CreateServerClientPair())
             {
                 PipeStream pipe = pair.readablePipe;

--- a/src/System.IO.Pipes/tests/PipeTest.Read.netcoreapp.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Read.netcoreapp.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Pipes.Tests
+{
+    public abstract partial class PipeTest_Read : PipeTestBase
+    {
+        [Fact]
+        public void WriteToReadOnlyPipe_Span_Throws_NotSupportedException()
+        {
+            if (SupportsBidirectionalReadingWriting)
+            {
+                return;
+            }
+
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                PipeStream pipe = pair.readablePipe;
+                Assert.True(pipe.IsConnected);
+                Assert.False(pipe.CanWrite);
+                Assert.False(pipe.CanSeek);
+
+                Assert.Throws<NotSupportedException>(() => pipe.Write(new ReadOnlySpan<byte>(new byte[5])));
+                Assert.Throws<NotSupportedException>(() => { pipe.WriteAsync(new ReadOnlyMemory<byte>(new byte[5])); });
+            }
+        }
+
+        [Fact]
+        public async Task ReadWithZeroLengthBuffer_Span_Nop()
+        {
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                PipeStream pipe = pair.readablePipe;
+                var buffer = new byte[] { };
+
+                Assert.Equal(0, pipe.Read(new Span<byte>(buffer)));
+                ValueTask<int> read = pipe.ReadAsync(new Memory<byte>(buffer));
+                Assert.Equal(0, await read);
+            }
+        }
+
+        [Fact]
+        public void ReadOnDisposedReadablePipe_Span_Throws_ObjectDisposedException()
+        {
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                PipeStream pipe = pair.readablePipe;
+                pipe.Dispose();
+                byte[] buffer = new byte[] { 0, 0, 0, 0 };
+
+                Assert.Throws<ObjectDisposedException>(() => pipe.Read(new Span<byte>(buffer)));
+                Assert.Throws<ObjectDisposedException>(() => { pipe.ReadAsync(new Memory<byte>(buffer)); });
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "There is a bug in netfx around async read on a broken PipeStream. See #2601 and #2899. This bug is fixed in netcore.")]
+        public virtual async Task ReadFromPipeWithClosedPartner_Span_ReadNoBytes()
+        {
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                pair.writeablePipe.Dispose();
+                byte[] buffer = new byte[] { 0, 0, 0, 0 };
+
+                // The pipe won't be marked as Broken until the first read, so prime it
+                // to test both the case where it's not yet marked as "Broken" and then 
+                // where it is.
+                Assert.Equal(0, pair.readablePipe.Read(new Span<byte>(buffer)));
+
+                Assert.Equal(0, pair.readablePipe.Read(new Span<byte>(buffer)));
+                Assert.Equal(0, await pair.readablePipe.ReadAsync(new Memory<byte>(buffer)));
+            }
+        }
+
+        [Fact]
+        public async Task ValidWriteAsync_Span_ValidReadAsync()
+        {
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                Assert.True(pair.writeablePipe.IsConnected);
+                Assert.True(pair.readablePipe.IsConnected);
+
+                byte[] sent = new byte[] { 123, 0, 5 };
+                byte[] received = new byte[] { 0, 0, 0 };
+
+                Task write = pair.writeablePipe.WriteAsync(new ReadOnlyMemory<byte>(sent));
+                Assert.Equal(sent.Length, await pair.readablePipe.ReadAsync(new Memory<byte>(received, 0, sent.Length)));
+                Assert.Equal(sent, received);
+                await write;
+            }
+        }
+
+        [Theory]
+        [OuterLoop]
+        [MemberData(nameof(AsyncReadWriteChain_MemberData))]
+        public async Task AsyncReadWriteChain_Span_ReadWrite(int iterations, int writeBufferSize, int readBufferSize, bool cancelableToken)
+        {
+            var writeBuffer = new byte[writeBufferSize];
+            var readBuffer = new byte[readBufferSize];
+            var rand = new Random();
+            var cancellationToken = cancelableToken ? new CancellationTokenSource().Token : CancellationToken.None;
+
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                // Repeatedly and asynchronously write to the writable pipe and read from the readable pipe,
+                // verifying that the correct data made it through.
+                for (int iter = 0; iter < iterations; iter++)
+                {
+                    rand.NextBytes(writeBuffer);
+                    Task writerTask = pair.writeablePipe.WriteAsync(new ReadOnlyMemory<byte>(writeBuffer), cancellationToken);
+
+                    int totalRead = 0;
+                    while (totalRead < writeBuffer.Length)
+                    {
+                        int numRead = await pair.readablePipe.ReadAsync(new Memory<byte>(readBuffer), cancellationToken);
+                        Assert.True(numRead > 0);
+                        Assert.Equal<byte>(
+                            new ArraySegment<byte>(writeBuffer, totalRead, numRead),
+                            new ArraySegment<byte>(readBuffer, 0, numRead));
+                        totalRead += numRead;
+                    }
+                    Assert.Equal(writeBuffer.Length, totalRead);
+
+                    await writerTask;
+                }
+            }
+        }
+    }
+}

--- a/src/System.IO.Pipes/tests/PipeTest.Write.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Write.cs
@@ -12,8 +12,10 @@ namespace System.IO.Pipes.Tests
     /// Tests that cover Write and WriteAsync behaviors that are shared between
     /// AnonymousPipes and NamedPipes
     /// </summary>
-    public abstract class PipeTest_Write : PipeTestBase
+    public abstract partial class PipeTest_Write : PipeTestBase
     {
+        public virtual bool SupportsBidirectionalReadingWriting => false;
+
         [Fact]
         public void WriteWithNullBuffer_Throws_ArgumentNullException()
         {
@@ -117,8 +119,13 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        public virtual void ReadOnWriteOnlyPipe_Throws_NotSupportedException()
+        public void ReadOnWriteOnlyPipe_Throws_NotSupportedException()
         {
+            if (SupportsBidirectionalReadingWriting)
+            {
+                return;
+            }
+
             using (ServerClientPair pair = CreateServerClientPair())
             {
                 PipeStream pipe = pair.writeablePipe;

--- a/src/System.IO.Pipes/tests/PipeTest.Write.netcoreapp.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Write.netcoreapp.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Pipes.Tests
+{
+    /// <summary>
+    /// Tests that cover Write and WriteAsync behaviors that are shared between
+    /// AnonymousPipes and NamedPipes
+    /// </summary>
+    public abstract partial class PipeTest_Write : PipeTestBase
+    {
+        [Fact]
+        public void ReadOnWriteOnlyPipe_Span_Throws_NotSupportedException()
+        {
+            if (SupportsBidirectionalReadingWriting)
+            {
+                return;
+            }
+
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                PipeStream pipe = pair.writeablePipe;
+                Assert.True(pipe.IsConnected);
+                Assert.False(pipe.CanRead);
+
+                Assert.Throws<NotSupportedException>(() => pipe.Read(new Span<byte>(new byte[9])));
+                Assert.Throws<NotSupportedException>(() => { pipe.ReadAsync(new Memory<byte>(new byte[10])); });
+            }
+        }
+
+        [Fact]
+        public async Task WriteZeroLengthBuffer_Span_Nop()
+        {
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                PipeStream pipe = pair.writeablePipe;
+
+                // Shouldn't throw
+                pipe.Write(new Span<byte>(Array.Empty<byte>()));
+                await pipe.WriteAsync(new Memory<byte>(Array.Empty<byte>()));
+            }
+        }
+
+        [Fact]
+        public void WriteToDisposedWriteablePipe_Span_Throws_ObjectDisposedException()
+        {
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                PipeStream pipe = pair.writeablePipe;
+                pipe.Dispose();
+                byte[] buffer = new byte[] { 0, 0, 0, 0 };
+
+                Assert.Throws<ObjectDisposedException>(() => pipe.Write(new Span<byte>(buffer)));
+                Assert.Throws<ObjectDisposedException>(() => { pipe.WriteAsync(new Memory<byte>(buffer)); });
+            }
+        }
+
+        [Fact]
+        public virtual void WriteToPipeWithClosedPartner_Span_Throws_IOException()
+        {
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                    (pair.readablePipe is NamedPipeClientStream || pair.writeablePipe is NamedPipeClientStream))
+                {
+                    // On Unix, NamedPipe*Stream is implemented in term of sockets, where information 
+                    // about shutdown is not immediately propagated.
+                    return;
+                }
+
+                pair.readablePipe.Dispose();
+                byte[] buffer = new byte[] { 0, 0, 0, 0 };
+
+                Assert.Throws<IOException>(() => pair.writeablePipe.Write(new Span<byte>(buffer)));
+                Assert.Throws<IOException>(() => { pair.writeablePipe.WriteAsync(new Memory<byte>(buffer)); });
+            }
+        }
+    }
+}

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -11,6 +11,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="NamedPipeTests\NamedPipeTest.cs" />
     <Compile Include="PipeTest.cs" />
@@ -29,6 +33,8 @@
     <Compile Include="NamedPipeTests\NamedPipeTest.Write.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.Specific.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.Simple.cs" />
+    <Compile Include="PipeTest.Read.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
+    <Compile Include="PipeTest.Write.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="PipeTestBase.cs" />
     <Compile Include="PipeTest.Read.cs" />
     <Compile Include="PipeTest.Write.cs" />

--- a/src/System.IO/tests/BufferedStream/BufferedStreamTests.netcoreapp.cs
+++ b/src/System.IO/tests/BufferedStream/BufferedStreamTests.netcoreapp.cs
@@ -2,7 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Tests
@@ -48,6 +49,42 @@ namespace System.IO.Tests
                 }
             }
             Assert.Equal(data, result.ToArray());
+        }
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(1, 2)]
+        [InlineData(1024, 4096)]
+        [InlineData(4096, 4097)]
+        [InlineData(4096, 1)]
+        [InlineData(2047, 4096)]
+        public async Task ReadMemory_WriteMemory_AllDataCopied(int spanSize, int bufferSize)
+        {
+            byte[] data = new byte[80000];
+            new Random(42).NextBytes(data);
+
+            var result = new MemoryStream();
+            using (var output = new BufferedStream(result, bufferSize))
+            using (var input = new BufferedStream(new MemoryStream(data), bufferSize))
+            {
+                Memory<byte> memory = new byte[spanSize];
+                int bytesRead;
+                while ((bytesRead = await input.ReadAsync(memory)) != 0)
+                {
+                    await output.WriteAsync(memory.Slice(0, bytesRead));
+                }
+            }
+            Assert.Equal(data, result.ToArray());
+        }
+
+        [Fact]
+        public void ReadWriteMemory_Precanceled_Throws()
+        {
+            using (var bs = new BufferedStream(new MemoryStream()))
+            {
+                Assert.Equal(TaskStatus.Canceled, bs.ReadAsync(new byte[1], new CancellationToken(true)).AsTask().Status);
+                Assert.Equal(TaskStatus.Canceled, bs.WriteAsync(new byte[1], new CancellationToken(true)).Status);
+            }
         }
     }
 }

--- a/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
@@ -589,7 +589,6 @@ namespace System.IO
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-
             if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer), SR.ArgumentNull_Buffer);
             if (offset < 0)
@@ -645,26 +644,58 @@ namespace System.IO
             }
 
             // Delegate to the async implementation.
-            return ReadFromUnderlyingStreamAsync(buffer, offset + bytesFromBuffer, count - bytesFromBuffer, cancellationToken,
-                                                 bytesFromBuffer, semaphoreLockTask);
+            return ReadFromUnderlyingStreamAsync(
+                new Memory<byte>(buffer, offset + bytesFromBuffer, count - bytesFromBuffer),
+                cancellationToken, bytesFromBuffer, semaphoreLockTask).AsTask();
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
+            }
+
+            EnsureNotClosed();
+            EnsureCanRead();
+
+            int bytesFromBuffer = 0;
+            SemaphoreSlim sem = LazyEnsureAsyncActiveSemaphoreInitialized();
+            Task semaphoreLockTask = sem.WaitAsync();
+            if (semaphoreLockTask.IsCompletedSuccessfully)
+            {
+                bool completeSynchronously = true;
+                try
+                {
+                    bytesFromBuffer = ReadFromBuffer(destination.Span);
+                    completeSynchronously = bytesFromBuffer == destination.Length;
+                    if (completeSynchronously)
+                    {
+                        // If we satisfied enough data from the buffer, we can complete synchronously.
+                        return new ValueTask<int>(bytesFromBuffer);
+                    }
+                }
+                finally
+                {
+                    if (completeSynchronously)  // if this is FALSE, we will be entering ReadFromUnderlyingStreamAsync and releasing there.
+                    {
+                        sem.Release();
+                    }
+                }
+            }
+
+            // Delegate to the async implementation.
+            return ReadFromUnderlyingStreamAsync(destination.Slice(bytesFromBuffer), cancellationToken, bytesFromBuffer, semaphoreLockTask);
         }
 
         /// <summary>BufferedStream should be as thin a wrapper as possible. We want ReadAsync to delegate to
         /// ReadAsync of the underlying _stream rather than calling the base Stream which implements the one in terms of the other.
         /// This allows BufferedStream to affect the semantics of the stream it wraps as little as possible. </summary>
         /// <returns>-2 if _bufferSize was set to 0 while waiting on the semaphore; otherwise num of bytes read.</returns>
-        private async Task<int> ReadFromUnderlyingStreamAsync(byte[] array, int offset, int count,
-                                                                CancellationToken cancellationToken,
-                                                                int bytesAlreadySatisfied,
-                                                                Task semaphoreLockTask)
+        private async ValueTask<int> ReadFromUnderlyingStreamAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken, int bytesAlreadySatisfied, Task semaphoreLockTask)
         {
-
             // Same conditions validated with exceptions in ReadAsync:
-            // (These should be Debug.Requires(..) but that method had some issues in async methods; using Assert(..) for now.)
-            Debug.Assert(array != null);
-            Debug.Assert(offset >= 0);
-            Debug.Assert(count >= 0);
-            Debug.Assert(array.Length - offset >= count);
             Debug.Assert(_stream != null);
             Debug.Assert(_stream.CanRead);
             Debug.Assert(_bufferSize > 0);
@@ -674,17 +705,17 @@ namespace System.IO
             await semaphoreLockTask.ConfigureAwait(false);
             try
             {
-
                 // The buffer might have been changed by another async task while we were waiting on the semaphore.
                 // Check it now again.            
-                int bytesFromBuffer = ReadFromBuffer(array, offset, count);
-                if (bytesFromBuffer == count)
+                int bytesFromBuffer = ReadFromBuffer(buffer.Span);
+                if (bytesFromBuffer == buffer.Length)
+                {
                     return bytesAlreadySatisfied + bytesFromBuffer;
+                }
 
                 if (bytesFromBuffer > 0)
                 {
-                    count -= bytesFromBuffer;
-                    offset += bytesFromBuffer;
+                    buffer = buffer.Slice(bytesFromBuffer);
                     bytesAlreadySatisfied += bytesFromBuffer;
                 }
 
@@ -693,21 +724,22 @@ namespace System.IO
 
                 // If there was anything in the write buffer, clear it.
                 if (_writePos > 0)
+                {
                     await FlushWriteAsync(cancellationToken).ConfigureAwait(false);  // no Begin-End read version for Flush. Use Async.            
+                }
 
                 // If the requested read is larger than buffer size, avoid the buffer and still use a single read:
-                if (count >= _bufferSize)
+                if (buffer.Length >= _bufferSize)
                 {
-                    return bytesAlreadySatisfied + await _stream.ReadAsync(array, offset, count, cancellationToken).ConfigureAwait(false);
+                    return bytesAlreadySatisfied + await _stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
                 }
 
                 // Ok. We can fill the buffer:
                 EnsureBufferAllocated();
                 _readLen = await _stream.ReadAsync(_buffer, 0, _bufferSize, cancellationToken).ConfigureAwait(false);
 
-                bytesFromBuffer = ReadFromBuffer(array, offset, count);
+                bytesFromBuffer = ReadFromBuffer(buffer.Span);
                 return bytesAlreadySatisfied + bytesFromBuffer;
-
             }
             finally
             {
@@ -769,7 +801,7 @@ namespace System.IO
             offset += bytesToWrite;
         }
 
-        private void WriteToBuffer(ref ReadOnlySpan<byte> source)
+        private int WriteToBuffer(ReadOnlySpan<byte> source)
         {
             int bytesToWrite = Math.Min(_bufferSize - _writePos, source.Length);
             if (bytesToWrite > 0)
@@ -777,8 +809,8 @@ namespace System.IO
                 EnsureBufferAllocated();
                 source.Slice(0, bytesToWrite).CopyTo(new Span<byte>(_buffer, _writePos, bytesToWrite));
                 _writePos += bytesToWrite;
-                source = source.Slice(bytesToWrite);
             }
+            return bytesToWrite;
         }
 
         private void WriteToBuffer(byte[] array, ref int offset, ref int count, out Exception error)
@@ -939,7 +971,7 @@ namespace System.IO
             {
                 ClearReadBufferBeforeWrite();
             }
-            Debug.Assert(_writePos < _bufferSize);
+            Debug.Assert(_writePos < _bufferSize, $"Expected {_writePos} < {_bufferSize}");
 
             int totalUserbytes;
             bool useBuffer;
@@ -954,12 +986,13 @@ namespace System.IO
             {
                 // Copy as much data to the buffer as will fit.  If there's still room in the buffer,
                 // everything must have fit.
-                WriteToBuffer(ref source);
+                int bytesWritten = WriteToBuffer(source);
                 if (_writePos < _bufferSize)
                 {
-                    Debug.Assert(source.IsEmpty);
+                    Debug.Assert(bytesWritten == source.Length);
                     return;
                 }
+                source = source.Slice(bytesWritten);
 
                 Debug.Assert(_writePos == _bufferSize);
                 Debug.Assert(_buffer != null);
@@ -969,9 +1002,9 @@ namespace System.IO
                 _writePos = 0;
 
                 // Now write the remainder.  It must fit, as we're only on this path if that's true.
-                WriteToBuffer(ref source);
+                bytesWritten = WriteToBuffer(source);
+                Debug.Assert(bytesWritten == source.Length);
 
-                Debug.Assert(source.IsEmpty);
                 Debug.Assert(_writePos < _bufferSize);
             }
             else // skip the buffer
@@ -1012,16 +1045,21 @@ namespace System.IO
             if (buffer.Length - offset < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
+            return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken);
+        }
+
+        public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default(CancellationToken))
+        {
             // Fast path check for cancellation already requested
             if (cancellationToken.IsCancellationRequested)
+            {
                 return Task.FromCanceled<int>(cancellationToken);
+            }
 
             EnsureNotClosed();
             EnsureCanWrite();
 
-            // Try to satisfy the request from the buffer synchronously. But still need a sem-lock in case that another
-            // Async IO Task accesses the buffer concurrently. If we fail to acquire the lock without waiting, make this 
-            // an Async operation.
+            // Try to satisfy the request from the buffer synchronously.
             SemaphoreSlim sem = LazyEnsureAsyncActiveSemaphoreInitialized();
             Task semaphoreLockTask = sem.WaitAsync();
             if (semaphoreLockTask.IsCompletedSuccessfully)
@@ -1029,25 +1067,20 @@ namespace System.IO
                 bool completeSynchronously = true;
                 try
                 {
-
                     if (_writePos == 0)
+                    {
                         ClearReadBufferBeforeWrite();
+                    }
 
                     Debug.Assert(_writePos < _bufferSize);
 
                     // If the write completely fits into the buffer, we can complete synchronously:
-                    completeSynchronously = (count < _bufferSize - _writePos);
-
+                    completeSynchronously = source.Length < _bufferSize - _writePos;
                     if (completeSynchronously)
                     {
-
-                        Exception error;
-                        WriteToBuffer(buffer, ref offset, ref count, out error);
-                        Debug.Assert(count == 0);
-
-                        return (error == null)
-                                    ? Task.CompletedTask
-                                    : Task.FromException(error);
+                        int bytesWritten = WriteToBuffer(source.Span);
+                        Debug.Assert(bytesWritten == source.Length);
+                        return Task.CompletedTask;
                     }
                 }
                 finally
@@ -1058,23 +1091,17 @@ namespace System.IO
             }
 
             // Delegate to the async implementation.
-            return WriteToUnderlyingStreamAsync(buffer, offset, count, cancellationToken, semaphoreLockTask);
+            return WriteToUnderlyingStreamAsync(source, cancellationToken, semaphoreLockTask);
         }
-
 
         /// <summary>BufferedStream should be as thin a wrapper as possible. We want WriteAsync to delegate to
         /// WriteAsync of the underlying _stream rather than calling the base Stream which implements the one 
         /// in terms of the other. This allows BufferedStream to affect the semantics of the stream it wraps as 
         /// little as possible.
         /// </summary>
-        private async Task WriteToUnderlyingStreamAsync(byte[] array, int offset, int count,
-                                                        CancellationToken cancellationToken,
-                                                        Task semaphoreLockTask)
+        private async Task WriteToUnderlyingStreamAsync(
+            ReadOnlyMemory<byte> source, CancellationToken cancellationToken, Task semaphoreLockTask)
         {
-            Debug.Assert(array != null);
-            Debug.Assert(offset >= 0);
-            Debug.Assert(count >= 0);
-            Debug.Assert(array.Length - offset >= count);
             Debug.Assert(_stream != null);
             Debug.Assert(_stream.CanWrite);
             Debug.Assert(_bufferSize > 0);
@@ -1085,7 +1112,6 @@ namespace System.IO
             await semaphoreLockTask.ConfigureAwait(false);
             try
             {
-
                 // The buffer might have been changed by another async task while we were waiting on the semaphore.
                 // However, note that if we recalculate the sync completion condition to TRUE, then useBuffer will also be TRUE.
 
@@ -1095,37 +1121,37 @@ namespace System.IO
                 int totalUserBytes;
                 bool useBuffer;
                 checked
-                {  // We do not expect buffer sizes big enough for an overflow, but if it happens, lets fail early:
-                    totalUserBytes = _writePos + count;
-                    useBuffer = (totalUserBytes + count < (_bufferSize + _bufferSize));
+                {
+                    // We do not expect buffer sizes big enough for an overflow, but if it happens, lets fail early:
+                    totalUserBytes = _writePos + source.Length;
+                    useBuffer = (totalUserBytes + source.Length < (_bufferSize + _bufferSize));
                 }
 
                 if (useBuffer)
                 {
-                    WriteToBuffer(array, ref offset, ref count);
+                    source = source.Slice(WriteToBuffer(source.Span));
 
                     if (_writePos < _bufferSize)
                     {
-                        Debug.Assert(count == 0);
+                        Debug.Assert(source.Length == 0);
                         return;
                     }
 
-                    Debug.Assert(count >= 0);
+                    Debug.Assert(source.Length >= 0);
                     Debug.Assert(_writePos == _bufferSize);
                     Debug.Assert(_buffer != null);
-
                    
                     await _stream.WriteAsync(_buffer, 0, _writePos, cancellationToken).ConfigureAwait(false);
                     _writePos = 0;
 
-                    WriteToBuffer(array, ref offset, ref count);
+                    int bytesWritten = WriteToBuffer(source.Span);
+                    Debug.Assert(bytesWritten == source.Length);
 
-                    Debug.Assert(count == 0);
                     Debug.Assert(_writePos < _bufferSize);
 
                 }
-                else
-                {  // if (!useBuffer)
+                else // !useBuffer
+                {
                     // Write out the buffer if necessary.
                     if (_writePos > 0)
                     {
@@ -1136,7 +1162,7 @@ namespace System.IO
                         if (totalUserBytes <= (_bufferSize + _bufferSize) && totalUserBytes <= MaxShadowBufferSize)
                         {
                             EnsureShadowBufferAllocated();
-                            Buffer.BlockCopy(array, offset, _buffer, _writePos, count);
+                            source.Span.CopyTo(new Span<byte>(_buffer, _writePos, source.Length));
 
                             await _stream.WriteAsync(_buffer, 0, totalUserBytes, cancellationToken).ConfigureAwait(false);
                             _writePos = 0;
@@ -1148,7 +1174,7 @@ namespace System.IO
                     }
 
                     // Write out user data.
-                    await _stream.WriteAsync(array, offset, count, cancellationToken).ConfigureAwait(false);
+                    await _stream.WriteAsync(source, cancellationToken).ConfigureAwait(false);
                 }
             }
             finally


### PR DESCRIPTION
BufferedStream, PipeStream, DeflateStream, and GZipStream

Fixes https://github.com/dotnet/corefx/issues/22397
Fixes https://github.com/dotnet/corefx/issues/22392
Fixes https://github.com/dotnet/corefx/issues/22390
Fixes https://github.com/dotnet/corefx/issues/22395

cc: @JeremyKuhne, @ianhays, @KrzysztofCwalina, @ahsonkhan 