### PR TITLE
Fix for GraphicsPathIterator.CopyData throws EntrypointNotFoundException when index is out of range.

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPathIterator.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPathIterator.cs
@@ -201,7 +201,7 @@ namespace System.Drawing.Drawing2D
             return resultCount;
         }
 
-        public int CopyData(ref PointF[] points, ref byte[] types, int startIndex, int endIndex)
+        public unsafe int CopyData(ref PointF[] points, ref byte[] types, int startIndex, int endIndex)
         {
             if ((points.Length != types.Length) || (endIndex - startIndex + 1 > points.Length))
                 throw SafeNativeMethods.Gdip.StatusException(SafeNativeMethods.Gdip.InvalidParameter);
@@ -224,7 +224,7 @@ namespace System.Drawing.Drawing2D
 
                 if (resultCount < count)
                 {
-                    SafeNativeMethods.ZeroMemory((IntPtr)(checked((long)memoryPts + resultCount * size)), (UIntPtr)((count - resultCount) * size));
+                    IntSafeNativeMethods.ZeroMemory((byte*)(checked((long)memoryPts + resultCount * size)), (ulong)((count - resultCount) * size));
                 }
 
                 points = SafeNativeMethods.Gdip.ConvertGPPOINTFArrayF(memoryPts, count);

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPathIterator.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPathIterator.cs
@@ -224,7 +224,7 @@ namespace System.Drawing.Drawing2D
 
                 if (resultCount < count)
                 {
-                    IntSafeNativeMethods.ZeroMemory((byte*)(checked((long)memoryPts + resultCount * size)), (ulong)((count - resultCount) * size));
+                    SafeNativeMethods.ZeroMemory((byte*)(checked((long)memoryPts + resultCount * size)), (ulong)((count - resultCount) * size));
                 }
 
                 points = SafeNativeMethods.Gdip.ConvertGPPOINTFArrayF(memoryPts, count);

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPathIterator.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPathIterator.cs
@@ -164,7 +164,7 @@ namespace System.Drawing.Drawing2D
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        public int Enumerate(ref PointF[] points, ref byte[] types)
+        public unsafe int Enumerate(ref PointF[] points, ref byte[] types)
         {
             if (points.Length != types.Length)
                 throw SafeNativeMethods.Gdip.StatusException(SafeNativeMethods.Gdip.InvalidParameter);
@@ -187,7 +187,7 @@ namespace System.Drawing.Drawing2D
 
                 if (resultCount < count)
                 {
-                    SafeNativeMethods.ZeroMemory((IntPtr)(checked((long)memoryPts + resultCount * size)), (UIntPtr)((count - resultCount) * size));
+                    SafeNativeMethods.ZeroMemory((byte*)(checked((long)memoryPts + resultCount * size)), (ulong)((count - resultCount) * size));
                 }
 
                 points = SafeNativeMethods.Gdip.ConvertGPPOINTFArrayF(memoryPts, count);

--- a/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
@@ -855,10 +855,8 @@ namespace System.Drawing
         
         static internal unsafe void ZeroMemory(byte* ptr, ulong length)
         {
-            for (ulong i = 0; i < length; i++)
-            {
-                *ptr++ = 0;
-            }
+            byte* end = ptr + length;
+            while (ptr != end) *ptr++ = 0;
         }
 
         public const int ERROR_ACCESS_DENIED = 5;

--- a/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
@@ -856,6 +856,14 @@ namespace System.Drawing
         [DllImport(ExternDll.Kernel32)]
         static internal extern void ZeroMemory(IntPtr destination, UIntPtr length);
 
+        static internal unsafe void ZeroMemory(byte* ptr, ulong length)
+        {
+            for (ulong i = 0; i < length; i++)
+            {
+                *ptr++ = 0;
+            }
+        }
+
         public const int ERROR_ACCESS_DENIED = 5;
         public const int ERROR_INVALID_PARAMETER = 87;
         public const int ERROR_PROC_NOT_FOUND = 127;

--- a/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
@@ -852,10 +852,7 @@ namespace System.Drawing
         {
             return IntGlobalAlloc(uFlags, new UIntPtr(dwBytes));
         }
-
-        [DllImport(ExternDll.Kernel32)]
-        static internal extern void ZeroMemory(IntPtr destination, UIntPtr length);
-
+        
         static internal unsafe void ZeroMemory(byte* ptr, ulong length)
         {
             for (ulong i = 0; i < length; i++)

--- a/src/System.Drawing.Common/src/misc/GDI/SafeNativeMethods.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/SafeNativeMethods.cs
@@ -39,5 +39,13 @@ namespace System.Drawing.Internal
             DbgUtil.AssertWin32(hRgn != IntPtr.Zero, "IntCreateRectRgn([x1={0}, y1={1}, x2={2}, y2={3}]) failed.", x1, y1, x2, y2);
             return hRgn;
         }
+
+        internal static unsafe void ZeroMemory(byte* ptr, ulong length)
+        {
+            for (ulong i = 0; i < length; i++)
+            {
+                *ptr++ = 0;
+            }
+        }
     }
 }

--- a/src/System.Drawing.Common/src/misc/GDI/SafeNativeMethods.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/SafeNativeMethods.cs
@@ -38,14 +38,6 @@ namespace System.Drawing.Internal
             IntPtr hRgn = System.Internal.HandleCollector.Add(IntCreateRectRgn(x1, y1, x2, y2), CommonHandles.GDI);
             DbgUtil.AssertWin32(hRgn != IntPtr.Zero, "IntCreateRectRgn([x1={0}, y1={1}, x2={2}, y2={3}]) failed.", x1, y1, x2, y2);
             return hRgn;
-        }
-
-        internal static unsafe void ZeroMemory(byte* ptr, ulong length)
-        {
-            for (ulong i = 0; i < length; i++)
-            {
-                *ptr++ = 0;
-            }
-        }
+        }        
     }
 }

--- a/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathIteratorTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathIteratorTests.cs
@@ -378,8 +378,7 @@ namespace System.Drawing.Drawing2D.Tests
             yield return new object[] { new PointF[3], new byte[3], 0, int.MaxValue };
             yield return new object[] { new PointF[3], new byte[3], 2, 0 };
         }
-
-        [ActiveIssue(22026)]
+        
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [MemberData(nameof(CopyData_StartEndIndexesOutOfRange_TestData))]
         public void CopyData_StartEndIndexesOutOfRange_ReturnsExpeced(PointF[] points, byte[] types, int startIndex, int endIndex)


### PR DESCRIPTION
Work related to (#22026)