### PR TITLE
Add ALPN support for SslStream.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -102,7 +102,7 @@ internal static partial class Interop
                 {
                     if (sslAuthenticationOptions.IsServer)
                     {
-                        byte[] protos = sslAuthenticationOptions.ConvertAlpnProtocolListToByteArray(sslAuthenticationOptions.ApplicationProtocols);
+                        byte[] protos = SslStreamPal.ConvertAlpnProtocolListToByteArray(sslAuthenticationOptions.ApplicationProtocols);
                         sslAuthenticationOptions.AlpnProtocolsHandle = GCHandle.Alloc(protos);
                         Interop.Ssl.SslCtxSetAplnSelectCb(innerContext, s_alpnServerCallback, GCHandle.ToIntPtr(sslAuthenticationOptions.AlpnProtocolsHandle));
                     }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -89,9 +89,8 @@ internal static partial class Interop
                     SetSslCertificate(innerContext, certHandle, certKeyHandle);
                 }
 
-                if (sslAuthenticationOptions.RemoteCertRequired)
+                if (sslAuthenticationOptions.IsServer && sslAuthenticationOptions.RemoteCertRequired)
                 {
-                    Debug.Assert(sslAuthenticationOptions.IsServer, "isServer flag should be true");
                     Ssl.SslCtxSetVerify(innerContext, s_verifyClientCertificate);
 
                     //update the client CA list 
@@ -102,13 +101,13 @@ internal static partial class Interop
                 {
                     if (sslAuthenticationOptions.IsServer)
                     {
-                        byte[] protos = SslStreamPal.ConvertAlpnProtocolListToByteArray(sslAuthenticationOptions.ApplicationProtocols);
+                        byte[] protos = Interop.Ssl.ConvertAlpnProtocolListToByteArray(sslAuthenticationOptions.ApplicationProtocols);
                         sslAuthenticationOptions.AlpnProtocolsHandle = GCHandle.Alloc(protos);
                         Interop.Ssl.SslCtxSetAplnSelectCb(innerContext, s_alpnServerCallback, GCHandle.ToIntPtr(sslAuthenticationOptions.AlpnProtocolsHandle));
                     }
                     else
                     {
-                        if (Interop.Ssl.SslCtxSetAplnProtos(innerContext, sslAuthenticationOptions.ApplicationProtocols) != 0)
+                        if (Interop.Ssl.SslCtxSetAlpnProtos(innerContext, sslAuthenticationOptions.ApplicationProtocols) != 0)
                         {
                             throw CreateSslException(SR.net_alpn_notsupported);
                         }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -20,8 +20,8 @@ internal static partial class Interop
 {
     internal static partial class OpenSsl
     {
-        private static Ssl.SslCtxSetVerifyCallback s_verifyClientCertificate = VerifyClientCertificate;
-        private static Ssl.SslCtxSetAplnCallback s_alpnServerCallback = AplnServerSelectCallback;
+        private static readonly Ssl.SslCtxSetVerifyCallback s_verifyClientCertificate = VerifyClientCertificate;
+        private static readonly Ssl.SslCtxSetAlpnCallback s_alpnServerCallback = AlpnServerSelectCallback;
 
         #region internal methods
 
@@ -103,13 +103,13 @@ internal static partial class Interop
                     {
                         byte[] protos = Interop.Ssl.ConvertAlpnProtocolListToByteArray(sslAuthenticationOptions.ApplicationProtocols);
                         sslAuthenticationOptions.AlpnProtocolsHandle = GCHandle.Alloc(protos);
-                        Interop.Ssl.SslCtxSetAplnSelectCb(innerContext, s_alpnServerCallback, GCHandle.ToIntPtr(sslAuthenticationOptions.AlpnProtocolsHandle));
+                        Interop.Ssl.SslCtxSetAlpnSelectCb(innerContext, s_alpnServerCallback, GCHandle.ToIntPtr(sslAuthenticationOptions.AlpnProtocolsHandle));
                     }
                     else
                     {
                         if (Interop.Ssl.SslCtxSetAlpnProtos(innerContext, sslAuthenticationOptions.ApplicationProtocols) != 0)
                         {
-                            throw CreateSslException(SR.net_alpn_notsupported);
+                            throw CreateSslException(SR.net_alpn_config_failed);
                         }
                     }
                 }
@@ -330,7 +330,7 @@ internal static partial class Interop
             return OpenSslSuccess;
         }
 
-        private static unsafe int AplnServerSelectCallback(IntPtr ssl, out IntPtr outp, out byte outlen, IntPtr inp, uint inlen, IntPtr arg)
+        private static unsafe int AlpnServerSelectCallback(IntPtr ssl, out IntPtr outp, out byte outlen, IntPtr inp, uint inlen, IntPtr arg)
         {
             GCHandle protocols = GCHandle.FromIntPtr(arg);
             byte[] server = (byte[])protocols.Target;

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -102,7 +102,7 @@ internal static partial class Interop
                 {
                     if (sslAuthenticationOptions.IsServer)
                     {
-                        byte[] protos = Ssl.AlpnStringListToByteArray(sslAuthenticationOptions.ApplicationProtocols);
+                        byte[] protos = sslAuthenticationOptions.ConvertAlpnProtocolListToByteArray(sslAuthenticationOptions.ApplicationProtocols);
                         sslAuthenticationOptions.AlpnProtocolsHandle = GCHandle.Alloc(protos);
                         Interop.Ssl.SslCtxSetAplnSelectCb(innerContext, s_alpnServerCallback, GCHandle.ToIntPtr(sslAuthenticationOptions.AlpnProtocolsHandle));
                     }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -54,13 +54,18 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGet0AlpnSelected")]
         internal static extern void SslGetAlpnSelected(SafeSslHandle ssl, out IntPtr protocol, out int len);
 
-        internal static unsafe string SslGetAlpnSelected(SafeSslHandle ssl)
+        internal static byte[] SslGetAlpnSelected(SafeSslHandle ssl)
         {
             IntPtr protocol;
             int len;
             SslGetAlpnSelected(ssl, out protocol, out len);
-            
-            return len == 0 ? null : Marshal.PtrToStringAnsi(protocol, len);
+
+            if (len == 0)
+                return null;
+
+            byte[] result = new byte[len];
+            Marshal.Copy(protocol, result, 0, len);
+            return result;
         }
 
         internal static string GetProtocolVersion(SafeSslHandle ssl)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -12,8 +12,8 @@ internal static partial class Interop
 {
     internal static partial class Ssl
     {
-        internal const int OPENSSL_NPN_NEGOTIATED = 1;
         internal const int SSL_TLSEXT_ERR_OK = 0;
+        internal const int OPENSSL_NPN_NEGOTIATED = 1;
         internal const int SSL_TLSEXT_ERR_NOACK = 3;
 
         internal delegate int SslCtxSetVerifyCallback(int preverify_ok, IntPtr x509_ctx);
@@ -180,12 +180,12 @@ internal static partial class Interop
             SSL_ERROR_WANT_WRITE = 3,
             SSL_ERROR_SYSCALL = 5,
             SSL_ERROR_ZERO_RETURN = 6,
-            
+
             // NOTE: this SslErrorCode value doesn't exist in OpenSSL, but
             // we use it to distinguish when a renegotiation is pending.
             // Choosing an arbitrarily large value that shouldn't conflict
             // with any actual OpenSSL error codes
-            SSL_ERROR_RENEGOTIATE = 29304 
+            SSL_ERROR_RENEGOTIATE = 29304
         }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -12,6 +12,10 @@ internal static partial class Interop
 {
     internal static partial class Ssl
     {
+        internal const int OPENSSL_NPN_NEGOTIATED = 1;
+        internal const int SSL_TLSEXT_ERR_OK = 0;
+        internal const int SSL_TLSEXT_ERR_NOACK = 3;
+
         internal delegate int SslCtxSetVerifyCallback(int preverify_ok, IntPtr x509_ctx);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EnsureLibSslInitialized")]
@@ -43,6 +47,21 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetVersion")]
         private static extern IntPtr SslGetVersion(SafeSslHandle ssl);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSelectNextProto")]
+        internal static extern int SslSelectNextProto(out IntPtr outp, out byte outlen, IntPtr server, uint serverlen, IntPtr client, uint clientlen);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGet0AlpnSelected")]
+        internal static extern void SslGetAlpnSelected(SafeSslHandle ssl, out IntPtr protocol, out int len);
+
+        internal static unsafe string SslGetAlpnSelected(SafeSslHandle ssl)
+        {
+            IntPtr protocol;
+            int len;
+            SslGetAlpnSelected(ssl, out protocol, out len);
+            
+            return len == 0 ? null : Marshal.PtrToStringAnsi(protocol, len);
+        }
 
         internal static string GetProtocolVersion(SafeSslHandle ssl)
         {

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -37,36 +37,11 @@ internal static partial class Interop
 
         internal static unsafe int SslCtxSetAplnProtos(SafeSslContextHandle ctx, IList<SslApplicationProtocol> protocols)
         {
-            byte[] buffer = AlpnStringListToByteArray(protocols);
+            byte[] buffer = SslAuthenticationOptions.ConvertAlpnProtocolListToByteArray(protocols);
             fixed (byte* b = buffer)
             {
                 return SslCtxSetAlpnProtos(ctx, (IntPtr)b, buffer.Length);
             }
-        }
-
-        internal static byte[] AlpnStringListToByteArray(IList<SslApplicationProtocol> protocols)
-        {
-            int protocolSize = 0;
-            foreach (SslApplicationProtocol protocol in protocols)
-            {
-                if (protocol.Length <= 0 || protocol.Length > byte.MaxValue)
-                {
-                    throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(protocols));
-                }
-
-                protocolSize += protocol.Length + 1;
-            }
-
-            byte[] buffer = new byte[protocolSize];
-            var offset = 0;
-            foreach (SslApplicationProtocol protocol in protocols)
-            {
-                buffer[offset++] = (byte)(protocol.Length);
-                Array.Copy(protocol.ToArray(), 0, buffer, offset, protocol.Length);
-                offset += protocol.Length;
-            }
-
-            return buffer;
         }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
     {
         internal delegate int AppVerifyCallback(IntPtr storeCtx, IntPtr arg);
         internal delegate int ClientCertCallback(IntPtr ssl, out IntPtr x509, out IntPtr pkey);
-        internal delegate int SslCtxSetAplnCallback(IntPtr ssl, out IntPtr outp, out byte outlen, IntPtr inp, uint inlen, IntPtr arg);
+        internal delegate int SslCtxSetAlpnCallback(IntPtr ssl, out IntPtr outp, out byte outlen, IntPtr inp, uint inlen, IntPtr arg);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxCreate")]
         internal static extern SafeSslContextHandle SslCtxCreate(IntPtr method);
@@ -32,10 +32,10 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetAlpnProtos")]
         internal static extern int SslCtxSetAlpnProtos(SafeSslContextHandle ctx, IntPtr protos, int len);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetAplnSelectCb")]
-        internal static unsafe extern void SslCtxSetAplnSelectCb(SafeSslContextHandle ctx, SslCtxSetAplnCallback callback, IntPtr arg);
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetAlpnSelectCb")]
+        internal static unsafe extern void SslCtxSetAlpnSelectCb(SafeSslContextHandle ctx, SslCtxSetAlpnCallback callback, IntPtr arg);
 
-        internal static unsafe int SslCtxSetAlpnProtos(SafeSslContextHandle ctx, IList<SslApplicationProtocol> protocols)
+        internal static unsafe int SslCtxSetAlpnProtos(SafeSslContextHandle ctx, List<SslApplicationProtocol> protocols)
         {
             byte[] buffer = ConvertAlpnProtocolListToByteArray(protocols);
             fixed (byte* b = buffer)
@@ -44,7 +44,7 @@ internal static partial class Interop
             }
         }
 
-        internal static byte[] ConvertAlpnProtocolListToByteArray(IList<SslApplicationProtocol> applicationProtocols)
+        internal static byte[] ConvertAlpnProtocolListToByteArray(List<SslApplicationProtocol> applicationProtocols)
         {
             int protocolSize = 0;
             foreach (SslApplicationProtocol protocol in applicationProtocols)
@@ -62,7 +62,7 @@ internal static partial class Interop
             foreach (SslApplicationProtocol protocol in applicationProtocols)
             {
                 buffer[offset++] = (byte)(protocol.Protocol.Length);
-                Array.Copy(protocol.Protocol.ToArray(), 0, buffer, offset, protocol.Protocol.Length);
+                protocol.Protocol.Span.CopyTo(new Span<byte>(buffer).Slice(offset));
                 offset += protocol.Protocol.Length;
             }
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Text;
 using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
@@ -12,6 +14,7 @@ internal static partial class Interop
     {
         internal delegate int AppVerifyCallback(IntPtr storeCtx, IntPtr arg);
         internal delegate int ClientCertCallback(IntPtr ssl, out IntPtr x509, out IntPtr pkey);
+        internal delegate int SslCtxSetAplnCallback(IntPtr ssl, out IntPtr outp, out byte outlen, IntPtr inp, uint inlen, IntPtr arg);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxCreate")]
         internal static extern SafeSslContextHandle SslCtxCreate(IntPtr method);
@@ -24,6 +27,45 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetClientCertCallback")]
         internal static extern void SslCtxSetClientCertCallback(IntPtr ctx, ClientCertCallback callback);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetAlpnProtos")]
+        internal static extern int SslCtxSetAlpnProtos(SafeSslContextHandle ctx, IntPtr protos, int len);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetAplnSelectCb")]
+        internal static unsafe extern void SslCtxSetAplnSelectCb(SafeSslContextHandle ctx, SslCtxSetAplnCallback callback, IntPtr arg);
+
+        internal static unsafe int SslCtxSetAplnProtos(SafeSslContextHandle ctx, IList<string> protocols)
+        {
+            byte[] buffer = AlpnStringListToByteArray(protocols);
+            fixed (byte* b = buffer)
+            {
+                return SslCtxSetAlpnProtos(ctx, (IntPtr)b, buffer.Length);
+            }
+        }
+
+        internal static byte[] AlpnStringListToByteArray(IList<string> protocols)
+        {
+            int protocolSize = 0;
+            foreach (string protocol in protocols)
+            {
+                if (string.IsNullOrEmpty(protocol) || protocol.Length > byte.MaxValue)
+                {
+                    throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(protocols));
+                }
+
+                protocolSize += protocol.Length + 1;
+            }
+
+            byte[] buffer = new byte[protocolSize];
+            var offset = 0;
+            foreach (string protocol in protocols)
+            {
+                buffer[offset++] = (byte)(protocol.Length);
+                offset += Encoding.ASCII.GetBytes(protocol, 0, protocol.Length, buffer, offset);
+            }
+
+            return buffer;
+        }
     }
 }
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -37,7 +37,7 @@ internal static partial class Interop
 
         internal static unsafe int SslCtxSetAplnProtos(SafeSslContextHandle ctx, IList<SslApplicationProtocol> protocols)
         {
-            byte[] buffer = SslAuthenticationOptions.ConvertAlpnProtocolListToByteArray(protocols);
+            byte[] buffer = SslStreamPal.ConvertAlpnProtocolListToByteArray(protocols);
             fixed (byte* b = buffer)
             {
                 return SslCtxSetAlpnProtos(ctx, (IntPtr)b, buffer.Length);

--- a/src/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
@@ -48,7 +48,8 @@ internal static partial class Interop
         SmartcardLogonRequired = unchecked((int)0x8009033E),
         UnsupportedPreauth = unchecked((int)0x80090343),
         BadBinding = unchecked((int)0x80090346),
-        DowngradeDetected = unchecked((int)0x80090350)
+        DowngradeDetected = unchecked((int)0x80090350),
+        ApplicationProtocolMismatch = unchecked((int)0x80090367)
     }
 
 #if TRACE_VERBOSE

--- a/src/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
@@ -49,7 +49,7 @@ internal static partial class Interop
         UnsupportedPreauth = unchecked((int)0x80090343),
         BadBinding = unchecked((int)0x80090346),
         DowngradeDetected = unchecked((int)0x80090350),
-        ApplicationProtocolMismatch = unchecked((int)0x80090367)
+        ApplicationProtocolMismatch = unchecked((int)0x80090367),
     }
 
 #if TRACE_VERBOSE

--- a/src/Common/src/Interop/Windows/SChannel/Interop.SecPkgContext_ApplicationProtocol.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.SecPkgContext_ApplicationProtocol.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -28,14 +29,14 @@ internal static partial class Interop
         public ApplicationProtocolNegotiationExt NegotiationExtension;
         public byte ProtocolIdSize;
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = MAX_PROTOCOL_ID_SIZE)]
-        public char[] ProtocolId;
+        public byte[] ProtocolId;
 
-        public string GetProtocolId()
+        public byte[] GetProtocolId()
         {
-            if (ProtocolId == null)
-                return null;
+            byte[] result = new byte[ProtocolIdSize];
+            Array.Copy(ProtocolId, result, ProtocolIdSize);
 
-            return new string(ProtocolId, 0, ProtocolIdSize);
+            return result;
         }
     }
 }

--- a/src/Common/src/Interop/Windows/SChannel/Interop.SecPkgContext_ApplicationProtocol.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.SecPkgContext_ApplicationProtocol.cs
@@ -22,7 +22,7 @@ internal static partial class Interop
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal unsafe class SecPkgContext_ApplicationProtocol
+    internal class SecPkgContext_ApplicationProtocol
     {
         private const int MaxProtocolIdSize = 0xFF;
 
@@ -35,10 +35,7 @@ internal static partial class Interop
         {
             get
             {
-                fixed (byte* p = ProtocolId)
-                {
-                    return new Span<byte>(p, ProtocolIdSize).ToArray();
-                }
+                return new Span<byte>(ProtocolId, 0, ProtocolIdSize).ToArray();
             }
         }
     }

--- a/src/Common/src/Interop/Windows/SChannel/Interop.SecPkgContext_ApplicationProtocol.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.SecPkgContext_ApplicationProtocol.cs
@@ -4,7 +4,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace System.Net
+internal static partial class Interop
 {
     internal enum ApplicationProtocolNegotiationStatus
     {
@@ -20,7 +20,7 @@ namespace System.Net
         ALPN
     }
 
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
     internal class SecPkgContext_ApplicationProtocol
     {
         private const int MAX_PROTOCOL_ID_SIZE = 0xFF;

--- a/src/Common/src/Interop/Windows/SChannel/Interop.SecPkgContext_ApplicationProtocol.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.SecPkgContext_ApplicationProtocol.cs
@@ -21,22 +21,25 @@ internal static partial class Interop
         ALPN
     }
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
-    internal class SecPkgContext_ApplicationProtocol
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe class SecPkgContext_ApplicationProtocol
     {
-        private const int MAX_PROTOCOL_ID_SIZE = 0xFF;
-        public ApplicationProtocolNegotiationStatus NegotiationStatus;
-        public ApplicationProtocolNegotiationExt NegotiationExtension;
+        private const int MaxProtocolIdSize = 0xFF;
+
+        public ApplicationProtocolNegotiationStatus ProtoNegoStatus;
+        public ApplicationProtocolNegotiationExt ProtoNegoExt;
         public byte ProtocolIdSize;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = MAX_PROTOCOL_ID_SIZE)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = MaxProtocolIdSize)]
         public byte[] ProtocolId;
-
-        public byte[] GetProtocolId()
+        public byte[] Protocol
         {
-            byte[] result = new byte[ProtocolIdSize];
-            Array.Copy(ProtocolId, result, ProtocolIdSize);
-
-            return result;
+            get
+            {
+                fixed (byte* p = ProtocolId)
+                {
+                    return new Span<byte>(p, ProtocolIdSize).ToArray();
+                }
+            }
         }
     }
 }

--- a/src/Common/src/Interop/Windows/SChannel/Interop.Sec_Application_Protocols.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.Sec_Application_Protocols.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 

