### PR TITLE
Update System.Net.Http to use Memory-based Stream methods

### DIFF
--- a/src/Common/src/System/IO/DelegatingStream.cs
+++ b/src/Common/src/System/IO/DelegatingStream.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -94,12 +93,10 @@ namespace System.Net.Http
             return _innerStream.Read(buffer, offset, count);
         }
 
-#if !NET46
         public override int Read(Span<byte> destination)
         {
             return _innerStream.Read(destination);
         }
-#endif
 
         public override int ReadByte()
         {
@@ -109,6 +106,11 @@ namespace System.Net.Http
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             return _innerStream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
+        {
+            return _innerStream.ReadAsync(destination, cancellationToken);
         }
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
@@ -145,12 +147,10 @@ namespace System.Net.Http
             _innerStream.Write(buffer, offset, count);
         }
 
-#if !NET46
         public override void Write(ReadOnlySpan<byte> source)
         {
             _innerStream.Write(source);
         }
-#endif
 
         public override void WriteByte(byte value)
         {
@@ -160,6 +160,11 @@ namespace System.Net.Http
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             return _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+        {
+            return _innerStream.WriteAsync(source, cancellationToken);
         }
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingWriteStream.cs
@@ -21,8 +21,12 @@ namespace System.Net.Http
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ignored)
             {
                 ValidateBufferArgs(buffer, offset, count);
-                
-                if (count == 0)
+                return WriteAsync(new Memory<byte>(buffer, offset, count), ignored);
+            }
+
+            public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+            {
+                if (source.Length == 0)
                 {
                     // Don't write if nothing was given, especially since we don't want to accidentally send a 0 chunk,
                     // which would indicate end of body.  Instead, just ensure no content is stuck in the buffer.
@@ -36,10 +40,10 @@ namespace System.Net.Http
                     return Task.CompletedTask;
                 }
 
-                return WriteChunkAsync(buffer, offset, count);
+                return WriteChunkAsync(source);
             }
 
-            private async Task WriteChunkAsync(byte[] buffer, int offset, int count)
+            private async Task WriteChunkAsync(ReadOnlyMemory<byte> source)
             {
                 // Write chunk length -- hex representation of count
                 bool digitWritten = false;
@@ -47,7 +51,7 @@ namespace System.Net.Http
                 {
                     int shift = i * 4;
                     int mask = 0xF << shift;
-                    int digit = (count & mask) >> shift;
+                    int digit = (source.Length & mask) >> shift;
                     if (digitWritten || digit != 0)
                     {
                         await _connection.WriteByteAsync((byte)(digit < 10 ? '0' + digit : 'A' + digit - 10), RequestCancellationToken).ConfigureAwait(false);
@@ -59,7 +63,7 @@ namespace System.Net.Http
                 await _connection.WriteTwoBytesAsync((byte)'\r', (byte)'\n', RequestCancellationToken).ConfigureAwait(false);
 
                 // Write chunk contents
-                await _connection.WriteAsync(buffer, offset, count, RequestCancellationToken).ConfigureAwait(false);
+                await _connection.WriteAsync(source, RequestCancellationToken).ConfigureAwait(false);
                 await _connection.WriteTwoBytesAsync((byte)'\r', (byte)'\n', RequestCancellationToken).ConfigureAwait(false);
 
                 // Flush the chunk.  This is reasonable from the standpoint of having just written a standalone piece

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ContentLengthWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ContentLengthWriteStream.cs
@@ -19,7 +19,11 @@ namespace System.Net.Http
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ignored)
             {
                 ValidateBufferArgs(buffer, offset, count);
+                return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), ignored);
+            }
 
+            public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+            {
                 if (_connection._currentRequest == null)
                 {
                     // Avoid sending anything if the response has already completed, in which case there's no point
@@ -30,7 +34,7 @@ namespace System.Net.Http
                 // Have the connection write the data, skipping the buffer. Importantly, this will
                 // force a flush of anything already in the buffer, i.e. any remaining request headers
                 // that are still buffered.
-                return _connection.WriteWithoutBufferingAsync(buffer, offset, count, RequestCancellationToken);
+                return _connection.WriteWithoutBufferingAsync(source, RequestCancellationToken);
             }
 
             public override Task FlushAsync(CancellationToken ignored)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/EmptyReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/EmptyReadStream.cs
@@ -25,6 +25,9 @@ namespace System.Net.Http
                 ValidateBufferArgs(buffer, offset, count);
                 return s_zeroTask;
             }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default) =>
+                new ValueTask<int>(0);
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentDuplexStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentDuplexStream.cs
@@ -19,8 +19,11 @@ namespace System.Net.Http
 
         public override void Flush() => FlushAsync().GetAwaiter().GetResult();
 
