### PR TITLE
IPAddress.GetHashCode based on Marvin instead of ToString

### DIFF
--- a/src/Common/Common.Tests.sln
+++ b/src/Common/Common.Tests.sln
@@ -11,10 +11,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C72FD34C-539A-4447-9796-62A229571199}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{C72FD34C-539A-4447-9796-62A229571199}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{C72FD34C-539A-4447-9796-62A229571199}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{C72FD34C-539A-4447-9796-62A229571199}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Common/src/System/Marvin.cs
+++ b/src/Common/src/System/Marvin.cs
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+
+namespace System
+{
+    internal static class Marvin
+    {
+        /// <summary>
+        /// Convenience method to compute a Marvin hash and collapse it into a 32-bit hash.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ComputeHash32(ref byte data, int count, ulong seed)
+        {
+            long hash64 = ComputeHash(ref data, count, seed);
+            return ((int)(hash64 >> 32)) ^ (int)hash64;
+        }
+
+        /// <summary>
+        /// Computes a 64-hash using the Marvin algorithm.
+        /// </summary>
+        public static long ComputeHash(ref byte data, int count, ulong seed)
+        {
+            uint ucount = (uint)count;
+            uint p0 = (uint)seed;
+            uint p1 = (uint)(seed >> 32);
+
+            int byteOffset = 0;  // declared as signed int so we don't have to cast everywhere (it's passed to Unsafe.Add() and used for nothing else.)
+
+            while (ucount >= 8)
+            {
+                p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset));
+                Block(ref p0, ref p1);
+
+                p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset + 4));
+                Block(ref p0, ref p1);
+
+                byteOffset += 8;
+                ucount -= 8;
+            }
+
+            switch (ucount)
+            {
+                case 4:
+                    p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset));
+                    Block(ref p0, ref p1);
+                    goto case 0;
+
+                case 0:
+                    p0 += 0x80u;
+                    break;
+
+                case 5:
+                    p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset));
+                    byteOffset += 4;
+                    Block(ref p0, ref p1);
+                    goto case 1;
+
+                case 1:
+                    p0 += 0x8000u | Unsafe.Add(ref data, byteOffset);
+                    break;
+
+                case 6:
+                    p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset));
+                    byteOffset += 4;
+                    Block(ref p0, ref p1);
+                    goto case 2;
+
+                case 2:
+                    p0 += 0x800000u | Unsafe.As<byte, ushort>(ref Unsafe.Add(ref data, byteOffset));
+                    break;
+
+                case 7:
+                    p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset));
+                    byteOffset += 4;
+                    Block(ref p0, ref p1);
+                    goto case 3;
+
+                case 3:
+                    p0 += 0x80000000u | (((uint)(Unsafe.Add(ref data, byteOffset + 2))) << 16)| (uint)(Unsafe.As<byte, ushort>(ref Unsafe.Add(ref data, byteOffset)));
+                    break;
+
+                default:
+                    Debug.Fail("Should not get here.");
+                    break;
+            }
+
+            Block(ref p0, ref p1);
+            Block(ref p0, ref p1);
+
+            return (((long)p1) << 32) | p0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Block(ref uint rp0, ref uint rp1)
+        {
+            uint p0 = rp0;
+            uint p1 = rp1;
+
+            p1 ^= p0;
+            p0 = _rotl(p0, 20);
+
+            p0 += p1;
+            p1 = _rotl(p1, 9);
+
+            p1 ^= p0;
+            p0 = _rotl(p0, 27);
+
+            p0 += p1;
+            p1 = _rotl(p1, 19);
+
+            rp0 = p0;
+            rp1 = p1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint _rotl(uint value, int shift)
+        {
+            // This is expected to be optimized into a single rol (or ror with negated shift value) instruction
+            return (value << shift) | (value >> (32 - shift));
+        }
+
+        public static ulong DefaultSeed => s_defaultSeed;
+
+        private static ulong s_defaultSeed = GenerateSeed();
+
+        private static ulong GenerateSeed()
+        {
+            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
+            {
+                var bytes = new byte[sizeof(ulong)];
+                rng.GetBytes(bytes);
+                return BitConverter.ToUInt64(bytes, 0);
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Marvin.cs
+++ b/src/Common/src/System/Marvin.cs
@@ -130,9 +130,9 @@ namespace System
         {
             using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
             {
-                Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+                var bytes = new byte[sizeof(ulong)];
                 rng.GetBytes(bytes);
-                return BitConverter.ToUInt64(bytes);
+                return BitConverter.ToUInt64(bytes, 0);
             }
         }
     }

--- a/src/Common/src/System/Marvin.cs
+++ b/src/Common/src/System/Marvin.cs
@@ -124,17 +124,15 @@ namespace System
             return (value << shift) | (value >> (32 - shift));
         }
 
-        public static ulong DefaultSeed => s_defaultSeed;
-
-        private static ulong s_defaultSeed = GenerateSeed();
+        public static ulong DefaultSeed { get; } = GenerateSeed();
 
         private static ulong GenerateSeed()
         {
             using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
             {
-                var bytes = new byte[sizeof(ulong)];
+                Span<byte> bytes = stackalloc byte[sizeof(ulong)];
                 rng.GetBytes(bytes);
-                return BitConverter.ToUInt64(bytes, 0);
+                return BitConverter.ToUInt64(bytes);
             }
         }
     }

