### PR TITLE
Fixing assertion failure happening on some of the unix machines

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        internal static unsafe int ForkAndExecProcess(
+        internal static unsafe void ForkAndExecProcess(
             string filename, string[] argv, string[] envp, string cwd,
             bool redirectStdin, bool redirectStdout, bool redirectStderr,
             out int lpChildPid, out int stdinFd, out int stdoutFd, out int stderrFd, bool shouldThrow = true)
@@ -39,8 +39,7 @@ internal static partial class Interop
                     // technically ambiguous, in the case of a failure with a 0 errno.  Simplest
                     // solution then is just to throw here the same exception the Process caller
                     // would have.  This can be revisited if we ever have another call site.
-                    if (shouldThrow)
-                        throw new Win32Exception();
+                    throw new Win32Exception();
                 }
             }
             finally
@@ -48,7 +47,6 @@ internal static partial class Interop
                 FreeArray(envpPtr, envp.Length);
                 FreeArray(argvPtr, argv.Length);
             }
-            return result;
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ForkAndExecProcess", SetLastError = true)]

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -211,7 +211,7 @@
     <value>The Process object must have the UseShellExecute property set to false in order to redirect IO streams.</value>
   </data>
   <data name="DirectoryNotValidAsInput" xml:space="preserve">
-    <value>The FileName property should not be a directory.</value>
+    <value>The FileName property should not be a directory unless UseShellExecute is set.</value>
   </data>
   <data name="PendingAsyncOperation" xml:space="preserve">
     <value>An async read operation has already been started on the stream.</value>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -241,16 +241,10 @@ namespace System.Diagnostics
             string[] envp = CreateEnvp(startInfo);
             string cwd = !string.IsNullOrWhiteSpace(startInfo.WorkingDirectory) ? startInfo.WorkingDirectory : null;
 
