### PR TITLE
Update build to clang/llvm 3.9

### DIFF
--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -25,7 +25,7 @@ For Ubuntu 14.04, the following packages should be installed to build the native
 components
 
 * git
-* clang-3.5
+* clang-3.9
 * cmake
 * make
 * libc6-dev
@@ -34,7 +34,7 @@ components
 * libcurl4-openssl-dev
 * zlib1g-dev
 
-`sudo apt-get install git clang-3.5 cmake make libc6-dev libssl-dev libkrb5-dev
+`sudo apt-get install git clang-3.9 cmake make libc6-dev libssl-dev libkrb5-dev
 libcurl4-openssl-dev zlib1g-dev`
 
 #### Managed build
@@ -49,8 +49,6 @@ For Ubuntu 14.04, install the following packages:
 
 For Ubuntu 16.04 LTS / Bash on Ubuntu on Windows you may need to replace libicu52 with libicu55.
 Ubuntu 16.10 and Ubuntu 17.04 will require libicu57. 
-Ubuntu 17.04 also no longer provides clang-3.5 and comes with clang-3.8 by default.
-One will need to use `build.sh -Clang=clang3.8` to build native parts properly.
 
 `sudo apt-get install libunwind8 libicu55 curl`
 

--- a/Documentation/debugging/unix-instructions.md
+++ b/Documentation/debugging/unix-instructions.md
@@ -6,7 +6,7 @@ CoreFX can be debugged on unix using both lldb and visual studio code
 ## Using lldb and SOS
 
 - Run the test using msbuild at least once with `/t:BuildAndTest`.
-- Install version 3.6 of lldb and launch lldb with dotnet as the process and arguments matching the arguments used when running the test through msbuild.
+- Install version 3.9 of lldb and launch lldb with dotnet as the process and arguments matching the arguments used when running the test through msbuild.
 - Load the sos plugin using `plugin load libsosplugin.so`.
 - Type `soshelp` to get help. You can now use all sos commands like `bpmd`.
 
@@ -21,8 +21,8 @@ It is also possible to debug .NET Core crash dumps using lldb and SOS. In order 
 - Matching runtime bits from the crash. To get these, you should either:
   - Download the matching Jenkins archive onto your repro machine.
   - Check out the corefx repository at the appropriate commit and re-build the necessary portions.
-- lldb version 3.8+. Versions 3.6+ of lldb work with regular debugging, but not core debugging. Make sure the version of lldb you have installed is >= 3.8.
-- libsosplugin.so built against a matching version of lldb. Unfortunately, the one that is included in the CoreCLR nuget package is built against version 3.6. You will need to build coreclr from source to get the correct version. Luckily, this will help you get the next file:
+- lldb version 3.9.
+- libsosplugin.so built against a matching version of lldb. The official libsosplugin.so is now built against 3.9.
 - Symbols for libcoreclr.so. libcoreclr.so.dbg should be copied to your "runtime" folder. To get this file, you can:
   - Build coreclr at the matching commit. In order to determine which commit was used to build a version of libcoreclr.so, run the following command:
     `strings libcoreclr.so | grep "@(#)"`

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -329,7 +329,7 @@
       "value": "microsoft/dotnet-buildtools-prereqs"
     },
     "PB_DockerTag": {
-      "value": "ubuntu-14.04-cross-0cd4667-20172211042239",
+      "value": "ubuntu-14.04-cross-0cd4667-20170319080304",
       "allowOverride": true
     },
     "PB_DockerVolumeName": {

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -399,7 +399,7 @@
       "value": "microsoft/dotnet-buildtools-prereqs"
     },
     "PB_DockerTag": {
-      "value": "rhel7_prereqs_2",
+      "value": "centos-7-34f1db9-20171620021620",
       "allowOverride": true
     },
     "PB_DockerVolumeName": {

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -17,7 +17,7 @@
       "Definitions": [{
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "rhel7_prereqs_2",
+            "PB_DockerTag": "centos-7-34f1db9-20171620021620",
             "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols",
             "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -Outerloop -- /p:ArchiveTests=true /p:EnableDumpling=true",
             "PB_SyncArguments": "-p -- /p:ArchGroup=x64",
@@ -51,7 +51,7 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux-Crossbuild",
           "Parameters": {
-            "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20172211042239",
+            "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20170319080304",
             "PB_Architecture": "arm",
             "PB_BuildArguments": "-buildArch=arm -Release -stripSymbols",
             "PB_SyncArguments": "-p -- /p:ArchGroup=arm"
@@ -345,7 +345,7 @@
       "Definitions": [{
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "rhel7_prereqs_2",
+            "PB_DockerTag": "centos-7-34f1db9-20171620021620",
             "PB_BuildArguments": "-buildArch=x64 -Debug",
             "PB_BuildTestsArguments": "-buildArch=x64 -Debug -SkipTests -Outerloop -- /p:ArchiveTests=true /p:EnableDumpling=true",
             "PB_SyncArguments": "-p -- /p:ArchGroup=x64",
@@ -379,7 +379,7 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux-Crossbuild",
           "Parameters": {
-            "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20172211042239",
+            "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20170319080304",
             "PB_Architecture": "arm",
             "PB_BuildArguments": "-buildArch=arm -Debug",
             "PB_SyncArguments": "-p -- /p:ArchGroup=arm"

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -362,18 +362,8 @@ esac
 
 # Set the default clang version if not already set
 if [[ $__ClangMajorVersion == 0 && $__ClangMinorVersion == 0 ]]; then
-    if [ $__CrossBuild == 1 ]; then
-        if [[ "$__BuildArch" == "arm" || "$__BuildArch" == "armel" ]]; then
-            __ClangMajorVersion=3
-            __ClangMinorVersion=9
-        else
-            __ClangMajorVersion=3
-            __ClangMinorVersion=6
-        fi
-    else
-        __ClangMajorVersion=3
-        __ClangMinorVersion=5
-    fi
+    __ClangMajorVersion=3
+    __ClangMinorVersion=9
 fi
 
 # Set the remaining variables based upon the determined build configuration


### PR DESCRIPTION
Update scripts, docs and build pipeline docker images to clang/llvm/lldb 3.9