### PR TITLE
[Do Not Merge] Force a crash in the System.AppContext tests.

### DIFF
--- a/src/System.AppContext/tests/AppContext.Switch.cs
+++ b/src/System.AppContext/tests/AppContext.Switch.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Tests

--- a/src/System.AppContext/tests/AppContext.Switch.cs
+++ b/src/System.AppContext/tests/AppContext.Switch.cs
@@ -10,6 +10,12 @@ namespace System.Tests
     public partial class AppContextTests
     {
         [Fact]
+        public void ForcedCrash()
+        {
+            Marshal.StructureToPtr(10, (IntPtr)10, true);
+        }
+
+        [Fact]
         public void SwitchNotFound()
         {
             string switchName = GetSwitchName();


### PR DESCRIPTION
This causes a deliberate access violation in the System.AppContext tests, so we can test out some fixes being made to our crash dump debugging experience.

@DrewScoggins 