-            filename = ResolvePath(startInfo.FileName);
-            argv = ParseArgv(startInfo);
-
             if (!startInfo.UseShellExecute)
             {
-                if (string.IsNullOrEmpty(filename))
-                {
-                    throw new Win32Exception(Interop.Error.ENOENT.Info().RawErrno);
-                }
-
+                filename = ResolvePath(startInfo.FileName);
+                argv = ParseArgv(startInfo);
                 if (Directory.Exists(startInfo.FileName))
                 {
                     throw new Win32Exception(SR.DirectoryNotValidAsInput);
@@ -258,14 +252,14 @@ namespace System.Diagnostics
             }
             else
             {
-                if (string.IsNullOrEmpty(filename))
-                {
-                    filename = startInfo.FileName; // is url
-                }
-
                 // use default program to open file/url
                 filename = GetPathToOpenFile();
                 argv = ParseArgv(startInfo, filename);
+            }
+
+            if (string.IsNullOrEmpty(filename))
+            {
+                throw new Win32Exception(Interop.Error.ENOENT.Info().RawErrno);
             }
 
             // Invoke the shim fork/execve routine.  It will create pipes for all requested

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -221,19 +221,13 @@ namespace System.Diagnostics
 
         /// <summary>
         /// Starts the process using the supplied start info. 
-        /// Even with UseShellExecute option, we try first running fileName just in case the caller is giving executable which we should run
-        /// Then if we couldn't run it we'll try the shell tools to launch it(e.g. "open fileName")
+        /// With UseShellExecute option, we'll try the shell tools to launch it(e.g. "open fileName")
         /// </summary>
         /// <param name="startInfo">The start info with which to start the process.</param>
         private bool StartCore(ProcessStartInfo startInfo)
         {
             string filename;
             string[] argv;
-
-            if (Directory.Exists(startInfo.FileName))
-            {
-                throw new Win32Exception(SR.DirectoryNotValidAsInput);
-            }
 
             if (startInfo.UseShellExecute)
             {
@@ -243,48 +237,47 @@ namespace System.Diagnostics
                 }
             }
 
-            int childPid = -1, stdinFd = -1, stdoutFd = -1, stderrFd = -1, result = -1;
+            int childPid, stdinFd, stdoutFd, stderrFd;
             string[] envp = CreateEnvp(startInfo);
             string cwd = !string.IsNullOrWhiteSpace(startInfo.WorkingDirectory) ? startInfo.WorkingDirectory : null;
 
-            filename = ResolvePath(startInfo.FileName); 
-            if (!string.IsNullOrEmpty(filename))
-            {
-                argv = ParseArgv(startInfo);
+            filename = ResolvePath(startInfo.FileName);
+            argv = ParseArgv(startInfo);
 
-                // Invoke the shim fork/execve routine.  It will create pipes for all requested
-                // redirects, fork a child process, map the pipe ends onto the appropriate stdin/stdout/stderr
-                // descriptors, and execve to execute the requested process.  The shim implementation
-                // is used to fork/execve as executing managed code in a forked process is not safe (only
-                // the calling thread will transfer, thread IDs aren't stable across the fork, etc.)
-                result = Interop.Sys.ForkAndExecProcess(
-                    filename, argv, envp, cwd,
-                    startInfo.RedirectStandardInput, startInfo.RedirectStandardOutput, startInfo.RedirectStandardError,
-                    out childPid,
-                    out stdinFd, out stdoutFd, out stderrFd, shouldThrow: !startInfo.UseShellExecute);
-            }
-
-            if (result != 0)
+            if (!startInfo.UseShellExecute)
             {
-                if (!startInfo.UseShellExecute)
+                if (string.IsNullOrEmpty(filename))
                 {
-                    // Could not find the file
-                    Debug.Assert(string.IsNullOrEmpty(filename));
                     throw new Win32Exception(Interop.Error.ENOENT.Info().RawErrno);
                 }
 
-                // this time, set the filename as default program to open file/url
-                filename = GetPathToOpenFile();
-                argv = ParseArgv(startInfo, GetPathToOpenFile());
+                if (Directory.Exists(startInfo.FileName))
+                {
+                    throw new Win32Exception(SR.DirectoryNotValidAsInput);
+                }
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(filename))
+                {
+                    filename = startInfo.FileName; // is url
+                }
 
-                result = Interop.Sys.ForkAndExecProcess(
+                // use default program to open file/url
+                filename = GetPathToOpenFile();
+                argv = ParseArgv(startInfo, filename);
+            }
+
+            // Invoke the shim fork/execve routine.  It will create pipes for all requested
+            // redirects, fork a child process, map the pipe ends onto the appropriate stdin/stdout/stderr
+            // descriptors, and execve to execute the requested process.  The shim implementation
+            // is used to fork/execve as executing managed code in a forked process is not safe (only
+            // the calling thread will transfer, thread IDs aren't stable across the fork, etc.)
+            Interop.Sys.ForkAndExecProcess(
                     filename, argv, envp, cwd,
                     startInfo.RedirectStandardInput, startInfo.RedirectStandardOutput, startInfo.RedirectStandardError,
                     out childPid,
                     out stdinFd, out stdoutFd, out stderrFd);
-
-                Debug.Assert(result == 0);
-            }
 
             // Store the child's information into this Process object.
             Debug.Assert(childPid >= 0);

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -16,8 +16,7 @@ namespace System.Diagnostics.Tests
 {
     public partial class ProcessTests : ProcessTestBase
     {
-        private const string s_xdg_open = "xdg-open";
-        private const int s_exit_code_kill = 137;  // using exit code 137 to show the process was killed
+        private const int EXIT_CODE_KILL = 137;  // using exit code 137 to show the process was killed
 
         [Fact]
         private void TestWindowApisUnix()
@@ -64,40 +63,57 @@ namespace System.Diagnostics.Tests
             Assert.Equal(1, p.Id);
         }
 
-        [Theory, InlineData(false), InlineData(true)] // Expected behavior varies on Windows and Unix. Refer to #23969
-        public void ProcessStart_TryOpenFolder_ThrowsWin32Exception(bool useShellExecute)
-        {
-            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = useShellExecute, FileName = Path.GetTempPath() }));
-        }
-
-        [Fact, PlatformSpecific(TestPlatforms.Linux)]
+        [Theory, InlineData(true), InlineData(false)] // Expected behavior varies on Windows and Unix. Refer to #23969
         [OuterLoop("Opens program")]
