### PR TITLE
Disable building Microsoft.XmlSerializer.Generator.Tests for ARM

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -6,7 +6,7 @@
     <DefineConstants>$(DefineConstants);XMLSERIALIZERGENERATORTESTS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <SkipTestsOnPlatform Condition="'$(TargetGroup)' == 'uap'">true</SkipTestsOnPlatform>
+    <SkipTestsOnPlatform Condition="'$(TargetGroup)' == 'uap' OR '$(ArchGroup)' == 'arm'">true</SkipTestsOnPlatform>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <!-- We're building netcoreap, run on the test CLI


### PR DESCRIPTION
Fix #24029 

`Microsoft.XmlSerializer.Generator.Tests` has been enabled for Linux from #23978.
However there is a build break when cross building for ARM, because it tries to use target `dotnet` which is ARM binary when building.

So simply disable building this test for ARM.