### PR TITLE
Ignore the type in SGEN if it contains any property that only have private setter

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -359,6 +359,22 @@ namespace Microsoft.XmlSerializer.Generator
             }
             if (xmlTypeMapping != null)
             {
+                if (xmlTypeMapping.Mapping != null && xmlTypeMapping.Mapping is StructMapping)
+                {
+                    foreach (MemberMapping memberMapping in ((StructMapping)xmlTypeMapping.Mapping).Members)
+                    {
+                        MemberInfo memberInfo = memberMapping.MemberInfo;
+                        if (memberInfo != null && memberInfo.MemberType == MemberTypes.Property)
+                        {
+                            PropertyInfo propertyInfo = memberInfo as PropertyInfo;
+                            if (propertyInfo != null && (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic))
+                            {
+                                return;
+                            }
+                        }
+                    }
+                }
+
                 xmlTypeMapping = importer.ImportTypeMapping(type);
                 mappings.Add(xmlTypeMapping);
                 importedTypes.Add(type);

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -2234,26 +2234,6 @@ public class TypeWithPrivateFieldAndPrivateGetPublicSetProperty
     }
 }
 
-public class TypeWithoutPublicSetter
-{
-    public string Name { get; private set; }
-
-    [XmlIgnore]
-    public int Age { get; private set; }
-
-    public Type MyType { get; private set; }
-
-    public string ValidProperty { get; set; }
-
-    public string PropertyWrapper
-    {
-        get
-        {
-            return ValidProperty;
-        }
-    }
-}
-
 [CompilerGenerated]
 public class TypeWithCompilerGeneratedAttributeButWithoutPublicSetter
 {

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -1166,3 +1166,23 @@ public class DefaultValuesSetToNaN
             this.DoubleField.GetHashCode() ^ this.SingleField.GetHashCode();
     }
 }
+
+public class TypeWithoutPublicSetter
+{
+    public string Name { get; private set; }
+
+    [XmlIgnore]
+    public int Age { get; private set; }
+
+    public Type MyType { get; private set; }
+
+    public string ValidProperty { get; set; }
+
+    public string PropertyWrapper
+    {
+        get
+        {
+            return ValidProperty;
+        }
+    }
+}


### PR DESCRIPTION
Fix #19723

@shmao @zhenlan @mconnew 