### PR TITLE
SSLStream : Add Async write overloads

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -189,21 +189,15 @@ internal static partial class Interop
             int retVal;
             unsafe
             {
-                MemoryHandle handle = input.Retain(true);
-                try
+                using (MemoryHandle handle = input.Retain(pin: true))
                 {
                     retVal = Ssl.SslWrite(context, (byte*)handle.PinnedPointer, input.Length);
-                }
-                finally
-                {
-                    handle.Dispose();
                 }
             }
 
             if (retVal != input.Length)
             {
-                Exception innerError;
-                errorCode = GetSslError(context, retVal, out innerError);
+                errorCode = GetSslError(context, retVal, out Exception innerError);
                 retVal = 0;
 
                 switch (errorCode)

--- a/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
@@ -288,6 +288,22 @@ namespace System.Net
             DumpBuffer(thisOrContextObject, buffer, 0, buffer.Length, memberName);
         }
 
+        /// <summary>Logs the contents of a buffer </summary>
+        /// <param name="thisOrContextObject">`this`, or another object that serves to provide context for the operation.</param>
+        /// <param name="buffer">The buffer to be logged.</param>
+        /// <param name="memberName">The calling member.</param>
+        [NonEvent]
+        public static void DumpBuffer(object thisOrContextObject, ReadOnlyMemory<byte> buffer, [CallerMemberName] string memberName = null)
+        {
+            if (IsEnabled)
+            {
+                int count = Math.Min(buffer.Length, MaxDumpSize);
+
+                byte[] slice = buffer.Slice(0, count).ToArray();
+                Log.DumpBuffer(IdOf(thisOrContextObject), memberName, slice);
+            }
+        }
+
         /// <summary>Logs the contents of a buffer.</summary>
         /// <param name="thisOrContextObject">`this`, or another object that serves to provide context for the operation.</param>
         /// <param name="buffer">The buffer to be logged.</param>

--- a/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
@@ -287,23 +287,7 @@ namespace System.Net
         {
             DumpBuffer(thisOrContextObject, buffer, 0, buffer.Length, memberName);
         }
-
-        /// <summary>Logs the contents of a buffer </summary>
-        /// <param name="thisOrContextObject">`this`, or another object that serves to provide context for the operation.</param>
-        /// <param name="buffer">The buffer to be logged.</param>
-        /// <param name="memberName">The calling member.</param>
-        [NonEvent]
-        public static void DumpBuffer(object thisOrContextObject, ReadOnlyMemory<byte> buffer, [CallerMemberName] string memberName = null)
-        {
-            if (IsEnabled)
-            {
-                int count = Math.Min(buffer.Length, MaxDumpSize);
-
-                byte[] slice = buffer.Slice(0, count).ToArray();
-                Log.DumpBuffer(IdOf(thisOrContextObject), memberName, slice);
-            }
-        }
-
+                
         /// <summary>Logs the contents of a buffer.</summary>
         /// <param name="thisOrContextObject">`this`, or another object that serves to provide context for the operation.</param>
         /// <param name="buffer">The buffer to be logged.</param>

--- a/src/System.Net.Security/System.Net.Security.sln
+++ b/src/System.Net.Security/System.Net.Security.sln
@@ -39,8 +39,8 @@ Global
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.ActiveCfg = netcoreapp-OSX-Debug|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.Build.0 = netcoreapp-OSX-Debug|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.ActiveCfg = netcoreapp-Unix-Debug|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.Build.0 = netcoreapp-Unix-Debug|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{A7488FC0-9A8F-4EF9-BC3E-C5EBA47E13F8}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU

--- a/src/System.Net.Security/System.Net.Security.sln
+++ b/src/System.Net.Security/System.Net.Security.sln
@@ -31,16 +31,16 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.ActiveCfg = netstandard-Unix-Debug|Any CPU
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.Build.0 = netstandard-Unix-Debug|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.ActiveCfg = netcoreapp-Unix-Debug|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.Build.0 = netcoreapp-Unix-Debug|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{A7488FC0-9A8F-4EF9-BC3E-C5EBA47E13F8}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU

--- a/src/System.Net.Security/System.Net.Security.sln
+++ b/src/System.Net.Security/System.Net.Security.sln
@@ -31,16 +31,16 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.ActiveCfg = netstandard-Unix-Debug|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.Build.0 = netstandard-Unix-Debug|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.ActiveCfg = netcoreapp-Unix-Debug|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.Build.0 = netcoreapp-Unix-Debug|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{A7488FC0-9A8F-4EF9-BC3E-C5EBA47E13F8}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU

