### PR TITLE
Remove invalid NameResolution tests

### DIFF
--- a/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -91,34 +91,6 @@ namespace System.Net.NameResolution.Tests
             await Assert.ThrowsAsync<ArgumentException>(() => Dns.GetHostEntryAsync(addressString));
         }
 
-        public static IEnumerable<object[]> GetNoneAddresses()
-        {
-            yield return new object[] { IPAddress.None };
-        }
-
-        [PlatformSpecific(~TestPlatforms.OSX)] // macOS will resolve IPAddress.None to broadcasthost and produce a valid listing
-        [Theory]
-        [MemberData(nameof(GetNoneAddresses))]
-        public async Task Dns_GetHostEntryAsync_NoneIPAddress_Fail(IPAddress address)
-        {
-            string addressString = address.ToString();
-
-            await Assert.ThrowsAnyAsync<SocketException>(() => Dns.GetHostEntryAsync(address));
-            await Assert.ThrowsAnyAsync<SocketException>(() => Dns.GetHostEntryAsync(addressString));
-        }
-
-        [PlatformSpecific(TestPlatforms.OSX)] // macOS will resolve IPAddress.None to broadcasthost and produce a valid listing
-        [Theory]
-        [MemberData(nameof(GetNoneAddresses))]
-        public async Task Dns_GetHostEntryAsync_NoneIPAddress_Success(IPAddress address)
-        {
-            IPHostEntry result = await Dns.GetHostEntryAsync(address);
-            Assert.NotNull(result);
-            Assert.NotNull(result.AddressList);
-            Assert.Equal(1, result.AddressList.Length);
-            Assert.Equal(address, result.AddressList[0]);
-        }
-
         [Fact]
         public void DnsBeginGetHostEntry_BadName_Throws()
         {


### PR DESCRIPTION
The Dns_GetHostEntryAsync_* tests are fundamentally invalid because it's
possible for the broadcast address, 255.255.255.255, to have a DNS
mapping via manually modifying the hosts file.  This was actually
happening on Mac systems as well as a virtual environment running on
top of that (i.e. Windows on Parallels).

Ref:
https://github.com/dotnet/corefx/issues/23992#issuecomment-330250642

Contributes to #23992