### PR TITLE
Add more parameters support in SGEN.

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -29,8 +29,8 @@ namespace Microsoft.XmlSerializer.Generator
             bool force = false;
             bool proxyOnly = false;
             bool disableRun = true;
-            bool nologo = false;
-            bool parsableerrors = false;
+            bool noLogo = false;
+            bool parsableErrors = false;
             bool silent = false;
             bool warnings = false;
 
@@ -96,7 +96,7 @@ namespace Microsoft.XmlSerializer.Generator
                     }
                     else if (ArgumentMatch(arg, "nologo"))
                     {
-                        nologo = true;
+                        noLogo = true;
                     }
                     else if (ArgumentMatch(arg, "silent"))
                     {
@@ -104,7 +104,7 @@ namespace Microsoft.XmlSerializer.Generator
                     }
                     else if (ArgumentMatch(arg, "parsableerrors"))
                     {
-                        parsableerrors = true;
+                        parsableErrors = true;
                     }
                     else if (ArgumentMatch(arg, "verbose"))
                     {
@@ -128,7 +128,7 @@ namespace Microsoft.XmlSerializer.Generator
                     }
                 }
 
-                if (!nologo)
+                if (!noLogo)
                 {
                     WriteHeader();
                 }
@@ -137,7 +137,7 @@ namespace Microsoft.XmlSerializer.Generator
                 {
                     foreach (string err in errs)
                     {
-                        Console.Error.WriteLine(FormatMessage(parsableerrors, true, SR.Format(SR.Warning, err)));
+                        Console.Error.WriteLine(FormatMessage(parsableErrors, true, SR.Format(SR.Warning, err)));
                     }
                 }
 
@@ -145,7 +145,7 @@ namespace Microsoft.XmlSerializer.Generator
                 {
                     if (assembly == null)
                     {
-                        Console.Error.WriteLine(FormatMessage(parsableerrors, false, SR.Format(SR.ErrMissingRequiredArgument, SR.Format(SR.ErrAssembly, "assembly"))));
+                        Console.Error.WriteLine(FormatMessage(parsableErrors, false, SR.Format(SR.ErrMissingRequiredArgument, SR.Format(SR.ErrAssembly, "assembly"))));
                     }
 
                     WriteHelp();
@@ -159,7 +159,7 @@ namespace Microsoft.XmlSerializer.Generator
                     return 0;
                 }
 
-                GenerateFile(types, assembly, proxyOnly, silent, warnings, force, codePath, parsableerrors);
+                GenerateFile(types, assembly, proxyOnly, silent, warnings, force, codePath, parsableErrors);
             }
             catch (Exception e)
             {
@@ -168,7 +168,7 @@ namespace Microsoft.XmlSerializer.Generator
                     throw;
                 }
 
-                WriteError(e, parsableerrors);
+                WriteError(e, parsableErrors);
                 return 1;
             }
 

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -29,6 +29,10 @@ namespace Microsoft.XmlSerializer.Generator
             bool force = false;
             bool proxyOnly = false;
             bool disableRun = true;
+            bool nologo = false;
+            bool parsableerrors = false;
+            bool silent = false;
+            bool warnings = false;
 
             try
             {
@@ -90,6 +94,22 @@ namespace Microsoft.XmlSerializer.Generator
                     {
                         disableRun = false;
                     }
+                    else if (ArgumentMatch(arg, "nologo"))
+                    {
+                        nologo = true;
+                    }
+                    else if (ArgumentMatch(arg, "silent"))
+                    {
+                        silent = true;
+                    }
+                    else if (ArgumentMatch(arg, "parsableerrors"))
+                    {
+                        parsableerrors = true;
+                    }
+                    else if (ArgumentMatch(arg, "verbose"))
+                    {
+                        warnings = true;
+                    }
                     else
                     {
                         if (arg.EndsWith(".dll") || arg.EndsWith(".exe"))
@@ -108,11 +128,16 @@ namespace Microsoft.XmlSerializer.Generator
                     }
                 }
 
