### PR TITLE
rel/1.0.0: Fix ECDsa ExportParameters segfault

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
@@ -97,7 +97,7 @@ internal static partial class Interop
 
 
         [DllImport(Libraries.CryptoNative)]
-        private static extern bool CryptoNative_GetECKeyParameters(
+        private static extern int CryptoNative_GetECKeyParameters(
             SafeEcKeyHandle key, 
             bool includePrivate,
             out SafeBignumHandle qx_bn, out int x_cb,
@@ -117,12 +117,18 @@ internal static partial class Interop
             try
             {
                 key.DangerousAddRef(ref refAdded); // Protect access to d_bn_not_owned
-                if (!CryptoNative_GetECKeyParameters(
+                int rc = CryptoNative_GetECKeyParameters(
                     key,
                     includePrivate,
                     out qx_bn, out qx_cb,
                     out qy_bn, out qy_cb,
-                    out d_bn_not_owned, out d_cb))
+                    out d_bn_not_owned, out d_cb);
+                    
+                if (rc == -1)
+                {
+                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                }
+                else if (rc != 1)
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
@@ -152,7 +158,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.CryptoNative)]
-        private static extern bool CryptoNative_GetECCurveParameters(
+        private static extern int CryptoNative_GetECCurveParameters(
             SafeEcKeyHandle key,
             bool includePrivate,
             out ECCurve.ECCurveType curveType,
@@ -181,7 +187,7 @@ internal static partial class Interop
             try
             {
                 key.DangerousAddRef(ref refAdded); // Protect access to d_bn_not_owned
-                if (!CryptoNative_GetECCurveParameters(
+                int rc = CryptoNative_GetECCurveParameters(
                     key,
                     includePrivate,
                     out curveType,
@@ -195,7 +201,13 @@ internal static partial class Interop
                     out gy_bn, out gy_cb,
                     out order_bn, out order_cb,
                     out cofactor_bn, out cofactor_cb,
-                    out seed_bn, out seed_cb))
+                    out seed_bn, out seed_cb);
+                    
+                if (rc == -1)
+                {
+                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);                    
+                }
+                else if (rc != 1)
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using Test.Cryptography;
 
 namespace System.Security.Cryptography.EcDsa.Tests
 {
@@ -234,6 +235,32 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 ECParameters parameters = ECDsaTestData.GetNistP224KeyTestData();
                 ec.ImportParameters(parameters);
                 VerifyNamedCurve(parameters, ec, 224, true);
+            }
+        }
+
+        [ConditionalFact(nameof(ECExplicitCurvesSupported))]
+        public static void ExportIncludingPrivateOnPublicOnlyKey()
+        {
+            ECParameters iutParameters = new ECParameters
+            {
+                Curve = ECCurve.NamedCurves.nistP521,
+                Q =
+                {
+                    X = "00d45615ed5d37fde699610a62cd43ba76bedd8f85ed31005fe00d6450fbbd101291abd96d4945a8b57bc73b3fe9f4671105309ec9b6879d0551d930dac8ba45d255".HexToByteArray(),
+                    Y = "01425332844e592b440c0027972ad1526431c06732df19cd46a242172d4dd67c2c8c99dfc22e49949a56cf90c6473635ce82f25b33682fb19bc33bd910ed8ce3a7fa".HexToByteArray(),
+                },
+                D = "00816f19c1fb10ef94d4a1d81c156ec3d1de08b66761f03f06ee4bb9dcebbbfe1eaa1ed49a6a990838d8ed318c14d74cc872f95d05d07ad50f621ceb620cd905cfb8".HexToByteArray(),
+            };
+
+            using (ECDsa iut = ECDsaFactory.Create())
+            using (ECDsa cavs = ECDsaFactory.Create())
+            {
+                iut.ImportParameters(iutParameters);
+                cavs.ImportParameters(iut.ExportParameters(false));
+
+                // Linux throws an Interop.Crypto.OpenSslCryptographicException : CryptographicException
+                Assert.ThrowsAny<CryptographicException>(() => cavs.ExportExplicitParameters(true));
+                Assert.ThrowsAny<CryptographicException>(() => cavs.ExportParameters(true));
             }
         }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
@@ -111,8 +111,17 @@ extern "C" int32_t CryptoNative_GetECKeyParameters(
 
     if (includePrivate)
     {
-        *d = const_cast<BIGNUM*>(EC_KEY_get0_private_key(key));
-        *cbD = BN_num_bytes(*d);
+        const BIGNUM* const_bignum_privateKey = EC_KEY_get0_private_key(key);
+        if (const_bignum_privateKey != nullptr)
+        {
+            *d = const_cast<BIGNUM*>(const_bignum_privateKey);
+            *cbD = BN_num_bytes(*d);
+        }
+        else
+        {
+            rc = -1;
+            goto error;
+        }
     }
     else
     {


### PR DESCRIPTION
ECDSa.Export(Explicit)Parameters(includePrivateParameters:true) on an EC object containing only a public key will currently segfault on Linux. It is supposed to throw a CryptographicException, so this commit changes it to do so.

Original: #24171