### PR TITLE
Support Reference Assemblies in SGEN.

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -1,52 +1,52 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SerializerName>$(AssemblyName).XmlSerializers</SerializerName>
-    <SerializerDllImmediatePath>$(IntermediateOutputPath)$(SerializerName).dll</SerializerDllImmediatePath>
-    <SerializerPdbImmediatePath>$(IntermediateOutputPath)$(SerializerName).pdb</SerializerPdbImmediatePath>
-    <SerializerCsImmediatePath>$(IntermediateOutputPath)$(SerializerName).cs</SerializerCsImmediatePath>
-    <SGenWarningText>SGEN : warning SGEN1: Fail to generate the serializer for $(AssemblyName).dll. Please follow the instructions in https://go.microsoft.com/fwlink/?linkid=858594 and try again.</SGenWarningText>
+    <_SerializerName>$(AssemblyName).XmlSerializers</_SerializerName>
+    <_SerializerDllIntermediatePath>$(IntermediateOutputPath)$(_SerializerName).dll</_SerializerDllIntermediatePath>
+    <_SerializerPdbIntermediatePath>$(IntermediateOutputPath)$(_SerializerName).pdb</_SerializerPdbIntermediatePath>
+    <_SerializerCsIntermediatePath>$(IntermediateOutputPath)$(_SerializerName).cs</_SerializerCsIntermediatePath>
+    <_SGenWarningText>SGEN : warning SGEN1: Fail to generate the serializer for $(AssemblyName).dll. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again.</_SGenWarningText>
   </PropertyGroup>
   <Target Name="GenerateSerializationAssembly" AfterTargets="Build">
-    <Delete Condition="Exists('$(SerializerDllImmediatePath)') == 'true'" Files="$(SerializerDllImmediatePath)" />
-    <Delete Condition="Exists('$(SerializerPdbImmediatePath)') == 'true'" Files="$(SerializerPdbImmediatePath)" />
-    <Delete Condition="Exists('$(SerializerCsImmediatePath)') == 'true'"  Files="$(SerializerCsImmediatePath)" />
+    <Delete Condition="Exists('$(_SerializerDllIntermediatePath)') == 'true'" Files="$(_SerializerDllIntermediatePath)" ContinueOnError="true"/>
+    <Delete Condition="Exists('$(_SerializerPdbIntermediatePath)') == 'true'" Files="$(_SerializerPdbIntermediatePath)" ContinueOnError="true"/>
+    <Delete Condition="Exists('$(_SerializerCsIntermediatePath)') == 'true'"  Files="$(_SerializerCsIntermediatePath)" ContinueOnError="true"/>
     <Message Text="Running Serialization Tool" Importance="normal" />
     <Exec Command="dotnet Microsoft.XmlSerializer.Generator $(IntermediateOutputPath)$(AssemblyName).dll /force /quiet" ContinueOnError="true"/>
-    <Warning Condition="Exists('$(SerializerCsImmediatePath)') != 'true'" Text="$(SGenWarningText)" />
-    <Csc Condition="Exists('$(SerializerCsImmediatePath)') == 'true'" ContinueOnError="true" OutputAssembly="$(SerializerDllImmediatePath)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(SerializerCsImmediatePath)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)"/>
-    <Warning Condition="Exists('$(SerializerDllImmediatePath)') != 'true' And Exists('$(SerializerCsImmediatePath)') == 'true'" Text="$(SGenWarningText)"/>
-    <Copy Condition="Exists('$(SerializerDllImmediatePath)') == 'true'" SourceFiles="$(SerializerDllImmediatePath)" DestinationFolder="$(OutputPath)" />
+    <Warning Condition="Exists('$(_SerializerCsIntermediatePath)') != 'true'" Text="$(_SGenWarningText)" />
+    <Csc Condition="Exists('$(_SerializerCsIntermediatePath)') == 'true'" ContinueOnError="true" OutputAssembly="$(_SerializerDllIntermediatePath)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(_SerializerCsIntermediatePath)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)"/>
+    <Warning Condition="Exists('$(_SerializerDllIntermediatePath)') != 'true' And Exists('$(_SerializerCsIntermediatePath)') == 'true'" Text="$(_SGenWarningText)"/>
+    <Copy Condition="Exists('$(_SerializerDllIntermediatePath)') == 'true'" SourceFiles="$(_SerializerDllIntermediatePath)" DestinationFolder="$(OutputPath)" />
   </Target>
   
   <Target Name="CleanSerializationAssembly" AfterTargets="CoreClean">
     <Message Text="Cleaning serialization files..." Importance="normal"/>
