### PR TITLE
Fix memory map imports

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.FlushViewOfFile.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.FlushViewOfFile.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32)]
-        internal extern static int FlushViewOfFile(IntPtr lpBaseAddress, UIntPtr dwNumberOfBytesToFlush);
+        [DllImport(Libraries.Kernel32, SetLastError = true)]
+        internal extern static bool FlushViewOfFile(IntPtr lpBaseAddress, UIntPtr dwNumberOfBytesToFlush);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.UnmapViewOfFile.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.UnmapViewOfFile.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32)]
-        internal extern static int UnmapViewOfFile(IntPtr lpBaseAddress);
+        [DllImport(Libraries.Kernel32, SetLastError = true)]
+        internal extern static bool UnmapViewOfFile(IntPtr lpBaseAddress);
     }
 }

--- a/src/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedViewHandle.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedViewHandle.Windows.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Win32.SafeHandles
         {
             IntPtr h = handle;
             handle = IntPtr.Zero;
-            return Interop.Kernel32.UnmapViewOfFile(h) != 0;
+            return Interop.Kernel32.UnmapViewOfFile(h);
         }
     }
 }

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
@@ -30,7 +30,7 @@ namespace System.IO.MemoryMappedFiles
             ulong nativeSize;
             long extraMemNeeded, newOffset;
             ValidateSizeAndOffset(
-                size, offset, GetSystemPageAllocationGranularity(), 
+                size, offset, GetSystemPageAllocationGranularity(),
                 out nativeSize, out extraMemNeeded, out newOffset);
 
             // if request is >= than total virtual, then MapViewOfFile will fail with meaningless error message 
@@ -107,9 +107,8 @@ namespace System.IO.MemoryMappedFiles
                 {
                     _viewHandle.AcquirePointer(ref firstPagePtr);
 
-                    bool success = Interop.Kernel32.FlushViewOfFile((IntPtr)firstPagePtr, capacity) != 0;
-                    if (success)
-                        return; // This will visit the finally block.
+                    if (Interop.Kernel32.FlushViewOfFile((IntPtr)firstPagePtr, capacity))
+                        return;
 
                     // It is a known issue within the NTFS transaction log system that
                     // causes FlushViewOfFile to intermittently fail with ERROR_LOCK_VIOLATION
@@ -119,24 +118,25 @@ namespace System.IO.MemoryMappedFiles
                     // this strategy successfully flushed the view after no more than 3 retries.
 
                     int error = Marshal.GetLastWin32Error();
-                    bool canRetry = (!success && error == Interop.Errors.ERROR_LOCK_VIOLATION);
+                    if (error != Interop.Errors.ERROR_LOCK_VIOLATION)
+                        throw Win32Marshal.GetExceptionForWin32Error(error);
 
                     SpinWait spinWait = new SpinWait();
-                    for (int w = 0; canRetry && w < MaxFlushWaits; w++)
+                    for (int w = 0; w < MaxFlushWaits; w++)
                     {
                         int pause = (1 << w);  // MaxFlushRetries should never be over 30
                         MemoryMappedFile.ThreadSleep(pause);
 
-                        for (int r = 0; canRetry && r < MaxFlushRetriesPerWait; r++)
+                        for (int r = 0; r < MaxFlushRetriesPerWait; r++)
                         {
-                            success = Interop.Kernel32.FlushViewOfFile((IntPtr)firstPagePtr, capacity) != 0;
-                            if (success)
-                                return; // This will visit the finally block.
+                            if (Interop.Kernel32.FlushViewOfFile((IntPtr)firstPagePtr, capacity))
+                                return;
 
                             spinWait.SpinOnce();
 
                             error = Marshal.GetLastWin32Error();
-                            canRetry = (error == Interop.Errors.ERROR_LOCK_VIOLATION);
+                            if (error != Interop.Errors.ERROR_LOCK_VIOLATION)
+                                throw Win32Marshal.GetExceptionForWin32Error(error);
                         }
                     }
 

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
@@ -132,11 +132,11 @@ namespace System.IO.MemoryMappedFiles
                             if (Interop.Kernel32.FlushViewOfFile((IntPtr)firstPagePtr, capacity))
                                 return;
 
-                            spinWait.SpinOnce();
-
                             error = Marshal.GetLastWin32Error();
                             if (error != Interop.Errors.ERROR_LOCK_VIOLATION)
                                 throw Win32Marshal.GetExceptionForWin32Error(error);
+
+                            spinWait.SpinOnce();
                         }
                     }
 


### PR DESCRIPTION
Imports lost the last error attribute. Add it back and change the results to be the more correct "bool". Tweak the usage based on the new return type.

#24159