--- a/src/System.Net.Security/System.Net.Security.sln
+++ b/src/System.Net.Security/System.Net.Security.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26923.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.Security.Tests", "tests\FunctionalTests\System.Net.Security.Tests.csproj", "{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -31,16 +31,16 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.ActiveCfg = netstandard-OSX-Debug|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.Build.0 = netstandard-OSX-Debug|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.ActiveCfg = netcoreapp-OSX-Debug|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.Build.0 = netcoreapp-OSX-Debug|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{A7488FC0-9A8F-4EF9-BC3E-C5EBA47E13F8}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
@@ -56,5 +56,8 @@ Global
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{A7488FC0-9A8F-4EF9-BC3E-C5EBA47E13F8} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {72DFF69F-F9E9-4112-91E8-5FC8169B6F1F}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Net.Security/System.Net.Security.sln
+++ b/src/System.Net.Security/System.Net.Security.sln
@@ -31,16 +31,16 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.ActiveCfg = netstandard-OSX-Debug|Any CPU
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.Build.0 = netstandard-OSX-Debug|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.ActiveCfg = netcoreapp-Unix-Debug|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.Build.0 = netcoreapp-Unix-Debug|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{A7488FC0-9A8F-4EF9-BC3E-C5EBA47E13F8}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -21,6 +21,7 @@
     <Compile Include="System\Net\CertificateValidationPal.cs" />
     <Compile Include="System\Net\FixedSizeReader.cs" />
     <Compile Include="System\Net\HelperAsyncResults.cs" />
+    <Compile Include="System\Net\Logging\NetEventSource.cs" />
     <Compile Include="System\Net\Security\SslStreamInternal.Adapters.cs" />
     <Compile Include="System\Net\SslStreamContext.cs" />
     <Compile Include="System\Net\Security\AuthenticatedStream.cs" />

--- a/src/System.Net.Security/src/System/Net/Logging/NetEventSource.cs
+++ b/src/System.Net.Security/src/System/Net/Logging/NetEventSource.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Tracing;
+using System.Runtime.CompilerServices;
+
+namespace System.Net
+{
+    internal sealed partial class NetEventSource : EventSource
+    {
+        /// <summary>Logs the contents of a buffer </summary>
+        /// <param name="thisOrContextObject">`this`, or another object that serves to provide context for the operation.</param>
+        /// <param name="buffer">The buffer to be logged.</param>
+        /// <param name="memberName">The calling member.</param>
+        [NonEvent]
+        public static void DumpBuffer(object thisOrContextObject, ReadOnlyMemory<byte> buffer, [CallerMemberName] string memberName = null)
+        {
+            if (IsEnabled)
+            {
+                int count = Math.Min(buffer.Length, MaxDumpSize);
+
+                byte[] slice = buffer.Slice(0, count).ToArray();
+                Log.DumpBuffer(IdOf(thisOrContextObject), memberName, slice);
+            }
+        }
+    }
+}

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -897,41 +897,20 @@ namespace System.Net.Security
                 size   -
                 output - Encrypted bytes
         --*/
-        internal SecurityStatusPal Encrypt(byte[] buffer, int offset, int size, ref byte[] output, out int resultSize)
+        internal SecurityStatusPal Encrypt(ReadOnlyMemory<byte> buffer, ref byte[] output, out int resultSize)
         {
             if (NetEventSource.IsEnabled)
             {
-                NetEventSource.Enter(this, buffer, offset, size);
-                NetEventSource.DumpBuffer(this, buffer, 0, Math.Min(buffer.Length, 128));
+                NetEventSource.Enter(this, buffer, 0, buffer.Length);
+                int eventLength = Math.Min(buffer.Length, 128);
+                NetEventSource.DumpBuffer(this, buffer.Slice(0, eventLength).ToArray(), 0, eventLength);
             }
 
             byte[] writeBuffer = output;
-
-            try
-            {
-                if (offset < 0 || offset > (buffer == null ? 0 : buffer.Length))
-                {
-                    throw new ArgumentOutOfRangeException(nameof(offset));
-                }
-
-                if (size < 0 || size > (buffer == null ? 0 : buffer.Length - offset))
-                {
-                    throw new ArgumentOutOfRangeException(nameof(size));
-                }
-
-                resultSize = 0;
-            }
-            catch (Exception e) when (!ExceptionCheck.IsFatal(e))
-            {
-                NetEventSource.Fail(this, "Arguments out of range.");
-                throw;
-            }
-
+                        
             SecurityStatusPal secStatus = SslStreamPal.EncryptMessage(
                 _securityContext,
                 buffer,
-                offset,
-                size,
                 _headerSize,
                 _trailerSize,
                 ref writeBuffer,

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -901,7 +901,7 @@ namespace System.Net.Security
         {
             if (NetEventSource.IsEnabled)
             {
-                NetEventSource.Enter(this, buffer, 0, buffer.Length);
+                NetEventSource.Enter(this, buffer, buffer.Length);
                 NetEventSource.DumpBuffer(this, buffer);
             }
 

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -902,8 +902,7 @@ namespace System.Net.Security
             if (NetEventSource.IsEnabled)
             {
                 NetEventSource.Enter(this, buffer, 0, buffer.Length);
-                int eventLength = Math.Min(buffer.Length, 128);
-                NetEventSource.DumpBuffer(this, buffer.Slice(0, eventLength).ToArray(), 0, eventLength);
+                NetEventSource.DumpBuffer(this, buffer);
             }
 
             byte[] writeBuffer = output;

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -479,10 +479,10 @@ namespace System.Net.Security
             }
         }
 
-        internal SecurityStatusPal EncryptData(byte[] buffer, int offset, int count, ref byte[] outBuffer, out int outSize)
+        internal SecurityStatusPal EncryptData(ReadOnlyMemory<byte> buffer, ref byte[] outBuffer, out int outSize)
         {
             CheckThrow(true);
-            return Context.Encrypt(buffer, offset, count, ref outBuffer, out outSize);
+            return Context.Encrypt(buffer, ref outBuffer, out outSize);
         }
 
         internal SecurityStatusPal DecryptData(byte[] buffer, ref int offset, ref int count)

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -568,7 +568,7 @@ namespace System.Net.Security
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return _sslState.SecureStream.WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken);
+            return _sslState.SecureStream.WriteAsync(buffer, offset, count, cancellationToken);
         }
 
         public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -565,5 +565,10 @@ namespace System.Net.Security
         {
             _sslState.SecureStream.EndWrite(asyncResult);
         }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _sslState.SecureStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
     }
 }

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -281,7 +281,7 @@ namespace System.Net.Security
         public virtual Task ShutdownAsync() =>
             Task.Factory.FromAsync(
                 (callback, state) => ((SslStream)state).BeginShutdown(callback, state),
-                iar => ((SslStream)iar.AsyncState).EndShutdown(iar), 
+                iar => ((SslStream)iar.AsyncState).EndShutdown(iar),
                 this);
         #endregion
 
