### PR TITLE
Re-enable Tizen leg for PRs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -329,8 +329,7 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
                 // Set up triggers
                 if (isPR) {
                     // We run Tizen Debug and Linux Release as default PR builds
-                    if (//(osName == "Tizen" && configurationGroup == "Debug") || // Temporarily disable Tizen leg on PRs until break is fixed
-                        (osName == "Linux" && configurationGroup == "Release") ) {
+                    if ((osName == "Tizen" && configurationGroup == "Debug") || (osName == "Linux" && configurationGroup == "Release")) {
                         Utilities.addGithubPRTriggerForBranch(newJob, branch, "${osName} ${abi} ${configurationGroup} Build")
                     }
                     else {


### PR DESCRIPTION
Tizen CI was disabled from https://github.com/dotnet/corefx/pull/24349 last week.

Re-enabling Tizen CI, because nuget packages are published correctly for Tizen now and Tizen CI works well.

Please do not merge until all CI passed correctly.