### PR TITLE
Expose/test DateTime{Offset}'s Span-based {Try}Parse{Exact} and TryFormat methods

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -710,9 +710,12 @@ namespace System
         public static System.DateTime Parse(string s) { throw null; }
         public static System.DateTime Parse(string s, System.IFormatProvider provider) { throw null; }
         public static System.DateTime Parse(string s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles) { throw null; }
+        public static System.DateTime Parse(System.ReadOnlySpan<char> s, System.IFormatProvider provider = null, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.DateTime ParseExact(string s, string format, System.IFormatProvider provider) { throw null; }
         public static System.DateTime ParseExact(string s, string format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style) { throw null; }
         public static System.DateTime ParseExact(string s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style) { throw null; }
+        public static System.DateTime ParseExact(System.ReadOnlySpan<char> s, string format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.DateTime ParseExact(System.ReadOnlySpan<char> s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.DateTime SpecifyKind(System.DateTime value, System.DateTimeKind kind) { throw null; }
         public System.TimeSpan Subtract(System.DateTime value) { throw null; }
         public System.DateTime Subtract(System.TimeSpan value) { throw null; }
@@ -748,10 +751,15 @@ namespace System
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
         public System.DateTime ToUniversalTime() { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, string format = null, System.IFormatProvider provider = null) { throw null; }
         public static bool TryParse(string s, out System.DateTime result) { throw null; }
         public static bool TryParse(string s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.DateTime result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { throw null; }
         public static bool TryParseExact(string s, string format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
         public static bool TryParseExact(string s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, string format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
     }
     public enum DateTimeKind
     {
@@ -820,9 +828,12 @@ namespace System
         public static System.DateTimeOffset Parse(string input) { throw null; }
         public static System.DateTimeOffset Parse(string input, System.IFormatProvider formatProvider) { throw null; }
         public static System.DateTimeOffset Parse(string input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles) { throw null; }
+        public static System.DateTimeOffset Parse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider = null, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.DateTimeOffset ParseExact(string input, string format, System.IFormatProvider formatProvider) { throw null; }
         public static System.DateTimeOffset ParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles) { throw null; }
         public static System.DateTimeOffset ParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles) { throw null; }
+        public static System.DateTimeOffset ParseExact(System.ReadOnlySpan<char> input, string format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.DateTimeOffset ParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
         public System.TimeSpan Subtract(System.DateTimeOffset value) { throw null; }
         public System.DateTimeOffset Subtract(System.TimeSpan value) { throw null; }
         int System.IComparable.CompareTo(object obj) { throw null; }
@@ -839,10 +850,15 @@ namespace System
         public System.DateTimeOffset ToUniversalTime() { throw null; }
         public long ToUnixTimeMilliseconds() { throw null; }
         public long ToUnixTimeSeconds() { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, string format = null, System.IFormatProvider formatProvider = null) { throw null; }
         public static bool TryParse(string input, out System.DateTimeOffset result) { throw null; }
         public static bool TryParse(string input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
         public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
         public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, string format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
     }
     public enum DayOfWeek
     {

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -181,6 +181,8 @@
     <Compile Include="System\ArraySegmentTests.netcoreapp.cs" />
     <Compile Include="System\BooleanTests.netcoreapp.cs" />
     <Compile Include="System\ByteTests.netcoreapp.cs" />
+    <Compile Include="System\DateTimeTests.netcoreapp.cs" />
+    <Compile Include="System\DateTimeOffsetTests.netcoreapp.cs" />
     <Compile Include="System\DecimalTests.netcoreapp.cs" />
     <Compile Include="System\EnumTests.netcoreapp.cs" />
     <Compile Include="System\GCTests.netcoreapp.cs" />

--- a/src/System.Runtime/tests/System/DateTimeOffsetTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/DateTimeOffsetTests.netcoreapp.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Xunit;
+
+namespace System.Tests
+{
+    public static partial class DateTimeOffsetTests
+    {
+        [Fact]
+        public static void ToString_ParseSpan_RoundtripsSuccessfully()
+        {
+            DateTimeOffset expected = DateTimeOffset.MaxValue;
+            string expectedString = expected.ToString();
+
+            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedString.AsReadOnlySpan()).ToString());
+            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedString.AsReadOnlySpan(), null).ToString());
+            Assert.Equal(expectedString, DateTimeOffset.Parse(expectedString.AsReadOnlySpan(), null, DateTimeStyles.None).ToString());
+
+            Assert.True(DateTimeOffset.TryParse(expectedString.AsReadOnlySpan(), out DateTimeOffset actual));
+            Assert.Equal(expectedString, actual.ToString());
+            Assert.True(DateTimeOffset.TryParse(expectedString.AsReadOnlySpan(), null, DateTimeStyles.None, out actual));
+            Assert.Equal(expectedString, actual.ToString());
+        }
+
+        [Fact]
+        public static void ToString_ParseExactSpan_RoundtripsSuccessfully()
+        {
+            DateTimeOffset expected = DateTimeOffset.MaxValue;
+            string expectedString = expected.ToString("u");
+
+            Assert.Equal(expectedString, DateTimeOffset.ParseExact(expectedString, "u", null, DateTimeStyles.None).ToString("u"));
+            Assert.Equal(expectedString, DateTimeOffset.ParseExact(expectedString, new[] { "u" }, null, DateTimeStyles.None).ToString("u"));
+
+            Assert.True(DateTimeOffset.TryParseExact(expectedString, "u", null, DateTimeStyles.None, out DateTimeOffset actual));
+            Assert.Equal(expectedString, actual.ToString("u"));
+            Assert.True(DateTimeOffset.TryParseExact(expectedString, new[] { "u" }, null, DateTimeStyles.None, out actual));
+            Assert.Equal(expectedString, actual.ToString("u"));
+        }
+
+        [Fact]
+        public static void TryFormat_ToString_EqualResults()
+        {
+            DateTimeOffset expected = DateTimeOffset.MaxValue;
+            string expectedString = expected.ToString();
+
+            // Just the right amount of space, succeeds
+            Span<char> actual = new char[expectedString.Length];
+            Assert.True(expected.TryFormat(actual, out int charsWritten));
+            Assert.Equal(expectedString.Length, charsWritten);
+            Assert.Equal<char>(expectedString.ToCharArray(), actual.ToArray());
+
+            // Too little space, fails
+            actual = new char[expectedString.Length - 1];
+            Assert.False(expected.TryFormat(actual, out charsWritten));
+            Assert.Equal(0, charsWritten);
+
+            // More than enough space, succeeds
+            actual = new char[expectedString.Length + 1];
+            Assert.True(expected.TryFormat(actual, out charsWritten));
+            Assert.Equal(expectedString.Length, charsWritten);
+            Assert.Equal<char>(expectedString.ToCharArray(), actual.Slice(0, expectedString.Length).ToArray());
+            Assert.Equal(0, actual[actual.Length - 1]);
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/DateTimeTests.cs
+++ b/src/System.Runtime/tests/System/DateTimeTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace System.Tests
 {
-    public static class DateTimeTests
+    public static partial class DateTimeTests
     {
         [Fact]
         public static void MaxValue()
@@ -555,7 +555,7 @@ namespace System.Tests
         {
             AssertExtensions.Throws<ArgumentNullException>("s", () => DateTime.Parse(null));
             AssertExtensions.Throws<ArgumentNullException>("s", () => DateTime.Parse(null, new MyFormatter()));
-            AssertExtensions.Throws<ArgumentNullException>("s", () => DateTime.Parse(null, new MyFormatter(), DateTimeStyles.NoCurrentDateDefault));
+            AssertExtensions.Throws<ArgumentNullException>("s", () => DateTime.Parse((string)null, new MyFormatter(), DateTimeStyles.NoCurrentDateDefault));
 
             Assert.Throws<FormatException>(() => DateTime.Parse(""));
             Assert.Throws<FormatException>(() => DateTime.Parse("", new MyFormatter()));
@@ -575,8 +575,8 @@ namespace System.Tests
         public static void ParseExact_InvalidArguments_Throws()
         {
             AssertExtensions.Throws<ArgumentNullException>("s", () => DateTime.ParseExact(null, "d", new MyFormatter()));
-            AssertExtensions.Throws<ArgumentNullException>("s", () => DateTime.ParseExact(null, "d", new MyFormatter(), DateTimeStyles.None));
-            AssertExtensions.Throws<ArgumentNullException>("s", () => DateTime.ParseExact(null, new[] { "d" }, new MyFormatter(), DateTimeStyles.NoCurrentDateDefault));
+            AssertExtensions.Throws<ArgumentNullException>("s", () => DateTime.ParseExact((string)null, "d", new MyFormatter(), DateTimeStyles.None));
+            AssertExtensions.Throws<ArgumentNullException>("s", () => DateTime.ParseExact((string)null, new[] { "d" }, new MyFormatter(), DateTimeStyles.NoCurrentDateDefault));
 
             Assert.Throws<FormatException>(() => DateTime.ParseExact("", "d", new MyFormatter()));
             Assert.Throws<FormatException>(() => DateTime.ParseExact("", "d", new MyFormatter(), DateTimeStyles.None));
@@ -596,8 +596,8 @@ namespace System.Tests
         [Fact]
         public static void TryParseExact_InvalidArguments_ReturnsFalse()
         {
-            Assert.False(DateTime.TryParseExact(null, "d", new MyFormatter(), DateTimeStyles.None, out DateTime result));
-            Assert.False(DateTime.TryParseExact(null, new[] { "d" }, new MyFormatter(), DateTimeStyles.None, out result));
+            Assert.False(DateTime.TryParseExact((string)null, "d", new MyFormatter(), DateTimeStyles.None, out DateTime result));
+            Assert.False(DateTime.TryParseExact((string)null, new[] { "d" }, new MyFormatter(), DateTimeStyles.None, out result));
 
             Assert.False(DateTime.TryParseExact("", "d", new MyFormatter(), DateTimeStyles.None, out result));
             Assert.False(DateTime.TryParseExact("", new[] { "d" }, new MyFormatter(), DateTimeStyles.None, out result));

--- a/src/System.Runtime/tests/System/DateTimeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/DateTimeTests.netcoreapp.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Xunit;
+
+namespace System.Tests
+{
+    public static partial class DateTimeTests
+    {
+        [Theory]
+        [MemberData(nameof(StandardFormatSpecifiers))]
+        public static void TryFormat_MatchesToString(string format)
+        {
+            DateTime dt = DateTime.UtcNow;
+            string expected = dt.ToString(format);
+
+            // Just the right length, succeeds
+            Span<char> dest = new char[expected.Length];
+            Assert.True(dt.TryFormat(dest, out int charsWritten, format));
+            Assert.Equal(expected.Length, charsWritten);
+            Assert.Equal<char>(expected.ToCharArray(), dest.ToArray());
+
+            // Too short, fails
+            dest = new char[expected.Length - 1];
+            Assert.False(dt.TryFormat(dest, out charsWritten, format));
+            Assert.Equal(0, charsWritten);
+
+            // Longer than needed, succeeds
+            dest = new char[expected.Length + 1];
+            Assert.True(dt.TryFormat(dest, out charsWritten, format));
+            Assert.Equal(expected.Length, charsWritten);
+            Assert.Equal<char>(expected.ToCharArray(), dest.Slice(0, expected.Length).ToArray());
+            Assert.Equal(0, dest[dest.Length - 1]);
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_ValidInput_Suceeds_MemberData))]
+        public static void Parse_Span_ValidInput_Suceeds(string input, CultureInfo culture, DateTime? expected)
+        {
+            Assert.Equal(expected, DateTime.Parse(input.AsReadOnlySpan(), culture));
+        }
+
+        [Theory]
+        [MemberData(nameof(ParseExact_ValidInput_Succeeds_MemberData))]
+        public static void ParseExact_Span_ValidInput_Succeeds(string input, string format, CultureInfo culture, DateTimeStyles style, DateTime? expected)
+        {
+            DateTime result1 = DateTime.ParseExact(input.AsReadOnlySpan(), format, culture, style);
+            DateTime result2 = DateTime.ParseExact(input.AsReadOnlySpan(), new[] { format }, culture, style);
+
+            Assert.True(DateTime.TryParseExact(input.AsReadOnlySpan(), format, culture, style, out DateTime result3));
+            Assert.True(DateTime.TryParseExact(input.AsReadOnlySpan(), new[] { format }, culture, style, out DateTime result4));
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result1, result3);
+            Assert.Equal(result1, result4);
+
+            if (expected != null) // some inputs don't roundtrip well
+            {
+                // Normalize values to make comparison easier
+                if (expected.Value.Kind != DateTimeKind.Utc)
+                {
+                    expected = expected.Value.ToUniversalTime();
+                }
+                if (result1.Kind != DateTimeKind.Utc)
+                {
+                    result1 = result1.ToUniversalTime();
+                }
+
+                Assert.Equal(expected, result1);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ParseExact_InvalidInputs_Fail_MemberData))]
+        public static void ParseExact_Span_InvalidInputs_Fail(string input, string format, CultureInfo culture, DateTimeStyles style)
+        {
+            Assert.Throws<FormatException>(() => DateTime.ParseExact(input.AsReadOnlySpan(), format, culture, style));
+            Assert.Throws<FormatException>(() => DateTime.ParseExact(input.AsReadOnlySpan(), new[] { format }, culture, style));
+
+            Assert.False(DateTime.TryParseExact(input.AsReadOnlySpan(), format, culture, style, out DateTime result));
+            Assert.False(DateTime.TryParseExact(input.AsReadOnlySpan(), new[] { format }, culture, style, out result));
+        }
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/dotnet/coreclr/pull/14352
Fixes https://github.com/dotnet/corefx/issues/22358
cc: @tarekgh, @AlexGhiondea, @joperezr 