### PR TITLE
SSLStream : Removed sync lock method

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.Adapters.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.Adapters.cs
@@ -39,7 +39,7 @@ namespace System.Net.Security
 
             public Task LockAsync()
             {
-                _sslState.CheckEnqueueWrite();
+                _sslState.CheckEnqueueWriteAsync().GetAwaiter().GetResult();
                 return Task.CompletedTask;
             }
 


### PR DESCRIPTION
Looking at the code, because this method is basically never actually blocked on (only if a renegotiation takes place during a write) there is no need for a second "sync" method.

Instead we can block on the Async method as it is controlled via a TCS anyway and doesn't go down to a "real blocking method" at the OS level so no extra threads should be generated from the original. This again simplifies the code maintenance going forward and refactoring SslState