### PR TITLE
Turn off symbol publishing if SignType is not "real"

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish-Symbols.json
+++ b/buildpipeline/DotNet-Trusted-Publish-Symbols.json
@@ -54,9 +54,9 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-ConfigGroup $(PB_ConfigurationGroup) -SymPkgGlob $(PB_AzureContainerSymbolPackageGlob) -Branch $(SourceBranch)",
+        "arguments": "-ConfigGroup $(PB_ConfigurationGroup) -SymPkgGlob $(PB_AzureContainerSymbolPackageGlob) -Branch $(SourceBranch) -SignType $(PB_SignType)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($ConfigGroup, $SymPkgGlob, $Branch)\nif ($ConfigGroup -ne \"Release\") { exit }\n$archive = $Branch.StartsWith(\"release/\")\n\n$target = \"GetAllSymbolFilesToPublish\"\nif ($archive) { $target = \"SubmitSymbolsRequest\" }\n\n.\\build-managed.cmd -- `\n/t:$target `\n/p:SymbolPackagesToPublishGlob=$SymPkgGlob `\n/p:ArchiveSymbols=$archive `\n/v:D",
+        "inlineScript": "param($ConfigGroup, $SymPkgGlob, $Branch)\nif ($ConfigGroup -ne \"Release\" -or $SignType.ToLower() -ne \"real\" ) { Write-host \"Chose not to publish\"; exit }\n$archive = $Branch.StartsWith(\"release/\")\n\n$target = \"GetAllSymbolFilesToPublish\"\nif ($archive) { $target = \"SubmitSymbolsRequest\" }\n\n.\\build-managed.cmd -- `\n/t:$target `\n/p:SymbolPackagesToPublishGlob=$SymPkgGlob `\n/p:ArchiveSymbols=$archive `\n/v:D",
         "failOnStandardError": "true"
       }
     },


### PR DESCRIPTION
Feedback after previous PR from @dagood  was that before this can be merged into release branches it also needs this check on symbol publish.