### PR TITLE
Update CentOS 6 and 7 docker images

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -399,7 +399,7 @@
       "value": "microsoft/dotnet-buildtools-prereqs"
     },
     "PB_DockerTag": {
-      "value": "centos-7-34f1db9-20171620021620",
+      "value": "centos-7-d485f41-20173404063424",
       "allowOverride": true
     },
     "PB_DockerVolumeName": {

--- a/buildpipeline/centos.6.groovy
+++ b/buildpipeline/centos.6.groovy
@@ -8,7 +8,7 @@
 
 def submittedHelixJson = null
 
-simpleDockerNode('microsoft/dotnet-buildtools-prereqs:centos-6-783abde-20171304101322') {
+simpleDockerNode('microsoft/dotnet-buildtools-prereqs:centos-6-d485f41-20173404063424') {
     stage ('Checkout source') {
         checkoutRepo()
     }

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -17,7 +17,7 @@
       "Definitions": [{
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "centos-7-34f1db9-20171620021620",
+            "PB_DockerTag": "centos-7-d485f41-20173404063424",
             "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols",
             "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -Outerloop -- /p:ArchiveTests=true /p:EnableDumpling=true",
             "PB_SyncArguments": "-p -- /p:ArchGroup=x64",
@@ -34,7 +34,7 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "centos-6-c8c9b08-20174310104313",
+            "PB_DockerTag": "centos-6-d485f41-20173404063424",
             "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols -RuntimeOS=rhel.6 -- /p:PortableBuild=false",
             "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -Outerloop -RuntimeOS=rhel.6 -- /p:ArchiveTests=true /p:EnableDumpling=true /p:PortableBuild=false",
             "PB_SyncArguments": "-p -RuntimeOS=rhel.6 -- /p:ArchGroup=x64 /p:PortableBuild=false",


### PR DESCRIPTION
The images now contain clang 3.9 with PGO support