### PR TITLE
revert part of #24098. do not use shell to find KDestroyCmd.

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
@@ -73,31 +73,14 @@ namespace System.Net.Security.Tests
             }
 
             // Clear the credentials
-            try
+            var startInfo = new ProcessStartInfo(KDestroyCmd);
+            startInfo.CreateNoWindow = true;
+            startInfo.Arguments = "-A";
+            using (Process clearCreds = Process.Start(startInfo))
             {
-                var startInfo = new ProcessStartInfo(KDestroyCmd);
-                startInfo.UseShellExecute = true;
-                startInfo.CreateNoWindow = true;
-                startInfo.Arguments = "-A";
-                using (Process clearCreds = Process.Start(startInfo))
-                {
-                    clearCreds.WaitForExit();
-                    output.WriteLine("kdestroy returned {0}", clearCreds.ExitCode);
-                    return (clearCreds.ExitCode == 0);
-                }
-            }
-            catch (Win32Exception)
-            {
-                // https://github.com/dotnet/corefx/issues/24000
-                // on these distros right now
-                Assert.True(PlatformDetection.IsUbuntu1704 ||
-                            PlatformDetection.IsUbuntu1710 ||
-                            PlatformDetection.IsOpenSUSE   ||
-                            PlatformDetection.IsFedora     ||
-                            PlatformDetection.IsDebian     ||
-                            PlatformDetection.IsCentos7);
-
-                return false;
+                clearCreds.WaitForExit();
+                output.WriteLine("kdestroy returned {0}", clearCreds.ExitCode);
+                return (clearCreds.ExitCode == 0);
             }
         }
 


### PR DESCRIPTION
@dotnet-bot test outerloop netcoreapp Ubuntu17.10 Release
@dotnet-bot test outerloop netcoreapp Ubuntu17.04 Release
@dotnet-bot test outerloop netcoreapp Centos7 Release

