### PR TITLE
Add TextReader/Writer Memory-based virtuals

### DIFF
--- a/src/System.IO/tests/StringReader/StringReader.CtorTests.cs
+++ b/src/System.IO/tests/StringReader/StringReader.CtorTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    public class ReaderTests
+    public partial class StringReaderTests
     {
         [Fact]
         public static void StringReaderWithNullString()

--- a/src/System.IO/tests/StringReader/StringReaderTests.netcoreapp.cs
+++ b/src/System.IO/tests/StringReader/StringReaderTests.netcoreapp.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public partial class StringReaderTests
+    {
+        [Fact]
+        public void ReadSpan_Success()
+        {
+            string input = "abcdef";
+            var reader = new StringReader(input);
+            Span<char> s = new char[2];
+
+            Assert.Equal(2, reader.Read(s));
+            Assert.Equal("ab", new string(s.ToArray()));
+
+            Assert.Equal(1, reader.Read(s.Slice(0, 1)));
+            Assert.Equal("cb", new string(s.ToArray()));
+
+            Assert.Equal(2, reader.Read(s));
+            Assert.Equal("de", new string(s.ToArray()));
+
+            Assert.Equal(1, reader.Read(s));
+            Assert.Equal("f", new string(s.Slice(0, 1).ToArray()));
+
+            Assert.Equal(0, reader.Read(s));
+        }
+
+        [Fact]
+        public void ReadBlockSpan_Success()
+        {
+            string input = "abcdef";
+            var reader = new StringReader(input);
+            Span<char> s = new char[2];
+
+            Assert.Equal(2, reader.ReadBlock(s));
+            Assert.Equal("ab", new string(s.ToArray()));
+
+            Assert.Equal(1, reader.ReadBlock(s.Slice(0, 1)));
+            Assert.Equal("cb", new string(s.ToArray()));
+
+            Assert.Equal(2, reader.ReadBlock(s));
+            Assert.Equal("de", new string(s.ToArray()));
+
+            Assert.Equal(1, reader.ReadBlock(s));
+            Assert.Equal("f", new string(s.Slice(0, 1).ToArray()));
+
+            Assert.Equal(0, reader.ReadBlock(s));
+        }
+
+        [Fact]
+        public async Task ReadMemoryAsync_Success()
+        {
+            string input = "abcdef";
+            var reader = new StringReader(input);
+            Memory<char> m = new char[2];
+
+            Assert.Equal(2, await reader.ReadAsync(m));
+            Assert.Equal("ab", new string(m.ToArray()));
+
+            Assert.Equal(1, await reader.ReadAsync(m.Slice(0, 1)));
+            Assert.Equal("cb", new string(m.ToArray()));
+
+            Assert.Equal(2, await reader.ReadAsync(m));
+            Assert.Equal("de", new string(m.ToArray()));
+
+            Assert.Equal(1, await reader.ReadAsync(m));
+            Assert.Equal("f", new string(m.Slice(0, 1).ToArray()));
+
+            Assert.Equal(0, await reader.ReadAsync(m));
+        }
+
+        [Fact]
+        public async Task ReadBlockMemoryAsync_Success()
+        {
+            string input = "abcdef";
+            var reader = new StringReader(input);
+            Memory<char> m = new char[2];
+
+            Assert.Equal(2, await reader.ReadBlockAsync(m));
+            Assert.Equal("ab", new string(m.ToArray()));
+
+            Assert.Equal(1, await reader.ReadBlockAsync(m.Slice(0, 1)));
+            Assert.Equal("cb", new string(m.ToArray()));
+
+            Assert.Equal(2, await reader.ReadBlockAsync(m));
+            Assert.Equal("de", new string(m.ToArray()));
+
+            Assert.Equal(1, await reader.ReadBlockAsync(m));
+            Assert.Equal("f", new string(m.Slice(0, 1).ToArray()));
+
+            Assert.Equal(0, await reader.ReadBlockAsync(m));
+        }
+
+        [Fact]
+        public void Disposed_ThrowsException()
+        {
+            var reader = new StringReader("abc");
+            reader.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => reader.Read(Span<char>.Empty));
+            Assert.Throws<ObjectDisposedException>(() => reader.ReadBlock(Span<char>.Empty));
+            Assert.Throws<ObjectDisposedException>(() => { reader.ReadAsync(Memory<char>.Empty); });
+            Assert.Throws<ObjectDisposedException>(() => { reader.ReadBlockAsync(Memory<char>.Empty); });
+        }
+
+        [Fact]
+        public async Task Precanceled_ThrowsException()
+        {
+            var reader = new StringReader("abc");
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => reader.ReadAsync(Memory<char>.Empty, new CancellationToken(true)).AsTask());
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => reader.ReadBlockAsync(Memory<char>.Empty, new CancellationToken(true)).AsTask());
+        }
+    }
+}

