### PR TITLE
Change the netfx compat pack to only ship stable packages, plus System.Drawing

### DIFF
--- a/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.pkgproj
+++ b/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.pkgproj
@@ -8,25 +8,23 @@
 
   <ItemDefinitionGroup>
     <LibraryPackage>
-      <Version>4.5.0</Version>
+      <Version>4.4.0</Version>
     </LibraryPackage>
+    <PrereleaseLibraryPackage>
+      <Version>4.5.0</Version>
+    </PrereleaseLibraryPackage>
   </ItemDefinitionGroup>
 
   <ItemGroup>
+    <LibraryPackage Include="Microsoft.Win32.Registry" />
+    <LibraryPackage Include="Microsoft.Win32.Registry.AccessControl" />
     <LibraryPackage Include="System.CodeDom" />
-    <LibraryPackage Include="System.ComponentModel.Annotations" />
     <LibraryPackage Include="System.Configuration.ConfigurationManager" />
     <LibraryPackage Include="System.Data.SqlClient" />
-    <LibraryPackage Include="System.DirectoryServices" />
-    <LibraryPackage Include="System.DirectoryServices.AccountManagement" />
-    <LibraryPackage Include="System.DirectoryServices.Protocols" />
-    <LibraryPackage Include="System.Drawing.Common" />
     <LibraryPackage Include="System.IO.FileSystem.AccessControl" />
     <LibraryPackage Include="System.IO.Packaging" />
     <LibraryPackage Include="System.IO.Pipes.AccessControl" />
     <LibraryPackage Include="System.IO.Ports" />
-    <LibraryPackage Include="System.Numerics.Vectors" />
-    <LibraryPackage Include="System.Reflection.TypeExtensions" />
     <LibraryPackage Include="System.Security.AccessControl" />
     <LibraryPackage Include="System.Security.Cryptography.Cng" />
     <LibraryPackage Include="System.Security.Cryptography.Pkcs" />
@@ -37,10 +35,12 @@
     <LibraryPackage Include="System.ServiceProcess.ServiceController" />
     <LibraryPackage Include="System.Text.Encoding.CodePages" />
     <LibraryPackage Include="System.Threading.AccessControl" />
+    <PrereleaseLibraryPackage Include="System.Drawing.Common" />
   </ItemGroup>
 
   <ItemGroup>
     <Dependency Include="@(LibraryPackage)" />
+    <Dependency Include="@(PrereleaseLibraryPackage)" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.pkgproj
+++ b/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.pkgproj
@@ -16,6 +16,10 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
+    <PackageIndex Include="$(MSBuildThisFileDirectory)externalIndex.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <LibraryPackage Include="Microsoft.Win32.Registry" />
     <LibraryPackage Include="Microsoft.Win32.Registry.AccessControl" />
     <LibraryPackage Include="System.CodeDom" />
@@ -35,6 +39,11 @@
     <LibraryPackage Include="System.ServiceProcess.ServiceController" />
     <LibraryPackage Include="System.Text.Encoding.CodePages" />
     <LibraryPackage Include="System.Threading.AccessControl" />
+    <LibraryPackage Include="System.ServiceModel.Primitives" />
+    <LibraryPackage Include="System.ServiceModel.Duplex" />
+    <LibraryPackage Include="System.ServiceModel.Http" />
+    <LibraryPackage Include="System.ServiceModel.NetTcp" />
+    <LibraryPackage Include="System.ServiceModel.Security" />
     <PrereleaseLibraryPackage Include="System.Drawing.Common" />
   </ItemGroup>
 

--- a/pkg/Microsoft.NETFramework.Compatibility/externalIndex.json
+++ b/pkg/Microsoft.NETFramework.Compatibility/externalIndex.json
@@ -1,0 +1,34 @@
+{
+  "Packages": {
+    "System.ServiceModel.Primitives": {
+      "StableVersions": [
+        "4.4.0",
+        "4.3.0"
+      ]
+    },
+    "System.ServiceModel.Duplex": {
+      "StableVersions": [
+        "4.4.0",
+        "4.3.0"
+      ]
+    },
+    "System.ServiceModel.Http": {
+      "StableVersions": [
+        "4.4.0",
+        "4.3.0"
+      ]
+    },
+    "System.ServiceModel.NetTcp": {
+      "StableVersions": [
+        "4.4.0",
+        "4.3.0"
+      ]
+    },
+    "System.ServiceModel.Security": {
+      "StableVersions": [
+        "4.4.0",
+        "4.3.0"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Also, I have removed the following packages because they are already in the reference set of .NET Core 2.0 and thus don't need to be in the compat pack:

* System.Numerics.Vectors
* System.Reflection.TypeExtensions
* System.ComponentModel.Annotations

Here is a gist of the resulting nuspec:

https://gist.github.com/mellinoe/31504172fa487acc94c62c5c6e5a0760

@weshaggard @danmosemsft 