### PR TITLE
Fix hang when SmtpClient.SendAsync fails to connect

### DIFF
--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -439,11 +439,11 @@ namespace System.Net.Mail
                 IAsyncResult result = _connection.BeginInitializeConnection(_host, _port, InitializeConnectionCallback, this);
                 if (result.CompletedSynchronously)
                 {
-                    _connection.EndInitializeConnection(result);
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Connect returned");
-
                     try
                     {
+                        _connection.EndInitializeConnection(result);
+                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Connect returned");
+
                         Handshake();
                     }
                     catch (Exception e)
@@ -458,11 +458,11 @@ namespace System.Net.Mail
                 if (!result.CompletedSynchronously)
                 {
                     ConnectAndHandshakeAsyncResult thisPtr = (ConnectAndHandshakeAsyncResult)result.AsyncState;
-                    thisPtr._connection.EndInitializeConnection(result);
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Connect returned {thisPtr}");
-
                     try
                     {
+                        thisPtr._connection.EndInitializeConnection(result);
+                        if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Connect returned {thisPtr}");
+
                         thisPtr.Handshake();
                     }
                     catch (Exception e)

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -281,6 +281,15 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
+        public async Task SendAsync_ServerDoesntExist_Throws()
+        {
+            using (var smtp = new SmtpClient(Guid.NewGuid().ToString("N")))
+            {
+                await Assert.ThrowsAsync<SmtpException>(() => smtp.SendMailAsync("anyone@anyone.com", "anyone@anyone.com", "subject", "body"));
+            }
+        }
+
+        [Fact]
         public void TestMailDelivery()
         {
             SmtpServer server = new SmtpServer();


### PR DESCRIPTION
If Send{Mail}Async fails to connect, an exception gets thrown/eaten, and the completion callback is never invoked / the returned Task is never completed.

(Ignore the first commit; it's just #24521, which this builds upon.  I'll squash it away when merging this.)
cc: @Priya91