--- a/src/System.IO/tests/StringWriter/StringWriterTests.cs
+++ b/src/System.IO/tests/StringWriter/StringWriterTests.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace System.IO.Tests
 {
-    public class StringWriterTests
+    public partial class StringWriterTests
     {
         static int[] iArrInvalidValues = new int[] { -1, -2, -100, -1000, -10000, -100000, -1000000, -10000000, -100000000, -1000000000, int.MinValue, short.MinValue };
         static int[] iArrLargeValues = new int[] { int.MaxValue, int.MaxValue - 1, int.MaxValue / 2, int.MaxValue / 10, int.MaxValue / 100 };

--- a/src/System.IO/tests/StringWriter/StringWriterTests.netcoreapp.cs
+++ b/src/System.IO/tests/StringWriter/StringWriterTests.netcoreapp.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public partial class StringWriterTests
+    {
+        [Fact]
+        public async Task WriteSpanMemory_Success()
+        {
+            var sw = new StringWriter();
+
+            sw.Write((Span<char>)new char[0]);
+            sw.Write((Span<char>)new char[] { 'a' });
+            sw.Write((Span<char>)new char[] { 'b', 'c', 'd' });
+            sw.WriteLine((Span<char>)new char[] { 'e' });
+
+            await sw.WriteAsync((ReadOnlyMemory<char>)new char[0]);
+            await sw.WriteAsync((ReadOnlyMemory<char>)new char[] { 'f' });
+            await sw.WriteAsync((ReadOnlyMemory<char>)new char[] { 'g', 'h', 'i' });
+            await sw.WriteLineAsync((ReadOnlyMemory<char>)new char[] { 'j' });
+
+            Assert.Equal("abcde" + Environment.NewLine + "fghij" + Environment.NewLine, sw.ToString());
+        }
+
+        [Fact]
+        public async Task Precanceled_ThrowsException()
+        {
+            var writer = new StringWriter();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => writer.WriteAsync(Memory<char>.Empty, new CancellationToken(true)));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => writer.WriteLineAsync(Memory<char>.Empty, new CancellationToken(true)));
+        }
+    }
+}

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -51,9 +51,11 @@
     <Compile Include="Stream\Stream.Methods.cs" />
     <Compile Include="Stream\Stream.TestLeaveOpen.cs" />
     <Compile Include="Stream\Stream.TimeoutTests.cs" />
+    <Compile Include="StringReader\StringReaderTests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="StringReader\StringReader.CtorTests.cs" />
+    <Compile Include="StringWriter\StringWriterTests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="StringWriter\StringWriterTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Buffers\NativeOwnedMemory.cs"  Condition="'$(TargetGroup)' == 'netcoreapp'" >
+    <Compile Include="$(CommonTestPath)\System\Buffers\NativeOwnedMemory.cs" Condition="'$(TargetGroup)' == 'netcoreapp'">
       <Link>Common\System\Buffers\NativeOwnedMemory.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\IO\CallTrackingStream.cs">

--- a/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
+++ b/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -30,6 +28,28 @@ namespace System.IO.Tests
                 var rs = new ReadOnlySpan<char>(TestDataProvider.CharData, 4, 6);
                 tw.WriteLine(rs);
                 Assert.Equal(new string(rs) + tw.NewLine, tw.Text);