--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -18,11 +18,17 @@
     <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+      <Link>Common\System\Security\Cryptography\ByteUtils.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Linux\procfs\Interop.ProcFsStat.cs">
       <Link>Common\Interop\Linux\procfs\Interop.ProcFsStat.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\CharArrayHelpers.cs">
       <Link>Common\System\CharArrayHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Marvin.cs">
+      <Link>Common\System\Marvin.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
@@ -64,6 +70,7 @@
     <Compile Include="Tests\System\AssertExtensionTests.cs" />
     <Compile Include="Tests\System\CharArrayHelpersTests.cs" />
     <Compile Include="Tests\System\IO\StringParserTests.cs" />
+    <Compile Include="Tests\System\MarvinTests.cs" />
     <Compile Include="Tests\System\Security\IdentityHelperTests.cs" />
     <Compile Include="Tests\System\StringExtensions.Tests.cs" />
     <Compile Include="Tests\System\Collections\Generic\ArrayBuilderTests.cs" />

--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -7,10 +7,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/src/Common/tests/Configurations.props
+++ b/src/Common/tests/Configurations.props
@@ -2,8 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard-Unix;
-      netstandard-Windows_NT;
+      netcoreapp-Unix;
+      netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/Common/tests/Tests/System/MarvinTests.cs
+++ b/src/Common/tests/Tests/System/MarvinTests.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Test.Cryptography;
+
+using Xunit;
+
+namespace Tests.System
+{
+    public class MarvinTests
+    {
+        private const ulong Seed1 = 0x4FB61A001BDBCCLU;
+        private const ulong Seed2 = 0x804FB61A001BDBCCLU;
+        private const ulong Seed3 = 0x804FB61A801BDBCCLU;
+
+        private const string TestDataString0Byte = "";
+        private const string TestDataString1Byte = "af";
+        private const string TestDataString2Byte = "e70f";
+        private const string TestDataString3Byte = "37f495";
+        private const string TestDataString4Byte = "8642dc59";
+        private const string TestDataString5Byte = "153fb79826";
+        private const string TestDataString6Byte = "0932e6246c47";
+        private const string TestDataString7Byte = "ab427ea8d10fc7";
+
+        [Theory]
+        [MemberData(nameof(TestDataAndExpectedHashes))]
+        public void ComputeHash_Success(ulong seed, string testDataString, ulong expectedHash)
+        {
+            var testDataSpan = new Span<byte>(testDataString.HexToByteArray());
+            long hash = Marvin.ComputeHash(ref testDataSpan.DangerousGetPinnableReference(), testDataSpan.Length, seed);
+            Assert.Equal((long)expectedHash, hash);
+        }
+
+        public static object[][] TestDataAndExpectedHashes =
+        {
+            new object[] { Seed1, TestDataString0Byte, 0x30ED35C100CD3C7DLU },
+            new object[] { Seed1, TestDataString1Byte, 0x48E73FC77D75DDC1LU },
+            new object[] { Seed1, TestDataString2Byte, 0xB5F6E1FC485DBFF8LU },
+            new object[] { Seed1, TestDataString3Byte, 0xF0B07C789B8CF7E8LU },
+            new object[] { Seed1, TestDataString4Byte, 0x7008F2E87E9CF556LU },
+            new object[] { Seed1, TestDataString5Byte, 0xE6C08C6DA2AFA997LU },
+            new object[] { Seed1, TestDataString6Byte, 0x6F04BF1A5EA24060LU },
+            new object[] { Seed1, TestDataString7Byte, 0xE11847E4F0678C41LU },
+
+            new object[] { Seed2, TestDataString0Byte, 0x10A9D5D3996FD65DLU },
+            new object[] { Seed2, TestDataString1Byte, 0x68201F91960EBF91LU },
+            new object[] { Seed2, TestDataString2Byte, 0x64B581631F6AB378LU },
+            new object[] { Seed2, TestDataString3Byte, 0xE1F2DFA6E5131408LU },
+            new object[] { Seed2, TestDataString4Byte, 0x36289D9654FB49F6LU },
+            new object[] { Seed2, TestDataString5Byte, 0xA06114B13464DBDLU },
+            new object[] { Seed2, TestDataString6Byte, 0xD6DD5E40AD1BC2EDLU },
+            new object[] { Seed2, TestDataString7Byte, 0xE203987DBA252FB3LU },
+
+            new object[] { Seed3, "00", 0xA37FB0DA2ECAE06CLU },
+            new object[] { Seed3, "FF", 0xFECEF370701AE054LU },
+            new object[] { Seed3, "00FF", 0xA638E75700048880LU },
+            new object[] { Seed3, "FF00", 0xBDFB46D969730E2ALU },
+            new object[] { Seed3, "FF00FF", 0x9D8577C0FE0D30BFLU },
+            new object[] { Seed3, "00FF00", 0x4F9FBDDE15099497LU },
+            new object[] { Seed3, "00FF00FF", 0x24EAA279D9A529CALU },
+            new object[] { Seed3, "FF00FF00", 0xD3BEC7726B057943LU },
+            new object[] { Seed3, "FF00FF00FF", 0x920B62BBCA3E0B72LU },
+            new object[] { Seed3, "00FF00FF00", 0x1D7DDF9DFDF3C1BFLU },
+            new object[] { Seed3, "00FF00FF00FF", 0xEC21276A17E821A5LU },
+            new object[] { Seed3, "FF00FF00FF00", 0x6911A53CA8C12254LU },
+            new object[] { Seed3, "FF00FF00FF00FF", 0xFDFD187B1D3CE784LU },
+            new object[] { Seed3, "00FF00FF00FF00", 0x71876F2EFB1B0EE8LU },
+        };
+    }
+}

