### PR TITLE
Enable end to end Alpine corefx build

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -37,7 +37,14 @@ if [ -z "$__DOTNET_PKG" ]; then
             __DOTNET_PKG=dotnet-dev-linux-x64
             OS=Linux
 			
-            if [ -e /etc/redhat-release ]; then
+            if [ -e /etc/os-release ]; then
+                source /etc/os-release
+                if [[ $ID == "alpine" ]]; then
+                    # remove the last version digit
+                    VERSION_ID=${VERSION_ID%.*}
+                    __DOTNET_PKG=dotnet-dev-alpine.$VERSION_ID-x64
+                fi
+            elif [ -e /etc/redhat-release ]; then
                 redhatRelease=$(</etc/redhat-release)
                 if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
                     __DOTNET_PKG=dotnet-dev-rhel.6-x64

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -26,7 +26,20 @@
         "android.21-arm64": {
             "#import": [ "android.21", "android-arm64" ]
         },
+        "alpine": {
+            "#import": [ "any" ]
+        },
 
+        "alpine-x64": {
+            "#import": [ "alpine" ]
+        },
+
+        "alpine.3.6": {
+            "#import": [ "alpine" ]
+        },
+        "alpine.3.6-x64": {
+            "#import": [ "alpine.3.6", "alpine-x64" ]
+        },
         "win": {
             "#import": [ "any" ]
         },

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
@@ -9,6 +9,7 @@
     </OfficialBuildRID>
     <OfficialBuildRID Include="linux-x64" />
     <OfficialBuildRID Include="rhel.6-x64" />
+    <OfficialBuildRID Include="alpine.3.6-x64" />
     <OfficialBuildRID Include="osx-x64" />
     <OfficialBuildRID Include="win-arm">
       <Platform>arm</Platform>

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -27,6 +27,10 @@ initHostDistroRid()
     if [ "$__HostOS" == "Linux" ]; then
         if [ -e /etc/os-release ]; then
             source /etc/os-release
+            if [[ $ID == "alpine" ]]; then
+                # remove the last version digit
+                VERSION_ID=${VERSION_ID%.*}
+            fi
             __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
         elif [ -e /etc/redhat-release ]; then
             local redhatRelease=$(</etc/redhat-release)


### PR DESCRIPTION
This change enables full end to end build of corefx including
managed code on Alpine Linux.