### PR TITLE
Use stackalloc directly into Span

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -102,6 +102,11 @@ Once you've built the source code for netfx from the root (`build.cmd -framework
 For advanced debugging using WinDBG see [Debugging CoreFX on Windows](https://github.com/dotnet/corefx/blob/master/Documentation/debugging/windows-instructions.md)
 
 ### Notes
+* At any given time, the corefx repo might be configured to use a more recent compiler than
+the one used by the most recent Visual Studio IDE release.  This means the corefx codebase might
+be using language features that are not understood by the IDE, which might result in errors that
+show up as red squiggles while writing code.  Such errors should, however, not affect the actual compilation.
+
 * Running tests from using the VS test explorer does not currently work after we switched to running on CoreCLR. [We will be working on enabling full VS test integration](https://github.com/dotnet/corefx/issues/1318) but we don't have an ETA yet. In the meantime, use the steps above to launch/debug the tests using the console runner.
 
 * VS 2015 is required to debug tests running on CoreCLR as the CoreCLR

--- a/dir.props
+++ b/dir.props
@@ -210,13 +210,9 @@
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
   </PropertyGroup>
   
-  <!-- Set up language configuration -->
+  <!-- Language configuration -->
   <PropertyGroup>
     <LangVersion>latest</LangVersion> <!-- default to allowing all language features -->
-  </PropertyGroup>
-  
-  <!-- Set up handling of build warnings -->
-  <PropertyGroup>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/dir.props
+++ b/dir.props
@@ -209,7 +209,12 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
   </PropertyGroup>
-
+  
+  <!-- Set up language configuration -->
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion> <!-- default to allowing all language features -->
+  </PropertyGroup>
+  
   <!-- Set up handling of build warnings -->
   <PropertyGroup>
     <WarningLevel>4</WarningLevel>

--- a/src/Common/src/System/Net/Internals/IPAddressExtensions.cs
+++ b/src/Common/src/System/Net/Internals/IPAddressExtensions.cs
@@ -18,13 +18,7 @@ namespace System.Net.Sockets
 #pragma warning restore CS0618
 
                 case AddressFamily.InterNetworkV6:
-                    Span<byte> addressBytes;
-                    unsafe
-                    {
-                        // TODO https://github.com/dotnet/roslyn/issues/17287: Clean up once we can stackalloc into a span
-                        byte* mem = stackalloc byte[IPAddressParserStatics.IPv6AddressBytes];
-                        addressBytes = new Span<byte>(mem, IPAddressParserStatics.IPv6AddressBytes);
-                    }
+                    Span<byte> addressBytes = stackalloc byte[IPAddressParserStatics.IPv6AddressBytes];
                     original.TryWriteBytes(addressBytes, out int bytesWritten);
                     Debug.Assert(bytesWritten == IPAddressParserStatics.IPv6AddressBytes);
                     return new IPAddress(addressBytes, (uint)original.ScopeId);

--- a/src/Common/src/System/Net/SocketAddress.cs
+++ b/src/Common/src/System/Net/SocketAddress.cs
@@ -103,13 +103,7 @@ namespace System.Net.Internals
 
             if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
             {
-                Span<byte> addressBytes;
-                unsafe
-                {
-                    // TODO https://github.com/dotnet/roslyn/issues/17287: Clean up once we can stackalloc into a span
-                    byte* mem = stackalloc byte[IPAddressParserStatics.IPv6AddressBytes];
-                    addressBytes = new Span<byte>(mem, IPAddressParserStatics.IPv6AddressBytes);
-                }
+                Span<byte> addressBytes = stackalloc byte[IPAddressParserStatics.IPv6AddressBytes];
                 ipAddress.TryWriteBytes(addressBytes, out int bytesWritten);
                 Debug.Assert(bytesWritten == IPAddressParserStatics.IPv6AddressBytes);
 
@@ -138,13 +132,7 @@ namespace System.Net.Internals
             {
                 Debug.Assert(Size >= IPv6AddressSize);
 
-                Span<byte> address;
-                unsafe
-                {
-                    // TODO https://github.com/dotnet/roslyn/issues/17287: Clean up once we can stackalloc into a span
-                    byte* mem = stackalloc byte[IPAddressParserStatics.IPv6AddressBytes];
-                    address = new Span<byte>(mem, IPAddressParserStatics.IPv6AddressBytes);
-                }
+                Span<byte> address = stackalloc byte[IPAddressParserStatics.IPv6AddressBytes];
                 uint scope;
                 SocketAddressPal.GetIPv6Address(Buffer, address, out scope);
 

--- a/src/System.Memory/ref/System.Memory.csproj
+++ b/src/System.Memory/ref/System.Memory.csproj
@@ -6,7 +6,6 @@
     <CLSCompliant>false</CLSCompliant>
     <ProjectGuid>{E883935B-D8FD-4FC9-A189-9D9E7F7EF550}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' Or '$(TargetGroup)' == 'uap'">true</IsPartialFacadeAssembly>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -9,7 +9,6 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">true</IsPartialFacadeAssembly>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.1'">$(DefineConstants);netstandard11</DefineConstants>
-     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />

--- a/src/System.Net.Http/src/System/Net/Http/Managed/AuthenticationHelper.Digest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/AuthenticationHelper.Digest.cs
@@ -218,12 +218,7 @@ namespace System.Net.Http
         private static string GetRandomAlphaNumericString()
         {
             const int Length = 16;
-            Span<byte> randomNumbers;
-            unsafe
-            {
-                byte* ptr = stackalloc byte[Length * 2];
-                randomNumbers = new Span<byte>(ptr, Length * 2);
-            }
+            Span<byte> randomNumbers = stackalloc byte[Length * 2];
             s_rng.GetBytes(randomNumbers);
 
             StringBuilder sb = StringBuilderCache.Acquire(Length);

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{13CE5E71-D373-4EA6-B3CB-166FF089A42A}</ProjectGuid>
     <SkipIncludeNewtonsoftJson>true</SkipIncludeNewtonsoftJson>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />

--- a/src/System.Runtime/ref/System.Runtime.csproj
+++ b/src/System.Runtime/ref/System.Runtime.csproj
@@ -5,7 +5,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsCoreAssembly>true</IsCoreAssembly>
     <ProjectGuid>{ADBCF120-3454-4A3C-9D1D-AC4293E795D6}</ProjectGuid>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -7,7 +7,6 @@
     <NoWarn>1718</NoWarn>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uapaot'">$(DefineConstants);uapaot</DefineConstants>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />


### PR DESCRIPTION
We have a few places in corefx where we were stackalloc'ing into a temporary pointer and then creating a Span from that.  Now that we're using a C# compiler which supports stackalloc'ing directly into span, use that feature instead.

@weshaggard, I changed dir.props to allow this in all projects by default.  Please let me know if there's a good reason not to do that.

cc: @VSadov, @ahsonkhan, @geoffkizer