--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -89,6 +89,9 @@
     <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformation.cs">
       <Link>Common\System\Net\NetworkInformation\HostInformation.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Marvin.cs">
+      <Link>Common\System\Marvin.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>
@@ -194,6 +197,7 @@
     <Reference Include="Microsoft.Win32.Primitives" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.NonGeneric" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tracing" />
@@ -202,6 +206,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Threading" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -626,16 +626,12 @@ namespace System.Net
             if (IsIPv6)
             {
                 const int addressAndScopeIdLength = IPAddressParserStatics.IPv6AddressBytes + sizeof(uint);
-                Span<byte> addressAndScopeIdSpan;
-                unsafe
-                {
-                    byte* addressAndScopeId = stackalloc byte[addressAndScopeIdLength];
-                    addressAndScopeIdSpan = new Span<byte>(addressAndScopeId, addressAndScopeIdLength);
-                }
+                Span<byte> addressAndScopeIdSpan = stackalloc byte[addressAndScopeIdLength];
 
                 new ReadOnlySpan<ushort>(_numbers).AsBytes().CopyTo(addressAndScopeIdSpan);
                 Span<byte> scopeIdSpan = addressAndScopeIdSpan.Slice(IPAddressParserStatics.IPv6AddressBytes);
-                BitConverter.TryWriteBytes(scopeIdSpan, _addressOrScopeId);
+                bool scopeWritten = BitConverter.TryWriteBytes(scopeIdSpan, _addressOrScopeId);
+                Debug.Assert(scopeWritten);
 
                 hashCode = Marvin.ComputeHash32(
                     ref addressAndScopeIdSpan[0],

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -83,6 +83,8 @@ namespace System.Net
             set
             {
                 Debug.Assert(IsIPv4);
+                _toString = null;
+                _hashCode = 0;
                 _addressOrScopeId = value;
             }
         }
@@ -97,6 +99,8 @@ namespace System.Net
             set
             {
                 Debug.Assert(IsIPv6);
+                _toString = null;
+                _hashCode = 0;
                 _addressOrScopeId = value;
             }
         }
