### PR TITLE
Disable binplacing test framework when -BuildTests=false

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -258,7 +258,7 @@
     <NetFxPackageRuntimePath>$(BinDir)pkg\netfx\lib</NetFxPackageRuntimePath>
 
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
-    <BinPlaceTestSharedFramework Condition="'$(_bc_TargetGroup)' == 'netcoreapp'">true</BinPlaceTestSharedFramework>
+    <BinPlaceTestSharedFramework Condition="'$(_bc_TargetGroup)' == 'netcoreapp' AND '$(BuildTests)'!='false'">true</BinPlaceTestSharedFramework>
     <BinPlaceILCInputFolder Condition="'$(_bc_TargetGroup)' == 'uapaot' And '$(BinPlaceILCInputFolder)' == ''">true</BinPlaceILCInputFolder>
     <BinPlaceUAPFramework Condition="'$(_bc_TargetGroup)' == 'uap'">true</BinPlaceUAPFramework>
     <BinPlaceNETFXRuntime Condition="'$(_bc_TargetGroup)' == 'netfx'">true</BinPlaceNETFXRuntime>


### PR DESCRIPTION
This change disables syncing and binplacing of test framework when the
-BuildTests option passed to build.sh or sync.sh is set to false.
This is helpful when bootstrapping a new platform where the core-setup
is not built yet and so the Microsoft.NETCore.DotNetHost and
Microsoft.NETCore.DotNetAppHost packages that are required for the
test running don't exist yet.