### PR TITLE
Use Array.Sort instead of custom QuickSort implementation in LINQ's OrderBy

### DIFF
--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -522,9 +522,67 @@ namespace System.Linq
         internal TElement ElementAt(TElement[] elements, int count, int idx) =>
             elements[QuickSelect(ComputeMap(elements, count), count - 1, idx)];
 
+        protected abstract void QuickSort(int[] map, int left, int right);
+
+        // Sorts the k elements between minIdx and maxIdx without sorting all elements
+        // Time complexity: O(n + k log k) best and average case. O(n^2) worse case.
+        protected abstract void PartialQuickSort(int[] map, int left, int right, int minIdx, int maxIdx);
+
+        // Finds the element that would be at idx if the collection was sorted.
+        // Time complexity: O(n) best and average case. O(n^2) worse case.
+        protected abstract int QuickSelect(int[] map, int right, int idx);
+    }
+
+    internal sealed class EnumerableSorter<TElement, TKey> : EnumerableSorter<TElement>
+    {
+        private readonly Func<TElement, TKey> _keySelector;
+        private readonly IComparer<TKey> _comparer;
+        private readonly bool _descending;
+        private readonly EnumerableSorter<TElement> _next;
+        private TKey[] _keys;
+
+        internal EnumerableSorter(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, EnumerableSorter<TElement> next)
+        {
+            _keySelector = keySelector;
+            _comparer = comparer;
+            _descending = descending;
+            _next = next;
+        }
+
+        internal override void ComputeKeys(TElement[] elements, int count)
+        {
+            _keys = new TKey[count];
+            for (int i = 0; i < count; i++)
+            {
+                _keys[i] = _keySelector(elements[i]);
+            }
+
+            _next?.ComputeKeys(elements, count);
+        }
+
+        internal override int CompareAnyKeys(int index1, int index2)
+        {
+            int c = _comparer.Compare(_keys[index1], _keys[index2]);
+            if (c == 0)
+            {
+                if (_next == null)
+                {
+                    return index1 - index2;
+                }
+
+                return _next.CompareAnyKeys(index1, index2);
+            }
+
+            // -c will result in a negative value for int.MinValue (-int.MinValue == int.MinValue).
+            // Flipping keys earlier is more likely to trigger something strange in a comparer,
+            // particularly as it comes to the sort being stable.
+            return (_descending != (c > 0)) ? 1 : -1;
+        }
+
+        
         private int CompareKeys(int index1, int index2) => index1 == index2 ? 0 : CompareAnyKeys(index1, index2);
 
-        private void QuickSort(int[] map, int left, int right)
+        protected override void QuickSort(int[] map, int left, int right)
         {
             do
             {
@@ -584,7 +642,7 @@ namespace System.Linq
 
         // Sorts the k elements between minIdx and maxIdx without sorting all elements
         // Time complexity: O(n + k log k) best and average case. O(n^2) worse case.
-        private void PartialQuickSort(int[] map, int left, int right, int minIdx, int maxIdx)
+        protected override void PartialQuickSort(int[] map, int left, int right, int minIdx, int maxIdx)
         {
             do
             {
@@ -653,7 +711,7 @@ namespace System.Linq
 
         // Finds the element that would be at idx if the collection was sorted.
         // Time complexity: O(n) best and average case. O(n^2) worse case.
-        private int QuickSelect(int[] map, int right, int idx)
+        protected override int QuickSelect(int[] map, int right, int idx)
         {
             int left = 0;
             do
@@ -721,53 +779,6 @@ namespace System.Linq
             while (left < right);
 
             return map[idx];
-        }
-    }
-
-    internal sealed class EnumerableSorter<TElement, TKey> : EnumerableSorter<TElement>
-    {
-        private readonly Func<TElement, TKey> _keySelector;
-        private readonly IComparer<TKey> _comparer;
-        private readonly bool _descending;
-        private readonly EnumerableSorter<TElement> _next;
-        private TKey[] _keys;
-
-        internal EnumerableSorter(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, EnumerableSorter<TElement> next)
-        {
-            _keySelector = keySelector;
-            _comparer = comparer;
-            _descending = descending;
-            _next = next;
-        }
-
-        internal override void ComputeKeys(TElement[] elements, int count)
-        {
-            _keys = new TKey[count];
-            for (int i = 0; i < count; i++)
-            {
-                _keys[i] = _keySelector(elements[i]);
-            }
-
-            _next?.ComputeKeys(elements, count);
-        }
-
-        internal override int CompareAnyKeys(int index1, int index2)
-        {
-            int c = _comparer.Compare(_keys[index1], _keys[index2]);
-            if (c == 0)
-            {
-                if (_next == null)
-                {
-                    return index1 - index2;
-                }
-
-                return _next.CompareAnyKeys(index1, index2);
-            }
-
-            // -c will result in a negative value for int.MinValue (-int.MinValue == int.MinValue).
-            // Flipping keys earlier is more likely to trigger something strange in a comparer,
-            // particularly as it comes to the sort being stable.
-            return (_descending != (c > 0)) ? 1 : -1;
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -567,7 +567,7 @@ namespace System.Linq
             {
                 if (_next == null)
                 {
-                    return index1 - index2;
+                    return index1 - index2; // ensure stability of sort
                 }
 
                 return _next.CompareAnyKeys(index1, index2);
@@ -582,63 +582,10 @@ namespace System.Linq
         
         private int CompareKeys(int index1, int index2) => index1 == index2 ? 0 : CompareAnyKeys(index1, index2);
 
-        protected override void QuickSort(int[] map, int left, int right)
-        {
-            do
-            {
-                int i = left;
-                int j = right;
-                int x = map[i + ((j - i) >> 1)];
-                do
-                {
-                    while (i < map.Length && CompareKeys(x, map[i]) > 0)
-                    {
-                        i++;
-                    }
+        protected override void QuickSort(int[] keys, int lo, int hi) =>
+            Array.Sort(keys, lo, hi - lo + 1, Comparer<int>.Create(CompareAnyKeys)); // TODO #24115: Remove Create call when delegate-based overload is available
 
-                    while (j >= 0 && CompareKeys(x, map[j]) < 0)
-                    {
-                        j--;
-                    }
 
-                    if (i > j)
-                    {
-                        break;
-                    }
-
-                    if (i < j)
-                    {
-                        int temp = map[i];
-                        map[i] = map[j];
-                        map[j] = temp;
-                    }
-
-                    i++;
-                    j--;
-                }
-                while (i <= j);
-
-                if (j - left <= right - i)
-                {
-                    if (left < j)
-                    {
-                        QuickSort(map, left, j);
-                    }
-
-                    left = i;
-                }
-                else
-                {
-                    if (i < right)
-                    {
-                        QuickSort(map, i, right);
-                    }
-
-                    right = j;
-                }
-            }
-            while (left < right);
-        }
 
         // Sorts the k elements between minIdx and maxIdx without sorting all elements
         // Time complexity: O(n + k log k) best and average case. O(n^2) worse case.

--- a/src/System.Linq/tests/OrderByDescendingTests.cs
+++ b/src/System.Linq/tests/OrderByDescendingTests.cs
@@ -184,5 +184,50 @@ namespace System.Linq.Tests
             Func<DateTime, int> keySelector = null;
             AssertExtensions.Throws<ArgumentNullException>("keySelector", () => Enumerable.Empty<DateTime>().OrderByDescending(keySelector));
         }
+
+        [Fact]
+        public void SortsLargeAscendingEnumerableCorrectly()
+        {
+            const int Items = 1_000_000;
+            IEnumerable<int> expected = NumberRangeGuaranteedNotCollectionType(0, Items);
+
+            IEnumerable<int> unordered = expected.Select(i => i);
+            IOrderedEnumerable<int> ordered = unordered.OrderByDescending(i => -i);
+
+            Assert.Equal(expected, ordered);
+        }
+
+        [Fact]
+        public void SortsLargeDescendingEnumerableCorrectly()
+        {
+            const int Items = 1_000_000;
+            IEnumerable<int> expected = NumberRangeGuaranteedNotCollectionType(0, Items);
+
+            IEnumerable<int> unordered = expected.Select(i => Items - i - 1);
+            IOrderedEnumerable<int> ordered = unordered.OrderByDescending(i => -i);
+
+            Assert.Equal(expected, ordered);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(8)]
+        [InlineData(16)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(1_000_000)]
+        public void SortsRandomizedEnumerableCorrectly(int items)
+        {
+            var r = new Random(42);
+
+            int[] randomized = Enumerable.Range(0, items).Select(i => r.Next()).ToArray();
+            int[] ordered = ForceNotCollection(randomized).OrderByDescending(i => -i).ToArray();
+
+            Array.Sort(randomized, (a, b) => a - b);
+            Assert.Equal(randomized, ordered);
+        }
     }
 }

--- a/src/System.Linq/tests/OrderByTests.cs
+++ b/src/System.Linq/tests/OrderByTests.cs
@@ -377,5 +377,50 @@ namespace System.Linq.Tests
                 Enumerable.Range(0, 100).Select(i => i.ToString()).OrderBy(i => i.Length).ThenBy(i => i).ToArray();
             Assert.Equal(expected, ordered);
         }
+
+        [Fact]
+        public void SortsLargeAscendingEnumerableCorrectly()
+        {
+            const int Items = 1_000_000;
+            IEnumerable<int> expected = NumberRangeGuaranteedNotCollectionType(0, Items);
+
+            IEnumerable<int> unordered = expected.Select(i => i);
+            IOrderedEnumerable<int> ordered = unordered.OrderBy(i => i);
+
+            Assert.Equal(expected, ordered);
+        }
+
+        [Fact]
+        public void SortsLargeDescendingEnumerableCorrectly()
+        {
+            const int Items = 1_000_000;
+            IEnumerable<int> expected = NumberRangeGuaranteedNotCollectionType(0, Items);
+
+            IEnumerable<int> unordered = expected.Select(i => Items - i - 1);
+            IOrderedEnumerable<int> ordered = unordered.OrderBy(i => i);
+
+            Assert.Equal(expected, ordered);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(8)]
+        [InlineData(16)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(1_000_000)]
+        public void SortsRandomizedEnumerableCorrectly(int items)
+        {
+            var r = new Random(42);
+
+            int[] randomized = Enumerable.Range(0, items).Select(i => r.Next()).ToArray();
+            int[] ordered = ForceNotCollection(randomized).OrderBy(i => i).ToArray();
+
+            Array.Sort(randomized);
+            Assert.Equal(randomized, ordered);
+        }
     }
 }

--- a/src/System.Linq/tests/ThenByDescendingTests.cs
+++ b/src/System.Linq/tests/ThenByDescendingTests.cs
@@ -165,5 +165,71 @@ And Immortality.".Split(new[] { ' ', '\n', '\r', '—' }, StringSplitOptions.Rem
             Func<DateTime, int> keySelector = null;
             AssertExtensions.Throws<ArgumentNullException>("keySelector", () => Enumerable.Empty<DateTime>().OrderBy(e => e).ThenByDescending(keySelector, null));
         }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void SortsLargeAscendingEnumerableCorrectly(int thenBys)
