### PR TITLE
Add auto dependency flow repo API

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -26,7 +26,7 @@
 
     <!-- We're currently not building a "live" baseline, instead we're using .NETCore 1.0 RTM stable versions as the baseline -->
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
-    <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">2.0.0</PlatformPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion Condition="'$(MicrosoftNETCorePlatformsPackageVersion)' == ''">2.0.0</MicrosoftNETCorePlatformsPackageVersion>
 
     <!-- by default all packages will use the same version which revs with respect to product version -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">4.4.0</PackageVersion>

--- a/dependencies.props
+++ b/dependencies.props
@@ -19,24 +19,33 @@
     <StandardCurrentRef>549ba26b2ed7c341a287c63b494e38496319802c</StandardCurrentRef>
   </PropertyGroup>
 
-  <!-- Auto-upgraded properties for each build info dependency. -->
+  <!-- Product dependency versions. -->
   <PropertyGroup>
-    <PlatformPackageVersion>2.0.0</PlatformPackageVersion>
+    <NETStandardLibraryPackageVersion>2.0.1</NETStandardLibraryPackageVersion>
+    <NETStandardLibraryPackageId>NETStandard.Library</NETStandardLibraryPackageId>
+
+    <!-- SNI runtime package -->
+    <RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion>
+  </PropertyGroup>
+
+  <!-- Tests/infrastructure dependency versions. -->
+  <PropertyGroup>
     <CoreFxExpectedPrerelease>servicing-25714-01</CoreFxExpectedPrerelease>
-    <CoreClrPackageVersion>2.0.2-servicing-25712-01</CoreClrPackageVersion>
-    <ExternalExpectedPrerelease>beta-25307-00</ExternalExpectedPrerelease>
+    <MicrosoftNETCorePlatformsPackageVersion>2.0.0</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.0.2-servicing-25712-01</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <ProjectNTfsExpectedPrerelease>beta-25317-00</ProjectNTfsExpectedPrerelease>
     <ProjectNTfsTestILCExpectedPrerelease>beta-25317-00</ProjectNTfsTestILCExpectedPrerelease>
     <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25317-00</ProjectNTfsTestILCPackageVersion>
-    <NETStandardPackageVersion>2.0.1</NETStandardPackageVersion>
-    <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
+    <MicrosoftNETCoreDotNetHostPackageVersion>2.0.1-servicing-25615-03</MicrosoftNETCoreDotNetHostPackageVersion>
+    <MicrosoftNETCoreDotNetHostPolicyPackageVersion>2.0.1-servicing-25615-03</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.0.0-preview2-25317-03</MicrosoftNETCoreAppPackageVersion>
-    <!-- Use the SNI runtime package -->
-    <SniPackageVersion>4.4.0</SniPackageVersion>
-  </PropertyGroup>
 
-  <!-- Full package version strings that are used in other parts of the build. -->
-  <PropertyGroup>
+    <!-- CoreFX-built SNI identity package -->
+    <RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniPackageVersion>
+
+    <!-- Backward compatibility for BuildTools usage. -->
+    <PlatformPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</PlatformPackageVersion>
+
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0007</XunitPerfAnalysisPackageVersion>
     <TraceEventPackageVersion>1.0.3-alpha-experimental</TraceEventPackageVersion>
@@ -96,25 +105,20 @@
     </XmlUpdateStep>
     <XmlUpdateStep Include="CoreFx">
       <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>PlatformPackageVersion</ElementName>
+      <ElementName>MicrosoftNETCorePlatformsPackageVersion</ElementName>
       <PackageId>Microsoft.NETCore.Platforms</PackageId>
     </XmlUpdateStep>
     <XmlUpdateStep Include="CoreClr">
       <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>CoreClrPackageVersion</ElementName>
+      <ElementName>MicrosoftNETCoreRuntimeCoreCLRPackageVersion</ElementName>
       <PackageId>Microsoft.NETCore.Runtime.CoreCLR</PackageId>
     </XmlUpdateStep>
     <XmlUpdateStep Include="Standard">
       <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>NETStandardPackageVersion</ElementName>
-      <PackageId>$(NETStandardPackageId)</PackageId>
+      <ElementName>NETStandardLibraryPackageVersion</ElementName>
+      <PackageId>$(NETStandardLibraryPackageId)</PackageId>
     </XmlUpdateStep>
 <!--
-    <XmlUpdateStep Include="External">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>ExternalExpectedPrerelease</ElementName>
-      <BuildInfoName>External</BuildInfoName>
-    </XmlUpdateStep>
     <XmlUpdateStep Include="ProjectNTfs">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>ProjectNTfsExpectedPrerelease</ElementName>
@@ -132,7 +136,7 @@
     </XmlUpdateStep>
     <XmlUpdateStep Include="Sni">
       <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>SniPackageVersion</ElementName>
+      <ElementName>RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion</ElementName>
       <PackageId>runtime.win-x64.runtime.native.System.Data.SqlClient.sni</PackageId>
     </XmlUpdateStep>
     <XmlUpdateStep Include="CoreSetup">
