### PR TITLE
Fix for OdbcParameter Error "Data type 0x23 is a deprecated large object..."

### DIFF
--- a/src/System.Data.Odbc/src/System/Data/Odbc/OdbcParameter.cs
+++ b/src/System.Data.Odbc/src/System/Data/Odbc/OdbcParameter.cs
@@ -747,8 +747,6 @@ namespace System.Data.Odbc
                 }
             };
 
-            int cbParameterSize = GetParameterSize(value, offset, ordinal); // count of bytes for the data, for SQLBindParameter
-
             // Upgrade input value type if the size of input value is bigger than the max size of the input value type.
             switch (_bindtype._sql_type)
             {
@@ -774,6 +772,8 @@ namespace System.Data.Odbc
                     }
                     break;
             }
+
+            int cbParameterSize = GetParameterSize(value, offset, ordinal); // count of bytes for the data, for SQLBindParameter
 
             _prepared_Sql_C_Type = sql_c_type;
             _preparedOffset = offset;

--- a/src/System.Data.Odbc/src/System/Data/Odbc/OdbcParameter.cs
+++ b/src/System.Data.Odbc/src/System/Data/Odbc/OdbcParameter.cs
@@ -752,21 +752,21 @@ namespace System.Data.Odbc
             {
                 case ODBC32.SQL_TYPE.VARBINARY:
                     // Max length of VARBINARY is 8,000 of byte array.
-                    if (_internalSize > 8000)
+                    if (size > 8000)
                     {
                         _bindtype = TypeMap._Image; // will change to LONGVARBINARY
                     }
                     break;
                 case ODBC32.SQL_TYPE.VARCHAR:
                     // Max length of VARCHAR is 8,000 of non-unicode characters.
-                    if (_internalSize > 8000)
+                    if (size > 8000)
                     {
                         _bindtype = TypeMap._Text; // will change to LONGVARCHAR
                     }
                     break;
                 case ODBC32.SQL_TYPE.WVARCHAR:
                     // Max length of WVARCHAR (NVARCHAR) is 4,000 of unicode characters. 
-                    if (_internalSize > 4000)
+                    if (size > 4000)
                     {
                         _bindtype = TypeMap._NText; // will change to WLONGVARCHAR
                     }

--- a/src/System.Data.Odbc/src/System/Data/Odbc/OdbcParameter.cs
+++ b/src/System.Data.Odbc/src/System/Data/Odbc/OdbcParameter.cs
@@ -747,26 +747,31 @@ namespace System.Data.Odbc
                 }
             };
 
-            int cbParameterSize = GetParameterSize(value, offset, ordinal);      // count of bytes for the data, for SQLBindParameter
+            int cbParameterSize = GetParameterSize(value, offset, ordinal); // count of bytes for the data, for SQLBindParameter
 
-            // here we upgrade the datatypes if the given values size is bigger than the types columnsize
-            //
+            // Upgrade input value type if the size of input value is bigger than the max size of the input value type.
             switch (_bindtype._sql_type)
             {
-                case ODBC32.SQL_TYPE.VARBINARY: // MDAC 74372
-                    // Note: per definition DbType.Binary does not support more than 8000 bytes so we change the type for binding
-                    if ((cbParameterSize > 8000))
-                    { _bindtype = TypeMap._Image; } // will change to LONGVARBINARY
+                case ODBC32.SQL_TYPE.VARBINARY:
+                    // Max length of VARBINARY is 8,000 of byte array.
+                    if (_internalSize > 8000)
+                    {
+                        _bindtype = TypeMap._Image; // will change to LONGVARBINARY
+                    }
                     break;
-                case ODBC32.SQL_TYPE.VARCHAR: // MDAC 74372
-                    // Note: per definition DbType.Binary does not support more than 8000 bytes so we change the type for binding
-                    if ((cbParameterSize > 8000))
-                    { _bindtype = TypeMap._Text; }  // will change to LONGVARCHAR
+                case ODBC32.SQL_TYPE.VARCHAR:
+                    // Max length of VARCHAR is 8,000 of non-unicode characters.
+                    if (_internalSize > 8000)
+                    {
+                        _bindtype = TypeMap._Text; // will change to LONGVARCHAR
+                    }
                     break;
-                case ODBC32.SQL_TYPE.WVARCHAR: // MDAC 75099
-                    // Note: per definition DbType.Binary does not support more than 8000 bytes so we change the type for binding
-                    if ((cbParameterSize > 4000))
-                    { _bindtype = TypeMap._NText; }  // will change to WLONGVARCHAR
+                case ODBC32.SQL_TYPE.WVARCHAR:
+                    // Max length of WVARCHAR (NVARCHAR) is 4,000 of unicode characters. 
+                    if (_internalSize > 4000)
+                    {
+                        _bindtype = TypeMap._NText; // will change to WLONGVARCHAR
+                    }
                     break;
             }
 