-        public override int Read(byte[] buffer, int offset, int count) =>
-            ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ValidateBufferArgs(buffer, offset, count);
+            return ReadAsync(new Memory<byte>(buffer, offset, count), CancellationToken.None).GetAwaiter().GetResult();
+        }
 
         public override void Write(byte[] buffer, int offset, int count) =>
             WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentReadStream.cs
@@ -20,8 +20,11 @@ namespace System.Net.Http
 
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
-        public override int Read(byte[] buffer, int offset, int count) =>
-            ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ValidateBufferArgs(buffer, offset, count);
+            return ReadAsync(new Memory<byte>(buffer, offset, count), CancellationToken.None).GetAwaiter().GetResult();
+        }
 
         public override void CopyTo(Stream destination, int bufferSize) =>
             CopyToAsync(destination, bufferSize, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -417,7 +417,6 @@ namespace System.Net.Http
                 }
             }
 
-#if !NET46
             public override int Read(Span<byte> destination)
             {
                 if (destination.Length == 0)
@@ -447,13 +446,15 @@ namespace System.Net.Http
                     _current = _streams[_next++];
                 }
             }
-#endif
 
             public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 ValidateReadArgs(buffer, offset, count);
-                return ReadAsyncPrivate(buffer, offset, count, cancellationToken);
+                return ReadAsyncPrivate(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
             }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default) =>
+                ReadAsyncPrivate(destination, cancellationToken);
 
             public override IAsyncResult BeginRead(byte[] array, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
                 TaskToApm.Begin(ReadAsync(array, offset, count, CancellationToken.None), asyncCallback, asyncState);
@@ -461,20 +462,18 @@ namespace System.Net.Http
             public override int EndRead(IAsyncResult asyncResult) =>
                 TaskToApm.End<int>(asyncResult);
 
-            public async Task<int> ReadAsyncPrivate(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            public async ValueTask<int> ReadAsyncPrivate(Memory<byte> destination, CancellationToken cancellationToken)
             {
-                if (count == 0)
+                if (destination.Length == 0)
                 {
                     return 0;
                 }
 
                 while (true)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-
                     if (_current != null)
                     {
-                        int bytesRead = await _current.ReadAsync(buffer, offset, count).ConfigureAwait(false);
+                        int bytesRead = await _current.ReadAsync(destination, cancellationToken).ConfigureAwait(false);
                         if (bytesRead != 0)
                         {
                             _position += bytesRead;
@@ -582,10 +581,9 @@ namespace System.Net.Http
             public override void Flush() { }
             public override void SetLength(long value) { throw new NotSupportedException(); }
             public override void Write(byte[] buffer, int offset, int count) { throw new NotSupportedException(); }
-#if !NET46
             public override void Write(ReadOnlySpan<byte> source) { throw new NotSupportedException(); }
-#endif
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) { throw new NotSupportedException(); }
+            public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default) { throw new NotSupportedException(); }
         }
         #endregion Serialization
     }

--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -143,12 +143,10 @@ namespace System.Net.Http
                 throw new NotSupportedException(SR.net_http_content_readonly_stream);
             }
 
-#if !NET46
             public override void Write(ReadOnlySpan<byte> source)
             {
                 throw new NotSupportedException(SR.net_http_content_readonly_stream);
             }
-#endif
 
             public override void WriteByte(byte value)
             {
@@ -156,6 +154,11 @@ namespace System.Net.Http
             }
 
             public override Task WriteAsync(byte[] buffer, int offset, int count, Threading.CancellationToken cancellationToken)
+            {
+                throw new NotSupportedException(SR.net_http_content_readonly_stream);
+            }
+
+            public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
             {
                 throw new NotSupportedException(SR.net_http_content_readonly_stream);
             }

--- a/src/System.Net.Http/tests/UnitTests/Configurations.props
+++ b/src/System.Net.Http/tests/UnitTests/Configurations.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
-      netfx;
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -5,14 +5,11 @@
     <ProjectGuid>{5F9C3C9F-652E-461E-B2D6-85D264F5A733}</ProjectGuid>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn Condition="'$(TargetGroup)' == 'netfx' Or '$(TargetGroup)' == 'uap'">$(NoWarn);0436</NoWarn>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netfx'">$(DefineConstants);NET46</DefineConstants>
+    <NoWarn Condition="'$(TargetGroup)' == 'uap'">$(NoWarn);0436</NoWarn>
     <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <!-- Do not reference these assemblies from the TargetingPack since we are building part of the source code for tests. -->


### PR DESCRIPTION
- Overrides Read/WriteAsync(Memory, ...) on streams
- Updates calls where relevant to use ReadAsync(Memory, ...) to avoid task allocation when possible
- Removed NET46 #ifdefs in files I was touching

Fixes https://github.com/dotnet/corefx/issues/22396
cc: @geoffkizer, @davidsh