--- a/src/Common/src/Interop/Windows/SChannel/Interop.Sec_Application_Protocols.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.Sec_Application_Protocols.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Security;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal struct Sec_Application_Protocols
+    {
+        private static readonly int ProtocolListOffset = Marshal.SizeOf<Sec_Application_Protocols>();
+        private static readonly int ProtocolListConstSize = ProtocolListOffset - (int)Marshal.OffsetOf<Sec_Application_Protocols>(nameof(ProtocolExtenstionType));
+        public uint ProtocolListsSize;
+        public ApplicationProtocolNegotiationExt ProtocolExtenstionType;
+        public short ProtocolListSize;
+
+        public static unsafe byte[] ToByteArray(IList<SslApplicationProtocol> applicationProtocols)
+        {
+            long protocolListSize = 0;
+            foreach (SslApplicationProtocol protocol in applicationProtocols)
+            {
+                if (protocol.Protocol.Length == 0 || protocol.Protocol.Length > byte.MaxValue)
+                {
+                    throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(applicationProtocols));
+                }
+
+                protocolListSize += protocol.Protocol.Length + 1;
+
+                if (protocolListSize > short.MaxValue)
+                {
+                    throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(applicationProtocols));
+                }
+            }
+
+            Sec_Application_Protocols protocols = new Sec_Application_Protocols();
+            protocols.ProtocolListsSize = (uint)(ProtocolListConstSize + protocolListSize);
+            protocols.ProtocolExtenstionType = ApplicationProtocolNegotiationExt.ALPN;
+            protocols.ProtocolListSize = (short)protocolListSize;
+
+            byte[] buffer = new byte[ProtocolListOffset + protocolListSize];
+            fixed (byte* bufferPtr = buffer)
+            {
+                Marshal.StructureToPtr(protocols, new IntPtr(bufferPtr), false);
+                byte* protocolList = bufferPtr + ProtocolListOffset;
+                foreach (SslApplicationProtocol applicationProtocol in applicationProtocols)
+                {
+                    *(protocolList++) = (byte)applicationProtocol.Protocol.Length;
+                    fixed (byte* p = applicationProtocol.Protocol.ToArray())
+                    {
+                        Buffer.MemoryCopy(p, protocolList, buffer.Length, applicationProtocol.Protocol.Length);
+                    }
+
+                    protocolList += applicationProtocol.Protocol.Length;
+                }
+            }
+
+            return buffer;
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/SChannel/SecPkgContext_ApplicationProtocol.cs
+++ b/src/Common/src/Interop/Windows/SChannel/SecPkgContext_ApplicationProtocol.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Net
+{
+    internal enum ApplicationProtocolNegotiationStatus
+    {
+        None = 0,
+        Success,
+        SelectedClientOnly
+    }
+
+    internal enum ApplicationProtocolNegotiationExt
+    {
+        None = 0,
+        NPN,
+        ALPN
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal class SecPkgContext_ApplicationProtocol
+    {
+        private const int MAX_PROTOCOL_ID_SIZE = 0xFF;
+        public ApplicationProtocolNegotiationStatus NegotiationStatus;
+        public ApplicationProtocolNegotiationExt NegotiationExtension;
+        public byte ProtocolIdSize;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = MAX_PROTOCOL_ID_SIZE)]
+        public char[] ProtocolId;
+
+        public string GetProtocolId()
+        {
+            if (ProtocolId == null)
+                return null;
+
+            return new string(ProtocolId, 0, ProtocolIdSize);
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/sspicli/Interop.SSPI.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.SSPI.cs
@@ -54,6 +54,7 @@ internal static partial class Interop
             SECPKG_ATTR_UNIQUE_BINDINGS = 25,
             SECPKG_ATTR_ENDPOINT_BINDINGS = 26,
             SECPKG_ATTR_CLIENT_SPECIFIED_TARGET = 27,
+            SECPKG_ATTR_APPLICATION_PROTOCOL = 35,
 
             // minschannel.h
             SECPKG_ATTR_REMOTE_CERT_CONTEXT = 0x53,    // returns PCCERT_CONTEXT

--- a/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
@@ -476,6 +476,10 @@ namespace System.Net
                     nativeBlockSize = Marshal.SizeOf<SecPkgContext_ConnectionInfo>();
                     break;
 
+                case Interop.SspiCli.ContextAttribute.SECPKG_ATTR_APPLICATION_PROTOCOL:
+                    nativeBlockSize = Marshal.SizeOf<SecPkgContext_ApplicationProtocol>();
+                    break;
+
                 default:
                     throw new ArgumentException(SR.Format(SR.net_invalid_enum, nameof(contextAttribute)), nameof(contextAttribute));
             }
@@ -540,6 +544,17 @@ namespace System.Net
                     case Interop.SspiCli.ContextAttribute.SECPKG_ATTR_CONNECTION_INFO:
                         attribute = new SecPkgContext_ConnectionInfo(nativeBuffer);
                         break;
+
+                    case Interop.SspiCli.ContextAttribute.SECPKG_ATTR_APPLICATION_PROTOCOL:
+                        unsafe
+                        {
+                            fixed (void *ptr = nativeBuffer)
+                            {
+                                attribute = Marshal.PtrToStructure<SecPkgContext_ApplicationProtocol>(new IntPtr(ptr));
+                            }
+                        }
+                        break;
+
                     default:
                         // Will return null.
                         break;

--- a/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
@@ -477,7 +477,7 @@ namespace System.Net
                     break;
 
                 case Interop.SspiCli.ContextAttribute.SECPKG_ATTR_APPLICATION_PROTOCOL:
-                    nativeBlockSize = Marshal.SizeOf<SecPkgContext_ApplicationProtocol>();
+                    nativeBlockSize = Marshal.SizeOf<Interop.SecPkgContext_ApplicationProtocol>();
                     break;
 
                 default:
@@ -550,7 +550,7 @@ namespace System.Net
                         {
                             fixed (void *ptr = nativeBuffer)
                             {
-                                attribute = Marshal.PtrToStructure<SecPkgContext_ApplicationProtocol>(new IntPtr(ptr));
+                                attribute = Marshal.PtrToStructure<Interop.SecPkgContext_ApplicationProtocol>(new IntPtr(ptr));
                             }
                         }
                         break;

--- a/src/Common/src/System/Net/Security/Unix/SafeDeleteSslContext.cs
+++ b/src/Common/src/System/Net/Security/Unix/SafeDeleteSslContext.cs
@@ -5,6 +5,7 @@
 using Microsoft.Win32.SafeHandles;
 
 using System.Diagnostics;
+using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
@@ -25,7 +26,7 @@ namespace System.Net.Security
             }
         }
 
-        public SafeDeleteSslContext(SafeFreeSslCredentials credential, bool isServer, bool remoteCertRequired)
+        public SafeDeleteSslContext(SafeFreeSslCredentials credential, bool isServer, bool remoteCertRequired, SslAuthenticationOptions sslAuthenticationOptions)
             : base(credential)
         {
             Debug.Assert((null != credential) && !credential.IsInvalid, "Invalid credential used in SafeDeleteSslContext");
@@ -38,7 +39,8 @@ namespace System.Net.Security
                     credential.CertKeyHandle,
                     credential.Policy,
                     isServer,
-                    remoteCertRequired);
+                    remoteCertRequired,
+                    sslAuthenticationOptions);
             }
             catch(Exception ex)
             {

--- a/src/Common/src/System/Net/Security/Unix/SafeDeleteSslContext.cs
+++ b/src/Common/src/System/Net/Security/Unix/SafeDeleteSslContext.cs
@@ -26,7 +26,7 @@ namespace System.Net.Security
             }
         }
 
-        public SafeDeleteSslContext(SafeFreeSslCredentials credential, bool isServer, bool remoteCertRequired, SslAuthenticationOptions sslAuthenticationOptions)
+        public SafeDeleteSslContext(SafeFreeSslCredentials credential, SslAuthenticationOptions sslAuthenticationOptions)
             : base(credential)
         {
             Debug.Assert((null != credential) && !credential.IsInvalid, "Invalid credential used in SafeDeleteSslContext");
@@ -38,8 +38,6 @@ namespace System.Net.Security
                     credential.CertHandle,
                     credential.CertKeyHandle,
                     credential.Policy,
-                    isServer,
-                    remoteCertRequired,
                     sslAuthenticationOptions);
             }
             catch(Exception ex)

--- a/src/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
+++ b/src/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
@@ -10,7 +10,7 @@ namespace System.Net
 {
     internal static class SecurityStatusAdapterPal
     {
-        private const int StatusDictionarySize = 40;
+        private const int StatusDictionarySize = 41;
 
 #if DEBUG
         static SecurityStatusAdapterPal()

--- a/src/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
+++ b/src/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
@@ -22,6 +22,7 @@ namespace System.Net
         private static readonly BidirectionalDictionary<Interop.SECURITY_STATUS, SecurityStatusPalErrorCode> s_statusDictionary = new BidirectionalDictionary<Interop.SECURITY_STATUS, SecurityStatusPalErrorCode>(StatusDictionarySize)
         {
             { Interop.SECURITY_STATUS.AlgorithmMismatch, SecurityStatusPalErrorCode.AlgorithmMismatch },
+            { Interop.SECURITY_STATUS.ApplicationProtocolMismatch, SecurityStatusPalErrorCode.ApplicationProtocolMismatch },
             { Interop.SECURITY_STATUS.BadBinding, SecurityStatusPalErrorCode.BadBinding },
             { Interop.SECURITY_STATUS.BufferNotEnough, SecurityStatusPalErrorCode.BufferNotEnough },
             { Interop.SECURITY_STATUS.CannotInstall, SecurityStatusPalErrorCode.CannotInstall },

--- a/src/Common/src/System/Net/SecurityStatusPal.cs
+++ b/src/Common/src/System/Net/SecurityStatusPal.cs
@@ -67,6 +67,7 @@ namespace System.Net
         SmartcardLogonRequired,
         UnsupportedPreauth,
         BadBinding,
-        DowngradeDetected
+        DowngradeDetected,
+        ApplicationProtocolMismatch
     }
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/configure.cmake
+++ b/src/Native/Unix/System.Security.Cryptography.Native/configure.cmake
@@ -13,6 +13,10 @@ check_function_exists(
     EC_GF2m_simple_method
     HAVE_OPENSSL_EC2M)
 
+check_function_exists(
+	SSL_get0_alpn_selected
+	HAVE_OPENSSL_ALPN)
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/pal_crypto_config.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/pal_crypto_config.h)

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -251,6 +251,8 @@ int EC_POINT_set_affine_coordinates_GF2m(const EC_GROUP *group, EC_POINT *p,
     PER_FUNCTION_BLOCK(SSL_CTX_ctrl, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_free, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_new, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_set_alpn_protos, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_set_alpn_select_cb, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_set_cert_verify_callback, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_set_cipher_list, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_set_client_CA_list, true) \
@@ -270,11 +272,13 @@ int EC_POINT_set_affine_coordinates_GF2m(const EC_GROUP *group, EC_POINT *p,
     PER_FUNCTION_BLOCK(SSL_get_peer_finished, true) \
     PER_FUNCTION_BLOCK(SSL_get_SSL_CTX, true) \
     PER_FUNCTION_BLOCK(SSL_get_version, true) \
+    PER_FUNCTION_BLOCK(SSL_get0_alpn_selected, true) \
     PER_FUNCTION_BLOCK(SSL_library_init, true) \
     PER_FUNCTION_BLOCK(SSL_load_error_strings, true) \
     PER_FUNCTION_BLOCK(SSL_new, true) \
     PER_FUNCTION_BLOCK(SSL_read, true) \
     PER_FUNCTION_BLOCK(SSL_renegotiate_pending, true) \
+    PER_FUNCTION_BLOCK(SSL_select_next_proto, true) \
     PER_FUNCTION_BLOCK(SSL_set_accept_state, true) \
     PER_FUNCTION_BLOCK(SSL_set_bio, true) \
     PER_FUNCTION_BLOCK(SSL_set_connect_state, true) \
@@ -541,6 +545,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_CTX_ctrl SSL_CTX_ctrl_ptr
 #define SSL_CTX_free SSL_CTX_free_ptr
 #define SSL_CTX_new SSL_CTX_new_ptr
+#define SSL_CTX_set_alpn_protos SSL_CTX_set_alpn_protos_ptr
+#define SSL_CTX_set_alpn_select_cb SSL_CTX_set_alpn_select_cb_ptr
 #define SSL_CTX_set_cert_verify_callback SSL_CTX_set_cert_verify_callback_ptr
 #define SSL_CTX_set_cipher_list SSL_CTX_set_cipher_list_ptr
 #define SSL_CTX_set_client_CA_list SSL_CTX_set_client_CA_list_ptr
@@ -560,11 +566,13 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_get_peer_finished SSL_get_peer_finished_ptr
 #define SSL_get_SSL_CTX SSL_get_SSL_CTX_ptr
 #define SSL_get_version SSL_get_version_ptr
+#define SSL_get0_alpn_selected SSL_get0_alpn_selected_ptr
 #define SSL_library_init SSL_library_init_ptr
 #define SSL_load_error_strings SSL_load_error_strings_ptr
 #define SSL_new SSL_new_ptr
 #define SSL_read SSL_read_ptr
 #define SSL_renegotiate_pending SSL_renegotiate_pending_ptr
+#define SSL_select_next_proto SSL_select_next_proto_ptr
 #define SSL_set_accept_state SSL_set_accept_state_ptr
 #define SSL_set_bio SSL_set_bio_ptr
 #define SSL_set_connect_state SSL_set_connect_state_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -60,7 +60,7 @@ void SSL_CTX_set_alpn_select_cb(SSL_CTX* ctx, int (*cb) (SSL *ssl,
                                             const unsigned char *in,
                                             unsigned int inlen,
                                             void *arg), void *arg);
-void SSL_get0_alpn_selected(SSL* ssl, const unsigned char** protocol, unsigned int* len);
+void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsigned int* len);
 int32_t SSL_select_next_proto(unsigned char** out, unsigned char* outlen, const unsigned char* server, unsigned int server_len, const unsigned char* client, unsigned int client_len);
 #endif
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -50,6 +50,20 @@ int EC_POINT_set_affine_coordinates_GF2m(const EC_GROUP *group, EC_POINT *p,
         const BIGNUM *x, const BIGNUM *y, BN_CTX *ctx);
 #endif
 
+#if !HAVE_OPENSSL_ALPN
+#undef HAVE_OPENSSL_ALPN
+#define HAVE_OPENSSL_ALPN 1
+int SSL_CTX_set_alpn_protos(SSL_CTX* ctx, const unsigned char* protos, unsigned int protos_len);
+void SSL_CTX_set_alpn_select_cb(SSL_CTX* ctx, int (*cb) (SSL *ssl,
+                                            const unsigned char **out,
+                                            unsigned char *outlen,
+                                            const unsigned char *in,
+                                            unsigned int inlen,
+                                            void *arg), void *arg);
+void SSL_get0_alpn_selected(SSL* ssl, const unsigned char** protocol, unsigned int* len);
+int32_t SSL_select_next_proto(unsigned char** out, unsigned char* outlen, const unsigned char* server, unsigned int server_len, const unsigned char* client, unsigned int client_len);
+#endif
+
 #define API_EXISTS(fn) (fn != nullptr)
 
 // List of all functions from the libssl that are used in the System.Security.Cryptography.Native.
@@ -251,8 +265,8 @@ int EC_POINT_set_affine_coordinates_GF2m(const EC_GROUP *group, EC_POINT *p,
     PER_FUNCTION_BLOCK(SSL_CTX_ctrl, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_free, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_new, true) \
-    PER_FUNCTION_BLOCK(SSL_CTX_set_alpn_protos, true) \
-    PER_FUNCTION_BLOCK(SSL_CTX_set_alpn_select_cb, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_set_alpn_protos, false) \
+    PER_FUNCTION_BLOCK(SSL_CTX_set_alpn_select_cb, false) \
     PER_FUNCTION_BLOCK(SSL_CTX_set_cert_verify_callback, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_set_cipher_list, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_set_client_CA_list, true) \
@@ -272,13 +286,13 @@ int EC_POINT_set_affine_coordinates_GF2m(const EC_GROUP *group, EC_POINT *p,
     PER_FUNCTION_BLOCK(SSL_get_peer_finished, true) \
     PER_FUNCTION_BLOCK(SSL_get_SSL_CTX, true) \
     PER_FUNCTION_BLOCK(SSL_get_version, true) \
-    PER_FUNCTION_BLOCK(SSL_get0_alpn_selected, true) \
+    PER_FUNCTION_BLOCK(SSL_get0_alpn_selected, false) \
     PER_FUNCTION_BLOCK(SSL_library_init, true) \
     PER_FUNCTION_BLOCK(SSL_load_error_strings, true) \
     PER_FUNCTION_BLOCK(SSL_new, true) \
     PER_FUNCTION_BLOCK(SSL_read, true) \
     PER_FUNCTION_BLOCK(SSL_renegotiate_pending, true) \
-    PER_FUNCTION_BLOCK(SSL_select_next_proto, true) \
+    PER_FUNCTION_BLOCK(SSL_select_next_proto, false) \
     PER_FUNCTION_BLOCK(SSL_set_accept_state, true) \
     PER_FUNCTION_BLOCK(SSL_set_bio, true) \
     PER_FUNCTION_BLOCK(SSL_set_connect_state, true) \

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_crypto_config.h.in
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_crypto_config.h.in
@@ -3,3 +3,4 @@
 #cmakedefine01 HAVE_TLS_V1_1
 #cmakedefine01 HAVE_TLS_V1_2
 #cmakedefine01 HAVE_OPENSSL_EC2M
+#cmakedefine01 HAVE_OPENSSL_ALPN

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -559,7 +559,7 @@ extern "C" int32_t CryptoNative_SslCtxSetAlpnProtos(SSL_CTX* ctx, const uint8_t*
     else
 #endif
     {
-        return -1;
+        return 0;
     }
 }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -527,20 +527,48 @@ extern "C" int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509)
 
 extern "C" int32_t CryptoNative_SslSelectNextProto(uint8_t** out, uint8_t* outlen, const uint8_t* server, uint32_t server_len, const uint8_t* client, uint32_t client_len)
 {
-    return SSL_select_next_proto(out, outlen, server, server_len, client, client_len);
+#ifdef HAVE_OPENSSL_ALPN
+    if (API_EXISTS(SSL_select_next_proto))
+    {
+        return SSL_select_next_proto(out, outlen, server, server_len, client, client_len);
+    }
+    else
+#endif
+    {
+        return -1;
+    }
 }
 
 extern "C" void CryptoNative_SslCtxSetAlpnSelectCb(SSL_CTX* ctx, SslCtxSetAlpnCallback cb, void* arg)
 {
-    SSL_CTX_set_alpn_select_cb(ctx, cb, arg);
+#ifdef HAVE_OPENSSL_ALPN
+    if (API_EXISTS(SSL_CTX_set_alpn_select_cb))
+    {
+        SSL_CTX_set_alpn_select_cb(ctx, cb, arg);
+    }
+#endif
 }
 
 extern "C" int32_t CryptoNative_SslCtxSetAlpnProtos(SSL_CTX* ctx, const uint8_t* protos, uint32_t protos_len)
 {
-    return SSL_CTX_set_alpn_protos(ctx, protos, protos_len);
+#ifdef HAVE_OPENSSL_ALPN
+    if (API_EXISTS(SSL_CTX_set_alpn_protos))
+    {
+        return SSL_CTX_set_alpn_protos(ctx, protos, protos_len);
+    }
+    else
+#endif
+    {
+        return -1;
+    }
 }
 
 extern "C" void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const uint8_t** protocol, uint32_t* len)
 {
-    SSL_get0_alpn_selected(ssl, protocol, len);
+#ifdef HAVE_OPENSSL_ALPN
+    if (API_EXISTS(SSL_get0_alpn_selected))
+    {
+        SSL_get0_alpn_selected(ssl, protocol, len);
+    }
+#endif
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -525,22 +525,22 @@ extern "C" int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509)
     return 0;
 }
 
-extern "C" int32_t CryptoNative_SslSelectNextProto(unsigned char** out, unsigned char* outlen, const unsigned char* server, unsigned int server_len, const unsigned char* client, unsigned int client_len)
+extern "C" int32_t CryptoNative_SslSelectNextProto(uint8_t** out, uint8_t* outlen, const uint8_t* server, uint32_t server_len, const uint8_t* client, uint32_t client_len)
 {
     return SSL_select_next_proto(out, outlen, server, server_len, client, client_len);
 }
 
-extern "C" void CryptoNative_SslCtxSetAplnSelectCb(SSL_CTX* ctx, SslCtxSetAplnCallback cb, void* arg)
+extern "C" void CryptoNative_SslCtxSetAlpnSelectCb(SSL_CTX* ctx, SslCtxSetAlpnCallback cb, void* arg)
 {
     SSL_CTX_set_alpn_select_cb(ctx, cb, arg);
 }
 
-extern "C" int32_t CryptoNative_SslCtxSetAlpnProtos(SSL_CTX* ctx, const unsigned char* protos, unsigned protos_len)
+extern "C" int32_t CryptoNative_SslCtxSetAlpnProtos(SSL_CTX* ctx, const uint8_t* protos, uint32_t protos_len)
 {
     return SSL_CTX_set_alpn_protos(ctx, protos, protos_len);
 }
 
-extern "C" void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const unsigned char** protocol, unsigned int* len)
+extern "C" void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const uint8_t** protocol, uint32_t* len)
 {
     SSL_get0_alpn_selected(ssl, protocol, len);
 }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -524,3 +524,23 @@ extern "C" int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509)
 
     return 0;
 }
+
+extern "C" int32_t CryptoNative_SslSelectNextProto(unsigned char** out, unsigned char* outlen, const unsigned char* server, unsigned int server_len, const unsigned char* client, unsigned int client_len)
+{
+    return SSL_select_next_proto(out, outlen, server, server_len, client, client_len);
+}
+
+extern "C" void CryptoNative_SslCtxSetAplnSelectCb(SSL_CTX* ctx, SslCtxSetAplnCallback cb, void* arg)
+{
+    SSL_CTX_set_alpn_select_cb(ctx, cb, arg);
+}
+
+extern "C" int32_t CryptoNative_SslCtxSetAlpnProtos(SSL_CTX* ctx, const unsigned char* protos, unsigned protos_len)
+{
+    return SSL_CTX_set_alpn_protos(ctx, protos, protos_len);
+}
+
+extern "C" void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const unsigned char** protocol, unsigned int* len)
+{
+    SSL_get0_alpn_selected(ssl, protocol, len);
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
@@ -117,6 +117,14 @@ typedef int32_t (*SslCtxSetCertVerifyCallbackCallback)(X509_STORE_CTX*, void* ar
 
 // the function pointer definition for the callback used in SslCtxSetClientCertCallback
 typedef int32_t (*SslClientCertCallback)(SSL* ssl, X509** x509, EVP_PKEY** pkey);
+
+// the function pointer definition for the callback used in SslCtxSetAplnSelectCb
+typedef int32_t (*SslCtxSetAplnCallback)(SSL* ssl,
+    const unsigned char** out,
+    unsigned char* outlen,
+    const unsigned char* in,
+    unsigned int inlen,
+    void* arg);
 /*
 Ensures that libssl is correctly initialized and ready to use.
 */
@@ -365,3 +373,25 @@ libssl frees the x509 object.
 Returns 1 if success and 0 in case of failure
 */
 extern "C" int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509);
+
+/*
+Shims the SSL_select_next_proto method.
+Returns 1 on success, 0 on failure.
+*/
+extern "C" int32_t CryptoNative_SslSelectNextProto(unsigned char** out, unsigned char* outlen, const unsigned char* server, unsigned int server_len, const unsigned char* client, unsigned int client_len);
+
+/*
+Shims the ssl_ctx_set_alpn_select_cb method.
+*/
+extern "C" void CryptoNative_SslCtxSetAplnSelectCb(SSL_CTX* ctx, SslCtxSetAplnCallback cb, void *arg);
+
+/*
+Shims the ssl_ctx_set_alpn_protos method.
+Returns 0 on success, non-zero on failure.
+*/
+extern "C" int32_t CryptoNative_SslCtxSetAlpnProtos(SSL_CTX* ctx, const unsigned char *protos, unsigned protos_len);
+
+/*
+Shims the ssl_get0_alpn_selected method.
+*/
+extern "C" void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const unsigned char** protocol, unsigned int* len);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
@@ -118,12 +118,12 @@ typedef int32_t (*SslCtxSetCertVerifyCallbackCallback)(X509_STORE_CTX*, void* ar
 // the function pointer definition for the callback used in SslCtxSetClientCertCallback
 typedef int32_t (*SslClientCertCallback)(SSL* ssl, X509** x509, EVP_PKEY** pkey);
 
-// the function pointer definition for the callback used in SslCtxSetAplnSelectCb
-typedef int32_t (*SslCtxSetAplnCallback)(SSL* ssl,
-    const unsigned char** out,
-    unsigned char* outlen,
-    const unsigned char* in,
-    unsigned int inlen,
+// the function pointer definition for the callback used in SslCtxSetAlpnSelectCb
+typedef int32_t (*SslCtxSetAlpnCallback)(SSL* ssl,
+    const uint8_t** out,
+    uint8_t* outlen,
+    const uint8_t* in,
+    uint32_t inlen,
     void* arg);
 /*
 Ensures that libssl is correctly initialized and ready to use.
@@ -378,20 +378,20 @@ extern "C" int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509);
 Shims the SSL_select_next_proto method.
 Returns 1 on success, 0 on failure.
 */
-extern "C" int32_t CryptoNative_SslSelectNextProto(unsigned char** out, unsigned char* outlen, const unsigned char* server, unsigned int server_len, const unsigned char* client, unsigned int client_len);
+extern "C" int32_t CryptoNative_SslSelectNextProto(uint8_t** out, uint8_t* outlen, const uint8_t* server, uint32_t server_len, const uint8_t* client, uint32_t client_len);
 
 /*
 Shims the ssl_ctx_set_alpn_select_cb method.
 */
-extern "C" void CryptoNative_SslCtxSetAplnSelectCb(SSL_CTX* ctx, SslCtxSetAplnCallback cb, void *arg);
+extern "C" void CryptoNative_SslCtxSetAlpnSelectCb(SSL_CTX* ctx, SslCtxSetAlpnCallback cb, void *arg);
 
 /*
 Shims the ssl_ctx_set_alpn_protos method.
 Returns 0 on success, non-zero on failure.
 */
-extern "C" int32_t CryptoNative_SslCtxSetAlpnProtos(SSL_CTX* ctx, const unsigned char *protos, unsigned protos_len);
+extern "C" int32_t CryptoNative_SslCtxSetAlpnProtos(SSL_CTX* ctx, const uint8_t* protos, uint32_t protos_len);
 
 /*
 Shims the ssl_get0_alpn_selected method.
 */
-extern "C" void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const unsigned char** protocol, unsigned int* len);
+extern "C" void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const uint8_t** protocol, uint32_t* len);

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -228,6 +228,7 @@
   </ItemGroup>
   <!-- Windows dependencies for Integrated Authentication for MANAGED_SNI build -->
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true' ">
+    <Reference Include="System.Memory" />
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -228,8 +228,8 @@
   </ItemGroup>
   <!-- Windows dependencies for Integrated Authentication for MANAGED_SNI build -->
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs">
-      <Link>Common\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
+      <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Windows.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Windows.cs</Link>

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -228,6 +228,9 @@
   </ItemGroup>
   <!-- Windows dependencies for Integrated Authentication for MANAGED_SNI build -->
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true' ">
+    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs">
+      <Link>Common\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Windows.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Windows.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -387,4 +387,7 @@
   <data name="IO_SeekBeforeBegin" xml:space="preserve">
     <value>An attempt was made to move the position before the beginning of the stream.</value>
   </data>
