### PR TITLE
Updating Buildtools to update Roslyn

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-02026-04
+2.0.0-prerelease-02027-03


### PR DESCRIPTION
FYI: @VSadov 

Updating Roslyn to version 2.6.0-beta1-62126-01 in corefx.