### PR TITLE
System.Drawing: Throw ArgumentNullException on Unix as well

### DIFF
--- a/src/System.Drawing.Common/src/Unix/System.Drawing.Imaging/Metafile.cs
+++ b/src/System.Drawing.Common/src/Unix/System.Drawing.Imaging/Metafile.cs
@@ -68,7 +68,7 @@ namespace System.Drawing.Imaging
         public Metafile(Stream stream)
         {
             if (stream == null)
-                throw new ArgumentException("stream");
+                throw new ArgumentNullException("stream");
 
             Status status;
             if (GDIPlus.RunningOnUnix())

--- a/src/System.Drawing.Common/src/Unix/System.Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/Unix/System.Drawing/Image.cs
@@ -283,7 +283,7 @@ namespace System.Drawing
         internal static IntPtr InitFromStream(Stream stream)
         {
             if (stream == null)
-                throw new ArgumentException("stream");
+                throw new ArgumentNullException(nameof(stream));
 
             IntPtr imagePtr;
             Status st;


### PR DESCRIPTION
The System.Drawing code was updated to throw `ArgumentNullException`s instead of `ArgumentException`s. However, in at least two scenarios, the Windows codebase was updated whereas the Unix codebase was not.

This PR fixes that.