@@ -558,8 +562,6 @@ namespace System.Net
                 {
                     if (PrivateAddress != value)
                     {
-                        _toString = null;
-                        _hashCode = 0;
                         PrivateAddress = unchecked((uint)value);
                     }
                 }

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -627,14 +627,13 @@ namespace System.Net
                 Span<byte> addressAndScopeIdSpan;
                 unsafe
                 {
-                    var addressSpan = new ReadOnlySpan<byte>(Unsafe.AsPointer(ref _numbers[0]), IPAddressParserStatics.IPv6AddressBytes);
-                    var scopeIdSpan = new ReadOnlySpan<byte>(Unsafe.AsPointer(ref _addressOrScopeId), sizeof(uint));
-
                     byte* addressAndScopeId = stackalloc byte[addressAndScopeIdLength];
                     addressAndScopeIdSpan = new Span<byte>(addressAndScopeId, addressAndScopeIdLength);
-                    addressSpan.CopyTo(addressAndScopeIdSpan);
-                    scopeIdSpan.CopyTo(addressAndScopeIdSpan.Slice(IPAddressParserStatics.IPv6AddressBytes));
                 }
+
+                new ReadOnlySpan<ushort>(_numbers).AsBytes().CopyTo(addressAndScopeIdSpan);
+                Span<byte> scopeIdSpan = addressAndScopeIdSpan.Slice(IPAddressParserStatics.IPv6AddressBytes);
+                BitConverter.TryWriteBytes(scopeIdSpan, _addressOrScopeId);
 
                 hashCode = Marvin.ComputeHash32(
                     ref addressAndScopeIdSpan[0],

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -44,7 +44,7 @@ namespace System.Net
         private string _toString;
 
         /// <summary>
-        /// This field is only used for IPv6 addresses. A lazily initialized cache of the <see cref="GetHashCode"/> value.
+        /// A lazily initialized cache of the <see cref="GetHashCode"/> value.
         /// </summary>
         private int _hashCode;
 
@@ -559,6 +559,7 @@ namespace System.Net
                     if (PrivateAddress != value)
                     {
                         _toString = null;
+                        _hashCode = 0;
                         PrivateAddress = unchecked((uint)value);
                     }
                 }
@@ -612,23 +613,45 @@ namespace System.Net
 
         public override int GetHashCode()
         {
-            // For IPv6 addresses, we cannot simply return the integer
-            // representation as the hashcode. Instead, we calculate
-            // the hashcode from the string representation of the address.
+            if (_hashCode != 0)
+            {
+                return _hashCode;
+            }
+
+            // For IPv6 addresses, we calculate the hashcode by using Marvin
+            // on a stack-allocated array containing the Address bytes and ScopeId.
+            int hashCode;
             if (IsIPv6)
             {
-                if (_hashCode == 0)
+                const int addressAndScopeIdLength = IPAddressParserStatics.IPv6AddressBytes + sizeof(uint);
+                Span<byte> addressAndScopeIdSpan;
+                unsafe
                 {
-                    _hashCode = StringComparer.OrdinalIgnoreCase.GetHashCode(ToString());
+                    var addressSpan = new ReadOnlySpan<byte>(Unsafe.AsPointer(ref _numbers[0]), IPAddressParserStatics.IPv6AddressBytes);
+                    var scopeIdSpan = new ReadOnlySpan<byte>(Unsafe.AsPointer(ref _addressOrScopeId), sizeof(uint));
+
+                    byte* addressAndScopeId = stackalloc byte[addressAndScopeIdLength];
+                    addressAndScopeIdSpan = new Span<byte>(addressAndScopeId, addressAndScopeIdLength);
+                    addressSpan.CopyTo(addressAndScopeIdSpan);
+                    scopeIdSpan.CopyTo(addressAndScopeIdSpan.Slice(IPAddressParserStatics.IPv6AddressBytes));
                 }
 
-                return _hashCode;
+                hashCode = Marvin.ComputeHash32(
+                    ref addressAndScopeIdSpan[0],
+                    addressAndScopeIdLength,
+                    Marvin.DefaultSeed);
             }
             else
             {
-                // For IPv4 addresses, we can simply use the integer representation.
-                return unchecked((int)PrivateAddress);
+                // For IPv4 addresses, we use Marvin on the integer representation of the Address.
+                hashCode = Marvin.ComputeHash32(
+                    ref Unsafe.As<uint, byte>(ref _addressOrScopeId),
+                    sizeof(uint),
+                    Marvin.DefaultSeed);
             }
+
+            _hashCode = hashCode;
+            return _hashCode;
         }
 
         // For security, we need to be able to take an IPAddress and make a copy that's immutable and not derived.

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Sockets;
 
 using Xunit;