+        {
+            const int Items = 100_000;
+            IEnumerable<int> expected = NumberRangeGuaranteedNotCollectionType(0, Items);
+
+            IEnumerable<int> unordered = expected.Select(i => i);
+            IOrderedEnumerable<int> ordered = unordered.OrderBy(_ => 0);
+            switch (thenBys)
+            {
+                case 1: ordered = ordered.ThenByDescending(i => -i); break;
+                case 2: ordered = ordered.ThenByDescending(i => 0).ThenByDescending(i => -i); break;
+                case 3: ordered = ordered.ThenByDescending(i => 0).ThenByDescending(i => 0).ThenByDescending(i => -i); break;
+            }
+
+            Assert.Equal(expected, ordered);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void SortsLargeDescendingEnumerableCorrectly(int thenBys)
+        {
+            const int Items = 100_000;
+            IEnumerable<int> expected = NumberRangeGuaranteedNotCollectionType(0, Items);
+
+            IEnumerable<int> unordered = expected.Select(i => Items - i - 1);
+            IOrderedEnumerable<int> ordered = unordered.OrderBy(_ => 0);
+            switch (thenBys)
+            {
+                case 1: ordered = ordered.ThenByDescending(i => -i); break;
+                case 2: ordered = ordered.ThenByDescending(i => 0).ThenByDescending(i => -i); break;
+                case 3: ordered = ordered.ThenByDescending(i => 0).ThenByDescending(i => 0).ThenByDescending(i => -i); break;
+            }
+
+            Assert.Equal(expected, ordered);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void SortsLargeRandomizedEnumerableCorrectly(int thenBys)
+        {
+            const int Items = 100_000;
+            var r = new Random(42);
+
+            int[] randomized = Enumerable.Range(0, Items).Select(i => r.Next()).ToArray();
+
+            IOrderedEnumerable<int> orderedEnumerable = randomized.OrderBy(_ => 0);
+            switch (thenBys)
+            {
+                case 1: orderedEnumerable = orderedEnumerable.ThenByDescending(i => -i); break;
+                case 2: orderedEnumerable = orderedEnumerable.ThenByDescending(i => 0).ThenByDescending(i => -i); break;
+                case 3: orderedEnumerable = orderedEnumerable.ThenByDescending(i => 0).ThenByDescending(i => 0).ThenByDescending(i => -i); break;
+            }
+            int[] ordered = orderedEnumerable.ToArray();
+
+            Array.Sort(randomized, (a, b) => a - b);
+            Assert.Equal(randomized, orderedEnumerable);
+        }
     }
 }

