### PR TITLE
Wrap exceptions from ManagedHandler's server validation callback

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
@@ -50,7 +50,14 @@ namespace System.Net.Http
             {
                 callback = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
                 {
-                    return _settings._serverCertificateCustomValidationCallback(request, certificate as X509Certificate2, chain, sslPolicyErrors);
+                    try
+                    {
+                        return _settings._serverCertificateCustomValidationCallback(request, certificate as X509Certificate2, chain, sslPolicyErrors);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new HttpRequestException(SR.net_http_ssl_connection_failed, e);
+                    }
                 };
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -208,11 +208,6 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact(nameof(BackendSupportsCustomCertificateHandling))]
         public async Task UseCallback_CallbackThrowsException_ExceptionPropagatesAsBaseException()
         {
-            if (ManagedHandlerTestHelpers.IsEnabled)
-            {
-                return; // TODO #21904: ManagedHandler is not properly wrapping exception.
-            }
-
             if (BackendDoesNotSupportCustomCertificateHandling) // can't use [Conditional*] right now as it's evaluated at the wrong time for the managed handler
             {
                 Console.WriteLine($"Skipping {nameof(UseCallback_CallbackThrowsException_ExceptionPropagatesAsBaseException)}()");


### PR DESCRIPTION
To match other handlers' behaviors.

Contributes to #21904 
cc: @davidsh, @geoffkizer 

(If this goes in before https://github.com/dotnet/corefx/pull/24107, https://github.com/dotnet/corefx/pull/24107/files#diff-ef1e42079489db8304cd3b3aac08d8c4R211 should be removed.  If that PR goes in first, I'll remove it in this one.)