### PR TITLE
Unifying the style of property delcarations and fixing bracket indents.

### DIFF
--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -163,9 +163,15 @@ namespace System
             set { ConsolePal.CursorSize = value; }
         }
 
-        public static bool NumberLock { get { return ConsolePal.NumberLock; } }
+        public static bool NumberLock
+        {
+            get { return ConsolePal.NumberLock; }
+        }
 
-        public static bool CapsLock { get { return ConsolePal.CapsLock; } }
+        public static bool CapsLock
+        {
+            get { return ConsolePal.CapsLock; }
+        }
 
         internal const ConsoleColor UnknownColor = (ConsoleColor)(-1);
 
@@ -217,26 +223,14 @@ namespace System
 
         public static int WindowWidth
         {
-            get
-            {
-                return ConsolePal.WindowWidth;
-            }
-            set
-            {
-                ConsolePal.WindowWidth = value;
-            }
+            get { return ConsolePal.WindowWidth; }
+            set { ConsolePal.WindowWidth = value; }
         }
 
         public static int WindowHeight
         {
-            get
-            {
-                return ConsolePal.WindowHeight;
-            }
-            set
-            {
-                ConsolePal.WindowHeight = value;
-            }
+            get { return ConsolePal.WindowHeight; }
+            set { ConsolePal.WindowHeight = value; }
         }
 
         public static void SetWindowPosition(int left, int top)

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -1074,14 +1074,14 @@ namespace System
                 ValidateRead(buffer, offset, count);
 
                 return ConsolePal.Read(_handle, buffer, offset, count);
-                }
+            }
 
             public override void Write(byte[] buffer, int offset, int count)
             {
                 ValidateWrite(buffer, offset, count);
 
                 ConsolePal.Write(_handle, buffer, offset, count);
-                }
+            }
 
             public override void Flush()
             {


### PR DESCRIPTION
Very small change set to unify the style of property declarations in the Console project. Also fixed some brackets that were nested too far to the right.