### PR TITLE
Fix HttpWebRequest when sending with HTTP/1.0

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1200,6 +1200,8 @@ namespace System.Net
                     request.Headers.ConnectionClose = true;
                 }
 
+                request.Version = ProtocolVersion;
+
                 _sendRequestTask = client.SendAsync(
                     request,
                     _allowReadStreamBuffering ? HttpCompletionOption.ResponseContentRead : HttpCompletionOption.ResponseHeadersRead,

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -736,6 +736,7 @@ namespace System.Net.Tests
             Assert.Equal(HttpVersion.Version11, request.ProtocolVersion);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP does not allow HTTP/1.0 requests.")]
         [OuterLoop]
         [Theory]
         [InlineData(false)]

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Cache;
@@ -733,6 +734,43 @@ namespace System.Net.Tests
 
             request.ProtocolVersion = HttpVersion.Version11;
             Assert.Equal(HttpVersion.Version11, request.ProtocolVersion);
+        }
+
+        [OuterLoop]
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ProtocolVersion_SetThenSendRequest_CorrectHttpRequestVersionSent(bool isVersion10)
+        {
+            Version requestVersion = isVersion10 ? HttpVersion.Version10 : HttpVersion.Version11;
+            Version receivedRequestVersion = null;
+
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                HttpWebRequest request = WebRequest.CreateHttp(url);
+                request.ProtocolVersion = requestVersion;
+
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server);
+
+                using (HttpWebResponse response = (HttpWebResponse) await getResponse)
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+
+                List<string> receivedRequest = await serverTask;
+                string statusLine = receivedRequest[0];
+                if (statusLine.Contains("/1.0"))
+                {
+                    receivedRequestVersion = HttpVersion.Version10;
+                }
+                else if (statusLine.Contains("/1.1"))
+                {
+                    receivedRequestVersion = HttpVersion.Version11;
+                }
+            });
+
+            Assert.Equal(requestVersion, receivedRequestVersion);
         }
 
         [Fact]


### PR DESCRIPTION
The HttpWebRequest.ProtocolVersion property was implemented. But it was
not checked when actually creating the request (which uses HttpClient
underneath). So, all requests were sent with HTTP/1.1.

This fix now uses the ProtocolVersion property and sends either
HTTP/1.0 or HTTP/1.1.

Note: HTTP/2.0 is currently not supported when setting the
ProtocolVersion property. An ArgumentException is thrown. This is the
existing .NET Framework behavior which was ported to .NET Core. We could
investigate changing this in the future to allow ProtocolVersion to be
set to 2.0.

Fixes #24597