### PR TITLE
Fix ECDsa ExportParameters segfault

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
@@ -97,7 +97,7 @@ internal static partial class Interop
 
 
         [DllImport(Libraries.CryptoNative)]
-        private static extern bool CryptoNative_GetECKeyParameters(
+        private static extern int CryptoNative_GetECKeyParameters(
             SafeEcKeyHandle key, 
             bool includePrivate,
             out SafeBignumHandle qx_bn, out int x_cb,
@@ -117,12 +117,18 @@ internal static partial class Interop
             try
             {
                 key.DangerousAddRef(ref refAdded); // Protect access to d_bn_not_owned
-                if (!CryptoNative_GetECKeyParameters(
+                int rc = CryptoNative_GetECKeyParameters(
                     key,
                     includePrivate,
                     out qx_bn, out qx_cb,
                     out qy_bn, out qy_cb,
-                    out d_bn_not_owned, out d_cb))
+                    out d_bn_not_owned, out d_cb);
+                    
+                if (rc == -1)
+                {
+                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                }
+                else if (rc != 1)
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
@@ -160,7 +166,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.CryptoNative)]
-        private static extern bool CryptoNative_GetECCurveParameters(
+        private static extern int CryptoNative_GetECCurveParameters(
             SafeEcKeyHandle key,
             bool includePrivate,
             out ECCurve.ECCurveType curveType,
@@ -189,7 +195,7 @@ internal static partial class Interop
             try
             {
                 key.DangerousAddRef(ref refAdded); // Protect access to d_bn_not_owned
-                if (!CryptoNative_GetECCurveParameters(
+                int rc = CryptoNative_GetECCurveParameters(
                     key,
                     includePrivate,
                     out curveType,
@@ -203,7 +209,13 @@ internal static partial class Interop
                     out gy_bn, out gy_cb,
                     out order_bn, out order_cb,
                     out cofactor_bn, out cofactor_cb,
-                    out seed_bn, out seed_cb))
+                    out seed_bn, out seed_cb);
+                    
+                if (rc == -1)
+                {
+                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);                    
+                }
+                else if (rc != 1)
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
@@ -108,8 +108,17 @@ extern "C" int32_t CryptoNative_GetECKeyParameters(
 
     if (includePrivate)
     {
-        *d = const_cast<BIGNUM*>(EC_KEY_get0_private_key(key));
-        *cbD = BN_num_bytes(*d);
+        const BIGNUM* const_bignum_privateKey = EC_KEY_get0_private_key(key);
+        if (const_bignum_privateKey != nullptr)
+        {
+            *d = const_cast<BIGNUM*>(const_bignum_privateKey);
+            *cbD = BN_num_bytes(*d);
+        }
+        else
+        {
+            rc = -1;
+            goto error;
+        }
     }
     else
     {


### PR DESCRIPTION
ECDSa.Export(Explicit)Parameters(includePrivateParameters:true) on an EC object containing only a public key will currently segfault on Linux. It is supposed to throw a CryptographicException, so this commit changes it to do so.

cc: @bartonjs @morganbr 

1.0, 1.1, and 2.0 PR's to come after merging this one.