### PR TITLE
Fix globalization tests to work with setting customization

### DIFF
--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyDecimalDigits.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyDecimalDigits.cs
@@ -13,8 +13,8 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> CurrencyDecimalDigits_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, 2, 2 };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, 2, 2 };
-            yield return new object[] { new CultureInfo("ko").NumberFormat, 0, 2 };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, 2, 2 };
+            yield return new object[] { CultureInfo.GetCultureInfo("ko").NumberFormat, 0, 2 };
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyGroupSizes.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyGroupSizes.cs
@@ -12,12 +12,12 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> CurrencyGroupSizes_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, new int[] { 3 } };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, new int[] { 3 } };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, new int[] { 3 } };
 
             if ((!PlatformDetection.IsUbuntu || PlatformDetection.IsUbuntu1404)
                 && !PlatformDetection.IsWindows7 && !PlatformDetection.IsWindows8x && !PlatformDetection.IsFedora)
             {
-                yield return new object[] { new CultureInfo("ur-IN").NumberFormat, new int[] { 3, 2 } };
+                yield return new object[] { CultureInfo.GetCultureInfo("ur-IN").NumberFormat, new int[] { 3, 2 } };
             }
         }
 

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
@@ -13,7 +13,7 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> CurrencyNegativePattern_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, new int[] { 0 } };
-            yield return new object[] { new CultureInfo("bg-BG").NumberFormat, new int[] { 8 } };
+            yield return new object[] { CultureInfo.GetCultureInfo("bg-BG").NumberFormat, new int[] { 8 } };
         }
 
         [Theory]
