### PR TITLE
Update CentOS 6 docker image

### DIFF
--- a/buildpipeline/centos.6.groovy
+++ b/buildpipeline/centos.6.groovy
@@ -8,7 +8,7 @@
 
 def submittedHelixJson = null
 
-simpleDockerNode('microsoft/dotnet-buildtools-prereqs:centos-6-d485f41-20173404063424') {
+simpleDockerNode('microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-20174311014331') {
     stage ('Checkout source') {
         checkoutRepo()
     }

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -34,7 +34,7 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "centos-6-d485f41-20173404063424",
+            "PB_DockerTag": "centos-6-376e1a3-20174311014331",
             "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols -RuntimeOS=rhel.6 -- /p:PortableBuild=false",
             "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -Outerloop -RuntimeOS=rhel.6 -- /p:ArchiveTests=true /p:EnableDumpling=true /p:PortableBuild=false",
             "PB_SyncArguments": "-p -RuntimeOS=rhel.6 -- /p:ArchGroup=x64 /p:PortableBuild=false",


### PR DESCRIPTION
This update fixes problem with git not supporting https protocol