### PR TITLE
add some code to make sure we sent datagram before we try to receive it

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -2765,21 +2765,10 @@ namespace System.Net.Sockets.Tests
 
                 SocketUdpClient client = new SocketUdpClient(_log, serverSocket, connectTo, port, sendNow: false);
 
-                if (NetEventSource.IsEnabled)
-                {
-                    NetEventSource.Info(this, $"SRC:{connectTo} {port} DST:{serverSocket.LocalEndPoint}");
-                }
-
-                // wait for send to finish instead of spawning background task to avoid race condition
                 client.ClientSend();
 
                 EndPoint receivedFrom = new IPEndPoint(connectTo, port);
                 int received = serverSocket.ReceiveFrom(new byte[1], ref receivedFrom);
-
-                if (NetEventSource.IsEnabled)
-                {
-                    NetEventSource.Info(this, $"SRC:{connectTo} {port} DST:{serverSocket.LocalEndPoint} RECEIVED:{received}");
-                }
 
                 Assert.Equal(1, received);
                 Assert.Equal<Type>(receivedFrom.GetType(), typeof(IPEndPoint));

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}</ProjectGuid>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
@@ -96,6 +97,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+      <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This has been long outstanding problem. I was able to reproduce this locally on old Ubuntu 14 and running ALL tests in loop. This did non repro while running only single test or running them in sequence. 

I was able to collect traces suggesting that in some cases send() is called after recv failed. 
I added Task.Wait() to increase changes that sent is actually done when we try to receive. 
With this change I was able to run the test for a day  where it would fail in about one hour before. 

My original change had 1s wait. However after one day, it failed again with new debug message that the sending task did not complete in 1s time. This is Azure VM instance where it is not clear what else is happening at the same time. I feel it would be better to be more liberal and possibly wait longer than have random failures. I bumped wait() timeout to 3s and receive timeout to 1s. 
This is still best guess but the tests are still running right now. When I get 3-5 days without failure I'll update this PR. I just wanted to get it out so people can comment on it.


fixes  #17681