### PR TITLE
rel/1.0.0: Fix ECDsa ExportParameters segfault

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -16,7 +16,7 @@
     <XmlDocFileRoot>$(PackagesDir)Microsoft.Private.Intellisense/1.0.0-rc4-24206-00/xmldocs</XmlDocFileRoot>
     <!-- We're currently not building a "live" baseline, instead we're using .NETCore 1.0 RTM stable versions as the baseline -->
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
-    <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.0.4</LineupPackageVersion>  
+    <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.0.5</LineupPackageVersion>  
     <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.0.2</PlatformPackageVersion>  
   </PropertyGroup>
 

--- a/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
@@ -421,7 +421,7 @@
       <Version>4.0.1</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="runtime.native.System.Security.Cryptography">
-      <Version>4.0.2</Version>
+      <Version>4.0.3</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Private.DataContractSerialization">
       <Version>4.1.2</Version>

--- a/pkg/Microsoft.Private.PackageBaseline/stable.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/stable.packages.props
@@ -1424,7 +1424,7 @@
       <Version>1.0.3</Version>
     </StablePackage>
     <StablePackage Include="runtime.native.System.Security.Cryptography">
-      <Version>4.0.3</Version>
+      <Version>4.0.2</Version>
     </StablePackage>
     <StablePackage Include="runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography">
       <Version>1.0.3</Version>

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
@@ -97,7 +97,7 @@ internal static partial class Interop
 
 
         [DllImport(Libraries.CryptoNative)]
