### PR TITLE
Updating corefx to use new roslyn compiler

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-02014-02
+2.0.0-prerelease-02015-01

--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-02015-01
+2.0.0-prerelease-02018-01

--- a/dir.props
+++ b/dir.props
@@ -297,6 +297,6 @@
   </PropertyGroup>
 
   <!-- Use Roslyn Compilers to build -->
-  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />
-  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)')" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false' and '$(RoslynIncompatibleMsbuildVersion)' != 'true'" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)') and '$(RoslynIncompatibleMsbuildVersion)' != 'true'" />
 </Project>

--- a/src/System.Collections.Immutable/src/PEVerifyCompat.rsp
+++ b/src/System.Collections.Immutable/src/PEVerifyCompat.rsp
@@ -1,0 +1,1 @@
+/features:peverify-compat

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -9,6 +9,7 @@
     <FileAlignment>512</FileAlignment>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>
+    <CompilerResponseFile>$(MSBuildThisFileDirectory)PEVerifyCompat.rsp;$(CompilerResponseFile)</CompilerResponseFile>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.0'">netstandard1.0;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />

--- a/src/System.Reflection.Metadata/tests/Metadata/Decoding/SignatureDecoderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Decoding/SignatureDecoderTests.cs
@@ -264,7 +264,7 @@ namespace System.Reflection.Metadata.Decoding.Tests
 
                 // Compiler can generate temporaries or re-order so just check the ones we expect are there.
                 // (They could get optimized away too. If that happens in practice, change this test to use hard-coded signatures.)
-                Assert.Contains("uint8& pinned", localTypes);
+                Assert.Contains("uint8[] pinned", localTypes);
                 Assert.Contains("uint8[]", localTypes);
             }
         }

--- a/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
@@ -127,8 +127,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
 #pragma warning disable 0169 // The private field 'class member' is never used
-        [System.Runtime.CompilerServices.IsByRefLike]
-        private struct StructWithSpanField
+        private ref struct StructWithSpanField
         {
             Span<byte> _bytes;
             int _position;

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{13CE5E71-D373-4EA6-B3CB-166FF089A42A}</ProjectGuid>
     <SkipIncludeNewtonsoftJson>true</SkipIncludeNewtonsoftJson>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -7,6 +7,7 @@
     <NoWarn>1718</NoWarn>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uapaot'">$(DefineConstants);uapaot</DefineConstants>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />

--- a/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
@@ -233,8 +233,7 @@ namespace System.Tests
             }
         }
 
-        [IsByRefLike]
-        private struct ByRefLikeStruct
+        private ref struct ByRefLikeStruct
         {
             public ByRefLikeStruct(int dummy)
             {


### PR DESCRIPTION
cc: @weshaggard @ericstj 

FYI: @ahsonkhan @RussKeldorph @VSadov since you were interested in corefx using a newer compiler

This PR will update the version of the roslyn compiler that we use in corefx.