--- a/src/System.Data.Odbc/src/System/Data/Odbc/OdbcParameter.cs
+++ b/src/System.Data.Odbc/src/System/Data/Odbc/OdbcParameter.cs
@@ -747,6 +747,8 @@ namespace System.Data.Odbc
                 }
             };
 
+            int cbParameterSize = GetParameterSize(value, offset, ordinal); // count of bytes for the data, for SQLBindParameter
+
             // Upgrade input value type if the size of input value is bigger than the max size of the input value type.
             switch (_bindtype._sql_type)
             {
@@ -772,8 +774,6 @@ namespace System.Data.Odbc
                     }
                     break;
             }
-
-            int cbParameterSize = GetParameterSize(value, offset, ordinal); // count of bytes for the data, for SQLBindParameter
 
             _prepared_Sql_C_Type = sql_c_type;
             _preparedOffset = offset;

--- a/src/System.Data.Odbc/tests/OdbcParameterTests.cs
+++ b/src/System.Data.Odbc/tests/OdbcParameterTests.cs
@@ -1,0 +1,265 @@
+using System.Data.SqlClient;
+using System.Text;
+using Xunit;
+
+namespace System.Data.Odbc.Tests
+{
+    public static class OdbcParameterTests
+    {
+        [CheckConnStrSetupFact]
+        public static void RunTest()
+        {
+            string str1000 = null;
+            string str2000 = null;
+            string str4000 = null;
+            string str5000 = null;
+            string str8000 = "";
+            for (int i = 0; i < 800; i++)
+            {
+                str8000 += "0123456789";
+                if (i == 99)
+                {
+                    str1000 = str8000;
+                }
+                else if (i == 199)
+                {
+                    str2000 = str8000;
+                }
+                else if (i == 399)
+                {
+                    str4000 = str8000;
+                }
+                else if (i == 499)
+                {
+                    str5000 = str8000;
+                }
+            }
+
+            byte[] byte1000 = Encoding.ASCII.GetBytes(str1000);
+            byte[] byte2000 = Encoding.ASCII.GetBytes(str2000);
+            byte[] byte4000 = Encoding.ASCII.GetBytes(str4000);
+            byte[] byte5000 = Encoding.ASCII.GetBytes(str5000);
+            byte[] byte8000 = Encoding.ASCII.GetBytes(str8000);
+
+            object output = null;
+            int inputLength = 0;
+            int outputLength = 0;
+
+            RunTestProcedure("VARBINARY", 8000, byte8000, out output, out inputLength, out outputLength);
+            string outputStr = Encoding.ASCII.GetString(output as byte[]);
+            Assert.Equal(str8000, outputStr);
+            Assert.Equal(byte8000.Length, inputLength);
+            Assert.Equal(byte8000.Length, outputLength);
+
+            RunTestProcedure("VARBINARY", 8000, byte5000, out output, out inputLength, out outputLength);
+            outputStr = Encoding.ASCII.GetString(output as byte[]);
+            Assert.Equal(str8000, outputStr);
+            Assert.Equal(byte5000.Length, inputLength);
+            Assert.Equal(byte8000.Length, outputLength);
+
+            RunTestProcedure("VARBINARY", 8000, byte4000, out output, out inputLength, out outputLength);
+            outputStr = Encoding.ASCII.GetString(output as byte[]);
+            Assert.Equal(str8000, outputStr);
+            Assert.Equal(byte4000.Length, inputLength);
+            Assert.Equal(str8000.Length, outputLength);
+
+            RunTestProcedure("VARBINARY", 8000, byte2000, out output, out inputLength, out outputLength);
+            outputStr = Encoding.ASCII.GetString(output as byte[]);
+            Assert.Equal(str4000, outputStr);
+            Assert.Equal(byte2000.Length, inputLength);
+            Assert.Equal(str4000.Length, outputLength);
+
+            RunTestProcedure("VARBINARY", 8000, byte1000, out output, out inputLength, out outputLength);
+            outputStr = Encoding.ASCII.GetString(output as byte[]);
+            Assert.Equal(str2000, outputStr);
+            Assert.Equal(byte1000.Length, inputLength);
+            Assert.Equal(byte2000.Length, outputLength);
+
+            RunTestProcedure("VARCHAR", 8000, str8000, out output, out inputLength, out outputLength);
+            outputStr = output as string;
+            Assert.Equal(str8000, outputStr);
+            Assert.Equal(str8000.Length, inputLength);
+            Assert.Equal(str8000.Length, outputLength);
+
+            RunTestProcedure("VARCHAR", 8000, str5000, out output, out inputLength, out outputLength);
+            outputStr = output as string;
+            Assert.Equal(str8000, outputStr);
+            Assert.Equal(str5000.Length, inputLength);
+            Assert.Equal(str8000.Length, outputLength);
+
+            RunTestProcedure("VARCHAR", 8000, str4000, out output, out inputLength, out outputLength);
+            outputStr = output as string;
+            Assert.Equal(str8000, outputStr);
+            Assert.Equal(str4000.Length, inputLength);
+            Assert.Equal(str8000.Length, outputLength);
+
+            RunTestProcedure("VARCHAR", 8000, str2000, out output, out inputLength, out outputLength);
+            outputStr = output as string;
+            Assert.Equal(str4000, outputStr);
+            Assert.Equal(str2000.Length, inputLength);
+            Assert.Equal(str4000.Length, outputLength);
+
+            RunTestProcedure("VARCHAR", 8000, str1000, out output, out inputLength, out outputLength);
+            outputStr = output as string;
+            Assert.Equal(str2000, outputStr);
+            Assert.Equal(str1000.Length, inputLength);
+            Assert.Equal(str2000.Length, outputLength);
+
+            RunTestProcedure("NVARCHAR", 4000, str8000, out output, out inputLength, out outputLength);
+            outputStr = output as string;
+            Assert.Equal(str4000, outputStr);
+            Assert.Equal(str4000.Length * 2, inputLength); // since NVARCHAR takes 2 bytes per character
+            Assert.Equal(str4000.Length * 2, outputLength);
+
+            RunTestProcedure("NVARCHAR", 4000, str5000, out output, out inputLength, out outputLength);
+            outputStr = output as string;
+            Assert.Equal(str4000, outputStr);
+            Assert.Equal(str4000.Length * 2, inputLength);
+            Assert.Equal(str4000.Length * 2, outputLength);
+
+            RunTestProcedure("NVARCHAR", 4000, str4000, out output, out inputLength, out outputLength);
+            outputStr = output as string;
+            Assert.Equal(str4000, outputStr);
+            Assert.Equal(str4000.Length * 2, inputLength);
+            Assert.Equal(str4000.Length * 2, outputLength);
+
+            RunTestProcedure("NVARCHAR", 4000, str2000, out output, out inputLength, out outputLength);
+            outputStr = output as string;
+            Assert.Equal(str4000, outputStr);
+            Assert.Equal(str2000.Length * 2, inputLength);
+            Assert.Equal(str4000.Length * 2, outputLength);
+
+            RunTestProcedure("NVARCHAR", 4000, str1000, out output, out inputLength, out outputLength);
+            outputStr = output as string;
+            Assert.Equal(str2000, outputStr);
+            Assert.Equal(str1000.Length * 2, inputLength);
+            Assert.Equal(str2000.Length * 2, outputLength);
+        }
+        
+
+        private static void RunTestProcedure(string procDataType, int procDataSize, object v1, out object v2, out int v3, out int v4)
+        {
+            string removeExistingStoredProcSql =
+                "IF OBJECT_ID('testStoredProc', 'P') IS NOT NULL " +
+                    "DROP PROCEDURE testStoredProc;";
+
+            string createTestStoredProcSql =
+                "CREATE PROCEDURE testStoredProc (" +
+                    $"@v1 {procDataType}({procDataSize}), " +
+                    $"@v2 {procDataType}({procDataSize}) OUT, " +
+                    "@v3 INTEGER OUT, " +
+                    "@v4 INTEGER OUT) " +
+                "AS BEGIN " +
+                    "SET @v2 = @v1 + @v1; " +
+                    "SET @v3 = datalength(@v1); " +
+                    "SET @v4 = datalength(@v2); " +
+                "END;";
+
+            DataTestUtility.RunNonQuery(DataTestUtility.TcpConnStr, removeExistingStoredProcSql);
+            DataTestUtility.RunNonQuery(DataTestUtility.TcpConnStr, createTestStoredProcSql);
+
+            DbAccessor dbAccessUtil = new DbAccessor();
+            dbAccessUtil.connectSqlServer(DataTestUtility.OdbcConnStr);
+            dbAccessUtil.callProc("{ call testStoredProc(?,?,?,?) }", procDataType, procDataSize, v1, out v2, out v3, out v4);
+            dbAccessUtil.commit();
+            dbAccessUtil.disconnect();
+
+            DataTestUtility.RunNonQuery(DataTestUtility.TcpConnStr, removeExistingStoredProcSql);
+        }
+        
+
+        private class DbAccessor
+        {
+            private OdbcConnection con = null;
+            private OdbcTransaction trn = null;
+
+            public bool connectSqlServer(string connStr)
+            {
+                if (con == null)
+                {
+                    con = new OdbcConnection(connStr);
+                }
+
+                con.Open();
+                trn = con.BeginTransaction();
+
+                return true;
+            }
+
+            public void disconnect()
+            {
+                if (trn != null)
+                {
+                    trn.Rollback();
+                    trn.Dispose();
+                    trn = null;
+                }
+                if (con != null)
+                {
+                    con.Close();
+                    con.Dispose();
+                    con = null;
+                }
+            }
+
+            public void callProc(string sql, string procDataType, int procDataSize, object v1, out object v2, out int v3, out int v4)
+            {
+                using (OdbcCommand command = new OdbcCommand(sql, con, trn))
+                {
+                    command.Parameters.Clear();
+                    command.CommandType = CommandType.StoredProcedure;
+
+                    OdbcType dataType = OdbcType.NVarChar;
+                    switch (procDataType.ToUpper())
+                    {
+                        case "VARBINARY":
+                            dataType = OdbcType.VarBinary;
+                            break;
+                        case "VARCHAR":
+                            dataType = OdbcType.VarChar;
+                            break;
+                    }
+                    
+                    command.Parameters.Add("@v1", dataType, procDataSize);
+                    command.Parameters.Add("@v2", dataType, procDataSize);
+                    command.Parameters.Add("@v3", OdbcType.Int);
+                    command.Parameters.Add("@v4", OdbcType.Int);
+
+                    command.Parameters["@v1"].Direction = ParameterDirection.Input;
+                    command.Parameters["@v2"].Direction = ParameterDirection.Output;
+                    command.Parameters["@v3"].Direction = ParameterDirection.Output;
+                    command.Parameters["@v4"].Direction = ParameterDirection.Output;
+
+                    command.Parameters["@v1"].Value = v1;
+                    command.ExecuteNonQuery();
+
+                    v2 = command.Parameters["@v2"].Value;
+                    v3 = Int32.Parse(command.Parameters["@v3"].Value.ToString());
+                    v4 = Int32.Parse(command.Parameters["@v4"].Value.ToString());
+                }
+            }
+
+            public bool commit()
+            {
+                if (trn == null)
+                {
+                    return false;
+                }
+                trn.Commit();
+                trn = null;
+                return true;
+            }
+
+            public bool rollback()
+            {
+                if (trn == null)
+                {
+                    return false;
+                }
+                trn.Rollback();
+                trn = null;
+                return true;
+            }
+        }
+    }
+}

