### PR TITLE
Remove System.Drawing.Common from the netfx compat package (temporary).

### DIFF
--- a/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.pkgproj
+++ b/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.pkgproj
@@ -44,7 +44,6 @@
     <LibraryPackage Include="System.ServiceModel.Http" />
     <LibraryPackage Include="System.ServiceModel.NetTcp" />
     <LibraryPackage Include="System.ServiceModel.Security" />
-    <PrereleaseLibraryPackage Include="System.Drawing.Common" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There is a name collision with an existing package on nuget.org, so we are unable to ship System.Drawing.Common at this time. We are removing the reference from this metapackage for the time being.