### PR TITLE
New tests covering GC.TryStartNoGCRegion

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.cs
+++ b/src/System.Runtime/tests/System/GCTests.cs
@@ -727,8 +727,9 @@ namespace System.Tests
 
         [Theory]
         [OuterLoop]
-        [InlineData(0)]
-        [InlineData(-1)]
+        [InlineData(0)]                   // invalid because lohSize ==
+        [InlineData(-1)]                  // invalid because lohSize < 0
+        [InlineData(1152921504606846976)] // invalid because lohSize > totalSize
         public static void TryStartNoGCRegion_LOHSizeInvalid(long size)
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
@@ -738,19 +739,6 @@ namespace System.Tests
                 Assert.Throws<ArgumentOutOfRangeException>("lohSize", () => GC.TryStartNoGCRegion(1024, long.Parse(sizeString)));
                 return SuccessExitCode;
             }, size.ToString(), options).Dispose();
-        }
-
-        [Fact]
-        [OuterLoop]
-        public static void TryStartNoGCRegion_TotalSizeLessThanLOHSize()
-        {
-            RemoteInvokeOptions options = new RemoteInvokeOptions();
-            options.TimeOut = TimeoutMilliseconds;
-            RemoteInvoke(() =>
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("lohSize", () => GC.TryStartNoGCRegion(1024, 1152921504606846976));
-                return SuccessExitCode;
-            }, options).Dispose();
         }
 
         public static void TestWait(bool approach, int timeout)

--- a/src/System.Runtime/tests/System/GCTests.cs
+++ b/src/System.Runtime/tests/System/GCTests.cs
@@ -710,6 +710,49 @@ namespace System.Tests
             }, options).Dispose();
         }
 
+        [Theory]
+        [OuterLoop]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public static void TryStartNoGCRegion_TotalSizeOutOfRange(long size)
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.TimeOut = TimeoutMilliseconds;
+            RemoteInvoke(sizeString =>
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("totalSize", () => GC.TryStartNoGCRegion(long.Parse(sizeString)));
+                return SuccessExitCode;
+            }, size.ToString(), options).Dispose();
+        }
+
+        [Theory]
+        [OuterLoop]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public static void TryStartNoGCRegion_LOHSizeInvalid(long size)
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.TimeOut = TimeoutMilliseconds;
+            RemoteInvoke(sizeString =>
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("lohSize", () => GC.TryStartNoGCRegion(1024, long.Parse(sizeString)));
+                return SuccessExitCode;
+            }, size.ToString(), options).Dispose();
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void TryStartNoGCRegion_TotalSizeLessThanLOHSize()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.TimeOut = TimeoutMilliseconds;
+            RemoteInvoke(() =>
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("lohSize", () => GC.TryStartNoGCRegion(1024, 1152921504606846976));
+                return SuccessExitCode;
+            }, options).Dispose();
+        }
+
         public static void TestWait(bool approach, int timeout)
         {
             GCNotificationStatus result = GCNotificationStatus.Failed;


### PR DESCRIPTION
Regression tests for https://github.com/dotnet/coreclr/pull/14088 and https://github.com/dotnet/coreclr/issues/13736. These tests will fail without the coreclr PR and may fail on other runtimes.

cc @sergiy-k @Maoni0 @adityamandaleeka @shimingsg 