### PR TITLE
Stop running Math.Clamp tests on UAP as API is not there

### DIFF
--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -33,14 +33,13 @@
     <Compile Include="System\MarshalByRefObjectTest.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
-    <!-- Math.Clamp is not yet in CoreRT -->
-    <Compile Include="System\MathTests.netcoreapp.cs" />
     <Compile Include="System\Random.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'!='netstandard'">
     <Compile Include="System\BitConverterSpan.cs" />
     <Compile Include="System\BitConverter.netcoreapp.cs" />
     <Compile Include="System\IO\Path.GetRelativePath.cs" />
+    <Compile Include="System\MathTests.netcoreapp.cs" />
     <Compile Include="System\MathF.netcoreapp.cs" />
     <Compile Include="System\StringComparer.netcoreapp.cs" />
     <Compile Include="System\UnloadingAndProcessExitTests.netcoreapp.cs" />

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -33,13 +33,14 @@
     <Compile Include="System\MarshalByRefObjectTest.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
+    <!-- Math.Clamp is not yet in CoreRT -->
+    <Compile Include="System\MathTests.netcoreapp.cs" />
     <Compile Include="System\Random.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'!='netstandard'">
     <Compile Include="System\BitConverterSpan.cs" />
     <Compile Include="System\BitConverter.netcoreapp.cs" />
     <Compile Include="System\IO\Path.GetRelativePath.cs" />
-    <Compile Include="System\MathTests.netcoreapp.cs" />
     <Compile Include="System\MathF.netcoreapp.cs" />
     <Compile Include="System\StringComparer.netcoreapp.cs" />
     <Compile Include="System\UnloadingAndProcessExitTests.netcoreapp.cs" />

--- a/src/System.Runtime.Extensions/tests/System/MathTests.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathTests.netcoreapp.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Math.Clamp is not in CoreRT yet.")]
     public static partial class MathTests
     {
         public static IEnumerable<object[]> Clamp_UnsignedInt_TestData()


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/23434

It looks like all the other tests in the `  <ItemGroup Condition="'$(TargetGroup)'!='netstandard'">` block have their necessary API present in CoreRT, despite their ".netcoreapp.cs" name.

We will need a pass at some point to find tests that should be enabled for CoreRT and possibly have '.netcoreapp.' removed from their name. As we move stuff to shared, API lights up as a side effect.