### PR TITLE
Switch WaitNamedPipe and CreateNamedPipeClient invocation ordering.

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -33,7 +33,6 @@ namespace System.IO.Pipes
                 _pipeFlags |= (((int)_impersonationLevel - 1) << 16);
             }
 
-            // Pipe server should be free.  Let's try to connect to it.
             int access = 0;
             if ((PipeDirection.In & _direction) != 0)
             {
@@ -43,6 +42,8 @@ namespace System.IO.Pipes
             {
                 access |= Interop.Kernel32.GenericOperations.GENERIC_WRITE;
             }
+
+            // Let's try to connect first
             SafePipeHandle handle = Interop.Kernel32.CreateNamedPipeClient(_normalizedPipePath,
                                         access,           // read and write access
                                         0,                  // sharing: none
@@ -55,48 +56,56 @@ namespace System.IO.Pipes
             {
                 int errorCode = Marshal.GetLastWin32Error();
 
-                if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND ||
-                    errorCode == Interop.Errors.ERROR_PIPE_BUSY)
+                if (errorCode != Interop.Errors.ERROR_PIPE_BUSY &&
+                    errorCode != Interop.Errors.ERROR_FILE_NOT_FOUND)
                 {
-                    // ERROR_PIPE_BUSY
-                    // Handle the possible race condition of someone else connecting to the server 
-                    // between our calls to WaitNamedPipe & CreateFile.
-                    
-                    // ERROR_FILE_NOT_FOUND
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                }
+
+                if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath, timeout))
+                {
+                    errorCode = Marshal.GetLastWin32Error();
+
                     // Server is not yet created
-
-                    // Fallback to WaitNamedPipe
-                    if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath, timeout))
+                    if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND)
                     {
-                        int waitErrorCode = Marshal.GetLastWin32Error();
-
-                        // Server is not yet created
-                        if (waitErrorCode == Interop.Errors.ERROR_FILE_NOT_FOUND)
-                        {
-                            return false;
-                        }
-
-                        // The timeout has expired.
-                        if (waitErrorCode == Interop.Errors.ERROR_SUCCESS)
-                        {
-                            if (cancellationToken.CanBeCanceled)
-                            {
-                                // It may not be real timeout.
-                                return false;
-                            }
-                            throw new TimeoutException();
-                        }
-
-                        throw Win32Marshal.GetExceptionForWin32Error(waitErrorCode);
-                    }
-                    else
-                    {
-                        // We have not timeouted yet, but we need to update the timeout value.
                         return false;
                     }
+
+                    // The timeout has expired.
+                    if (errorCode == Interop.Errors.ERROR_SUCCESS)
+                    {
+                        if (cancellationToken.CanBeCanceled)
+                        {
+                            // It may not be real timeout.
+                            return false;
+                        }
+                        throw new TimeoutException();
+                    }
+
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
                 }
-                else
+
+                // Pipe server should be free.  Let's try to connect to it.
+                handle = Interop.Kernel32.CreateNamedPipeClient(_normalizedPipePath,
+                                            access,           // read and write access
+                                            0,                  // sharing: none
+                                            ref secAttrs,           // security attributes
+                                            FileMode.Open,      // open existing 
+                                            _pipeFlags,         // impersonation flags
+                                            IntPtr.Zero);  // template file: null
+
+                if (handle.IsInvalid)
                 {
+                    errorCode = Marshal.GetLastWin32Error();
+
+                    // Handle the possible race condition of someone else connecting to the server 
+                    // between our calls to WaitNamedPipe & CreateFile.
+                    if (errorCode == Interop.Errors.ERROR_PIPE_BUSY)
+                    {
+                        return false;
+                    }
+
                     throw Win32Marshal.GetExceptionForWin32Error(errorCode);
                 }
             }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -33,30 +33,6 @@ namespace System.IO.Pipes
                 _pipeFlags |= (((int)_impersonationLevel - 1) << 16);
             }
 
-            if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath, timeout))
-            {
-                int errorCode = Marshal.GetLastWin32Error();
-
-                // Server is not yet created
-                if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND)
-                {
-                    return false;
-                }
-
-                // The timeout has expired.
-                if (errorCode == Interop.Errors.ERROR_SUCCESS)
-                {
-                    if (cancellationToken.CanBeCanceled)
-                    {
-                        // It may not be real timeout.
-                        return false;
-                    }
-                    throw new TimeoutException();
-                }
-
-                throw Win32Marshal.GetExceptionForWin32Error(errorCode);
-            }
-
             // Pipe server should be free.  Let's try to connect to it.
             int access = 0;
             if ((PipeDirection.In & _direction) != 0)
@@ -79,14 +55,50 @@ namespace System.IO.Pipes
             {
                 int errorCode = Marshal.GetLastWin32Error();
 
-                // Handle the possible race condition of someone else connecting to the server 
-                // between our calls to WaitNamedPipe & CreateFile.
-                if (errorCode == Interop.Errors.ERROR_PIPE_BUSY)
+                if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND ||
+                    errorCode == Interop.Errors.ERROR_PIPE_BUSY)
                 {
-                    return false;
-                }
+                    // ERROR_PIPE_BUSY
+                    // Handle the possible race condition of someone else connecting to the server 
+                    // between our calls to WaitNamedPipe & CreateFile.
+                    
+                    // ERROR_FILE_NOT_FOUND
+                    // Server is not yet created
 
-                throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                    // Fallback to WaitNamedPipe
+                    if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath, timeout))
+                    {
+                        int waitErrorCode = Marshal.GetLastWin32Error();
+
+                        // Server is not yet created
+                        if (waitErrorCode == Interop.Errors.ERROR_FILE_NOT_FOUND)
+                        {
+                            return false;
+                        }
+
+                        // The timeout has expired.
+                        if (waitErrorCode == Interop.Errors.ERROR_SUCCESS)
+                        {
+                            if (cancellationToken.CanBeCanceled)
+                            {
+                                // It may not be real timeout.
+                                return false;
+                            }
+                            throw new TimeoutException();
+                        }
+
+                        throw Win32Marshal.GetExceptionForWin32Error(waitErrorCode);
+                    }
+                    else
+                    {
+                        // We have not timeouted yet, but we need to update the timeout value.
+                        return false;
+                    }
+                }
+                else
+                {
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                }
             }
 
             // Success! 


### PR DESCRIPTION
We need to do this as WaitNamedPipe is not supported in Windows Containers.
With this change, CreateNamedPipeClient will be called first, with call to WaitNamedPipe as
a fallback only. This will allow us to use NamedPipeClientStream inside Windows
Containers.

This should handle both https://github.com/dotnet/corefx/issues/24594 and https://github.com/dotnet/corefx/issues/22014.