### PR TITLE
Add a NuGet package for System.Runtime.Intrinsics.X86.

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -3572,6 +3572,12 @@
         "4.0.2.0": "4.3.0"
       }
     },
+    "System.Runtime.Intrinsics.X86": {
+      "InboxOn": {},
+      "AssemblyVersionInPackageVersion": {
+        "4.0.0.0": "4.5.0"
+      }
+    },
     "System.Runtime.Loader": {
       "StableVersions": [
         "4.0.0",

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -1398,6 +1398,16 @@
     ]
   },
   {
+    "Name": "System.Runtime.Intrinsics.X86",
+    "Description": "Provides classes which expose low-level processor intrinsics for the x86 family of instruction set architectures.",
+    "CommonTypes": [
+      "System.Runtime.Intrinsics.X86.Sse",
+      "System.Runtime.Intrinsics.X86.Avx",
+      "System.Runtime.Intrinsics.X86.Popcnt",
+      "System.Runtime.Intrinsics.X86.Fma",
+    ]
+  },
+  {
     "Name": "System.Runtime.Loader",
     "Description": "Provides the System.Runtime.Loader.AssemblyLoadContext class, which provides members for loading assemblies.",
     "CommonTypes": [

--- a/src/System.Runtime.Intrinsics.X86/pkg/System.Runtime.Intrinsics.X86.pkgproj
+++ b/src/System.Runtime.Intrinsics.X86/pkg/System.Runtime.Intrinsics.X86.pkgproj
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Runtime.Intrinsics.X86.csproj">
+      <SupportedFramework>netcoreapp2.1</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Runtime.Intrinsics.X86.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
This adds basic packaging for System.Runtime.Intrinsics.X86. The package is only supported on .NET Core 2.1.

@ericstj @fiigii 