--- a/src/System.Data.Odbc/tests/OdbcParameterTests.cs
+++ b/src/System.Data.Odbc/tests/OdbcParameterTests.cs
@@ -154,14 +154,13 @@ namespace System.Data.Odbc.Tests
                     "SET @v4 = datalength(@v2); " +
                 "END;";
 
-            DataTestUtility.RunNonQuery(DataTestUtility.OdbcConnStr, removeExistingStoredProcSql);
-            DataTestUtility.RunNonQuery(DataTestUtility.OdbcConnStr, createTestStoredProcSql);
-
-            DbAccessor dbAccessUtil = new DbAccessor();
-            dbAccessUtil.connectSqlServer(DataTestUtility.OdbcConnStr);
-
             try
             {
+                DataTestUtility.RunNonQuery(DataTestUtility.OdbcConnStr, removeExistingStoredProcSql);
+                DataTestUtility.RunNonQuery(DataTestUtility.OdbcConnStr, createTestStoredProcSql);
+
+                DbAccessor dbAccessUtil = new DbAccessor();
+                dbAccessUtil.connectSqlServer(DataTestUtility.OdbcConnStr);
                 dbAccessUtil.callProc("{ call testStoredProc(?,?,?,?) }", procDataType, procDataSize, v1, out v2, out v3, out v4);
                 dbAccessUtil.commit();
                 dbAccessUtil.disconnect();

--- a/src/System.Data.Odbc/tests/OdbcParameterTests.cs
+++ b/src/System.Data.Odbc/tests/OdbcParameterTests.cs
@@ -138,12 +138,14 @@ namespace System.Data.Odbc.Tests
 
         private static void RunTestProcedure(string procDataType, int procDataSize, object v1, out object v2, out int v3, out int v4)
         {
+            string procName = DataTestUtility.GetUniqueName("ODBCTEST", "", "");
+
             string removeExistingStoredProcSql =
-                "IF OBJECT_ID('testStoredProc', 'P') IS NOT NULL " +
-                    "DROP PROCEDURE testStoredProc;";
+                $"IF OBJECT_ID('{procName}', 'P') IS NOT NULL " +
+                    $"DROP PROCEDURE {procName};";
 
             string createTestStoredProcSql =
-                "CREATE PROCEDURE testStoredProc (" +
+                $"CREATE PROCEDURE {procName} (" +
                     $"@v1 {procDataType}({procDataSize}), " +
                     $"@v2 {procDataType}({procDataSize}) OUT, " +
                     "@v3 INTEGER OUT, " +
@@ -161,7 +163,7 @@ namespace System.Data.Odbc.Tests
 
                 DbAccessor dbAccessUtil = new DbAccessor();
                 dbAccessUtil.connectSqlServer(DataTestUtility.OdbcConnStr);
-                dbAccessUtil.callProc("{ call testStoredProc(?,?,?,?) }", procDataType, procDataSize, v1, out v2, out v3, out v4);
+                dbAccessUtil.callProc("{ call "+ procName+"(?,?,?,?) }", procDataType, procDataSize, v1, out v2, out v3, out v4);
                 dbAccessUtil.commit();
                 dbAccessUtil.disconnect();
             }

--- a/src/System.Data.Odbc/tests/OdbcParameterTests.cs
+++ b/src/System.Data.Odbc/tests/OdbcParameterTests.cs
@@ -135,7 +135,6 @@ namespace System.Data.Odbc.Tests
             Assert.Equal(str1000.Length * 2, inputLength);
             Assert.Equal(str2000.Length * 2, outputLength);
         }
