### PR TITLE
[release/2.0.0] Port missing System.Net.Http NETFX fixes

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
@@ -525,8 +525,13 @@ namespace System.Net.Http
                 webRequest.ServerCertificateValidationCallback = ServerCertificateValidationCallback;
             }
 
-            if (_defaultProxyCredentials != null && webRequest.Proxy != null)
+            if (_defaultProxyCredentials != null && _useProxy && _proxy == null && webRequest.Proxy != null)
             {
+                // The HttpClientHandler has specified to use a proxy but has not set an explicit IWebProxy.
+                // That means to use the default proxy on the underlying webrequest object. The initial value
+                // of the webrequest.Proxy when first created comes from the static WebRequest.DefaultWebProxy.
+                // In the default case, this value is non-null. But can be set later to null. That is why the
+                // 'if' check above validates for a non-null webRequest.Proxy.
                 webRequest.Proxy.Credentials = _defaultProxyCredentials;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -12,7 +12,6 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16805")]
     public class HttpClientHandler_DefaultProxyCredentials_Test : RemoteExecutorTestBase
     {
         [Fact]
@@ -109,5 +108,23 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal($"{ExpectedUsername}:{ExpectedPassword}", proxyTask.Result.AuthenticationHeaderValue);
         }
 
+        // The purpose of this test is mainly to validate the .NET Framework OOB System.Net.Http implementation
+        // since it has an underlying dependency to WebRequest. While .NET Core implementations of System.Net.Http
+        // are not using any WebRequest code, the test is still useful to validate correctness.
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        public async Task ProxyNotExplicitlyProvided_DefaultCredentialsSet_DefaultWebProxySetToNull_Success()
+        {
+            WebRequest.DefaultWebProxy = null;
+
+            using (var handler = new HttpClientHandler())
+            using (var client = new HttpClient(handler))
+            {
+                handler.DefaultProxyCredentials = new NetworkCredential("UsernameNotUsed", "PasswordNotUsed");
+                HttpResponseMessage response = await client.GetAsync(Configuration.Http.RemoteEchoServer);
+
+                Assert.Equal(response.StatusCode, HttpStatusCode.OK);
+            }
+        }
     }
 }


### PR DESCRIPTION
Issue #23702 showed some Http test failures on NETFX. This was because
PRs, #21325 and #21373 are missing from the release/2.0.0 branch.

These fixes are needed for the OOB System.Net.Http.dll that is being
built for the NETStandard Support Package.  This package is used when
NETStandard is targeted and the platform is NETFX but less than .NET
4.7.1.