### PR TITLE
Remove faulty assert in ArrayList.Remove

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Collections/ArrayList.cs
+++ b/src/System.Runtime.Extensions/src/System/Collections/ArrayList.cs
@@ -633,7 +633,6 @@ namespace System.Collections
             Contract.Ensures(Count >= 0);
 
             int index = IndexOf(obj);
-            Debug.Assert(index >= 0 || !(obj is Int32), "You passed an Int32 to Remove that wasn't in the ArrayList." + Environment.NewLine + "Did you mean RemoveAt?  int: " + obj + "  Count: " + Count);
             if (index >= 0)
                 RemoveAt(index);
         }


### PR DESCRIPTION
It's perfectly valid to call Remove with a boxed int that doesn't exist in the list.  This is causing fail fasts in ArrayList's perf tests.
cc: @danmosemsft 