-    <Delete Condition="Exists('$(OutputPath)\$(SerializerName).dll') == 'true'" Files="$(OutputPath)\$(SerializerName).dll" />
+    <Delete Condition="Exists('$(OutputPath)\$(_SerializerName).dll') == 'true'" Files="$(OutputPath)\$(_SerializerName).dll" />
   </Target>
   
-  <Target Name="CopySerializer" AfterTargets="PrepareForPublish">
+  <Target Name="CopySerializationAssembly" AfterTargets="PrepareForPublish">
     <Copy Condition="Exists('$(OutputPath)\$(AssemblyName).XmlSerializers.dll')=='true'" SourceFiles="$(OutputPath)\$(AssemblyName).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
   </Target>
   
   <Target Name="GenerateSerializationAssemblyForReferenceAssemblies" AfterTargets="GenerateSerializationAssembly" Condition="@(SerializationAssembly)!=''">
     <ItemGroup>
-      <SearchSerializationAssembly Include="@(Reference)">
+      <_SearchSerializationAssembly Include="@(Reference)">
         <AssemblyName>%(SerializationAssembly.Identity)</AssemblyName>
         <SerializationTypes>%(SerializationAssembly.SerializationType)</SerializationTypes>
-      </SearchSerializationAssembly>
-      <TargetSerializationAssembly Include="@(SearchSerializationAssembly)" Condition="$([System.String]::new('%(SearchSerializationAssembly.Identity)').EndsWith('%(SearchSerializationAssembly.AssemblyName).dll'))" />
-      <ReferenceSerializerName Include="%(SerializationAssembly.Identity).XmlSerializers" />
-      <ReferenceSerializeImmediatePath Include="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity)" />
+      </_SearchSerializationAssembly>
+      <_TargetSerializationAssembly Include="@(_SearchSerializationAssembly)" Condition="$([System.String]::new('%(_SearchSerializationAssembly.Identity)').EndsWith('%(_SearchSerializationAssembly.AssemblyName).dll'))" />
+      <_ReferenceSerializationAssemblyName Include="%(SerializationAssembly.Identity).XmlSerializers" />
+      <_ReferenceSerializerIntermediatePath Include="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity)" />
     </ItemGroup>
     
-    <Delete Files="%(ReferenceSerializeImmediatePath.Identity).dll" />
-    <Delete Files="%(ReferenceSerializeImmediatePath.Identity).cs" />
-    <Delete Files="%(ReferenceSerializeImmediatePath.Identity).pdb" />
+    <Delete Files="%(_ReferenceSerializerIntermediatePath.Identity).dll" ContinueOnError="true"/>
+    <Delete Files="%(_ReferenceSerializerIntermediatePath.Identity).cs" ContinueOnError="true"/>
+    <Delete Files="%(_ReferenceSerializerIntermediatePath.Identity).pdb" ContinueOnError="true"/>
     <Message Text="Running Serialization Tool for Reference Assembly" Importance="normal" />
-    <Exec Command="dotnet Microsoft.XmlSerializer.Generator /force /quiet /assembly:%(TargetSerializationAssembly.Identity) /type:%(TargetSerializationAssembly.SerializationTypes) /out:$(IntermediateOutputPath)" ContinueOnError="true" />
-    <Warning Condition="Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs') != 'true'" Text="SGEN : warning SGEN1: Fail to generate %(ReferenceSerializerName.Identity)'. Please follow the instructions in https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
-    <Csc Condition="Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs') == 'true'" ContinueOnError="true" OutputAssembly="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).dll" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" />
-    <Warning Condition="Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).dll') != 'true' And Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs') == 'true'" Text="SGEN : warning SGEN1: Fail to compile %(ReferenceSerializerName.Identity).cs. Please follow the instructions in https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
-    <Copy Condition="Exists('%(ReferenceSerializeImmediatePath.Identity).dll') == 'true'" SourceFiles="%(ReferenceSerializeImmediatePath.Identity).dll" DestinationFolder="$(OutputPath)" />
+    <Exec Command="dotnet Microsoft.XmlSerializer.Generator /force /quiet /assembly:%(_TargetSerializationAssembly.Identity) /type:%(_TargetSerializationAssembly.SerializationTypes) /out:$(IntermediateOutputPath)" ContinueOnError="true" />
+    <Warning Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') != 'true'" Text="SGEN : warning SGEN1: Fail to generate %(_ReferenceSerializationAssemblyName.Identity)'. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
+    <Csc Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') == 'true'" ContinueOnError="true" OutputAssembly="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).dll" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" />
+    <Warning Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).dll') != 'true' And Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') == 'true'" Text="SGEN : warning SGEN1: Fail to compile %(_ReferenceSerializationAssemblyName.Identity).cs. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
+    <Copy Condition="Exists('%(_ReferenceSerializerIntermediatePath.Identity).dll') == 'true'" SourceFiles="%(_ReferenceSerializerIntermediatePath.Identity).dll" DestinationFolder="$(OutputPath)" />
   </Target>
 
   <Target Name="CleanReferenceSerializationAssemblies" AfterTargets="CoreClean" Condition="@(SerializationAssembly)!=''">

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -27,7 +27,7 @@
     <Copy Condition="Exists('$(OutputPath)\$(AssemblyName).XmlSerializers.dll')=='true'" SourceFiles="$(OutputPath)\$(AssemblyName).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
   </Target>
   
