### PR TITLE
Remove dead code from Microsoft.VisualBasic

### DIFF
--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Symbols.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Symbols.vb
@@ -510,11 +510,6 @@ Namespace Microsoft.VisualBasic.CompilerServices
             Return method.GetGenericArguments
         End Function
 
-        Friend Shared Function GetTypeParameters(ByVal type As Type) As Type()
-            Debug.Assert(type.GetGenericTypeDefinition Is Nothing, "expected unbound generic type")
-            Return type.GetGenericArguments
-        End Function
-
         Friend Shared Function GetTypeArguments(ByVal type As Type) As Type()
             Debug.Assert(type.GetGenericTypeDefinition IsNot Nothing, "expected bound generic type")
             Return type.GetGenericArguments

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.LateBinder.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.LateBinder.vb
@@ -47,7 +47,6 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
         Friend Const OptionCompareTextFlags As CompareOptions = (CompareOptions.IgnoreCase Or CompareOptions.IgnoreWidth Or CompareOptions.IgnoreKanaType)
 
-        ' DON'T ACCESS DIRECTLY! Go through the property below
         Private Shared ReadOnly s_resourceManagerSyncObj As Object = New Object
 
         Friend Shared m_achIntlSpace() As Char = {chSpace, chIntlSpace}

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.LateBinder.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.LateBinder.vb
@@ -48,8 +48,6 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Friend Const OptionCompareTextFlags As CompareOptions = (CompareOptions.IgnoreCase Or CompareOptions.IgnoreWidth Or CompareOptions.IgnoreKanaType)
 
         ' DON'T ACCESS DIRECTLY! Go through the property below
-        Private Shared s_VBAResourceManager As System.Resources.ResourceManager
-        Private Shared s_triedLoadingResourceManager As Boolean
         Private Shared ReadOnly s_resourceManagerSyncObj As Object = New Object
 
         Friend Shared m_achIntlSpace() As Char = {chSpace, chIntlSpace}
@@ -79,7 +77,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         '         This one is exposed because I have to be able to get at localized error
         '         strings from the MY template
         '  Param: ID - Identifier for the string to be retrieved
-        '  Param: Args - An array of params used to replace placeholders. 
+        '  Param: Args - An array of params used to replace placeholders.
         'Returns: The resource string if found or an error message string
         '*****************************************************************************
         Public Shared Function GetResourceString(ByVal resourceKey As String, ByVal ParamArray args() As String) As String

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.vb
@@ -57,32 +57,8 @@ Namespace Global.Microsoft.VisualBasic.CompilerServices
     Friend Module ReflectionExtensions
 
         <System.Runtime.CompilerServices.ExtensionAttribute()>
-        Public Function MemberType(ByVal memberInfo As MemberInfo) As MemberTypes
-            If TypeOf memberInfo Is ConstructorInfo Then
-                Return MemberTypes.Constructor
-            ElseIf TypeOf memberInfo Is MethodInfo Then
-                Return MemberTypes.Method
-            ElseIf TypeOf memberInfo Is PropertyInfo Then
-                Return MemberTypes.Property
-            ElseIf TypeOf memberInfo Is FieldInfo Then
-                Return MemberTypes.Field
-            ElseIf TypeOf memberInfo Is EventInfo Then
-                Return MemberTypes.Event
-            ElseIf TypeOf memberInfo Is System.Reflection.TypeInfo Then
-                Return MemberTypes.TypeInfo
-            Else
-                Throw New System.ArgumentException
-            End If
-        End Function
-
-        <System.Runtime.CompilerServices.ExtensionAttribute()>
         Public Function GetTypeCode(type As Type) As TypeCode
             Return Type.GetTypeCode(type)
-        End Function
-
-        <System.Runtime.CompilerServices.ExtensionAttribute()>
-        Public Function IsSubclassOf(source As Type, other As Type) As Boolean
-            Return source.IsSubclassOf(other)
         End Function
 
         Public ReadOnly Property BindingFlagsInvokeMethod As BindingFlags
@@ -334,7 +310,7 @@ Namespace Global.Microsoft.VisualBasic.CompilerServices
                 ' fallback to "IsEquivalentTo"
                 Dim fallbackMemberEquivalence As Func(Of MethodBase, MethodBase, Boolean) = Function(m1param, m2param) m1param.IsEquivalentTo(m2param)
 
-                ' fallback must work 
+                ' fallback must work
                 s_MemberEquivalence = fallbackMemberEquivalence
                 Return fallbackMemberEquivalence(m1, m2)
             End Function


### PR DESCRIPTION
PR addresses issue #17905, project **Microsoft.VisualBasic**.

There were just a few things to remove. In the [diff file](http://tempcoverage.blob.core.windows.net/report2/Microsoft.VisualBasic.diff.html), there are some parts marked red, which I did not remove (extra to the _not to remove cases_ mentioned in the issue itself):

- Enum `vbErrors`: it is used in the `ExceptionUtils` class. Probably it was not used when the diff was created.
- `!=` operators (`<>` in Visual Basic) in `Method` class (`Symbols.vb` file). I believe that even if they are not used, the should stay there as counterparts to `==` operators.