### PR TITLE
Adding MemoryHandle AddOffset to fix Memory.Retain impl

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -178,7 +178,8 @@ namespace System.Buffers
     {
         public MemoryHandle(IRetainable owner, void* pinnedPointer = null,  System.Runtime.InteropServices.GCHandle handle = default(System.Runtime.InteropServices.GCHandle))  { throw null; }
         public void* PinnedPointer { get { throw null; } }
-        public void Dispose()  { throw null; }
+        public void AddOffset(int offset) { throw null; }
+        public void Dispose() { throw null; }
     }
 
     public interface IRetainable 

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -178,7 +178,7 @@ namespace System.Buffers
     {
         public MemoryHandle(IRetainable owner, void* pinnedPointer = null,  System.Runtime.InteropServices.GCHandle handle = default(System.Runtime.InteropServices.GCHandle))  { throw null; }
         public void* PinnedPointer { get { throw null; } }
-        public void AddOffset(int offset) { throw null; }
+        internal void AddOffset(int offset) { throw null; }
         public void Dispose() { throw null; }
     }
 

--- a/src/System.Memory/src/System/Buffers/MemoryHandle.cs
+++ b/src/System.Memory/src/System/Buffers/MemoryHandle.cs
@@ -40,7 +40,7 @@ namespace System.Buffers
         /// <exception cref="System.ArgumentNullException">
         /// Throw when pinned pointer is null.
         /// </exception>
-        public void AddOffset(int offset)
+        internal void AddOffset(int offset)
         {
             if (_pointer == null)
             {

--- a/src/System.Memory/src/System/Buffers/MemoryHandle.cs
+++ b/src/System.Memory/src/System/Buffers/MemoryHandle.cs
@@ -35,6 +35,24 @@ namespace System.Buffers
         public void* PinnedPointer => _pointer;
 
         /// <summary>
+        /// Adds an offset to the pinned pointer.
+        /// </summary>
+        /// <exception cref="System.ArgumentNullException">
+        /// Throw when pinned pointer is null.
+        /// </exception>
+        public void AddOffset(int offset)
+        {
+            if (_pointer == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.pointer);
+            }
+            else
+            {
+                _pointer = (void*)((byte*)_pointer + offset);
+            }
+        }
+
+        /// <summary>
         /// Frees the pinned handle and releases IRetainable.
         /// </summary>
         public void Dispose()

--- a/src/System.Memory/src/System/Memory.cs
+++ b/src/System.Memory/src/System/Memory.cs
@@ -193,6 +193,7 @@ namespace System
                 if (_index < 0)
                 {
                     memoryHandle = ((OwnedMemory<T>)_arrayOrOwnedMemory).Pin();
+                    memoryHandle.AddOffset((_index & RemoveOwnedFlagBitMask) * Unsafe.SizeOf<T>());
                 }
                 else
                 {

--- a/src/System.Memory/src/System/ReadOnlyMemory.cs
+++ b/src/System.Memory/src/System/ReadOnlyMemory.cs
@@ -178,6 +178,7 @@ namespace System
                 if (_index < 0)
                 {
                     memoryHandle = ((OwnedMemory<T>)_arrayOrOwnedMemory).Pin();
+                    memoryHandle.AddOffset((_index & RemoveOwnedFlagBitMask) * Unsafe.SizeOf<T>());
                 }
                 else
                 {

--- a/src/System.Memory/src/System/ThrowHelper.cs
+++ b/src/System.Memory/src/System/ThrowHelper.cs
@@ -63,6 +63,7 @@ namespace System
         start,
         text,
         obj,
-        ownedMemory
+        ownedMemory,
+        pointer
     }
 }

--- a/src/System.Memory/tests/Memory/Retain.cs
+++ b/src/System.Memory/tests/Memory/Retain.cs
@@ -46,6 +46,34 @@ namespace System.MemoryTests
         }
 
         [Fact]
