### PR TITLE
Increase some networking test timeouts

### DIFF
--- a/src/Common/tests/System/Net/Sockets/TestSettings.cs
+++ b/src/Common/tests/System/Net/Sockets/TestSettings.cs
@@ -7,7 +7,7 @@ namespace System.Net.Sockets.Tests
     public static class TestSettings
     {
         // Timeout values in milliseconds.
-        public const int PassingTestTimeout = 5000;
+        public const int PassingTestTimeout = 10000;
         public const int FailingTestTimeout = 100;
 
         // Number of redundant UDP packets to send to increase test reliability

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1048,8 +1048,8 @@ namespace System.Net.Sockets.Tests
             // TODO #5185: harden against packet loss
             const int DatagramSize = 256;
             const int DatagramsToSend = 256;
-            const int AckTimeout = 1000;
-            const int TestTimeout = 30000;
+            const int AckTimeout = 10000;
+            const int TestTimeout = 60000;
 
             using (var left = new UdpClient(new IPEndPoint(leftAddress, 0)))
             using (var right = new UdpClient(new IPEndPoint(rightAddress, 0)))


### PR DESCRIPTION
In response to ongoing failures. I do not know whether the increased timeouts will help, and the numbers are arbitrary.

Relates to #18907 #23533 #23099 etc.
