### PR TITLE
IPAddress: Change to faster algo to bigendian->littleendian flip of numbers

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -397,8 +397,11 @@ namespace System.Net
 #if BIGENDIAN
             return host;
 #else
-            return (((long)HostToNetworkOrder(unchecked((int)host)) & 0xFFFFFFFF) << 32)
-                    | ((long)HostToNetworkOrder(unchecked((int)(host >> 32))) & 0xFFFFFFFF);
+            ulong value = (ulong)host;
+            value = (value << 32) | (value >> 32);
+            value = (value & 0x0000FFFF0000FFFF) << 16 | (value & 0xFFFF0000FFFF0000) >> 16;
+            value = (value & 0x00FF00FF00FF00FF) << 8 | (value & 0xFF00FF00FF00FF00) >> 8;
+            return (long)value;
 #endif
         }
 
@@ -407,8 +410,10 @@ namespace System.Net
 #if BIGENDIAN
             return host;
 #else
-            return (((int)HostToNetworkOrder(unchecked((short)host)) & 0xFFFF) << 16)
-                    | ((int)HostToNetworkOrder(unchecked((short)(host >> 16))) & 0xFFFF);
+            uint value = (uint)host;
+            value = (value << 16) | (value >> 16);
+            value = (value & 0x00FF00FF) << 8 | (value & 0xFF00FF00) >> 8;
+            return (int)value;
 #endif
         }
 

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -142,13 +142,13 @@ namespace System.Net.Primitives.Functional.Tests
         {
             long l1 = (long)0x1350;
             long l2 = (long)0x5013000000000000;
-            long l3 = (long)0x0123456789ABCDEF;
-            long l4 = (long)0xFEDCBA9876543210;
+            long l3 = (long)0x1122334455667788;
+            long l4 = unchecked((long)0x8877665544332211);
 
             int i1 = (int)0x1350;
             int i2 = (int)0x50130000;
-            int i3 = (int)0x01234567;
-            int i4 = (int)0x76543210;
+            int i3 = (int)0x11223344;
+            int i4 = (int)0x44332211;
 
             short s1 = (short)0x1350;
             short s2 = (short)0x5013;
@@ -156,7 +156,7 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Equal(l2, IPAddress.HostToNetworkOrder(l1));
             Assert.Equal(l4, IPAddress.HostToNetworkOrder(l3));
             Assert.Equal(i2, IPAddress.HostToNetworkOrder(i1));
-            Assert.Equal(l4, IPAddress.HostToNetworkOrder(l3));
+            Assert.Equal(i4, IPAddress.HostToNetworkOrder(i3));
             Assert.Equal(s2, IPAddress.HostToNetworkOrder(s1));
 
             Assert.Equal(l1, IPAddress.NetworkToHostOrder(l2));

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -142,14 +142,14 @@ namespace System.Net.Primitives.Functional.Tests
         {
             long l1 = (long)0x1350;
             long l2 = (long)0x5013000000000000;
-            long l3 = (long)0x1122334455667788;
-            long l4 = unchecked((long)0x8877665544332211);
+            long l3 = (long)0x0123456789ABCDEF;
+            long l4 = unchecked((long)0xEFCDAB8967452301);
 
             int i1 = (int)0x1350;
             int i2 = (int)0x50130000;
-            int i3 = (int)0x11223344;
-            int i4 = (int)0x44332211;
-
+            int i3 = (int)0x01234567;
+            int i4 = (int)0x67452301;
+            
             short s1 = (short)0x1350;
             short s2 = (short)0x5013;
             

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -142,19 +142,27 @@ namespace System.Net.Primitives.Functional.Tests
         {
             long l1 = (long)0x1350;
             long l2 = (long)0x5013000000000000;
+            long l3 = (long)0x0123456789ABCDEF;
+            long l4 = (long)0xFEDCBA9876543210;
 
             int i1 = (int)0x1350;
             int i2 = (int)0x50130000;
+            int i3 = (int)0x01234567;
+            int i4 = (int)0x76543210;
 
             short s1 = (short)0x1350;
             short s2 = (short)0x5013;
-
+            
             Assert.Equal(l2, IPAddress.HostToNetworkOrder(l1));
+            Assert.Equal(l4, IPAddress.HostToNetworkOrder(l3));
             Assert.Equal(i2, IPAddress.HostToNetworkOrder(i1));
+            Assert.Equal(l4, IPAddress.HostToNetworkOrder(l3));
             Assert.Equal(s2, IPAddress.HostToNetworkOrder(s1));
 
             Assert.Equal(l1, IPAddress.NetworkToHostOrder(l2));
+            Assert.Equal(l3, IPAddress.NetworkToHostOrder(l4));
             Assert.Equal(i1, IPAddress.NetworkToHostOrder(i2));
+            Assert.Equal(i3, IPAddress.NetworkToHostOrder(i4));
             Assert.Equal(s1, IPAddress.NetworkToHostOrder(s2));
         }
 


### PR DESCRIPTION
As per my comment in CoreFXLabs, its also identified there that the IPAddress methods are a lot slower

(The version I have submitted is the (2) versions of the algo below)

[Ref Issue from CoreFxLab](https://github.com/dotnet/corefxlab/pull/1779#issuecomment-331647487)

|Test|AVERAGE | STDEV.S |     MIN |     MAX|
|---|---|---|----|----|
|MeasureReverse|  200.318 |   4.356 |  195.937 |  217.856|
|MeasureReverse2|165.578 |   1.875 |  162.408 |  172.572|
MeasureReverseUsingNtoH| 562.256 |   5.355 |  554.489 |  579.212|
|MeasureReverseLong| 331.710 |   1.982 |  327.835 |  336.525|
|MeasureReverseLong2|264.985 |   1.956 |  260.660 |  270.584|
|MeasureReverseUsingNtoHLong|1241.993 |  59.340 | 1189.954 | 1361.043|
