### PR TITLE
Change CookieContainer to return all relevant cookies

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -808,8 +808,6 @@ namespace System.Net
         {
             for (int i = 0; i < domainAttribute.Count; i++)
             {
-                bool found = false;
-                bool defaultAdded = false;
                 PathList pathList;
                 lock (m_domainTable.SyncRoot)
                 {
@@ -829,32 +827,10 @@ namespace System.Net
                         string path = (string)e.Key;
                         if (uri.AbsolutePath.StartsWith(CookieParser.CheckQuoted(path)))
                         {
-                            found = true;
-
                             CookieCollection cc = (CookieCollection)e.Value;
                             cc.TimeStamp(CookieCollection.Stamp.Set);
                             MergeUpdateCollections(ref cookies, cc, port, isSecure, matchOnlyPlainCookie);
-
-                            if (path == "/")
-                            {
-                                defaultAdded = true;
-                            }
                         }
-                        else if (found)
-                        {
-                            break;
-                        }
-                    }
-                }
-
-                if (!defaultAdded)
-                {
-                    CookieCollection cc = (CookieCollection)pathList["/"];
-
-                    if (cc != null)
-                    {
-                        cc.TimeStamp(CookieCollection.Stamp.Set);
-                        MergeUpdateCollections(ref cookies, cc, port, isSecure, matchOnlyPlainCookie);
                     }
                 }
 

--- a/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
@@ -518,7 +518,6 @@ namespace System.Net.Primitives.Unit.Tests
         }
 
         [Fact]
-        [ActiveIssue(24368)]
         public void GetCookies_DifferentPaths_ReturnsConsistentResults()
         {
             Cookie c1 = new Cookie("name1", "value", "/base", ".url.com");


### PR DESCRIPTION
Test case and fix for #24368.

Adding a new non-matching cookie could cause matching cookies to not be returned.