-        
 
         private static void RunTestProcedure(string procDataType, int procDataSize, object v1, out object v2, out int v3, out int v4)
         {
@@ -155,18 +154,23 @@ namespace System.Data.Odbc.Tests
                     "SET @v4 = datalength(@v2); " +
                 "END;";
 
-            DataTestUtility.RunNonQuery(DataTestUtility.TcpConnStr, removeExistingStoredProcSql);
-            DataTestUtility.RunNonQuery(DataTestUtility.TcpConnStr, createTestStoredProcSql);
+            DataTestUtility.RunNonQuery(DataTestUtility.OdbcConnStr, removeExistingStoredProcSql);
+            DataTestUtility.RunNonQuery(DataTestUtility.OdbcConnStr, createTestStoredProcSql);
 
             DbAccessor dbAccessUtil = new DbAccessor();
             dbAccessUtil.connectSqlServer(DataTestUtility.OdbcConnStr);
-            dbAccessUtil.callProc("{ call testStoredProc(?,?,?,?) }", procDataType, procDataSize, v1, out v2, out v3, out v4);
-            dbAccessUtil.commit();
-            dbAccessUtil.disconnect();
 
-            DataTestUtility.RunNonQuery(DataTestUtility.TcpConnStr, removeExistingStoredProcSql);
+            try
+            {
+                dbAccessUtil.callProc("{ call testStoredProc(?,?,?,?) }", procDataType, procDataSize, v1, out v2, out v3, out v4);
+                dbAccessUtil.commit();
+                dbAccessUtil.disconnect();
+            }
+            finally
+            {
+                DataTestUtility.RunNonQuery(DataTestUtility.OdbcConnStr, removeExistingStoredProcSql);
+            }
         }
