### PR TITLE
Fix a spurious test failure in System.Drawing.Common.Tests

### DIFF
--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -638,7 +638,7 @@ namespace System.Drawing.Tests
                 };
                 using (Font font = Font.FromLogFont(logFont))
                 {
-                    VerifyFont(font, family.Name, 16, fontStyle, GraphicsUnit.World, charSet, expectedGdiVerticalFont: false);
+                    VerifyFont(font, family.Name, font.Size, fontStyle, GraphicsUnit.World, charSet, expectedGdiVerticalFont: false);
                 }
             }
         }

--- a/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
@@ -256,7 +256,8 @@ namespace System.Drawing.Printing.Tests
                     break;
 
                 default:
-                    Assert.False(true, "Unexpected default paper size");
+                    string message = $"Unexpected default paper size. Kind={pageSettings.PaperSize.Kind}, Bounds={pageSettings.Bounds}";
+                    Assert.False(true, message);
                     break;
             }
 


### PR DESCRIPTION
Also, add a better message to another failure being hit.