### PR TITLE
Generate Microsoft.XmlSerializer.Generator.props.

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/pkg/GenerateNupkgProps.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/GenerateNupkgProps.targets
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+      <BuildDependsOn>
+        GenerateNupkgProps;
+        $(BuildDependsOn)
+      </BuildDependsOn>
+      <PackageBuildPath>$(PackageOutputPath)build/</PackageBuildPath>
+      <PropsFilePath>$(PackageBuildPath)$(Id).props</PropsFilePath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageFile Include="$(PropsFilePath)">
+      <TargetPath>build\</TargetPath>
+    </PackageFile>
+  </ItemGroup>
+  <Target Name="GenerateNupkgProps" DependsOnTargets="CalculatePackageVersion">
+    <PropertyGroup>
+      <PropsFileContents>
+&lt;Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"&gt;
+  &lt;ItemGroup&gt;
+    &lt;DotNetCliToolReference Include="$(Id)" Version="$(PackageVersion)" /&gt;
+  &lt;/ItemGroup&gt;
+&lt;/Project&gt;
+      </PropsFileContents>
+    </PropertyGroup>
+    <MakeDir Directories="$(PackageBuildPath)"/>  
+    <WriteLinesToFile
+      File="$(PropsFilePath)"
+      Lines="$(PropsFileContents)"
+      Overwrite="true" />
+  </Target>
+</Project>

--- a/src/Microsoft.XmlSerializer.Generator/pkg/Microsoft.XmlSerializer.Generator.pkgproj
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/Microsoft.XmlSerializer.Generator.pkgproj
@@ -9,9 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageFile Include=".\build\prefercliruntime"/>
-    <PackageFile Include=".\build\Microsoft.XmlSerializer.Generator.props">
-      <TargetPath>build\</TargetPath>
-    </PackageFile>
     <PackageFile Include=".\build\Microsoft.XmlSerializer.Generator.targets">
       <TargetPath>build\</TargetPath>
     </PackageFile>
@@ -20,4 +17,5 @@
     </PackageFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <Import Project=".\GenerateNupkgProps.targets" />
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.props
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.props
@@ -1,5 +1,0 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.XmlSerializer.Generator" Version="1.0.0-preview2-25628-0" />
-  </ItemGroup>
-</Project>


### PR DESCRIPTION
Generate the props file on the fly so that the file can use the correct reference version.