@@ -17,22 +18,32 @@ namespace System.Net.Primitives.Functional.Tests
         private const long MinScopeId = 0;
         private const long MaxScopeId = 0xFFFFFFFF;
 
-        private static byte[] ipV6AddressBytes1 = new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16 };
-        private static byte[] ipV6AddressBytes2 = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16 };
+        private const string IpV4AddressString1 = "192.168.0.9";
+        private const string IpV4AddressString2 = "169.192.1.10";
+        private const string IpV6AddressString = "fe80::200:f8ff:fe21:67cf";
 
-        private static IPAddress IPV4Address()
+        private static readonly byte[] IpV4AddressBytes = { 0x01, 0x02, 0x03, 0x04 };
+        private static readonly byte[] IpV6AddressBytes1 = { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16 };
+        private static readonly byte[] IpV6AddressBytes2 = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16 };
+
+        private static IPAddress IPV4Address1()
         {
-            return IPAddress.Parse("192.168.0.9");
+            return IPAddress.Parse(IpV4AddressString1);
+        }
+
+        private static IPAddress IPV4Address2()
+        {
+            return IPAddress.Parse(IpV4AddressString2);
         }
 
         private static IPAddress IPV6Address1()
         {
-            return new IPAddress(ipV6AddressBytes1);
+            return new IPAddress(IpV6AddressBytes1);
         }
 
         private static IPAddress IPV6Address2()
         {
-            return new IPAddress(ipV6AddressBytes2);
+            return new IPAddress(IpV6AddressBytes2);
         }
 
         [Theory]
@@ -69,8 +80,8 @@ namespace System.Net.Primitives.Functional.Tests
         public static object[][] AddressBytesAndFamilies =
         {
             new object[] { new byte[] { 0x8f, 0x18, 0x14, 0x24 }, AddressFamily.InterNetwork },
-            new object[] { ipV6AddressBytes1, AddressFamily.InterNetworkV6 },
-            new object[] { ipV6AddressBytes2, AddressFamily.InterNetworkV6 }
+            new object[] { IpV6AddressBytes1, AddressFamily.InterNetworkV6 },
+            new object[] { IpV6AddressBytes2, AddressFamily.InterNetworkV6 }
         };
 
         [Fact]
@@ -96,8 +107,8 @@ namespace System.Net.Primitives.Functional.Tests
             {
                 foreach (long scopeId in new long[] { MinScopeId, MaxScopeId, 500 })
                 {
-                    yield return new object[] { ipV6AddressBytes1, scopeId };
-                    yield return new object[] { ipV6AddressBytes2, scopeId };
+                    yield return new object[] { IpV6AddressBytes1, scopeId };
+                    yield return new object[] { IpV6AddressBytes2, scopeId };
                 }
             }
         }
