### PR TITLE
NOMERGE: failing some tests intentionally to see call stacks

### DIFF
--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectorySecurityTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectorySecurityTests.cs
@@ -13,6 +13,7 @@ namespace System.DirectoryServices.Tests
         public void Ctor_Default()
         {
             var security = new ActiveDirectorySecurity();
+            Assert.Equal(true, false);
             Assert.Equal(typeof(ActiveDirectoryRights), security.AccessRightType);
             Assert.Equal(typeof(ActiveDirectoryAccessRule), security.AccessRuleType);
             Assert.Equal(typeof(ActiveDirectoryAuditRule), security.AuditRuleType);

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryEntryTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryEntryTests.cs
@@ -75,6 +75,7 @@ namespace System.DirectoryServices.Tests
         [InlineData(1)]
         public void Ctor_InvalidAdsObject_ThrowsArgumentException(object adsObject)
         {
+            var x = new DirectoryEntry(adsObject);
             AssertExtensions.Throws<ArgumentException>(null, () => new DirectoryEntry(adsObject));
         }
 

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryVirtualListViewTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryVirtualListViewTests.cs
@@ -31,6 +31,7 @@ namespace System.DirectoryServices.Tests
             Assert.Equal(afterCount, listView.AfterCount);
             Assert.Equal(0, listView.ApproximateTotal);
             Assert.Equal(0, listView.BeforeCount);
+            Assert.NotNull(listView.DirectoryVirtualListViewContext);
             Assert.Null(listView.DirectoryVirtualListViewContext);
             Assert.Equal(0, listView.Offset);
             Assert.Equal(string.Empty, listView.Target);

--- a/src/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/System.Runtime/tests/System/ArrayTests.cs
@@ -34,6 +34,7 @@ namespace System.Tests
         public static void IList_GetSetItem_Invalid()
         {
             IList iList = new int[] { 7, 8, 9, 10, 11, 12, 13 };
+            var x = iList[-1];
             Assert.Throws<IndexOutOfRangeException>(() => iList[-1]); // Index < 0
             Assert.Throws<IndexOutOfRangeException>(() => iList[iList.Count]); // Index >= list.Count
 


### PR DESCRIPTION
cc: @MattGal 

Do not merge this PR as it is only to validate right call stacks on failing tests. This is an investigation related to issue #22979