### PR TITLE
Remove methods marked as internal from reference assembly

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -128,7 +128,6 @@ namespace System
         public static ReadOnlyMemory<T> Empty { get { throw null; } }
         public ReadOnlyMemory(T[] array) { throw null;}
         public ReadOnlyMemory(T[] array, int start, int length) { throw null;}
-        internal ReadOnlyMemory(Buffers.OwnedMemory<T> owner, int index, int length) { throw null;}
         public bool IsEmpty { get { throw null; } }
         public int Length { get { throw null; } }
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -152,7 +151,6 @@ namespace System
         public static Memory<T> Empty { get { throw null; } }
         public Memory(T[] array) { throw null;}
         public Memory(T[] array, int start, int length) { throw null;}
-        internal Memory(Buffers.OwnedMemory<T> owner, int index, int length) { throw null;}
         public bool IsEmpty { get { throw null; } }
         public int Length { get { throw null; } }
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -178,7 +176,6 @@ namespace System.Buffers
     {
         public MemoryHandle(IRetainable owner, void* pinnedPointer = null,  System.Runtime.InteropServices.GCHandle handle = default(System.Runtime.InteropServices.GCHandle))  { throw null; }
         public void* PinnedPointer { get { throw null; } }
-        internal void AddOffset(int offset) { throw null; }
         public void Dispose() { throw null; }
     }
 

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -1642,7 +1642,6 @@ namespace System
         public static Memory<T> Empty { get { throw null; } }
         public Memory(T[] array) { throw null;}
         public Memory(T[] array, int start, int length) { throw null;}
-        internal Memory(Buffers.OwnedMemory<T> owner, int index, int length) { throw null;}
         public bool IsEmpty { get { throw null; } }
         public int Length { get { throw null; } }
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -1866,7 +1865,6 @@ namespace System
         public static ReadOnlyMemory<T> Empty { get { throw null; } }
         public ReadOnlyMemory(T[] array) { throw null;}
         public ReadOnlyMemory(T[] array, int start, int length) { throw null;}
-        internal ReadOnlyMemory(Buffers.OwnedMemory<T> owner, int index, int length) { throw null;}
         public bool IsEmpty { get { throw null; } }
         public int Length { get { throw null; } }
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -3843,7 +3841,6 @@ namespace System.Buffers
         public MemoryHandle(IRetainable owner, void* pinnedPointer = null,  System.Runtime.InteropServices.GCHandle handle = default(System.Runtime.InteropServices.GCHandle))  { throw null; }
         [System.CLSCompliantAttribute(false)]
         public void* PinnedPointer { get { throw null; } }
-        internal void AddOffset(int offset) { throw null; }
         public void Dispose() { throw null; }
     }
 


### PR DESCRIPTION
From https://github.com/dotnet/corefx/pull/24323#discussion_r143102130

Removing internal methods on Memory and MemoryHandle from the System.Memory and System.Runtime reference assembly.

cc @stephentoub, @KrzysztofCwalina 