### PR TITLE
[UWP]allow all security flags on named pipe client

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.CreateNamedPipeClient.Uap.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CreateNamedPipeClient.Uap.cs
@@ -32,7 +32,7 @@ internal partial class Interop
             parameters.dwSize = (uint)Marshal.SizeOf<Interop.Kernel32.CREATEFILE2_EXTENDED_PARAMETERS>();
 
             parameters.dwFileAttributes = (uint)dwFlagsAndAttributes & 0x0000FFFF;
-            parameters.dwSecurityQosFlags = (uint)dwFlagsAndAttributes & 0x000F0000;
+            parameters.dwSecurityQosFlags = (uint)dwFlagsAndAttributes & 0x001F0000;
             parameters.dwFileFlags = (uint)dwFlagsAndAttributes & 0xFFF00000;
 
             parameters.hTemplateFile = hTemplateFile;

--- a/src/Common/src/Interop/Windows/kernel32/Interop.CreateNamedPipeClient.Uap.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CreateNamedPipeClient.Uap.cs
@@ -31,8 +31,12 @@ internal partial class Interop
             Interop.Kernel32.CREATEFILE2_EXTENDED_PARAMETERS parameters;
             parameters.dwSize = (uint)Marshal.SizeOf<Interop.Kernel32.CREATEFILE2_EXTENDED_PARAMETERS>();
 
+            // The dwFlagsAndAttributes is carrying a combination of flags that are mapped to different fields of the extended
+            // parameters. The possible range of values for dwFileAttributes and dwFileFlags cannot be fully covered coming from 
+            // a single int but are enough for correction creation of the named pipe client. The SECURITY_VALID_SQOS_FLAGS need
+            // to be all available for proper impersonation.
             parameters.dwFileAttributes = (uint)dwFlagsAndAttributes & 0x0000FFFF;
-            parameters.dwSecurityQosFlags = (uint)dwFlagsAndAttributes & 0x001F0000;
+            parameters.dwSecurityQosFlags = (uint)dwFlagsAndAttributes & 0x001F0000; // SECURITY_VALID_SQOS_FLAGS
             parameters.dwFileFlags = (uint)dwFlagsAndAttributes & 0xFFF00000;
 
             parameters.hTemplateFile = hTemplateFile;

--- a/src/Common/src/Interop/Windows/kernel32/Interop.CreateNamedPipeClient.Uap.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CreateNamedPipeClient.Uap.cs
@@ -32,9 +32,9 @@ internal partial class Interop
             parameters.dwSize = (uint)Marshal.SizeOf<Interop.Kernel32.CREATEFILE2_EXTENDED_PARAMETERS>();
 
             // The dwFlagsAndAttributes is carrying a combination of flags that are mapped to different fields of the extended
-            // parameters. The possible range of values for dwFileAttributes and dwFileFlags cannot be fully covered coming from 
-            // a single int but are enough for correction creation of the named pipe client. The SECURITY_VALID_SQOS_FLAGS need
-            // to be all available for proper impersonation.
+            // parameters. The possible range of values for dwFileAttributes, dwSecurityQosFlags, and dwFileFlags cannot be fully
+            // covered coming from a single int but are enough for correction creation of the named pipe client. The SECURITY_VALID_SQOS_FLAGS
+            //  needs to be all available for proper impersonation.
             parameters.dwFileAttributes = (uint)dwFlagsAndAttributes & 0x0000FFFF;
             parameters.dwSecurityQosFlags = (uint)dwFlagsAndAttributes & 0x001F0000; // SECURITY_VALID_SQOS_FLAGS
             parameters.dwFileFlags = (uint)dwFlagsAndAttributes & 0xFFF00000;

--- a/src/Common/src/Interop/Windows/kernel32/Interop.CreateNamedPipeClient.Uap.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CreateNamedPipeClient.Uap.cs
@@ -34,9 +34,11 @@ internal partial class Interop
             // The dwFlagsAndAttributes is carrying a combination of flags that are mapped to different fields of the extended
             // parameters. The possible range of values for dwFileAttributes, dwSecurityQosFlags, and dwFileFlags cannot be fully
             // covered coming from a single int but are enough for correction creation of the named pipe client. The SECURITY_VALID_SQOS_FLAGS
-            //  needs to be all available for proper impersonation.
+            // needs to be all available for proper impersonation.
+            const uint SECURITY_VALID_SQOS_FLAGS = 0x001F0000;
+            
             parameters.dwFileAttributes = (uint)dwFlagsAndAttributes & 0x0000FFFF;
-            parameters.dwSecurityQosFlags = (uint)dwFlagsAndAttributes & 0x001F0000; // SECURITY_VALID_SQOS_FLAGS
+            parameters.dwSecurityQosFlags = (uint)dwFlagsAndAttributes & SECURITY_VALID_SQOS_FLAGS;
             parameters.dwFileFlags = (uint)dwFlagsAndAttributes & 0xFFF00000;
 
             parameters.hTemplateFile = hTemplateFile;

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -171,11 +171,11 @@ namespace System.IO.Pipes
             // now handle win32 impersonate/revert specific errors by throwing corresponding exceptions
             if (execHelper._impersonateErrorCode != 0)
             {
-                WinIOError(execHelper._impersonateErrorCode);
+                throw WinIOError(execHelper._impersonateErrorCode);
             }
             else if (execHelper._revertImpersonateErrorCode != 0)
             {
-                WinIOError(execHelper._revertImpersonateErrorCode);
+                throw WinIOError(execHelper._revertImpersonateErrorCode);
             }
         }
 

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Windows.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Windows.cs
@@ -13,14 +13,19 @@ namespace System.IO.Pipes.Tests
 {
     public partial class NamedPipeTest_RunAsClient : RemoteExecutorTestBase
     {
-        [Fact]
+        [Theory]
+        [InlineData(TokenImpersonationLevel.None)]
+        [InlineData(TokenImpersonationLevel.Anonymous)]
+        [InlineData(TokenImpersonationLevel.Identification)]
+        [InlineData(TokenImpersonationLevel.Impersonation)]
+        [InlineData(TokenImpersonationLevel.Delegation)]
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes
         [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
-        public async Task RunAsClient_Windows()
+        public async Task RunAsClient_Windows(TokenImpersonationLevel tokenImpersonationLevel)
         {
             string pipeName = GetUniquePipeName();
             using (var server = new NamedPipeServerStream(pipeName))
-            using (var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None, TokenImpersonationLevel.Impersonation))
+            using (var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None, tokenImpersonationLevel))
             {
                 Task serverTask = server.WaitForConnectionAsync();
 
@@ -28,8 +33,16 @@ namespace System.IO.Pipes.Tests
                 await serverTask;
 
                 bool ran = false;
-                server.RunAsClient(() => ran = true);
-                Assert.True(ran, "Expected delegate to have been invoked");
+                if (tokenImpersonationLevel == TokenImpersonationLevel.None)
+                {
+                    Assert.Throws<IOException>(() => server.RunAsClient(() => ran = true));
+                    Assert.False(ran, "Expected delegate to not have been invoked");
+                }
+                else
+                {
+                    server.RunAsClient(() => ran = true);
+                    Assert.True(ran, "Expected delegate to have been invoked");
+                }
             }
         }
 


### PR DESCRIPTION
Perhaps the more proper way to deal with this is to define proper
constants and enumerations but that needs to be done for the whole IO
area/usage. However, even after that likely we should change the signature of the
method since there will be some values that are not supported with the
current signature.

Opportunistic fix: RunAsClient was not raising proper exceptions in case
of error.

Fixes #24318