### PR TITLE
Use Docker host's tools version for cleanup

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -283,9 +283,9 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "$(PB_GitDirectory)/Tools/msbuild.sh",
+        "filename": "$(DockerHost_ToolsDirectory)/msbuild.sh",
         "arguments": "cleanupagent.proj /p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
-        "workingFolder": "$(PB_GitDirectory)/Tools/scripts/vstsagent/",
+        "workingFolder": "$(DockerHost_ToolsDirectory)/scripts/vstsagent/",
         "failOnStandardError": "false"
       }
     }


### PR DESCRIPTION
When doing Cleanup VSTS agent, we should use the tools in Docker host. For CentOS-6 using non-sand boxed tools failed with "Aborted (core dumped)". https://github.com/dotnet/core-eng/issues/1807