### PR TITLE
Remove Thread.Sleep workaround

### DIFF
--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -189,6 +189,7 @@
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Tasks" />
+    <Reference Include="System.Threading.Thread" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Windows.cs
@@ -146,7 +146,7 @@ namespace System.IO.MemoryMappedFiles
                     }
                     else
                     {
-                        ThreadSleep(waitSleep);
+                        Thread.Sleep(waitSleep);
                         waitSleep *= 2;
                     }
                 }
@@ -255,14 +255,6 @@ namespace System.IO.MemoryMappedFiles
                 secAttrs.bInheritHandle = Interop.BOOL.TRUE;
             }
             return secAttrs;
-        }
-
-        /// <summary>
-        /// Replacement for Thread.Sleep(milliseconds), which isn't available.
-        /// </summary>
-        internal static void ThreadSleep(int milliseconds)
-        {
-            new ManualResetEventSlim(initialState: false).Wait(milliseconds);
         }
     }
 }

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
@@ -125,7 +125,7 @@ namespace System.IO.MemoryMappedFiles
                     for (int w = 0; canRetry && w < MaxFlushWaits; w++)
                     {
                         int pause = (1 << w);  // MaxFlushRetries should never be over 30
-                        MemoryMappedFile.ThreadSleep(pause);
+                        Thread.Sleep(pause);
 
                         for (int r = 0; canRetry && r < MaxFlushRetriesPerWait; r++)
                         {


### PR DESCRIPTION
Both S.IO.MMF and S.Th.Th are part of the shared framework. It does not seem essential anymore for the former to not reference the latter.