### PR TITLE
Set.TryGetValue not-found behavior/docs inconsistent

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -458,7 +458,7 @@ namespace System.Collections.Generic
         /// Searches the set for a given value and returns the equal value it finds, if any.
         /// </summary>
         /// <param name="equalValue">The value to search for.</param>
-        /// <param name="actualValue">The value from the set that the search found, or the default value of T when the search yielded no match.</param>
+        /// <param name="actualValue">The value from the set that the search found, or the default value of <typeparamref name="T"/> when the search yielded no match.</param>
         /// <returns>A value indicating whether the search was successful.</returns>
         /// <remarks>
         /// This can be useful when you want to reuse a previously stored reference instead of 

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -458,7 +458,7 @@ namespace System.Collections.Generic
         /// Searches the set for a given value and returns the equal value it finds, if any.
         /// </summary>
         /// <param name="equalValue">The value to search for.</param>
-        /// <param name="actualValue">The value from the set that the search found, or the original value if the search yielded no match.</param>
+        /// <param name="actualValue">The value from the set that the search found, or the default value for the type of the <paramref name="actualValue"/> parameter when the search yielded no match.</param>
         /// <returns>A value indicating whether the search was successful.</returns>
         /// <remarks>
         /// This can be useful when you want to reuse a previously stored reference instead of 

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -458,7 +458,7 @@ namespace System.Collections.Generic
         /// Searches the set for a given value and returns the equal value it finds, if any.
         /// </summary>
         /// <param name="equalValue">The value to search for.</param>
-        /// <param name="actualValue">The value from the set that the search found, or the default value for the type of the <paramref name="actualValue"/> parameter when the search yielded no match.</param>
+        /// <param name="actualValue">The value from the set that the search found, or the default value of T when the search yielded no match.</param>
         /// <returns>A value indicating whether the search was successful.</returns>
         /// <remarks>
         /// This can be useful when you want to reuse a previously stored reference instead of 

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -2089,7 +2089,7 @@ namespace System.Collections.Generic
         /// Searches the set for a given value and returns the equal value it finds, if any.
         /// </summary>
         /// <param name="equalValue">The value to search for.</param>
-        /// <param name="actualValue">The value from the set that the search found, or the default value of T when the search yielded no match.</param>
+        /// <param name="actualValue">The value from the set that the search found, or the default value of <typeparamref name="T"/> when the search yielded no match.</param>
         /// <returns>A value indicating whether the search was successful.</returns>
         /// <remarks>
         /// This can be useful when you want to reuse a previously stored reference instead of 

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -2089,7 +2089,7 @@ namespace System.Collections.Generic
         /// Searches the set for a given value and returns the equal value it finds, if any.
         /// </summary>
         /// <param name="equalValue">The value to search for.</param>
-        /// <param name="actualValue">The value from the set that the search found, or the default value for the type of the <paramref name="actualValue"/> parameter when the search yielded no match.</param>
+        /// <param name="actualValue">The value from the set that the search found, or the default value of T when the search yielded no match.</param>
         /// <returns>A value indicating whether the search was successful.</returns>
         /// <remarks>
         /// This can be useful when you want to reuse a previously stored reference instead of 

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -2089,7 +2089,7 @@ namespace System.Collections.Generic
         /// Searches the set for a given value and returns the equal value it finds, if any.
         /// </summary>
         /// <param name="equalValue">The value to search for.</param>
-        /// <param name="actualValue">The value from the set that the search found, or the original value if the search yielded no match.</param>
+        /// <param name="actualValue">The value from the set that the search found, or the default value for the type of the <paramref name="actualValue"/> parameter when the search yielded no match.</param>
         /// <returns>A value indicating whether the search was successful.</returns>
         /// <remarks>
         /// This can be useful when you want to reuse a previously stored reference instead of 


### PR DESCRIPTION
Either the behavior or the inline documentation is incorrect for SortedSet/HashSet TryGetValue when the item is not found. The code returns default(T) but the inline comments state it should return the original value. I expect this is because the comments are copied from their Immutable counterparts where the original value is returned.

TryGetValue not found out value for other classes:

Function | actual out value when not found | what docs say the out value will be when not found
--------- | ------------- | -------------
SortedSet.TryGetValue | [default(T)](https://github.com/dotnet/corefx/blob/6ad6bce5f9fd1f2d98ea30a049bdfcee3f4d0ed3/src/System.Collections/src/System/Collections/Generic/SortedSet.cs#L2108) | [original value](https://github.com/dotnet/corefx/blob/6ad6bce5f9fd1f2d98ea30a049bdfcee3f4d0ed3/src/System.Collections/src/System/Collections/Generic/SortedSet.cs#L2092)
HashSet.TryGetValue | [default(T)](https://github.com/dotnet/corefx/blob/master/src/System.Collections/src/System/Collections/Generic/HashSet.cs#L480) | [original value](https://github.com/dotnet/corefx/blob/master/src/System.Collections/src/System/Collections/Generic/HashSet.cs#L461)
ImmutableHashSet.TryGetValue | [original value](https://github.com/dotnet/corefx/blob/3143b836af48be68d3b02b45188b134dca25b27c/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs#L237) | [original value](https://github.com/dotnet/corefx/blob/3143b836af48be68d3b02b45188b134dca25b27c/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs#L219)
ImmutableSortedSet.TryGetValue | [original value](https://github.com/dotnet/corefx/blob/3143b836af48be68d3b02b45188b134dca25b27c/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs#L219) | [original value](https://github.com/dotnet/corefx/blob/3143b836af48be68d3b02b45188b134dca25b27c/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs#L205)
Dictionary | default(T) | default(T)
SortedList| default(T) | default(T)
SortedDictionary| default(T) | default(T)


"original value" here refers to the `equalValue` for which we are searching. I expect we want to just fix the comment to match the behavior which this PR aims to do. If we decide else-wise, I will update the PR as necessary.

cc: @TylerBrinkley @stephentoub 