### PR TITLE
PerfCounter: Override SystemDiagnosticsSection.Properties

### DIFF
--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerfCounterSection.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerfCounterSection.cs
@@ -8,31 +8,12 @@ namespace System.Diagnostics
 {
     internal class PerfCounterSection : ConfigurationElement
     {
-        private static readonly ConfigurationPropertyCollection s_properties;
         private static readonly ConfigurationProperty s_propFileMappingSize = new ConfigurationProperty("filemappingsize", typeof(int), 524288, ConfigurationPropertyOptions.None);
-
-        static PerfCounterSection()
-        {
-            s_properties = new ConfigurationPropertyCollection();
-            s_properties.Add(s_propFileMappingSize);
-        }
+        private static readonly ConfigurationPropertyCollection s_properties = new ConfigurationPropertyCollection { s_propFileMappingSize };
 
         [ConfigurationProperty("filemappingsize", DefaultValue = 524288)]
-        public int FileMappingSize
-        {
-            get
-            {
-                return (int)this[s_propFileMappingSize];
-            }
-        }
+        public int FileMappingSize => (int)this[s_propFileMappingSize];
 
-        protected override ConfigurationPropertyCollection Properties
-        {
-            get
-            {
-                return s_properties;
-            }
-        }
+        protected override ConfigurationPropertyCollection Properties => s_properties;
     }
 }
-

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SystemDiagnosticsSection.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SystemDiagnosticsSection.cs
@@ -8,23 +8,12 @@ namespace System.Diagnostics
 {
     internal class SystemDiagnosticsSection : ConfigurationSection
     {
-        private static readonly ConfigurationPropertyCollection s_properties;
         private static readonly ConfigurationProperty s_propPerfCounters = new ConfigurationProperty("performanceCounters", typeof(PerfCounterSection), new PerfCounterSection(), ConfigurationPropertyOptions.None);
-
-        static SystemDiagnosticsSection()
-        {
-            s_properties = new ConfigurationPropertyCollection();
-            s_properties.Add(s_propPerfCounters);
-        }
+        private static readonly ConfigurationPropertyCollection s_properties = new ConfigurationPropertyCollection { s_propPerfCounters };
 
         [ConfigurationProperty("performanceCounters")]
-        public PerfCounterSection PerfCounters
-        {
-            get
-            {
-                return (PerfCounterSection)base[s_propPerfCounters];
-            }
-        }
+        public PerfCounterSection PerfCounters => (PerfCounterSection)base[s_propPerfCounters];
+
+        protected override ConfigurationPropertyCollection Properties => s_properties;
     }
 }
-


### PR DESCRIPTION
I noticed `s_properties` in `SystemDiagnosticsSection` wasn't used. In the [reference source](https://github.com/Microsoft/referencesource/blob/master/System/compmod/system/diagnostics/SystemDiagnosticsSection.cs#L42-L46) `Properties` is overridden to return `s_properties`, so do that here. Also, minor cleanup while making changes here (and do the same in `PerfCounterSection`).