### PR TITLE
Fix for 2nd Connection hangs in Mirroring Environment

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1416,7 +1416,7 @@ namespace System.Data.SqlClient
             // Determine unit interval
             if (timeout.IsInfinite)
             {
-                timeoutUnitInterval = checked((long)ADP.FailoverTimeoutStep * ADP.TimerFromSeconds(ADP.DefaultConnectionTimeout));
+                timeoutUnitInterval = checked((long)(ADP.FailoverTimeoutStep * ADP.TimerFromSeconds(ADP.DefaultConnectionTimeout)));
             }
             else
             {

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
@@ -23,9 +23,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             {
                 SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
                 builder.ConnectTimeout = 0;
-                string connectionString = builder.ConnectionString;
 
-                TestWorker worker = new TestWorker(connectionString);
+                TestWorker worker = new TestWorker(builder.ConnectionString);
                 Thread childThread = new Thread(() => worker.TestMultipleConnection());
                 childThread.Start();
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
@@ -50,7 +50,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
             string dbname = builder.InitialCatalog;
 
-            builder.Remove("Connection Timeout");
+            builder.ConnectTimeout = 5;
             connectionString = builder.ConnectionString;
 
             DataTable dt = DataTestUtility.RunQuery(connectionString, $"select mirroring_state_desc from sys.database_mirroring where database_id = DB_ID('{dbname}')");

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
@@ -1,0 +1,111 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace System.Data.SqlClient.ManualTesting.Tests
+{
+    public static class ConnectionOnMirroringTest
+    {
+        [CheckConnStrSetupFact]
+        public static void TestMultipleConnectionToMirroredServer()
+        {
+            string connectionString = DataTestUtility.TcpConnStr;
+            int mirroringState;
+            string failoverPartnerName;
+            bool isMirroring = GetMirroringInfo(connectionString, out mirroringState, out failoverPartnerName);
+            List<SqlConnection> list = new List<SqlConnection>();
+            if (isMirroring && mirroringState == 4 && !string.IsNullOrEmpty(failoverPartnerName))
+            {
+                Stopwatch stopWatch = new Stopwatch();
+                TestWorker worker = new TestWorker(connectionString);
+                Thread childThread = new Thread(() => worker.TestMultipleConnection());
+
+                stopWatch.Start();
+                childThread.Start();
+                while (!worker.IsDone && stopWatch.ElapsedMilliseconds <= 10000);
+                stopWatch.Stop();
+
+                if (worker.IsDone)
+                {
+                    childThread.Join();
+                }
+                else
+                {
+                    childThread.Interrupt();
+                    throw new Exception();
+                }
+            }
+        }
+
+        private static bool GetMirroringInfo(string connectionString, out int mirroringState, out string failoverPartnerName)
+        {
+            mirroringState = -1;
+            failoverPartnerName = null;
+
+            SqlConnectionStringBuilder existingConnStrBuilder = new SqlConnectionStringBuilder(connectionString);
+            SqlConnectionStringBuilder newConnStrBuilder = new SqlConnectionStringBuilder();
+            newConnStrBuilder.DataSource = existingConnStrBuilder.DataSource;
+            if (!string.IsNullOrEmpty(existingConnStrBuilder.UserID))
+            {
+                newConnStrBuilder.UserID = existingConnStrBuilder.UserID;
+            }
+            if (!string.IsNullOrEmpty(existingConnStrBuilder.Password))
+            {
+                newConnStrBuilder.Password = existingConnStrBuilder.Password;
+            }
+            if (existingConnStrBuilder.IntegratedSecurity)
+            {
+                newConnStrBuilder.IntegratedSecurity = true;
+            }
+
+            string dbname = existingConnStrBuilder.InitialCatalog;
+            DataTable dt = DataTestUtility.RunQuery(newConnStrBuilder.ConnectionString, $"select mirroring_state from sys.database_mirroring where database_id = DB_ID('{dbname}')");
+            bool isMirroring = Int32.TryParse(dt.Rows[0][0].ToString(), out mirroringState);
+
+            if (isMirroring)
+            {
+                dt = DataTestUtility.RunQuery(newConnStrBuilder.ConnectionString, $"select mirroring_partner_name from sys.database_mirroring where database_id = DB_ID('{dbname}')");
+                failoverPartnerName = dt.Rows[0][0].ToString();
+            }
+
+            return isMirroring;
+        }
+
+        private class TestWorker
+        {
+            private string _connectionString;
+            private bool _isDone;
+
+            public TestWorker(string connectionString)
+            {
+                _connectionString = connectionString;
+                _isDone = false;
+            }
+
+            public bool IsDone { get => _isDone; }
+
+            public void TestMultipleConnection()
+            {
+                List<SqlConnection> list = new List<SqlConnection>();
+
+                for (int i = 0; i < 10; ++i)
+                {
+                    SqlConnection conn = new SqlConnection(_connectionString);
+                    list.Add(conn);
+                    conn.Open();
+                }
+
+                foreach (SqlConnection conn in list)
+                {
+                    conn.Dispose();
+                }
+
+                _isDone = true;
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
@@ -35,6 +35,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 }
                 else
                 {
+                    //thread.Abort() is not implemented yet in CoreFx.
                     childThread.Interrupt();
                     throw new Exception();
                 }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
@@ -15,16 +15,16 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [CheckConnStrSetupFact]
         public static void TestMultipleConnectionToMirroredServer()
         {
-            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
-            builder.ConnectTimeout = 0;
-            string connectionString = builder.ConnectionString;
-
             string mirroringStateDesc;
             string failoverPartnerName;
-            bool isMirroring = GetMirroringInfo(connectionString, out mirroringStateDesc, out failoverPartnerName);
+            bool isMirroring = GetMirroringInfo(DataTestUtility.TcpConnStr, out mirroringStateDesc, out failoverPartnerName);
             bool isSynchronized = "SYNCHRONIZED".Equals(mirroringStateDesc, StringComparison.InvariantCultureIgnoreCase);
             if (isMirroring && isSynchronized && !string.IsNullOrEmpty(failoverPartnerName))
             {
+                SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
+                builder.ConnectTimeout = 0;
+                string connectionString = builder.ConnectionString;
+
                 TestWorker worker = new TestWorker(connectionString);
                 Thread childThread = new Thread(() => worker.TestMultipleConnection());
                 childThread.Start();

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="SQL\LocalDBTest\LocalDBTest.cs" />
     <Compile Include="SQL\MARSSessionPoolingTest\MARSSessionPoolingTest.cs" />
     <Compile Include="SQL\MARSTest\MARSTest.cs" />
+    <Compile Include="SQL\MirroringTest\ConnectionOnMirroringTest.cs" />
     <Compile Include="SQL\ParallelTransactionsTest\ParallelTransactionsTest.cs" />
     <Compile Include="SQL\SqlSchemaInfoTest\SqlSchemaInfoTest.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\AdjustPrecScaleForBulkCopy.cs" />


### PR DESCRIPTION
This is a fix for Issue: https://github.com/dotnet/corefx/issues/24148
Customer reported a bug for hanging connection to mirrored SQL Server. When customer creates and opens ***2 connections*** one after another to ***mirrored server*** with ***connection timeout set to 0***, the 2nd connection hangs infinitely.