@@ -568,7 +568,12 @@ namespace System.Net.Security
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return _sslState.SecureStream.WriteAsync(buffer, offset, count, cancellationToken);
+            return _sslState.SecureStream.WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken);
+        }
+
+        public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
+        {
+            return _sslState.SecureStream.WriteAsync(source, cancellationToken);
         }
     }
 }

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -157,7 +157,7 @@ namespace System.Net.Security
 
         internal IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
         {
-            return TaskToApm.Begin(WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), CancellationToken.None), asyncCallback, asyncState);
+            return TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
         }
 
         internal void EndWrite(IAsyncResult asyncResult) => TaskToApm.End(asyncResult);
@@ -166,6 +166,12 @@ namespace System.Net.Security
         {
             SslWriteAsync writeAdapter = new SslWriteAsync(_sslState, cancellationToken);
             return WriteAsyncInternal(writeAdapter, buffer);
+        }
+
+        internal Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateParameters(buffer, offset, count);
+            return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken);
         }
 
         private void ResetReadBuffer()

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -111,7 +111,7 @@ namespace System.Net.Security
             ValidateParameters(buffer, offset, count);
 
             SslWriteSync writeAdapter = new SslWriteSync(_sslState);
-            WriteAsyncInternal(writeAdapter, buffer, offset, count).GetAwaiter().GetResult();
+            WriteAsyncInternal(writeAdapter, new ReadOnlyMemory<byte>(buffer, offset, count)).GetAwaiter().GetResult();
         }
 
         internal IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
@@ -157,17 +157,15 @@ namespace System.Net.Security
 
         internal IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
         {
-            return TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
+            return TaskToApm.Begin(WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), CancellationToken.None), asyncCallback, asyncState);
         }
 
         internal void EndWrite(IAsyncResult asyncResult) => TaskToApm.End(asyncResult);
 
