### PR TITLE
Disable NegotiateStreamTest fixture for distros without working Kerberos

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -77,6 +77,9 @@ namespace System
         public static Version ICUVersion { get { return null; } }
         public static bool IsUbuntu { get { throw null; } }
         public static bool IsUbuntu1404 { get { throw null; } }
+        public static bool IsUbuntu1604 { get { throw null; } }
+        public static bool IsUbuntu1704 { get { throw null; } }
+        public static bool IsUbuntu1710 { get { throw null; } }
         public static bool IsWindows { get { throw null; } }
         public static bool IsWindows10InsiderPreviewBuild16215OrGreater { get { throw null; } }
         public static bool IsWindows10Version1607OrGreater { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -33,6 +33,9 @@ namespace System
         public static bool IsDebian => IsDistroAndVersion("debian");
         public static bool IsDebian8 => IsDistroAndVersion("debian", "8");
         public static bool IsUbuntu1404 => IsDistroAndVersion("ubuntu", "14.04");
+        public static bool IsUbuntu1604 => IsDistroAndVersion("ubuntu", "16.04");
+        public static bool IsUbuntu1704 => IsDistroAndVersion("ubuntu", "17.04");
+        public static bool IsUbuntu1710 => IsDistroAndVersion("ubuntu", "17.10");
         public static bool IsCentos7 => IsDistroAndVersion("centos", "7");
         public static bool IsTizen => IsDistroAndVersion("tizen");
         public static bool IsNotFedoraOrRedHatOrCentos => !IsDistroAndVersion("fedora") && !IsDistroAndVersion("rhel") && !IsDistroAndVersion("centos");

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -21,6 +21,9 @@ namespace System
         public static bool IsDebian => false;
         public static bool IsDebian8 => false;
         public static bool IsUbuntu1404 => false;
+        public static bool IsUbuntu1604 => false;
+        public static bool IsUbuntu1704 => false;
+        public static bool IsUbuntu1710 => false;
         public static bool IsCentos7 => false;
         public static bool IsTizen => false;
         public static bool IsNotFedoraOrRedHatOrCentos => true;

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Test.Common;
+using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Principal;
 using System.Text;

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
@@ -3,11 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Test.Common;
-using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Principal;
 using System.Text;

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
@@ -115,6 +115,7 @@ namespace System.Net.Security.Tests
     }
 
     [PlatformSpecific(TestPlatforms.Linux)]
+    [ActiveIssue(24000)]
     [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
     public class NegotiateStreamTest : IDisposable, IClassFixture<KDCSetup>
     {


### PR DESCRIPTION
because setup-kdc.sh is broken on some distros and this is failing 350 tests.

Relates to https://github.com/dotnet/corefx/issues/24000
