### PR TITLE
Try find PDB from all DebugDirectoryEntry

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
@@ -690,11 +690,13 @@ namespace System.Reflection.PortableExecutable
 
             // First try .pdb file specified in CodeView data (we prefer .pdb file on disk over embedded PDB
             // since embedded PDB needs decompression which is less efficient than memory-mapping the file).
-            var codeViewEntry = entries.FirstOrDefault(e => e.IsPortableCodeView);
-            if (codeViewEntry.DataSize != 0 && 
-                TryOpenCodeViewPortablePdb(codeViewEntry, peImageDirectory, pdbFileStreamProvider, out pdbReaderProvider, out pdbPath, ref errorToReport))
+            foreach (var codeViewEntry in entries)
             {
-                return true;
+                if (codeViewEntry.IsPortableCodeView && codeViewEntry.DataSize != 0 && 
+                    TryOpenCodeViewPortablePdb(codeViewEntry, peImageDirectory, pdbFileStreamProvider, out pdbReaderProvider, out pdbPath, ref errorToReport))
+                {
+                    return true;
+                }
             }
 
             // if it failed try Embedded Portable PDB (if available):


### PR DESCRIPTION
Currently it tries from only one DebugDirectoryEntry so when we run
a NI file without `.ni.pdb`, most of time it fails loading.
(tested on Linux)