-        internal Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        internal Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
-            ValidateParameters(buffer, offset, count);
-
             SslWriteAsync writeAdapter = new SslWriteAsync(_sslState, cancellationToken);
-            return WriteAsyncInternal(writeAdapter, buffer, offset, count);
+            return WriteAsyncInternal(writeAdapter, buffer);
         }
 
         private void ResetReadBuffer()
@@ -236,12 +234,12 @@ namespace System.Net.Security
             return request;
         }
 
-        private Task WriteAsyncInternal<TWriteAdapter>(TWriteAdapter writeAdapter, byte[] buffer, int offset, int count)
+        private Task WriteAsyncInternal<TWriteAdapter>(TWriteAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
             where TWriteAdapter : struct, ISslWriteAdapter
         {
             _sslState.CheckThrow(authSuccessCheck: true, shutdownCheck: true);
 
-            if (count == 0 && !SslStreamPal.CanEncryptEmptyMessage)
+            if (buffer.Length == 0 && !SslStreamPal.CanEncryptEmptyMessage)
             {
                 // If it's an empty message and the PAL doesn't support that, we're done.
                 return Task.CompletedTask;
@@ -252,9 +250,9 @@ namespace System.Net.Security
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, nameof(WriteAsync), "write"));
             }
 
-            Task t = count < _sslState.MaxDataSize ?
-                    WriteSingleChunk(writeAdapter, buffer, offset, count) :
-                    WriteAsyncChunked(writeAdapter, buffer, offset, count);
+            Task t = buffer.Length < _sslState.MaxDataSize ?
+                    WriteSingleChunk(writeAdapter, buffer) :
+                    WriteAsyncChunked(writeAdapter, buffer);
 
             if (t.IsCompletedSuccessfully)
             {
@@ -287,7 +285,7 @@ namespace System.Net.Security
             }
         }
 
-        private Task WriteSingleChunk<TWriteAdapter>(TWriteAdapter writeAdapter, byte[] buffer, int offset, int count)
+        private Task WriteSingleChunk<TWriteAdapter>(TWriteAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
             where TWriteAdapter : struct, ISslWriteAdapter
         {
             // Request a write IO slot.
@@ -295,13 +293,13 @@ namespace System.Net.Security
             if (!ioSlot.IsCompletedSuccessfully)
             {
                 // Operation is async and has been queued, return.
-                return WaitForWriteIOSlot(writeAdapter, ioSlot, buffer, offset, count);
+                return WaitForWriteIOSlot(writeAdapter, ioSlot, buffer);
             }
 
-            byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(count + FrameOverhead);
+            byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length + FrameOverhead);
             byte[] outBuffer = rentedBuffer;
 
-            SecurityStatusPal status = _sslState.EncryptData(buffer, offset, count, ref outBuffer, out int encryptedBytes);
+            SecurityStatusPal status = _sslState.EncryptData(buffer, ref outBuffer, out int encryptedBytes);
 
             if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
             {
@@ -323,10 +321,10 @@ namespace System.Net.Security
                 return CompleteAsync(t, rentedBuffer);
             }
 
-            async Task WaitForWriteIOSlot(TWriteAdapter wAdapter, Task lockTask, byte[] buff, int off, int c)
+            async Task WaitForWriteIOSlot(TWriteAdapter wAdapter, Task lockTask, ReadOnlyMemory<byte> buff)
             {
                 await lockTask.ConfigureAwait(false);
-                await WriteSingleChunk(wAdapter, buff, off, c).ConfigureAwait(false);
+                await WriteSingleChunk(wAdapter, buff).ConfigureAwait(false);
             }
 
             async Task CompleteAsync(Task writeTask, byte[] bufferToReturn)
@@ -343,17 +341,16 @@ namespace System.Net.Security
             }
         }
 
-        private async Task WriteAsyncChunked<TWriteAdapter>(TWriteAdapter writeAdapter, byte[] buffer, int offset, int count)
+        private async Task WriteAsyncChunked<TWriteAdapter>(TWriteAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
             where TWriteAdapter : struct, ISslWriteAdapter
         {
             do
             {
-                int chunkBytes = Math.Min(count, _sslState.MaxDataSize);
-                await WriteSingleChunk(writeAdapter, buffer, offset, chunkBytes).ConfigureAwait(false);
-                offset += chunkBytes;
-                count -= chunkBytes;
+                int chunkBytes = Math.Min(buffer.Length, _sslState.MaxDataSize);
+                await WriteSingleChunk(writeAdapter, buffer.Slice(0, chunkBytes)).ConfigureAwait(false);
+                buffer = buffer.Slice(chunkBytes);
 
-            } while (count != 0);
+            } while (buffer.Length != 0);
         }
 
         // Fill the buffer up to the minimum specified size (or more, if possible).

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -2,14 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
 
