### PR TITLE
Change Dictionary to ConcurrentDictionary

### DIFF
--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -29,20 +29,14 @@
     <Compile Include="System\Collections\Specialized\DictionaryWrapper.cs" />
     <Compile Include="System\Diagnostics\AsyncStreamReader.cs" />
     <Compile Include="System\Diagnostics\DataReceivedEventArgs.cs" />
-    <Compile Include="System\Diagnostics\Process.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="System\Diagnostics\Process.cs" />
     <Compile Include="System\Diagnostics\ProcessInfo.cs" />
     <Compile Include="System\Diagnostics\ProcessManager.cs" />
-    <Compile Include="System\Diagnostics\ProcessModule.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="System\Diagnostics\ProcessModule.cs" />
     <Compile Include="System\Diagnostics\ProcessModuleCollection.cs" />
     <Compile Include="System\Diagnostics\ProcessPriorityClass.cs" />
     <Compile Include="System\Diagnostics\ProcessStartInfo.cs" />
-    <Compile Include="System\Diagnostics\ProcessThread.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="System\Diagnostics\ProcessThread.cs" />
     <Compile Include="System\Diagnostics\ProcessThreadCollection.cs" />
     <Compile Include="System\Diagnostics\ProcessWindowStyle.cs" />
     <Compile Include="System\Diagnostics\ThreadInfo.cs" />
@@ -393,9 +387,7 @@
     <Compile Include="$(CommonPath)\Interop\Windows\shell32\Interop.ShellExecuteExW.cs">
       <Link>Common\Interop\Windows\shell32\Interop.ShellExecuteExW.cs</Link>
     </Compile>
-    <Compile Include="System\Diagnostics\Process.Win32.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="System\Diagnostics\Process.Win32.cs" />
     <Compile Include="System\Diagnostics\ProcessManager.Win32.cs" />
     <Compile Include="System\Diagnostics\ProcessStartInfo.Win32.cs" />
   </ItemGroup>

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -269,14 +269,10 @@
     <Compile Include="Microsoft\Win32\SafeHandles\SafeThreadHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeTokenHandle.cs" />
     <Compile Include="System\Diagnostics\PerformanceCounterLib.cs" />
-    <Compile Include="System\Diagnostics\Process.Windows.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="System\Diagnostics\Process.Windows.cs" />
     <Compile Include="System\Diagnostics\ProcessManager.Windows.cs" />
     <Compile Include="System\Diagnostics\ProcessStartInfo.Windows.cs" />
-    <Compile Include="System\Diagnostics\ProcessThread.Windows.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="System\Diagnostics\ProcessThread.Windows.cs" />
     <Compile Include="System\Diagnostics\ProcessThreadTimes.cs" />
     <Compile Include="System\Diagnostics\ProcessWaitHandle.Windows.cs" />
   </ItemGroup>

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -29,14 +29,20 @@
     <Compile Include="System\Collections\Specialized\DictionaryWrapper.cs" />
     <Compile Include="System\Diagnostics\AsyncStreamReader.cs" />
     <Compile Include="System\Diagnostics\DataReceivedEventArgs.cs" />
-    <Compile Include="System\Diagnostics\Process.cs" />
+    <Compile Include="System\Diagnostics\Process.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Diagnostics\ProcessInfo.cs" />
     <Compile Include="System\Diagnostics\ProcessManager.cs" />
-    <Compile Include="System\Diagnostics\ProcessModule.cs" />
+    <Compile Include="System\Diagnostics\ProcessModule.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Diagnostics\ProcessModuleCollection.cs" />
     <Compile Include="System\Diagnostics\ProcessPriorityClass.cs" />
     <Compile Include="System\Diagnostics\ProcessStartInfo.cs" />
-    <Compile Include="System\Diagnostics\ProcessThread.cs" />
+    <Compile Include="System\Diagnostics\ProcessThread.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Diagnostics\ProcessThreadCollection.cs" />
     <Compile Include="System\Diagnostics\ProcessWindowStyle.cs" />
     <Compile Include="System\Diagnostics\ThreadInfo.cs" />
@@ -269,10 +275,14 @@
     <Compile Include="Microsoft\Win32\SafeHandles\SafeThreadHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeTokenHandle.cs" />
     <Compile Include="System\Diagnostics\PerformanceCounterLib.cs" />
-    <Compile Include="System\Diagnostics\Process.Windows.cs" />
+    <Compile Include="System\Diagnostics\Process.Windows.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Diagnostics\ProcessManager.Windows.cs" />
     <Compile Include="System\Diagnostics\ProcessStartInfo.Windows.cs" />
-    <Compile Include="System\Diagnostics\ProcessThread.Windows.cs" />
+    <Compile Include="System\Diagnostics\ProcessThread.Windows.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Diagnostics\ProcessThreadTimes.cs" />
     <Compile Include="System\Diagnostics\ProcessWaitHandle.Windows.cs" />
   </ItemGroup>
