### PR TITLE
Cache regexes for assembly name check in DataContract

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -30,10 +30,6 @@ namespace System.Runtime.Serialization
         // this the global dictionary for data contracts introduced for multi-file.
         private static Dictionary<Type, DataContract> s_dataContracts = new Dictionary<Type, DataContract>();
 
-        // static regexes that are used again over time
-        private static readonly Regex s_simpleSRSInternalsVisibleRegex = new Regex(Globals.SimpleSRSInternalsVisiblePattern);
-        private static readonly Regex s_fullSRSInternalsVisibleRegex = new Regex(Globals.FullSRSInternalsVisiblePattern);
-
         public static Dictionary<Type, DataContract> GetDataContracts()
         {
             return s_dataContracts;
@@ -2297,8 +2293,8 @@ namespace System.Runtime.Serialization
             {
                 string internalsVisibleAttributeAssemblyName = internalsVisibleAttribute.AssemblyName;
 
-                if (s_simpleSRSInternalsVisibleRegex.IsMatch(internalsVisibleAttributeAssemblyName) ||
-                    s_fullSRSInternalsVisibleRegex.IsMatch(internalsVisibleAttributeAssemblyName))
+                if (internalsVisibleAttributeAssemblyName.Trim().Equals("System.Runtime.Serialization") ||
+                    Regex.IsMatch(internalsVisibleAttributeAssemblyName, Globals.FullSRSInternalsVisiblePattern))
                 {
                     return true;
                 }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -30,6 +30,10 @@ namespace System.Runtime.Serialization
         // this the global dictionary for data contracts introduced for multi-file.
         private static Dictionary<Type, DataContract> s_dataContracts = new Dictionary<Type, DataContract>();
 
+        // static regexes that are used again over time
+        private static readonly Regex s_simpleSRSInternalsVisibleRegex = new Regex(Globals.SimpleSRSInternalsVisiblePattern);
+        private static readonly Regex s_fullSRSInternalsVisibleRegex = new Regex(Globals.FullSRSInternalsVisiblePattern);
+
         public static Dictionary<Type, DataContract> GetDataContracts()
         {
             return s_dataContracts;
@@ -2293,8 +2297,8 @@ namespace System.Runtime.Serialization
             {
                 string internalsVisibleAttributeAssemblyName = internalsVisibleAttribute.AssemblyName;
 
-                if (Regex.IsMatch(internalsVisibleAttributeAssemblyName, Globals.SimpleSRSInternalsVisiblePattern) ||
-                    Regex.IsMatch(internalsVisibleAttributeAssemblyName, Globals.FullSRSInternalsVisiblePattern))
+                if (s_simpleSRSInternalsVisibleRegex.IsMatch(internalsVisibleAttributeAssemblyName) ||
+                    s_fullSRSInternalsVisibleRegex.IsMatch(internalsVisibleAttributeAssemblyName))
                 {
                     return true;
                 }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -896,7 +896,6 @@ namespace System.Runtime.Serialization
         //     instead of string comparison method calls in IL.)
         public static readonly string NewObjectId = string.Empty;
         public const string NullObjectId = null;
-        public const string SimpleSRSInternalsVisiblePattern = @"^[\s]*System\.Runtime\.Serialization[\s]*$";
         public const string FullSRSInternalsVisiblePattern = @"^[\s]*System\.Runtime\.Serialization[\s]*,[\s]*PublicKey[\s]*=[\s]*(?i:00240000048000009400000006020000002400005253413100040000010001008d56c76f9e8649383049f383c44be0ec204181822a6c31cf5eb7ef486944d032188ea1d3920763712ccb12d75fb77e9811149e6148e5d32fbaab37611c1878ddc19e20ef135d0cb2cff2bfec3d115810c3d9069638fe4be215dbf795861920e5ab6f7db2e2ceef136ac23d5dd2bf031700aec232f6c6b1c785b4305c123b37ab)[\s]*$";
         public const string Space = " ";
         public const string XsiPrefix = "i";


### PR DESCRIPTION
Not sure how often `IsAssemblyFriendOfSerialization(Assembly)` is being hit but it looks like at least multiple times. This PR reduces heap allocation and therefore GC pressure by "caching" two regex objects statically instead of always creating new ones for every method invocation.

@shmao I'm not familiar with the codebase. If you think the method is easily hit over 1000 times we could also add the Compiled flag to it.

cc @danmosemsft 