### PR TITLE
Re-enable InstalledFontCollection tests on Unix.

### DIFF
--- a/src/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
+++ b/src/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
@@ -7,7 +7,6 @@ namespace System.Drawing.Text.Tests
 {
     public class InstalledFontCollectionTests
     {
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Ctor_Default()
         {
@@ -17,7 +16,6 @@ namespace System.Drawing.Text.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Families_GetWhenDisposed_ReturnsNonEmpty()
         {

--- a/src/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
+++ b/src/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
@@ -7,7 +7,7 @@ namespace System.Drawing.Text.Tests
 {
     public class InstalledFontCollectionTests
     {
-        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
         public void Ctor_Default()
         {
             using (var fontCollection = new InstalledFontCollection())
@@ -16,7 +16,7 @@ namespace System.Drawing.Text.Tests
             }
         }
 
-        [ConditionalFact(Helpers.GdiplusIsAvailable)]
+        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
         public void Families_GetWhenDisposed_ReturnsNonEmpty()
         {
             var fontCollection = new InstalledFontCollection();


### PR DESCRIPTION
These pass on my Ubuntu 16.04 box -- I'd like to see how all our other distros behave. It's possible these were disabled because our CI machines didn't have fonts installed (they should now).

@qmfrederik I looked at the mono test cases for System.Drawing.Text and found that our coverage was equal or better, but these tests are disabled. This should cover that namespace from your large PR.