### PR TITLE
Fix libgdiplus function loading on OSX.

### DIFF
--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -32,6 +32,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
     <Reference Include="System.ComponentModel" />
     <Reference Include="System.ComponentModel.Primitives" />
     <Reference Include="System.Threading" />

--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -18,20 +18,26 @@ namespace System.Drawing
         {
             private static IntPtr LoadNativeLibrary()
             {
-                // Various Unix package managers have chosen different names for the "libgdiplus" shared library.
-                // The mono project, where libgdiplus originated, allowed both of the names below to be used, via
-                // a global configuration setting. We prefer the "unversioned" shared object name, and fallback to
-                // the name suffixed with ".0".
-                IntPtr lib = Interop.Libdl.dlopen("libgdiplus.so", Interop.Libdl.RTLD_NOW);
-                if (lib == IntPtr.Zero)
+                IntPtr lib = IntPtr.Zero;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    lib = Interop.Libdl.dlopen("libgdiplus.so.0", Interop.Libdl.RTLD_NOW);
+                    lib = Interop.Libdl.dlopen("libgdiplus.dylib", Interop.Libdl.RTLD_NOW);
+                }
+                else
+                {
+                    // Various Unix package managers have chosen different names for the "libgdiplus" shared library.
+                    // The mono project, where libgdiplus originated, allowed both of the names below to be used, via
+                    // a global configuration setting. We prefer the "unversioned" shared object name, and fallback to
+                    // the name suffixed with ".0".
+                    lib = Interop.Libdl.dlopen("libgdiplus.so", Interop.Libdl.RTLD_NOW);
                     if (lib == IntPtr.Zero)
                     {
-                        throw new DllNotFoundException(SR.LibgdiplusNotFound);
+                        lib = Interop.Libdl.dlopen("libgdiplus.so.0", Interop.Libdl.RTLD_NOW);
                     }
                 }
 
+                // This function may return a null handle. If it does, individual functions loaded from it will throw a DllNotFoundException,
+                // but not until an attempt is made to actually use the function (rather than load it). This matches how PInvokes behave.
                 return lib;
             }
 

--- a/src/System.Drawing.Common/tests/Helpers.cs
+++ b/src/System.Drawing.Common/tests/Helpers.cs
@@ -23,10 +23,18 @@ namespace System.Drawing
             }
             else
             {
-                IntPtr nativeLib = dlopen("libgdiplus.so", RTLD_NOW);
-                if (nativeLib == IntPtr.Zero)
+                IntPtr nativeLib;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    nativeLib = dlopen("libgdiplus.so.0", RTLD_NOW);
+                    nativeLib = dlopen("libgdiplus.dylib", RTLD_NOW);
+                }
+                else
+                {
+                    nativeLib = dlopen("libgdiplus.so", RTLD_NOW);
+                    if (nativeLib == IntPtr.Zero)
+                    {
+                        nativeLib = dlopen("libgdiplus.so.0", RTLD_NOW);
+                    }
                 }
 
                 return nativeLib != IntPtr.Zero;


### PR DESCRIPTION
Since switching to manual function loading, the OSX configuration of System.Drawing has been broken, because it tries to load functions from "libgdiplus.so", rather than "libgdiplus.dylib". The fix is fairly straightforward -- we just load a different file name when on OSX.