- <Target Name="GenerateSerializationAssemblyForReferenceAssembly" AfterTargets="GenerateSerializationAssembly" Condition="@(SerializationAssembly)!=''">
+  <Target Name="GenerateSerializationAssemblyForReferenceAssembly" AfterTargets="GenerateSerializationAssembly" Condition="@(SerializationAssembly)!=''">
     <ItemGroup Condition="@(SerializationAssembly)!=''" Label="Parse SerializationAssembly">
       <SearchSerializationAssembly Include="@(Reference)">
         <AssemblyName>%(SerializationAssembly.Identity)</AssemblyName>
@@ -39,7 +39,7 @@
     <ItemGroup>
       <ReferenceSerializerName Include="%(SerializationAssembly.Identity).XmlSerializers" />
       <ReferenceSerializeImmediatePath Include="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity)" />
-  </ItemGroup>
+    </ItemGroup>
     
     <Delete Files="%(ReferenceSerializeImmediatePath.Identity).dll" />
     <Delete Files="%(ReferenceSerializeImmediatePath.Identity).cs" />
@@ -58,6 +58,6 @@
   </Target>
 
   <Target Name="CopySerializerForReferenceAssembly" AfterTargets="PrepareForPublish" Condition="@(SerializationAssembly)!=''">
-    <Copy Condition="Exists('$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll') == 'true'" SourceFiles="$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
+    <Copy Condition="Exists('$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll') == 'true'" SourceFiles="$(OutputPath)\$(AssemblyName).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
   </Target>
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -53,7 +53,7 @@
   </Target>
 
   <Target Name="CleanReferenceSerializationAssembly" AfterTargets="CoreClean" Condition="@(SerializationAssembly)!=''">
-    <Message Text="Cleaning serialization files..." Importance="normal" />
+    <Message Text="Cleaning serialization files for reference assemblies ..." Importance="normal" />
     <Delete Condition="Exists('$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll') == 'true'" Files="$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll" />
   </Target>
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -1,26 +1,26 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_SerializerName>$(AssemblyName).XmlSerializers</_SerializerName>
-    <_SerializerDllIntermediatePath>$(IntermediateOutputPath)$(_SerializerName).dll</_SerializerDllIntermediatePath>
-    <_SerializerPdbIntermediatePath>$(IntermediateOutputPath)$(_SerializerName).pdb</_SerializerPdbIntermediatePath>
-    <_SerializerCsIntermediatePath>$(IntermediateOutputPath)$(_SerializerName).cs</_SerializerCsIntermediatePath>
+    <_SerializationAssemblyName>$(AssemblyName).XmlSerializers</_SerializationAssemblyName>
+    <_SerializerDllIntermediateFolder>$(IntermediateOutputPath)$(_SerializationAssemblyName).dll</_SerializerDllIntermediateFolder>
+    <_SerializerPdbIntermediateFolder>$(IntermediateOutputPath)$(_SerializationAssemblyName).pdb</_SerializerPdbIntermediateFolder>
+    <_SerializerCsIntermediateFolder>$(IntermediateOutputPath)$(_SerializationAssemblyName).cs</_SerializerCsIntermediateFolder>
     <_SGenWarningText>SGEN : warning SGEN1: Fail to generate the serializer for $(AssemblyName).dll. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again.</_SGenWarningText>
   </PropertyGroup>
   <Target Name="GenerateSerializationAssembly" AfterTargets="Build">
