### PR TITLE
Wrap cert callback leaked exceptions in WinHttpHandler

### DIFF
--- a/src/Common/src/System/Net/Http/WinHttpException.cs
+++ b/src/Common/src/System/Net/Http/WinHttpException.cs
@@ -15,6 +15,11 @@ namespace System.Net.Http
             this.HResult = ConvertErrorCodeToHR(error);
         }
 
+        public WinHttpException(int error, string message, Exception innerException) : base(message, innerException)
+        {
+            this.HResult = ConvertErrorCodeToHR(error);
+        }
+
         public static int ConvertErrorCodeToHR(int error)
         {
             // This method allows common error detection code to be used by consumers
@@ -48,6 +53,13 @@ namespace System.Net.Http
         public static WinHttpException CreateExceptionUsingError(int error)
         {
             var e = new WinHttpException(error, GetErrorMessage(error));
+            ExceptionStackTrace.AddCurrentStack(e);
+            return e;
+        }
+
+        public static WinHttpException CreateExceptionUsingError(int error, Exception innerException)
+        {
+            var e = new WinHttpException(error, GetErrorMessage(error), innerException);
             ExceptionStackTrace.AddCurrentStack(e);
             return e;
         }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -270,6 +270,7 @@ namespace System.Net.Http
 
                 X509Chain chain = null;
                 SslPolicyErrors sslPolicyErrors;
+                bool result = false;
 
                 try
                 {
@@ -281,16 +282,16 @@ namespace System.Net.Http
                         out chain,
                         out sslPolicyErrors);
 
-                    bool result = state.ServerCertificateValidationCallback(
+                    result = state.ServerCertificateValidationCallback(
                         state.RequestMessage,
                         serverCertificate,
                         chain,
                         sslPolicyErrors);
-                    if (!result)
-                    {
-                        throw WinHttpException.CreateExceptionUsingError(
-                            (int)Interop.WinHttp.ERROR_WINHTTP_SECURE_FAILURE);
-                    }
+                }
+                catch (Exception ex)
+                {
+                    throw WinHttpException.CreateExceptionUsingError(
+                        (int)Interop.WinHttp.ERROR_WINHTTP_SECURE_FAILURE, ex);
                 }
                 finally
                 {
@@ -300,6 +301,12 @@ namespace System.Net.Http
                     }
 
                     serverCertificate.Dispose();
+                }
+
+                if (!result)
+                {
+                    throw WinHttpException.CreateExceptionUsingError(
+                        (int)Interop.WinHttp.ERROR_WINHTTP_SECURE_FAILURE);
                 }
             }
         }

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
@@ -111,14 +111,16 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
-        public async Task UseCallback_CallbackThrowsSpecificException_ThrowsInnerSpecificException()
+        public async Task UseCallback_CallbackThrowsSpecificException_SpecificExceptionPropagatesAsBaseException()
         {
             var handler = new WinHttpHandler();
             handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
             using (var client = new HttpClient(handler))
             {
                 _validationCallbackHistory.ThrowException = true;
-                await Assert.ThrowsAsync<CustomException>(() => client.GetAsync(System.Net.Test.Common.Configuration.Http.SecureRemoteEchoServer));
+                HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() =>
+                    client.GetAsync(System.Net.Test.Common.Configuration.Http.SecureRemoteEchoServer));
+                Assert.True(ex.GetBaseException() is CustomException);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -204,14 +204,18 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(21904, ~TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendSupportsCustomCertificateHandling))]
-        public async Task UseCallback_CallbackThrowsException_ExceptionPropagatesAsInnerException()
+        public async Task UseCallback_CallbackThrowsException_ExceptionPropagatesAsBaseException()
         {
+            if (ManagedHandlerTestHelpers.IsEnabled)
+            {
+                return; // TODO #21904: ManagedHandler is not properly wrapping exception.
+            }
+
             if (BackendDoesNotSupportCustomCertificateHandling) // can't use [Conditional*] right now as it's evaluated at the wrong time for the managed handler
             {
-                Console.WriteLine($"Skipping {nameof(UseCallback_CallbackThrowsException_ExceptionPropagatesAsInnerException)}()");
+                Console.WriteLine($"Skipping {nameof(UseCallback_CallbackThrowsException_ExceptionPropagatesAsBaseException)}()");
                 return;
             }
 
@@ -222,7 +226,7 @@ namespace System.Net.Http.Functional.Tests
                 handler.ServerCertificateCustomValidationCallback = delegate { throw e; };
                 
                 HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(Configuration.Http.SecureRemoteEchoServer));
-                Assert.Same(e, ex.InnerException);
+                Assert.Same(e, ex.GetBaseException());
             }
         }
 


### PR DESCRIPTION
 Wrap cert callback leaked exceptions in WinHttpHandler
    
Similar to the fix done for CurlHandler (#21938), fix WinHttpHandler so
that leaked exceptions from the user-provided certificate callback are
properly wrapped.
    
The ManagedHandler still needs to be fixed since it is not wrapping
properly.
    
Contributes to #21904