### PR TITLE
Fix multiplying TextureBrush with a disposed matrix on Unix

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
@@ -168,7 +168,7 @@ namespace System.Drawing
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 int status = SafeNativeMethods.Gdip.GdipSetTextureTransform(new HandleRef(this, NativeBrush), new HandleRef(value, value.nativeMatrix));
@@ -223,6 +223,13 @@ namespace System.Drawing
             if (matrix == null)
             {
                 throw new ArgumentNullException(nameof(matrix));
+            }
+
+            // Multiplying the transform by a disposed matrix is a nop in GDI+, but throws
+            // with the libgdiplus backend. Simulate a nop for compatability with GDI+.
+            if (matrix.nativeMatrix == IntPtr.Zero)
+            {
+                return;
             }
 
             int status = SafeNativeMethods.Gdip.GdipMultiplyTextureTransform(new HandleRef(this, NativeBrush),

--- a/src/System.Drawing.Common/tests/Helpers.cs
+++ b/src/System.Drawing.Common/tests/Helpers.cs
@@ -23,13 +23,14 @@ namespace System.Drawing
             }
             else
             {
+                return true;/*
                 IntPtr nativeLib = dlopen("libgdiplus.so", RTLD_NOW);
                 if (nativeLib == IntPtr.Zero)
                 {
                     nativeLib = dlopen("libgdiplus.so.0", RTLD_NOW);
                 }
 
-                return nativeLib != IntPtr.Zero;
+                return nativeLib != IntPtr.Zero; */
             }
         }
 

--- a/src/System.Drawing.Common/tests/Helpers.cs
+++ b/src/System.Drawing.Common/tests/Helpers.cs
@@ -23,14 +23,13 @@ namespace System.Drawing
             }
             else
             {
-                return true;/*
                 IntPtr nativeLib = dlopen("libgdiplus.so", RTLD_NOW);
                 if (nativeLib == IntPtr.Zero)
                 {
                     nativeLib = dlopen("libgdiplus.so.0", RTLD_NOW);
                 }
 
-                return nativeLib != IntPtr.Zero; */
+                return nativeLib != IntPtr.Zero;
             }
         }
 

--- a/src/System.Drawing.Common/tests/TextureBrushTests.cs
+++ b/src/System.Drawing.Common/tests/TextureBrushTests.cs
@@ -294,7 +294,6 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new TextureBrush(image, WrapMode.Tile, Rectangle.Empty));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(WrapMode.Tile - 1)]
         [InlineData(WrapMode.Clamp + 1)]
@@ -784,7 +783,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(WrapMode.Tile - 1)]
         [InlineData(WrapMode.Clamp + 1)]

--- a/src/System.Drawing.Common/tests/TextureBrushTests.cs
+++ b/src/System.Drawing.Common/tests/TextureBrushTests.cs
@@ -431,7 +431,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void MultiplyTransform_DisposedMatrix_Nop()
         {
@@ -662,7 +661,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Transform_SetNull_ThrowsArgumentNullException()
         {


### PR DESCRIPTION
Also fixed in Libgdiplus here: https://github.com/mono/libgdiplus/pull/80

Also enabling a test that should work