### PR TITLE
Avoid StringBuilder/int[] overhead when p/invoking GetComputerName

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetComputerName.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetComputerName.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using System.Text;
 
 internal partial class Interop
 {
@@ -11,9 +10,6 @@ internal partial class Interop
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "GetComputerNameW")]
         private static extern unsafe int GetComputerName(char* lpBuffer, ref uint nSize);
-
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, BestFitMapping = false)]
-        public static extern bool GetComputerName(StringBuilder lpBuffer, int[] nSize);
 
         // maximum length of the NETBIOS name (not including NULL)
         private const int MAX_COMPUTERNAME_LENGTH = 15;

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -91,9 +91,7 @@ namespace System.Diagnostics
                     {
                         if (s_computerName == null)
                         {
-                            StringBuilder sb = new StringBuilder(256);
-                            Interop.Kernel32.GetComputerName(sb, new int[] { sb.Capacity });
-                            s_computerName = sb.ToString();
+                            s_computerName = Interop.Kernel32.GetComputerName() ?? string.Empty;
                         }
                     }
                 }


### PR DESCRIPTION
Minor nit: #24579 introduced another extern overload of `Interop.Kernel32.GetComputerName` that requires allocating/marshaling a `StringBuilder` and allocating an `int[]`. It's only called once from `PerformanceCounterLib` and the result is cached in a static field so it's not a huge perf concern, but I'd prefer simply calling the existing more efficient `GetComputerName` helper (used by `Environment.MachineName` on Windows) that avoids the extra code and overhead.

I decided not to switch `PerformanceCounterLib` to call `Environment.MachineName` because if the p/invoke fails, `Environment.MachineName` throws, whereas `PerformanceCounterLib` ignores errors and just returns an empty string (via call to `StringBuilder.ToString()` on an empty builder).