### PR TITLE
Remove dead code from System.IO.Compression

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/FileFormats.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/FileFormats.cs
@@ -17,29 +17,5 @@ namespace System.IO.Compression
         bool ReadFooter(InputBuffer input);
         void UpdateWithBytesRead(byte[] buffer, int offset, int bytesToCopy);
         void Validate();
-
-        /// <summary>
-        /// A reader corresponds to an expected file format and contains methods
-        /// to read header/footer data from a file of that format. If the Zlib library
-        /// is instead being used and the file format is supported, we can simply pass
-        /// a supported WindowSize and let Zlib do the header/footer parsing for us.
-        ///
-        /// This Property allows getting of a ZLibWindowSize that can be used in place
-        /// of manually parsing the raw data stream.
-        /// </summary>
-        /// <return>
-        /// For raw data, return -8..-15
-        /// For GZip header detection and decoding, return 16..31
-        /// For GZip and Zlib header detection and decoding, return 32..47
-        /// </return>
-        /// <remarks>
-        /// The windowBits parameter for inflation must be greater than or equal to the
-        /// windowBits parameter used in deflation.
-        /// </remarks>
-        /// <remarks>
-        /// If the incorrect header information is used, zlib inflation will likely throw a
-        /// Z_DATA_ERROR exception.
-        ///</remarks>
-        int ZLibWindowSize { get; }
     }
 }

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -91,17 +91,6 @@ namespace System.IO.Compression
 
         private IFileFormatReader _formatReader; // class to decode header and footer (e.g. gzip)
 
-        public InflaterManaged(bool deflate64)
-        {
-            _output = new OutputWindow();
-            _input = new InputBuffer();
-
-            _codeList = new byte[HuffmanTree.MaxLiteralTreeElements + HuffmanTree.MaxDistTreeElements];
-            _codeLengthTreeCodeLength = new byte[HuffmanTree.NumberOfCodeLengthTreeElements];
-            _deflate64 = deflate64;
-            Reset();
-        }
-
         internal InflaterManaged(IFileFormatReader reader, bool deflate64)
         {
             _output = new OutputWindow();
@@ -118,13 +107,6 @@ namespace System.IO.Compression
             Reset();
         }
 
-        public void SetFileFormatReader(IFileFormatReader reader)
-        {
-            _formatReader = reader;
-            _hasFormatReader = true;
-            Reset();
-        }
-
         private void Reset()
         {
             _state = _hasFormatReader ?
@@ -138,8 +120,6 @@ namespace System.IO.Compression
         public bool Finished() => _state == InflaterState.Done || _state == InflaterState.VerifyingFooter;
 
         public int AvailableOutput => _output.AvailableBytes;
-
-        public bool NeedsInput() => _input.NeedsInput();
 
         public int Inflate(byte[] bytes, int offset, int length)
         {

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibException.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibException.cs
@@ -37,13 +37,6 @@ namespace System.IO.Compression
         /// developers should prefer using the constructor
         /// <code>public ZLibException(string message, string zlibErrorContext, ZLibNative.ErrorCode zlibErrorCode, string zlibErrorMessage)</code>.
         /// </summary>
-        public ZLibException() { }
-
-        /// <summary>
-        /// This constructor is provided in compliance with common NetFx design patterns;
-        /// developers should prefer using the constructor
-        /// <code>public ZLibException(string message, string zlibErrorContext, ZLibNative.ErrorCode zlibErrorCode, string zlibErrorMessage)</code>.
-        /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         public ZLibException(string message) : base(message) { }
 
@@ -55,23 +48,5 @@ namespace System.IO.Compression
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="inner">The exception that is the cause of the current exception, or a <code>null</code>.</param>
         public ZLibException(string message, Exception innerException) : base(message, innerException) { }
-
-        public string ZLibContext
-        {
-            [SecurityCritical]
-            get { return _zlibErrorContext; }
-        }
-
-        public int ZLibErrorCode
-        {
-            [SecurityCritical]
-            get { return (int)_zlibErrorCode; }
-        }
-
-        public string ZLibErrorMessage
-        {
-            [SecurityCritical]
-            get { return _zlibErrorMessage; }
-        }
     }
 }

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibException.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibException.cs
@@ -37,8 +37,7 @@ namespace System.IO.Compression
         /// developers should prefer using the constructor
         /// <code>public ZLibException(string message, string zlibErrorContext, ZLibNative.ErrorCode zlibErrorCode, string zlibErrorMessage)</code>.
         /// </summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        public ZLibException(string message) : base(message) { }
+        public ZLibException() { }
 
         /// <summary>
         /// This constructor is provided in compliance with common NetFx design patterns;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibNative.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibNative.cs
@@ -327,29 +327,6 @@ namespace System.IO.Compression
                 return errC;
             }
 
-            /// <summary>
-            /// This function is equivalent to inflateEnd followed by inflateInit.
-            /// The stream will keep attributes that may have been set by inflateInit2.
-            /// </summary>
-            [SecurityCritical]
-            public ErrorCode InflateReset(int windowBits)
-            {
-                EnsureNotDisposed();
-                EnsureState(State.InitializedForInflate);
-
-                ErrorCode errC = Interop.zlib.InflateEnd(ref _zStream);
-                if (errC != ErrorCode.Ok)
-                {
-                    _initializationState = State.Disposed;
-                    return errC;
-                }
-
-                errC = Interop.zlib.InflateInit2_(ref _zStream, windowBits);
-                _initializationState = State.InitializedForInflate;
-
-                return errC;
-            }
-
             // This can work even after XxflateEnd().
             [SecurityCritical]
             public string GetErrorMessage() => _zStream.msg != ZNullPtr ? Marshal.PtrToStringAnsi(_zStream.msg) : string.Empty;

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -49,13 +49,6 @@ namespace System.IO.Compression
         private CompressionLevel? _compressionLevel;
 
         // Initializes, attaches it to archive
-        internal ZipArchiveEntry(ZipArchive archive, ZipCentralDirectoryFileHeader cd, CompressionLevel compressionLevel)
-            : this(archive, cd)
-        {
-            _compressionLevel = compressionLevel;
-        }
-
-        // Initializes, attaches it to archive
         internal ZipArchiveEntry(ZipArchive archive, ZipCentralDirectoryFileHeader cd)
         {
             _archive = archive;
@@ -1239,7 +1232,5 @@ namespace System.IO.Compression
         private enum BitFlagValues : ushort { DataDescriptor = 0x8, UnicodeFileName = 0x800 }
 
         internal enum CompressionMethodValues : ushort { Stored = 0x0, Deflate = 0x8, Deflate64 = 0x9, BZip2 = 0xC, LZMA = 0xE }
-
-        private enum OpenableValues { Openable, FileNonExistent, FileTooLarge }
     }
 }


### PR DESCRIPTION
PR addresses issue #17905 , project **System.IO.Compression**.

I did not remove these things:
- Members of `PathInternal` class. This class is in `src\Common` and not directly in `System.IO.Compression`.
- `SR.Argument_InvalidPathChars` - used in `PathInternal`.
- `zlib.internal unsafe static extern uint crc32(uint crc, byte* buffer, int len)` - used in `Crc32Helper`.
- `DeflateManagedStream.SetFileFormatWriter(IFileFormatWriter writer)` - not used. But when removed, the project will not compile with _error CS0649: Field 'DeflateManagedStream.\_formatWriter' is never assigned to..._ So there is probably some bigger refactoring needed.