@@ -195,4 +199,8 @@
     <!-- project.json files to update -->
     <ProjectJsonFiles Include="$(MSBuildThisFileDirectory)external\**\optional.json" />
   </ItemGroup>
+
+  <!-- Override isolated build dependency versions with versions from Repo API. -->
+  <Import Project="$(DotNetPackageVersionPropsPath)"
+          Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
 </Project>

--- a/external/ilasm/ilasm.depproj
+++ b/external/ilasm/ilasm.depproj
@@ -12,13 +12,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.Platforms">
-      <Version>$(PlatformPackageVersion)</Version>
+      <Version>$(MicrosoftNETCorePlatformsPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR">
-      <Version>$(CoreClrPackageVersion)</Version>
+      <Version>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.ILAsm">
-      <Version>$(CoreClrPackageVersion)</Version>
+      <Version>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/external/netfx/netfx.depproj
+++ b/external/netfx/netfx.depproj
@@ -24,7 +24,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="NETStandard.Library" Condition="'$(TargetGroup)' == 'netfx'">
-      <Version>$(NETStandardPackageVersion)</Version>
+      <Version>$(NETStandardLibraryPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
@@ -40,7 +40,7 @@
   <Target Name="FilterNETStandardShims" BeforeTargets="FilterNugetPackages"
           Condition="'$(RefOutputPath)' == '$(NetFxRefPath)'">
     <PropertyGroup>
-      <_NETStandardRefFolder>$(PackagesDir)$(NETStandardPackageId.ToLower())\$(NETStandardPackageVersion)\build\netstandard2.0\ref</_NETStandardRefFolder>
+      <_NETStandardRefFolder>$(PackagesDir)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\netstandard2.0\ref</_NETStandardRefFolder>
     </PropertyGroup>
     <ItemGroup>
       <_excludeForNetFx Include="@(NetFxReference);netstandard" />
@@ -56,8 +56,8 @@
     <ItemGroup>
       <Reference Include="@(_netstandardShimAssemblies)">
         <Private>False</Private>
-        <NuGetPackageId>$(NETStandardPackageId)</NuGetPackageId>
-        <NuGetPackageVersion>$(NETStandardPackageVersion)</NuGetPackageVersion>
+        <NuGetPackageId>$(NETStandardLibraryPackageId)</NuGetPackageId>
+        <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
       </Reference>
     </ItemGroup>
   </Target>

--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="NETStandard.Library">
-      <Version>$(NETStandardPackageVersion)</Version>
+      <Version>$(NETStandardLibraryPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
 
@@ -54,13 +54,13 @@
   <Target Name="AddNETStandardRefs" AfterTargets="ResolveReferences"
           Condition="'$(_NETStandardTFMFolder)' != ''">
     <PropertyGroup>
-      <_NETStandardRefFolder>$(PackagesDir)$(NETStandardPackageId.ToLower())\$(NETStandardPackageVersion)\build\$(_NETStandardTFMFolder)\ref</_NETStandardRefFolder>
+      <_NETStandardRefFolder>$(PackagesDir)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\$(_NETStandardTFMFolder)\ref</_NETStandardRefFolder>
     </PropertyGroup>
     <ItemGroup>
       <Reference Include="$(_NETStandardRefFolder)\*.dll">
         <Private>False</Private>
-        <NuGetPackageId>$(NETStandardPackageId)</NuGetPackageId>
-        <NuGetPackageVersion>$(NETStandardPackageVersion)</NuGetPackageVersion>
+        <NuGetPackageId>$(NETStandardLibraryPackageId)</NuGetPackageId>
+        <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
       </Reference>
     </ItemGroup>
   </Target>

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -26,22 +26,22 @@
 
   <ItemGroup Condition="'$(TargetGroup)'!='uapaot'">
     <PackageReference Include="Microsoft.NETCore.Platforms">
-      <Version>$(PlatformPackageVersion)</Version>
+      <Version>$(MicrosoftNETCorePlatformsPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR">
-      <Version>$(CoreClrPackageVersion)</Version>
+      <Version>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.TestHost">
-      <Version>$(CoreClrPackageVersion)</Version>
+      <Version>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="runtime.native.System.Data.SqlClient.sni">
-      <Version>4.4.0</Version>
+      <Version>$(RuntimeNativeSystemDataSqlClientSniPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.DotNetHost">
-      <Version>2.0.1-servicing-25615-03</Version>
+      <Version>$(MicrosoftNETCoreDotNetHostPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy">
-      <Version>2.0.1-servicing-25615-03</Version>
+      <Version>$(MicrosoftNETCoreDotNetHostPolicyPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
+++ b/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <PackageVersion>$(PlatformPackageVersion)</PackageVersion>
+    <PackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>

--- a/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
+++ b/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
@@ -36,10 +36,10 @@
       <FrameworkLayout Include="$(UAPPackageRefPath)">
         <TargetFramework>uap10.1</TargetFramework>
       </FrameworkLayout>
-      <FrameworkLayout Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\netstandard2.0\ref">
+      <FrameworkLayout Include="$(PackagesDir)$(NETStandardLibraryPackageId)\$(NETStandardLibraryPackageVersion)\build\netstandard2.0\ref">
         <TargetFramework>netstandard2.0</TargetFramework>
       </FrameworkLayout>
-      <FrameworkLayout Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\net461\ref">
+      <FrameworkLayout Include="$(PackagesDir)$(NETStandardLibraryPackageId)\$(NETStandardLibraryPackageVersion)\build\net461\ref">
         <TargetFramework>net461</TargetFramework>
       </FrameworkLayout>
     </ItemGroup>

--- a/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
+++ b/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
@@ -88,8 +88,8 @@
       <!-- ApplyBaseline doesn't handle NuGet versions, so workaround that by
            adding after we've baselined.
            https://github.com/dotnet/buildtools/issues/1432 -->
-      <Dependency Include="$(NETStandardPackageId)">
-        <Version>$(NETStandardPackageVersion)</Version>
+      <Dependency Include="$(NETStandardLibraryPackageId)">
+        <Version>$(NETStandardLibraryPackageVersion)</Version>
         <TargetFramework>$(TargetFramework)</TargetFramework>
       </Dependency>
     </ItemGroup>

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -6,7 +6,7 @@
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
 
     <NETStandardVersion Condition="'$(NETStandardVersion)' == ''">2.0</NETStandardVersion>
-    <NETStandardPackageRefPath Condition="'$(NETStandardPackageRefPath)' == ''">$(PackagesDir)$(NETStandardPackageId.ToLower())\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref</NETStandardPackageRefPath>
+    <NETStandardPackageRefPath Condition="'$(NETStandardPackageRefPath)' == ''">$(PackagesDir)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\netstandard$(NETStandardVersion)\ref</NETStandardPackageRefPath>
 
     <IncludeReferenceFiles Condition="'$(IncludeReferenceFiles)' == '' AND '$(PackageTargetRuntime)' == ''">true</IncludeReferenceFiles>
     <IncludeLibFiles Condition="'$(IncludeLibFiles)' == '' AND '$(PackageTargetRuntime)' != ''">true</IncludeLibFiles>
@@ -29,7 +29,7 @@
     <Dependency Include="@(_buildRIDWithMetadata->'runtime.%(Identity).$(Id)')" />
 
     <Dependency Include="Microsoft.NETCore.Platforms">
-      <Version>$(PlatformPackageVersion)</Version>
+      <Version>$(MicrosoftNETCorePlatformsPackageVersion)</Version>
       <TargetFramework>$(TargetFramework)</TargetFramework>
     </Dependency>
 
@@ -172,8 +172,8 @@
     <Error Condition="'@(_NETStandardFile)' == ''"
            Text="Could not locate NETStandard package content at '$(NETStandardPackageRefPath)'" />
 
-    <Message Condition="'@(_NETStandardSuppressedMissingFile)' != ''" Text="Files'@(_NETStandardSuppressedMissingFile)' are part of '$(NETStandardPackageId)' but missing from this package's $(_fileSet) files.  This error has been suppressed." />
-    <Error Condition="'@(_NETStandardMissingFileError)' != ''" Text="Files '@(_NETStandardMissingFileError)' are part of '$(NETStandardPackageId)' but missing from this package's $(_fileSet) files." />
+    <Message Condition="'@(_NETStandardSuppressedMissingFile)' != ''" Text="Files'@(_NETStandardSuppressedMissingFile)' are part of '$(NETStandardLibraryPackageId)' but missing from this package's $(_fileSet) files.  This error has been suppressed." />
+    <Error Condition="'@(_NETStandardMissingFileError)' != ''" Text="Files '@(_NETStandardMissingFileError)' are part of '$(NETStandardLibraryPackageId)' but missing from this package's $(_fileSet) files." />
   </Target>
 
   <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Dependency Include="runtime.win-x64.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(SniPackageVersion)</Version>
+      <Version>$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion)</Version>
     </Dependency>
     <Dependency Include="runtime.win-x86.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(SniPackageVersion)</Version>
+      <Version>$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion)</Version>
     </Dependency>
     <Dependency Include="runtime.win-arm64.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(SniPackageVersion)</Version>
+      <Version>$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion)</Version>
     </Dependency>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
Implement [auto dependency flow repo API](https://github.com/dotnet/source-build/blob/dev/release/2.0/Documentation/auto-dependency-flow/api.md). https://github.com/dotnet/source-build/issues/199

The new BuildTools package provides a common implementation for most of the args (https://github.com/dotnet/buildtools/pull/1707), but some changes are required:
 * The `dir.props` source changes are because BuildTools now provides a default value of `RestoreSources` based on repo API args. BuildTools also now automatically flows the property into the restore command.
 * In `dependencies.props`, I globally standardized package version property names so they are overridden by the `DotNetPackageVersionPropsPath` file without any special handling.