### PR TITLE
Remove an assertion from PrintDocumentTests.cs.

### DIFF
--- a/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
@@ -254,11 +254,6 @@ namespace System.Drawing.Printing.Tests
                 case PaperKind.Letter:
                     Assert.Equal(new Rectangle(0, 0, 850, 1100), pageSettings.Bounds);
                     break;
-
-                default:
-                    string message = $"Unexpected default paper size. Kind={pageSettings.PaperSize.Kind}, Bounds={pageSettings.Bounds}";
-                    Assert.False(true, message);
-                    break;
             }
 
             Assert.False(pageSettings.Landscape);


### PR DESCRIPTION
There are tons of PaperKinds (like 100+), so it's not really reasonable to make an assertion about every single one of them. The two we have above this seem to be the most common and are probably okay to check explicitly. I added some logging to see what kind of printer was in use in https://github.com/dotnet/corefx/issues/23992, but it turned out to be `PaperKind.Custom`. I don't think we can make any reasonable guesses about what the size of that is supposed to be, so I'm just going to remove this block here.