### PR TITLE
Fix handling of empty inputs to TakeLast

### DIFF
--- a/src/Common/tests/System/Linq/SkipTakeData.cs
+++ b/src/Common/tests/System/Linq/SkipTakeData.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Collections.Generic;
 
 namespace System.Linq.Tests
@@ -11,7 +10,7 @@ namespace System.Linq.Tests
     {
         public static IEnumerable<object[]> EnumerableData()
         {
-            IEnumerable<int> sourceCounts = new[] { 1, 2, 3, 5, 8, 13, 55, 100, 250 };
+            IEnumerable<int> sourceCounts = new[] { 0, 1, 2, 3, 5, 8, 13, 55, 100, 250 };
 
             IEnumerable<int> counts = new[] { 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 100, 250, 500, int.MaxValue };
             counts = counts.Concat(counts.Select(c => -c)).Append(0).Append(int.MinValue);

--- a/src/System.Linq/src/System/Linq/Take.cs
+++ b/src/System.Linq/src/System/Linq/Take.cs
@@ -116,10 +116,18 @@ namespace System.Linq
             Debug.Assert(source != null);
             Debug.Assert(count > 0);
 
-            var queue = new Queue<TSource>();
+            Queue<TSource> queue;
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
+                if (!e.MoveNext())
+                {
+                    yield break;
+                }
+
+                queue = new Queue<TSource>();
+                queue.Enqueue(e.Current);
+
                 while (e.MoveNext())
                 {
                     if (queue.Count < count)


### PR DESCRIPTION
It currently ends up trying to remove an element from an empty queue, causing an exception.

Fixes https://github.com/dotnet/corefx/issues/24327
cc: @JonHanna, @jamesqo, @VSadov, @OmarTawfik, @bfcamara