### PR TITLE
Update XunitNetcoreExtensionsVersion to 1.0.1-prerelease-02116-01

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -148,6 +148,11 @@
       <Path>$(MSBuildThisFileDirectory)BuildToolsVersion.txt</Path>
       <PackageId>Microsoft.DotNet.BuildTools</PackageId>
     </UpdateStep>
+    <XmlUpdateStep Include="BuildTools">
+       <Path>$(MSBuildThisFileFullPath)</Path>
+       <ElementName>XunitNetcoreExtensionsVersion</ElementName>
+       <PackageId>Microsoft.xunit.netcore.extensions</PackageId>
+     </XmlUpdateStep>
   </ItemGroup>
 
   <PropertyGroup>

--- a/dependencies.props
+++ b/dependencies.props
@@ -41,7 +41,7 @@
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0007</XunitPerfAnalysisPackageVersion>
     <TraceEventPackageVersion>1.0.3-alpha-experimental</TraceEventPackageVersion>
-    <XunitNetcoreExtensionsVersion>1.0.1-prerelease-01911-02</XunitNetcoreExtensionsVersion>
+    <XunitNetcoreExtensionsVersion>1.0.1-prerelease-02116-01</XunitNetcoreExtensionsVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->


### PR DESCRIPTION
Can I update the [XunitNetcoreExtensionsVersion](https://dotnet.myget.org/feed/dotnet-buildtools/package/nuget/Microsoft.xunit.netcore.extensions) or it's a more complicated process? We need [this](https://github.com/dotnet/buildtools/pull/1690) change to be in corefx to mark several tests with [SkipOnTarget(Mono)]