+                if (!nologo)
+                {
+                    WriteHeader();
+                }
+
                 if (errs.Count > 0)
                 {
                     foreach (string err in errs)
                     {
-                        Console.Error.WriteLine(FormatMessage(true, SR.Format(SR.Warning, err)));
+                        Console.Error.WriteLine(FormatMessage(parsableerrors, true, SR.Format(SR.Warning, err)));
                     }
                 }
 
@@ -120,7 +145,7 @@ namespace Microsoft.XmlSerializer.Generator
                 {
                     if (assembly == null)
                     {
-                        Console.Error.WriteLine(FormatMessage(false, SR.Format(SR.ErrMissingRequiredArgument, SR.Format(SR.ErrAssembly, "assembly"))));
+                        Console.Error.WriteLine(FormatMessage(parsableerrors, false, SR.Format(SR.ErrMissingRequiredArgument, SR.Format(SR.ErrAssembly, "assembly"))));
                     }
 
                     WriteHelp();
@@ -130,12 +155,11 @@ namespace Microsoft.XmlSerializer.Generator
                 if(disableRun)
                 {
                     Console.WriteLine("This tool is not intended to be used directly.");
-                    Console.WriteLine("The feature is still under development.");
-                    Console.WriteLine("Please refer to https://go.microsoft.com/fwlink/?linkid=858539 for more detail.");
+                    Console.WriteLine("Please refer to https://github.com/dotnet/core/blob/master/samples/xmlserializergenerator-instructions.md on how to use it.");
                     return 0;
                 }
 
-                GenerateFile(types, assembly, proxyOnly, force, codePath);
+                GenerateFile(types, assembly, proxyOnly, silent, warnings, force, codePath, parsableerrors);
             }
             catch (Exception e)
             {
@@ -144,14 +168,14 @@ namespace Microsoft.XmlSerializer.Generator
                     throw;
                 }
 
-                WriteError(e);
+                WriteError(e, parsableerrors);
                 return 1;
             }
 
             return 0;
         }
 
-        private void GenerateFile(List<string> typeNames, string assemblyName, bool proxyOnly, bool force, string outputDirectory)
+        private void GenerateFile(List<string> typeNames, string assemblyName, bool proxyOnly, bool silent, bool warnings, bool force, string outputDirectory, bool parsableerrors)
         {
             Assembly assembly = LoadAssembly(assemblyName, true);
             Type[] types;
@@ -185,7 +209,7 @@ namespace Microsoft.XmlSerializer.Generator
                     Type type = assembly.GetType(typeName);
                     if (type == null)
                     {
-                        Console.Error.WriteLine(FormatMessage(false, SR.Format(SR.ErrorDetails, SR.Format(SR.ErrLoadType, typeName, assemblyName))));
+                        Console.Error.WriteLine(FormatMessage(parsableerrors, false, SR.Format(SR.ErrorDetails, SR.Format(SR.ErrLoadType, typeName, assemblyName))));
                     }
 
                     types[typeIndex++] = type;
@@ -221,7 +245,7 @@ namespace Microsoft.XmlSerializer.Generator
 
                 if (!proxyOnly)
                 {
-                    ImportType(type, mappings, importedTypes, importer);
+                    ImportType(type, mappings, importedTypes, warnings, importer, parsableerrors);
                 }
             }
 
@@ -281,17 +305,20 @@ namespace Microsoft.XmlSerializer.Generator
 
                 if (success)
                 {
-                    Console.Out.WriteLine(SR.Format(SR.InfoFileName, codePath));
-                    Console.Out.WriteLine(SR.Format(SR.InfoGeneratedFile, assembly.Location, codePath));
+                    if (!silent)
+                    {
+                        Console.Out.WriteLine(SR.Format(SR.InfoFileName, codePath));
+                        Console.Out.WriteLine(SR.Format(SR.InfoGeneratedFile, assembly.Location, codePath));
+                    }
                 }
                 else
                 {
-                    Console.Out.WriteLine(FormatMessage(false, SR.Format(SR.ErrGenerationFailed, assembly.Location)));
+                    Console.Out.WriteLine(FormatMessage(parsableerrors, false, SR.Format(SR.ErrGenerationFailed, assembly.Location)));
                 }
             }
             else
             {
-                Console.Out.WriteLine(FormatMessage(true, SR.Format(SR.InfoNoSerializableTypes, assembly.Location)));
+                Console.Out.WriteLine(FormatMessage(parsableerrors, true, SR.Format(SR.InfoNoSerializableTypes, assembly.Location)));
             }
         }
 
