### PR TITLE
Fix DebuggerDisplay for XmlNode

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Dom/XmlNode.cs
+++ b/src/System.Private.Xml/src/System/Xml/Dom/XmlNode.cs
@@ -1419,5 +1419,50 @@ namespace System.Xml
 
             nextNode.parentNode = prevNode.ParentNode;
         }
+
+        private object debuggerDisplayProxy { get { return new DebuggerDisplayXmlNodeProxy(this); } }
+
+        [DebuggerDisplay("{ToString()}")]
+        internal struct DebuggerDisplayXmlNodeProxy
+        {
+            private readonly XmlNode _node;
+
+            public DebuggerDisplayXmlNodeProxy(XmlNode node)
+            {
+                _node = node;
+            }
+
+            public override string ToString()
+            {
+                XmlNodeType nodeType = _node.NodeType;
+                string result = nodeType.ToString();
+                switch (nodeType)
+                {
+                    case XmlNodeType.Element:
+                    case XmlNodeType.EntityReference:
+                        result += ", Name=\"" + _node.Name + "\"";
+                        break;
+                    case XmlNodeType.Attribute:
+                    case XmlNodeType.ProcessingInstruction:
+                        result += ", Name=\"" + _node.Name + "\", Value=\"" + XmlConvert.EscapeValueForDebuggerDisplay(_node.Value) + "\"";
+                        break;
+                    case XmlNodeType.Text:
+                    case XmlNodeType.CDATA:
+                    case XmlNodeType.Comment:
+                    case XmlNodeType.Whitespace:
+                    case XmlNodeType.SignificantWhitespace:
+                    case XmlNodeType.XmlDeclaration:
+                        result += ", Value=\"" + XmlConvert.EscapeValueForDebuggerDisplay(_node.Value) + "\"";
+                        break;
+                    case XmlNodeType.DocumentType:
+                        XmlDocumentType documentType = (XmlDocumentType)_node;
+                        result += ", Name=\"" + documentType.Name + "\", SYSTEM=\"" + documentType.SystemId + "\", PUBLIC=\"" + documentType.PublicId + "\", Value=\"" + XmlConvert.EscapeValueForDebuggerDisplay(documentType.InternalSubset) + "\"";
+                        break;
+                    default:
+                        break;
+                }
+                return result;
+            }
+        }
     }
 }


### PR DESCRIPTION
Somewhere along the way XmlNode's debuggerDisplayProxy property was removed.  That doesn't break the build, as it's only used via reflection, but it does break the debugger display tooltip.

This just copy-and-pastes the corresponding implementation from reference source to fix it.  The only other change I made was renaming "node" to "_node" and making it readonly.

Fixes https://github.com/dotnet/corefx/issues/24360
cc: @krwq, @pjanotti, @angelcalvasp

(Subsequently we should ideally add tests for these debugger displays like we have elsewhere in corefx, so that we don't inadvertently break them again.  We may even find we have similar issues elsewhere.)