+            }
+        }
+
+        [Fact]
+        public async Task WriteCharMemoryTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                var rs = new Memory<char>(TestDataProvider.CharData, 4, 6);
+                await tw.WriteAsync(rs);
+                Assert.Equal(new string(rs.Span), tw.Text);
+            }
+        }
+
+        [Fact]
+        public async Task WriteLineCharMemoryTest()
+        {
+            using (CharArrayTextWriter tw = NewTextWriter)
+            {
+                var rs = new Memory<char>(TestDataProvider.CharData, 4, 6);
+                await tw.WriteLineAsync(rs);
+                Assert.Equal(new string(rs.Span) + tw.NewLine, tw.Text);
             }
         }
     }

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -141,47 +141,47 @@ namespace System
         public static double Int64BitsToDouble(long value) { throw null; }
         public static int SingleToInt32Bits(float value) { throw null; }
         public static bool ToBoolean(byte[] value, int startIndex) { throw null; }
-        public static bool ToBoolean(ReadOnlySpan<byte> value) { throw null; }
+        public static bool ToBoolean(System.ReadOnlySpan<byte> value) { throw null; }
         public static char ToChar(byte[] value, int startIndex) { throw null; }
-        public static char ToChar(ReadOnlySpan<byte> value) { throw null; }
+        public static char ToChar(System.ReadOnlySpan<byte> value) { throw null; }
         public static double ToDouble(byte[] value, int startIndex) { throw null; }
-        public static double ToDouble(ReadOnlySpan<byte> value) { throw null; }
+        public static double ToDouble(System.ReadOnlySpan<byte> value) { throw null; }
         public static short ToInt16(byte[] value, int startIndex) { throw null; }
-        public static short ToInt16(ReadOnlySpan<byte> value) { throw null; }
+        public static short ToInt16(System.ReadOnlySpan<byte> value) { throw null; }
         public static int ToInt32(byte[] value, int startIndex) { throw null; }
-        public static int ToInt32(ReadOnlySpan<byte> value) { throw null; }
+        public static int ToInt32(System.ReadOnlySpan<byte> value) { throw null; }
         public static long ToInt64(byte[] value, int startIndex) { throw null; }
-        public static long ToInt64(ReadOnlySpan<byte> value) { throw null; }
+        public static long ToInt64(System.ReadOnlySpan<byte> value) { throw null; }
         public static float ToSingle(byte[] value, int startIndex) { throw null; }