-        
 
         private class DbAccessor
         {

--- a/src/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
+++ b/src/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
@@ -13,6 +13,9 @@
     <Compile Include="CommandBuilderTests.cs" />
     <Compile Include="ReaderTests.cs" />
     <Compile Include="SmokeTest.cs" />
+    <Compile Include="TestCommon\DataTestUtility.cs" />
+    <Compile Include="TestCommon\CheckConnStrSetupFactAttribute.cs" />
+    <Compile Include="OdbcParameterTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="ConnectionStrings.Windows.cs" />

--- a/src/System.Data.Odbc/tests/TestCommon/CheckConnStrSetupFactAttribute.cs
+++ b/src/System.Data.Odbc/tests/TestCommon/CheckConnStrSetupFactAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Data.Odbc.Tests
+{
+    public class CheckConnStrSetupFactAttribute : FactAttribute
+    {
+        public CheckConnStrSetupFactAttribute()
+        {
+            if(!DataTestUtility.AreConnStringsSetup())
+            {
+                Skip = "Connection Strings Not Setup";
+            }
+        }
+    }
+}

--- a/src/System.Data.Odbc/tests/TestCommon/DataTestUtility.cs
+++ b/src/System.Data.Odbc/tests/TestCommon/DataTestUtility.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Data.SqlClient;
+
+namespace System.Data.Odbc.Tests
+{
+    public static class DataTestUtility
+    {
+        public static readonly string OdbcConnStr = null;
+        public static readonly string TcpConnStr = null;
+
+        static DataTestUtility()
+        {
+            OdbcConnStr = Environment.GetEnvironmentVariable("TEST_ODBC_CONN_STR");
+            TcpConnStr = Environment.GetEnvironmentVariable("TEST_TCP_CONN_STR");
+        }
+
+        public static bool AreConnStringsSetup()
+        {
+            return !string.IsNullOrEmpty(OdbcConnStr) && !string.IsNullOrEmpty(TcpConnStr);
+        }
+
+        public static void RunNonQuery(string connectionString, string sql)
+        {
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    command.CommandText = sql;
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+    }
+}

--- a/src/System.Data.Odbc/tests/TestCommon/DataTestUtility.cs
+++ b/src/System.Data.Odbc/tests/TestCommon/DataTestUtility.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Data.SqlClient;
+using System.Globalization;
 
 namespace System.Data.Odbc.Tests
 {
@@ -18,6 +18,19 @@ namespace System.Data.Odbc.Tests
         public static bool AreConnStringsSetup()
         {
             return !string.IsNullOrEmpty(OdbcConnStr);
+        }
+
+        // the name length will be no more then (16 + prefix.Length + escapeLeft.Length + escapeRight.Length)
+        // some providers does not support names (Oracle supports up to 30)
+        public static string GetUniqueName(string prefix, string escapeLeft, string escapeRight)
+        {
+            string uniqueName = string.Format("{0}{1}_{2}_{3}{4}",
+                escapeLeft,
+                prefix,
+                DateTime.Now.Ticks.ToString("X", CultureInfo.InvariantCulture), // up to 8 characters
+                Guid.NewGuid().ToString().Substring(0, 6), // take the first 6 characters only
+                escapeRight);
+            return uniqueName;
         }
 
         public static void RunNonQuery(string connectionString, string sql)

--- a/src/System.Data.Odbc/tests/TestCommon/DataTestUtility.cs
+++ b/src/System.Data.Odbc/tests/TestCommon/DataTestUtility.cs
@@ -9,27 +9,24 @@ namespace System.Data.Odbc.Tests
     public static class DataTestUtility
     {
         public static readonly string OdbcConnStr = null;
-        public static readonly string TcpConnStr = null;
 
         static DataTestUtility()
         {
             OdbcConnStr = Environment.GetEnvironmentVariable("TEST_ODBC_CONN_STR");
-            TcpConnStr = Environment.GetEnvironmentVariable("TEST_TCP_CONN_STR");
         }
 
         public static bool AreConnStringsSetup()
         {
-            return !string.IsNullOrEmpty(OdbcConnStr) && !string.IsNullOrEmpty(TcpConnStr);
+            return !string.IsNullOrEmpty(OdbcConnStr);
         }
 
         public static void RunNonQuery(string connectionString, string sql)
         {
-            using (SqlConnection connection = new SqlConnection(connectionString))
+            using (OdbcConnection connection = new OdbcConnection(connectionString))
             {
-                connection.Open();
-                using (SqlCommand command = connection.CreateCommand())
+                using (OdbcCommand command = new OdbcCommand(sql, connection))
                 {
-                    command.CommandText = sql;
+                    connection.Open();
                     command.ExecuteNonQuery();
                 }
             }


### PR DESCRIPTION
This is fix for the issue https://github.com/dotnet/corefx/issues/24417
***
Customer reported a bug for error in `OdbcParameter`. Customer was trying to get a `VARCHAR(8000)` type return value (output) from SQL Server stored procedure by `OdbcCommand`, and got exception thrown with error message:
```
[Microsoft][ODBC Driver 13 for SQL Server][SQL Server]Invalid parameter 2 (''):  
Data type 0x23 is a deprecated large object, or LOB, but is marked as output parameter.  
Deprecated types are not supported as output parameters. Use current large object types instead.
```
Customer was not able to receive any string output longer than 3,999 characters from the stored procedure. 
```
<Quotes from sample code>

OdbcCommand command = new OdbcCommand(sql, con, trn);
command.Parameters.Clear();
command.CommandType = CommandType.StoredProcedure;
command.Parameters.Add("@v1", OdbcType.VarChar, 8000); //Input

//Output. The error will not occur when 4000 is 3999.
command.Parameters.Add("@v2", OdbcType.VarChar, 4000); 

command.Parameters.Add("@v3", OdbcType.Int);
command.Parameters.Add("@v4", OdbcType.Int);
command.Parameters["@v1"].Direction = ParameterDirection.Input;
command.Parameters["@v2"].Direction = ParameterDirection.Output;
```
```
<Quotes from the StoredProcedure>

CREATE PROCEDURE testCSProc1 (
	@v1  VARCHAR(8000),
	@v2  VARCHAR(8000) OUT,
	@v3  INTEGER OUT,
	@v4  INTEGER OUT
)
AS
BEGIN
	SET @v2 = @v1 + @v1;
	SET @v3 = datalength(@v1);
	SET @v4 = datalength(@v2);
END;
GO
```