-        public void ProcessStart_UseShellExecuteTrue_OpenFile_ThrowsIfNoDefaultProgramInstalledSucceedsOtherwise()
+        public void ProcessStart_UseShellExecute_OnUnix_ThrowsIfNoProgramInstalled(bool isFolder)
         {
-            string fileToOpen = GetTestFilePath() + ".txt";
-            File.WriteAllText(fileToOpen, $"{nameof(ProcessStart_UseShellExecuteTrue_OpenFile_ThrowsIfNoDefaultProgramInstalledSucceedsOtherwise)}");
-
-            string[] allowedProgramsToRun = { s_xdg_open, "gnome-open", "kfmclient" };
-            foreach (var program in allowedProgramsToRun)
+            string fileToOpen;
+            string programToOpen = null;
+            if (isFolder)
             {
-                if (IsProgramInstalled(program))
-                {
-                    var startInfo = new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen };
-                    using (var px = Process.Start(startInfo))
-                    {
-                        Assert.NotNull(px);
-                        Console.WriteLine($"{nameof(ProcessStart_UseShellExecuteTrue_OpenFile_ThrowsIfNoDefaultProgramInstalledSucceedsOtherwise)}(): {program} was used to open file on this machine. ProcessName: {px.ProcessName}");
-                        Assert.Equal(program, px.ProcessName);
-                        px.Kill();
-                        px.WaitForExit();
-                        Assert.True(px.HasExited);
-                        Assert.Equal(s_exit_code_kill, px.ExitCode);
-                    }
-                    return;
-                }
+                fileToOpen = Environment.CurrentDirectory;
+            }
+            else
+            {
+                fileToOpen = GetTestFilePath() + ".txt";
+                File.WriteAllText(fileToOpen, $"{nameof(ProcessStart_UseShellExecute_OnUnix_ThrowsIfNoProgramInstalled)}");
             }
 
-            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                string[] allowedProgramsToRun = { "xdg-open", "gnome-open", "kfmclient" };
+                foreach (var program in allowedProgramsToRun)
+                {
+                    if (IsProgramInstalled(program))
+                    {
+                        programToOpen = program;
+                        break;
+                    }
+                }
+                if (string.IsNullOrEmpty(programToOpen))
+                {
+                    Console.WriteLine($"None of the following programs were installed on this machine: {string.Join(",", allowedProgramsToRun)}.");
+                    Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }));
+                }
+            }
+            
+            using (var px = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }))
+            {
+                Assert.NotNull(px); // on Windows px is null for some reason
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    Assert.Equal(programToOpen, px.ProcessName);
+                }
+                else
+                {
+                    // Assert.Equal(programToOpenWith, px.ProcessName); // on OSX, process name is dotnet for some reason. Refer to #23972
+                    Console.WriteLine($"{nameof(ProcessStart_UseShellExecute_OnUnix_ThrowsIfNoProgramInstalled)}(isFolder: {isFolder}), ProcessName: {px.ProcessName}");
+                }
+                px.Kill();
+                px.WaitForExit();
+                Assert.True(px.HasExited);
+                Assert.Equal(EXIT_CODE_KILL, px.ExitCode);
+            }
         }
 
         [Theory, InlineData("nano"), InlineData("vi")]
@@ -115,48 +131,12 @@ namespace System.Diagnostics.Tests
                     px.Kill();
                     px.WaitForExit();
                     Assert.True(px.HasExited);
-                    Assert.Equal(s_exit_code_kill, px.ExitCode);
+                    Assert.Equal(EXIT_CODE_KILL, px.ExitCode);
                 }
             }
             else
             {
                 Console.WriteLine($"Program specified to open file with {programToOpenWith} is not installed on this machine.");
-            }
-        }
-
-        [Fact, PlatformSpecific(TestPlatforms.Linux)]
-        [OuterLoop("Opens program")]
-        public void ProcessStart_UseShellExecuteTrue_OpenMissingFile_XdgOpenReturnsExitCode2()
-        {
-            // The exit code is coming from xdg-open. Which is why I split this test for OSX and Linux to assert against two different exit code values.
-            if (IsProgramInstalled(s_xdg_open))
-            {
-                string fileToOpen = Path.Combine(Environment.CurrentDirectory, "_no_such_file.TXT");
-                using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }))
-                {
-                    Assert.NotNull(p);
-                    Assert.Equal(s_xdg_open, p.ProcessName);
-                    p.WaitForExit();
-                    Assert.True(p.HasExited);
-                    Assert.Equal(2, p.ExitCode); // Exit Code 2 from xdg-open means file was not found 
-                }
-            }
-            else
-            {
-                Console.WriteLine($"{nameof(ProcessStart_UseShellExecuteTrue_OpenMissingFile_XdgOpenReturnsExitCode2)}(): {s_xdg_open} is not installed on this machine.");
-            }
-        }
-
-        [Fact, PlatformSpecific(TestPlatforms.OSX)]
-        [OuterLoop("Opens program")]
-        public void ProcessStart_UseShellExecuteTrue_TryOpenFileThatDoesntExist_ReturnsExitCode1()
-        {
-            // The exit code is coming from open. Which is why I split this test for OSX and Linux to assert against two different exit code values.
-            string file = Path.Combine(Environment.CurrentDirectory, "_no_such_file.TXT");
-            using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = file }))
-            {
-                Assert.True(p.WaitForExit(WaitInMS));
-                Assert.Equal(1, p.ExitCode); // Exit Code 1 from open means something went wrong
             }
         }
 
