### PR TITLE
Revert "Remove System.Drawing.Common from the netfx compat package

### DIFF
--- a/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.pkgproj
+++ b/pkg/Microsoft.NETFramework.Compatibility/Microsoft.NETFramework.Compatibility.pkgproj
@@ -44,6 +44,7 @@
     <LibraryPackage Include="System.ServiceModel.Http" />
     <LibraryPackage Include="System.ServiceModel.NetTcp" />
     <LibraryPackage Include="System.ServiceModel.Security" />
+    <PrereleaseLibraryPackage Include="System.Drawing.Common" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This reverts commit f6b0fbd09b8a6dc312e55644a1353cea0fb2936d.

We've gotten ownership of the package transferred to us, so we don't need to remove this from the metapackage.

@danmosemsft 