@@ -383,7 +393,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\shell32\Interop.ShellExecuteExW.cs">
       <Link>Common\Interop\Windows\shell32\Interop.ShellExecuteExW.cs</Link>
     </Compile>
-    <Compile Include="System\Diagnostics\Process.Win32.cs" />
+    <Compile Include="System\Diagnostics\Process.Win32.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Diagnostics\ProcessManager.Win32.cs" />
     <Compile Include="System\Diagnostics\ProcessStartInfo.Win32.cs" />
   </ItemGroup>
@@ -402,6 +414,7 @@
     <Reference Condition="'$(TargetGroup)' != 'uap'" Include="Microsoft.Win32.Registry" />
     <Reference Condition="'$(TargetGroup)' == 'uap'" Include="System.Buffers" />
     <Reference Include="System.Collections" />
+    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Collections.Specialized" />
     <Reference Include="System.ComponentModel.Primitives" />

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -73,8 +73,7 @@ namespace System.Diagnostics
 
             string libraryKey = machineName + ":" + lcidString;
 
-	        return PerformanceCounterLib.s_libraryTable.GetOrAdd(libraryKey,
-		        (k) => new PerformanceCounterLib(machineName, lcidString));
+	        return PerformanceCounterLib.s_libraryTable.GetOrAdd(libraryKey,(k, arg) => new PerformanceCounterLib(arg.machineName, arg.lcidString), (machineName: machineName, lcidString: lcidString));
         }
 
         internal byte[] GetPerformanceData(string item)

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -23,7 +23,7 @@ namespace System.Diagnostics
         private string _machineName;
         private string _perfLcid;
 
-        private static ConcurrentDictionary<String, PerformanceCounterLib> s_libraryTable;
+        private static ConcurrentDictionary<(string, string), PerformanceCounterLib> s_libraryTable;
         private Dictionary<int, string> _nameTable;
         private readonly object _nameTableLock = new Object();
 
@@ -69,11 +69,10 @@ namespace System.Diagnostics
             else
                 machineName = machineName.ToLowerInvariant();
 
-            LazyInitializer.EnsureInitialized(ref s_libraryTable, ref s_internalSyncObject, () => new ConcurrentDictionary<string, PerformanceCounterLib>());
+            LazyInitializer.EnsureInitialized(ref s_libraryTable, ref s_internalSyncObject, () => new ConcurrentDictionary<(string, string), PerformanceCounterLib>());
+            (string machineName, string lcidString) libraryIdentity = (machineName, lcidString);
 
-            string libraryKey = machineName + ":" + lcidString;
-
-	        return PerformanceCounterLib.s_libraryTable.GetOrAdd(libraryKey,(k, arg) => new PerformanceCounterLib(arg.machineName, arg.lcidString), (machineName: machineName, lcidString: lcidString));
+            return PerformanceCounterLib.s_libraryTable.GetOrAdd(libraryIdentity, (k, arg) => new PerformanceCounterLib(arg.machineName, arg.lcidString), libraryIdentity);
         }
 
         internal byte[] GetPerformanceData(string item)

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -23,7 +23,7 @@ namespace System.Diagnostics
         private string _machineName;
         private string _perfLcid;
 
-        private static ConcurrentDictionary<(string, string), PerformanceCounterLib> s_libraryTable;
+        private static ConcurrentDictionary<(string machineName, string lcidString), PerformanceCounterLib> s_libraryTable;
         private Dictionary<int, string> _nameTable;
         private readonly object _nameTableLock = new Object();
 
@@ -70,9 +70,8 @@ namespace System.Diagnostics
                 machineName = machineName.ToLowerInvariant();
 
             LazyInitializer.EnsureInitialized(ref s_libraryTable, ref s_internalSyncObject, () => new ConcurrentDictionary<(string, string), PerformanceCounterLib>());
-            (string machineName, string lcidString) libraryIdentity = (machineName, lcidString);
 
-            return PerformanceCounterLib.s_libraryTable.GetOrAdd(libraryIdentity, (k, arg) => new PerformanceCounterLib(arg.machineName, arg.lcidString), libraryIdentity);
+            return PerformanceCounterLib.s_libraryTable.GetOrAdd((machineName, lcidString), (key) => new PerformanceCounterLib(key.machineName, key.lcidString));
         }
 
         internal byte[] GetPerformanceData(string item)

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-using System.Collections.Concurrent;
 #if FEATURE_REGISTRY
 using Microsoft.Win32;
 #endif
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;


### PR DESCRIPTION
Change type from Dictionary to ConcurrentDictionary to make PerformanceCounterLib.GetPerformanceCounterLib method thread-safe.