### PR TITLE
Fix null ref exception when Dispose'ing SmtpClient

### DIFF
--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -152,7 +152,7 @@ namespace System.Net.Mail
                             _channelBindingToken.Close();
                         }
 
-                        _networkStream.Close();
+                        _networkStream?.Close();
                         _tcpClient.Dispose();
                     }
 

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -272,6 +272,15 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
+        public void Send_ServerDoesntExist_Throws()
+        {
+            using (var smtp = new SmtpClient(Guid.NewGuid().ToString("N")))
+            {
+                Assert.Throws<SmtpException>(() => smtp.Send("anyone@anyone.com", "anyone@anyone.com", "subject", "body"));
+            }
+        }
+
+        [Fact]
         public void TestMailDelivery()
         {
             SmtpServer server = new SmtpServer();


### PR DESCRIPTION
If SmtpClient is disposed after a failed send and no successful sends, it attempts to call Close on a null NetworkStream field.

I can't reproduce the exact situation called out in https://github.com/dotnet/corefx/issues/24485, but this fixes the issue I noted in that thread, and I expect it'll fix the original issue as well.

cc: @Priya91, @Petermarcu 
Fixes https://github.com/dotnet/corefx/issues/24485

(Separately, it looks like the connection mgmt in core's SmtpMail could be cleaned up; since a new connection is created per send, it's not clear to me why this close call is required at all.)