-    <Delete Condition="Exists('$(_SerializerDllIntermediatePath)') == 'true'" Files="$(_SerializerDllIntermediatePath)" ContinueOnError="true"/>
-    <Delete Condition="Exists('$(_SerializerPdbIntermediatePath)') == 'true'" Files="$(_SerializerPdbIntermediatePath)" ContinueOnError="true"/>
-    <Delete Condition="Exists('$(_SerializerCsIntermediatePath)') == 'true'"  Files="$(_SerializerCsIntermediatePath)" ContinueOnError="true"/>
+    <Delete Condition="Exists('$(_SerializerDllIntermediateFolder)') == 'true'" Files="$(_SerializerDllIntermediateFolder)" ContinueOnError="true"/>
+    <Delete Condition="Exists('$(_SerializerPdbIntermediateFolder)') == 'true'" Files="$(_SerializerPdbIntermediateFolder)" ContinueOnError="true"/>
+    <Delete Condition="Exists('$(_SerializerCsIntermediateFolder)') == 'true'"  Files="$(_SerializerCsIntermediateFolder)" ContinueOnError="true"/>
     <Message Text="Running Serialization Tool" Importance="normal" />
     <Exec Command="dotnet Microsoft.XmlSerializer.Generator $(IntermediateOutputPath)$(AssemblyName).dll /force /quiet" ContinueOnError="true"/>
-    <Warning Condition="Exists('$(_SerializerCsIntermediatePath)') != 'true'" Text="$(_SGenWarningText)" />
-    <Csc Condition="Exists('$(_SerializerCsIntermediatePath)') == 'true'" ContinueOnError="true" OutputAssembly="$(_SerializerDllIntermediatePath)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(_SerializerCsIntermediatePath)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)"/>
-    <Warning Condition="Exists('$(_SerializerDllIntermediatePath)') != 'true' And Exists('$(_SerializerCsIntermediatePath)') == 'true'" Text="$(_SGenWarningText)"/>
-    <Copy Condition="Exists('$(_SerializerDllIntermediatePath)') == 'true'" SourceFiles="$(_SerializerDllIntermediatePath)" DestinationFolder="$(OutputPath)" />
+    <Warning Condition="Exists('$(_SerializerCsIntermediateFolder)') != 'true'" Text="$(_SGenWarningText)" />
+    <Csc Condition="Exists('$(_SerializerCsIntermediateFolder)') == 'true'" ContinueOnError="true" OutputAssembly="$(_SerializerDllIntermediateFolder)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(_SerializerCsIntermediateFolder)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)"/>
+    <Warning Condition="Exists('$(_SerializerDllIntermediateFolder)') != 'true' And Exists('$(_SerializerCsIntermediateFolder)') == 'true'" Text="$(_SGenWarningText)"/>
+    <Copy Condition="Exists('$(_SerializerDllIntermediateFolder)') == 'true'" SourceFiles="$(_SerializerDllIntermediateFolder)" DestinationFolder="$(OutputPath)" />
   </Target>
   
   <Target Name="CleanSerializationAssembly" AfterTargets="CoreClean">
     <Message Text="Cleaning serialization files..." Importance="normal"/>
-    <Delete Condition="Exists('$(OutputPath)\$(_SerializerName).dll') == 'true'" Files="$(OutputPath)\$(_SerializerName).dll" />
+    <Delete Condition="Exists('$(OutputPath)\$(_SerializationAssemblyName).dll') == 'true'" Files="$(OutputPath)\$(_SerializationAssemblyName).dll" />
   </Target>
   
   <Target Name="CopySerializationAssembly" AfterTargets="PrepareForPublish">
@@ -35,18 +35,18 @@
       </_SearchSerializationAssembly>
       <_TargetSerializationAssembly Include="@(_SearchSerializationAssembly)" Condition="$([System.String]::new('%(_SearchSerializationAssembly.Identity)').EndsWith('%(_SearchSerializationAssembly.AssemblyName).dll'))" />
       <_ReferenceSerializationAssemblyName Include="%(SerializationAssembly.Identity).XmlSerializers" />
-      <_ReferenceSerializerIntermediatePath Include="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity)" />
+      <_ReferenceSerializerIntermediateFolder Include="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity)" />
     </ItemGroup>
     
-    <Delete Files="%(_ReferenceSerializerIntermediatePath.Identity).dll" ContinueOnError="true"/>
-    <Delete Files="%(_ReferenceSerializerIntermediatePath.Identity).cs" ContinueOnError="true"/>
-    <Delete Files="%(_ReferenceSerializerIntermediatePath.Identity).pdb" ContinueOnError="true"/>
+    <Delete Files="%(_ReferenceSerializerIntermediateFolder.Identity).dll" ContinueOnError="true"/>
+    <Delete Files="%(_ReferenceSerializerIntermediateFolder.Identity).cs" ContinueOnError="true"/>
+    <Delete Files="%(_ReferenceSerializerIntermediateFolder.Identity).pdb" ContinueOnError="true"/>
     <Message Text="Running Serialization Tool for Reference Assembly" Importance="normal" />
     <Exec Command="dotnet Microsoft.XmlSerializer.Generator /force /quiet /assembly:%(_TargetSerializationAssembly.Identity) /type:%(_TargetSerializationAssembly.SerializationTypes) /out:$(IntermediateOutputPath)" ContinueOnError="true" />
     <Warning Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') != 'true'" Text="SGEN : warning SGEN1: Fail to generate %(_ReferenceSerializationAssemblyName.Identity)'. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
     <Csc Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') == 'true'" ContinueOnError="true" OutputAssembly="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).dll" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" />
     <Warning Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).dll') != 'true' And Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') == 'true'" Text="SGEN : warning SGEN1: Fail to compile %(_ReferenceSerializationAssemblyName.Identity).cs. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
