### PR TITLE
Remove search trimming

### DIFF
--- a/src/System.IO.FileSystem/src/Resources/Strings.resx
+++ b/src/System.IO.FileSystem/src/Resources/Strings.resx
@@ -73,9 +73,6 @@
   <data name="Arg_InvalidHandle" xml:space="preserve">
     <value>Invalid handle.</value>
   </data>
-  <data name="Arg_InvalidSearchPattern" xml:space="preserve">
-    <value>Search pattern cannot contain '..' to move up directories and can be contained only internally in file/directory names, as in 'a..b'.</value>
-  </data>
   <data name="Arg_Path2IsRooted" xml:space="preserve">
     <value>Second path fragment must not be a drive or UNC name.</value>
   </data>

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Unix.cs
@@ -13,21 +13,6 @@ namespace System.IO
             return false;
         }
 
-        internal static void CheckSearchPattern(string searchPattern)
-        {
-            // ".." should not be used to move up directories. On Windows, this is more strict, and ".."
-            // can only be used in particular places in a name, whereas on Unix it can be used anywhere.
-            // So, throw if we find a ".." that's its own component in the path.
-            for (int index = 0; (index = searchPattern.IndexOf("..", index, StringComparison.Ordinal)) >= 0; index += 2)
-            {
-                if ((index == 0 || PathInternal.IsDirectorySeparator(searchPattern[index - 1])) && // previous character is directory separator
-                    (index + 2 == searchPattern.Length || PathInternal.IsDirectorySeparator(searchPattern[index + 2]))) // next character is directory separator
-                {
-                    throw new ArgumentException(SR.Arg_InvalidSearchPattern, nameof(searchPattern));
-                }
-            }
-        }
-
         internal static string TrimEndingDirectorySeparator(string path) =>
             path.Length > 1 && PathInternal.IsDirectorySeparator(path[path.Length - 1]) ? // exclude root "/"
                 path.Substring(0, path.Length - 1) :

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -510,7 +510,6 @@ namespace System.IO
                 searchPattern = NormalizeSearchPattern(searchPattern);
                 if (searchPattern.Length > 0)
                 {
-                    PathHelpers.CheckSearchPattern(searchPattern);
                     PathHelpers.ThrowIfEmptyOrRootedPath(searchPattern);
 
                     // If the search pattern contains any paths, make sure we factor those into 

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
@@ -138,8 +138,11 @@ namespace System.IO
                 // normalize search criteria
                 _searchCriteria = GetNormalizedSearchCriteria(fullSearchString, _normalizedSearchPath);
 
-                // fix up user path
-                string searchPatternDirName = Path.GetDirectoryName(normalizedSearchPattern);
+                // We allow for user search patterns to include directory separators. If it does,
+                // move the directory part out of the search pattern.
+                string searchPatternDirName = PathHelpers.IsEffectivelyEmpty(normalizedSearchPattern)
+                        ? null
+                        : Path.GetDirectoryName(normalizedSearchPattern);
                 _userPath = string.IsNullOrEmpty(searchPatternDirName) ?
                     originalUserPath :
                     Path.Combine(originalUserPath, searchPatternDirName);

--- a/src/System.IO.FileSystem/tests/Directory/EnumerableAPIs.cs
+++ b/src/System.IO.FileSystem/tests/Directory/EnumerableAPIs.cs
@@ -82,16 +82,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void Clone_Enumerator_Trimmed_SearchPattern()
-        {
-            DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            var enumerator1 = Directory.EnumerateFileSystemEntries(testDir.FullName, ((char)0xA).ToString());
-            var enumerator2 = enumerator1;
-            Assert.Empty(enumerator1.ToArray());
-            Assert.Empty(enumerator2.ToArray());
-        }
-
-        [Fact]
         public void Delete_Directory_After_Creating_Enumerable()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -879,13 +879,9 @@ namespace System.IO.Tests
             // search pattern is valid but directory doesn't exist
             Assert.Throws<DirectoryNotFoundException>(() => GetEntries(TestDirectory, Path.Combine("..ab ab.. .. abc..d", "abc..")));
 
-            // invalid search pattern trying to go up a directory with ..
-            Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, ".."));
-            Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, @".." + Path.DirectorySeparatorChar));
-            Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, Path.Combine("..ab ab.. .. abc..d", "abc", "..")));
-            Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, Path.Combine("..ab ab.. .. abc..d", "..", "abc")));
-            Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, Path.Combine("..", "..ab ab.. .. abc..d", "abc")));
-            Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, Path.Combine("..", "..ab ab.. .. abc..d", "abc") + Path.DirectorySeparatorChar));
+            // Use GetTestFilePath to make sure we don't walk out of our directory
+            GetEntries(GetTestFilePath(), "..");
+            GetEntries(GetTestFilePath(), @".." + Path.DirectorySeparatorChar);
         }
 
         #endregion

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -652,11 +652,26 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Search pattern with double dots throws ArgumentException
-        public void WindowsSearchPatternWithDoubleDots()
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public void WindowsSearchPatternWithDoubleDots_NetFX()
         {
             Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, Path.Combine("..ab ab.. .. abc..d", "abc..")));
             Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, ".."));
             Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, @".." + Path.DirectorySeparatorChar));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void WindowsSearchPatternWithDoubleDots()
+        {
+            // Throwing for these sorts of paths was an artifact of trying to enforce limited trust scenarios.
+            // It prevents access to real paths, and we already don't do this on Unix so we've removed it from CoreFX.
+            Assert.Throws<DirectoryNotFoundException>(() => GetEntries(TestDirectory, Path.Combine("..ab ab.. .. abc..d", "abc..")));
+
+            // Use GetTestFilePath to make sure we don't walk out of our directory
+            GetEntries(GetTestFilePath(), "..");
+            GetEntries(GetTestFilePath(), @".." + Path.DirectorySeparatorChar);
         }
 
         private static char[] OldWildcards = new char[] { '*', '?' };
@@ -759,12 +774,29 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Whitespace in search pattern returns nothing
-        public void WindowsSearchPatternWhitespace()
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public void WindowsSearchPatternWhitespace_NetFX()
         {
             Assert.Empty(GetEntries(TestDirectory, "           "));
             Assert.Empty(GetEntries(TestDirectory, "\n"));
             Assert.Empty(GetEntries(TestDirectory, " "));
             Assert.Empty(GetEntries(TestDirectory, "\t"));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void WindowsSearchPatternWhitespace()
+        {
+            // Trimming prevents finding actual files that can exist.
+            // We no longer trim proactively, and leave it to Windows.
+            Assert.Empty(GetEntries(TestDirectory, "           "));
+
+            // Illegal characters in path.
+            Assert.Throws<ArgumentException>(() => (GetEntries(TestDirectory, "\n")));
+            Assert.Empty(GetEntries(TestDirectory, " "));
+            // Illegal characters in path.
+            Assert.Throws<ArgumentException>(() => (GetEntries(TestDirectory, "\t")));
         }
 
         [Fact]


### PR DESCRIPTION
Trimming prevents access to valid Windows paths. We've removed trimming from the rest of our API surface, this is the last place we have it.

Fixes #21096