### PR TITLE
Use ManagedHandler in managed ClientWebSocket

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -127,7 +127,7 @@
     <Compile Include="System\Net\Http\Managed\ChunkedEncodingReadStream.cs" />
     <Compile Include="System\Net\Http\Managed\ChunkedEncodingWriteStream.cs" />
     <Compile Include="System\Net\Http\Managed\ConnectHelper.cs" />
-    <Compile Include="System\Net\Http\Managed\ConnectionCloseStream.cs" />
+    <Compile Include="System\Net\Http\Managed\ConnectionCloseReadStream.cs" />
     <Compile Include="System\Net\Http\Managed\ContentLengthReadStream.cs" />
     <Compile Include="System\Net\Http\Managed\ContentLengthWriteStream.cs" />
     <Compile Include="System\Net\Http\Managed\CookieHandler.cs" />
@@ -146,6 +146,7 @@
     <Compile Include="System\Net\Http\Managed\HttpContentWriteStream.cs" />
     <Compile Include="System\Net\Http\Managed\HttpProxyConnectionHandler.cs" />
     <Compile Include="System\Net\Http\Managed\ManagedHandler.cs" />
+    <Compile Include="System\Net\Http\Managed\RawConnectionStream.cs" />
   </ItemGroup>
   <!-- Common, except for Windows net46 build -->
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'  And '$(TargetGroup)' != 'netfx'">

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -127,7 +127,7 @@
     <Compile Include="System\Net\Http\Managed\ChunkedEncodingReadStream.cs" />
     <Compile Include="System\Net\Http\Managed\ChunkedEncodingWriteStream.cs" />
     <Compile Include="System\Net\Http\Managed\ConnectHelper.cs" />
-    <Compile Include="System\Net\Http\Managed\ConnectionCloseReadStream.cs" />
+    <Compile Include="System\Net\Http\Managed\ConnectionCloseStream.cs" />
     <Compile Include="System\Net\Http\Managed\ContentLengthReadStream.cs" />
     <Compile Include="System\Net\Http\Managed\ContentLengthWriteStream.cs" />
     <Compile Include="System\Net\Http\Managed\CookieHandler.cs" />
@@ -140,6 +140,7 @@
     <Compile Include="System\Net\Http\Managed\HttpConnectionPool.cs" />
     <Compile Include="System\Net\Http\Managed\HttpConnectionPools.cs" />
     <Compile Include="System\Net\Http\Managed\HttpConnectionSettings.cs" />
+    <Compile Include="System\Net\Http\Managed\HttpContentDuplexStream.cs" />
     <Compile Include="System\Net\Http\Managed\HttpContentReadStream.cs" />
     <Compile Include="System\Net\Http\Managed\HttpContentStream.cs" />
     <Compile Include="System\Net\Http\Managed\HttpContentWriteStream.cs" />

--- a/src/System.Net.Http/src/System/Net/Http/HttpUtilities.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpUtilities.cs
@@ -25,11 +25,20 @@ namespace System.Net.Http
         internal static bool IsHttpUri(Uri uri)
         {
             Debug.Assert(uri != null);
-
-            string scheme = uri.Scheme;
-            return string.Equals("http", scheme, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals("https", scheme, StringComparison.OrdinalIgnoreCase);
+            return IsSupportedScheme(uri.Scheme);
         }
+
+        internal static bool IsSupportedScheme(string scheme) =>
+            IsSupportedNonSecureScheme(scheme) ||
+            IsSupportedSecureScheme(scheme);
+
+        internal static bool IsSupportedNonSecureScheme(string scheme) =>
+            string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(scheme, "ws", StringComparison.OrdinalIgnoreCase);
+
+        internal static bool IsSupportedSecureScheme(string scheme) =>
+            string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(scheme, "wss", StringComparison.OrdinalIgnoreCase);
 
         // Returns true if the task was faulted or canceled and sets tcs accordingly.
         internal static bool HandleFaultsAndCancelation<T>(Task task, TaskCompletionSource<T> tcs)

--- a/src/System.Net.Http/src/System/Net/Http/HttpUtilities.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpUtilities.cs
@@ -33,12 +33,10 @@ namespace System.Net.Http
             IsSupportedSecureScheme(scheme);
 
         internal static bool IsSupportedNonSecureScheme(string scheme) =>
-            string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(scheme, "ws", StringComparison.OrdinalIgnoreCase);
+            string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase);
 
         internal static bool IsSupportedSecureScheme(string scheme) =>
-            string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(scheme, "wss", StringComparison.OrdinalIgnoreCase);
+            string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase);
 
         // Returns true if the task was faulted or canceled and sets tcs accordingly.
         internal static bool HandleFaultsAndCancelation<T>(Task task, TaskCompletionSource<T> tcs)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
@@ -80,10 +80,10 @@ namespace System.Net.Http
                     location = new Uri(request.RequestUri, location);
                 }
 
-                // Disallow automatic redirection from https to http
+                // Disallow automatic redirection from secure to non-secure schemes
                 bool allowed =
