### PR TITLE
Diabled non-deterministic Test_Write_Metric_EventListener test.

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
@@ -42,7 +42,7 @@ namespace BasicEventSourceTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Disabled for non-deterministic errors.  Already fixed in master branch.")]
         public void Test_Write_Metric_EventListener()
         {
             using (var listener = new EventListenerListener())


### PR DESCRIPTION
This test was failing non-determinsiticsally it was fixed in master, but it took several commits
to do it.  It is safer to simply disable it here (the test was not enabled before in this branch).