### PR TITLE
Update how we do filtering to avoid path comparsions

### DIFF
--- a/external/netfx/netfx.depproj
+++ b/external/netfx/netfx.depproj
@@ -44,8 +44,10 @@
     </PropertyGroup>
     <ItemGroup>
       <_excludeForNetFx Include="@(NetFxReference);netstandard" />
-      <_netstandardShimAssemblies Include="$(_NETStandardRefFolder)\*.dll" Exclude="@(_excludeForNetFx->'$(_NETStandardRefFolder)\%(Identity).dll')" />
-      <FileToExclude Include="@(_netstandardShimAssemblies->'%(FileName)')" />
+      <_allnetstandardAssemblies Include="$(_NETStandardRefFolder)\*.dll" />
+      <_netstandardAssemblyFileNames Include="@(_allnetstandardAssemblies->'%(Filename)')" Exclude="@(_excludeForNetFx)" />
+      <_netstandardShimAssemblies Include="@(_netstandardAssemblyFileNames->'$(_NETStandardRefFolder)\%(Identity).dll')" />
+      <FileToExclude Include="@(_netstandardAssemblyFileNames)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
In some cases we end up copying the incorrect set of files because
the path comparisions fail. It appears that in some cases msbuild
will normalize paths for *.dll wildcard expansion and switch slashes
around which causes the path comparsion to fail. We should avoid
comparing paths at all so instead do the filtering based on filename.

cc @ericstj @eerhardt 