### PR TITLE
Don't update runtime.*.json during the build

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/readme.md
+++ b/pkg/Microsoft.NETCore.Platforms/readme.md
@@ -100,7 +100,7 @@ For example:
 
 This will create a new RID for `myLinuxDistro` where `myLinuxDistro` should be the string used for the `ID=` value in the `/etc/os-release` file.
 
-Whenever modifying the `runtimeGroups.props` you should rebuild the project so that your changes will be regenerated in the checked-in `runtime.json`.
+Whenever modifying the `runtimeGroups.props` you should rebuild the project with `/p:UpdateRuntimeFiles=true` so that your changes will be regenerated in the checked-in `runtime.json`.
 
 RuntimeGroup items have the following format:
 - `Identity`: the base string for the RID, without version architecture, or qualifiers.

--- a/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -140,14 +140,15 @@
     </RuntimeGroupWithQualifiers>
   </ItemGroup>
 
-  <Target Name="GenerateRuntimeJson">
-    <!-- Note that we intentionally modify the runtime*json that is under source control.
-         We want to keep this up to date in source control so that we can see the diff in the 
-         runtime.json over time as changes are made to RuntimeGroups. -->
+  <Target Name="GenerateRuntimeJson" BeforeTargets="CreatePackage">
+    <!-- Generates a Runtime graph using RuntimeGroups and diffs it with the graph described by runtime.json and runtime.compatibility.json
+         Specifying UpdateRuntimeFiles=true skips the diff and updates those files.
+         The graph can be visualized using the generated dmgl -->
     <MakeDir Directories="$(PackageReportDir)" />
     <GenerateRuntimeGraph RuntimeGroups="@(RuntimeGroupWithQualifiers)"
                           RuntimeJson="runtime.json"
                           CompatibilityMap="runtime.compatibility.json"
-                          RuntimeDirectedGraph="$(PackageReportDir)$(Id)$(NuspecSuffix)-runtime.json.dgml" />
+                          RuntimeDirectedGraph="$(PackageReportDir)$(Id)$(NuspecSuffix)-runtime.json.dgml"
+                          UpdateRuntimeFiles="$(UpdateRuntimeFiles)" />
   </Target>
 </Project>


### PR DESCRIPTION
This was breaking for folks that attrib -r their source directories.

I was also noticing breaks in the builds where other packages were reading the
runtime.json from source for asset applicability testing at the same time we
were writing the file, resulting in a sharing violation.

Finally it is easy to miss checking in a file that you didn't
update yourself, and there was nothing in the build forcing folks
to check in the updated generated files.

To handle these cases I've changed the generated file to be written to the
intermediate directory.  I've added a target that checks that the generated
file matches the checked in file, and fails if they are out of sync.  In that
case the developer needs to run msbuild /t:UpdateRuntimeJson.

Fixes #24303 

/cc @AtsushiKan @stephentoub @weshaggard 

I'm hoping my method for diff-ing the file is good enough and can deal 
with different line endings (it depends on whether or not the Json writer uses 
the same defaults as the git client).  If not I'll need to make a change on the
buildtools side to honor the source encoding/line-endings in order to get a
clean diff.  It should fail CI if its broken.