@@ -307,7 +334,7 @@ namespace Microsoft.XmlSerializer.Generator
             return (arg == formal || (arg.Length == 1 && arg[0] == formal[0]));
         }
 
-        private void ImportType(Type type, ArrayList mappings, ArrayList importedTypes, XmlReflectionImporter importer)
+        private void ImportType(Type type, ArrayList mappings, ArrayList importedTypes, bool verbose, XmlReflectionImporter importer, bool parsableerrors)
         {
             XmlTypeMapping xmlTypeMapping = null;
             var localImporter = new XmlReflectionImporter();
@@ -321,6 +348,13 @@ namespace Microsoft.XmlSerializer.Generator
                 {
                     throw;
                 }
+
+                if (verbose)
+                {
+                    Console.Out.WriteLine(FormatMessage(parsableerrors, true, SR.Format(SR.InfoIgnoreType, type.FullName)));
+                    WriteWarning(e, parsableerrors);
+                }
+
                 return;
             }
             if (xmlTypeMapping != null)
@@ -366,22 +400,36 @@ namespace Microsoft.XmlSerializer.Generator
             Console.Out.WriteLine(SR.Format(SR.HelpHelp, "/?", "/help"));
         }
 
-        private static string FormatMessage(bool warning, string message)
+        private static string FormatMessage(bool parsableerrors, bool warning, string message)
         {
-            return FormatMessage(warning, "SGEN1", message);
+            return FormatMessage(parsableerrors, warning, "SGEN1", message);
         }
 
-        private static string FormatMessage(bool warning, string code, string message)
+        private static string FormatMessage(bool parsableerrors, bool warning, string code, string message)
         {
+            if (!parsableerrors)
+            {
+                return message;
+            }
+
             return "SGEN: " + (warning ? "warning " : "error ") + code + ": " + message;
         }
 
-        private static void WriteError(Exception e)
+        private static void WriteError(Exception e, bool parsableerrors)
         {
-            Console.Error.WriteLine(FormatMessage(false, e.Message));
+            Console.Error.WriteLine(FormatMessage(parsableerrors, false, e.Message));
             if (e.InnerException != null)
             {
-                WriteError(e.InnerException);
+                WriteError(e.InnerException, parsableerrors);
+            }
+        }
+
+        static void WriteWarning(Exception e, bool parsableerrors)
+        {
+            Console.Out.WriteLine(FormatMessage(parsableerrors, true, e.Message));
+            if (e.InnerException != null)
+            {
+                WriteWarning(e.InnerException, parsableerrors);
             }
         }
     }

--- a/src/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/System.Private.Xml/src/Resources/Strings.resx
@@ -3399,6 +3399,9 @@
   <data name="InfoNoSerializableTypes" xml:space="preserve">
     <value>Assembly '{0}' does not contain any types that can be serialized using XmlSerializer.</value>
   </data>
+  <data name="InfoIgnoreType" xml:space="preserve">
+    <value>Ignoring '{0}'.</value>
+  </data>
   <data name="FailLoadAssemblyUnderPregenMode" xml:space="preserve">
     <value>"Fail to load assembly {0} or {0} doesn't exist under PreGen Mode.</value>
   </data>


### PR DESCRIPTION
Add following four parameters.

nologo - Prevents displaying of logo.
silent - Prevents displaying of success messages.
verbose - List types from the target assembly that cannot be serialized. This is related to #22938
parsableerrors - Print errors in a format similar to those reported by compilers.

Fix #22931 
Fix #22938

@shmao @zhenlan @mconnew 