### PR TITLE
Port clean-up of CreateFileW

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
+++ b/src/System.IO.FileSystem.Watcher/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
@@ -1,3 +1,0 @@
-## need to create a uap config that uses CreateFileFromApp, then remove this baseline ##
-# https://github.com/dotnet/corefx/issues/21025
-kernel32.dll!CreateFileW

--- a/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -41,9 +41,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateFile.cs">
-      <Link>Common\Interop\Windows\kernel32\Interop.CreateFile.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.BOOL.cs">
       <Link>Common\Interop\Windows\Interop.BOOL.cs</Link>
     </Compile>
@@ -57,6 +54,30 @@
       <Link>Common\Interop\Windows\kernel32\Interop.ReadDirectoryChangesW.cs</Link>
     </Compile>
     <Compile Include="System\IO\FileSystemWatcher.Win32.cs" />
+  </ItemGroup>
+  <!-- Windows : Win32 only -->
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(TargetGroup)' != 'uap'">
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.UnsafeCreateFile.cs">
+      <Link>Common\Interop\Windows\Interop.UnsafeCreateFile.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateFile.cs">
+      <Link>Common\Interop\Windows\Interop.CreateFile.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Windows : UAP - Win32 + WinRT -->
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(TargetGroup)' == 'uap'">
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateFile2.cs">
+      <Link>Common\Interop\Windows\Interop.CreateFile2.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.UnsafeCreateFile.uap.cs">
+      <Link>Common\Interop\Windows\Interop.UnsafeCreateFile.uap.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.COPYFILE2_EXTENDED_PARAMETERS.cs">
+      <Link>Common\Interop\Windows\Interop.COPYFILE2_EXTENDED_PARAMETERS.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CREATEFILE2_EXTENDED_PARAMETERS.cs">
+      <Link>Common\Interop\Windows\Interop.CREATEFILE2_EXTENDED_PARAMETERS.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -27,7 +27,7 @@ namespace System.IO
 
             // Create handle to directory being monitored
             var defaultSecAttrs = default(Interop.Kernel32.SECURITY_ATTRIBUTES);
-            _directoryHandle = Interop.Kernel32.CreateFile(
+            _directoryHandle = Interop.Kernel32.UnsafeCreateFile(
                 lpFileName: _directory,
                 dwDesiredAccess: Interop.Kernel32.FileOperations.FILE_LIST_DIRECTORY,
                 dwShareMode: FileShare.Read | FileShare.Delete | FileShare.Write,

--- a/src/System.IO.Pipes/src/PinvokeAnalyzerExceptionList.analyzerdata
+++ b/src/System.IO.Pipes/src/PinvokeAnalyzerExceptionList.analyzerdata
@@ -1,3 +1,0 @@
-## need to create a uap config that uses CreateFileFromApp, then remove this baseline ##
-# https://github.com/dotnet/corefx/issues/21025
-kernel32.dll!CreateFileW

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -95,9 +95,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetNamedPipeInfo.cs">
       <Link>Common\Interop\Windows\Interop.GetNamedPipeInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateNamedPipeClient.cs">
-      <Link>Common\Interop\Windows\Interop.CreateNamedPipeClient.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetNamedPipeHandleState.cs">
       <Link>Common\Interop\Windows\Interop.SetNamedPipeHandleState.cs</Link>
     </Compile>
@@ -145,6 +142,21 @@
     <Compile Include="System\IO\Pipes\PipeCompletionSource.cs" />
     <Compile Include="System\IO\Pipes\PipeStream.Windows.cs" />
     <Compile Include="System\IO\Pipes\ReadWriteCompletionSource.cs" />
+  </ItemGroup>
+  <!-- Windows : Win32 only -->
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(TargetGroup)' != 'uap'">
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateNamedPipeClient.cs">
+      <Link>Common\Interop\Windows\Interop.CreateNamedPipeClient.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Windows : UAP - Win32 + WinRT -->
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(TargetGroup)' == 'uap'">
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateNamedPipeClient.Uap.cs">
+      <Link>Common\Interop\Windows\Interop.CreateNamedPipeClient.Uap.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CREATEFILE2_EXTENDED_PARAMETERS.cs">
+      <Link>Common\Interop\Windows\Interop.CREATEFILE2_EXTENDED_PARAMETERS.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="Microsoft\Win32\SafeHandles\SafePipeHandle.Unix.cs" />

--- a/src/System.IO.Ports/src/PinvokeAnalyzerExceptionList.analyzerdata
+++ b/src/System.IO.Ports/src/PinvokeAnalyzerExceptionList.analyzerdata
@@ -1,3 +1,0 @@
-## need to create a uap config that uses CreateFileFromApp, then remove this baseline ##
-# https://github.com/dotnet/corefx/issues/21025
-kernel32.dll!CreateFileW

--- a/src/System.IO.Ports/src/PinvokeAnalyzerExceptionList.analyzerdata.netstandard
+++ b/src/System.IO.Ports/src/PinvokeAnalyzerExceptionList.analyzerdata.netstandard
@@ -1,0 +1,2 @@
+# not available in OneCore
+kernel32.dll!CreateFileW

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -85,9 +85,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WaitCommEvent.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.WaitCommEvent.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateFile.cs">
-      <Link>Common\Interop\Windows\kernel32\Interop.CreateFile.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs</Link>
     </Compile>
@@ -132,6 +129,11 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.BOOL.cs">
       <Link>Common\Interop\Windows\Interop.BOOL.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'uap' and '$(TargetsWindows)' == 'true'">
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateFile.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.CreateFile.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uap'">

--- a/src/System.Runtime.Extensions/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
+++ b/src/System.Runtime.Extensions/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
@@ -1,1 +1,0 @@
-shell32.dll!SHGetKnownFolderPath

--- a/src/System.Runtime.Extensions/src/PinvokeAnalyzerExceptionList.analyzerdata.uapaot
+++ b/src/System.Runtime.Extensions/src/PinvokeAnalyzerExceptionList.analyzerdata.uapaot
@@ -1,1 +1,0 @@
-shell32.dll!SHGetKnownFolderPath


### PR DESCRIPTION
* Removing CreateFileW from UWP

* CR: move conditional to its own ItemGroup

* removed pinvoke exceptions for Runtime.Extensions

* Fixed condition for CreateFile ItemGroup

* exception still needed for netstandard