### PR TITLE
[WIP] Fix RedHat System.Globalization failures

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -161,6 +161,7 @@ namespace System
         public static bool IsNotFedoraOrRedHatOrCentos => !IsDistroAndVersion("fedora") && !IsDistroAndVersion("rhel") && !IsDistroAndVersion("centos");
 
         public static bool IsFedora => IsDistroAndVersion("fedora");
+        public static bool IsRedHat69 => IsDistroAndVersion("rhel", "6.9") || IsDistroAndVersion("rhl", "6.9");
 
         private static bool GetIsWindowsSubsystemForLinux()
         {

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -17,6 +17,7 @@ namespace System.Globalization.Tests
                 || (PlatformDetection.IsUbuntu && !PlatformDetection.IsUbuntu1404)
                 || PlatformDetection.IsFedora
                 || (PlatformDetection.IsDebian && !PlatformDetection.IsDebian8)
+                || PlatformDetection.IsRedHat69
                )
             {
                 return new int[] { 3 };


### PR DESCRIPTION
This is WIP - I do not have RedHat to test, so currently using CentOS
https://github.com/dotnet/corefx/issues/24304

Original fix made by @tarekgh will require changes to CoreCLR (add ICU version detection to native code) which is likely not appropriate as servicing change which does not fix any product bugs.

This PR replaces https://github.com/dotnet/corefx/pull/24338 which was against dev/release/2.0.0