### PR TITLE
Generate ThisAssembly.cs to get Package Version.

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/dir.props
+++ b/src/Microsoft.XmlSerializer.Generator/dir.props
@@ -2,9 +2,11 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
+    <PreReleaseLabel>preview1</PreReleaseLabel>
     <PackageVersion>1.0.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>$(AssemblyVersion)</AssemblyFileVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/src/GenerateThisAssemblyCs.targets
+++ b/src/Microsoft.XmlSerializer.Generator/src/GenerateThisAssemblyCs.targets
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+      <CompileDependsOn>
+        GenerateThisAssemblyCs;
+        $(CompileDependsOn)
+      </CompileDependsOn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(IntermediateOutputPath)\ThisAssembly.cs"/>
+  </ItemGroup>
+
+  <Target Name="GenerateThisAssemblyCs">
+    <PropertyGroup>
+      <ThisAssemblyCsContents>
+using System%3B
+namespace Microsoft.XmlSerializer.Generator
+{
+    internal static class ThisAssembly
+    {
+        internal const string PackageVersion = "$(PackageVersion)"%3B
+        internal const string AssemblyVersion = "$(AssemblyVersion)"%3B
+        internal const string Version = "$(AssemblyFileVersion)"%3B
+        internal const string PreReleaseLabel = "$(PreReleaseLabel)"%3B
+        
+        internal static string InformationalVersion
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(PreReleaseLabel))
+                {
+                    return PackageVersion%3B
+                }
+                else
+                {
+                    return $"{PackageVersion}-{PreReleaseLabel}"%3B
+                }
+            }
+        }
+    }
+}
+      </ThisAssemblyCsContents>
+    </PropertyGroup>
+
+    <!-- Write ThisAssembly.cs if this is a new version number, or it is missing -->
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)\ThisAssembly.cs"
+      Lines="$(ThisAssemblyCsContents)"
+      Overwrite="true"
+      Encoding="Unicode"/>
+  </Target>
+</Project>

--- a/src/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
@@ -161,4 +161,5 @@
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <Import Project=".\GenerateThisAssemblyCs.targets" />
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -334,7 +334,7 @@ namespace Microsoft.XmlSerializer.Generator
         private void WriteHeader()
         {
             // do not localize Copyright header
-            Console.WriteLine(String.Format(CultureInfo.CurrentCulture, "[Microsoft (R) .NET Framework, Version {0}]", TempAssembly.ThisAssembly.InformationalVersion));
+            Console.WriteLine(String.Format(CultureInfo.CurrentCulture, "[Microsoft (R) .NET Framework, Version {0}]", ThisAssembly.InformationalVersion));
             Console.WriteLine("Copyright (C) Microsoft Corporation. All rights reserved.");
         }
 

--- a/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -233,12 +233,6 @@ namespace System.Xml.Serialization
         }
 
 #if XMLSERIALIZERGENERATOR
-        internal static class ThisAssembly
-        {
-            internal const string Version = "1.0.0.0";
-            internal const string InformationalVersion = "1.0.0.0";
-        }
-
         private static string GenerateAssemblyId(Type type)
         {
             Module[] modules = type.Assembly.GetModules();


### PR DESCRIPTION
The fix is to generate ThisAssembly.cs during build and include the file in the build so that we can get the package version, assembly file version, and etc. at runtime.

