### PR TITLE
Port the assembly load path change into 2.0 branch

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -172,9 +172,10 @@ namespace System.Xml.Serialization
                 name.Name = serializerName;
                 name.CodeBase = null;
                 name.CultureInfo = CultureInfo.InvariantCulture;
+                string serializerPath = Path.Combine(Path.GetDirectoryName(type.Assembly.Location), serializerName + ".dll");
                 try
                 {
-                    serializer = Assembly.LoadFile(Path.GetFullPath(serializerName) + ".dll");
+                    serializer = Assembly.LoadFile(serializerPath);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Port the change https://github.com/dotnet/corefx/commit/49f89e475fbba3b64650cafbec27830829450414#diff-963a351caa5eb7b91c08bd702b437637 to 2.0 branch.

Fix #24179 
@shmao @zhenlan @mconnew 