-        private static extern bool CryptoNative_GetECKeyParameters(
+        private static extern int CryptoNative_GetECKeyParameters(
             SafeEcKeyHandle key, 
             bool includePrivate,
             out SafeBignumHandle qx_bn, out int x_cb,
@@ -117,12 +117,18 @@ internal static partial class Interop
             try
             {
                 key.DangerousAddRef(ref refAdded); // Protect access to d_bn_not_owned
-                if (!CryptoNative_GetECKeyParameters(
+                int rc = CryptoNative_GetECKeyParameters(
                     key,
                     includePrivate,
                     out qx_bn, out qx_cb,
                     out qy_bn, out qy_cb,
-                    out d_bn_not_owned, out d_cb))
+                    out d_bn_not_owned, out d_cb);
+                    
+                if (rc == -1)
+                {
+                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                }
+                else if (rc != 1)
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
@@ -152,7 +158,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.CryptoNative)]
-        private static extern bool CryptoNative_GetECCurveParameters(
+        private static extern int CryptoNative_GetECCurveParameters(
             SafeEcKeyHandle key,
             bool includePrivate,
             out ECCurve.ECCurveType curveType,
@@ -181,7 +187,7 @@ internal static partial class Interop
             try
             {
                 key.DangerousAddRef(ref refAdded); // Protect access to d_bn_not_owned
-                if (!CryptoNative_GetECCurveParameters(
+                int rc = CryptoNative_GetECCurveParameters(
                     key,
                     includePrivate,
                     out curveType,
@@ -195,7 +201,13 @@ internal static partial class Interop
                     out gy_bn, out gy_cb,
                     out order_bn, out order_cb,
                     out cofactor_bn, out cofactor_cb,
-                    out seed_bn, out seed_cb))
+                    out seed_bn, out seed_cb);
+                    
+                if (rc == -1)
+                {
+                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);                    
+                }
+                else if (rc != 1)
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using Test.Cryptography;
 
 namespace System.Security.Cryptography.EcDsa.Tests
 {
@@ -235,32 +234,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 ECParameters parameters = ECDsaTestData.GetNistP224KeyTestData();
                 ec.ImportParameters(parameters);
                 VerifyNamedCurve(parameters, ec, 224, true);
-            }
-        }
-
-        [ConditionalFact(nameof(ECExplicitCurvesSupported))]
-        public static void ExportIncludingPrivateOnPublicOnlyKey()
-        {
-            ECParameters iutParameters = new ECParameters
-            {
-                Curve = ECCurve.NamedCurves.nistP521,
-                Q =
-                {
-                    X = "00d45615ed5d37fde699610a62cd43ba76bedd8f85ed31005fe00d6450fbbd101291abd96d4945a8b57bc73b3fe9f4671105309ec9b6879d0551d930dac8ba45d255".HexToByteArray(),
-                    Y = "01425332844e592b440c0027972ad1526431c06732df19cd46a242172d4dd67c2c8c99dfc22e49949a56cf90c6473635ce82f25b33682fb19bc33bd910ed8ce3a7fa".HexToByteArray(),
-                },
-                D = "00816f19c1fb10ef94d4a1d81c156ec3d1de08b66761f03f06ee4bb9dcebbbfe1eaa1ed49a6a990838d8ed318c14d74cc872f95d05d07ad50f621ceb620cd905cfb8".HexToByteArray(),
-            };
-
-            using (ECDsa iut = ECDsaFactory.Create())
-            using (ECDsa cavs = ECDsaFactory.Create())
-            {
-                iut.ImportParameters(iutParameters);
-                cavs.ImportParameters(iut.ExportParameters(false));
-
-                // Linux throws an Interop.Crypto.OpenSslCryptographicException : CryptographicException
-                Assert.ThrowsAny<CryptographicException>(() => cavs.ExportExplicitParameters(true));
-                Assert.ThrowsAny<CryptographicException>(() => cavs.ExportParameters(true));
             }
         }
 

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using Test.Cryptography;
 
 namespace System.Security.Cryptography.EcDsa.Tests
 {
@@ -234,6 +235,32 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 ECParameters parameters = ECDsaTestData.GetNistP224KeyTestData();
                 ec.ImportParameters(parameters);
                 VerifyNamedCurve(parameters, ec, 224, true);
+            }
+        }
+
+        [ConditionalFact(nameof(ECExplicitCurvesSupported))]
+        public static void ExportIncludingPrivateOnPublicOnlyKey()
+        {
+            ECParameters iutParameters = new ECParameters
+            {
+                Curve = ECCurve.NamedCurves.nistP521,
+                Q =
+                {
+                    X = "00d45615ed5d37fde699610a62cd43ba76bedd8f85ed31005fe00d6450fbbd101291abd96d4945a8b57bc73b3fe9f4671105309ec9b6879d0551d930dac8ba45d255".HexToByteArray(),
+                    Y = "01425332844e592b440c0027972ad1526431c06732df19cd46a242172d4dd67c2c8c99dfc22e49949a56cf90c6473635ce82f25b33682fb19bc33bd910ed8ce3a7fa".HexToByteArray(),
+                },
+                D = "00816f19c1fb10ef94d4a1d81c156ec3d1de08b66761f03f06ee4bb9dcebbbfe1eaa1ed49a6a990838d8ed318c14d74cc872f95d05d07ad50f621ceb620cd905cfb8".HexToByteArray(),
+            };
+
+            using (ECDsa iut = ECDsaFactory.Create())
+            using (ECDsa cavs = ECDsaFactory.Create())
+            {
+                iut.ImportParameters(iutParameters);
+                cavs.ImportParameters(iut.ExportParameters(false));
+
+                // Linux throws an Interop.Crypto.OpenSslCryptographicException : CryptographicException
+                Assert.ThrowsAny<CryptographicException>(() => cavs.ExportExplicitParameters(true));
+                Assert.ThrowsAny<CryptographicException>(() => cavs.ExportParameters(true));
             }
         }
 

--- a/src/Native/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
@@ -111,8 +111,17 @@ extern "C" int32_t CryptoNative_GetECKeyParameters(
 
     if (includePrivate)
     {
-        *d = const_cast<BIGNUM*>(EC_KEY_get0_private_key(key));
-        *cbD = BN_num_bytes(*d);
+        const BIGNUM* const_bignum_privateKey = EC_KEY_get0_private_key(key);
+        if (const_bignum_privateKey != nullptr)
+        {
+            *d = const_cast<BIGNUM*>(const_bignum_privateKey);
+            *cbD = BN_num_bytes(*d);
+        }
+        else
+        {
+            rc = -1;
+            goto error;
+        }
     }
     else
     {

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageTargetRuntime>debian.8-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageTargetRuntime>rhel.7-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>4.0.2</Version>
+    <Version>4.0.3</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.2.1</Version>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\4.0\System.Security.Cryptography.Algorithms.csproj">
       <SupportedFramework>net46</SupportedFramework>

--- a/src/System.Security.Cryptography.Algorithms/pkg/ValidationSuppression.txt
+++ b/src/System.Security.Cryptography.Algorithms/pkg/ValidationSuppression.txt
@@ -1,0 +1,6 @@
+// The netfx facades have their versions locked, but we should
+// permit the netcoreapp implementations to use a higher runtime assembly
+// version than the ref assembly.
+// The refs shouldn't get bumped because that could push the 1.0 assembly to
+// a higher version than the 1.1 assembly.
+PermitHigherCompatibleImplementationVersion

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Algorithms</AssemblyName>
-    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <AssemblyVersion>4.2.0.1</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetGroup)'=='net46'">4.0.0.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetGroup)'=='net461' or '$(TargetGroup)' == 'netcore50'">4.1.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -13,6 +13,7 @@
     <AssemblyVersion>4.2.0.1</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetGroup)'=='net46'">4.0.0.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetGroup)'=='net461' or '$(TargetGroup)' == 'netcore50'">4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='net463'">4.2.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
     <DefineConstants>INTERNAL_ASYMMETRIC_IMPLEMENTATIONS</DefineConstants>

--- a/src/System.Security.Cryptography.OpenSsl/pkg/System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/System.Security.Cryptography.OpenSsl/pkg/System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.OpenSsl.csproj">
       <SupportedFramework>net463;netcoreapp1.0</SupportedFramework>

--- a/src/System.Security.Cryptography.OpenSsl/pkg/ValidationSuppression.txt
+++ b/src/System.Security.Cryptography.OpenSsl/pkg/ValidationSuppression.txt
@@ -1,0 +1,6 @@
+// The netfx facades have their versions locked, but we should
+// permit the netcoreapp implementations to use a higher runtime assembly
+// version than the ref assembly.
+// The refs shouldn't get bumped because that could push the 1.0 assembly to
+// a higher version than the 1.1 assembly.
+PermitHigherCompatibleImplementationVersion

--- a/src/System.Security.Cryptography.OpenSsl/pkg/ValidationSuppression.txt
+++ b/src/System.Security.Cryptography.OpenSsl/pkg/ValidationSuppression.txt
@@ -1,6 +1,0 @@
-// The netfx facades have their versions locked, but we should
-// permit the netcoreapp implementations to use a higher runtime assembly
-// version than the ref assembly.
-// The refs shouldn't get bumped because that could push the 1.0 assembly to
-// a higher version than the 1.1 assembly.
-PermitHigherCompatibleImplementationVersion

--- a/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.1</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.6</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{78452F3E-BA91-47E7-BB0F-02E8A5C116C4}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.OpenSsl</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.1</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
     <PackageTargetFramework>netstandard1.6</PackageTargetFramework>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -27,11 +27,18 @@
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
+    <Project Include="..\pkg\Microsoft.NETCore.Targets\Microsoft.NETCore.Targets.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >
     <!-- add specific native builds / pkgproj's here to include in servicing builds -->
-  </ItemGroup>
+    <Project Include="Native\pkg\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
+    </Project>
+ </ItemGroup>
 
   <UsingTask TaskName="GenerateNetStandardSupportTable" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll" />
   <Target Name="GenerateNETStandardDocs">

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -30,6 +30,12 @@
     <Project Include="..\pkg\Microsoft.NETCore.Targets\Microsoft.NETCore.Targets.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="System.Security.Cryptography.Algorithms\pkg\System.Security.Cryptography.Algorithms.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="System.Security.Cryptography.OpenSsl\pkg\System.Security.Cryptography.OpenSsl.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >


### PR DESCRIPTION
ECDSa.Export(Explicit)Parameters(includePrivateParameters:true) on an EC object containing only a public key will currently segfault on Linux. It is supposed to throw a CryptographicException, so this commit changes it to do so.

Original: #24171