### PR TITLE
Disable RecursiveDelete_DeepNesting (Issue #24242).

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -254,6 +254,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ActiveIssue(24242)]
         [PlatformSpecific(TestPlatforms.Windows)]
         [OuterLoop("This test is very slow.")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop does not have the fix for #22596")]


### PR DESCRIPTION
This disables a test which has failed on recent code coverage test runs. 

https://github.com/dotnet/corefx/issues/24240, #24242
@stephentoub @JeremyKuhne 