### PR TITLE
Add warning by default in SGEN

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -11,7 +11,7 @@
     <Delete Condition="Exists('$(SerializerPdbImmediatePath)') == 'true'" Files="$(SerializerPdbImmediatePath)" />
     <Delete Condition="Exists('$(SerializerCsImmediatePath)') == 'true'"  Files="$(SerializerCsImmediatePath)" />
     <Message Text="Running Serialization Tool" Importance="normal" />
-    <Exec Command="dotnet Microsoft.XmlSerializer.Generator $(IntermediateOutputPath)$(AssemblyName).dll /force" ContinueOnError="true"/>
+    <Exec Command="dotnet Microsoft.XmlSerializer.Generator $(IntermediateOutputPath)$(AssemblyName).dll /force /quiet" ContinueOnError="true"/>
     <Warning Condition="Exists('$(SerializerCsImmediatePath)') != 'true'" Text="$(SGenWarningText)" />
     <Csc Condition="Exists('$(SerializerCsImmediatePath)') == 'true'" ContinueOnError="true" OutputAssembly="$(SerializerDllImmediatePath)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(SerializerCsImmediatePath)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)"/>
     <Warning Condition="Exists('$(SerializerDllImmediatePath)') != 'true' And Exists('$(SerializerCsImmediatePath)') == 'true'" Text="$(SGenWarningText)"/>

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -129,7 +129,7 @@ namespace Microsoft.XmlSerializer.Generator
 
                 if(disableRun)
                 {
-                    Console.WriteLine("You are not supposed to run this tool directly!!!");
+                    Console.WriteLine("This tool is not intended to be used directly.");
                     Console.WriteLine("The feature is still under development.");
                     Console.WriteLine("Please refer to https://go.microsoft.com/fwlink/?linkid=858539 for more detail.");
                     return 0;

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -28,6 +28,7 @@ namespace Microsoft.XmlSerializer.Generator
             var errs = new ArrayList();
             bool force = false;
             bool proxyOnly = false;
+            bool disableRun = true;
 
             try
             {
@@ -85,6 +86,10 @@ namespace Microsoft.XmlSerializer.Generator
 
                         assembly = value;
                     }
+                    else if (ArgumentMatch(arg, "quiet"))
+                    {
+                        disableRun = false;
+                    }
                     else
                     {
                         if (arg.EndsWith(".dll") || arg.EndsWith(".exe"))
@@ -119,6 +124,14 @@ namespace Microsoft.XmlSerializer.Generator
                     }
 
                     WriteHelp();
+                    return 0;
+                }
+
+                if(disableRun)
+                {
+                    Console.WriteLine("You are not supposed to run this tool directly!!!");
+                    Console.WriteLine("The feature is still under development.");
+                    Console.WriteLine("Please refer to https://go.microsoft.com/fwlink/?linkid=858539 for more detail.");
                     return 0;
                 }
 

--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -54,7 +54,7 @@
       <SerializerName>$(AssemblyName).XmlSerializers</SerializerName>
     </PropertyGroup>
     <Message Text="Running Serialization Tool" Importance="normal" />
-    <Exec Command="$(GeneratorCliPath)dotnet $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)Microsoft.XmlSerializer.Generator.Tests.dll /force"  />
+    <Exec Command="$(GeneratorCliPath)dotnet $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)Microsoft.XmlSerializer.Generator.Tests.dll /force /quiet"  />
     <Warning Condition="Exists('$(OutputPath)$(SerializerName).cs') != 'true'" Text="Fail to generate $(OutputPath)$(SerializerName).cs"/>
     <Csc Condition="Exists('$(OutputPath)$(SerializerName).cs') == 'true' AND '$(MSBuildRuntimeType)' != 'core'" 
          OutputAssembly="$(OutputPath)$(SerializerName).dll" 

--- a/src/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
+++ b/src/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.XmlSerializer.Generator.Tests
         public static void SgenCommandTest()
         {
             string codefile = "Microsoft.XmlSerializer.Generator.Tests.XmlSerializers.cs";
-            int n = Sgen.Main(new string[] { "Microsoft.XmlSerializer.Generator.Tests.dll", "/force"});
+            int n = Sgen.Main(new string[] { "Microsoft.XmlSerializer.Generator.Tests.dll", "/force /quiet"});
             Assert.Equal(0, n);
             Assert.True(File.Exists(codefile), string.Format("Fail to generate {0}.", codefile));
         }

--- a/src/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
+++ b/src/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.XmlSerializer.Generator.Tests
         public static void SgenCommandTest()
         {
             string codefile = "Microsoft.XmlSerializer.Generator.Tests.XmlSerializers.cs";
-            int n = Sgen.Main(new string[] { "Microsoft.XmlSerializer.Generator.Tests.dll", "/force /quiet"});
+            int n = Sgen.Main(new string[] { "Microsoft.XmlSerializer.Generator.Tests.dll", "/force", "/quiet"});
             Assert.Equal(0, n);
             Assert.True(File.Exists(codefile), string.Format("Fail to generate {0}.", codefile));
         }


### PR DESCRIPTION
Output the warning by default when the customer try to run our tool directly. Add a parameter quiet to suppress this message when using it in the .csproj. 

@shmao @zhenlan @mconnew 