+        public static void MemoryRetainWithPinningAndSlice()
+        {
+            int[] array = { 1, 2, 3, 4, 5 };
+            Memory<int> memory = array;
+            memory = memory.Slice(1);
+            MemoryHandle handle = memory.Retain(pin: true);
+            Span<int> span = memory.Span;
+            unsafe
+            {
+                int* pointer = (int*)handle.PinnedPointer;
+                Assert.True(pointer != null);
+
+                GC.Collect();
+
+                for (int i = 0; i < memory.Length; i++)
+                {
+                    Assert.Equal(array[i + 1], pointer[i]);
+                }
+
+                for (int i = 0; i < memory.Length; i++)
+                {
+                    Assert.Equal(array[i + 1], span[i]);
+                }
+            }
+            handle.Dispose();
+        }
+
+        [Fact]
         public static void OwnedMemoryRetainWithoutPinning()
         {
             int[] array = { 1, 2, 3, 4, 5 };
@@ -77,6 +105,34 @@ namespace System.MemoryTests
                 for (int i = 0; i < memory.Length; i++)
                 {
                     Assert.Equal(array[i], pointer[i]);
+                }
+            }
+            handle.Dispose();
+        }
+
+        [Fact]
+        public static void OwnedMemoryRetainWithPinningAndSlice()
+        {
+            int[] array = { 1, 2, 3, 4, 5 };
+            OwnedMemory<int> owner = new CustomMemoryForTest<int>(array);
+            Memory<int> memory = owner.Memory.Slice(1);
+            MemoryHandle handle = memory.Retain(pin: true);
+            Span<int> span = memory.Span;
+            unsafe
+            {
+                int* pointer = (int*)handle.PinnedPointer;
+                Assert.True(pointer != null);
+
+                GC.Collect();
+
+                for (int i = 0; i < memory.Length; i++)
+                {
+                    Assert.Equal(array[i + 1], pointer[i]);
+                }
+
+                for (int i = 0; i < memory.Length; i++)
+                {
+                    Assert.Equal(array[i + 1], span[i]);
                 }
             }
             handle.Dispose();

--- a/src/System.Memory/tests/ReadOnlyMemory/Retain.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Retain.cs
@@ -46,6 +46,34 @@ namespace System.MemoryTests
         }
 
         [Fact]
+        public static void MemoryRetainWithPinningAndSlice()
+        {
+            int[] array = { 1, 2, 3, 4, 5 };
+            ReadOnlyMemory<int> memory = array;
+            memory = memory.Slice(1);
+            MemoryHandle handle = memory.Retain(pin: true);
+            ReadOnlySpan<int> span = memory.Span;
+            unsafe
+            {
+                int* pointer = (int*)handle.PinnedPointer;
+                Assert.True(pointer != null);
+
+                GC.Collect();
+
+                for (int i = 0; i < memory.Length; i++)
+                {
+                    Assert.Equal(array[i + 1], pointer[i]);
+                }
+
+                for (int i = 0; i < memory.Length; i++)
+                {
+                    Assert.Equal(array[i + 1], span[i]);
+                }
+            }
+            handle.Dispose();
+        }
+
+        [Fact]
         public static void OwnedMemoryRetainWithoutPinning()
         {
             int[] array = { 1, 2, 3, 4, 5 };
@@ -77,6 +105,34 @@ namespace System.MemoryTests
                 for (int i = 0; i < memory.Length; i++)
                 {
                     Assert.Equal(array[i], pointer[i]);
+                }
+            }
+            handle.Dispose();
+        }
+
+        [Fact]
+        public static void OwnedMemoryRetainWithPinningAndSlice()
+        {
+            int[] array = { 1, 2, 3, 4, 5 };
+            OwnedMemory<int> owner = new CustomMemoryForTest<int>(array);
+            ReadOnlyMemory<int> memory = owner.Memory.Slice(1);
+            MemoryHandle handle = memory.Retain(pin: true);
+            ReadOnlySpan<int> span = memory.Span;
+            unsafe
+            {
+                int* pointer = (int*)handle.PinnedPointer;
+                Assert.True(pointer != null);
+
+                GC.Collect();
+
+                for (int i = 0; i < memory.Length; i++)
+                {
+                    Assert.Equal(array[i + 1], pointer[i]);
+                }
+
+                for (int i = 0; i < memory.Length; i++)
+                {
+                    Assert.Equal(array[i + 1], span[i]);
                 }
             }
             handle.Dispose();

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -3841,7 +3841,7 @@ namespace System.Buffers
         public MemoryHandle(IRetainable owner, void* pinnedPointer = null,  System.Runtime.InteropServices.GCHandle handle = default(System.Runtime.InteropServices.GCHandle))  { throw null; }
         [System.CLSCompliantAttribute(false)]
         public void* PinnedPointer { get { throw null; } }
-        public void AddOffset(int offset) { throw null; }
+        internal void AddOffset(int offset) { throw null; }
         public void Dispose() { throw null; }
     }
 

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -3841,7 +3841,8 @@ namespace System.Buffers
         public MemoryHandle(IRetainable owner, void* pinnedPointer = null,  System.Runtime.InteropServices.GCHandle handle = default(System.Runtime.InteropServices.GCHandle))  { throw null; }
         [System.CLSCompliantAttribute(false)]
         public void* PinnedPointer { get { throw null; } }
-        public void Dispose()  { throw null; }
+        public void AddOffset(int offset) { throw null; }
+        public void Dispose() { throw null; }
     }
 
     public interface IRetainable 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/24317

- AddOffset throws if PinnedPointer is null. Should it fail silently and do nothing?
- Would it be better to create a setter for PinnedPointer instead of the AddOffset API?

Related PR: https://github.com/dotnet/coreclr/pull/14248

cc @pakrym, @KrzysztofCwalina, @stephentoub, @davidfowl, @jkotas 