### PR TITLE
Bump Microsoft.NETCore.Plaftorms package version and include it for servicing

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -21,7 +21,7 @@
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
-    <PlatformPackageVersion>2.0.0</PlatformPackageVersion>
+    <PlatformPackageVersion>2.0.1</PlatformPackageVersion>
     <CoreFxExpectedPrerelease>servicing-25727-01</CoreFxExpectedPrerelease>
     <CoreClrPackageVersion>2.0.2-servicing-25730-01</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25307-00</ExternalExpectedPrerelease>

--- a/dependencies.props
+++ b/dependencies.props
@@ -21,7 +21,7 @@
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
-    <PlatformPackageVersion>2.0.1</PlatformPackageVersion>
+    <PlatformPackageVersion>2.0.0</PlatformPackageVersion>
     <CoreFxExpectedPrerelease>servicing-25727-01</CoreFxExpectedPrerelease>
     <CoreClrPackageVersion>2.0.2-servicing-25730-01</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25307-00</ExternalExpectedPrerelease>

--- a/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
+++ b/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <PackageVersion>$(PlatformPackageVersion)</PackageVersion>
+    <PackageVersion>2.0.1</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -27,7 +27,7 @@
     <Project Include="$(MSBuildThisFileDirectory)..\pkg\NETStandard.Library.NETFramework\NETStandard.Library.NETFramework.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
-    <Project Include="$(MSBuildThisFileDirectory)..pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
   </ItemGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -27,6 +27,9 @@
     <Project Include="$(MSBuildThisFileDirectory)..\pkg\NETStandard.Library.NETFramework\NETStandard.Library.NETFramework.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)..pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <UsingTask TaskName="GenerateNetStandardSupportTable" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll" />


### PR DESCRIPTION
Note that .builds file is conditioned to include .pkgproj project to when `OfficialBuildId == ''` or `BuildAllConfigurations == true`. I wasn't sure which to include but I followed what we've been doing.

https://github.com/dotnet/corefx/blob/c2fb45936857c64fda2add64c5a950bd5bee4a9e/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.builds#L4-L6

Fixes: https://github.com/dotnet/corefx/issues/24551
cc: @weshaggard @janvorli @eerhardt 