### PR TITLE
Fix lookup path for perfcounter.dll

### DIFF
--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/CounterSampleCalculator.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/CounterSampleCalculator.cs
@@ -237,7 +237,7 @@ namespace System.Diagnostics
 
             new FileIOPermission(PermissionState.Unrestricted).Assert();
 
-            string installPath = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+            string installPath = SharedUtils.GetLatestBuildDllDirectory(".");
             string perfcounterPath = Path.Combine(installPath, "perfcounter.dll");
             if (Interop.Kernel32.LoadLibrary(perfcounterPath) == IntPtr.Zero)
             {

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedUtils.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedUtils.cs
@@ -176,14 +176,7 @@ namespace System.Diagnostics
 
             try
             {
-                if (machineName.Equals("."))
-                {
-                    return GetLocalBuildDirectory();
-                }
-                else
-                {
-                    baseKey = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, machineName);
-                }
+                baseKey = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, machineName);
                 if (baseKey == null)
                     throw new InvalidOperationException(SR.Format(SR.RegKeyMissingShort, "HKEY_LOCAL_MACHINE", machineName));
 


### PR DESCRIPTION
We need to update the lookup path for perfcounter.dll to look in the
full framework directory, rather than a local path for .Net Core.