### PR TITLE
Add null check when setting Packaging property

### DIFF
--- a/src/System.IO.Packaging/src/System/IO/Packaging/PartBasedPackageProperties.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/PartBasedPackageProperties.cs
@@ -397,8 +397,8 @@ namespace System.IO.Packaging
                 // If the binding is an assignment rather than an initialization, set the dirty flag.
                 _dirty = !initializing;
             }
-            // Case of an initial value being set for a property.
-            else
+            // Case of an initial value being set for a property. If value is null, no need to do anything
+            else if (value != null)
             {
                 _propertyDictionary.Add(propertyenum, value);
                 // If the binding is an assignment rather than an initialization, set the dirty flag.

--- a/src/System.IO.Packaging/tests/Tests.cs
+++ b/src/System.IO.Packaging/tests/Tests.cs
@@ -3496,21 +3496,52 @@ namespace System.IO.Packaging.Tests
             using (var package = Package.Open(ms, FileMode.Create))
             {
                 package.PackageProperties.Category = null;
+                Assert.Null(package.PackageProperties.Category);
+
                 package.PackageProperties.ContentStatus = null;
+                Assert.Null(package.PackageProperties.ContentStatus);
+
                 package.PackageProperties.ContentType = null;
+                Assert.Null(package.PackageProperties.ContentType);
+
                 package.PackageProperties.Created = null;
+                Assert.Null(package.PackageProperties.Created);
+
                 package.PackageProperties.Creator = null;
+                Assert.Null(package.PackageProperties.Creator);
+
                 package.PackageProperties.Description = null;
+                Assert.Null(package.PackageProperties.Description);
+
                 package.PackageProperties.Identifier = null;
+                Assert.Null(package.PackageProperties.Identifier);
+
                 package.PackageProperties.Keywords = null;
+                Assert.Null(package.PackageProperties.Keywords);
+
                 package.PackageProperties.Language = null;
+                Assert.Null(package.PackageProperties.Language);
+
                 package.PackageProperties.LastModifiedBy = null;
+                Assert.Null(package.PackageProperties.LastModifiedBy);
+
                 package.PackageProperties.LastPrinted = null;
+                Assert.Null(package.PackageProperties.LastPrinted);
+
                 package.PackageProperties.Modified = null;
+                Assert.Null(package.PackageProperties.Modified);
+
                 package.PackageProperties.Revision = null;
+                Assert.Null(package.PackageProperties.Revision);
+
                 package.PackageProperties.Subject = null;
+                Assert.Null(package.PackageProperties.Subject);
+
                 package.PackageProperties.Title = null;
+                Assert.Null(package.PackageProperties.Title);
+
                 package.PackageProperties.Version = null;
+                Assert.Null(package.PackageProperties.Version);
             }
         }
 

--- a/src/System.IO.Packaging/tests/Tests.cs
+++ b/src/System.IO.Packaging/tests/Tests.cs
@@ -3489,6 +3489,31 @@ namespace System.IO.Packaging.Tests
             tempGuidName.Delete();
         }
 
+        [Fact]
+        public void SetEmptyPropertyToNull()
+        {
+            using (var ms = new MemoryStream())
+            using (var package = Package.Open(ms, FileMode.Create))
+            {
+                package.PackageProperties.Category = null;
+                package.PackageProperties.ContentStatus = null;
+                package.PackageProperties.ContentType = null;
+                package.PackageProperties.Created = null;
+                package.PackageProperties.Creator = null;
+                package.PackageProperties.Description = null;
+                package.PackageProperties.Identifier = null;
+                package.PackageProperties.Keywords = null;
+                package.PackageProperties.Language = null;
+                package.PackageProperties.LastModifiedBy = null;
+                package.PackageProperties.LastPrinted = null;
+                package.PackageProperties.Modified = null;
+                package.PackageProperties.Revision = null;
+                package.PackageProperties.Subject = null;
+                package.PackageProperties.Title = null;
+                package.PackageProperties.Version = null;
+            }
+        }
+
         private const string DocumentRelationshipType = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
     }
 


### PR DESCRIPTION
System.IO.Packaging properties use `null` to delete a property. However, the case where a property is set to `null` when it has never been set before was not covered and was hitting a `Debug.Assert`. This adds a null check when setting the property to cover this case.

Fixes #23795 