### PR TITLE
Disable PngCodecTests on Unix

### DIFF
--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTesst.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTesst.cs
@@ -37,6 +37,7 @@ using Xunit;
 
 namespace MonoTests.System.Drawing.Imaging
 {
+    [ActiveIssue(24354, TestPlatforms.AnyUnix)]
     public class PngCodecTest
     {
         private bool IsArm64Process()


### PR DESCRIPTION
Lots of ArgumentException failures are taking out CI runs.
https://github.com/dotnet/corefx/issues/24354