-    <Copy Condition="Exists('%(_ReferenceSerializerIntermediatePath.Identity).dll') == 'true'" SourceFiles="%(_ReferenceSerializerIntermediatePath.Identity).dll" DestinationFolder="$(OutputPath)" />
+    <Copy Condition="Exists('%(_ReferenceSerializerIntermediateFolder.Identity).dll') == 'true'" SourceFiles="%(_ReferenceSerializerIntermediateFolder.Identity).dll" DestinationFolder="$(OutputPath)" />
   </Target>
 
   <Target Name="CleanReferenceSerializationAssemblies" AfterTargets="CoreClean" Condition="@(SerializationAssembly)!=''">

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -27,16 +27,13 @@
     <Copy Condition="Exists('$(OutputPath)\$(AssemblyName).XmlSerializers.dll')=='true'" SourceFiles="$(OutputPath)\$(AssemblyName).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
   </Target>
   
-  <Target Name="GenerateSerializationAssemblyForReferenceAssembly" AfterTargets="GenerateSerializationAssembly" Condition="@(SerializationAssembly)!=''">
-    <ItemGroup Condition="@(SerializationAssembly)!=''" Label="Parse SerializationAssembly">
+  <Target Name="GenerateSerializationAssemblyForReferenceAssemblies" AfterTargets="GenerateSerializationAssembly" Condition="@(SerializationAssembly)!=''">
+    <ItemGroup>
       <SearchSerializationAssembly Include="@(Reference)">
         <AssemblyName>%(SerializationAssembly.Identity)</AssemblyName>
         <SerializationTypes>%(SerializationAssembly.SerializationType)</SerializationTypes>
       </SearchSerializationAssembly>
       <TargetSerializationAssembly Include="@(SearchSerializationAssembly)" Condition="$([System.String]::new('%(SearchSerializationAssembly.Identity)').EndsWith('%(SearchSerializationAssembly.AssemblyName).dll'))" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ReferenceSerializerName Include="%(SerializationAssembly.Identity).XmlSerializers" />
       <ReferenceSerializeImmediatePath Include="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity)" />
     </ItemGroup>
@@ -52,12 +49,12 @@
     <Copy Condition="Exists('%(ReferenceSerializeImmediatePath.Identity).dll') == 'true'" SourceFiles="%(ReferenceSerializeImmediatePath.Identity).dll" DestinationFolder="$(OutputPath)" />
   </Target>
 
-  <Target Name="CleanReferenceSerializationAssembly" AfterTargets="CoreClean" Condition="@(SerializationAssembly)!=''">
+  <Target Name="CleanReferenceSerializationAssemblies" AfterTargets="CoreClean" Condition="@(SerializationAssembly)!=''">
     <Message Text="Cleaning serialization files for reference assemblies ..." Importance="normal" />
     <Delete Condition="Exists('$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll') == 'true'" Files="$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll" />
   </Target>
 
-  <Target Name="CopySerializerForReferenceAssembly" AfterTargets="PrepareForPublish" Condition="@(SerializationAssembly)!=''">
+  <Target Name="CopySerializerForReferenceAssemblies" AfterTargets="PrepareForPublish" Condition="@(SerializationAssembly)!=''">
     <Copy Condition="Exists('$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll') == 'true'" SourceFiles="$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
   </Target>
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -30,31 +30,26 @@
  <Target Name="GenerateSerializationAssemblyForReferenceAssembly" AfterTargets="GenerateSerializationAssembly" Condition="@(SerializationAssembly)!=''">
     <ItemGroup Condition="@(SerializationAssembly)!=''" Label="Parse SerializationAssembly">
       <SearchSerializationAssembly Include="@(Reference)">
-        <SerializationAssembly>%(SerializationAssembly.Identity)</SerializationAssembly>
+        <AssemblyName>%(SerializationAssembly.Identity)</AssemblyName>
+        <SerializationTypes>%(SerializationAssembly.SerializationType)</SerializationTypes>
       </SearchSerializationAssembly>