--- a/src/System.Linq/tests/ThenByTests.cs
+++ b/src/System.Linq/tests/ThenByTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Linq.Tests
 {
-    public class ThenByTests
+    public class ThenByTests : EnumerableTests
     {
         [Fact]
         public void SameResultsRepeatCallsIntQuery()
@@ -169,6 +169,72 @@ And Immortality.".Split(new[] { ' ', '\n', '\r', '—' }, StringSplitOptions.Rem
         {
             Func<DateTime, int> keySelector = null;
             AssertExtensions.Throws<ArgumentNullException>("keySelector", () => Enumerable.Empty<DateTime>().OrderBy(e => e).ThenBy(keySelector, null));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void SortsLargeAscendingEnumerableCorrectly(int thenBys)
+        {
+            const int Items = 100_000;
+            IEnumerable<int> expected = NumberRangeGuaranteedNotCollectionType(0, Items);
+
+            IEnumerable<int> unordered = expected.Select(i => i);
+            IOrderedEnumerable<int> ordered = unordered.OrderBy(_ => 0);
+            switch (thenBys)
+            {
+                case 1: ordered = ordered.ThenBy(i => i); break;
+                case 2: ordered = ordered.ThenBy(i => 0).ThenBy(i => i); break;
+                case 3: ordered = ordered.ThenBy(i => 0).ThenBy(i => 0).ThenBy(i => i); break;
+            }
+
+            Assert.Equal(expected, ordered);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void SortsLargeDescendingEnumerableCorrectly(int thenBys)
+        {
+            const int Items = 100_000;
+            IEnumerable<int> expected = NumberRangeGuaranteedNotCollectionType(0, Items);
+
+            IEnumerable<int> unordered = expected.Select(i => Items - i - 1);
+            IOrderedEnumerable<int> ordered = unordered.OrderBy(_ => 0);
+            switch (thenBys)
+            {
+                case 1: ordered = ordered.ThenBy(i => i); break;
+                case 2: ordered = ordered.ThenBy(i => 0).ThenBy(i => i); break;
+                case 3: ordered = ordered.ThenBy(i => 0).ThenBy(i => 0).ThenBy(i => i); break;
+            }
+
+            Assert.Equal(expected, ordered);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void SortsLargeRandomizedEnumerableCorrectly(int thenBys)
+        {
+            const int Items = 100_000;
+            var r = new Random(42);
+
+            int[] randomized = Enumerable.Range(0, Items).Select(i => r.Next()).ToArray();
+
+            IOrderedEnumerable<int> orderedEnumerable = randomized.OrderBy(_ => 0);
+            switch (thenBys)
+            {
+                case 1: orderedEnumerable = orderedEnumerable.ThenBy(i => i); break;
+                case 2: orderedEnumerable = orderedEnumerable.ThenBy(i => 0).ThenBy(i => i); break;
+                case 3: orderedEnumerable = orderedEnumerable.ThenBy(i => 0).ThenBy(i => 0).ThenBy(i => i); break;
+            }
+            int[] ordered = orderedEnumerable.ToArray();
+
+            Array.Sort(randomized, (a, b) => a - b);
+            Assert.Equal(randomized, orderedEnumerable);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/24110

The first commit just moves the various QuickSort implementations to the derived sealed class, to avoid some virtual dispatch for some of the comparison operations.  The second commit then addresses the core of the problem, by using Array.Sort (an IntroSort implementation) instead of the custom QuickSort implementation used today; stability is provided by comparison operator utilizing the provided indices.

It'll be easiest to review the commits individually.

cc: @JonHanna, @VSadov, @OmarTawfik, @maxzav