+  <data name="net_ssl_app_protocols_invalid" xml:space="preserve">
+    <value>The application protocol list is invalid.</value>
+  </data>
 </root>

--- a/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
+++ b/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
@@ -143,6 +143,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs">
+      <Link>Common\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.BOOL.cs">
       <Link>Common\Interop\Windows\Interop.BOOL.cs</Link>
     </Compile>

--- a/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
+++ b/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
@@ -143,8 +143,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs">
-      <Link>Common\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
+      <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.BOOL.cs">
       <Link>Common\Interop\Windows\Interop.BOOL.cs</Link>

--- a/src/System.Net.Mail/src/System.Net.Mail.csproj
+++ b/src/System.Net.Mail/src/System.Net.Mail.csproj
@@ -203,8 +203,8 @@
   </ItemGroup>
   <!-- Windows specific files -->
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
-  	<Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs">
-      <Link>Common\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
+      <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\Security\SecurityContextTokenHandle.cs">
       <Link>Common\System\Net\Security\SecurityContextTokenHandle.cs</Link>

--- a/src/System.Net.Mail/src/System.Net.Mail.csproj
+++ b/src/System.Net.Mail/src/System.Net.Mail.csproj
@@ -203,6 +203,9 @@
   </ItemGroup>
   <!-- Windows specific files -->
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
+  	<Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs">
+      <Link>Common\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Security\SecurityContextTokenHandle.cs">
       <Link>Common\System\Net\Security\SecurityContextTokenHandle.cs</Link>
     </Compile>

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -5,6 +5,7 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 
 namespace System.Net.Security
 {
@@ -94,13 +95,23 @@ namespace System.Net.Security
         EncryptAndSign = 2
     }
     public delegate bool RemoteCertificateValidationCallback(object sender, System.Security.Cryptography.X509Certificates.X509Certificate certificate, System.Security.Cryptography.X509Certificates.X509Chain chain, System.Net.Security.SslPolicyErrors sslPolicyErrors);
+    public partial class SslAuthenticationOptions
+    {
+        public IList<string> ApplicationProtocols { get { throw null; } set { } }
+        public Dictionary<string, System.Security.Cryptography.X509Certificates.X509Certificate2> ServerCertificates { get { throw null; } set { } }
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get { throw null; } set { } }
+        public LocalCertificateSelectionCallback UserCertificateSelectionCallback { get { throw null; } set { } }
+        public EncryptionPolicy EncryptionPolicy { get { throw null; } set { } }
+    }
     public partial class SslStream : AuthenticatedStream
     {
         public SslStream(System.IO.Stream innerStream) : base(innerStream, false) { }
+        public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, SslAuthenticationOptions sslauthenticationOptions) : base(innerStream, leaveInnerStreamOpen) { }
         public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen) : base(innerStream, leaveInnerStreamOpen) { }
         public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback) : base(innerStream, leaveInnerStreamOpen) { }
         public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback, System.Net.Security.LocalCertificateSelectionCallback userCertificateSelectionCallback) : base(innerStream, leaveInnerStreamOpen) { }
         public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback, System.Net.Security.LocalCertificateSelectionCallback userCertificateSelectionCallback, System.Net.Security.EncryptionPolicy encryptionPolicy) : base(innerStream, leaveInnerStreamOpen) { }
+        public string NegotiatedApplicationProtocol { get { throw null; } }
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanTimeout { get { throw null; } }

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -6,6 +6,10 @@
 // ------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Security
 {
@@ -95,18 +99,49 @@ namespace System.Net.Security
         EncryptAndSign = 2
     }
     public delegate bool RemoteCertificateValidationCallback(object sender, System.Security.Cryptography.X509Certificates.X509Certificate certificate, System.Security.Cryptography.X509Certificates.X509Chain chain, System.Net.Security.SslPolicyErrors sslPolicyErrors);
-    public partial class SslAuthenticationOptions
+    public class SslServerAuthenticationOptions
     {
-        public IList<string> ApplicationProtocols { get { throw null; } set { } }
-        public Dictionary<string, System.Security.Cryptography.X509Certificates.X509Certificate2> ServerCertificates { get { throw null; } set { } }
+        public bool AllowRenegotiation { get { throw null;  } set { } }
+        public X509Certificate ServerCertificate { get { throw null;  } set { } }
+        public bool ClientCertificateRequired { get { throw null;  } set { } }
+        public SslProtocols EnabledSslProtocols { get { throw null;  } set { } }
+        public X509RevocationMode CheckCertificateRevocation { get { throw null;  } set { } }
+        public IList<SslApplicationProtocol> ApplicationProtocols { get; }
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get { throw null;  } set { } }
+        public EncryptionPolicy EncryptionPolicy { get { throw null;  } set { } }
+    }
+    public partial class SslClientAuthenticationOptions
+    {
+        public bool AllowRenegotiation { get { throw null;  } set { } }
+        public string TargetHost { get { throw null; } set { } }
+        public X509CertificateCollection ClientCertificates { get { throw null; } set { } }
+        public LocalCertificateSelectionCallback LocalCertificateSelectionCallback { get { throw null; } set { } }
+        public SslProtocols EnabledSslProtocols { get { throw null; } set { } }
+        public X509RevocationMode CheckCertificateRevocation { get { throw null; } set { } }
+        public IList<SslApplicationProtocol> ApplicationProtocols { get { throw null; } }
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get { throw null; } set { } }
-        public LocalCertificateSelectionCallback UserCertificateSelectionCallback { get { throw null; } set { } }
         public EncryptionPolicy EncryptionPolicy { get { throw null; } set { } }
+    }
+    public partial struct SslApplicationProtocol : IEquatable<SslApplicationProtocol>
+    {
+        public static readonly SslApplicationProtocol Http2;
+        public static readonly SslApplicationProtocol Http11;
+
+        public SslApplicationProtocol(byte[] protocol) { }
+        public SslApplicationProtocol(string protocol) { }
+
+        public ReadOnlyMemory<byte> Protocol { get { throw null; } }
+
+        public bool Equals(SslApplicationProtocol other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override string ToString() { throw null; }
+        public static bool operator ==(SslApplicationProtocol left, SslApplicationProtocol right) { throw null; }
+        public static bool operator !=(SslApplicationProtocol left, SslApplicationProtocol right) { throw null; }
     }
     public partial class SslStream : AuthenticatedStream
     {
         public SslStream(System.IO.Stream innerStream) : base(innerStream, false) { }
-        public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, SslAuthenticationOptions sslauthenticationOptions) : base(innerStream, leaveInnerStreamOpen) { }
         public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen) : base(innerStream, leaveInnerStreamOpen) { }
         public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback) : base(innerStream, leaveInnerStreamOpen) { }
         public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback, System.Net.Security.LocalCertificateSelectionCallback userCertificateSelectionCallback) : base(innerStream, leaveInnerStreamOpen) { }
@@ -145,9 +180,11 @@ namespace System.Net.Security
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost) { throw null; }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { throw null; }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, bool checkCertificateRevocation) { throw null; }
+        public Task AuthenticateAsClientAsync(SslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken) { throw null; }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate) { throw null; }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { throw null; }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation) { throw null; }
+        public Task AuthenticateAsServerAsync(SslServerAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken) { throw null; }
         public virtual System.IAsyncResult BeginAuthenticateAsClient(string targetHost, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
         public virtual System.IAsyncResult BeginAuthenticateAsClient(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
         public virtual System.IAsyncResult BeginAuthenticateAsClient(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, bool checkCertificateRevocation, System.AsyncCallback asyncCallback, object asyncState) { throw null; }

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -105,8 +105,8 @@ namespace System.Net.Security
         public X509Certificate ServerCertificate { get { throw null;  } set { } }
         public bool ClientCertificateRequired { get { throw null;  } set { } }
         public SslProtocols EnabledSslProtocols { get { throw null;  } set { } }
-        public X509RevocationMode CheckCertificateRevocation { get { throw null;  } set { } }
-        public IList<SslApplicationProtocol> ApplicationProtocols { get { throw null; } set { } }
+        public X509RevocationMode CertificateRevocationCheckMode { get { throw null;  } set { } }
+        public List<SslApplicationProtocol> ApplicationProtocols { get { throw null; } set { } }
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get { throw null;  } set { } }
         public EncryptionPolicy EncryptionPolicy { get { throw null;  } set { } }
     }
@@ -117,8 +117,8 @@ namespace System.Net.Security
         public X509CertificateCollection ClientCertificates { get { throw null; } set { } }
         public LocalCertificateSelectionCallback LocalCertificateSelectionCallback { get { throw null; } set { } }
         public SslProtocols EnabledSslProtocols { get { throw null; } set { } }
-        public X509RevocationMode CheckCertificateRevocation { get { throw null; } set { } }
-        public IList<SslApplicationProtocol> ApplicationProtocols { get { throw null; } set { } }
+        public X509RevocationMode CertificateRevocationCheckMode { get { throw null; } set { } }
+        public List<SslApplicationProtocol> ApplicationProtocols { get { throw null; } set { } }
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get { throw null; } set { } }
         public EncryptionPolicy EncryptionPolicy { get { throw null; } set { } }
     }

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -106,7 +106,7 @@ namespace System.Net.Security
         public bool ClientCertificateRequired { get { throw null;  } set { } }
         public SslProtocols EnabledSslProtocols { get { throw null;  } set { } }
         public X509RevocationMode CheckCertificateRevocation { get { throw null;  } set { } }
-        public IList<SslApplicationProtocol> ApplicationProtocols { get; }
+        public IList<SslApplicationProtocol> ApplicationProtocols { get { throw null; } set { } }
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get { throw null;  } set { } }
         public EncryptionPolicy EncryptionPolicy { get { throw null;  } set { } }
     }
@@ -118,7 +118,7 @@ namespace System.Net.Security
         public LocalCertificateSelectionCallback LocalCertificateSelectionCallback { get { throw null; } set { } }
         public SslProtocols EnabledSslProtocols { get { throw null; } set { } }
         public X509RevocationMode CheckCertificateRevocation { get { throw null; } set { } }
-        public IList<SslApplicationProtocol> ApplicationProtocols { get { throw null; } }
+        public IList<SslApplicationProtocol> ApplicationProtocols { get { throw null; } set { } }
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get { throw null; } set { } }
         public EncryptionPolicy EncryptionPolicy { get { throw null; } set { } }
     }

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -146,7 +146,7 @@ namespace System.Net.Security
         public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback) : base(innerStream, leaveInnerStreamOpen) { }
         public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback, System.Net.Security.LocalCertificateSelectionCallback userCertificateSelectionCallback) : base(innerStream, leaveInnerStreamOpen) { }
         public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback, System.Net.Security.LocalCertificateSelectionCallback userCertificateSelectionCallback, System.Net.Security.EncryptionPolicy encryptionPolicy) : base(innerStream, leaveInnerStreamOpen) { }
-        public string NegotiatedApplicationProtocol { get { throw null; } }
+        public SslApplicationProtocol NegotiatedApplicationProtocol { get { throw null; } }
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanTimeout { get { throw null; } }

--- a/src/System.Net.Security/ref/System.Net.Security.csproj
+++ b/src/System.Net.Security/ref/System.Net.Security.csproj
@@ -22,5 +22,8 @@
     <ProjectReference Include="..\..\System.Security.Principal\ref\System.Security.Principal.csproj" />
     <ProjectReference Include="..\..\System.Threading.Tasks\ref\System.Threading.Tasks.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Memory" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.Security/ref/System.Net.Security.csproj
+++ b/src/System.Net.Security/ref/System.Net.Security.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Collections.NonGeneric\ref\System.Collections.NonGeneric.csproj" />
+    <ProjectReference Include="..\..\System.Collections\ref\System.Collections.csproj" />
     <ProjectReference Include="..\..\System.IO\ref\System.IO.csproj" />
     <ProjectReference Include="..\..\System.Net.Primitives\ref\System.Net.Primitives.csproj" />
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -361,14 +361,14 @@
   <data name="net_encryptionpolicy_notsupported" xml:space="preserve">
     <value>The '{0}' encryption policy is not supported on this platform.</value>
   </data>
-  <data name="net_alpn_notsupported" xml:space="preserve">
-    <value>ALPN is not supported on the current platform.</value>
+  <data name="net_alpn_config_failed" xml:space="preserve">
+    <value>ALPN configuration failed on this platform.</value>
   </data>
   <data name="net_ssl_app_protocols_invalid" xml:space="preserve">
     <value>The application protocol list is invalid.</value>
   </data>
-  <data name="net_ssl_app_protocol_empty" xml:space="preserve">
-    <value>The application protocol cannot be empty.</value>
+  <data name="net_ssl_app_protocol_invalid" xml:space="preserve">
+    <value>The application protocol value is invalid.</value>
   </data>
   <data name="net_conflicting_options" xml:space="preserve">
     <value>The '{0}' option was already set in the SslStream constructor.</value>

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -367,4 +367,10 @@
   <data name="net_ssl_app_protocols_invalid" xml:space="preserve">
     <value>The application protocol list is invalid.</value>
   </data>
+  <data name="net_ssl_app_protocol_empty" xml:space="preserve">
+    <value>The application protocol cannot be empty.</value>
+  </data>
+  <data name="net_conflicting_options" xml:space="preserve">
+    <value>The '{0}' option was already set in the SslStream constructor.</value>
+  </data>
 </root>

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -361,4 +361,10 @@
   <data name="net_encryptionpolicy_notsupported" xml:space="preserve">
     <value>The '{0}' encryption policy is not supported on this platform.</value>
   </data>
+  <data name="net_alpn_notsupported" xml:space="preserve">
+    <value>ALPN is not supported on the current platform.</value>
+  </data>
+  <data name="net_ssl_app_protocols_invalid" xml:space="preserve">
+    <value>The application protocol list is invalid.</value>
+  </data>
 </root>

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -165,8 +165,11 @@
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs">
-      <Link>Common\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
+      <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.Sec_Application_Protocols.cs">
+      <Link>Common\Interop\Windows\SChannel\Interop.Sec_Application_Protocols.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\UnmanagedCertificateContext.cs">
       <Link>Common\Interop\Windows\SChannel\UnmanagedCertificateContext.cs</Link>

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -165,6 +165,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs">
+      <Link>Common\Interop\Windows\SChannel\SecPkgContext_ApplicationProtocol.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\UnmanagedCertificateContext.cs">
       <Link>Common\Interop\Windows\SChannel\UnmanagedCertificateContext.cs</Link>
     </Compile>

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -22,6 +22,10 @@
     <Compile Include="System\Net\FixedSizeReader.cs" />
     <Compile Include="System\Net\HelperAsyncResults.cs" />
     <Compile Include="System\Net\Logging\NetEventSource.cs" />
+    <Compile Include="System\Net\Security\SslApplicationProtocol.cs" />
+    <Compile Include="System\Net\Security\SslAuthenticationOptions.cs" />
+    <Compile Include="System\Net\Security\SslClientAuthenticationOptions.cs" />
+    <Compile Include="System\Net\Security\SslServerAuthenticationOptions.cs" />
     <Compile Include="System\Net\Security\SslStreamInternal.Adapters.cs" />
     <Compile Include="System\Net\SslStreamContext.cs" />
     <Compile Include="System\Net\Security\AuthenticatedStream.cs" />
@@ -396,6 +400,7 @@
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tracing" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Net.Primitives" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />

--- a/src/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -22,7 +22,7 @@ namespace System.Net
 
         public SafeSslHandle SslContext => _sslContext;
 
-        public SafeDeleteSslContext(SafeFreeSslCredentials credential, bool isServer)
+        public SafeDeleteSslContext(SafeFreeSslCredentials credential, SslAuthenticationOptions sslAuthenticationOptions)
             : base(credential)
         {
             Debug.Assert((null != credential) && !credential.IsInvalid, "Invalid credential used in SafeDeleteSslContext");
@@ -35,7 +35,7 @@ namespace System.Net
                     _writeCallback = WriteToConnection;
                 }
 
-                _sslContext = CreateSslContext(credential, isServer);
+                _sslContext = CreateSslContext(credential, sslAuthenticationOptions.IsServer);
 
                 int osStatus = Interop.AppleCrypto.SslSetIoCallbacks(
                     _sslContext,

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -37,6 +37,7 @@ namespace System.Net.Security
         private bool _refreshCredentialNeeded;
 
         private SslAuthenticationOptions _sslAuthenticationOptions;
+        private string _negotiatedApplicationProtocol;
 
         private readonly Oid _serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.1");
         private readonly Oid _clientAuthOid = new Oid("1.3.6.1.5.5.7.3.2", "1.3.6.1.5.5.7.3.2");
@@ -173,7 +174,7 @@ namespace System.Net.Security
         {
             get
             {
-                return SslStreamPal.GetNegotiatedApplicationProtocol(_securityContext);
+                return _negotiatedApplicationProtocol;
             }
         }
 
@@ -769,15 +770,38 @@ namespace System.Net.Security
 
             SecurityBuffer incomingSecurity = null;
             SecurityBuffer[] incomingSecurityBuffers = null;
+            SecurityBuffer alpnBuffer = null;
+
+            if (_sslAuthenticationOptions.ApplicationProtocols != null && _sslAuthenticationOptions.ApplicationProtocols.Count != 0)
+            {
+                byte[] alpnBytes = SslAuthenticationOptions.ConvertAlpnProtocolListToByteArray(_sslAuthenticationOptions.ApplicationProtocols);
+                alpnBuffer = new SecurityBuffer(alpnBytes, 0, alpnBytes.Length, SecurityBufferType.SECBUFFER_APPLICATION_PROTOCOLS);
+            }
 
             if (input != null)
             {
                 incomingSecurity = new SecurityBuffer(input, offset, count, SecurityBufferType.SECBUFFER_TOKEN);
-                incomingSecurityBuffers = new SecurityBuffer[]
+                if (alpnBuffer != null)
                 {
-                    incomingSecurity,
-                    new SecurityBuffer(null, 0, 0, SecurityBufferType.SECBUFFER_EMPTY)
-                };
+                    incomingSecurityBuffers = new SecurityBuffer[]
+                    {
+                        incomingSecurity,
+                        new SecurityBuffer(null, 0, 0, SecurityBufferType.SECBUFFER_EMPTY),
+                        alpnBuffer
+                    };
+                }
+                else
+                {
+                    incomingSecurityBuffers = new SecurityBuffer[]
+                    {
+                        incomingSecurity,
+                        new SecurityBuffer(null, 0, 0, SecurityBufferType.SECBUFFER_EMPTY)
+                    };
+                }
+            }
+            else if (alpnBuffer != null)
+            {
+                incomingSecurity = alpnBuffer;
             }
 
             SecurityBuffer outgoingSecurity = new SecurityBuffer(null, SecurityBufferType.SECBUFFER_TOKEN);
