### PR TITLE
Enable ImageAttributes tests which pass on Unix System.Drawing.

### DIFF
--- a/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
@@ -31,8 +31,6 @@ using Xunit;
 
 namespace System.Drawing.Imaging.Tests
 {
-    // Disposing any ImageAttributes seems to cause a crash on Unix.
-    [ActiveIssue(20884, TestPlatforms.AnyUnix)]
     public class ImageAttributesTests
     {
         private readonly Rectangle _rectangle = new Rectangle(0, 0, 64, 64);
@@ -69,6 +67,7 @@ namespace System.Drawing.Imaging.Tests
             imageAttr.Dispose();
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)] // Causes a crash on libgdiplus.
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Clone_Success()
         {
@@ -521,6 +520,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetThreshold_Threshold_Success()
         {
@@ -535,6 +535,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_TestData))]
         public void SetThreshold_ThresholdType_Success(ColorAdjustType type)
@@ -550,7 +551,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ConditionalTheory(Helpers.GdiplusIsAvailable)]
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [MemberData(nameof(ColorAdjustTypeI_TestData))]
         public void SetThreshold_ThresholdTypeI_Success(ColorAdjustType type)
         {
@@ -565,6 +566,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetThreshold_Disposed_ThrowsArgumentException()
         {
@@ -574,6 +576,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetThreshold(0.5f));
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void SetThreshold_InvalidType_ThrowsArgumentException(ColorAdjustType type)
@@ -598,6 +601,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_AllTypesAllowed_TestData))]
         public void ClearThreshold_ThresholdTypeI_Success(ColorAdjustType type)
@@ -614,6 +618,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void ClearThreshold_Disposed_ThrowsArgumentException()
         {
@@ -623,6 +628,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearThreshold(ColorAdjustType.Default));
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void ClearThreshold_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)
@@ -633,6 +639,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetGamma_Gamma_Success()
         {
@@ -647,6 +654,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_TestData))]
         public void SetGamma_GammaType_Success(ColorAdjustType type)
@@ -662,6 +670,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustTypeI_TestData))]
         public void SetGamma_GammaTypeI_Success(ColorAdjustType type)
@@ -733,6 +742,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetNoOp_Success()
         {
@@ -749,6 +759,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_AllTypesAllowed_TestData))]
         public void SetNoOp_Type_Success(ColorAdjustType type)
@@ -805,6 +816,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_TestData))]
         public void ClearNoOp_Type_Success(ColorAdjustType type)
@@ -843,6 +855,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void ClearNoOp_Disposed_ThrowsArgumentException()
         {
@@ -995,6 +1008,7 @@ namespace System.Drawing.Imaging.Tests
             yield return new object[] { ColorChannelFlag.ColorChannelY, Color.FromArgb(255, 100, 100, 100), Color.FromArgb(255, 207, 207, 207) };
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(SetOutputChannel_ColorChannelFlag_TestData))]
         public void SetOutputChannel_Flag_Success(ColorChannelFlag flag, Color actualColor, Color expectedColor)
@@ -1023,6 +1037,7 @@ namespace System.Drawing.Imaging.Tests
             yield return new object[] { ColorChannelFlag.ColorChannelY, ColorAdjustType.Bitmap, Color.FromArgb(255, 100, 100, 100), Color.FromArgb(255, 207, 207, 207) };
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(SetOutputChannel_ColorChannelFlagType_TestData))]
         public void SetOutputChannel_FlagType_Success(ColorChannelFlag flag, ColorAdjustType type, Color actualColor, Color expectedColor)
@@ -1055,6 +1070,7 @@ namespace System.Drawing.Imaging.Tests
             yield return new object[] { ColorChannelFlag.ColorChannelY, ColorAdjustType.Text, Color.FromArgb(255, 100, 100, 100) };
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(SetOutputChannel_ColorChannelFlagTypeI_TestData))]
         public void SetOutputChannel_FlagTypeI_Success(ColorChannelFlag flag, ColorAdjustType type, Color color)
@@ -1071,6 +1087,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetOutputChannel_Disposed_ThrowsArgumentException()
         {
@@ -1081,6 +1098,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetOutputChannel(ColorChannelFlag.ColorChannelY, ColorAdjustType.Default));
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void SetOutputChannel_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)
@@ -1100,6 +1118,7 @@ namespace System.Drawing.Imaging.Tests
             yield return new object[] { (ColorChannelFlag)int.MaxValue };
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(SetOutputChannel_InvalidColorChannelFlags_TestData))]
         public void SetOutputChannel_InvalidFlags_ThrowsArgumentException(ColorChannelFlag flag)
@@ -1111,6 +1130,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void ClearOutputChannel_Success()
         {
@@ -1127,6 +1147,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_AllTypesAllowed_TestData))]
         public void ClearOutputChannel_Type_Success(ColorAdjustType type)
@@ -1144,6 +1165,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void ClearOutputChannel_Disposed_ThrowsArgumentException()
         {
@@ -1154,6 +1176,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearOutputChannel(ColorAdjustType.Default));
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void ClearOutputChannel_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)
@@ -1164,6 +1187,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetOutputChannelColorProfile_Name_Success()
         {
@@ -1179,6 +1203,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetOutputChannelColorProfile_Disposed_ThrowsArgumentException()
         {
@@ -1212,6 +1237,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetOutputChannelColorProfile_InvalidPath_ThrowsOutOfMemoryException()
         {
@@ -1222,6 +1248,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetOutputChannelColorProfile_InvalidPath_ThrowsPathTooLongException()
         {
@@ -1233,7 +1260,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void SetOutputChannelColorProfile_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)
@@ -1244,6 +1271,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void ClearOutputChannelColorProfile_Success()
         {
@@ -1261,6 +1289,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_AllTypesAllowed_TestData))]
         public void ClearOutputChannelColorProfile_Type_Success(ColorAdjustType type)
@@ -1279,6 +1308,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void ClearOutputChannelColorProfile_Disposed_ThrowsArgumentException()
         {
@@ -1289,6 +1319,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearOutputChannelColorProfile(ColorAdjustType.Default));
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void ClearOutputChannelColorProfile_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)
@@ -1381,6 +1412,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetRemapTable_EmptyMap_ThrowsArgumentException()
         {
@@ -1390,6 +1422,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void ClearRemapTable_Success()
         {
@@ -1405,6 +1438,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_AllTypesAllowed_TestData))]
         public void ClearRemapTable_Type_Success(ColorAdjustType type)
@@ -1452,6 +1486,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetWrapMode(WrapMode.Clamp, Color.Black, true));
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void GetAdjustedPalette_Disposed_ThrowsArgumentException()
         {
@@ -1473,6 +1508,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void GetAdjustedPalette_Disposed_ThrowsArgumentException(ColorAdjustType type)


### PR DESCRIPTION
I have found that only the `Clone_Success` test causes a crash on libgdiplus. The rest are able to run, but a large number still have other issues. Namely, many of these receive a NotImplemented status from libgdiplus.