@@ -109,8 +120,8 @@ namespace System.Net.Primitives.Functional.Tests
 
             AssertExtensions.Throws<ArgumentException>("address", () => new IPAddress(new byte[] { 0x01, 0x01, 0x02 }, 500));
 
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("scopeid", () => new IPAddress(ipV6AddressBytes1, MinScopeId - 1));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("scopeid", () => new IPAddress(ipV6AddressBytes1, MaxScopeId + 1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("scopeid", () => new IPAddress(IpV6AddressBytes1, MinScopeId - 1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("scopeid", () => new IPAddress(IpV6AddressBytes1, MaxScopeId + 1));
         }
 
         [Fact]
@@ -128,7 +139,7 @@ namespace System.Net.Primitives.Functional.Tests
         [Fact]
         public static void ScopeId_Set_Invalid()
         {
-            IPAddress ip = IPV4Address(); //IpV4
+            IPAddress ip = IPV4Address1(); //IpV4
             Assert.ThrowsAny<Exception>(() => ip.ScopeId = 500);
             Assert.ThrowsAny<Exception>(() => ip.ScopeId);
 
@@ -169,7 +180,7 @@ namespace System.Net.Primitives.Functional.Tests
         [Fact]
         public static void IsLoopback_Get_Success()
         {
-            IPAddress ip = IPV4Address(); //IpV4
+            IPAddress ip = IPV4Address1(); //IpV4
             Assert.False(IPAddress.IsLoopback(ip));
 
             ip = new IPAddress(IPAddress.Loopback.GetAddressBytes()); //IpV4 loopback
@@ -193,7 +204,7 @@ namespace System.Net.Primitives.Functional.Tests
         {
             Assert.True(IPAddress.Parse("ff02::1").IsIPv6Multicast);
             Assert.False(IPAddress.Parse("Fe08::1").IsIPv6Multicast);
-            Assert.False(IPV4Address().IsIPv6Multicast);
+            Assert.False(IPV4Address1().IsIPv6Multicast);
         }
 
         [Fact]
@@ -201,7 +212,7 @@ namespace System.Net.Primitives.Functional.Tests
         {
             Assert.True(IPAddress.Parse("fe80::1").IsIPv6LinkLocal);
             Assert.False(IPAddress.Parse("Fe08::1").IsIPv6LinkLocal);
-            Assert.False(IPV4Address().IsIPv6LinkLocal);
+            Assert.False(IPV4Address1().IsIPv6LinkLocal);
         }
 
         [Fact]
@@ -209,7 +220,7 @@ namespace System.Net.Primitives.Functional.Tests
         {
             Assert.True(IPAddress.Parse("FEC0::1").IsIPv6SiteLocal);
             Assert.False(IPAddress.Parse("Fe08::1").IsIPv6SiteLocal);
-            Assert.False(IPV4Address().IsIPv6SiteLocal);
+            Assert.False(IPV4Address1().IsIPv6SiteLocal);
         }
 
         [Fact]
@@ -217,19 +228,19 @@ namespace System.Net.Primitives.Functional.Tests
         {
             Assert.True(IPAddress.Parse("2001::1").IsIPv6Teredo);
             Assert.False(IPAddress.Parse("Fe08::1").IsIPv6Teredo);
-            Assert.False(IPV4Address().IsIPv6Teredo);
+            Assert.False(IPV4Address1().IsIPv6Teredo);
         }
 
         [Fact]
         public static void Equals_Compare_Success()
         {
-            IPAddress ip1 = IPAddress.Parse("192.168.0.9"); //IpV4
-            IPAddress ip2 = IPAddress.Parse("192.168.0.9"); //IpV4
-            IPAddress ip3 = IPAddress.Parse("169.192.1.10"); //IpV4
+            IPAddress ip1 = IPAddress.Parse(IpV4AddressString1); //IpV4
+            IPAddress ip2 = IPAddress.Parse(IpV4AddressString1); //IpV4
+            IPAddress ip3 = IPAddress.Parse(IpV4AddressString2); //IpV4
 
-            IPAddress ip4 = new IPAddress(ipV6AddressBytes1); //IpV6
-            IPAddress ip5 = new IPAddress(ipV6AddressBytes1); //IpV6
-            IPAddress ip6 = new IPAddress(ipV6AddressBytes2); //IpV6
+            IPAddress ip4 = IPV6Address1(); //IpV6
+            IPAddress ip5 = IPV6Address1(); //IpV6
+            IPAddress ip6 = IPV6Address2(); //IpV6
 
             Assert.True(ip1.Equals(ip2));
             Assert.True(ip2.Equals(ip1));
@@ -250,23 +261,56 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.False(ip4.GetHashCode().Equals(ip6.GetHashCode()));
         }
 
+        [Theory]
+        [MemberData(nameof(GetValidIPAddresses))]
+        [MemberData(nameof(GeneratedIPAddresses))]
+        public static void GetHashCode_ValidIPAddresses_Success(IPAddress ip)
+        {
+            Assert.Equal(ip.GetHashCode(), ip.GetHashCode());
+
+            var clonedIp = ip.AddressFamily == AddressFamily.InterNetworkV6 ?
+                new IPAddress(ip.GetAddressBytes(), ip.ScopeId) :
+                new IPAddress(ip.GetAddressBytes());
+
+            Assert.Equal(ip.GetHashCode(), clonedIp.GetHashCode());
+        }
+
+        private static IEnumerable<object[]> GetValidIPAddresses()
+        {
+            return IPAddressParsing.ValidIpv4Addresses
+                .Concat(IPAddressParsing.ValidIpv6Addresses)
+                .Select(array => new object[] {IPAddress.Parse((string)array[0])});
+        }
+
+        public static readonly object[][] GeneratedIPAddresses =
+        {
+            new object[] {IPAddress.Parse(IpV4AddressString1)},
+            new object[] {IPAddress.Parse(IpV6AddressString)},
+            new object[] {new IPAddress(MinAddress)},
+            new object[] {new IPAddress(MaxAddress)},
+            new object[] {new IPAddress(IpV4AddressBytes)},
+            new object[] {new IPAddress(IpV6AddressBytes1)},
+            new object[] {new IPAddress(IpV6AddressBytes1, MinScopeId)},
+        };
+
 #pragma warning disable 618
-         [Fact]
-         public static void Address_Property_Failure()
-         {
-             IPAddress ip1 = IPAddress.Parse("fe80::200:f8ff:fe21:67cf");
-             Assert.Throws<SocketException>(() => ip1.Address);
-         }
- 
-         [Fact]
-         public static void Address_Property_Success()
-         {
-             IPAddress ip1 = IPAddress.Parse("192.168.0.9");
-             //192.168.0.10
-             long newIp4Address = 192 << 24 | 168 << 16 | 0 << 8 | 10;
-             ip1.Address = newIp4Address;
-             Assert.Equal("10.0.168.192" , ip1.ToString());
-         }
+        [Fact]
+        public static void Address_Property_Failure()
+        {
+            IPAddress ip = IPAddress.Parse("fe80::200:f8ff:fe21:67cf");
+            Assert.Throws<SocketException>(() => ip.Address);
+        }
+
+        [Fact]
+        public static void Address_Property_Success()
+        {
+            IPAddress ip1 = IPV4Address1();
+            IPAddress ip2 = IPV4Address2();
+            ip1.Address = ip2.Address;
+
+            Assert.Equal(ip1, ip2);
+            Assert.Equal(ip1.GetHashCode(), ip2.GetHashCode());
+        }
 #pragma warning restore 618
     }
 }

--- a/src/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
+++ b/src/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
@@ -51,6 +51,9 @@
     <Compile Include="..\..\src\System\Net\EndPoint.cs">
       <Link>ProductionCode\System\Net\EndPoint.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Marvin.cs">
+      <Link>ProductionCode\Common\System\Marvin.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>ProductionCode\Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>

--- a/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
+++ b/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
@@ -95,6 +95,9 @@
     <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
       <Link>ProductionCode\Common\System\Net\UriScheme.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Marvin.cs">
+      <Link>Common\System\Marvin.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>


### PR DESCRIPTION
This addresses #24117.

I've used [`System.Numerics.Hashing.HashHelpers`](https://github.com/dotnet/corefx/blob/master/src/Common/src/System/Numerics/Hashing/HashHelpers.cs) instead of writing a custom implementation as it's deemed good enough for the various `ValueTuple`s.

I've used BenchmarkDotNet to compare the current and suggest implementations without caching the results on `GetHashCode` or `ToString` as that represents the more interesting scenario: Invoking `GetHashCode` on a constant stream of new `IPAddress` instances. The differences become less relevant the more instances are being reused.

The code for the comparison is [here](https://gist.github.com/i3arnon/e9f85402790fcbd1d14450540f7ec496) and the results are:

``` ini

BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=Intel Core i7-7600U CPU 2.80GHz (Kaby Lake), ProcessorCount=4
Frequency=2835941 Hz, Resolution=352.6166 ns, Timer=TSC
.NET Core SDK=2.0.0
  [Host]     : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT


```
 |                 Method |       Mean |     Error |    StdDev |  Gen 0 | Allocated |
 |----------------------- |-----------:|----------:|----------:|-------:|----------:|
 |    GetHashCodeToString | 182.927 ns | 3.5535 ns | 3.4900 ns | 0.0341 |      72 B |
 | GetHashCodeHashHelpers |   6.685 ns | 0.1681 ns | 0.1936 ns |      - |       0 B |