-using PAL_TlsHandshakeState=Interop.AppleCrypto.PAL_TlsHandshakeState;
-using PAL_TlsIo=Interop.AppleCrypto.PAL_TlsIo;
+using PAL_TlsHandshakeState = Interop.AppleCrypto.PAL_TlsHandshakeState;
+using PAL_TlsIo = Interop.AppleCrypto.PAL_TlsIo;
 
 namespace System.Net.Security
 {
@@ -76,9 +77,7 @@ namespace System.Net.Security
 
         public static SecurityStatusPal EncryptMessage(
             SafeDeleteContext securityContext,
-            byte[] input,
-            int offset,
-            int size,
+            ReadOnlyMemory<byte> input,
             int headerSize,
             int trailerSize,
             ref byte[] output,
@@ -86,7 +85,7 @@ namespace System.Net.Security
         {
             resultSize = 0;
 
-            Debug.Assert(size > 0, $"{nameof(size)} > 0 since {nameof(CanEncryptEmptyMessage)} is false");
+            Debug.Assert(input.Length > 0, $"{nameof(input.Length)} > 0 since {nameof(CanEncryptEmptyMessage)} is false");
 
             try
             {
@@ -95,10 +94,11 @@ namespace System.Net.Security
 
                 unsafe
                 {
-                    fixed (byte* offsetInput = &input[offset])
+                    MemoryHandle memHandle = input.Retain(true);
+                    try
                     {
                         int written;
-                        PAL_TlsIo status = Interop.AppleCrypto.SslWrite(sslHandle, offsetInput, size, out written);
+                        PAL_TlsIo status = Interop.AppleCrypto.SslWrite(sslHandle, (byte*)memHandle.PinnedPointer, input.Length, out written);
 
                         if (status < 0)
                         {
@@ -127,6 +127,10 @@ namespace System.Net.Security
                                 Debug.Fail($"Unknown status value: {status}");
                                 return new SecurityStatusPal(SecurityStatusPalErrorCode.InternalError);
                         }
+                    }
+                    finally
+                    {
+                        memHandle.Dispose();
                     }
                 }
             }

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -94,11 +94,10 @@ namespace System.Net.Security
 
                 unsafe
                 {
-                    MemoryHandle memHandle = input.Retain(true);
+                    MemoryHandle memHandle = input.Retain(pin: true);
                     try
                     {
-                        int written;
-                        PAL_TlsIo status = Interop.AppleCrypto.SslWrite(sslHandle, (byte*)memHandle.PinnedPointer, input.Length, out written);
+                        PAL_TlsIo status = Interop.AppleCrypto.SslWrite(sslHandle, (byte*)memHandle.PinnedPointer, input.Length, out int written);
 
                         if (status < 0)
                         {

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -53,9 +53,9 @@ namespace System.Net.Security
             return new SafeFreeSslCredentials(certificate, protocols, policy);
         }
 
-        public static SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, byte[] input, int offset, int size, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
+        public static SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, ReadOnlyMemory<byte> input, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
         {
-            return EncryptDecryptHelper(securityContext, input, offset, size, true, ref output, out resultSize);
+            return EncryptDecryptHelper(securityContext, input, true, ref output, out resultSize);
         }
 
         public static SecurityStatusPal DecryptMessage(SafeDeleteContext securityContext, byte[] buffer, ref int offset, ref int count)

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeAuthenticatedStream.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeAuthenticatedStream.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Security
 {
@@ -30,6 +32,8 @@ namespace System.Net.Security
         public abstract bool IsEncrypted { get; }
         public abstract bool IsSigned { get; }
         public abstract bool IsServer { get; }
+
+        public abstract Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token);
     }
 }
 

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
@@ -268,8 +268,8 @@ namespace System.Net.Security
         {
             throw new NotImplementedException();
         }
-
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                
+        public Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Added Async overloads on the write side. This includes a ReadOnlyMemory overload. This required a pushing of readonly memory right through the layers. 

This is in the effort to simplify and remove old code from SslStream and modernise the internals. It vastly simplifies the chained method calls, (byte[] buffer, int offset, int count becomes ReadOnlyMemory<byte> buffer).

It also removes a lot of duplicated bounds checks because it's taken care of in the memory struct.

If the changes look close to good I will be happy to start the benchmarking process.

Cheers

Tim