@@ -36,7 +36,7 @@ namespace System.Globalization.Tests
             CultureInfo culture; 
             try
             {
-                culture = new CultureInfo(locale);
+                culture = CultureInfo.GetCultureInfo(locale);
             }
             catch(CultureNotFoundException)
             {

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyPositivePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyPositivePattern.cs
@@ -12,8 +12,8 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> CurrencyPositivePattern_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, 0 };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, 0 };
-            yield return new object[] { new CultureInfo("fr-FR").NumberFormat, 3 };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, 0 };
+            yield return new object[] { CultureInfo.GetCultureInfo("fr-FR").NumberFormat, 3 };
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencySymbol.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencySymbol.cs
@@ -14,7 +14,7 @@ namespace System.Globalization.Tests
         [InlineData("", "\x00a4")] // international
         public void CurrencySymbol_Get(string name, string expected)
         {
-            Assert.Equal(expected, new CultureInfo(name).NumberFormat.CurrencySymbol);
+            Assert.Equal(expected, CultureInfo.GetCultureInfo(name).NumberFormat.CurrencySymbol);
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
@@ -12,8 +12,8 @@ namespace System.Globalization.Tests
     {
         public static IEnumerable<object[]> CurrentInfo_CustomCulture_TestData()
         {
-            yield return new object[] { new CultureInfo("en") };
-            yield return new object[] { new CultureInfo("en-US") };
+            yield return new object[] { CultureInfo.GetCultureInfo("en") };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US") };
             yield return new object[] { CultureInfo.InvariantCulture };
         }
 
@@ -23,7 +23,7 @@ namespace System.Globalization.Tests
         {
             RemoteInvoke((cultureName) =>
             {
-                CultureInfo newCulture = new CultureInfo(cultureName);
+                CultureInfo newCulture = CultureInfo.GetCultureInfo(cultureName);
                 CultureInfo.CurrentCulture = newCulture;
                 Assert.Same(newCulture.NumberFormat, NumberFormatInfo.CurrentInfo);
                 return SuccessExitCode;
@@ -56,7 +56,7 @@ namespace System.Globalization.Tests
         {
             public CultureInfoSubclassOverridesGetFormat(string name): base(name) { }
 
-            public static NumberFormatInfo CustomFormat { get; } = new CultureInfo("fr-FR").NumberFormat;
+            public static NumberFormatInfo CustomFormat { get; } = CultureInfo.GetCultureInfo("fr-FR").NumberFormat;
 
             public override object GetFormat(Type formatType) => CustomFormat;
         }
@@ -65,7 +65,7 @@ namespace System.Globalization.Tests
         {
             public CultureInfoSubclassOverridesNumberFormat(string name): base(name) { }
 
-            public static NumberFormatInfo CustomFormat { get; } = new CultureInfo("fr-FR").NumberFormat;
+            public static NumberFormatInfo CustomFormat { get; } = CultureInfo.GetCultureInfo("fr-FR").NumberFormat;
 
             public override NumberFormatInfo NumberFormat
             {

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -68,7 +68,7 @@ namespace System.Globalization.Tests
                     return PlatformDetection.IsWindows ? new int[] { 15 } : new int[] { 8, 15 };
             }
 
-            throw DateTimeFormatInfoData.GetCultureNotSupportedException(new CultureInfo(localeName));
+            throw DateTimeFormatInfoData.GetCultureNotSupportedException(CultureInfo.GetCultureInfo(localeName));
         }
     }
 }

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoGetInstance.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoGetInstance.cs
@@ -11,7 +11,7 @@ namespace System.Globalization.Tests
     {
         public static IEnumerable<object[]> GetInstance_TestData()
         {
-            CultureInfo frFRCulture = new CultureInfo("fr-FR");
+            CultureInfo frFRCulture = CultureInfo.GetCultureInfo("fr-FR");
             yield return new object[] { frFRCulture, frFRCulture.NumberFormat };
             yield return new object[] { frFRCulture.NumberFormat, frFRCulture.NumberFormat };
             yield return new object[] { new CustomFormatProvider(), CustomFormatProvider.CustomFormat };
@@ -55,7 +55,7 @@ namespace System.Globalization.Tests
 
         private class CustomFormatProvider : IFormatProvider
         {
-            public static NumberFormatInfo CustomFormat { get; } = new CultureInfo("fr-FR").NumberFormat;
+            public static NumberFormatInfo CustomFormat { get; } = CultureInfo.GetCultureInfo("fr-FR").NumberFormat;
 
             public object GetFormat(Type formatType) => CustomFormat;
         }

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNegativeInfinitySymbol.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNegativeInfinitySymbol.cs
@@ -12,8 +12,8 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> NegativeInfinitySymbol_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat };
-            yield return new object[] { new CultureInfo("fr-FR").NumberFormat };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat };
+            yield return new object[] { CultureInfo.GetCultureInfo("fr-FR").NumberFormat };
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNegativeSign.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNegativeSign.cs
@@ -12,7 +12,7 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> NegativeSign_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, "-" };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, "-" };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, "-" };
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberDecimalDigits.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberDecimalDigits.cs
@@ -13,7 +13,7 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> NumberDecimalDigits_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, 2, 2 };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, 2, 3 };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, 2, 3 };
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
@@ -12,12 +12,12 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> NumberGroupSizes_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, new int[] { 3 } };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, new int[] { 3 } };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, new int[] { 3 } };
 
             // Culture does not exist on Windows 7
             if (!PlatformDetection.IsWindows7)
             {
-                yield return new object[] { new CultureInfo("ur-IN").NumberFormat, NumberFormatInfoData.UrINNumberGroupSizes() };
+                yield return new object[] { CultureInfo.GetCultureInfo("ur-IN").NumberFormat, NumberFormatInfoData.UrINNumberGroupSizes() };
             }
         }
 

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberNegativePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberNegativePattern.cs
@@ -12,7 +12,7 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> NumberNegativePattern_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, 1 };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, 1 };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, 1 };
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentGroupSizes.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentGroupSizes.cs
@@ -12,7 +12,7 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> PercentGroupSizes_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, new int[] { 3 } };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, new int[] { 3 } };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, new int[] { 3 } };
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentNegativePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentNegativePattern.cs
@@ -12,9 +12,9 @@ namespace System.Globalization.Tests
     {
         public static IEnumerable<object[]> PercentNegativePattern_TestData()
         {
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, 1 };
-            yield return new object[] { new CultureInfo("en-MY").NumberFormat, 1 };
-            yield return new object[] { new CultureInfo("tr").NumberFormat, 2 };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, 1 };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-MY").NumberFormat, 1 };
+            yield return new object[] { CultureInfo.GetCultureInfo("tr").NumberFormat, 2 };
         }
 
         /// <summary>

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentPositivePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentPositivePattern.cs
@@ -12,9 +12,9 @@ namespace System.Globalization.Tests
     {
         public static IEnumerable<object[]> PercentPositivePattern_TestData()
         {
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, 1 };
-            yield return new object[] { new CultureInfo("en-MY").NumberFormat, 1 };
-            yield return new object[] { new CultureInfo("tr").NumberFormat, 2 };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, 1 };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-MY").NumberFormat, 1 };
+            yield return new object[] { CultureInfo.GetCultureInfo("tr").NumberFormat, 2 };
         }
 
         /// <summary>

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentSymbol.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentSymbol.cs
@@ -12,7 +12,7 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> PercentSymbol_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, "%" };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, "%" };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, "%" };
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPositiveInfinitySymbol.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPositiveInfinitySymbol.cs
@@ -12,8 +12,8 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> PositiveInfinitySymbol_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat };
-            yield return new object[] { new CultureInfo("fr-FR").NumberFormat };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat };
+            yield return new object[] { CultureInfo.GetCultureInfo("fr-FR").NumberFormat };
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPositiveSign.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPositiveSign.cs
@@ -12,7 +12,7 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> PositiveSign_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, "+" };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, "+" };
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, "+" };
         }
 
         [Theory]


### PR DESCRIPTION
We used new CultureInfo in many places to check the NumberFormatInfo properties values. these tests can fail if the user customized the user settings on the running machine. The fix here is to use GetCultureInfo which always ignore the change in the settings and return the original values we need to test against.