### PR TITLE
Re-enabling disabled Span/Memory tests for uapaot

### DIFF
--- a/src/System.Memory/tests/Memory/Retain.cs
+++ b/src/System.Memory/tests/Memory/Retain.cs
@@ -110,6 +110,7 @@ namespace System.MemoryTests
             handle.Dispose();
         }
 
+        [ActiveIssue(24384, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void OwnedMemoryRetainWithPinningAndSlice()
         {

--- a/src/System.Memory/tests/Memory/Span.cs
+++ b/src/System.Memory/tests/Memory/Span.cs
@@ -41,7 +41,6 @@ namespace System.MemoryTests
             owner.Memory.Span.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void SpanFromCtorArrayObject()
         {

--- a/src/System.Memory/tests/ReadOnlyMemory/CtorArray.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/CtorArray.cs
@@ -41,7 +41,6 @@ namespace System.MemoryTests
             memory.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorArrayObject()
         {
@@ -93,7 +92,6 @@ namespace System.MemoryTests
             memory.Validate(42, -1);
         }
 
-        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorVariantArrayType()
         {

--- a/src/System.Memory/tests/ReadOnlyMemory/Retain.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Retain.cs
@@ -110,6 +110,7 @@ namespace System.MemoryTests
             handle.Dispose();
         }
 
+        [ActiveIssue(24384, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void OwnedMemoryRetainWithPinningAndSlice()
         {

--- a/src/System.Memory/tests/ReadOnlyMemory/Span.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Span.cs
@@ -41,7 +41,6 @@ namespace System.MemoryTests
             ((ReadOnlyMemory<long>)owner.Memory).Span.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void SpanFromCtorArrayObject()
         {

--- a/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
@@ -69,7 +69,6 @@ namespace System.SpanTests
             spanLong.Validate(-3, 7, -15);
         }
 
-        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void ObjectArraySegmentAsSpan()
         {

--- a/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
@@ -41,7 +41,6 @@ namespace System.SpanTests
             span.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorArray3()
         {
@@ -93,7 +92,6 @@ namespace System.SpanTests
             span.Validate(42, -1);
         }
 
-        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorVariantArrayType()
         {

--- a/src/System.Memory/tests/Span/AsSpan.cs
+++ b/src/System.Memory/tests/Span/AsSpan.cs
@@ -24,7 +24,6 @@ namespace System.SpanTests
             spanLong.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void ObjectArrayAsSpan()
         {
@@ -61,7 +60,6 @@ namespace System.SpanTests
             spanLong.Validate(-92, 93, 94);
         }
 
-        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void ObjectArraySegmentAsSpan()
         {

--- a/src/System.Memory/tests/Span/CtorArray.cs
+++ b/src/System.Memory/tests/Span/CtorArray.cs
@@ -40,7 +40,6 @@ namespace System.SpanTests
             span.Validate(91, -92, 93, 94, -95);
         }
 
-        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void CtorArray3()
         {

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
@@ -587,7 +587,6 @@ namespace System.Runtime.CompilerServices
             Assert.Equal(0x12, r3);
         }
 
-        [ActiveIssue(23953, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void RefAreSame()
         {


### PR DESCRIPTION
The tests that were disabled in https://github.com/dotnet/corefx/pull/23905 can now be re-enabled since the bugs have been fixed for uapaot.

Opened a new issue and disabled the new tests that are failing still:
https://github.com/dotnet/corefx/issues/24384

cc @jkotas, @safern, @jfree, @KrzysztofCwalina, @crummel, @leekir