### PR TITLE
Reduce costs of local single process information retrieval - fixes #23887

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -250,14 +250,16 @@ namespace System.Diagnostics
 
     internal static partial class NtProcessInfoHelper
     {
+        private const int AllProcessIds = -1;
+
         // Cache a single buffer for use in GetProcessInfos().
         private static long[] CachedBuffer;
 
-        public static ProcessInfo[] GetProcessInfos()
+        internal static ProcessInfo[] GetProcessInfos(int processId = AllProcessIds)
         {
             int requiredSize = 0;
             int status;
-
+            
             ProcessInfo[] processInfos;
             GCHandle bufferHandle = new GCHandle();
 
@@ -304,7 +306,7 @@ namespace System.Diagnostics
                 }
 
                 // Parse the data block to get process information
-                processInfos = GetProcessInfos(bufferHandle.AddrOfPinnedObject());
+                processInfos = GetProcessInfos(bufferHandle.AddrOfPinnedObject(), processId);
             }
             finally
             {

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -50,14 +50,28 @@ namespace System.Diagnostics
         /// <returns>The ProcessInfo for the process if it could be found; otherwise, null.</returns>
         public static ProcessInfo GetProcessInfo(int processId, string machineName)
         {
-            ProcessInfo[] processInfos = ProcessManager.GetProcessInfos(machineName);
-            foreach (ProcessInfo processInfo in processInfos)
+            if (IsRemoteMachine(machineName))
             {
-                if (processInfo.ProcessId == processId)
+                // remote case: we take the hit of looping through all results
+                ProcessInfo[] processInfos = NtProcessManager.GetProcessInfos(machineName, isRemoteMachine: true);
+                foreach (ProcessInfo processInfo in processInfos)
                 {
-                    return processInfo;
+                    if (processInfo.ProcessId == processId)
+                    {
+                        return processInfo;
+                    }
                 }
             }
+            else
+            {
+                // local case: we attempt to get the matching (by pid) process only
+                ProcessInfo[] processInfos = NtProcessInfoHelper.GetProcessInfos(processId);
+                if (processInfos.Length == 1)
+                {
+                    return processInfos[0];
+                }
+            }
+
             return null;
         }
 
@@ -676,7 +690,7 @@ namespace System.Diagnostics
         private const int DefaultCachedBufferSize = 128 * 1024;
 #endif
 
-        private static unsafe ProcessInfo[] GetProcessInfos(IntPtr dataPtr)
+        private static unsafe ProcessInfo[] GetProcessInfos(IntPtr dataPtr, int processId = AllProcessIds)
         {
             // Use a dictionary to avoid duplicate entries if any
             // 60 is a reasonable number for processes on a normal machine.
@@ -689,67 +703,70 @@ namespace System.Diagnostics
                 IntPtr currentPtr = (IntPtr)((long)dataPtr + totalOffset);
                 ref SystemProcessInformation pi = ref *(SystemProcessInformation *)(currentPtr);
 
-                // get information for a process
-                ProcessInfo processInfo = new ProcessInfo();
                 // Process ID shouldn't overflow. OS API GetCurrentProcessID returns DWORD.
-                processInfo.ProcessId = pi.UniqueProcessId.ToInt32();
-                processInfo.SessionId = (int)pi.SessionId;
-                processInfo.PoolPagedBytes = (long)pi.QuotaPagedPoolUsage; ;
-                processInfo.PoolNonPagedBytes = (long)pi.QuotaNonPagedPoolUsage;
-                processInfo.VirtualBytes = (long)pi.VirtualSize;
-                processInfo.VirtualBytesPeak = (long)pi.PeakVirtualSize;
-                processInfo.WorkingSetPeak = (long)pi.PeakWorkingSetSize;
-                processInfo.WorkingSet = (long)pi.WorkingSetSize;
-                processInfo.PageFileBytesPeak = (long)pi.PeakPagefileUsage;
-                processInfo.PageFileBytes = (long)pi.PagefileUsage;
-                processInfo.PrivateBytes = (long)pi.PrivatePageCount;
-                processInfo.BasePriority = pi.BasePriority;
-                processInfo.HandleCount = (int)pi.HandleCount;
-
-
-                if (pi.ImageName.Buffer == IntPtr.Zero)
+                var processInfoProcessId = pi.UniqueProcessId.ToInt32();
+                if (processId == AllProcessIds || processId == processInfoProcessId)
                 {
-                    if (processInfo.ProcessId == NtProcessManager.SystemProcessID)
+                    // get information for a process
+                    ProcessInfo processInfo = new ProcessInfo();
+                    processInfo.ProcessId = processInfoProcessId;
+                    processInfo.SessionId = (int)pi.SessionId;
+                    processInfo.PoolPagedBytes = (long)pi.QuotaPagedPoolUsage;
+                    processInfo.PoolNonPagedBytes = (long)pi.QuotaNonPagedPoolUsage;
+                    processInfo.VirtualBytes = (long)pi.VirtualSize;
+                    processInfo.VirtualBytesPeak = (long)pi.PeakVirtualSize;
+                    processInfo.WorkingSetPeak = (long)pi.PeakWorkingSetSize;
+                    processInfo.WorkingSet = (long)pi.WorkingSetSize;
+                    processInfo.PageFileBytesPeak = (long)pi.PeakPagefileUsage;
+                    processInfo.PageFileBytes = (long)pi.PagefileUsage;
+                    processInfo.PrivateBytes = (long)pi.PrivatePageCount;
+                    processInfo.BasePriority = pi.BasePriority;
+                    processInfo.HandleCount = (int)pi.HandleCount;
+
+                    if (pi.ImageName.Buffer == IntPtr.Zero)
                     {
-                        processInfo.ProcessName = "System";
-                    }
-                    else if (processInfo.ProcessId == NtProcessManager.IdleProcessID)
-                    {
-                        processInfo.ProcessName = "Idle";
+                        if (processInfo.ProcessId == NtProcessManager.SystemProcessID)
+                        {
+                            processInfo.ProcessName = "System";
+                        }
+                        else if (processInfo.ProcessId == NtProcessManager.IdleProcessID)
+                        {
+                            processInfo.ProcessName = "Idle";
+                        }
+                        else
+                        {
+                            // for normal process without name, using the process ID. 
+                            processInfo.ProcessName = processInfo.ProcessId.ToString(CultureInfo.InvariantCulture);
+                        }
                     }
                     else
                     {
-                        // for normal process without name, using the process ID. 
-                        processInfo.ProcessName = processInfo.ProcessId.ToString(CultureInfo.InvariantCulture);
+                        string processName = GetProcessShortName(Marshal.PtrToStringUni(pi.ImageName.Buffer, pi.ImageName.Length / sizeof(char)));
+                        processInfo.ProcessName = processName;
                     }
-                }
-                else
-                {
-                    string processName = GetProcessShortName(Marshal.PtrToStringUni(pi.ImageName.Buffer, pi.ImageName.Length / sizeof(char)));
-                    processInfo.ProcessName = processName;
-                }
 
-                // get the threads for current process
-                processInfos[processInfo.ProcessId] = processInfo;
+                    // get the threads for current process
+                    processInfos[processInfo.ProcessId] = processInfo;
 
-                currentPtr = (IntPtr)((long)currentPtr + Marshal.SizeOf(pi));
-                int i = 0;
-                while (i < pi.NumberOfThreads)
-                {
-                    ref SystemThreadInformation ti = ref *(SystemThreadInformation *)(currentPtr);
-                    ThreadInfo threadInfo = new ThreadInfo();
+                    currentPtr = (IntPtr)((long)currentPtr + Marshal.SizeOf(pi));
+                    int i = 0;
+                    while (i < pi.NumberOfThreads)
+                    {
+                        ref SystemThreadInformation ti = ref *(SystemThreadInformation *)(currentPtr);
+                        ThreadInfo threadInfo = new ThreadInfo();
 
-                    threadInfo._processId = (int)ti.ClientId.UniqueProcess;
-                    threadInfo._threadId = (ulong)ti.ClientId.UniqueThread;
-                    threadInfo._basePriority = ti.BasePriority;
-                    threadInfo._currentPriority = ti.Priority;
-                    threadInfo._startAddress = ti.StartAddress;
-                    threadInfo._threadState = (ThreadState)ti.ThreadState;
-                    threadInfo._threadWaitReason = NtProcessManager.GetThreadWaitReason((int)ti.WaitReason);
+                        threadInfo._processId = (int)ti.ClientId.UniqueProcess;
+                        threadInfo._threadId = (ulong)ti.ClientId.UniqueThread;
+                        threadInfo._basePriority = ti.BasePriority;
+                        threadInfo._currentPriority = ti.Priority;
+                        threadInfo._startAddress = ti.StartAddress;
+                        threadInfo._threadState = (ThreadState)ti.ThreadState;
+                        threadInfo._threadWaitReason = NtProcessManager.GetThreadWaitReason((int)ti.WaitReason);
 
-                    processInfo._threadInfoList.Add(threadInfo);
-                    currentPtr = (IntPtr)((long)currentPtr + Marshal.SizeOf(ti));
-                    i++;
+                        processInfo._threadInfoList.Add(threadInfo);
+                        currentPtr = (IntPtr)((long)currentPtr + Marshal.SizeOf(ti));
+                        i++;
+                    }
                 }
 
                 if (pi.NextEntryOffset == 0)


### PR DESCRIPTION
Here we go then. Nothing spectactular, really, but should get the job done.

I was wondering how to go about the PID filter parameter and I ended up using the dreaded "default value: magic number" approach to disable the PID filter and return all information about all processes like so:

`private const int AllProcessIds = -1;`
`internal static ProcessInfo[] GetProcessInfos(int processId = AllProcessIds)`

Other alternatives I considered were a `Predicate<int>` based one and a `params int[]` based one - none of which seemed particularly more readable or fast. Also, coming up with an entirely new piece of code for the single position retrieval didn't seem like a great idea since the `Interop.NtDll.NtQuerySystemInformation` seems to return one big blob of information about all processes anyway so I would have had to duplicate lots of code.