@@ -808,13 +832,13 @@ namespace System.Net.Security
                         status = SslStreamPal.AcceptSecurityContext(
                                       ref _credentialsHandle,
                                       ref _securityContext,
-                                      incomingSecurity,
+                                      incomingSecurityBuffers,
                                       outgoingSecurity,
                                       _sslAuthenticationOptions);
                     }
                     else
                     {
-                        if (incomingSecurity == null)
+                        if (incomingSecurityBuffers == null)
                         {
                             status = SslStreamPal.InitializeSecurityContext(
                                            ref _credentialsHandle,
@@ -869,6 +893,7 @@ namespace System.Net.Security
             }
 
             output = outgoingSecurity.token;
+            _negotiatedApplicationProtocol = SslStreamPal.GetNegotiatedApplicationProtocol(_securityContext);
 
             return status;
         }

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -24,27 +24,15 @@ namespace System.Net.Security
 
         private SafeFreeCredentials _credentialsHandle;
         private SafeDeleteContext _securityContext;
-        private readonly string _destination;
-        private readonly string _hostName;
 
-        private readonly bool _serverMode;
-        private readonly bool _remoteCertRequired;
-        private readonly SslProtocols _sslProtocols;
         private SslConnectionInfo _connectionInfo;
-
-        private X509Certificate _serverCertificate;
         private X509Certificate _selectedClientCertificate;
         private bool _isRemoteCertificateAvailable;
-
-        private X509CertificateCollection _clientCertificates;
 
         // These are the MAX encrypt buffer output sizes, not the actual sizes.
         private int _headerSize = 5; //ATTN must be set to at least 5 by default
         private int _trailerSize = 16;
         private int _maxDataSize = 16354;
-
-        private bool _checkCertRevocation;
-        private bool _checkCertName;
 
         private bool _refreshCredentialNeeded;
 
@@ -53,38 +41,27 @@ namespace System.Net.Security
         private readonly Oid _serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.1");
         private readonly Oid _clientAuthOid = new Oid("1.3.6.1.5.5.7.3.2", "1.3.6.1.5.5.7.3.2");
 
-        internal SecureChannel(string hostname, bool serverMode, SslProtocols sslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertName,
-                                                  bool checkCertRevocationStatus, SslAuthenticationOptions sslAuthenticationOptions)
+        internal SecureChannel(SslAuthenticationOptions sslAuthenticationOptions)
         {
             if (NetEventSource.IsEnabled)
             {
-                NetEventSource.Enter(this, hostname, clientCertificates);
-                NetEventSource.Log.SecureChannelCtor(this, hostname, clientCertificates, sslAuthenticationOptions.EncryptionPolicy);
+                NetEventSource.Enter(this, sslAuthenticationOptions.TargetHost, sslAuthenticationOptions.ClientCertificates);
+                NetEventSource.Log.SecureChannelCtor(this, sslAuthenticationOptions.TargetHost, sslAuthenticationOptions.ClientCertificates, sslAuthenticationOptions.EncryptionPolicy);
             }
 
             SslStreamPal.VerifyPackageInfo();
 
-            _destination = hostname;
-
-            if (hostname == null)
+            if (sslAuthenticationOptions.TargetHost == null)
             {
-                NetEventSource.Fail(this, "hostname == null");
+                NetEventSource.Fail(this, "sslAuthenticationOptions.TargetHost == null");
             }
-            _hostName = hostname;
-            _serverMode = serverMode;
 
-            _sslProtocols = sslProtocols;
-
-            _serverCertificate = serverCertificate;
-            _clientCertificates = clientCertificates;
-            _remoteCertRequired = remoteCertRequired;
             _securityContext = null;
-            _checkCertRevocation = checkCertRevocationStatus;
-            _checkCertName = checkCertName;
             _refreshCredentialNeeded = true;
             _sslAuthenticationOptions = sslAuthenticationOptions;
-            
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Exit(this);
         }
 
         //
@@ -100,7 +77,7 @@ namespace System.Net.Security
         {
             get
             {
-                return _serverCertificate;
+                return _sslAuthenticationOptions.ServerCertificate;
             }
         }
 
@@ -122,7 +99,8 @@ namespace System.Net.Security
 
         internal ChannelBinding GetChannelBinding(ChannelBindingKind kind)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, kind);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Enter(this, kind);
 
             ChannelBinding result = null;
             if (_securityContext != null)
@@ -130,15 +108,16 @@ namespace System.Net.Security
                 result = SslStreamPal.QueryContextChannelBinding(_securityContext, kind);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, result);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Exit(this, result);
             return result;
         }
 
-        internal bool CheckCertRevocationStatus
+        internal X509RevocationMode CheckCertRevocationStatus
         {
             get
             {
-                return _checkCertRevocation;
+                return _sslAuthenticationOptions.CheckCertificateRevocation;
             }
         }
 
@@ -178,7 +157,7 @@ namespace System.Net.Security
         {
             get
             {
-                return _serverMode;
+                return _sslAuthenticationOptions.IsServer;
             }
         }
 
@@ -186,7 +165,7 @@ namespace System.Net.Security
         {
             get
             {
-                return _remoteCertRequired;
+                return _sslAuthenticationOptions.RemoteCertRequired;
             }
         }
 
@@ -205,9 +184,9 @@ namespace System.Net.Security
 
         internal void Close()
         {
-            if (_sslAuthenticationOptions._alpnProtocolsHandle.IsAllocated)
+            if (_sslAuthenticationOptions.AlpnProtocolsHandle.IsAllocated)
             {
-                _sslAuthenticationOptions._alpnProtocolsHandle.Free();
+                _sslAuthenticationOptions.AlpnProtocolsHandle.Free();
             }
 
             if (_securityContext != null)
@@ -232,7 +211,8 @@ namespace System.Net.Security
                 return null;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Log.LocatingPrivateKey(certificate, this);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Log.LocatingPrivateKey(certificate, this);
 
             try
             {
@@ -247,7 +227,8 @@ namespace System.Net.Security
                 {
                     if (certEx.HasPrivateKey)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Log.CertIsType2(this);
+                        if (NetEventSource.IsEnabled)
+                            NetEventSource.Log.CertIsType2(this);
 
                         return certEx;
                     }
@@ -262,24 +243,26 @@ namespace System.Net.Security
 
                 // ELSE Try the MY user and machine stores for private key check.
                 // For server side mode MY machine store takes priority.
-                X509Store store = CertificateValidationPal.EnsureStoreOpened(_serverMode);
+                X509Store store = CertificateValidationPal.EnsureStoreOpened(_sslAuthenticationOptions.IsServer);
                 if (store != null)
                 {
                     collectionEx = store.Certificates.Find(X509FindType.FindByThumbprint, certHash, false);
                     if (collectionEx.Count > 0 && collectionEx[0].HasPrivateKey)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Log.FoundCertInStore(_serverMode, this);
+                        if (NetEventSource.IsEnabled)
+                            NetEventSource.Log.FoundCertInStore(_sslAuthenticationOptions.IsServer, this);
                         return collectionEx[0];
                     }
                 }
 
-                store = CertificateValidationPal.EnsureStoreOpened(!_serverMode);
+                store = CertificateValidationPal.EnsureStoreOpened(!_sslAuthenticationOptions.IsServer);
                 if (store != null)
                 {
                     collectionEx = store.Certificates.Find(X509FindType.FindByThumbprint, certHash, false);
                     if (collectionEx.Count > 0 && collectionEx[0].HasPrivateKey)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Log.FoundCertInStore(_serverMode, this);
+                        if (NetEventSource.IsEnabled)
+                            NetEventSource.Log.FoundCertInStore(_sslAuthenticationOptions.IsServer, this);
                         return collectionEx[0];
                     }
                 }
@@ -288,7 +271,8 @@ namespace System.Net.Security
             {
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Log.NotFoundCertInStore(this);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Log.NotFoundCertInStore(this);
             return null;
         }
 
@@ -369,7 +353,8 @@ namespace System.Net.Security
 
         private bool AcquireClientCredentials(ref byte[] thumbPrint)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Enter(this);
 
             // Acquire possible Client Certificate information and set it on the handle.
             X509Certificate clientCertificate = null;        // This is a candidate that can come from the user callback or be guessed when targeting a session restart.
@@ -378,22 +363,23 @@ namespace System.Net.Security
 
             bool sessionRestartAttempt = false; // If true and no cached creds we will use anonymous creds.
 
-            if (_sslAuthenticationOptions._certSelectionDelegate != null)
+            if (_sslAuthenticationOptions.CertSelectionDelegate != null)
             {
                 issuers = GetRequestCertificateAuthorities();
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling CertificateSelectionCallback");
+                if (NetEventSource.IsEnabled)
+                    NetEventSource.Info(this, "Calling CertificateSelectionCallback");
 
                 X509Certificate2 remoteCert = null;
                 try
                 {
                     X509Certificate2Collection dummyCollection;
                     remoteCert = CertificateValidationPal.GetRemoteCertificate(_securityContext, out dummyCollection);
-                    if (_clientCertificates == null)
+                    if (_sslAuthenticationOptions.ClientCertificates == null)
                     {
-                        _clientCertificates = new X509CertificateCollection();
+                        _sslAuthenticationOptions.ClientCertificates = new X509CertificateCollection();
                     }
-                    clientCertificate = _sslAuthenticationOptions._certSelectionDelegate(_hostName, _clientCertificates, remoteCert, issuers);
+                    clientCertificate = _sslAuthenticationOptions.CertSelectionDelegate(_sslAuthenticationOptions.TargetHost, _sslAuthenticationOptions.ClientCertificates, remoteCert, issuers);
                 }
                 finally
                 {
@@ -412,36 +398,40 @@ namespace System.Net.Security
                     }
 
                     filteredCerts.Add(clientCertificate);
-                    if (NetEventSource.IsEnabled) NetEventSource.Log.CertificateFromDelegate(this);
+                    if (NetEventSource.IsEnabled)
+                        NetEventSource.Log.CertificateFromDelegate(this);
                 }
                 else
                 {
-                    if (_clientCertificates == null || _clientCertificates.Count == 0)
+                    if (_sslAuthenticationOptions.ClientCertificates == null || _sslAuthenticationOptions.ClientCertificates.Count == 0)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Log.NoDelegateNoClientCert(this);
+                        if (NetEventSource.IsEnabled)
+                            NetEventSource.Log.NoDelegateNoClientCert(this);
 
                         sessionRestartAttempt = true;
                     }
                     else
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Log.NoDelegateButClientCert(this);
+                        if (NetEventSource.IsEnabled)
+                            NetEventSource.Log.NoDelegateButClientCert(this);
                     }
                 }
             }
-            else if (_credentialsHandle == null && _clientCertificates != null && _clientCertificates.Count > 0)
+            else if (_credentialsHandle == null && _sslAuthenticationOptions.ClientCertificates != null && _sslAuthenticationOptions.ClientCertificates.Count > 0)
             {
                 // This is where we attempt to restart a session by picking the FIRST cert from the collection.
                 // Otherwise it is either server sending a client cert request or the session is renegotiated.
-                clientCertificate = _clientCertificates[0];
+                clientCertificate = _sslAuthenticationOptions.ClientCertificates[0];
                 sessionRestartAttempt = true;
                 if (clientCertificate != null)
                 {
                     filteredCerts.Add(clientCertificate);
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Log.AttemptingRestartUsingCert(clientCertificate, this);
+                if (NetEventSource.IsEnabled)
+                    NetEventSource.Log.AttemptingRestartUsingCert(clientCertificate, this);
             }
-            else if (_clientCertificates != null && _clientCertificates.Count > 0)
+            else if (_sslAuthenticationOptions.ClientCertificates != null && _sslAuthenticationOptions.ClientCertificates.Count > 0)
             {
                 //
                 // This should be a server request for the client cert sent over currently anonymous sessions.
@@ -460,7 +450,7 @@ namespace System.Net.Security
                     }
                 }
 
-                for (int i = 0; i < _clientCertificates.Count; ++i)
+                for (int i = 0; i < _sslAuthenticationOptions.ClientCertificates.Count; ++i)
                 {
                     //
                     // Make sure we add only if the cert matches one of the issuers.
@@ -472,13 +462,14 @@ namespace System.Net.Security
                         X509Chain chain = null;
                         try
                         {
-                            certificateEx = MakeEx(_clientCertificates[i]);
+                            certificateEx = MakeEx(_sslAuthenticationOptions.ClientCertificates[i]);
                             if (certificateEx == null)
                             {
                                 continue;
                             }
 
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Root cert: {certificateEx}");
+                            if (NetEventSource.IsEnabled)
+                                NetEventSource.Info(this, $"Root cert: {certificateEx}");
 
                             chain = new X509Chain();
 
@@ -498,10 +489,12 @@ namespace System.Net.Security
                                     found = Array.IndexOf(issuers, issuer) != -1;
                                     if (found)
                                     {
-                                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Matched {issuer}");
+                                        if (NetEventSource.IsEnabled)
+                                            NetEventSource.Info(this, $"Matched {issuer}");
                                         break;
                                     }
-                                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"No match: {issuer}");
+                                    if (NetEventSource.IsEnabled)
+                                        NetEventSource.Info(this, $"No match: {issuer}");
                                 }
                             }
 
@@ -517,16 +510,17 @@ namespace System.Net.Security
                                 chain.Dispose();
                             }
 
-                            if (certificateEx != null && (object)certificateEx != (object)_clientCertificates[i])
+                            if (certificateEx != null && (object)certificateEx != (object)_sslAuthenticationOptions.ClientCertificates[i])
                             {
                                 certificateEx.Dispose();
                             }
                         }
                     }
 
-                    if (NetEventSource.IsEnabled) NetEventSource.Log.SelectedCert(_clientCertificates[i], this);
+                    if (NetEventSource.IsEnabled)
+                        NetEventSource.Log.SelectedCert(_sslAuthenticationOptions.ClientCertificates[i], this);
 
-                    filteredCerts.Add(_clientCertificates[i]);
+                    filteredCerts.Add(_sslAuthenticationOptions.ClientCertificates[i]);
                 }
             }
 
@@ -568,7 +562,8 @@ namespace System.Net.Security
                 NetEventSource.Fail(this, "'selectedCert' does not match 'clientCertificate'.");
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Selected cert = {selectedCert}");
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Info(this, $"Selected cert = {selectedCert}");
 
             try
             {
@@ -577,7 +572,7 @@ namespace System.Net.Security
                 // SECURITY: selectedCert ref if not null is a safe object that does not depend on possible **user** inherited X509Certificate type.
                 //
                 byte[] guessedThumbPrint = selectedCert == null ? null : selectedCert.GetCertHash();
-                SafeFreeCredentials cachedCredentialHandle = SslSessionsCache.TryCachedCredential(guessedThumbPrint, _sslProtocols, _serverMode, _sslAuthenticationOptions.EncryptionPolicy);
+                SafeFreeCredentials cachedCredentialHandle = SslSessionsCache.TryCachedCredential(guessedThumbPrint, _sslAuthenticationOptions.EnabledSslProtocols, _sslAuthenticationOptions.IsServer, _sslAuthenticationOptions.EncryptionPolicy);
 
                 // We can probably do some optimization here. If the selectedCert is returned by the delegate
                 // we can always go ahead and use the certificate to create our credential
@@ -587,7 +582,8 @@ namespace System.Net.Security
                     selectedCert != null &&
                     SslStreamPal.StartMutualAuthAsAnonymous)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Reset to anonymous session.");
+                    if (NetEventSource.IsEnabled)
+                        NetEventSource.Info(this, "Reset to anonymous session.");
 
                     // IIS does not renegotiate a restarted session if client cert is needed.
                     // So we don't want to reuse **anonymous** cached credential for a new SSL connection if the client has passed some certificate.
@@ -605,7 +601,8 @@ namespace System.Net.Security
 
                 if (cachedCredentialHandle != null)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Log.UsingCachedCredential(this);
+                    if (NetEventSource.IsEnabled)
+                        NetEventSource.Log.UsingCachedCredential(this);
 
                     _credentialsHandle = cachedCredentialHandle;
                     _selectedClientCertificate = clientCertificate;
@@ -613,7 +610,7 @@ namespace System.Net.Security
                 }
                 else
                 {
-                    _credentialsHandle = SslStreamPal.AcquireCredentialsHandle(selectedCert, _sslProtocols, _sslAuthenticationOptions.EncryptionPolicy, _serverMode);
+                    _credentialsHandle = SslStreamPal.AcquireCredentialsHandle(selectedCert, _sslAuthenticationOptions.EnabledSslProtocols, _sslAuthenticationOptions.EncryptionPolicy, _sslAuthenticationOptions.IsServer);
 
                     thumbPrint = guessedThumbPrint; // Delay until here in case something above threw.
                     _selectedClientCertificate = clientCertificate;
@@ -628,7 +625,8 @@ namespace System.Net.Security
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, cachedCred, _credentialsHandle);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Exit(this, cachedCred, _credentialsHandle);
             return cachedCred;
         }
 
@@ -638,21 +636,23 @@ namespace System.Net.Security
         //
         private bool AcquireServerCredentials(ref byte[] thumbPrint)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Enter(this);
 
             X509Certificate localCertificate = null;
             bool cachedCred = false;
 
-            if (_sslAuthenticationOptions._certSelectionDelegate != null)
+            if (_sslAuthenticationOptions.CertSelectionDelegate != null)
             {
                 X509CertificateCollection tempCollection = new X509CertificateCollection();
-                tempCollection.Add(_serverCertificate);
-                localCertificate = _sslAuthenticationOptions._certSelectionDelegate(string.Empty, tempCollection, null, Array.Empty<string>());
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Use delegate selected Cert");
+                tempCollection.Add(_sslAuthenticationOptions.ServerCertificate);
+                localCertificate = _sslAuthenticationOptions.CertSelectionDelegate(string.Empty, tempCollection, null, Array.Empty<string>());
+                if (NetEventSource.IsEnabled)
+                    NetEventSource.Info(this, "Use delegate selected Cert");
             }
             else
             {
-                localCertificate = _serverCertificate;
+                localCertificate = _sslAuthenticationOptions.ServerCertificate;
             }
 
             if (localCertificate == null)
@@ -681,19 +681,19 @@ namespace System.Net.Security
             byte[] guessedThumbPrint = selectedCert.GetCertHash();
             try
             {
-                SafeFreeCredentials cachedCredentialHandle = SslSessionsCache.TryCachedCredential(guessedThumbPrint, _sslProtocols, _serverMode, _sslAuthenticationOptions.EncryptionPolicy);
+                SafeFreeCredentials cachedCredentialHandle = SslSessionsCache.TryCachedCredential(guessedThumbPrint, _sslAuthenticationOptions.EnabledSslProtocols, _sslAuthenticationOptions.IsServer, _sslAuthenticationOptions.EncryptionPolicy);
 
                 if (cachedCredentialHandle != null)
                 {
                     _credentialsHandle = cachedCredentialHandle;
-                    _serverCertificate = localCertificate;
+                    _sslAuthenticationOptions.ServerCertificate = localCertificate;
                     cachedCred = true;
                 }
                 else
                 {
-                    _credentialsHandle = SslStreamPal.AcquireCredentialsHandle(selectedCert, _sslProtocols, _sslAuthenticationOptions.EncryptionPolicy, _serverMode);
+                    _credentialsHandle = SslStreamPal.AcquireCredentialsHandle(selectedCert, _sslAuthenticationOptions.EnabledSslProtocols, _sslAuthenticationOptions.EncryptionPolicy, _sslAuthenticationOptions.IsServer);
                     thumbPrint = guessedThumbPrint;
-                    _serverCertificate = localCertificate;
+                    _sslAuthenticationOptions.ServerCertificate = localCertificate;
                 }
             }
             finally
@@ -705,28 +705,32 @@ namespace System.Net.Security
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, cachedCred, _credentialsHandle);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Exit(this, cachedCred, _credentialsHandle);
             return cachedCred;
         }
 
         //
         internal ProtocolToken NextMessage(byte[] incoming, int offset, int count)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Enter(this);
 
             byte[] nextmsg = null;
             SecurityStatusPal status = GenerateToken(incoming, offset, count, ref nextmsg);
 
-            if (!_serverMode && status.ErrorCode == SecurityStatusPalErrorCode.CredentialsNeeded)
+            if (!_sslAuthenticationOptions.IsServer && status.ErrorCode == SecurityStatusPalErrorCode.CredentialsNeeded)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "NextMessage() returned SecurityStatusPal.CredentialsNeeded");
+                if (NetEventSource.IsEnabled)
+                    NetEventSource.Info(this, "NextMessage() returned SecurityStatusPal.CredentialsNeeded");
 
                 SetRefreshCredentialNeeded();
                 status = GenerateToken(incoming, offset, count, ref nextmsg);
             }
 
             ProtocolToken token = new ProtocolToken(nextmsg, status);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, token);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Exit(this, token);
             return token;
         }
 
@@ -794,19 +798,18 @@ namespace System.Net.Security
                     thumbPrint = null;
                     if (_refreshCredentialNeeded)
                     {
-                        cachedCreds = _serverMode
+                        cachedCreds = _sslAuthenticationOptions.IsServer
                                         ? AcquireServerCredentials(ref thumbPrint)
                                         : AcquireClientCredentials(ref thumbPrint);
                     }
 
-                    if (_serverMode)
+                    if (_sslAuthenticationOptions.IsServer)
                     {
                         status = SslStreamPal.AcceptSecurityContext(
                                       ref _credentialsHandle,
                                       ref _securityContext,
                                       incomingSecurity,
                                       outgoingSecurity,
-                                      _remoteCertRequired,
                                       _sslAuthenticationOptions);
                     }
                     else
@@ -816,7 +819,7 @@ namespace System.Net.Security
                             status = SslStreamPal.InitializeSecurityContext(
                                            ref _credentialsHandle,
                                            ref _securityContext,
-                                           _destination,
+                                           _sslAuthenticationOptions.TargetHost,
                                            incomingSecurity,
                                            outgoingSecurity,
                                            _sslAuthenticationOptions);
@@ -826,7 +829,7 @@ namespace System.Net.Security
                             status = SslStreamPal.InitializeSecurityContext(
                                            _credentialsHandle,
                                            ref _securityContext,
-                                           _destination,
+                                           _sslAuthenticationOptions.TargetHost,
                                            incomingSecurityBuffers,
                                            outgoingSecurity,
                                            _sslAuthenticationOptions);
@@ -836,9 +839,9 @@ namespace System.Net.Security
             }
             finally
             {
-                if (_sslAuthenticationOptions._alpnProtocolsHandle.IsAllocated)
+                if (_sslAuthenticationOptions.AlpnProtocolsHandle.IsAllocated)
                 {
-                    _sslAuthenticationOptions._alpnProtocolsHandle.Free();
+                    _sslAuthenticationOptions.AlpnProtocolsHandle.Free();
                 }
 
                 if (_refreshCredentialNeeded)
@@ -860,13 +863,13 @@ namespace System.Net.Security
                     //
                     if (!cachedCreds && _securityContext != null && !_securityContext.IsInvalid && _credentialsHandle != null && !_credentialsHandle.IsInvalid)
                     {
-                        SslSessionsCache.CacheCredential(_credentialsHandle, thumbPrint, _sslProtocols, _serverMode, _sslAuthenticationOptions.EncryptionPolicy);
+                        SslSessionsCache.CacheCredential(_credentialsHandle, thumbPrint, _sslAuthenticationOptions.EnabledSslProtocols, _sslAuthenticationOptions.IsServer, _sslAuthenticationOptions.EncryptionPolicy);
                     }
                 }
             }
 
             output = outgoingSecurity.token;
-            
+
             return status;
         }
 
@@ -879,7 +882,8 @@ namespace System.Net.Security
         --*/
         internal void ProcessHandshakeSuccess()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Enter(this);
 
             StreamSizes streamSizes;
             SslStreamPal.QueryContextStreamSizes(_securityContext, out streamSizes);