-      <TargetSerializationAssembly Include="@(SearchSerializationAssembly)" Condition="$([System.String]::new('%(SearchSerializationAssembly.Identity)').EndsWith('%(SearchSerializationAssembly.SerializationAssembly).dll'))" />
-      <TargetSerializationAssemblyAndType Include="@(TargetSerializationAssembly)">
-        <TargetSerializationAssembly>%(SerializationAssembly.Identity)</TargetSerializationAssembly>
-        <TargetSerializationType>@(SerializationAssembly-&gt;Metadata('SerializationType'))</TargetSerializationType>
-      </TargetSerializationAssemblyAndType>
+      <TargetSerializationAssembly Include="@(SearchSerializationAssembly)" Condition="$([System.String]::new('%(SearchSerializationAssembly.Identity)').EndsWith('%(SearchSerializationAssembly.AssemblyName).dll'))" />
     </ItemGroup>
 
     <ItemGroup>
       <ReferenceSerializerName Include="%(SerializationAssembly.Identity).XmlSerializers" />
-      <ReferenceSerializerDllImmediatePath Include="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).dll" />
-      <ReferenceSerializerPdbImmediatePath Include="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).pdb" />
-      <ReferenceSerializerCsImmediatePath Include="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs" />
+      <ReferenceSerializeImmediatePath Include="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity)" />
   </ItemGroup>
     
-    <Delete Files="@(ReferenceSerializerDllImmediatePath)" />
-    <Delete Files="@(ReferenceSerializerPdbImmediatePath)" />
-    <Delete Files="@(ReferenceSerializerCsImmediatePath)" />
+    <Delete Files="%(ReferenceSerializeImmediatePath.Identity).dll" />
+    <Delete Files="%(ReferenceSerializeImmediatePath.Identity).cs" />
+    <Delete Files="%(ReferenceSerializeImmediatePath.Identity).pdb" />
     <Message Text="Running Serialization Tool for Reference Assembly" Importance="normal" />
-    <Exec Command="dotnet Microsoft.XmlSerializer.Generator /force /quiet /assembly:%(TargetSerializationAssemblyAndType.Identity) /type:%(TargetSerializationAssemblyAndType.TargetSerializationType) /out:$(IntermediateOutputPath)" Condition="$([System.String]::new('%(TargetSerializationAssemblyAndType.Identity)').EndsWith('%(TargetSerializationAssemblyAndType.TargetSerializationAssembly).dll'))" ContinueOnError="true" />
+    <Exec Command="dotnet Microsoft.XmlSerializer.Generator /force /quiet /assembly:%(TargetSerializationAssembly.Identity) /type:%(TargetSerializationAssembly.SerializationTypes) /out:$(IntermediateOutputPath)" ContinueOnError="true" />
     <Warning Condition="Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs') != 'true'" Text="SGEN : warning SGEN1: Fail to generate %(ReferenceSerializerName.Identity)'. Please follow the instructions in https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
     <Csc Condition="Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs') == 'true'" ContinueOnError="true" OutputAssembly="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).dll" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" />
     <Warning Condition="Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).dll') != 'true' And Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs') == 'true'" Text="SGEN : warning SGEN1: Fail to compile %(ReferenceSerializerName.Identity).cs. Please follow the instructions in https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
-    <Copy Condition="Exists('%(ReferenceSerializerDllImmediatePath.Identity)') == 'true'" SourceFiles="%(ReferenceSerializerDllImmediatePath.Identity)" DestinationFolder="$(OutputPath)" />
+    <Copy Condition="Exists('%(ReferenceSerializeImmediatePath.Identity).dll') == 'true'" SourceFiles="%(ReferenceSerializeImmediatePath.Identity).dll" DestinationFolder="$(OutputPath)" />
   </Target>
 
   <Target Name="CleanReferenceSerializationAssembly" AfterTargets="CoreClean" Condition="@(SerializationAssembly)!=''">

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -58,6 +58,6 @@
   </Target>
 
   <Target Name="CopySerializerForReferenceAssembly" AfterTargets="PrepareForPublish" Condition="@(SerializationAssembly)!=''">
-    <Copy Condition="Exists('$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll') == 'true'" SourceFiles="$(OutputPath)\$(AssemblyName).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
+    <Copy Condition="Exists('$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll') == 'true'" SourceFiles="$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
   </Target>
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -56,4 +56,8 @@
     <Message Text="Cleaning serialization files for reference assemblies ..." Importance="normal" />
     <Delete Condition="Exists('$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll') == 'true'" Files="$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll" />
   </Target>