@@ -169,12 +149,12 @@ namespace System.Diagnostics.Tests
             File.WriteAllText(fileToOpen, $"{nameof(ProcessStart_OpenFileOnOsx_UsesSpecifiedProgram)}");
             using (var px = Process.Start(programToOpenWith, fileToOpen))
             {
-                Console.WriteLine($"in OSX, {nameof(programToOpenWith)} is {programToOpenWith}, while {nameof(px.ProcessName)} is {px.ProcessName}.");
                 // Assert.Equal(programToOpenWith, px.ProcessName); // on OSX, process name is dotnet for some reason. Refer to #23972
+                Console.WriteLine($"in OSX, {nameof(programToOpenWith)} is {programToOpenWith}, while {nameof(px.ProcessName)} is {px.ProcessName}.");
                 px.Kill();
                 px.WaitForExit();
                 Assert.True(px.HasExited);
-                Assert.Equal(s_exit_code_kill, px.ExitCode);
+                Assert.Equal(EXIT_CODE_KILL, px.ExitCode);
             }
         }
 
@@ -189,7 +169,7 @@ namespace System.Diagnostics.Tests
                 px.Kill();
                 px.WaitForExit();
                 Assert.True(px.HasExited);
-                Assert.Equal(s_exit_code_kill, px.ExitCode);
+                Assert.Equal(EXIT_CODE_KILL, px.ExitCode);
             }
         }
 
@@ -205,7 +185,7 @@ namespace System.Diagnostics.Tests
                 px.Kill();
                 px.WaitForExit();
                 Assert.True(px.HasExited);
-                Assert.Equal(s_exit_code_kill, px.ExitCode);
+                Assert.Equal(EXIT_CODE_KILL, px.ExitCode);
             }
         }
 

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -16,7 +16,7 @@ namespace System.Diagnostics.Tests
 {
     public partial class ProcessTests : ProcessTestBase
     {
-        private const int EXIT_CODE_KILL = 137;  // using exit code 137 to show the process was killed
+        private const int ExitCodeKill  = 137;  // using exit code 137 to show the process was killed
 
         [Fact]
         private void TestWindowApisUnix()
@@ -63,7 +63,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(1, p.Id);
         }
 
-        [Theory, InlineData(true), InlineData(false)] // Expected behavior varies on Windows and Unix. Refer to #23969
+        [Theory, InlineData(true), InlineData(false)]
         [OuterLoop("Opens program")]
         public void ProcessStart_UseShellExecute_OnUnix_ThrowsIfNoProgramInstalled(bool isFolder)
         {
@@ -90,7 +90,7 @@ namespace System.Diagnostics.Tests
                         break;
                     }
                 }
-                if (string.IsNullOrEmpty(programToOpen))
+                if (programToOpen == null)
                 {
                     Console.WriteLine($"None of the following programs were installed on this machine: {string.Join(",", allowedProgramsToRun)}.");
                     Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }));
@@ -112,7 +112,7 @@ namespace System.Diagnostics.Tests
                 px.Kill();
                 px.WaitForExit();
                 Assert.True(px.HasExited);
-                Assert.Equal(EXIT_CODE_KILL, px.ExitCode);
+                Assert.Equal(ExitCodeKill , px.ExitCode);
             }
         }
 
@@ -131,7 +131,7 @@ namespace System.Diagnostics.Tests
                     px.Kill();
                     px.WaitForExit();
                     Assert.True(px.HasExited);
-                    Assert.Equal(EXIT_CODE_KILL, px.ExitCode);
+                    Assert.Equal(ExitCodeKill , px.ExitCode);
                 }
             }
             else
@@ -154,7 +154,7 @@ namespace System.Diagnostics.Tests
                 px.Kill();
                 px.WaitForExit();
                 Assert.True(px.HasExited);
-                Assert.Equal(EXIT_CODE_KILL, px.ExitCode);
+                Assert.Equal(ExitCodeKill , px.ExitCode);
             }
         }
 
