### PR TITLE
Skip GC tests on desktop with difference in behavior

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.cs
+++ b/src/System.Runtime/tests/System/GCTests.cs
@@ -714,6 +714,7 @@ namespace System.Tests
         [OuterLoop]
         [InlineData(0)]
         [InlineData(-1)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Difference in behavior, full framework doesn't throw, fixed in .NET Core")]
         public static void TryStartNoGCRegion_TotalSizeOutOfRange(long size)
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
@@ -730,6 +731,7 @@ namespace System.Tests
         [InlineData(0)]                   // invalid because lohSize ==
         [InlineData(-1)]                  // invalid because lohSize < 0
         [InlineData(1152921504606846976)] // invalid because lohSize > totalSize
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Difference in behavior, full framework doesn't throw, fixed in .NET Core")]
         public static void TryStartNoGCRegion_LOHSizeInvalid(long size)
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();


### PR DESCRIPTION
This tests fail in desktop because the fix made in https://github.com/dotnet/coreclr/pull/14088 is not in desktop. Since they are outerloop that is why CI passed, but official build is failing. 

We should probably mark that fix as netfx-port-consider.

cc: @danmosemsft @swgillespie 