+
+  <Target Name="CopySerializerForReferenceAssembly" AfterTargets="PrepareForPublish" Condition="@(SerializationAssembly)!=''">
+    <Copy Condition="Exists('$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll') == 'true'" SourceFiles="$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
+  </Target>
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -17,11 +17,48 @@
     <Warning Condition="Exists('$(SerializerDllImmediatePath)') != 'true' And Exists('$(SerializerCsImmediatePath)') == 'true'" Text="$(SGenWarningText)"/>
     <Copy Condition="Exists('$(SerializerDllImmediatePath)') == 'true'" SourceFiles="$(SerializerDllImmediatePath)" DestinationFolder="$(OutputPath)" />
   </Target>
+  
   <Target Name="CleanSerializationAssembly" AfterTargets="CoreClean">
     <Message Text="Cleaning serialization files..." Importance="normal"/>
     <Delete Condition="Exists('$(OutputPath)\$(SerializerName).dll') == 'true'" Files="$(OutputPath)\$(SerializerName).dll" />
   </Target>
+  
   <Target Name="CopySerializer" AfterTargets="PrepareForPublish">
     <Copy Condition="Exists('$(OutputPath)\$(AssemblyName).XmlSerializers.dll')=='true'" SourceFiles="$(OutputPath)\$(AssemblyName).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
