### PR TITLE
 Expose/test CancellationTokenRegistration.Token

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/ConnectionCompletionSource.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/ConnectionCompletionSource.cs
@@ -11,8 +11,8 @@ namespace System.IO.Pipes
         private readonly NamedPipeServerStream _serverStream;
 
         // Using RunContinuationsAsynchronously for compat reasons (old API used ThreadPool.QueueUserWorkItem for continuations)
-        internal ConnectionCompletionSource(NamedPipeServerStream server, CancellationToken cancellationToken)
-            : base(server._threadPoolBinding, cancellationToken, ReadOnlyMemory<byte>.Empty)
+        internal ConnectionCompletionSource(NamedPipeServerStream server)
+            : base(server._threadPoolBinding, ReadOnlyMemory<byte>.Empty)
         {
             _serverStream = server;
         }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -248,7 +248,7 @@ namespace System.IO.Pipes
                 throw new InvalidOperationException(SR.InvalidOperation_PipeNotAsync);
             }
 
-            var completionSource = new ConnectionCompletionSource(this, cancellationToken);
+            var completionSource = new ConnectionCompletionSource(this);
 
             if (!Interop.Kernel32.ConnectNamedPipe(InternalHandle, completionSource.Overlapped))
             {
@@ -280,7 +280,7 @@ namespace System.IO.Pipes
             }
 
             // If we are here then connection is pending.
-            completionSource.RegisterForCancellation();
+            completionSource.RegisterForCancellation(cancellationToken);
 
             return completionSource.Task;
         }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -83,7 +83,7 @@ namespace System.IO.Pipes
         [SecuritySafeCritical]
         private Task<int> ReadAsyncCore(Memory<byte> buffer, CancellationToken cancellationToken)
         {
-            var completionSource = new ReadWriteCompletionSource(this, buffer, cancellationToken, isWrite: false);
+            var completionSource = new ReadWriteCompletionSource(this, buffer, isWrite: false);
 
             // Queue an async ReadFile operation and pass in a packed overlapped
             int errorCode = 0;
@@ -131,7 +131,7 @@ namespace System.IO.Pipes
                 }
             }
 
-            completionSource.RegisterForCancellation();
+            completionSource.RegisterForCancellation(cancellationToken);
             return completionSource.Task;
         }
 
@@ -151,7 +151,7 @@ namespace System.IO.Pipes
         [SecuritySafeCritical]
         private Task WriteAsyncCore(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
-            var completionSource = new ReadWriteCompletionSource(this, buffer, cancellationToken, isWrite: true);
+            var completionSource = new ReadWriteCompletionSource(this, buffer, isWrite: true);
             int errorCode = 0;
 
             // Queue an async WriteFile operation and pass in a packed overlapped
@@ -177,7 +177,7 @@ namespace System.IO.Pipes
                 throw WinIOError(errorCode);
             }
 
-            completionSource.RegisterForCancellation();
+            completionSource.RegisterForCancellation(cancellationToken);
             return completionSource.Task;
         }
 

--- a/src/System.IO.Pipes/src/System/IO/Pipes/ReadWriteCompletionSource.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/ReadWriteCompletionSource.cs
@@ -14,8 +14,8 @@ namespace System.IO.Pipes
         private bool _isMessageComplete;
         private int _numBytes; // number of buffer read OR written
 
-        internal ReadWriteCompletionSource(PipeStream stream, ReadOnlyMemory<byte> bufferToPin, CancellationToken cancellationToken, bool isWrite)
-            : base(stream._threadPoolBinding, cancellationToken, bufferToPin)
+        internal ReadWriteCompletionSource(PipeStream stream, ReadOnlyMemory<byte> bufferToPin, bool isWrite)
+            : base(stream._threadPoolBinding, bufferToPin)
         {
             _pipeStream = stream;
             _isWrite = isWrite;

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -7592,6 +7592,7 @@ namespace System.Threading
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Threading.CancellationTokenRegistration other) { throw null; }
         public override int GetHashCode() { throw null; }
+        public CancellationToken Token { get { throw null; } }
         public static bool operator ==(System.Threading.CancellationTokenRegistration left, System.Threading.CancellationTokenRegistration right) { throw null; }
         public static bool operator !=(System.Threading.CancellationTokenRegistration left, System.Threading.CancellationTokenRegistration right) { throw null; }
     }

--- a/src/System.Threading.Tasks/tests/CancellationTokenTests.cs
+++ b/src/System.Threading.Tasks/tests/CancellationTokenTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace System.Threading.Tasks.Tests
 {
-    public static class CancellationTokenTests
+    public static partial class CancellationTokenTests
     {
         [Fact]
         public static void CancellationTokenRegister_Exceptions()

--- a/src/System.Threading.Tasks/tests/CancellationTokenTests.netcoreapp.cs
+++ b/src/System.Threading.Tasks/tests/CancellationTokenTests.netcoreapp.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Threading.Tasks.Tests
+{
+    public static partial class CancellationTokenTests
+    {
+        [Fact]
+        public static void CancellationTokenRegistration_Token_MatchesExpectedValue()
+        {
+            Assert.Equal(default(CancellationToken), default(CancellationTokenRegistration).Token);
+
+            var cts = new CancellationTokenSource();
+            Assert.NotEqual(default(CancellationToken), cts.Token);
+
+            using (var ctr = cts.Token.Register(() => { }))
+            {
+                Assert.Equal(cts.Token, ctr.Token);
+            }
+        }
+    }
+}

--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Task\TaskDisposeTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Compile Include="CancellationTokenTests.netcoreapp.cs" />
     <Compile Include="Task\TaskStatusTest.netcoreapp.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
Expose/test the new CancellationTokenRegistration.Token property.

Then also use it in System.IO.Pipes to reduce the size of the object allocated for each async read/write by a reference field.

Fixes https://github.com/dotnet/corefx/issues/23828
cc: @pjanotti, @JeremyKuhne, @tarekgh, @kouvel 