### PR TITLE
Increase timeout on BackgroundWorker test

### DIFF
--- a/src/System.ComponentModel.EventBasedAsync/tests/BackgroundWorkerTests.cs
+++ b/src/System.ComponentModel.EventBasedAsync/tests/BackgroundWorkerTests.cs
@@ -88,10 +88,12 @@ namespace System.ComponentModel.EventBasedAsync.Tests
             stopwatch.Start();
             while (!isCompleted)
             {
-                if (stopwatch.Elapsed > TimeSpan.FromSeconds(10))
+                if (stopwatch.Elapsed > TimeSpan.FromSeconds(20))
                 {
-                    throw new Exception("The background worker never completed.");
+                    throw new Exception("The background worker did not complete in 20 sec.");
                 }
+
+                Thread.Sleep(50);
             }
         }
 

--- a/src/System.ComponentModel.EventBasedAsync/tests/BackgroundWorkerTests.cs
+++ b/src/System.ComponentModel.EventBasedAsync/tests/BackgroundWorkerTests.cs
@@ -72,29 +72,21 @@ namespace System.ComponentModel.EventBasedAsync.Tests
         }
 
         [Fact]
-        public void RunWorkerAsync_NoOnWorkHandler_SetsResultToNull()
+        public async Task RunWorkerAsync_NoOnWorkHandler_SetsResultToNull()
         {
+            var tcs = new TaskCompletionSource<bool>();
             var backgroundWorker = new BackgroundWorker { WorkerReportsProgress = true };
-            bool isCompleted = false;
             backgroundWorker.RunWorkerCompleted += (sender, e) =>
             {
-                isCompleted = true;
                 Assert.Null(e.Result);
                 Assert.False(backgroundWorker.IsBusy);
+                tcs.SetResult(true);
             };
+
             backgroundWorker.RunWorkerAsync();
 
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
-            while (!isCompleted)
-            {
-                if (stopwatch.Elapsed > TimeSpan.FromSeconds(20))
-                {
-                    throw new Exception("The background worker did not complete in 20 sec.");
-                }
-
-                Thread.Sleep(50);
-            }
+            await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(10))); // Usually takes 100th of a sec
+            Assert.True(tcs.Task.IsCompleted);
         }
 
         #region TestCancelAsync


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/24679

Increase timeout, also make the loop not monopolize the CPU.