### PR TITLE
Fix RHEL6 linux/in.h file detection

### DIFF
--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -29,7 +29,7 @@ set(CMAKE_REQUIRED_FLAGS -Werror)
 
 # in_pktinfo: Find whether this struct exists
 check_include_files(
-    linux/in.h
+    "sys/socket.h;linux/in.h"
     HAVE_LINUX_IN_H)
 
 if (HAVE_LINUX_IN_H)
@@ -40,6 +40,7 @@ endif ()
 
 check_c_source_compiles(
     "
+    #include <sys/socket.h>
     #include <${SOCKET_INCLUDES}>
     int main()
     {
@@ -51,6 +52,7 @@ check_c_source_compiles(
 
 check_c_source_compiles(
     "
+    #include <sys/socket.h>
     #include <${SOCKET_INCLUDES}>
     int main()
     {


### PR DESCRIPTION
On RHEL6, the build got broken by my recent fix of the in_pktinfo /
ip_mreqn detection fix. The reason is that on that platform, linux/in.h
cannot be included on its own, the sys/socket.h needs to be included
before that to provide definitions of some structures. In fact, Linux
doc states that the sys/socket.h should be included before the
linux/in.h. So I am fixing that by adding that include to the detection
code.

I have verified that it works on RHEL 6, Ubuntu 14.04, Alpine Linux and FreeBSD.