### PR TITLE
Environment.SystemDirectory: Avoid StringBuilder overhead

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetSystemDirectoryW.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetSystemDirectoryW.cs
@@ -2,14 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 internal static partial class Interop
 {
     internal static partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int GetSystemDirectoryW([Out] StringBuilder lpBuffer, int jSize);
+        private static extern unsafe int GetSystemDirectoryW(char* lpBuffer, int jSize);
+
+        internal static unsafe int GetSystemDirectoryW(Span<char> buffer)
+        {
+            fixed (char* bufferPtr = &buffer.DangerousGetPinnableReference())
+            {
+                return GetSystemDirectoryW(bufferPtr, buffer.Length);
+            }
+        }
     }
 }


### PR DESCRIPTION
Use a stack allocated buffer, with fallback to a char array.

Results on my machine:

| Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------- |----------:|----------:|----------:|-------:|----------:|
| Before | 186.50 ns | 1.6456 ns | 1.5393 ns | 0.1447 |     608 B |
|  After |  68.68 ns | 0.6775 ns | 0.6006 ns | 0.0151 |      64 B |