@@ -169,7 +169,7 @@ namespace System.Diagnostics.Tests
                 px.Kill();
                 px.WaitForExit();
                 Assert.True(px.HasExited);
-                Assert.Equal(EXIT_CODE_KILL, px.ExitCode);
+                Assert.Equal(ExitCodeKill , px.ExitCode);
             }
         }
 
@@ -185,7 +185,7 @@ namespace System.Diagnostics.Tests
                 px.Kill();
                 px.WaitForExit();
                 Assert.True(px.HasExited);
-                Assert.Equal(EXIT_CODE_KILL, px.ExitCode);
+                Assert.Equal(ExitCodeKill , px.ExitCode);
             }
         }
 

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -145,7 +145,7 @@ namespace System.Diagnostics.Tests
             Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }));
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)] // Expected behavior varies on Windows and Unix. Refer to #23969
+        [PlatformSpecific(TestPlatforms.Windows)]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.HasWindowsShell)), InlineData(true), InlineData(false)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "not supported on UAP")]
         [OuterLoop("Launches File Explorer")]
@@ -170,10 +170,17 @@ namespace System.Diagnostics.Tests
                 }
                 else
                 {
-                    Assert.Equal("notepad", px.ProcessName);
+                    if (px != null)
+                    {
+                        Assert.Equal("notepad", px.ProcessName);
 
-                    px.Kill();
-                    Assert.True(px.WaitForExit(WaitInMS));
+                        px.Kill();
+                        Assert.True(px.WaitForExit(WaitInMS));
+                    }
+                    else
+                    {
+                        Console.WriteLine("Warning: Need to investigate why process is null when opening file on this machine. Refer to #24048");
+                    }
                 }
             }
         }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -136,15 +136,45 @@ namespace System.Diagnostics.Tests
             Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = Path.GetTempPath() }));
         }
         
-        [PlatformSpecific(TestPlatforms.Windows)] // Expected behavior varies on Windows and Unix. Refer to #23969
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasWindowsShell))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "not supported on UAP")]
         [OuterLoop("Launches File Explorer")]
-        public void ProcessStart_TryOpenFolder_UseShellExecuteIsTrue_DoesNotThrow()
+        public void ProcessStart_UseShellExecuteTrue_OpenMissingFile_Throws()
         {
-            using (var px = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = Path.GetTempPath() }))
+            string fileToOpen = Path.Combine(Environment.CurrentDirectory, "_no_such_file.TXT");
+            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }));
+        }
+
+        [PlatformSpecific(TestPlatforms.Windows)] // Expected behavior varies on Windows and Unix. Refer to #23969
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.HasWindowsShell)), InlineData(true), InlineData(false)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "not supported on UAP")]
+        [OuterLoop("Launches File Explorer")]
+        public void ProcessStart_UseShellExecute_OnWindows_DoesNotThrow(bool isFolder)
+        {
+            string fileToOpen;
+            if (isFolder)
             {
-                Assert.Null(px); // Not sure why px returned is null. but the call does not throw and opens folder successfully.
+                fileToOpen = Environment.CurrentDirectory;
+            }
+            else
+            {
+                fileToOpen = GetTestFilePath() + ".txt";
+                File.WriteAllText(fileToOpen, $"{nameof(ProcessStart_UseShellExecute_OnWindows_DoesNotThrow)}");
+            }
+
+            using (var px = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = fileToOpen }))
+            {
+                if (isFolder)
+                {
+                    Assert.Null(px); // Not sure why px returned is null. but the call does not throw and opens folder successfully.
+                }
+                else
+                {
+                    Assert.Equal("notepad", px.ProcessName);
+
+                    px.Kill();
+                    Assert.True(px.WaitForExit(WaitInMS));
+                }
             }
         }
 


### PR DESCRIPTION
This PR is a follow up to this other PR which is recently merged: https://github.com/dotnet/corefx/pull/23705

This PR attempts to fix this failure: https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fcli~2F/build/20170912.03/workItem/System.Diagnostics.Process.Tests

```
src/Native/Unix/System.Native/pal_process.cpp:115: int32_t SystemNative_ForkAndExecProcess(const char *, char *const *, char *const *, const char *, int32_t, int32_t, int32_t, int32_t *, int32_t *, int32_t *, int32_t *): Assertion `false && "null argument."' failed.
```

Making sure we dont hit this assertion:
https://github.com/dotnet/corefx/blob/8160fdc65a53190599e922a32b088d08b94344d2/src/Native/Unix/System.Native/pal_process.cpp#L115