### PR TITLE
Revert bad PR that was merged to soon

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
@@ -122,18 +122,7 @@ namespace System.ComponentModel.DataAnnotations
                 return true;
             }
 
-            PropertyInfo property = null;
-            try
-            {
-                // On CoreRT, this property may not be enabled for reflection.
-                // It may be possible to eliminate the exception by using direct reflection
-                // (i.e. not via the RuntimeReflectionExtensions or the new split TypeInfo format.
-                property = value.GetType().GetRuntimeProperty("Count");
-            }
-            catch (TypeAccessException)
-            {
-            }
-
+            PropertyInfo property = value.GetType().GetRuntimeProperty("Count");
             if (property != null && property.CanRead && property.PropertyType == typeof(int))
             {
                 count = (int)property.GetValue(value);


### PR DESCRIPTION
See #24064. The checked in fix is wrong because it changes the behavior when .NET Native is being used such that a nonsensical exception will be thrown which would never be thrown when .NET Native is not being used. These kinds of errors are really hard for developers to debug.

Instead we will let .NET Native fail in the normal way when rd.xml data is not available. This will direct people to add metadata appropriately when they need to get this to work.
