### PR TITLE
Make FileSystemWatcher tests tolerant of spurious/extra events.

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
@@ -11,7 +11,6 @@ namespace System.IO.Tests
     public class File_Create_Tests : FileSystemWatcherTest
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/14154", TestPlatforms.AnyUnix)]
         public void FileSystemWatcher_File_Create()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
@@ -197,7 +197,6 @@ namespace System.IO.Tests
         /// EndInit will begin EnableRaisingEvents if we previously set EnableRaisingEvents=true
         /// </summary>
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/14154", TestPlatforms.AnyUnix)]
         public void EndInit_ResumesPausedEnableRaisingEvents()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -216,7 +215,6 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/14154", TestPlatforms.AnyUnix)]
         public void EndInit_ResumesPausedEnableRaisingEvents(bool setBeforeBeginInit)
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -202,26 +202,14 @@ namespace System.IO.Tests
             AutoResetEvent changed = null, created = null, deleted = null, renamed = null;
             string[] expectedFullPaths = expectedPaths == null ? null : expectedPaths.Select(e => Path.GetFullPath(e)).ToArray();
 
-            // On OSX we get a number of extra events tacked onto valid events. As such, we can not ever confidently
-            // say that an event won't occur, only that one will occur.
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                if (verifyChanged = ((expectedEvents & WatcherChangeTypes.Changed) > 0))
-                    changed = WatchChanged(watcher, expectedPaths);
-                if (verifyCreated = ((expectedEvents & WatcherChangeTypes.Created) > 0))
-                    created = WatchCreated(watcher, expectedPaths);
-                if (verifyDeleted = ((expectedEvents & WatcherChangeTypes.Deleted) > 0))
-                    deleted = WatchDeleted(watcher, expectedPaths);
-                if (verifyRenamed = ((expectedEvents & WatcherChangeTypes.Renamed) > 0))
-                    renamed = WatchRenamed(watcher, expectedPaths);
-            }
-            else
-            {
-                changed = WatchChanged(watcher, (expectedEvents & WatcherChangeTypes.Changed) > 0 ? expectedPaths : null);
-                created = WatchCreated(watcher, (expectedEvents & WatcherChangeTypes.Created) > 0 ? expectedPaths : null);
-                deleted = WatchDeleted(watcher, (expectedEvents & WatcherChangeTypes.Deleted) > 0 ? expectedPaths : null);
-                renamed = WatchRenamed(watcher, (expectedEvents & WatcherChangeTypes.Renamed) > 0 ? expectedPaths : null);
-            }
+            if (verifyChanged = ((expectedEvents & WatcherChangeTypes.Changed) > 0))
+                changed = WatchChanged(watcher, expectedPaths);
+            if (verifyCreated = ((expectedEvents & WatcherChangeTypes.Created) > 0))
+                created = WatchCreated(watcher, expectedPaths);
+            if (verifyDeleted = ((expectedEvents & WatcherChangeTypes.Deleted) > 0))
+                deleted = WatchDeleted(watcher, expectedPaths);
+            if (verifyRenamed = ((expectedEvents & WatcherChangeTypes.Renamed) > 0))
+                renamed = WatchRenamed(watcher, expectedPaths);
 
             watcher.EnableRaisingEvents = true;
             action();


### PR DESCRIPTION
This changes ExecuteAndVerifyEvents in src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs to use what was previously the OSX behaviour on all platforms. Fixes dotnet/coreclr#14154.