-                    (request.RequestUri.Scheme == UriScheme.Http && (location.Scheme == UriScheme.Http || location.Scheme == UriScheme.Https)) ||
-                    (request.RequestUri.Scheme == UriScheme.Https && location.Scheme == UriScheme.Https);
+                    (HttpUtilities.IsSupportedNonSecureScheme(request.RequestUri.Scheme) && HttpUtilities.IsSupportedScheme(location.Scheme)) ||
+                    (HttpUtilities.IsSupportedSecureScheme(request.RequestUri.Scheme) && HttpUtilities.IsSupportedSecureScheme(location.Scheme));
                 if (!allowed)
                 {
                     break;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ConnectionCloseReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ConnectionCloseReadStream.cs
@@ -10,9 +10,9 @@ namespace System.Net.Http
 {
     internal sealed partial class HttpConnection : IDisposable
     {
-        private sealed class ConnectionCloseStream : HttpContentDuplexStream
+        private sealed class ConnectionCloseReadStream : HttpContentReadStream
         {
-            public ConnectionCloseStream(HttpConnection connection) : base(connection)
+            public ConnectionCloseReadStream(HttpConnection connection) : base(connection)
             {
             }
 
@@ -37,19 +37,6 @@ namespace System.Net.Http
 
                 return bytesRead;
             }
-
-            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-            {
-                ValidateBufferArgs(buffer, offset, count);
-                return
-                    _connection == null ? Task.FromException(new IOException(SR.net_http_io_write)) :
-                    count > 0 ? _connection.WriteWithoutBufferingAsync(buffer, offset, count, cancellationToken) :
-                    Task.CompletedTask;
-            }
-
-            public override Task FlushAsync(CancellationToken cancellationToken) =>
-                _connection != null ? _connection.FlushAsync(cancellationToken) :
-                Task.CompletedTask;
 
             public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
             {

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -347,7 +347,7 @@ namespace System.Net.Http
                 }
 
                 // Create the response stream.
-                HttpContentReadStream responseStream;
+                HttpContentStream responseStream;
                 if (request.Method == HttpMethod.Head || (int)response.StatusCode == 204 || (int)response.StatusCode == 304)
                 {
                     responseStream = EmptyReadStream.Instance;
@@ -372,7 +372,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    responseStream = new ConnectionCloseReadStream(this);
+                    responseStream = new ConnectionCloseStream(this);
                 }
                 ((HttpConnectionContent)response.Content).SetStream(responseStream);
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -370,9 +370,13 @@ namespace System.Net.Http
                 {
                     responseStream = new ChunkedEncodingReadStream(this);
                 }
+                else if (response.StatusCode == HttpStatusCode.SwitchingProtocols)
+                {
+                    responseStream = new RawConnectionStream(this);
+                }
                 else
                 {
-                    responseStream = new ConnectionCloseStream(this);
+                    responseStream = new ConnectionCloseReadStream(this);
                 }
                 ((HttpConnectionContent)response.Content).SetStream(responseStream);
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionContent.cs
@@ -14,14 +14,14 @@ namespace System.Net.Http
         private sealed class HttpConnectionContent : HttpContent
         {
             private readonly CancellationToken _cancellationToken;
-            private HttpContentReadStream _stream;
+            private HttpContentStream _stream;
 
             public HttpConnectionContent(CancellationToken cancellationToken)
             {
                 _cancellationToken = cancellationToken;
             }
 
-            public void SetStream(HttpContentReadStream stream)
+            public void SetStream(HttpContentStream stream)
             {
                 Debug.Assert(stream != null);
                 Debug.Assert(stream.CanRead);
@@ -29,14 +29,14 @@ namespace System.Net.Http
                 _stream = stream;
             }
 
-            private HttpContentReadStream ConsumeStream()
+            private HttpContentStream ConsumeStream()
             {
                 if (_stream == null)
                 {
                     throw new InvalidOperationException(SR.net_http_content_stream_already_read);
                 }
 
-                HttpContentReadStream stream = _stream;
+                HttpContentStream stream = _stream;
                 _stream = null;
                 return stream;
             }
@@ -45,7 +45,7 @@ namespace System.Net.Http
             {
                 Debug.Assert(stream != null);
 
-                using (HttpContentReadStream contentStream = ConsumeStream())
+                using (HttpContentStream contentStream = ConsumeStream())
                 {
                     const int BufferSize = 8192;
                     await contentStream.CopyToAsync(stream, BufferSize, _cancellationToken).ConfigureAwait(false);

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
@@ -89,7 +89,7 @@ namespace System.Net.Http
 
             TransportContext transportContext = null;
 
-            if (uri.Scheme == UriScheme.Https)
+            if (HttpUtilities.IsSupportedSecureScheme(uri.Scheme))
             {
                 SslStream sslStream = await EstablishSslConnection(uri.IdnHost, request, stream).ConfigureAwait(false);
                 stream = sslStream;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
@@ -12,9 +12,9 @@ namespace System.Net.Http
 
         public HttpConnectionKey(Uri uri)
         {
-            UsingSSL = 
-                uri.Scheme == UriScheme.Http ? false :
-                uri.Scheme == UriScheme.Https ? true :
+            UsingSSL =
+                HttpUtilities.IsSupportedNonSecureScheme(uri.Scheme) ? false :
+                HttpUtilities.IsSupportedSecureScheme(uri.Scheme) ? true :
                 throw new ArgumentException(SR.net_http_client_http_baseaddress_required, nameof(uri));
 
             Host = uri.Host;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentDuplexStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentDuplexStream.cs
@@ -2,26 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 
 namespace System.Net.Http
 {
-    internal abstract class HttpContentReadStream : HttpContentStream
+    internal abstract class HttpContentDuplexStream : HttpContentStream
     {
-        public HttpContentReadStream(HttpConnection connection) : base(connection)
+        public HttpContentDuplexStream(HttpConnection connection) : base(connection)
         {
         }
 
         public override bool CanRead => true;
-        public override bool CanWrite => false;
+        public override bool CanWrite => true;
 
-        public override void Flush() { }
-
-        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override void Flush() => FlushAsync().GetAwaiter().GetResult();
 
         public override int Read(byte[] buffer, int offset, int count) =>
             ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
 
         public override void CopyTo(Stream destination, int bufferSize) =>
             CopyToAsync(destination, bufferSize, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentStream.cs
@@ -3,11 +3,60 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
     internal abstract class HttpContentStream : Stream
     {
+        protected HttpConnection _connection;
+
+        public HttpContentStream(HttpConnection connection)
+        {
+            _connection = connection;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_connection != null)
+                {
+                    _connection.Dispose();
+                    _connection = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override bool CanSeek => false;
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+            TaskToApm.Begin(ReadAsync(buffer, offset, count, default(CancellationToken)), callback, state);
+
+        public override int EndRead(IAsyncResult asyncResult) =>
+            TaskToApm.End<int>(asyncResult);
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+            TaskToApm.Begin(WriteAsync(buffer, offset, count, default(CancellationToken)), callback, state);
+
+        public override void EndWrite(IAsyncResult asyncResult) =>
+            TaskToApm.End(asyncResult);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(); }
+        }
+
         protected static void ValidateBufferArgs(byte[] buffer, int offset, int count)
         {
             if (buffer == null)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentWriteStream.cs
@@ -11,12 +11,9 @@ namespace System.Net.Http
 {
     internal abstract class HttpContentWriteStream : HttpContentStream
     {
-        protected HttpConnection _connection;
-
-        public HttpContentWriteStream(HttpConnection connection, CancellationToken cancellationToken)
+        public HttpContentWriteStream(HttpConnection connection, CancellationToken cancellationToken) : base(connection)
         {
             Debug.Assert(connection != null);
-            _connection = connection;
             RequestCancellationToken = cancellationToken;
         }
 
@@ -29,22 +26,9 @@ namespace System.Net.Http
         internal CancellationToken RequestCancellationToken { get; }
 
         public override bool CanRead => false;
-        public override bool CanSeek => false;
         public override bool CanWrite => true;
 
-        public override long Length => throw new NotSupportedException();
-
-        public override long Position
-        {
-            get { throw new NotSupportedException(); }
-            set { throw new NotSupportedException(); }
-        }
-
         public override void Flush() => FlushAsync().GetAwaiter().GetResult();
-
-        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
-
-        public override void SetLength(long value) => throw new NotSupportedException();
 
         public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
@@ -52,19 +36,5 @@ namespace System.Net.Http
             WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
 
         public abstract Task FinishAsync();
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (_connection != null)
-                {
-                    _connection.Dispose();
-                    _connection = null;
-                }
-            }
-
-            base.Dispose(disposing);
-        }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -59,7 +59,7 @@ namespace System.Net.Http
                 throw new InvalidOperationException(SR.net_http_invalid_proxy_scheme);
             }
 
-            if (request.RequestUri.Scheme == UriScheme.Https)
+            if (!HttpUtilities.IsSupportedNonSecureScheme(request.RequestUri.Scheme))
             {
                 // TODO #23136: Implement SSL tunneling through proxy
                 throw new NotImplementedException("no support for SSL tunneling through proxy");

--- a/src/System.Net.Http/src/System/Net/Http/Managed/RawConnectionStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/RawConnectionStream.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http
+{
+    internal sealed partial class HttpConnection : IDisposable
+    {
+        private sealed class RawConnectionStream : HttpContentDuplexStream
+        {
+            public RawConnectionStream(HttpConnection connection) : base(connection)
+            {
+            }
+
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                ValidateBufferArgs(buffer, offset, count);
+
+                if (_connection == null || count == 0)
+                {
+                    // Response body fully consumed or the caller didn't ask for any data
+                    return 0;
+                }
+
+                int bytesRead = await _connection.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    // We cannot reuse this connection, so close it.
+                    _connection.Dispose();
+                    _connection = null;
+                    return 0;
+                }
+
+                return bytesRead;
+            }
+
+            public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            {
+                if (destination == null)
+                {
+                    throw new ArgumentNullException(nameof(destination));
+                }
+
+                if (_connection != null) // null if response body fully consumed
+                {
+                    await _connection.CopyToAsync(destination, cancellationToken).ConfigureAwait(false);
+
+                    // We cannot reuse this connection, so close it.
+                    _connection.Dispose();
+                    _connection = null;
+                }
+            }
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                ValidateBufferArgs(buffer, offset, count);
+                return
+                    _connection == null ? Task.FromException(new IOException(SR.net_http_io_write)) :
+                    count > 0 ? _connection.WriteWithoutBufferingAsync(buffer, offset, count, cancellationToken) :
+                    Task.CompletedTask;
+            }
+
+            public override Task FlushAsync(CancellationToken cancellationToken) =>
+                _connection != null ? _connection.FlushAsync(cancellationToken) :
+                Task.CompletedTask;
+        }
+    }
+}

--- a/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -138,6 +138,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Reference Include="System.Buffers" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.NameResolution" />
     <Reference Include="System.Net.Security" />
     <Reference Include="System.Net.Sockets" />
@@ -146,6 +147,7 @@
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Primitives" />
     <Reference Include="System.Text.Encoding.Extensions" />
+    <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Threading.Timer" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -5,6 +5,8 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.ExceptionServices;
@@ -17,15 +19,6 @@ namespace System.Net.WebSockets
 {
     internal sealed class WebSocketHandle
     {
-        /// <summary>Per-thread cached StringBuilder for building of strings to send on the connection.</summary>
-        [ThreadStatic]
-        private static StringBuilder t_cachedStringBuilder;
-
-        /// <summary>Default encoding for HTTP requests. Latin alphabet no 1, ISO/IEC 8859-1.</summary>
-        private static readonly Encoding s_defaultHttpEncoding = Encoding.GetEncoding(28591);
-
-        /// <summary>Size of the receive buffer to use.</summary>
-        private const int DefaultReceiveBufferSize = 0x1000;
         /// <summary>GUID appended by the server as part of the security key response.  Defined in the RFC.</summary>
         private const string WSServerGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
@@ -71,56 +64,112 @@ namespace System.Net.WebSockets
         public Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken) =>
             _webSocket.CloseOutputAsync(closeStatus, statusDescription, cancellationToken);
 
+        private sealed class DirectManagedHttpClientHandler : HttpClientHandler
+        {
+            private const string ManagedHandlerEnvVar = "COMPlus_UseManagedHttpClientHandler";
+            private static readonly LocalDataStoreSlot s_managedHandlerSlot = GetSlot();
+            private static readonly object s_true = true;
+
+            private static LocalDataStoreSlot GetSlot()
+            {
+                LocalDataStoreSlot slot = Thread.GetNamedDataSlot(ManagedHandlerEnvVar);
+                if (slot != null)
+                {
+                    return slot;
+                }
+
+                try
+                {
+                    return Thread.AllocateNamedDataSlot(ManagedHandlerEnvVar);
+                }
+                catch (ArgumentException) // in case of a race condition where multiple threads all try to allocate the slot concurrently
+                {
+                    return Thread.GetNamedDataSlot(ManagedHandlerEnvVar);
+                }
+            }
+
+            public static DirectManagedHttpClientHandler CreateHandler()
+            {
+                Thread.SetData(s_managedHandlerSlot, s_true);
+                try
+                {
+                    return new DirectManagedHttpClientHandler();
+                }
+                finally { Thread.SetData(s_managedHandlerSlot, null); }
+            }
+
+            public new Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken) =>
+                base.SendAsync(request, cancellationToken);
+        }
+
         public async Task ConnectAsyncCore(Uri uri, CancellationToken cancellationToken, ClientWebSocketOptions options)
         {
-            // TODO #14480 : Not currently implemented, or explicitly ignored:
-            // - ClientWebSocketOptions.UseDefaultCredentials
-            // - ClientWebSocketOptions.Credentials
-            // - ClientWebSocketOptions.Proxy
-            // - ClientWebSocketOptions._sendBufferSize
-
-            // Establish connection to the server
-            CancellationTokenRegistration registration = cancellationToken.Register(s => ((WebSocketHandle)s).Abort(), this);
             try
             {
-                // Connect to the remote server
-                Socket connectedSocket = await ConnectSocketAsync(uri.Host, uri.Port, cancellationToken).ConfigureAwait(false);
-                Stream stream = new NetworkStream(connectedSocket, ownsSocket:true);
+                var request = new HttpRequestMessage(HttpMethod.Get, uri);
 
-                // Upgrade to SSL if needed
-                if (uri.Scheme == UriScheme.Wss)
+                if (options._requestHeaders?.Count > 0) // use field to avoid lazily initializing the collection
                 {
-                    var sslStream = new SslStream(stream);
-                    await sslStream.AuthenticateAsClientAsync(
-                        uri.Host,
-                        options.ClientCertificates,
-                        SecurityProtocol.AllowedSecurityProtocols,
-                        checkCertificateRevocation: false).ConfigureAwait(false);
-                    stream = sslStream;
+                    foreach (string key in options.RequestHeaders)
+                    {
+                        request.Headers.Add(key, options.RequestHeaders[key]);
+                    }
                 }
 
                 // Create the security key and expected response, then build all of the request headers
                 KeyValuePair<string, string> secKeyAndSecWebSocketAccept = CreateSecKeyAndSecWebSocketAccept();
-                byte[] requestHeader = BuildRequestHeader(uri, options, secKeyAndSecWebSocketAccept.Key);
+                AddWebSocketHeaders(request, secKeyAndSecWebSocketAccept.Key, options);
 
-                // Write out the header to the connection
-                await stream.WriteAsync(requestHeader, 0, requestHeader.Length, cancellationToken).ConfigureAwait(false);
-
-                // Parse the response and store our state for the remainder of the connection
-                string subprotocol = await ParseAndValidateConnectResponseAsync(stream, options, secKeyAndSecWebSocketAccept.Value, cancellationToken).ConfigureAwait(false);
-
-                _webSocket = WebSocket.CreateClientWebSocket(
-                    stream, subprotocol, options.ReceiveBufferSize, options.SendBufferSize, options.KeepAliveInterval, false, options.Buffer.GetValueOrDefault());
-
-                // If a concurrent Abort or Dispose came in before we set _webSocket, make sure to update it appropriately
-                if (_state == WebSocketState.Aborted)
+                DirectManagedHttpClientHandler handler = DirectManagedHttpClientHandler.CreateHandler();
+                handler.UseDefaultCredentials = options.UseDefaultCredentials;
+                handler.Credentials = options.Credentials;
+                handler.Proxy = options.Proxy;
+                handler.CookieContainer = options.Cookies;
+                if (options._clientCertificates?.Count > 0) // use field to avoid lazily initializing the collection
                 {
-                    _webSocket.Abort();
+                    handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+                    handler.ClientCertificates.AddRange(options.ClientCertificates);
                 }
-                else if (_state == WebSocketState.Closed)
+
+                HttpResponseMessage response = await handler.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                if (response.StatusCode != HttpStatusCode.SwitchingProtocols)
                 {
-                    _webSocket.Dispose();
+                    throw new WebSocketException(SR.net_webstatus_ConnectFailure);
                 }
+
+                // The Connection, Upgrade, and SecWebSocketAccept headers are required and with specific values.
+                ValidateHeader(response.Headers, HttpKnownHeaderNames.Connection, "Upgrade");
+                ValidateHeader(response.Headers, HttpKnownHeaderNames.Upgrade, "websocket");
+                ValidateHeader(response.Headers, HttpKnownHeaderNames.SecWebSocketAccept, secKeyAndSecWebSocketAccept.Value);
+
+                // The SecWebSocketProtocol header is optional.  We should only get it with a non-empty value if we requested subprotocols,
+                // and then it must only be one of the ones we requested.  If we got a subprotocol other than one we requested (or if we
+                // already got one in a previous header), fail. Otherwise, track which one we got.
+                string subprotocol = null;
+                IEnumerable<string> subprotocolEnumerableValues;
+                if (response.Headers.TryGetValues(HttpKnownHeaderNames.SecWebSocketProtocol, out subprotocolEnumerableValues))
+                {
+                    Debug.Assert(subprotocolEnumerableValues is string[]);
+                    string[] subprotocolArray = (string[])subprotocolEnumerableValues;
+                    if (subprotocolArray.Length != 1 ||
+                        (subprotocol = options.RequestedSubProtocols.Find(requested => string.Equals(requested, subprotocolArray[0], StringComparison.OrdinalIgnoreCase))) == null)
+                    {
+                        throw new WebSocketException(
+                            WebSocketError.UnsupportedProtocol,
+                            SR.Format(SR.net_WebSockets_AcceptUnsupportedProtocol, string.Join(", ", options.RequestedSubProtocols), subprotocol));
+                    }
+                }
+
+                Stream connectedStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                _webSocket = WebSocket.CreateClientWebSocket( // TODO https://github.com/dotnet/corefx/issues/21537: Use new API when available
+                    connectedStream,
+                    subprotocol,
+                    options.ReceiveBufferSize,
+                    options.SendBufferSize,
+                    options.KeepAliveInterval,
+                    useZeroMaskingKey: false,
+                    internalBuffer:options.Buffer.GetValueOrDefault());
             }
             catch (Exception exc)
             {
@@ -137,136 +186,18 @@ namespace System.Net.WebSockets
                 }
                 throw new WebSocketException(SR.net_webstatus_ConnectFailure, exc);
             }
-            finally
-            {
-                registration.Dispose();
-            }
         }
 
-        /// <summary>Connects a socket to the specified host and port, subject to cancellation and aborting.</summary>
-        /// <param name="host">The host to which to connect.</param>
-        /// <param name="port">The port to which to connect on the host.</param>
-        /// <param name="cancellationToken">The CancellationToken to use to cancel the websocket.</param>
-        /// <returns>The connected Socket.</returns>
-        private async Task<Socket> ConnectSocketAsync(string host, int port, CancellationToken cancellationToken)
-        {
-            IPAddress[] addresses = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
-
-            ExceptionDispatchInfo lastException = null;
-            foreach (IPAddress address in addresses)
-            {
-                var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-                try
-                {
-                    using (cancellationToken.Register(s => ((Socket)s).Dispose(), socket))
-                    using (_abortSource.Token.Register(s => ((Socket)s).Dispose(), socket))
-                    {
-                        try
-                        {
-                            await socket.ConnectAsync(address, port).ConfigureAwait(false);
-                        }
-                        catch (ObjectDisposedException ode)
-                        {
-                            // If the socket was disposed because cancellation was requested, translate the exception
-                            // into a new OperationCanceledException.  Otherwise, let the original ObjectDisposedexception propagate.
-                            CancellationToken token = cancellationToken.IsCancellationRequested ? cancellationToken : _abortSource.Token;
-                            if (token.IsCancellationRequested)
-                            {
-                                throw new OperationCanceledException(new OperationCanceledException().Message, ode, token);
-                            }
-                        }
-                    }
-                    cancellationToken.ThrowIfCancellationRequested(); // in case of a race and socket was disposed after the await
-                    _abortSource.Token.ThrowIfCancellationRequested();
-                    return socket;
-                }
-                catch (Exception exc)
-                {
-                    socket.Dispose();
-                    lastException = ExceptionDispatchInfo.Capture(exc);
-                }
-            }
-
-            lastException?.Throw();
-
-            Debug.Fail("We should never get here. We should have already returned or an exception should have been thrown.");
-            throw new WebSocketException(SR.net_webstatus_ConnectFailure);
-        }
-
-        /// <summary>Creates a byte[] containing the headers to send to the server.</summary>
-        /// <param name="uri">The Uri of the server.</param>
-        /// <param name="options">The options used to configure the websocket.</param>
         /// <param name="secKey">The generated security key to send in the Sec-WebSocket-Key header.</param>
-        /// <returns>The byte[] containing the encoded headers ready to send to the network.</returns>
-        private static byte[] BuildRequestHeader(Uri uri, ClientWebSocketOptions options, string secKey)
+        private static void AddWebSocketHeaders(HttpRequestMessage request, string secKey, ClientWebSocketOptions options)
         {
-            StringBuilder builder = t_cachedStringBuilder ?? (t_cachedStringBuilder = new StringBuilder());
-            Debug.Assert(builder.Length == 0, $"Expected builder to be empty, got one of length {builder.Length}");
-            try
+            request.Headers.TryAddWithoutValidation(HttpKnownHeaderNames.Connection, HttpKnownHeaderNames.Upgrade);
+            request.Headers.TryAddWithoutValidation(HttpKnownHeaderNames.Upgrade, "websocket");
+            request.Headers.TryAddWithoutValidation(HttpKnownHeaderNames.SecWebSocketVersion, "13");
+            request.Headers.TryAddWithoutValidation(HttpKnownHeaderNames.SecWebSocketKey, secKey);
+            if (options._requestedSubProtocols?.Count > 0)
             {
-                builder.Append("GET ").Append(uri.PathAndQuery).Append(" HTTP/1.1\r\n");
-
-                // Add all of the required headers, honoring Host header if set.
-                string hostHeader = options.RequestHeaders[HttpKnownHeaderNames.Host];
-                builder.Append("Host: ");
-                if (string.IsNullOrEmpty(hostHeader))
-                {
-                    builder.Append(uri.IdnHost).Append(':').Append(uri.Port).Append("\r\n");
-                }
-                else
-                {
-                    builder.Append(hostHeader).Append("\r\n");
-                }
-
-                builder.Append("Connection: Upgrade\r\n");
-                builder.Append("Upgrade: websocket\r\n");
-                builder.Append("Sec-WebSocket-Version: 13\r\n");
-                builder.Append("Sec-WebSocket-Key: ").Append(secKey).Append("\r\n");
-
-                // Add all of the additionally requested headers
-                foreach (string key in options.RequestHeaders.AllKeys)
-                {
-                    if (string.Equals(key, HttpKnownHeaderNames.Host, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Host header handled above
-                        continue;
-                    }
-
-                    builder.Append(key).Append(": ").Append(options.RequestHeaders[key]).Append("\r\n");
-                }
-
-                // Add the optional subprotocols header
-                if (options.RequestedSubProtocols.Count > 0)
-                {
-                    builder.Append(HttpKnownHeaderNames.SecWebSocketProtocol).Append(": ");
-                    builder.Append(options.RequestedSubProtocols[0]);
-                    for (int i = 1; i < options.RequestedSubProtocols.Count; i++)
-                    {
-                        builder.Append(", ").Append(options.RequestedSubProtocols[i]);
-                    }
-                    builder.Append("\r\n");
-                }
-
-                // Add an optional cookies header
-                if (options.Cookies != null)
-                {
-                    string header = options.Cookies.GetCookieHeader(uri);
-                    if (!string.IsNullOrWhiteSpace(header))
-                    {
-                        builder.Append(HttpKnownHeaderNames.Cookie).Append(": ").Append(header).Append("\r\n");
-                    }
-                }
-
-                // End the headers
-                builder.Append("\r\n");
-
-                // Return the bytes for the built up header
-                return s_defaultHttpEncoding.GetBytes(builder.ToString());
-            }
-            finally
-            {
-                // Make sure we clear the builder
-                builder.Clear();
+                request.Headers.Add(HttpKnownHeaderNames.SecWebSocketProtocol, string.Join(", ", options.RequestedSubProtocols));
             }
         }
 
@@ -287,174 +218,21 @@ namespace System.Net.WebSockets
             }
         }
 
-        /// <summary>Read and validate the connect response headers from the server.</summary>
-        /// <param name="stream">The stream from which to read the response headers.</param>
-        /// <param name="options">The options used to configure the websocket.</param>
-        /// <param name="expectedSecWebSocketAccept">The expected value of the Sec-WebSocket-Accept header.</param>
-        /// <param name="cancellationToken">The CancellationToken to use to cancel the websocket.</param>
-        /// <returns>The agreed upon subprotocol with the server, or null if there was none.</returns>
-        private async Task<string> ParseAndValidateConnectResponseAsync(
-            Stream stream, ClientWebSocketOptions options, string expectedSecWebSocketAccept, CancellationToken cancellationToken)
+        private static void ValidateHeader(HttpHeaders headers, string name, string expectedValue)
         {
-            // Read the first line of the response
-            string statusLine = await ReadResponseHeaderLineAsync(stream, cancellationToken).ConfigureAwait(false);
-
-            // Depending on the underlying sockets implementation and timing, connecting to a server that then
-            // immediately closes the connection may either result in an exception getting thrown from the connect
-            // earlier, or it may result in getting to here but reading 0 bytes.  If we read 0 bytes and thus have
-            // an empty status line, treat it as a connect failure.
-            if (string.IsNullOrEmpty(statusLine))
+            if (!headers.TryGetValues(name, out IEnumerable<string> values))
             {
-                throw new WebSocketException(SR.Format(SR.net_webstatus_ConnectFailure));
+                ThrowConnectFailure();
             }
 
-            const string ExpectedStatusStart = "HTTP/1.1 ";
-            const string ExpectedStatusStatWithCode = "HTTP/1.1 101"; // 101 == SwitchingProtocols
-
-            // If the status line doesn't begin with "HTTP/1.1" or isn't long enough to contain a status code, fail.
-            if (!statusLine.StartsWith(ExpectedStatusStart, StringComparison.Ordinal) || statusLine.Length < ExpectedStatusStatWithCode.Length)
+            Debug.Assert(values is string[]);
+            string[] array = (string[])values;
+            if (array.Length != 1 || !string.Equals(array[0], expectedValue, StringComparison.OrdinalIgnoreCase))
             {
-                throw new WebSocketException(WebSocketError.HeaderError);
-            }
-
-            // If the status line doesn't contain a status code 101, or if it's long enough to have a status description
-            // but doesn't contain whitespace after the 101, fail.
-            if (!statusLine.StartsWith(ExpectedStatusStatWithCode, StringComparison.Ordinal) ||
-                (statusLine.Length > ExpectedStatusStatWithCode.Length && !char.IsWhiteSpace(statusLine[ExpectedStatusStatWithCode.Length])))
-            {
-                throw new WebSocketException(SR.net_webstatus_ConnectFailure);
-            }
-
-            // Read each response header. Be liberal in parsing the response header, treating
-            // everything to the left of the colon as the key and everything to the right as the value, trimming both.
-            // For each header, validate that we got the expected value.
-            bool foundUpgrade = false, foundConnection = false, foundSecWebSocketAccept = false;
-            string subprotocol = null;
-            string line;
-            while (!string.IsNullOrEmpty(line = await ReadResponseHeaderLineAsync(stream, cancellationToken).ConfigureAwait(false)))
-            {
-                int colonIndex = line.IndexOf(':');
-                if (colonIndex == -1)
-                {
-                    throw new WebSocketException(WebSocketError.HeaderError);
-                }
-
-                string headerName = line.SubstringTrim(0, colonIndex);
-                string headerValue = line.SubstringTrim(colonIndex + 1);
-
-                // The Connection, Upgrade, and SecWebSocketAccept headers are required and with specific values.
-                ValidateAndTrackHeader(HttpKnownHeaderNames.Connection, "Upgrade", headerName, headerValue, ref foundConnection);
-                ValidateAndTrackHeader(HttpKnownHeaderNames.Upgrade, "websocket", headerName, headerValue, ref foundUpgrade);
-                ValidateAndTrackHeader(HttpKnownHeaderNames.SecWebSocketAccept, expectedSecWebSocketAccept, headerName, headerValue, ref foundSecWebSocketAccept);
-
-                // The SecWebSocketProtocol header is optional.  We should only get it with a non-empty value if we requested subprotocols,
-                // and then it must only be one of the ones we requested.  If we got a subprotocol other than one we requested (or if we
-                // already got one in a previous header), fail. Otherwise, track which one we got.
-                if (string.Equals(HttpKnownHeaderNames.SecWebSocketProtocol, headerName, StringComparison.OrdinalIgnoreCase) &&
-                    !string.IsNullOrWhiteSpace(headerValue))
-                {
-                    string newSubprotocol = options.RequestedSubProtocols.Find(requested => string.Equals(requested, headerValue, StringComparison.OrdinalIgnoreCase));
-                    if (newSubprotocol == null || subprotocol != null)
-                    {
-                        throw new WebSocketException(
-                            WebSocketError.UnsupportedProtocol,
-                            SR.Format(SR.net_WebSockets_AcceptUnsupportedProtocol, string.Join(", ", options.RequestedSubProtocols), subprotocol));
-                    }
-                    subprotocol = newSubprotocol;
-                }
-            }
-            if (!foundUpgrade || !foundConnection || !foundSecWebSocketAccept)
-            {
-                throw new WebSocketException(SR.net_webstatus_ConnectFailure);
-            }
-
-            return subprotocol;
-        }
-
-        /// <summary>Validates a received header against expected values and tracks that we've received it.</summary>
-        /// <param name="targetHeaderName">The header name against which we're comparing.</param>
-        /// <param name="targetHeaderValue">The header value against which we're comparing.</param>
-        /// <param name="foundHeaderName">The actual header name received.</param>
-        /// <param name="foundHeaderValue">The actual header value received.</param>
-        /// <param name="foundHeader">A bool tracking whether this header has been seen.</param>
-        private static void ValidateAndTrackHeader(
-            string targetHeaderName, string targetHeaderValue,
-            string foundHeaderName, string foundHeaderValue,
-            ref bool foundHeader)
-        {
-            bool isTargetHeader = string.Equals(targetHeaderName, foundHeaderName, StringComparison.OrdinalIgnoreCase);
-            if (!foundHeader)
-            {
-                if (isTargetHeader)
-                {
-                    if (!string.Equals(targetHeaderValue, foundHeaderValue, StringComparison.OrdinalIgnoreCase))
-                    {
-                        throw new WebSocketException(SR.Format(SR.net_WebSockets_InvalidResponseHeader, targetHeaderName, foundHeaderValue));
-                    }
-                    foundHeader = true;
-                }
-            }
-            else
-            {
-                if (isTargetHeader)
-                {
-                    throw new WebSocketException(SR.Format(SR.net_webstatus_ConnectFailure));
-                }
+                throw new WebSocketException(SR.Format(SR.net_WebSockets_InvalidResponseHeader, name, string.Join(", ", array)));
             }
         }
 
-        /// <summary>Reads a line from the stream.</summary>
-        /// <param name="stream">The stream from which to read.</param>
-        /// <param name="cancellationToken">The CancellationToken used to cancel the websocket.</param>
-        /// <returns>The read line, or null if none could be read.</returns>
-        private static async Task<string> ReadResponseHeaderLineAsync(Stream stream, CancellationToken cancellationToken)
-        {
-            StringBuilder sb = t_cachedStringBuilder;
-            if (sb != null)
-            {
-                t_cachedStringBuilder = null;
-                Debug.Assert(sb.Length == 0, $"Expected empty StringBuilder");
-            }
-            else
-            {
-                sb = new StringBuilder();
-            }
-
-            var arr = new byte[1];
-            char prevChar = '\0';
-            try
-            {
-                // TODO: Reading one byte is extremely inefficient.  The problem, however,
-                // is that if we read multiple bytes, we could end up reading bytes post-headers
-                // that are part of messages meant to be read by the managed websocket after
-                // the connection.  The likely solution here is to wrap the stream in a BufferedStream,
-                // though a) that comes at the expense of an extra set of virtual calls, b) 
-                // it adds a buffer when the managed websocket will already be using a buffer, and
-                // c) it's not exposed on the version of the System.IO contract we're currently using.
-                while (await stream.ReadAsync(arr, 0, 1, cancellationToken).ConfigureAwait(false) == 1)
-                {
-                    // Process the next char
-                    char curChar = (char)arr[0];
-                    if (prevChar == '\r' && curChar == '\n')
-                    {
-                        break;
-                    }
-                    sb.Append(curChar);
-                    prevChar = curChar;
-                }
-
-                if (sb.Length > 0 && sb[sb.Length - 1] == '\r')
-                {
-                    sb.Length = sb.Length - 1;
-                }
-
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Clear();
-                t_cachedStringBuilder = sb;
-            }
-        }
+        private static void ThrowConnectFailure() => throw new WebSocketException(SR.net_webstatus_ConnectFailure);
     }
 }

--- a/src/System.Net.WebSockets.Client/tests/AbortTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/AbortTest.cs
@@ -16,9 +16,10 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public AbortTest(ITestOutputHelper output) : base(output) { }
 
+        [ActiveIssue(23151, TestPlatforms.AnyUnix)] // need ManagedHandler support for canceling a ConnectAsync operation
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        public void Abort_ConnectAndAbort_ThrowsWebSocketExceptionWithmessage(Uri server)
+        public async Task Abort_ConnectAndAbort_ThrowsWebSocketExceptionWithmessage(Uri server)
         {
             using (var cws = new ClientWebSocket())
             {
@@ -29,7 +30,7 @@ namespace System.Net.WebSockets.Client.Tests
 
                 Task t = cws.ConnectAsync(ub.Uri, cts.Token);
                 cws.Abort();
-                WebSocketException ex = Assert.Throws<WebSocketException>(() => t.GetAwaiter().GetResult());
+                WebSocketException ex = await Assert.ThrowsAsync<WebSocketException>(() => t);
 
                 Assert.Equal(ResourceHelper.GetExceptionMessage("net_webstatus_ConnectFailure"), ex.Message);
 

--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -14,6 +14,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public CancelTest(ITestOutputHelper output) : base(output) { }
 
+        [ActiveIssue(23151, TestPlatforms.AnyUnix)] // connection opening currently can't be canceled on ManagedHandler
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ConnectAsync_Cancel_ThrowsWebSocketExceptionWithMessage(Uri server)

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketTestBase.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketTestBase.cs
@@ -20,7 +20,7 @@ namespace System.Net.WebSockets.Client.Tests
         public static readonly object[][] EchoServers = System.Net.Test.Common.Configuration.WebSockets.EchoServers;
         public static readonly object[][] EchoHeadersServers = System.Net.Test.Common.Configuration.WebSockets.EchoHeadersServers;
 
-        public const int TimeOutMilliseconds = 10000;
+        public const int TimeOutMilliseconds = 20000;
         public const int CloseDescriptionMaxLength = 123;
         public readonly ITestOutputHelper _output;
 
@@ -80,6 +80,24 @@ namespace System.Net.WebSockets.Client.Tests
 
                     Assert.Equal(WebSocketError.InvalidState, exception.WebSocketErrorCode);
                     Assert.Equal(WebSocketState.Aborted, cws.State);
+                }
+            }
+        }
+
+        protected static async Task<WebSocketReceiveResult> ReceiveEntireMessageAsync(WebSocket ws, ArraySegment<byte> segment, CancellationToken cancellationToken)
+        {
+            int bytesReceived = 0;
+            while (true)
+            {
+                WebSocketReceiveResult r = await ws.ReceiveAsync(segment, cancellationToken);
+                if (r.EndOfMessage)
+                {
+                    return new WebSocketReceiveResult(bytesReceived + r.Count, r.MessageType, true, r.CloseStatus, r.CloseStatusDescription);
+                }
+                else
+                {
+                    bytesReceived += r.Count;
+                    segment = new ArraySegment<byte>(segment.Array, segment.Offset + r.Count, segment.Count - r.Count);
                 }
             }
         }

--- a/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -69,15 +69,14 @@ namespace System.Net.WebSockets.Client.Tests
                 Assert.Equal(WebSocketState.Open, cws.State);
 
                 byte[] buffer = new byte[65536];
-                var segment = new ArraySegment<byte>(buffer, 0, buffer.Length);
                 WebSocketReceiveResult recvResult;
                 using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
                 {
-                    recvResult = await cws.ReceiveAsync(segment, cts.Token);
+                    recvResult = await ReceiveEntireMessageAsync(cws, new ArraySegment<byte>(buffer), cts.Token);
                 }
 
                 Assert.Equal(WebSocketMessageType.Text, recvResult.MessageType);
-                string headers = WebSocketData.GetTextFromBuffer(segment);
+                string headers = WebSocketData.GetTextFromBuffer(new ArraySegment<byte>(buffer, 0, recvResult.Count));
                 Assert.True(headers.Contains("X-CustomHeader1:Value1"));
                 Assert.True(headers.Contains("X-CustomHeader2:Value2"));
 
@@ -114,15 +113,14 @@ namespace System.Net.WebSockets.Client.Tests
                 Assert.Equal(WebSocketState.Open, cws.State);
 
                 byte[] buffer = new byte[65536];
-                var segment = new ArraySegment<byte>(buffer, 0, buffer.Length);
                 WebSocketReceiveResult recvResult;
                 using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
                 {
-                    recvResult = await cws.ReceiveAsync(segment, cts.Token);
+                    recvResult = await ReceiveEntireMessageAsync(cws, new ArraySegment<byte>(buffer), cts.Token);
                 }
 
                 Assert.Equal(WebSocketMessageType.Text, recvResult.MessageType);
-                string headers = WebSocketData.GetTextFromBuffer(segment);
+                string headers = WebSocketData.GetTextFromBuffer(new ArraySegment<byte>(buffer, 0, recvResult.Count));
                 Assert.Contains($"Host:{logicalHost}", headers, StringComparison.Ordinal);
 
                 await cws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
@@ -161,15 +159,14 @@ namespace System.Net.WebSockets.Client.Tests
                 Assert.Equal(WebSocketState.Open, cws.State);
 
                 byte[] buffer = new byte[65536];
-                var segment = new ArraySegment<byte>(buffer);
                 WebSocketReceiveResult recvResult;
                 using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
                 {
-                    recvResult = await cws.ReceiveAsync(segment, cts.Token);
+                    recvResult = await ReceiveEntireMessageAsync(cws, new ArraySegment<byte>(buffer), cts.Token);
                 }
 
                 Assert.Equal(WebSocketMessageType.Text, recvResult.MessageType);
-                string headers = WebSocketData.GetTextFromBuffer(segment);
+                string headers = WebSocketData.GetTextFromBuffer(new ArraySegment<byte>(buffer, 0, recvResult.Count));
 
                 Assert.True(headers.Contains("Cookies=Are Yummy"));
                 Assert.True(headers.Contains("Especially=Chocolate Chip"));

--- a/src/System.Net.WebSockets.Client/tests/KeepAliveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/KeepAliveTest.cs
@@ -21,11 +21,11 @@ namespace System.Net.WebSockets.Client.Tests
         [OuterLoop] // involves long delay
         public async Task KeepAlive_LongDelayBetweenSendReceives_Succeeds()
         {
-            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(System.Net.Test.Common.Configuration.WebSockets.RemoteEchoServer, TimeOutMilliseconds, _output, TimeSpan.FromSeconds(10)))
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(System.Net.Test.Common.Configuration.WebSockets.RemoteEchoServer, TimeOutMilliseconds, _output, TimeSpan.FromSeconds(1)))
             {
                 await cws.SendAsync(new ArraySegment<byte>(new byte[1] { 42 }), WebSocketMessageType.Binary, true, CancellationToken.None);
 
-                await Task.Delay(TimeSpan.FromSeconds(60));
+                await Task.Delay(TimeSpan.FromSeconds(10));
 
                 byte[] receiveBuffer = new byte[1];
                 Assert.Equal(1, (await cws.ReceiveAsync(new ArraySegment<byte>(receiveBuffer), CancellationToken.None)).Count);


### PR DESCRIPTION
ClientWebSocket's managed implementation currently has its own basic Socket-based code for establishing a websocket connection.  This change switches it to use ManagedHandler instead, and in doing so benefits from improvements made to ManagedHandler thus far and in the future.  For example, currently the managed ClientWebSocket doesn't support ClientWebSocketOptions.Proxy or ClientWebSocketOptions.Credentials, but since ManagedHandler does, now the managed ClientWebSocket does, too.

As part of this, there are several additional commits:
- Making some tweaks to how ManagedWebSocket works: not using the ArrayPool for receive buffers (doing so ends up not being particularly useful in real scenarios and ends up draining the corresponding pool bucket for other users of it), and reducing spurious completions to try to return complete received messages when possible.
- Reducing some unnecessary allocations from ClientWebSocketOptions.
- Fixing several tests that were either unreliable or super long running.

cc: @geoffkizer, @Priya91, @wfurt, @anurse 
Fixes https://github.com/dotnet/corefx/issues/23152