@@ -903,7 +907,8 @@ namespace System.Net.Security
 
             SslStreamPal.QueryContextConnectionInfo(_securityContext, out _connectionInfo);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Exit(this);
         }
 
         /*++
@@ -938,12 +943,14 @@ namespace System.Net.Security
 
             if (secStatus.ErrorCode != SecurityStatusPalErrorCode.OK)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, $"ERROR {secStatus}");
+                if (NetEventSource.IsEnabled)
+                    NetEventSource.Exit(this, $"ERROR {secStatus}");
             }
             else
             {
                 output = writeBuffer;
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, $"OK data size:{resultSize}");
+                if (NetEventSource.IsEnabled)
+                    NetEventSource.Exit(this, $"OK data size:{resultSize}");
             }
 
             return secStatus;
@@ -951,7 +958,8 @@ namespace System.Net.Security
 
         internal SecurityStatusPal Decrypt(byte[] payload, ref int offset, ref int count)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, payload, offset, count);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Enter(this, payload, offset, count);
 
             if (offset < 0 || offset > (payload == null ? 0 : payload.Length))
             {
@@ -983,7 +991,8 @@ namespace System.Net.Security
         //
         internal bool VerifyRemoteCertificate(RemoteCertValidationCallback remoteCertValidationCallback, ref ProtocolToken alertToken)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Enter(this);
 
             SslPolicyErrors sslPolicyErrors = SslPolicyErrors.None;
 
@@ -1000,17 +1009,18 @@ namespace System.Net.Security
 
                 if (remoteCertificateEx == null)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(this, "(no remote cert)", !_remoteCertRequired);
+                    if (NetEventSource.IsEnabled)
+                        NetEventSource.Exit(this, "(no remote cert)", !_sslAuthenticationOptions.RemoteCertRequired);
                     sslPolicyErrors |= SslPolicyErrors.RemoteCertificateNotAvailable;
                 }
                 else
                 {
                     chain = new X509Chain();
-                    chain.ChainPolicy.RevocationMode = _checkCertRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck;
+                    chain.ChainPolicy.RevocationMode = _sslAuthenticationOptions.CheckCertificateRevocation;
                     chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
 
                     // Authenticate the remote party: (e.g. when operating in server mode, authenticate the client).
-                    chain.ChainPolicy.ApplicationPolicy.Add(_serverMode ? _clientAuthOid : _serverAuthOid);
+                    chain.ChainPolicy.ApplicationPolicy.Add(_sslAuthenticationOptions.IsServer ? _clientAuthOid : _serverAuthOid);
 
                     if (remoteCertificateStore != null)
                     {
@@ -1021,18 +1031,18 @@ namespace System.Net.Security
                         _securityContext,
                         chain,
                         remoteCertificateEx,
-                        _checkCertName,
-                        _serverMode,
-                        _hostName);
+                        _sslAuthenticationOptions.CheckCertName,
+                        _sslAuthenticationOptions.IsServer,
+                        _sslAuthenticationOptions.TargetHost);
                 }
 
                 if (remoteCertValidationCallback != null)
                 {
-                    success = remoteCertValidationCallback(_hostName, remoteCertificateEx, chain, sslPolicyErrors);
+                    success = remoteCertValidationCallback(_sslAuthenticationOptions.TargetHost, remoteCertificateEx, chain, sslPolicyErrors);
                 }
                 else
                 {
-                    if (sslPolicyErrors == SslPolicyErrors.RemoteCertificateNotAvailable && !_remoteCertRequired)
+                    if (sslPolicyErrors == SslPolicyErrors.RemoteCertificateNotAvailable && !_sslAuthenticationOptions.RemoteCertRequired)
                     {
                         success = true;
                     }
@@ -1045,7 +1055,8 @@ namespace System.Net.Security
                 if (NetEventSource.IsEnabled)
                 {
                     LogCertificateValidation(remoteCertValidationCallback, sslPolicyErrors, success, chain);
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Cert validation, remote cert = {remoteCertificateEx}");
+                    if (NetEventSource.IsEnabled)
+                        NetEventSource.Info(this, $"Cert validation, remote cert = {remoteCertificateEx}");
                 }
 
                 if (!success)
@@ -1068,14 +1079,16 @@ namespace System.Net.Security
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, success);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Exit(this, success);
 
             return success;
         }
 
         public ProtocolToken CreateFatalHandshakeAlertToken(SslPolicyErrors sslPolicyErrors, X509Chain chain)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Enter(this);
 
             TlsAlertMessage alertMessage;
 
@@ -1093,14 +1106,16 @@ namespace System.Net.Security
                     break;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"alertMessage:{alertMessage}");
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Info(this, $"alertMessage:{alertMessage}");
 
             SecurityStatusPal status;
             status = SslStreamPal.ApplyAlertToken(ref _credentialsHandle, _securityContext, TlsAlertType.Fatal, alertMessage);
 
             if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"ApplyAlertToken() returned {status.ErrorCode}");
+                if (NetEventSource.IsEnabled)
+                    NetEventSource.Info(this, $"ApplyAlertToken() returned {status.ErrorCode}");
 
                 if (status.Exception != null)
                 {
@@ -1111,20 +1126,23 @@ namespace System.Net.Security
             }
 
             ProtocolToken token = GenerateAlertToken();
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, token);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Exit(this, token);
             return token;
         }
 
         public ProtocolToken CreateShutdownToken()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Enter(this);
 
             SecurityStatusPal status;
             status = SslStreamPal.ApplyShutdownToken(ref _credentialsHandle, _securityContext);
 
             if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"ApplyAlertToken() returned {status.ErrorCode}");
+                if (NetEventSource.IsEnabled)
+                    NetEventSource.Info(this, $"ApplyAlertToken() returned {status.ErrorCode}");
 
                 if (status.Exception != null)
                 {
@@ -1135,7 +1153,8 @@ namespace System.Net.Security
             }
 
             ProtocolToken token = GenerateAlertToken();
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, token);
+            if (NetEventSource.IsEnabled)
+                NetEventSource.Exit(this, token);
             return token;
         }
 
@@ -1150,7 +1169,7 @@ namespace System.Net.Security
 
             return token;
         }
-        
+
         private static TlsAlertMessage GetAlertMessageFromChain(X509Chain chain)
         {
             foreach (X509ChainStatus chainStatus in chain.ChainStatus)
@@ -1168,7 +1187,7 @@ namespace System.Net.Security
                 }
 
                 if ((chainStatus.Status &
-                    (X509ChainStatusFlags.Revoked | X509ChainStatusFlags.OfflineRevocation )) != 0)
+                    (X509ChainStatusFlags.Revoked | X509ChainStatusFlags.OfflineRevocation)) != 0)
                 {
                     return TlsAlertMessage.CertificateRevoked;
                 }
@@ -1182,7 +1201,7 @@ namespace System.Net.Security
 
                 if ((chainStatus.Status & X509ChainStatusFlags.CtlNotValidForUsage) != 0)
                 {
-                    return TlsAlertMessage.UnsupportedCert; 
+                    return TlsAlertMessage.UnsupportedCert;
                 }
 
                 if ((chainStatus.Status &
@@ -1203,7 +1222,8 @@ namespace System.Net.Security
 
         private void LogCertificateValidation(RemoteCertValidationCallback remoteCertValidationCallback, SslPolicyErrors sslPolicyErrors, bool success, X509Chain chain)
         {
-            if (!NetEventSource.IsEnabled) return;
+            if (!NetEventSource.IsEnabled)
+                return;
 
             if (sslPolicyErrors != SslPolicyErrors.None)
             {

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -774,7 +774,7 @@ namespace System.Net.Security
 
             if (_sslAuthenticationOptions.ApplicationProtocols != null && _sslAuthenticationOptions.ApplicationProtocols.Count != 0)
             {
-                byte[] alpnBytes = SslAuthenticationOptions.ConvertAlpnProtocolListToByteArray(_sslAuthenticationOptions.ApplicationProtocols);
+                byte[] alpnBytes = SslStreamPal.ConvertAlpnProtocolListToByteArray(_sslAuthenticationOptions.ApplicationProtocols);
                 alpnBuffer = new SecurityBuffer(alpnBytes, 0, alpnBytes.Length, SecurityBufferType.SECBUFFER_APPLICATION_PROTOCOLS);
             }
 

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -118,7 +118,7 @@ namespace System.Net.Security
         {
             get
             {
-                return _sslAuthenticationOptions.CheckCertificateRevocation;
+                return _sslAuthenticationOptions.CertificateRevocationCheckMode;
             }
         }
 
@@ -1017,7 +1017,7 @@ namespace System.Net.Security
                 else
                 {
                     chain = new X509Chain();
-                    chain.ChainPolicy.RevocationMode = _sslAuthenticationOptions.CheckCertificateRevocation;
+                    chain.ChainPolicy.RevocationMode = _sslAuthenticationOptions.CertificateRevocationCheckMode;
                     chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
 
                     // Authenticate the remote party: (e.g. when operating in server mode, authenticate the client).

--- a/src/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
@@ -72,10 +72,14 @@ namespace System.Net.Security
 
         public override int GetHashCode()
         {
+            if (_readOnlyProtocol.Length == 0)
+                return 0;
+
             int hash1 = 0;
+            ReadOnlySpan<byte> pSpan = _readOnlyProtocol.Span;
             for (int i = 0; i < _readOnlyProtocol.Length; i++)
             {
-                hash1 = ((hash1 << 5) + hash1) ^ _readOnlyProtocol.Span[i];
+                hash1 = ((hash1 << 5) + hash1) ^ pSpan[i];
             }
 
             return hash1;
@@ -99,9 +103,10 @@ namespace System.Net.Security
                 char[] byteChars = new char[byteCharsLength];
                 int index = 0;
 
+                ReadOnlySpan<byte> pSpan = _readOnlyProtocol.Span;
                 for (int i = 0; i < byteCharsLength; i += 5)
                 {
-                    byte b = _readOnlyProtocol.Span[index++];
+                    byte b = pSpan[index++];
                     byteChars[i] = '0';
                     byteChars[i + 1] = 'x';
                     byteChars[i + 2] = GetHexValue(Math.DivRem(b, 16, out int rem));

--- a/src/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace System.Net.Security
+{
+    public struct SslApplicationProtocol : IEquatable<SslApplicationProtocol>
+    {
+        private ReadOnlyMemory<byte> _protocol;
+
+        // h2
+        public static readonly SslApplicationProtocol Http2 = new SslApplicationProtocol(new ReadOnlyMemory<byte>(new byte[] { 0x68, 0x32 }));
+        // http/1.1
+        public static readonly SslApplicationProtocol Http11 = new SslApplicationProtocol(new ReadOnlyMemory<byte>(new byte[] { 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31 }));
+
+        internal SslApplicationProtocol(ReadOnlyMemory<byte> protocol)
+        {
+            _protocol = protocol;
+        }
+
+        public SslApplicationProtocol(byte[] protocol)
+        {
+            if (protocol == null)
+            {
+                throw new ArgumentNullException(nameof(protocol));
+            }
+
+            if (protocol.Length == 0)
+            {
+                throw new ArgumentException(SR.net_ssl_app_protocol_empty, nameof(protocol));
+            }
+
+            byte[] temp = new byte[protocol.Length];
+            Array.Copy(protocol, temp, protocol.Length);
+
+            _protocol = new ReadOnlyMemory<byte>(temp);
+        }
+
+        public SslApplicationProtocol(string protocol)
+        {
+            if (protocol == null)
+            {
+                throw new ArgumentNullException(nameof(protocol));
+            }
+
+            if (protocol.Length == 0)
+            {
+                throw new ArgumentException(SR.net_ssl_app_protocol_empty, nameof(protocol));
+            }
+
+            _protocol = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(protocol));
+        }
+
+        public ReadOnlyMemory<byte> Protocol => _protocol;
+
+        public bool Equals(SslApplicationProtocol other)
+        {
+            return _protocol.Equals(other._protocol);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ReadOnlyMemory<byte> protocol)
+            {
+                return _protocol.Equals(protocol);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return _protocol.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            try
+            {
+                return Encoding.UTF8.GetString(_protocol.ToArray());
+            }
+            catch
+            {
+                // In case of decoding errors, return the byte values as hex string.
+                byte[] temp = _protocol.ToArray();
+                int byteCharsLength = temp.Length * 3;
+                char[] byteChars = new char[byteCharsLength];
+                int index = 0;
+
+                for (int i = 0; i < byteCharsLength; i += 3)
+                {
+                    byte b = temp[index++];
+                    byteChars[i] = GetHexValue(b / 16);
+                    byteChars[i + 1] = GetHexValue(b % 16);
+                    byteChars[i + 2] = ' ';
+                }
+
+                return new string(byteChars, 0, byteCharsLength - 1);
+
+                char GetHexValue(int i)
+                {
+                    if (i < 10)
+                        return (char)(i + '0');
+
+                    return (char)(i - 10 + 'a');
+                }
+            }
+        }
+
+        public static bool operator ==(SslApplicationProtocol left, SslApplicationProtocol right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(SslApplicationProtocol left, SslApplicationProtocol right)
+        {
+            return !(left == right);
+        }
+    }
+}
+

--- a/src/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
@@ -52,7 +52,7 @@ namespace System.Net.Security
 
             _protocol = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(protocol));
         }
-
+        
         public ReadOnlyMemory<byte> Protocol => _protocol;
 
         public bool Equals(SslApplicationProtocol other)

--- a/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -13,48 +13,54 @@ namespace System.Net.Security
     {
         internal SslAuthenticationOptions(SslClientAuthenticationOptions sslClientAuthenticationOptions)
         {
+            // Common options.
             AllowRenegotiation = sslClientAuthenticationOptions.AllowRenegotiation;
             ApplicationProtocols = sslClientAuthenticationOptions.ApplicationProtocols;
-            CheckCertificateRevocation = sslClientAuthenticationOptions.CheckCertificateRevocation;
-            ClientCertificates = sslClientAuthenticationOptions.ClientCertificates;
+            CertValidationDelegate = sslClientAuthenticationOptions._certValidationDelegate;
+            CheckCertName = true;
             EnabledSslProtocols = sslClientAuthenticationOptions.EnabledSslProtocols;
             EncryptionPolicy = sslClientAuthenticationOptions.EncryptionPolicy;
-            LocalCertificateSelectionCallback = sslClientAuthenticationOptions.LocalCertificateSelectionCallback;
-            RemoteCertificateValidationCallback = sslClientAuthenticationOptions.RemoteCertificateValidationCallback;
-            CertValidationDelegate = sslClientAuthenticationOptions._certValidationDelegate;
-            CertSelectionDelegate = sslClientAuthenticationOptions._certSelectionDelegate;
-            TargetHost = sslClientAuthenticationOptions.TargetHost;
             IsServer = false;
-            CheckCertName = true;
             RemoteCertRequired = true;
+            RemoteCertificateValidationCallback = sslClientAuthenticationOptions.RemoteCertificateValidationCallback;
+            TargetHost = sslClientAuthenticationOptions.TargetHost;
+
+            // Client specific options.
+            CertSelectionDelegate = sslClientAuthenticationOptions._certSelectionDelegate;
+            CertificateRevocationCheckMode = sslClientAuthenticationOptions.CertificateRevocationCheckMode;
+            ClientCertificates = sslClientAuthenticationOptions.ClientCertificates;
+            LocalCertificateSelectionCallback = sslClientAuthenticationOptions.LocalCertificateSelectionCallback;
         }
 
         internal SslAuthenticationOptions(SslServerAuthenticationOptions sslServerAuthenticationOptions)
         {
-            TargetHost = string.Empty;
+            // Common options.
             AllowRenegotiation = sslServerAuthenticationOptions.AllowRenegotiation;
-            RemoteCertRequired = sslServerAuthenticationOptions.ClientCertificateRequired;
             ApplicationProtocols = sslServerAuthenticationOptions.ApplicationProtocols;
-            RemoteCertificateValidationCallback = sslServerAuthenticationOptions.RemoteCertificateValidationCallback;
             CertValidationDelegate = sslServerAuthenticationOptions._certValidationDelegate;
-            ServerCertificate = sslServerAuthenticationOptions.ServerCertificate;
-            EnabledSslProtocols = sslServerAuthenticationOptions.EnabledSslProtocols;
-            CheckCertificateRevocation = sslServerAuthenticationOptions.CheckCertificateRevocation;
-            EncryptionPolicy = sslServerAuthenticationOptions.EncryptionPolicy;
             CheckCertName = false;
+            EnabledSslProtocols = sslServerAuthenticationOptions.EnabledSslProtocols;
+            EncryptionPolicy = sslServerAuthenticationOptions.EncryptionPolicy;
             IsServer = true;
+            RemoteCertRequired = sslServerAuthenticationOptions.ClientCertificateRequired;
+            RemoteCertificateValidationCallback = sslServerAuthenticationOptions.RemoteCertificateValidationCallback;
+            TargetHost = string.Empty;
+
+            // Server specific options.
+            CertificateRevocationCheckMode = sslServerAuthenticationOptions.CertificateRevocationCheckMode;
+            ServerCertificate = sslServerAuthenticationOptions.ServerCertificate;
         }
 
         internal bool AllowRenegotiation { get; set; }
         internal string TargetHost { get; set; }
         internal X509CertificateCollection ClientCertificates { get; set; }
-        internal IList<SslApplicationProtocol> ApplicationProtocols { get; }
+        internal List<SslApplicationProtocol> ApplicationProtocols { get; }
         internal bool IsServer { get; set; }
         internal RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
         internal LocalCertificateSelectionCallback LocalCertificateSelectionCallback { get; set; }
         internal X509Certificate ServerCertificate { get; set; }
         internal SslProtocols EnabledSslProtocols { get; set; }
-        internal X509RevocationMode CheckCertificateRevocation { get; set; }
+        internal X509RevocationMode CertificateRevocationCheckMode { get; set; }
         internal EncryptionPolicy EncryptionPolicy { get; set; }
         internal bool RemoteCertRequired { get; set; }
         internal bool CheckCertName { get; set; }

--- a/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -61,31 +61,6 @@ namespace System.Net.Security
         internal RemoteCertValidationCallback CertValidationDelegate { get; set; }
         internal LocalCertSelectionCallback CertSelectionDelegate { get; set; }
         internal GCHandle AlpnProtocolsHandle { get; set; }
-
-        internal static byte[] ConvertAlpnProtocolListToByteArray(IList<SslApplicationProtocol> protocols)
-        {
-            int protocolSize = 0;
-            foreach (SslApplicationProtocol protocol in protocols)
-            {
-                if (protocol.Protocol.Length <= 0 || protocol.Protocol.Length > byte.MaxValue)
-                {
-                    throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(protocols));
-                }
-
-                protocolSize += protocol.Protocol.Length + 1;
-            }
-
-            byte[] buffer = new byte[protocolSize];
-            var offset = 0;
-            foreach (SslApplicationProtocol protocol in protocols)
-            {
-                buffer[offset++] = (byte)(protocol.Protocol.Length);
-                Array.Copy(protocol.Protocol.ToArray(), 0, buffer, offset, protocol.Protocol.Length);
-                offset += protocol.Protocol.Length;
-            }
-
-            return buffer;
-        }
     }
 }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -61,6 +61,31 @@ namespace System.Net.Security
         internal RemoteCertValidationCallback CertValidationDelegate { get; set; }
         internal LocalCertSelectionCallback CertSelectionDelegate { get; set; }
         internal GCHandle AlpnProtocolsHandle { get; set; }
+
+        internal static byte[] ConvertAlpnProtocolListToByteArray(IList<SslApplicationProtocol> protocols)
+        {
+            int protocolSize = 0;
+            foreach (SslApplicationProtocol protocol in protocols)
+            {
+                if (protocol.Protocol.Length <= 0 || protocol.Protocol.Length > byte.MaxValue)
+                {
+                    throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(protocols));
+                }
+
+                protocolSize += protocol.Protocol.Length + 1;
+            }
+
+            byte[] buffer = new byte[protocolSize];
+            var offset = 0;
+            foreach (SslApplicationProtocol protocol in protocols)
+            {
+                buffer[offset++] = (byte)(protocol.Protocol.Length);
+                Array.Copy(protocol.Protocol.ToArray(), 0, buffer, offset, protocol.Protocol.Length);
+                offset += protocol.Protocol.Length;
+            }
+
+            return buffer;
+        }
     }
 }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Security
+{
+    internal class SslAuthenticationOptions
+    {
+        internal SslAuthenticationOptions(SslClientAuthenticationOptions sslClientAuthenticationOptions)
+        {
+            AllowRenegotiation = sslClientAuthenticationOptions.AllowRenegotiation;
+            ApplicationProtocols = sslClientAuthenticationOptions.ApplicationProtocols;
+            CheckCertificateRevocation = sslClientAuthenticationOptions.CheckCertificateRevocation;
+            ClientCertificates = sslClientAuthenticationOptions.ClientCertificates;
+            EnabledSslProtocols = sslClientAuthenticationOptions.EnabledSslProtocols;
+            EncryptionPolicy = sslClientAuthenticationOptions.EncryptionPolicy;
+            LocalCertificateSelectionCallback = sslClientAuthenticationOptions.LocalCertificateSelectionCallback;
+            RemoteCertificateValidationCallback = sslClientAuthenticationOptions.RemoteCertificateValidationCallback;
+            CertValidationDelegate = sslClientAuthenticationOptions._certValidationDelegate;
+            CertSelectionDelegate = sslClientAuthenticationOptions._certSelectionDelegate;
+            TargetHost = sslClientAuthenticationOptions.TargetHost;
+            IsServer = false;
+            CheckCertName = true;
+            RemoteCertRequired = true;
+        }
+
+        internal SslAuthenticationOptions(SslServerAuthenticationOptions sslServerAuthenticationOptions)
+        {
+            TargetHost = string.Empty;
+            AllowRenegotiation = sslServerAuthenticationOptions.AllowRenegotiation;
+            RemoteCertRequired = sslServerAuthenticationOptions.ClientCertificateRequired;
+            ApplicationProtocols = sslServerAuthenticationOptions.ApplicationProtocols;
+            RemoteCertificateValidationCallback = sslServerAuthenticationOptions.RemoteCertificateValidationCallback;
+            CertValidationDelegate = sslServerAuthenticationOptions._certValidationDelegate;
+            ServerCertificate = sslServerAuthenticationOptions.ServerCertificate;
+            EnabledSslProtocols = sslServerAuthenticationOptions.EnabledSslProtocols;
+            CheckCertificateRevocation = sslServerAuthenticationOptions.CheckCertificateRevocation;
+            EncryptionPolicy = sslServerAuthenticationOptions.EncryptionPolicy;
+            CheckCertName = false;
+            IsServer = true;
+        }
+
+        internal bool AllowRenegotiation { get; set; }
+        internal string TargetHost { get; set; }
+        internal X509CertificateCollection ClientCertificates { get; set; }
+        internal IList<SslApplicationProtocol> ApplicationProtocols { get; }
+        internal bool IsServer { get; set; }
+        internal RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
+        internal LocalCertificateSelectionCallback LocalCertificateSelectionCallback { get; set; }
+        internal X509Certificate ServerCertificate { get; set; }
+        internal SslProtocols EnabledSslProtocols { get; set; }
+        internal X509RevocationMode CheckCertificateRevocation { get; set; }
+        internal EncryptionPolicy EncryptionPolicy { get; set; }
+        internal bool RemoteCertRequired { get; set; }
+        internal bool CheckCertName { get; set; }
+        internal RemoteCertValidationCallback CertValidationDelegate { get; set; }
+        internal LocalCertSelectionCallback CertSelectionDelegate { get; set; }
+        internal GCHandle AlpnProtocolsHandle { get; set; }
+    }
+}
+

--- a/src/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
@@ -26,21 +26,21 @@ namespace System.Net.Security
 
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 
-        public IList<SslApplicationProtocol> ApplicationProtocols { get; set; }
+        public List<SslApplicationProtocol> ApplicationProtocols { get; set; }
 
         public string TargetHost
         {
             get => _targetHost;
-            set => _targetHost = value ?? throw new ArgumentNullException(nameof(value));
+            set => _targetHost = value;
         }
 
         public X509CertificateCollection ClientCertificates
         {
             get => _clientCertificates;
-            set => _clientCertificates = value ?? new X509CertificateCollection();
+            set => _clientCertificates = value;
         }
 
-        public X509RevocationMode CheckCertificateRevocation
+        public X509RevocationMode CertificateRevocationCheckMode
         {
             get => _checkCertificateRevocation;
             set

--- a/src/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
@@ -11,8 +11,6 @@ namespace System.Net.Security
 {
     public class SslClientAuthenticationOptions
     {
-        private string _targetHost;
-        private X509CertificateCollection _clientCertificates;
         private EncryptionPolicy _encryptionPolicy = EncryptionPolicy.RequireEncryption;
         private X509RevocationMode _checkCertificateRevocation = X509RevocationMode.NoCheck;
         private SslProtocols _enabledSslProtocols = SecurityProtocol.SystemDefaultSecurityProtocols;
@@ -28,17 +26,9 @@ namespace System.Net.Security
 
         public List<SslApplicationProtocol> ApplicationProtocols { get; set; }
 
-        public string TargetHost
-        {
-            get => _targetHost;
-            set => _targetHost = value;
-        }
+        public string TargetHost { get; set; }
 
-        public X509CertificateCollection ClientCertificates
-        {
-            get => _clientCertificates;
-            set => _clientCertificates = value;
-        }
+        public X509CertificateCollection ClientCertificates { get; set; }
 
         public X509RevocationMode CertificateRevocationCheckMode
         {

--- a/src/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Security
+{
+    public class SslClientAuthenticationOptions
+    {
+        private string _targetHost;
+        private X509CertificateCollection _clientCertificates;
+        private EncryptionPolicy _encryptionPolicy = EncryptionPolicy.RequireEncryption;
+        private X509RevocationMode _checkCertificateRevocation = X509RevocationMode.NoCheck;
+        private SslProtocols _enabledSslProtocols = SecurityProtocol.SystemDefaultSecurityProtocols;
+
+        internal RemoteCertValidationCallback _certValidationDelegate;
+        internal LocalCertSelectionCallback _certSelectionDelegate;
+
+        public bool AllowRenegotiation { get; set; }
+
+        public LocalCertificateSelectionCallback LocalCertificateSelectionCallback { get; set; }
+
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
+
+        public IList<SslApplicationProtocol> ApplicationProtocols { get; set; }
+
+        public string TargetHost
+        {
+            get => _targetHost;
+            set => _targetHost = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public X509CertificateCollection ClientCertificates
+        {
+            get => _clientCertificates;
+            set => _clientCertificates = value ?? new X509CertificateCollection();
+        }
+
+        public X509RevocationMode CheckCertificateRevocation
+        {
+            get => _checkCertificateRevocation;
+            set
+            {
+                if (value != X509RevocationMode.NoCheck && value != X509RevocationMode.Offline && value != X509RevocationMode.Online)
+                {
+                    throw new ArgumentException(SR.Format(SR.net_invalid_enum, nameof(X509RevocationMode)), nameof(value));
+                }
+
+                _checkCertificateRevocation = value;
+            }
+        }
+
+        public EncryptionPolicy EncryptionPolicy
+        {
+            get => _encryptionPolicy;
+            set
+            {
+                if (value != EncryptionPolicy.RequireEncryption && value != EncryptionPolicy.AllowNoEncryption && value != EncryptionPolicy.NoEncryption)
+                {
+                    throw new ArgumentException(SR.Format(SR.net_invalid_enum, nameof(EncryptionPolicy)), nameof(value));
+                }
+
+                _encryptionPolicy = value;
+            }
+        }
+
+        public SslProtocols EnabledSslProtocols
+        {
+            get => _enabledSslProtocols;
+            set => _enabledSslProtocols = value;
+        }
+    }
+}
+

--- a/src/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
@@ -22,14 +22,14 @@ namespace System.Net.Security
 
         public bool ClientCertificateRequired { get; set; }
 
-        public IList<SslApplicationProtocol> ApplicationProtocols { get; set; }
+        public List<SslApplicationProtocol> ApplicationProtocols { get; set; }
 
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 
         public X509Certificate ServerCertificate
         {
             get => _serverCertificate;
-            set => _serverCertificate = value ?? throw new ArgumentNullException(nameof(value));
+            set => _serverCertificate = value;
         }
 
         public SslProtocols EnabledSslProtocols
@@ -38,7 +38,7 @@ namespace System.Net.Security
             set => _enabledSslProtocols = value;
         }
 
-        public X509RevocationMode CheckCertificateRevocation
+        public X509RevocationMode CertificateRevocationCheckMode
         {
             get => _checkCertificateRevocation;
             set

--- a/src/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
@@ -16,7 +16,6 @@ namespace System.Net.Security
         private EncryptionPolicy _encryptionPolicy = EncryptionPolicy.RequireEncryption;
 
         internal RemoteCertValidationCallback _certValidationDelegate;
-        internal LocalCertSelectionCallback _certSelectionDelegate;
 
         public bool AllowRenegotiation { get; set; }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
@@ -10,7 +10,6 @@ namespace System.Net.Security
 {
     public class SslServerAuthenticationOptions
     {
-        private X509Certificate _serverCertificate;
         private X509RevocationMode _checkCertificateRevocation = X509RevocationMode.NoCheck;
         private SslProtocols _enabledSslProtocols = SecurityProtocol.SystemDefaultSecurityProtocols;
         private EncryptionPolicy _encryptionPolicy = EncryptionPolicy.RequireEncryption;
@@ -25,11 +24,7 @@ namespace System.Net.Security
 
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 
-        public X509Certificate ServerCertificate
-        {
-            get => _serverCertificate;
-            set => _serverCertificate = value;
-        }
+        public X509Certificate ServerCertificate { get; set; }
 
         public SslProtocols EnabledSslProtocols
         {

--- a/src/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
@@ -22,9 +22,9 @@ namespace System.Net.Security
 
         public bool ClientCertificateRequired { get; set; }
 
-        public IList<SslApplicationProtocol> ApplicationProtocols { get; }
+        public IList<SslApplicationProtocol> ApplicationProtocols { get; set; }
 
-        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get;set; }
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 
         public X509Certificate ServerCertificate
         {

--- a/src/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Security
+{
+    public class SslServerAuthenticationOptions
+    {
+        private X509Certificate _serverCertificate;
+        private X509RevocationMode _checkCertificateRevocation = X509RevocationMode.NoCheck;
+        private SslProtocols _enabledSslProtocols = SecurityProtocol.SystemDefaultSecurityProtocols;
+        private EncryptionPolicy _encryptionPolicy = EncryptionPolicy.RequireEncryption;
+
+        internal RemoteCertValidationCallback _certValidationDelegate;
+        internal LocalCertSelectionCallback _certSelectionDelegate;
+
+        public bool AllowRenegotiation { get; set; }
+
+        public bool ClientCertificateRequired { get; set; }
+
+        public IList<SslApplicationProtocol> ApplicationProtocols { get; }
+
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get;set; }
+
+        public X509Certificate ServerCertificate
+        {
+            get => _serverCertificate;
+            set => _serverCertificate = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public SslProtocols EnabledSslProtocols
+        {
+            get => _enabledSslProtocols;
+            set => _enabledSslProtocols = value;
+        }
+
+        public X509RevocationMode CheckCertificateRevocation
+        {
+            get => _checkCertificateRevocation;
+            set
+            {
+                if (value != X509RevocationMode.NoCheck && value != X509RevocationMode.Offline && value != X509RevocationMode.Online)
+                {
+                    throw new ArgumentException(SR.Format(SR.net_invalid_enum, nameof(X509RevocationMode)), nameof(value));
+                }
+
+                _checkCertificateRevocation = value;
+            }
+        }
+
+        public EncryptionPolicy EncryptionPolicy
+        {
+            get => _encryptionPolicy;
+            set
+            {
+                if (value != EncryptionPolicy.RequireEncryption && value != EncryptionPolicy.AllowNoEncryption && value != EncryptionPolicy.NoEncryption)
+                {
+                    throw new ArgumentException(SR.Format(SR.net_invalid_enum, nameof(EncryptionPolicy)), nameof(value));
+                }
+
+                _encryptionPolicy = value;
+            }
+        }
+    }
+}
+

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -599,13 +599,13 @@ namespace System.Net.Security
                 {
                     if (NetEventSource.IsEnabled)
                         NetEventSource.Log.SspiSelectedCipherSuite(nameof(ProcessAuthentication),
-SslProtocol,
-CipherAlgorithm,
-CipherStrength,
-HashAlgorithm,
-HashStrength,
-KeyExchangeAlgorithm,
-KeyExchangeStrength);
+                                                                    SslProtocol,
+                                                                    CipherAlgorithm,
+                                                                    CipherStrength,
+                                                                    HashAlgorithm,
+                                                                    HashStrength,
+                                                                    KeyExchangeAlgorithm,
+                                                                    KeyExchangeStrength);
                 }
             }
             catch (Exception)
@@ -734,13 +734,13 @@ KeyExchangeStrength);
             {
                 if (NetEventSource.IsEnabled)
                     NetEventSource.Log.SspiSelectedCipherSuite(nameof(EndProcessAuthentication),
-SslProtocol,
-CipherAlgorithm,
-CipherStrength,
-HashAlgorithm,
-HashStrength,
-KeyExchangeAlgorithm,
-KeyExchangeStrength);
+                                                                SslProtocol,
+                                                                CipherAlgorithm,
+                                                                CipherStrength,
+                                                                HashAlgorithm,
+                                                                HashStrength,
+                                                                KeyExchangeAlgorithm,
+                                                                KeyExchangeStrength);
             }
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -37,7 +37,7 @@ namespace System.Net.Security
 
         private SecurityStatusPal _securityStatus;
         private ExceptionDispatchInfo _exception;
-        
+
         private enum CachedSessionStatus : byte
         {
             Unknown = 0,
@@ -94,7 +94,7 @@ namespace System.Net.Security
             {
                 throw new InvalidOperationException(SR.net_auth_client_server);
             }
-            
+
             if (sslClientAuthenticationOptions.TargetHost == null)
             {
                 throw new ArgumentNullException(nameof(sslClientAuthenticationOptions.TargetHost));
@@ -151,11 +151,14 @@ namespace System.Net.Security
             }
         }
 
-        internal string NegotiatedApplicationProtocol
+        internal SslApplicationProtocol NegotiatedApplicationProtocol
         {
             get
             {
-                return _context?.NegotiatedApplicationProtocol;
+                if (Context == null)
+                    return default;
+
+                return Context.NegotiatedApplicationProtocol;
             }
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -155,7 +155,7 @@ namespace System.Net.Security
         {
             get
             {
-                return _context.NegotiatedApplicationProtocol;
+                return _context?.NegotiatedApplicationProtocol;
             }
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -84,7 +84,7 @@ namespace System.Net.Security
             _sslState = new SslState(innerStream);
         }
 
-        public string NegotiatedApplicationProtocol
+        public SslApplicationProtocol NegotiatedApplicationProtocol
         {
             get
             {

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -92,7 +92,7 @@ namespace System.Net.Security
             }
         }
 
-        private void SetandVerifyValidationCallback(RemoteCertificateValidationCallback callback)
+        private void SetAndVerifyValidationCallback(RemoteCertificateValidationCallback callback)
         {
             if (_userCertificateValidationCallback == null)
             {
@@ -165,7 +165,7 @@ namespace System.Net.Security
                 TargetHost = targetHost,
                 ClientCertificates = clientCertificates,
                 EnabledSslProtocols = enabledSslProtocols,
-                CheckCertificateRevocation = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
+                CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
                 EncryptionPolicy = _encryptionPolicy,
                 _certSelectionDelegate = _certSelectionDelegate,
                 _certValidationDelegate = _certValidationDelegate
@@ -177,7 +177,7 @@ namespace System.Net.Security
         internal virtual IAsyncResult BeginAuthenticateAsClient(SslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken, AsyncCallback asyncCallback, object asyncState)
         {
             SecurityProtocol.ThrowOnNotAllowed(sslClientAuthenticationOptions.EnabledSslProtocols);
-            SetandVerifyValidationCallback(sslClientAuthenticationOptions.RemoteCertificateValidationCallback);
+            SetAndVerifyValidationCallback(sslClientAuthenticationOptions.RemoteCertificateValidationCallback);
             SetAndVerifySelectionCallback(sslClientAuthenticationOptions.LocalCertificateSelectionCallback);
 
             _sslState.ValidateCreateContext(sslClientAuthenticationOptions);
@@ -219,7 +219,7 @@ namespace System.Net.Security
                 ServerCertificate = serverCertificate,
                 ClientCertificateRequired = clientCertificateRequired,
                 EnabledSslProtocols = enabledSslProtocols,
-                CheckCertificateRevocation = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
+                CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
                 EncryptionPolicy = _encryptionPolicy,
                 _certSelectionDelegate = _certSelectionDelegate,
                 _certValidationDelegate = _certValidationDelegate
@@ -231,7 +231,7 @@ namespace System.Net.Security
         private IAsyncResult BeginAuthenticateAsServer(SslServerAuthenticationOptions sslServerAuthenticationOptions, CancellationToken cancellationToken, AsyncCallback asyncCallback, object asyncState)
         {
             SecurityProtocol.ThrowOnNotAllowed(sslServerAuthenticationOptions.EnabledSslProtocols);
-            SetandVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
+            SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
 
             _sslState.ValidateCreateContext(sslServerAuthenticationOptions);
 
@@ -286,19 +286,19 @@ namespace System.Net.Security
                 TargetHost = targetHost,
                 ClientCertificates = clientCertificates,
                 EnabledSslProtocols = enabledSslProtocols,
-                CheckCertificateRevocation = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
+                CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
                 EncryptionPolicy = _encryptionPolicy,
                 _certSelectionDelegate = _certSelectionDelegate,
                 _certValidationDelegate = _certValidationDelegate
             };
 
-            AuthenticateAsClient(options, CancellationToken.None);
+            AuthenticateAsClient(options);
         }
 
-        private void AuthenticateAsClient(SslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken)
+        private void AuthenticateAsClient(SslClientAuthenticationOptions sslClientAuthenticationOptions)
         {
             SecurityProtocol.ThrowOnNotAllowed(sslClientAuthenticationOptions.EnabledSslProtocols);
-            SetandVerifyValidationCallback(sslClientAuthenticationOptions.RemoteCertificateValidationCallback);
+            SetAndVerifyValidationCallback(sslClientAuthenticationOptions.RemoteCertificateValidationCallback);
             SetAndVerifySelectionCallback(sslClientAuthenticationOptions.LocalCertificateSelectionCallback);
 
             _sslState.ValidateCreateContext(sslClientAuthenticationOptions);
@@ -322,19 +322,19 @@ namespace System.Net.Security
                 ServerCertificate = serverCertificate,
                 ClientCertificateRequired = clientCertificateRequired,
                 EnabledSslProtocols = enabledSslProtocols,
-                CheckCertificateRevocation = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
+                CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
                 EncryptionPolicy = _encryptionPolicy,
                 _certSelectionDelegate = _certSelectionDelegate,
                 _certValidationDelegate = _certValidationDelegate
             };
 
-            AuthenticateAsServer(options, CancellationToken.None);
+            AuthenticateAsServer(options);
         }
 
-        private void AuthenticateAsServer(SslServerAuthenticationOptions sslServerAuthenticationOptions, CancellationToken cancellationToken)
+        private void AuthenticateAsServer(SslServerAuthenticationOptions sslServerAuthenticationOptions)
         {
             SecurityProtocol.ThrowOnNotAllowed(sslServerAuthenticationOptions.EnabledSslProtocols);
-            SetandVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
+            SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
 
             _sslState.ValidateCreateContext(sslServerAuthenticationOptions);
             _sslState.ProcessAuthentication(null);

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -167,8 +167,6 @@ namespace System.Net.Security
                 EnabledSslProtocols = enabledSslProtocols,
                 CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
                 EncryptionPolicy = _encryptionPolicy,
-                _certSelectionDelegate = _certSelectionDelegate,
-                _certValidationDelegate = _certValidationDelegate
             };
 
             return BeginAuthenticateAsClient(options, CancellationToken.None, asyncCallback, asyncState);
@@ -179,6 +177,10 @@ namespace System.Net.Security
             SecurityProtocol.ThrowOnNotAllowed(sslClientAuthenticationOptions.EnabledSslProtocols);
             SetAndVerifyValidationCallback(sslClientAuthenticationOptions.RemoteCertificateValidationCallback);
             SetAndVerifySelectionCallback(sslClientAuthenticationOptions.LocalCertificateSelectionCallback);
+
+            // Set the delegates on the options.
+            sslClientAuthenticationOptions._certValidationDelegate = _certValidationDelegate;
+            sslClientAuthenticationOptions._certSelectionDelegate = _certSelectionDelegate;
 
             _sslState.ValidateCreateContext(sslClientAuthenticationOptions);
 
@@ -221,8 +223,6 @@ namespace System.Net.Security
                 EnabledSslProtocols = enabledSslProtocols,
                 CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
                 EncryptionPolicy = _encryptionPolicy,
-                _certSelectionDelegate = _certSelectionDelegate,
-                _certValidationDelegate = _certValidationDelegate
             };
 
             return BeginAuthenticateAsServer(options, CancellationToken.None, asyncCallback, asyncState);
@@ -232,6 +232,9 @@ namespace System.Net.Security
         {
             SecurityProtocol.ThrowOnNotAllowed(sslServerAuthenticationOptions.EnabledSslProtocols);
             SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
+
+            // Set the delegate on the options.
+            sslServerAuthenticationOptions._certValidationDelegate = _certValidationDelegate;
 
             _sslState.ValidateCreateContext(sslServerAuthenticationOptions);
 
@@ -288,8 +291,6 @@ namespace System.Net.Security
                 EnabledSslProtocols = enabledSslProtocols,
                 CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
                 EncryptionPolicy = _encryptionPolicy,
-                _certSelectionDelegate = _certSelectionDelegate,
-                _certValidationDelegate = _certValidationDelegate
             };
 
             AuthenticateAsClient(options);
@@ -300,6 +301,10 @@ namespace System.Net.Security
             SecurityProtocol.ThrowOnNotAllowed(sslClientAuthenticationOptions.EnabledSslProtocols);
             SetAndVerifyValidationCallback(sslClientAuthenticationOptions.RemoteCertificateValidationCallback);
             SetAndVerifySelectionCallback(sslClientAuthenticationOptions.LocalCertificateSelectionCallback);
+
+            // Set the delegates on the options.
+            sslClientAuthenticationOptions._certValidationDelegate = _certValidationDelegate;
+            sslClientAuthenticationOptions._certSelectionDelegate = _certSelectionDelegate;
 
             _sslState.ValidateCreateContext(sslClientAuthenticationOptions);
             _sslState.ProcessAuthentication(null);
@@ -324,8 +329,6 @@ namespace System.Net.Security
                 EnabledSslProtocols = enabledSslProtocols,
                 CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
                 EncryptionPolicy = _encryptionPolicy,
-                _certSelectionDelegate = _certSelectionDelegate,
-                _certValidationDelegate = _certValidationDelegate
             };
 
             AuthenticateAsServer(options);
@@ -335,6 +338,9 @@ namespace System.Net.Security
         {
             SecurityProtocol.ThrowOnNotAllowed(sslServerAuthenticationOptions.EnabledSslProtocols);
             SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
+
+            // Set the delegate on the options.
+            sslServerAuthenticationOptions._certValidationDelegate = _certValidationDelegate;
 
             _sslState.ValidateCreateContext(sslServerAuthenticationOptions);
             _sslState.ProcessAuthentication(null);

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -37,11 +37,21 @@ namespace System.Net.Security
         public static SecurityStatusPal AcceptSecurityContext(
             ref SafeFreeCredentials credential,
             ref SafeDeleteContext context,
-            SecurityBuffer inputBuffer,
+            SecurityBuffer[] inputBuffers,
             SecurityBuffer outputBuffer,
-            bool remoteCertRequired)
+            SslAuthenticationOptions sslAuthenticationOptions)
         {
-            return HandshakeInternal(credential, ref context, inputBuffer, outputBuffer, true, remoteCertRequired, null);
+            if (inputBuffers != null)
+            {
+                Debug.Assert(inputBuffers.Length == 2);
+                Debug.Assert(inputBuffers[1].token == null);
+
+                return HandshakeInternal(credential, ref context, inputBuffers[0], outputBuffer, sslAuthenticationOptions);
+            }
+            else
+            {
+                return HandshakeInternal(credential, ref context, inputBuffer: null, outputBuffer, sslAuthenticationOptions);
+            }
         }
 
         public static SecurityStatusPal InitializeSecurityContext(
@@ -49,9 +59,10 @@ namespace System.Net.Security
             ref SafeDeleteContext context,
             string targetName,
             SecurityBuffer inputBuffer,
-            SecurityBuffer outputBuffer)
+            SecurityBuffer outputBuffer,
+            SslAuthenticationOptions sslAuthenticationOptions)
         {
-            return HandshakeInternal(credential, ref context, inputBuffer, outputBuffer, false, false, targetName);
+            return HandshakeInternal(credential, ref context, inputBuffer, outputBuffer, sslAuthenticationOptions);
         }
 
         public static SecurityStatusPal InitializeSecurityContext(
@@ -59,11 +70,28 @@ namespace System.Net.Security
             ref SafeDeleteContext context,
             string targetName,
             SecurityBuffer[] inputBuffers,
-            SecurityBuffer outputBuffer)
+            SecurityBuffer outputBuffer,
+            SslAuthenticationOptions sslAuthenticationOptions)
         {
             Debug.Assert(inputBuffers.Length == 2);
             Debug.Assert(inputBuffers[1].token == null);
-            return HandshakeInternal(credential, ref context, inputBuffers[0], outputBuffer, false, false, targetName);
+            return HandshakeInternal(credential, ref context, inputBuffers[0], outputBuffer, sslAuthenticationOptions);
+        }
+
+        public static SecurityBuffer[] GetIncomingSecurityBuffers(SslAuthenticationOptions options, ref SecurityBuffer incomingSecurity)
+        {
+            SecurityBuffer[] incomingSecurityBuffers = null;
+
+            if (incomingSecurity != null)
+            {
+                incomingSecurityBuffers = new SecurityBuffer[]
+                {
+                    incomingSecurity,
+                    new SecurityBuffer(null, 0, 0, SecurityBufferType.SECBUFFER_EMPTY)
+                };
+            }
+
+            return incomingSecurityBuffers;
         }
 
         public static SafeFreeCredentials AcquireCredentialsHandle(
@@ -75,7 +103,7 @@ namespace System.Net.Security
             return new SafeFreeSslCredentials(certificate, protocols, policy);
         }
 
-        internal static string GetNegotiatedApplicationProtocol(SafeDeleteContext context)
+        internal static byte[] GetNegotiatedApplicationProtocol(SafeDeleteContext context)
         {
             // OSX SecureTransport does not export APIs to support ALPN, no-op.
             return null;
@@ -232,9 +260,7 @@ namespace System.Net.Security
             ref SafeDeleteContext context,
             SecurityBuffer inputBuffer,
             SecurityBuffer outputBuffer,
-            bool isServer,
-            bool remoteCertRequired,
-            string targetName)
+            SslAuthenticationOptions sslAuthenticationOptions)
         {
             Debug.Assert(!credential.IsInvalid);
 
@@ -244,18 +270,17 @@ namespace System.Net.Security
 
                 if ((null == context) || context.IsInvalid)
                 {
-                    sslContext = new SafeDeleteSslContext(credential as SafeFreeSslCredentials, isServer);
+                    sslContext = new SafeDeleteSslContext(credential as SafeFreeSslCredentials, sslAuthenticationOptions);
                     context = sslContext;
 
-                    if (!string.IsNullOrEmpty(targetName))
+                    if (!string.IsNullOrEmpty(sslAuthenticationOptions.TargetHost))
                     {
-                        Debug.Assert(!isServer, "targetName should not be set for server-side handshakes");
-                        Interop.AppleCrypto.SslSetTargetName(sslContext.SslContext, targetName);
+                        Debug.Assert(!sslAuthenticationOptions.IsServer, "targetName should not be set for server-side handshakes");
+                        Interop.AppleCrypto.SslSetTargetName(sslContext.SslContext, sslAuthenticationOptions.TargetHost);
                     }
 
-                    if (remoteCertRequired)
+                    if (sslAuthenticationOptions.IsServer && sslAuthenticationOptions.RemoteCertRequired)
                     {
-                        Debug.Assert(isServer, "remoteCertRequired should not be set for client-side handshakes");
                         Interop.AppleCrypto.SslSetAcceptClientCert(sslContext.SslContext);
                     }
                 }

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -75,6 +75,12 @@ namespace System.Net.Security
             return new SafeFreeSslCredentials(certificate, protocols, policy);
         }
 
+        internal static string GetNegotiatedApplicationProtocol(SafeDeleteContext context)
+        {
+            // OSX SecureTransport does not export APIs to support ALPN, no-op.
+            return null;
+        }
+
         public static SecurityStatusPal EncryptMessage(
             SafeDeleteContext securityContext,
             ReadOnlyMemory<byte> input,

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -29,9 +29,9 @@ namespace System.Net.Security
         }
 
         public static SecurityStatusPal AcceptSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context,
-            SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, bool remoteCertRequired, SslAuthenticationOptions sslAuthenticationOptions)
+            SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
         {
-            return HandshakeInternal(credential, ref context, inputBuffer, outputBuffer, true, remoteCertRequired, sslAuthenticationOptions);
+            return HandshakeInternal(credential, ref context, inputBuffer, outputBuffer, true, sslAuthenticationOptions);
         }
 
         public static SecurityStatusPal InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context,
@@ -102,8 +102,8 @@ namespace System.Net.Security
             connectionInfo = new SslConnectionInfo(((SafeDeleteSslContext)securityContext).SslContext);
         }
 
-        private static SecurityStatusPal HandshakeInternal(SafeFreeCredentials credential, ref SafeDeleteContext context,
-            SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, bool isServer, bool remoteCertRequired, SslAuthenticationOptions sslAuthenticationOptions)
+        private static SecurityStatusPal HandshakeInternal(SafeFreeCredentials credential, ref SafeDeleteContext context, SecurityBuffer inputBuffer,
+            SecurityBuffer outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
         {
             Debug.Assert(!credential.IsInvalid);
 

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -130,7 +130,7 @@ namespace System.Net.Security
             connectionInfo = new SslConnectionInfo(((SafeDeleteSslContext)securityContext).SslContext);
         }
 
-        public static byte[] ConvertAlpnProtocolListToByteArray(IList<SslApplicationProtocol> applicationProtocols)
+        public static byte[] ConvertAlpnProtocolListToByteArray(List<SslApplicationProtocol> applicationProtocols)
         {
             return Interop.Ssl.ConvertAlpnProtocolListToByteArray(applicationProtocols);
         }

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -102,6 +102,31 @@ namespace System.Net.Security
             connectionInfo = new SslConnectionInfo(((SafeDeleteSslContext)securityContext).SslContext);
         }
 
+        public static byte[] ConvertAlpnProtocolListToByteArray(IList<SslApplicationProtocol> applicationProtocols)
+        {
+            int protocolSize = 0;
+            foreach (SslApplicationProtocol protocol in applicationProtocols)
+            {
+                if (protocol.Protocol.Length == 0 || protocol.Protocol.Length > byte.MaxValue)
+                {
+                    throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(applicationProtocols));
+                }
+
+                protocolSize += protocol.Protocol.Length + 1;
+            }
+
+            byte[] buffer = new byte[protocolSize];
+            var offset = 0;
+            foreach (SslApplicationProtocol protocol in applicationProtocols)
+            {
+                buffer[offset++] = (byte)(protocol.Protocol.Length);
+                Array.Copy(protocol.Protocol.ToArray(), 0, buffer, offset, protocol.Protocol.Length);
+                offset += protocol.Protocol.Length;
+            }
+
+            return buffer;
+        }
+
         private static SecurityStatusPal HandshakeInternal(SafeFreeCredentials credential, ref SafeDeleteContext context, SecurityBuffer inputBuffer,
             SecurityBuffer outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
         {

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -41,7 +41,7 @@ namespace System.Net.Security
             SSPIWrapper.GetVerifyPackageInfo(GlobalSSPI.SSPISecureChannel, SecurityPackage, true);
         }
 
-        public static byte[] ConvertAlpnProtocolListToByteArray(IList<SslApplicationProtocol> protocols)
+        public static byte[] ConvertAlpnProtocolListToByteArray(List<SslApplicationProtocol> protocols)
         {
             return Interop.Sec_Application_Protocols.ToByteArray(protocols);
         }
@@ -182,12 +182,14 @@ namespace System.Net.Security
                 context,
                 Interop.SspiCli.ContextAttribute.SECPKG_ATTR_APPLICATION_PROTOCOL) as Interop.SecPkgContext_ApplicationProtocol;
 
-            if (alpnContext == null || alpnContext.NegotiationExtension != Interop.ApplicationProtocolNegotiationExt.ALPN || alpnContext.NegotiationStatus != Interop.ApplicationProtocolNegotiationStatus.Success)
+            if (alpnContext == null ||
+                alpnContext.ProtoNegoExt != Interop.ApplicationProtocolNegotiationExt.ALPN ||
+                alpnContext.ProtoNegoStatus != Interop.ApplicationProtocolNegotiationStatus.Success)
             {
                 return null;
             }
 
-            return alpnContext.GetProtocolId();
+            return alpnContext.Protocol;
         }
 
         public static unsafe SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, ReadOnlyMemory<byte> input, int headerSize, int trailerSize, ref byte[] output, out int resultSize)

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -10,6 +10,7 @@ using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.Net.Security
 {
@@ -38,6 +39,11 @@ namespace System.Net.Security
         public static void VerifyPackageInfo()
         {
             SSPIWrapper.GetVerifyPackageInfo(GlobalSSPI.SSPISecureChannel, SecurityPackage, true);
+        }
+
+        public static byte[] ConvertAlpnProtocolListToByteArray(IList<SslApplicationProtocol> protocols)
+        {
+            return Interop.Sec_Application_Protocols.ToByteArray(protocols);
         }
 
         public static SecurityStatusPal AcceptSecurityContext(ref SafeFreeCredentials credentialsHandle, ref SafeDeleteContext context, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
@@ -132,12 +138,12 @@ namespace System.Net.Security
 
         internal static string GetNegotiatedApplicationProtocol(SafeDeleteContext context)
         {
-            SecPkgContext_ApplicationProtocol alpnContext = SSPIWrapper.QueryContextAttributes(
+            Interop.SecPkgContext_ApplicationProtocol alpnContext = SSPIWrapper.QueryContextAttributes(
                 GlobalSSPI.SSPISecureChannel,
                 context,
-                Interop.SspiCli.ContextAttribute.SECPKG_ATTR_APPLICATION_PROTOCOL) as SecPkgContext_ApplicationProtocol;
+                Interop.SspiCli.ContextAttribute.SECPKG_ATTR_APPLICATION_PROTOCOL) as Interop.SecPkgContext_ApplicationProtocol;
 
-            if (alpnContext == null || alpnContext.NegotiationExtension != ApplicationProtocolNegotiationExt.ALPN || alpnContext.NegotiationStatus != ApplicationProtocolNegotiationStatus.Success)
+            if (alpnContext == null || alpnContext.NegotiationExtension != Interop.ApplicationProtocolNegotiationExt.ALPN || alpnContext.NegotiationStatus != Interop.ApplicationProtocolNegotiationStatus.Success)
             {
                 return null;
             }

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -182,6 +182,7 @@ namespace System.Net.Security
                 context,
                 Interop.SspiCli.ContextAttribute.SECPKG_ATTR_APPLICATION_PROTOCOL) as Interop.SecPkgContext_ApplicationProtocol;
 
+            // Check if the context returned is alpn data, with successful negotiation.
             if (alpnContext == null ||
                 alpnContext.ProtoNegoExt != Interop.ApplicationProtocolNegotiationExt.ALPN ||
                 alpnContext.ProtoNegoStatus != Interop.ApplicationProtocolNegotiationStatus.Success)

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -5,7 +5,6 @@
 using Microsoft.Win32.SafeHandles;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
@@ -41,7 +40,7 @@ namespace System.Net.Security
             SSPIWrapper.GetVerifyPackageInfo(GlobalSSPI.SSPISecureChannel, SecurityPackage, true);
         }
 
-        public static SecurityStatusPal AcceptSecurityContext(ref SafeFreeCredentials credentialsHandle, ref SafeDeleteContext context, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, bool remoteCertRequired)
+        public static SecurityStatusPal AcceptSecurityContext(ref SafeFreeCredentials credentialsHandle, ref SafeDeleteContext context, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
         {
             Interop.SspiCli.ContextFlags unusedAttributes = default(Interop.SspiCli.ContextFlags);
 
@@ -49,7 +48,7 @@ namespace System.Net.Security
                 GlobalSSPI.SSPISecureChannel,
                 ref credentialsHandle,
                 ref context,
-                ServerRequiredFlags | (remoteCertRequired ? Interop.SspiCli.ContextFlags.MutualAuth : Interop.SspiCli.ContextFlags.Zero),
+                ServerRequiredFlags | (sslAuthenticationOptions.RemoteCertRequired ? Interop.SspiCli.ContextFlags.MutualAuth : Interop.SspiCli.ContextFlags.Zero),
                 Interop.SspiCli.Endianness.SECURITY_NATIVE_DREP,
                 inputBuffer,
                 outputBuffer,
@@ -58,7 +57,7 @@ namespace System.Net.Security
             return SecurityStatusAdapterPal.GetSecurityStatusPalFromNativeInt(errorCode);
         }
 
-        public static SecurityStatusPal InitializeSecurityContext(ref SafeFreeCredentials credentialsHandle, ref SafeDeleteContext context, string targetName, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer)
+        public static SecurityStatusPal InitializeSecurityContext(ref SafeFreeCredentials credentialsHandle, ref SafeDeleteContext context, string targetName, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
         {
             Interop.SspiCli.ContextFlags unusedAttributes = default(Interop.SspiCli.ContextFlags);
 
@@ -76,7 +75,7 @@ namespace System.Net.Security
             return SecurityStatusAdapterPal.GetSecurityStatusPalFromNativeInt(errorCode);
         }
 
-        public static SecurityStatusPal InitializeSecurityContext(SafeFreeCredentials credentialsHandle, ref SafeDeleteContext context, string targetName, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer)
+        public static SecurityStatusPal InitializeSecurityContext(SafeFreeCredentials credentialsHandle, ref SafeDeleteContext context, string targetName, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
         {
             Interop.SspiCli.ContextFlags unusedAttributes = default(Interop.SspiCli.ContextFlags);
 
@@ -129,6 +128,11 @@ namespace System.Net.Security
                 policy);
 
             return AcquireCredentialsHandle(direction, secureCredential);
+        }
+
+        internal static string GetNegotiatedApplicationProtocol(SafeDeleteContext context)
+        {
+            throw new NotImplementedException();
         }
 
         public static unsafe SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, ReadOnlyMemory<byte> input, int headerSize, int trailerSize, ref byte[] output, out int resultSize)

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -87,6 +87,7 @@ namespace System.Net.Security.Tests
         }
 
         [Theory]
+        [ActiveIssue(24722, TestPlatforms.Linux)]
         [MemberData(nameof(Alpn_TestData))]
         public void SslStream_StreamToStream_Alpn_Success(List<SslApplicationProtocol> clientProtocols, List<SslApplicationProtocol> serverProtocols, SslApplicationProtocol expected)
         {

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -1,0 +1,173 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Test.Common;
+using System.Runtime.InteropServices;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Security.Tests
+{
+    using Configuration = System.Net.Test.Common.Configuration;
+
+    public class SslStreamAlpnTests
+    {
+        private bool DoHandshakeWithOptions(SslStream clientSslStream, SslStream serverSslStream, SslClientAuthenticationOptions clientOptions, SslServerAuthenticationOptions serverOptions)
+        {
+            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            {
+                clientOptions.RemoteCertificateValidationCallback = AllowAnyServerCertificate;
+                clientOptions.TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false);
+                serverOptions.ServerCertificate = certificate;
+
+                Task t1 = clientSslStream.AuthenticateAsClientAsync(clientOptions, CancellationToken.None);
+                Task t2 = serverSslStream.AuthenticateAsServerAsync(serverOptions, CancellationToken.None);
+
+                return Task.WaitAll(new[] { t1, t2 }, TestConfiguration.PassingTestTimeoutMilliseconds);
+            }
+        }
+
+        protected bool AllowAnyServerCertificate(
+            object sender,
+            X509Certificate certificate,
+            X509Chain chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            SslPolicyErrors expectedSslPolicyErrors = SslPolicyErrors.None;
+
+            if (!Capability.IsTrustedRootCertificateInstalled())
+            {
+                expectedSslPolicyErrors = SslPolicyErrors.RemoteCertificateChainErrors;
+            }
+
+            Assert.Equal(expectedSslPolicyErrors, sslPolicyErrors);
+
+            if (sslPolicyErrors == expectedSslPolicyErrors)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        [Fact]
+        public void SslStream_StreamToStream_DuplicateOptions_Throws()
+        {
+            RemoteCertificateValidationCallback rCallback = (sender, certificate, chain, errors) => { return true; };
+            LocalCertificateSelectionCallback lCallback = (sender, host, localCertificates, remoteCertificate, issuers) => { return null; };
+
+            VirtualNetwork network = new VirtualNetwork();
+            using (var clientStream = new VirtualNetworkStream(network, false))
+            using (var serverStream = new VirtualNetworkStream(network, true))
+            using (var client = new SslStream(clientStream, false, rCallback, lCallback, EncryptionPolicy.RequireEncryption))
+            using (var server = new SslStream(serverStream, false, rCallback))
+            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            {
+                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions();
+                clientOptions.RemoteCertificateValidationCallback = AllowAnyServerCertificate;
+                clientOptions.TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false);
+
+                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions();
+                serverOptions.ServerCertificate = certificate;
+                serverOptions.RemoteCertificateValidationCallback = AllowAnyServerCertificate;
+
+                Assert.ThrowsAsync<InvalidOperationException>(() => { return client.AuthenticateAsClientAsync(clientOptions, CancellationToken.None); });
+                Assert.ThrowsAsync<InvalidOperationException>(() => { return server.AuthenticateAsServerAsync(serverOptions, CancellationToken.None); });
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Alpn_TestData))]
+        public void SslStream_StreamToStream_Alpn_Success(List<SslApplicationProtocol> clientProtocols, List<SslApplicationProtocol> serverProtocols, SslApplicationProtocol expected)
+        {
+            VirtualNetwork network = new VirtualNetwork();
+            using (var clientStream = new VirtualNetworkStream(network, false))
+            using (var serverStream = new VirtualNetworkStream(network, true))
+            using (var client = new SslStream(clientStream, false))
+            using (var server = new SslStream(serverStream, false))
+            {
+                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
+                {
+                    ApplicationProtocols = clientProtocols,
+                };
+
+                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions
+                {
+                    ApplicationProtocols = serverProtocols,
+                };
+
+                Assert.True(DoHandshakeWithOptions(client, server, clientOptions, serverOptions));
+
+                Assert.Equal(expected, client.NegotiatedApplicationProtocol);
+                Assert.Equal(expected, server.NegotiatedApplicationProtocol);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(~TestPlatforms.OSX)]
+        public void SslStream_StreamToStream_Alpn_NonMatchingProtocols_Fail()
+        {
+            VirtualNetwork network = new VirtualNetwork();
+            using (var clientStream = new VirtualNetworkStream(network, false))
+            using (var serverStream = new VirtualNetworkStream(network, true))
+            using (var client = new SslStream(clientStream, false))
+            using (var server = new SslStream(serverStream, false))
+            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            {
+                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
+                {
+                    ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http11 },
+                    RemoteCertificateValidationCallback = AllowAnyServerCertificate,
+                    TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false),
+                };
+
+                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions
+                {
+                    ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 },
+                    ServerCertificate = certificate,
+                };
+
+                Assert.ThrowsAsync<AuthenticationException>(() => { return client.AuthenticateAsClientAsync(clientOptions, CancellationToken.None); });
+                Assert.ThrowsAsync<AuthenticationException>(() => { return server.AuthenticateAsServerAsync(serverOptions, CancellationToken.None); });
+            }
+        }
+
+        internal static IEnumerable<object[]> Alpn_TestData()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                yield return new object[] { new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 }, null };
+                yield return new object[] { new List<SslApplicationProtocol> { SslApplicationProtocol.Http11 }, new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, null };
+                yield return new object[] { new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, null };
+                yield return new object[] { null, new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, null };
+                yield return new object[] { new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, null, null };
+                yield return new object[] { new List<SslApplicationProtocol> { SslApplicationProtocol.Http11 }, new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 }, null };
+                yield return new object[] { null, null, null };
+            }
+            else
+            {
+                // Works on linux distros with openssl 1.0.2, CI machines Ubuntu14.04 and Debian 87 don't have openssl 1.0.2
+                // Works on Windows OSes > 7.0
+                bool featureWorks = (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !(PlatformDetection.IsUbuntu1404 || PlatformDetection.IsDebian)) ||
+                                    (PlatformDetection.IsWindows && !PlatformDetection.IsWindows7);
+
+                yield return new object[] { new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 }, featureWorks ? SslApplicationProtocol.Http2 : default };
+                yield return new object[] { new List<SslApplicationProtocol> { SslApplicationProtocol.Http11 }, new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, featureWorks ? SslApplicationProtocol.Http11 : default };
+                yield return new object[] { new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, featureWorks ? SslApplicationProtocol.Http11 : default };
+                yield return new object[] { null, new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, default(SslApplicationProtocol) };
+                yield return new object[] { new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, null, default(SslApplicationProtocol) };
+                yield return new object[] { null, null, default(SslApplicationProtocol) };
+            }
+        }
+    }
+}

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -23,6 +23,27 @@ namespace System.Net.Security.Tests
         protected abstract bool DoHandshake(SslStream clientSslStream, SslStream serverSslStream);
 
         [Fact]
+        [Trait("category", "alpn")]
+        public void SslStream_StreamToStream_Alpn_Success()
+        {
+            VirtualNetwork network = new VirtualNetwork();
+            SslAuthenticationOptions options1 = new SslAuthenticationOptions();
+            options1.ApplicationProtocols = new [] { "h2", "http/1.1"};
+            options1.UserCertificateValidationCallback = AllowAnyServerCertificate;
+            SslAuthenticationOptions options2 = new SslAuthenticationOptions();
+            options2.ApplicationProtocols = new [] { "h2"};
+            using (var clientStream = new VirtualNetworkStream(network, false))
+            using (var serverStream = new VirtualNetworkStream(network, true))
+            using (var client = new SslStream(clientStream, false, options1))
+            using (var server = new SslStream(serverStream, false, options2))
+            {
+                Assert.True(DoHandshake(client, server));
+                Assert.Equal("h2", client.NegotiatedApplicationProtocol);
+                Assert.Equal("h2", server.NegotiatedApplicationProtocol);
+            }
+        }
+
+        [Fact]
         public void SslStream_StreamToStream_Authentication_Success()
         {
             VirtualNetwork network = new VirtualNetwork();

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -7,7 +7,6 @@
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Windows_NT-Debug|AnyCPU'" />
@@ -20,13 +19,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-OSX-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-OSX-Release|AnyCPU'" />
-
   <ItemGroup>
     <Compile Include="NotifyReadVirtualNetworkStream.cs" />
     <Compile Include="DummyTcpServer.cs" />
     <Compile Include="TestConfiguration.cs" />
     <!-- SslStream Tests -->
-
     <Compile Include="CertificateChainValidation.cs" />
     <Compile Include="CertificateValidationClientServer.cs" />
     <Compile Include="CertificateValidationRemoteServer.cs" />
@@ -40,12 +37,10 @@
     <Compile Include="SslStreamStreamToStreamTest.cs" />
     <Compile Include="SslStreamNetworkStreamTest.cs" />
     <Compile Include="TransportContextTest.cs" />
-
     <!-- NegotiateStream Tests -->
     <Compile Include="NegotiateStreamStreamToStreamTest.cs" />
     <Compile Include="ServiceNameCollectionTest.cs" />
     <Compile Include="NegotiateStreamKerberosTest.cs" />
-
     <!-- Common test files -->
     <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
       <Link>Common\System\Net\Capability.Security.cs</Link>
@@ -96,6 +91,7 @@
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
     <!-- TODO #13070: Add net463 to the condition after the TFM gets updated to the actual .Net 4.7-->
     <Compile Include="SslStreamAlertsTest.cs" />
+    <Compile Include="SslStreamAlpnTests.cs" />
     <Compile Include="SslStreamEKUTest.cs" />
     <Compile Include="SslStreamSchSendAuxRecordTest.cs" />
     <Compile Include="SslStreamCredentialCacheTest.cs" />

--- a/src/System.Net.Security/tests/UnitTests/Configurations.props
+++ b/src/System.Net.Security/tests/UnitTests/Configurations.props
@@ -2,8 +2,10 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard-Unix;
-      netstandard-Windows_NT;
+      netcoreapp-OSX;
+      netcoreapp-Unix;
+      netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeAuthenticatedStream.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeAuthenticatedStream.cs
@@ -33,7 +33,7 @@ namespace System.Net.Security
         public abstract bool IsSigned { get; }
         public abstract bool IsServer { get; }
 
-        public abstract Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token);
+        public new abstract Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token);
     }
 }
 

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
@@ -17,7 +17,7 @@ namespace System.Net.Security
         //  The public Client and Server classes enforce the parameters rules before
         //  calling into this .ctor.
         //
-        internal SslState(Stream innerStream, RemoteCertValidationCallback certValidationCallback, LocalCertSelectionCallback certSelectionCallback, EncryptionPolicy encryptionPolicy)
+        internal SslState(Stream innerStream, SslAuthenticationOptions sslAuthenticationOptions)
         {
         }
         //
@@ -25,6 +25,14 @@ namespace System.Net.Security
         //
         internal void ValidateCreateContext(bool isServer, string targetHost, SslProtocols enabledSslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertRevocationStatus)
         {
+        }
+
+        internal string NegotiatedApplicationProtocol
+        {
+            get
+            {
+                return null;
+            }
         }
 
         internal bool IsAuthenticated

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
@@ -17,13 +17,15 @@ namespace System.Net.Security
         //  The public Client and Server classes enforce the parameters rules before
         //  calling into this .ctor.
         //
-        internal SslState(Stream innerStream, SslAuthenticationOptions sslAuthenticationOptions)
+        internal SslState(Stream innerStream)
         {
         }
-        //
-        //
-        //
-        internal void ValidateCreateContext(bool isServer, string targetHost, SslProtocols enabledSslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertRevocationStatus)
+
+        internal void ValidateCreateContext(SslClientAuthenticationOptions sslClientAuthenticationOptions)
+        {
+        }
+
+        internal void ValidateCreateContext(SslServerAuthenticationOptions sslServerAuthenticationOptions)
         {
         }
 

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
@@ -279,7 +279,7 @@ namespace System.Net.Security
             throw new NotImplementedException();
         }
                 
-        public Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        public new Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
@@ -29,11 +29,11 @@ namespace System.Net.Security
         {
         }
 
-        internal string NegotiatedApplicationProtocol
+        internal SslApplicationProtocol NegotiatedApplicationProtocol
         {
             get
             {
-                return null;
+                return default;
             }
         }
 

--- a/src/System.Net.Security/tests/UnitTests/SslApplicationProtocolTests.cs
+++ b/src/System.Net.Security/tests/UnitTests/SslApplicationProtocolTests.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.Net.Security.Tests
+{
+    public class SslApplicationProtocolTests
+    {
+        [Fact]
+        public void Constants_Values_AreCorrect()
+        {
+            Assert.Equal(new SslApplicationProtocol(new byte[] { 0x68, 0x32 }), SslApplicationProtocol.Http2);
+            Assert.Equal(new SslApplicationProtocol(new byte[] { 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31 }), SslApplicationProtocol.Http11);
+        }
+
+        [Fact]
+        public void Constructor_Overloads_Succeeds()
+        {
+            const string hello = "hello";
+            byte[] expected = Encoding.UTF8.GetBytes(hello);
+            SslApplicationProtocol byteProtocol = new SslApplicationProtocol(expected);
+            SslApplicationProtocol stringProtocol = new SslApplicationProtocol(hello);
+            Assert.Equal(byteProtocol, stringProtocol);
+
+            SslApplicationProtocol defaultProtocol = default;
+            Assert.True(defaultProtocol.Protocol.IsEmpty);
+
+            Assert.Throws<ArgumentNullException>(() => { new SslApplicationProtocol((byte[])null); });
+            Assert.Throws<ArgumentNullException>(() => { new SslApplicationProtocol((string)null); });
+            Assert.Throws<ArgumentException>(() => { new SslApplicationProtocol(new byte[] { }); });
+            Assert.Throws<ArgumentException>(() => { new SslApplicationProtocol(string.Empty); });
+            Assert.Throws<EncoderFallbackException>(() => { new SslApplicationProtocol("\uDC00"); });
+        }
+
+        [Theory]
+        [MemberData(nameof(Protocol_Equality_TestData))]
+        public void Equality_Tests_Succeeds(SslApplicationProtocol left, SslApplicationProtocol right)
+        {
+            Assert.Equal(left, right);
+            Assert.True(left == right);
+            Assert.False(left != right);
+
+            if (!left.Protocol.IsEmpty && !right.Protocol.IsEmpty)
+                Assert.Equal(left.GetHashCode(), right.GetHashCode());
+        }
+
+        [Theory]
+        [MemberData(nameof(Protocol_InEquality_TestData))]
+        public void InEquality_Tests_Succeeds(SslApplicationProtocol left, SslApplicationProtocol right)
+        {
+            Assert.NotEqual(left, right);
+            Assert.True(left != right);
+            Assert.False(left == right);
+
+            if (!left.Protocol.IsEmpty && !right.Protocol.IsEmpty)
+                Assert.NotEqual(left.GetHashCode(), right.GetHashCode());
+        }
+
+        [Fact]
+        public void ToString_Rendering_Succeeds()
+        {
+            const string expected = "hello";
+            SslApplicationProtocol protocol = new SslApplicationProtocol(expected);
+            Assert.Equal(expected, protocol.ToString());
+
+            byte[] bytes = new byte[] { 0x0B, 0xEE };
+            protocol = new SslApplicationProtocol(bytes);
+            Assert.Equal("0x0b 0xee", protocol.ToString());
+
+            protocol = default;
+            Assert.Null(protocol.ToString());
+        }
+
+        public static IEnumerable<object[]> Protocol_Equality_TestData()
+        {
+            yield return new object[] { new SslApplicationProtocol("hello"), new SslApplicationProtocol("hello") };
+            yield return new object[] { new SslApplicationProtocol(new byte[] { 0x42 }), new SslApplicationProtocol(new byte[] { 0x42 }) };
+            yield return new object[] { null, null };
+            yield return new object[] { default, default };
+            yield return new object[] { null, default };
+            yield return new object[] { default, null };
+        }
+
+        public static IEnumerable<object[]> Protocol_InEquality_TestData()
+        {
+            yield return new object[] { new SslApplicationProtocol("hello"), new SslApplicationProtocol("world") };
+            yield return new object[] { new SslApplicationProtocol(new byte[] { 0x42 }), new SslApplicationProtocol(new byte[] { 0x52, 0x62 }) };
+            yield return new object[] { null, new SslApplicationProtocol(new byte[] { 0x42 }) };
+            yield return new object[] { new SslApplicationProtocol(new byte[] { 0x42 }), null };
+        }
+    }
+}

--- a/src/System.Net.Security/tests/UnitTests/SslApplicationProtocolTests.cs
+++ b/src/System.Net.Security/tests/UnitTests/SslApplicationProtocolTests.cs
@@ -33,6 +33,8 @@ namespace System.Net.Security.Tests
             Assert.Throws<ArgumentNullException>(() => { new SslApplicationProtocol((string)null); });
             Assert.Throws<ArgumentException>(() => { new SslApplicationProtocol(new byte[] { }); });
             Assert.Throws<ArgumentException>(() => { new SslApplicationProtocol(string.Empty); });
+            Assert.Throws<ArgumentException>(() => { new SslApplicationProtocol(Encoding.UTF8.GetBytes(new string('a', 256))); });
+            Assert.Throws<ArgumentException>(() => { new SslApplicationProtocol(new string('a', 256)); });
             Assert.Throws<EncoderFallbackException>(() => { new SslApplicationProtocol("\uDC00"); });
         }
 
@@ -43,9 +45,7 @@ namespace System.Net.Security.Tests
             Assert.Equal(left, right);
             Assert.True(left == right);
             Assert.False(left != right);
-
-            if (!left.Protocol.IsEmpty && !right.Protocol.IsEmpty)
-                Assert.Equal(left.GetHashCode(), right.GetHashCode());
+            Assert.Equal(left.GetHashCode(), right.GetHashCode());
         }
 
         [Theory]
@@ -55,9 +55,7 @@ namespace System.Net.Security.Tests
             Assert.NotEqual(left, right);
             Assert.True(left != right);
             Assert.False(left == right);
-
-            if (!left.Protocol.IsEmpty && !right.Protocol.IsEmpty)
-                Assert.NotEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.NotEqual(left.GetHashCode(), right.GetHashCode());
         }
 
         [Fact]

--- a/src/System.Net.Security/tests/UnitTests/SslAuthenticationOptionsTests.cs
+++ b/src/System.Net.Security/tests/UnitTests/SslAuthenticationOptionsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using Xunit;
@@ -10,8 +11,8 @@ namespace System.Net.Security.Tests
 {
     public class SslAuthenticationOptionsTests
     {
-        private SslClientAuthenticationOptions _clientOptions = new SslClientAuthenticationOptions();
-        private SslServerAuthenticationOptions _serverOptions = new SslServerAuthenticationOptions();
+        private readonly SslClientAuthenticationOptions _clientOptions = new SslClientAuthenticationOptions();
+        private readonly SslServerAuthenticationOptions _serverOptions = new SslServerAuthenticationOptions();
 
         [Fact]
         public void AllowRenegotiation_Get_Set_Succeeds()
@@ -41,7 +42,7 @@ namespace System.Net.Security.Tests
             Assert.Null(_clientOptions.ApplicationProtocols);
             Assert.Null(_serverOptions.ApplicationProtocols);
 
-            SslApplicationProtocol[] applnProtos = new SslApplicationProtocol[] { SslApplicationProtocol.Http2, SslApplicationProtocol.Http11 };
+            List<SslApplicationProtocol> applnProtos = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2, SslApplicationProtocol.Http11 };
             _clientOptions.ApplicationProtocols = applnProtos;
             _serverOptions.ApplicationProtocols = applnProtos;
 
@@ -79,11 +80,10 @@ namespace System.Net.Security.Tests
         [InlineData("\u0bee")]
         [InlineData("hello")]
         [InlineData(" \t")]
+        [InlineData(null)]
         public void TargetHost_Get_Set_Succeeds(string expected)
         {
             Assert.Null(_clientOptions.TargetHost);
-            Assert.Throws<ArgumentNullException>(() => _clientOptions.TargetHost = null);
-
             _clientOptions.TargetHost = expected;
             Assert.Equal(expected, _clientOptions.TargetHost);
         }
@@ -106,8 +106,9 @@ namespace System.Net.Security.Tests
         public void ServerCertificate_Get_Set_Succeeds()
         {
             Assert.Null(_serverOptions.ServerCertificate);
-            Assert.Throws<ArgumentNullException>(() => _serverOptions.ServerCertificate = null);
+            _serverOptions.ServerCertificate = null;
 
+            Assert.Null(_serverOptions.ServerCertificate);
             X509Certificate cert = new X509Certificate();
             _serverOptions.ServerCertificate = cert;
 
@@ -130,17 +131,17 @@ namespace System.Net.Security.Tests
         [Fact]
         public void CheckCertificateRevocation_Get_Set_Succeeds()
         {
-            Assert.Equal(X509RevocationMode.NoCheck, _clientOptions.CheckCertificateRevocation);
-            Assert.Equal(X509RevocationMode.NoCheck, _serverOptions.CheckCertificateRevocation);
+            Assert.Equal(X509RevocationMode.NoCheck, _clientOptions.CertificateRevocationCheckMode);
+            Assert.Equal(X509RevocationMode.NoCheck, _serverOptions.CertificateRevocationCheckMode);
 
-            _clientOptions.CheckCertificateRevocation = X509RevocationMode.Online;
-            _serverOptions.CheckCertificateRevocation = X509RevocationMode.Offline;
+            _clientOptions.CertificateRevocationCheckMode = X509RevocationMode.Online;
+            _serverOptions.CertificateRevocationCheckMode = X509RevocationMode.Offline;
 
-            Assert.Equal(X509RevocationMode.Online, _clientOptions.CheckCertificateRevocation);
-            Assert.Equal(X509RevocationMode.Offline, _serverOptions.CheckCertificateRevocation);
+            Assert.Equal(X509RevocationMode.Online, _clientOptions.CertificateRevocationCheckMode);
+            Assert.Equal(X509RevocationMode.Offline, _serverOptions.CertificateRevocationCheckMode);
 
-            Assert.Throws<ArgumentException>(() => _clientOptions.CheckCertificateRevocation = (X509RevocationMode)3);
-            Assert.Throws<ArgumentException>(() => _serverOptions.CheckCertificateRevocation = (X509RevocationMode)3);
+            Assert.Throws<ArgumentException>(() => _clientOptions.CertificateRevocationCheckMode = (X509RevocationMode)3);
+            Assert.Throws<ArgumentException>(() => _serverOptions.CertificateRevocationCheckMode = (X509RevocationMode)3);
         }
 
         [Fact]

--- a/src/System.Net.Security/tests/UnitTests/SslAuthenticationOptionsTests.cs
+++ b/src/System.Net.Security/tests/UnitTests/SslAuthenticationOptionsTests.cs
@@ -93,11 +93,10 @@ namespace System.Net.Security.Tests
         {
             Assert.Null(_clientOptions.ClientCertificates);
 
-            X509CertificateCollection expected = new X509CertificateCollection();
-
             _clientOptions.ClientCertificates = null;
-            Assert.Equal(expected, _clientOptions.ClientCertificates);
+            Assert.Null(_clientOptions.ClientCertificates);
 
+            X509CertificateCollection expected = new X509CertificateCollection();
             _clientOptions.ClientCertificates = expected;
             Assert.Equal(expected, _clientOptions.ClientCertificates);
         }

--- a/src/System.Net.Security/tests/UnitTests/SslAuthenticationOptionsTests.cs
+++ b/src/System.Net.Security/tests/UnitTests/SslAuthenticationOptionsTests.cs
@@ -1,0 +1,162 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace System.Net.Security.Tests
+{
+    public class SslAuthenticationOptionsTests
+    {
+        private SslClientAuthenticationOptions _clientOptions = new SslClientAuthenticationOptions();
+        private SslServerAuthenticationOptions _serverOptions = new SslServerAuthenticationOptions();
+
+        [Fact]
+        public void AllowRenegotiation_Get_Set_Succeeds()
+        {
+            Assert.False(_clientOptions.AllowRenegotiation);
+            Assert.False(_serverOptions.AllowRenegotiation);
+
+            _clientOptions.AllowRenegotiation = true;
+            _serverOptions.AllowRenegotiation = true;
+
+            Assert.True(_clientOptions.AllowRenegotiation);
+            Assert.True(_serverOptions.AllowRenegotiation);
+        }
+
+        [Fact]
+        public void ClientCertificateRequired_Get_Set_Succeeds()
+        {
+            Assert.False(_serverOptions.ClientCertificateRequired);
+
+            _serverOptions.ClientCertificateRequired = true;
+            Assert.True(_serverOptions.ClientCertificateRequired);
+        }
+
+        [Fact]
+        public void ApplicationProtocols_Get_Set_Succeeds()
+        {
+            Assert.Null(_clientOptions.ApplicationProtocols);
+            Assert.Null(_serverOptions.ApplicationProtocols);
+
+            SslApplicationProtocol[] applnProtos = new SslApplicationProtocol[] { SslApplicationProtocol.Http2, SslApplicationProtocol.Http11 };
+            _clientOptions.ApplicationProtocols = applnProtos;
+            _serverOptions.ApplicationProtocols = applnProtos;
+
+            Assert.Equal(applnProtos, _clientOptions.ApplicationProtocols);
+            Assert.Equal(applnProtos, _serverOptions.ApplicationProtocols);
+        }
+
+        [Fact]
+        public void RemoteCertificateValidationCallback_Get_Set_Succeeds()
+        {
+            Assert.Null(_clientOptions.RemoteCertificateValidationCallback);
+            Assert.Null(_serverOptions.RemoteCertificateValidationCallback);
+
+            RemoteCertificateValidationCallback callback = (sender, certificate, chain, errors) => { return true; };
+            _clientOptions.RemoteCertificateValidationCallback = callback;
+            _serverOptions.RemoteCertificateValidationCallback = callback;
+
+            Assert.Equal(callback, _clientOptions.RemoteCertificateValidationCallback);
+            Assert.Equal(callback, _serverOptions.RemoteCertificateValidationCallback);
+        }
+
+        [Fact]
+        public void LocalCertificateSelectionCallback_Get_Set_Succeeds()
+        {
+            Assert.Null(_clientOptions.LocalCertificateSelectionCallback);
+
+            LocalCertificateSelectionCallback callback = (sender, host, localCertificates, remoteCertificate, issuers) => { return new X509Certificate(); };
+            _clientOptions.LocalCertificateSelectionCallback = callback;
+
+            Assert.Equal(callback, _clientOptions.LocalCertificateSelectionCallback);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("\u0bee")]
+        [InlineData("hello")]
+        [InlineData(" \t")]
+        public void TargetHost_Get_Set_Succeeds(string expected)
+        {
+            Assert.Null(_clientOptions.TargetHost);
+            Assert.Throws<ArgumentNullException>(() => _clientOptions.TargetHost = null);
+
+            _clientOptions.TargetHost = expected;
+            Assert.Equal(expected, _clientOptions.TargetHost);
+        }
+
+        [Fact]
+        public void ClientCertificates_Get_Set_Succeeds()
+        {
+            Assert.Null(_clientOptions.ClientCertificates);
+
+            X509CertificateCollection expected = new X509CertificateCollection();
+
+            _clientOptions.ClientCertificates = null;
+            Assert.Equal(expected, _clientOptions.ClientCertificates);
+
+            _clientOptions.ClientCertificates = expected;
+            Assert.Equal(expected, _clientOptions.ClientCertificates);
+        }
+
+        [Fact]
+        public void ServerCertificate_Get_Set_Succeeds()
+        {
+            Assert.Null(_serverOptions.ServerCertificate);
+            Assert.Throws<ArgumentNullException>(() => _serverOptions.ServerCertificate = null);
+
+            X509Certificate cert = new X509Certificate();
+            _serverOptions.ServerCertificate = cert;
+
+            Assert.Equal(cert, _serverOptions.ServerCertificate);
+        }
+
+        [Fact]
+        public void EnabledSslProtocols_Get_Set_Succeeds()
+        {
+            Assert.Equal(SslProtocols.None, _clientOptions.EnabledSslProtocols);
+            Assert.Equal(SslProtocols.None, _serverOptions.EnabledSslProtocols);
+
+            _clientOptions.EnabledSslProtocols = SslProtocols.Tls12;
+            _serverOptions.EnabledSslProtocols = SslProtocols.Tls12;
+
+            Assert.Equal(SslProtocols.Tls12, _clientOptions.EnabledSslProtocols);
+            Assert.Equal(SslProtocols.Tls12, _serverOptions.EnabledSslProtocols);
+        }
+
+        [Fact]
+        public void CheckCertificateRevocation_Get_Set_Succeeds()
+        {
+            Assert.Equal(X509RevocationMode.NoCheck, _clientOptions.CheckCertificateRevocation);
+            Assert.Equal(X509RevocationMode.NoCheck, _serverOptions.CheckCertificateRevocation);
+
+            _clientOptions.CheckCertificateRevocation = X509RevocationMode.Online;
+            _serverOptions.CheckCertificateRevocation = X509RevocationMode.Offline;
+
+            Assert.Equal(X509RevocationMode.Online, _clientOptions.CheckCertificateRevocation);
+            Assert.Equal(X509RevocationMode.Offline, _serverOptions.CheckCertificateRevocation);
+
+            Assert.Throws<ArgumentException>(() => _clientOptions.CheckCertificateRevocation = (X509RevocationMode)3);
+            Assert.Throws<ArgumentException>(() => _serverOptions.CheckCertificateRevocation = (X509RevocationMode)3);
+        }
+
+        [Fact]
+        public void EncryptionPolicy_Get_Set_Succeeds()
+        {
+            Assert.Equal(EncryptionPolicy.RequireEncryption, _clientOptions.EncryptionPolicy);
+            Assert.Equal(EncryptionPolicy.RequireEncryption, _serverOptions.EncryptionPolicy);
+
+            _clientOptions.EncryptionPolicy = EncryptionPolicy.AllowNoEncryption;
+            _serverOptions.EncryptionPolicy = EncryptionPolicy.NoEncryption;
+
+            Assert.Equal(EncryptionPolicy.AllowNoEncryption, _clientOptions.EncryptionPolicy);
+            Assert.Equal(EncryptionPolicy.NoEncryption, _serverOptions.EncryptionPolicy);
+
+            Assert.Throws<ArgumentException>(() => _clientOptions.EncryptionPolicy = (EncryptionPolicy)3);
+            Assert.Throws<ArgumentException>(() => _serverOptions.EncryptionPolicy = (EncryptionPolicy)3);
+        }
+    }
+}

--- a/src/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -17,6 +17,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="SslApplicationProtocolTests.cs" />
+    <Compile Include="SslAuthenticationOptionsTests.cs" />
     <Compile Include="SslStreamAllowedProtocolsTest.cs" />
     <Compile Include="System\Security\Authentication\ExtendedProtection\ExtendedProtectionPolicyTest.cs" />
     <Compile Include="TlsAlertsMatchWindowsInterop.cs" />

--- a/src/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -12,10 +12,14 @@
     -->
     <NoWarn>436</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="SslApplicationProtocolTests.cs" />
     <Compile Include="SslAuthenticationOptionsTests.cs" />
@@ -70,6 +74,14 @@
     <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
       <Link>ProductionCode\Common\System\Net\InternalException.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Memory" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Threading" />
+    <Reference Include="System.Threading.Tasks" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -34,6 +34,18 @@
     <Compile Include="..\..\src\System\Net\Security\SslStream.cs">
       <Link>ProductionCode\System\Net\Security\SslStream.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Security\SslClientAuthenticationOptions.cs">
+      <Link>ProductionCode\System\Net\Security\SslClientAuthenticationOptions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Security\SslServerAuthenticationOptions.cs">
+      <Link>ProductionCode\System\Net\Security\SslServerAuthenticationOptions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Security\SslAuthenticationOptions.cs">
+      <Link>ProductionCode\System\Net\Security\SslAuthenticationOptions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Security\SslApplicationProtocol.cs">
+      <Link>ProductionCode\System\Net\Security\SslApplicationProtocol.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\SslStreamContext.cs">
       <Link>ProductionCode\System\Net\SslStreamContext.cs</Link>
     </Compile>


### PR DESCRIPTION
cc @stephentoub @bartonjs @geoffkizer @wfurt @karelz @Drawaes @Tratcher 

fixes #23177 

In this PR, only ALPN support is added. This PR does not include:

1. CancellationToken implementation
2. AllowRenegotiation
3. SNI

I'll file issues separately for followup on above items at the time of merging this PR. 