-        public static float ToSingle(ReadOnlySpan<byte> value) { throw null; }
+        public static float ToSingle(System.ReadOnlySpan<byte> value) { throw null; }
         public static string ToString(byte[] value) { throw null; }
         public static string ToString(byte[] value, int startIndex) { throw null; }
         public static string ToString(byte[] value, int startIndex, int length) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static ushort ToUInt16(byte[] value, int startIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static ushort ToUInt16(ReadOnlySpan<byte> value) { throw null; }
+        public static ushort ToUInt16(System.ReadOnlySpan<byte> value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static uint ToUInt32(byte[] value, int startIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static uint ToUInt32(ReadOnlySpan<byte> value) { throw null; }
+        public static uint ToUInt32(System.ReadOnlySpan<byte> value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static ulong ToUInt64(byte[] value, int startIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static ulong ToUInt64(ReadOnlySpan<byte> value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, bool value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, char value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, double value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, short value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, int value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, long value) { throw null; }
-        public static bool TryWriteBytes(Span<byte> destination, float value) { throw null; }
+        public static ulong ToUInt64(System.ReadOnlySpan<byte> value) { throw null; }
+        public static bool TryWriteBytes(System.Span<byte> destination, bool value) { throw null; }
+        public static bool TryWriteBytes(System.Span<byte> destination, char value) { throw null; }
+        public static bool TryWriteBytes(System.Span<byte> destination, double value) { throw null; }
+        public static bool TryWriteBytes(System.Span<byte> destination, short value) { throw null; }
+        public static bool TryWriteBytes(System.Span<byte> destination, int value) { throw null; }
+        public static bool TryWriteBytes(System.Span<byte> destination, long value) { throw null; }
+        public static bool TryWriteBytes(System.Span<byte> destination, float value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryWriteBytes(Span<byte> destination, ushort value) { throw null; }
+        public static bool TryWriteBytes(System.Span<byte> destination, ushort value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryWriteBytes(Span<byte> destination, uint value) { throw null; }
+        public static bool TryWriteBytes(System.Span<byte> destination, uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryWriteBytes(Span<byte> destination, ulong value) { throw null; }
+        public static bool TryWriteBytes(System.Span<byte> destination, ulong value) { throw null; }
     }
     public static partial class Convert
     {
@@ -1283,8 +1283,8 @@ namespace System.IO
         public virtual void Write(uint value) { }
         [System.CLSCompliantAttribute(false)]
         public virtual void Write(ulong value) { }
-        public virtual void Write(ReadOnlySpan<byte> span) { }
-        public virtual void Write(ReadOnlySpan<char> span) { }
+        public virtual void Write(System.ReadOnlySpan<byte> span) { }
+        public virtual void Write(System.ReadOnlySpan<char> span) { }
         protected void Write7BitEncodedInt(int value) { }
     }
     public sealed partial class BufferedStream : System.IO.Stream
@@ -1440,7 +1440,7 @@ namespace System.IO
         public override System.Threading.Tasks.Task<int> ReadAsync(char[] buffer, int index, int count) { throw null; }
         public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<char> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task<int> ReadBlockAsync(char[] buffer, int index, int count) { throw null; }
-        public override System.Threading.Tasks.ValueTask<int> ReadBlockAsync(Memory<char> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override System.Threading.Tasks.ValueTask<int> ReadBlockAsync(System.Memory<char> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override string ReadLine() { throw null; }
         public override System.Threading.Tasks.Task<string> ReadLineAsync() { throw null; }
         public override string ReadToEnd() { throw null; }
@@ -1465,11 +1465,11 @@ namespace System.IO
         public override void WriteLine(System.ReadOnlySpan<char> source) { throw null; }
         public override System.Threading.Tasks.Task WriteAsync(char value) { throw null; }
         public override System.Threading.Tasks.Task WriteAsync(char[] buffer, int index, int count) { throw null; }
-        public override System.Threading.Tasks.Task WriteAsync(ReadOnlyMemory<char> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override System.Threading.Tasks.Task WriteAsync(System.ReadOnlyMemory<char> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteAsync(string value) { throw null; }
         public override System.Threading.Tasks.Task WriteLineAsync(char value) { throw null; }
         public override System.Threading.Tasks.Task WriteLineAsync(char[] buffer, int index, int count) { throw null; }
-        public override System.Threading.Tasks.Task WriteLineAsync(ReadOnlyMemory<char> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override System.Threading.Tasks.Task WriteLineAsync(System.ReadOnlyMemory<char> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteLineAsync(string value) { throw null; }
     }
     public abstract partial class TextReader : System.MarshalByRefObject, System.IDisposable
@@ -1482,13 +1482,13 @@ namespace System.IO
         public virtual int Peek() { throw null; }
         public virtual int Read() { throw null; }
         public virtual int Read(char[] buffer, int index, int count) { throw null; }
-        public virtual int Read(Span<char> destination) { throw null; }
+        public virtual int Read(System.Span<char> destination) { throw null; }
         public virtual System.Threading.Tasks.Task<int> ReadAsync(char[] buffer, int index, int count) { throw null; }
         public virtual System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<char> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual int ReadBlock(char[] buffer, int index, int count) { throw null; }
-        public virtual int ReadBlock(Span<char> destination) { throw null; }
+        public virtual int ReadBlock(System.Span<char> destination) { throw null; }
         public virtual System.Threading.Tasks.Task<int> ReadBlockAsync(char[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.ValueTask<int> ReadBlockAsync(Memory<char> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<int> ReadBlockAsync(System.Memory<char> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual string ReadLine() { throw null; }
         public virtual System.Threading.Tasks.Task<string> ReadLineAsync() { throw null; }
         public virtual string ReadToEnd() { throw null; }
@@ -1529,11 +1529,11 @@ namespace System.IO
         public virtual void Write(uint value) { }
         [System.CLSCompliantAttribute(false)]
         public virtual void Write(ulong value) { }
-        public virtual void Write(ReadOnlySpan<char> source) { }
+        public virtual void Write(System.ReadOnlySpan<char> source) { }
         public virtual System.Threading.Tasks.Task WriteAsync(char value) { throw null; }
         public System.Threading.Tasks.Task WriteAsync(char[] buffer) { throw null; }
         public virtual System.Threading.Tasks.Task WriteAsync(char[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task WriteAsync(ReadOnlyMemory<char> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task WriteAsync(System.ReadOnlyMemory<char> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task WriteAsync(string value) { throw null; }
         public virtual void WriteLine() { }
         public virtual void WriteLine(bool value) { }
@@ -1555,7 +1555,7 @@ namespace System.IO
         public virtual void WriteLine(uint value) { }
         [System.CLSCompliantAttribute(false)]
         public virtual void WriteLine(ulong value) { }
-        public virtual void WriteLine(ReadOnlySpan<char> source) { }
+        public virtual void WriteLine(System.ReadOnlySpan<char> source) { }
         public virtual System.Threading.Tasks.Task WriteLineAsync() { throw null; }
         public virtual System.Threading.Tasks.Task WriteLineAsync(char value) { throw null; }
         public System.Threading.Tasks.Task WriteLineAsync(char[] buffer) { throw null; }

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1435,8 +1435,12 @@ namespace System.IO
         public override int Peek() { throw null; }
         public override int Read() { throw null; }
         public override int Read(char[] buffer, int index, int count) { throw null; }
+        public override int Read(System.Span<char> destination) { throw null; }
+        public override int ReadBlock(System.Span<char> destination) { throw null; }
         public override System.Threading.Tasks.Task<int> ReadAsync(char[] buffer, int index, int count) { throw null; }
+        public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<char> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task<int> ReadBlockAsync(char[] buffer, int index, int count) { throw null; }
+        public override System.Threading.Tasks.ValueTask<int> ReadBlockAsync(Memory<char> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override string ReadLine() { throw null; }
         public override System.Threading.Tasks.Task<string> ReadLineAsync() { throw null; }
         public override string ReadToEnd() { throw null; }
@@ -1456,12 +1460,16 @@ namespace System.IO
         public override string ToString() { throw null; }
         public override void Write(char value) { }
         public override void Write(char[] buffer, int index, int count) { }
+        public override void Write(System.ReadOnlySpan<char> source) { throw null; }
         public override void Write(string value) { }
+        public override void WriteLine(System.ReadOnlySpan<char> source) { throw null; }
         public override System.Threading.Tasks.Task WriteAsync(char value) { throw null; }
         public override System.Threading.Tasks.Task WriteAsync(char[] buffer, int index, int count) { throw null; }
+        public override System.Threading.Tasks.Task WriteAsync(ReadOnlyMemory<char> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteAsync(string value) { throw null; }
         public override System.Threading.Tasks.Task WriteLineAsync(char value) { throw null; }
         public override System.Threading.Tasks.Task WriteLineAsync(char[] buffer, int index, int count) { throw null; }
+        public override System.Threading.Tasks.Task WriteLineAsync(ReadOnlyMemory<char> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteLineAsync(string value) { throw null; }
     }
     public abstract partial class TextReader : System.MarshalByRefObject, System.IDisposable

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1476,9 +1476,11 @@ namespace System.IO
         public virtual int Read(char[] buffer, int index, int count) { throw null; }
         public virtual int Read(Span<char> destination) { throw null; }
         public virtual System.Threading.Tasks.Task<int> ReadAsync(char[] buffer, int index, int count) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<char> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual int ReadBlock(char[] buffer, int index, int count) { throw null; }
         public virtual int ReadBlock(Span<char> destination) { throw null; }
         public virtual System.Threading.Tasks.Task<int> ReadBlockAsync(char[] buffer, int index, int count) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<int> ReadBlockAsync(Memory<char> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual string ReadLine() { throw null; }
         public virtual System.Threading.Tasks.Task<string> ReadLineAsync() { throw null; }
         public virtual string ReadToEnd() { throw null; }
@@ -1523,6 +1525,7 @@ namespace System.IO
         public virtual System.Threading.Tasks.Task WriteAsync(char value) { throw null; }
         public System.Threading.Tasks.Task WriteAsync(char[] buffer) { throw null; }
         public virtual System.Threading.Tasks.Task WriteAsync(char[] buffer, int index, int count) { throw null; }
+        public virtual System.Threading.Tasks.Task WriteAsync(ReadOnlyMemory<char> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task WriteAsync(string value) { throw null; }
         public virtual void WriteLine() { }
         public virtual void WriteLine(bool value) { }
@@ -1549,6 +1552,7 @@ namespace System.IO
         public virtual System.Threading.Tasks.Task WriteLineAsync(char value) { throw null; }
         public System.Threading.Tasks.Task WriteLineAsync(char[] buffer) { throw null; }
         public virtual System.Threading.Tasks.Task WriteLineAsync(char[] buffer, int index, int count) { throw null; }
+        public virtual System.Threading.Tasks.Task WriteLineAsync(System.ReadOnlyMemory<char> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task WriteLineAsync(string value) { throw null; }
     }
 }

--- a/src/System.Runtime.Extensions/src/System/IO/StringReader.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StringReader.cs
@@ -122,6 +122,8 @@ namespace System.IO
         {
             if (GetType() != typeof(StringReader))
             {
+                // This overload was added affter the Read(char[], ...) overload, and so in case
+                // a derived type may have overridden it, we need to delegate to it, which the base does.
                 return base.Read(destination);
             }
 

--- a/src/System.Runtime.Extensions/src/System/IO/StringWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StringWriter.cs
@@ -129,6 +129,8 @@ namespace System.IO
         {
             if (GetType() != typeof(StringWriter))
             {
+                // This overload was added affter the Write(char[], ...) overload, and so in case
+                // a derived type may have overridden it, we need to delegate to it, which the base does.
                 base.Write(source);
                 return;
             }
@@ -161,6 +163,8 @@ namespace System.IO
         {
             if (GetType() != typeof(StringWriter))
             {
+                // This overload was added affter the WriteLine(char[], ...) overload, and so in case
+                // a derived type may have overridden it, we need to delegate to it, which the base does.
                 base.WriteLine(source);
                 return;
             }

--- a/src/System.Runtime.Extensions/src/System/IO/TextWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/TextWriter.cs
@@ -544,6 +544,15 @@ namespace System.IO
             tuple, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
+        public virtual Task WriteAsync(ReadOnlyMemory<char> source, CancellationToken cancellationToken = default(CancellationToken)) =>
+            source.DangerousTryGetArray(out ArraySegment<char> array) ?
+                WriteAsync(array.Array, array.Offset, array.Count) :
+                Task.Factory.StartNew(state =>
+                {
+                    var t = (Tuple<TextWriter, ReadOnlyMemory<char>>)state;
+                    t.Item1.Write(t.Item2.Span);
+                }, Tuple.Create(this, source), cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+
         public virtual Task WriteLineAsync(char value)
         {
             var tuple = new Tuple<TextWriter, char>(this, value);
@@ -586,6 +595,15 @@ namespace System.IO
             },
             tuple, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
+
+        public virtual Task WriteLineAsync(ReadOnlyMemory<char> source, CancellationToken cancellationToken = default(CancellationToken)) =>
+            source.DangerousTryGetArray(out ArraySegment<char> array) ?
+                WriteLineAsync(array.Array, array.Offset, array.Count) :
+                Task.Factory.StartNew(state =>
+                {
+                    var t = (Tuple<TextWriter, ReadOnlyMemory<char>>)state;
+                    t.Item1.WriteLine(t.Item2.Span);
+                }, Tuple.Create(this, source), cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 
         public virtual Task WriteLineAsync()
         {


### PR DESCRIPTION
And override both the Span and Memory-based virtuals on StringReader and StringWriter.

Fixes https://github.com/dotnet/corefx/issues/22410
Fixes https://github.com/dotnet/corefx/issues/22406
Fixes https://github.com/dotnet/corefx/issues/22411

cc: @JeremyKuhne, @pjanotti, @KrzysztofCwalina, @ahsonkhan 