+  </Target>
+  
+ <Target Name="GenerateSerializationAssemblyForReferenceAssembly" AfterTargets="GenerateSerializationAssembly" Condition="@(SerializationAssembly)!=''">
+    <ItemGroup Condition="@(SerializationAssembly)!=''" Label="Parse SerializationAssembly">
+      <SearchSerializationAssembly Include="@(Reference)">
+        <SerializationAssembly>%(SerializationAssembly.Identity)</SerializationAssembly>
+      </SearchSerializationAssembly>
+      <TargetSerializationAssembly Include="@(SearchSerializationAssembly)" Condition="$([System.String]::new('%(SearchSerializationAssembly.Identity)').EndsWith('%(SearchSerializationAssembly.SerializationAssembly).dll'))" />
+      <TargetSerializationAssemblyAndType Include="@(TargetSerializationAssembly)">
+        <TargetSerializationAssembly>%(SerializationAssembly.Identity)</TargetSerializationAssembly>
+        <TargetSerializationType>@(SerializationAssembly-&gt;Metadata('SerializationType'))</TargetSerializationType>
+      </TargetSerializationAssemblyAndType>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ReferenceSerializerName Include="%(SerializationAssembly.Identity).XmlSerializers" />
+      <ReferenceSerializerDllImmediatePath Include="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).dll" />
+      <ReferenceSerializerPdbImmediatePath Include="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).pdb" />
+      <ReferenceSerializerCsImmediatePath Include="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs" />
+  </ItemGroup>
+    
+    <Delete Files="@(ReferenceSerializerDllImmediatePath)" />
+    <Delete Files="@(ReferenceSerializerPdbImmediatePath)" />
+    <Delete Files="@(ReferenceSerializerCsImmediatePath)" />
+    <Message Text="Running Serialization Tool for Reference Assembly" Importance="normal" />
+    <Exec Command="dotnet Microsoft.XmlSerializer.Generator /force /quiet /assembly:%(TargetSerializationAssemblyAndType.Identity) /type:%(TargetSerializationAssemblyAndType.TargetSerializationType) /out:$(IntermediateOutputPath)" Condition="$([System.String]::new('%(TargetSerializationAssemblyAndType.Identity)').EndsWith('%(TargetSerializationAssemblyAndType.TargetSerializationAssembly).dll'))" ContinueOnError="true" />
+    <Warning Condition="Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs') != 'true'" Text="SGEN : warning SGEN1: Fail to generate %(ReferenceSerializerName.Identity)'. Please follow the instructions in https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
+    <Csc Condition="Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs') == 'true'" ContinueOnError="true" OutputAssembly="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).dll" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" />
+    <Warning Condition="Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).dll') != 'true' And Exists('$(IntermediateOutputPath)%(ReferenceSerializerName.Identity).cs') == 'true'" Text="SGEN : warning SGEN1: Fail to compile %(ReferenceSerializerName.Identity).cs. Please follow the instructions in https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
+    <Copy Condition="Exists('%(ReferenceSerializerDllImmediatePath.Identity)') == 'true'" SourceFiles="%(ReferenceSerializerDllImmediatePath.Identity)" DestinationFolder="$(OutputPath)" />
+  </Target>
+
+  <Target Name="CleanReferenceSerializationAssembly" AfterTargets="CoreClean" Condition="@(SerializationAssembly)!=''">
+    <Message Text="Cleaning serialization files..." Importance="normal" />
+    <Delete Condition="Exists('$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll') == 'true'" Files="$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll" />
   </Target>
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -79,7 +79,7 @@ namespace Microsoft.XmlSerializer.Generator
                     }
                     else if (ArgumentMatch(arg, "type"))
                     {
-                        if(value != string.Empty)
+                        if (value != string.Empty)
                         {
                             string[] typelist = value.Split(';');
                             foreach (var type in typelist)

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -79,7 +79,18 @@ namespace Microsoft.XmlSerializer.Generator
                     }
                     else if (ArgumentMatch(arg, "type"))
                     {
-                        types.Add(value);
+                        if (value.Contains(";"))
+                        {
+                            var typelist = value.Split(';');
+                            foreach (var type in typelist)
+                            {
+                                types.Add(type);
+                            }
+                        }
+                        else if(value != string.Empty)
+                        {
+                            types.Add(value);
+                        }
                     }
                     else if (ArgumentMatch(arg, "assembly"))
                     {
@@ -384,7 +395,16 @@ namespace Microsoft.XmlSerializer.Generator
         private static Assembly LoadAssembly(string assemblyName, bool throwOnFail)
         {
             Assembly assembly = null;
-            string path = Path.GetFullPath(assemblyName);
+            string path;
+            if(Path.IsPathRooted(assemblyName))
+            {
+                path = assemblyName;
+            }
+            else
+            {
+                path = Path.GetFullPath(assemblyName);
+            }
+
             assembly = Assembly.LoadFile(path);
             if (assembly == null)
             {

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -79,17 +79,13 @@ namespace Microsoft.XmlSerializer.Generator
                     }
                     else if (ArgumentMatch(arg, "type"))
                     {
-                        if (value.Contains(";"))
+                        if(value != string.Empty)
                         {
                             var typelist = value.Split(';');
                             foreach (var type in typelist)
                             {
                                 types.Add(type);
                             }
-                        }
-                        else if(value != string.Empty)
-                        {
-                            types.Add(value);
                         }
                     }
                     else if (ArgumentMatch(arg, "assembly"))
@@ -395,16 +391,7 @@ namespace Microsoft.XmlSerializer.Generator
         private static Assembly LoadAssembly(string assemblyName, bool throwOnFail)
         {
             Assembly assembly = null;
-            string path;
-            if(Path.IsPathRooted(assemblyName))
-            {
-                path = assemblyName;
-            }
-            else
-            {
-                path = Path.GetFullPath(assemblyName);
-            }
-
+            string path = Path.IsPathRooted(assemblyName) ? assemblyName : Path.GetFullPath(assemblyName);
             assembly = Assembly.LoadFile(path);
             if (assembly == null)
             {

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -81,7 +81,7 @@ namespace Microsoft.XmlSerializer.Generator
                     {
                         if(value != string.Empty)
                         {
-                            var typelist = value.Split(';');
+                            string[] typelist = value.Split(';');
                             foreach (var type in typelist)
                             {
                                 types.Add(type);

--- a/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -173,7 +173,7 @@ namespace System.Xml.Serialization
                 name.CodeBase = null;
                 name.CultureInfo = CultureInfo.InvariantCulture;
                 string serializerPath = Path.Combine(Path.GetDirectoryName(type.Assembly.Location), serializerName + ".dll");
-                if(!File.Exists(serializerPath))
+                if (!File.Exists(serializerPath))
                 {
                     serializerPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), serializerName + ".dll");
                 }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -173,6 +173,11 @@ namespace System.Xml.Serialization
                 name.CodeBase = null;
                 name.CultureInfo = CultureInfo.InvariantCulture;
                 string serializerPath = Path.Combine(Path.GetDirectoryName(type.Assembly.Location), serializerName + ".dll");
+                if(!File.Exists(serializerPath))
+                {
+                    serializerPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), serializerName + ".dll");
+                }
+
                 try
                 {
                     serializer = Assembly.LoadFile(serializerPath);


### PR DESCRIPTION
Customer can define the reference assemblies as well as the related types that need pregenerated serializer as the followings.

  ```
<ItemGroup>
    <SerializationAssembly Include="MyData06">
      <SerializationType>MyData06.Class1;MyData06.Class3</SerializationType>
    </SerializationAssembly>
    <SerializationAssembly Include="MyData07">
      <SerializationType>MyData07.Class5;MyData07.Class6</SerializationType>
    </SerializationAssembly>
  </ItemGroup>
```

Fix #22937

@shmao @mconnew @zhenlan 