### PR TITLE
Remove dead code from System.IO.FileSystem

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Error.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Error.cs
@@ -16,25 +16,5 @@ namespace System.IO
         {
             return new EndOfStreamException(SR.IO_EOF_ReadBeyondEOF);
         }
-
-        internal static Exception GetFileNotOpen()
-        {
-            return new ObjectDisposedException(null, SR.ObjectDisposed_FileClosed);
-        }
-
-        internal static Exception GetReadNotSupported()
-        {
-            return new NotSupportedException(SR.NotSupported_UnreadableStream);
-        }
-
-        internal static Exception GetSeekNotSupported()
-        {
-            return new NotSupportedException(SR.NotSupported_UnseekableStream);
-        }
-
-        internal static Exception GetWriteNotSupported()
-        {
-            return new NotSupportedException(SR.NotSupported_UnwritableStream);
-        }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
@@ -9,19 +9,19 @@ namespace System.IO
     internal static partial class PathHelpers
     {
         // Trim trailing whitespace, tabs etc but don't be aggressive in removing everything that has UnicodeCategory of trailing space.
-        // string.WhitespaceChars will trim more aggressively than what the underlying FS does (for ex, NTFS, FAT).    
+        // string.WhitespaceChars will trim more aggressively than what the underlying FS does (for ex, NTFS, FAT).
         internal static readonly char[] TrimEndChars = { (char)0x9, (char)0xA, (char)0xB, (char)0xC, (char)0xD, (char)0x20, (char)0x85, (char)0xA0 };
         internal static readonly char[] TrimStartChars = { ' ' };
 
         internal static bool ShouldReviseDirectoryPathToCurrent(string path)
         {
-            // In situations where this method is invoked, "<DriveLetter>:" should be special-cased 
+            // In situations where this method is invoked, "<DriveLetter>:" should be special-cased
             // to instead go to the current directory.
             return path.Length == 2 && path[1] == ':';
         }
 
         // ".." can only be used if it is specified as a part of a valid File/Directory name. We disallow
-        //  the user being able to use it to move up directories. Here are some examples eg 
+        //  the user being able to use it to move up directories. Here are some examples eg
         //    Valid: a..b  abc..d
         //    Invalid: ..ab   ab..  ..   abc..d\abc..
         //
@@ -30,52 +30,11 @@ namespace System.IO
             for (int index = 0; (index = searchPattern.IndexOf("..", index, StringComparison.Ordinal)) != -1; index += 2)
             {
                 // Terminal ".." or "..\". File and directory names cannot end in "..".
-                if (index + 2 == searchPattern.Length || 
+                if (index + 2 == searchPattern.Length ||
                     PathInternal.IsDirectorySeparator(searchPattern[index + 2]))
                 {
                     throw new ArgumentException(SR.Arg_InvalidSearchPattern, nameof(searchPattern));
                 }
-            }
-        }
-
-        // this is a lightweight version of GetDirectoryName that doesn't renormalize
-        internal static string GetDirectoryNameInternal(string path)
-        {
-            string directory, file;
-            SplitDirectoryFile(path, out directory, out file);
-
-            // file is null when we reach the root
-            return (file == null) ? null : directory;
-        }
-
-        internal static void SplitDirectoryFile(string path, out string directory, out string file)
-        {
-            directory = null;
-            file = null;
-
-            // assumes a validated full path
-            if (path != null)
-            {
-                int length = path.Length;
-                int rootLength = PathInternal.GetRootLength(path);
-
-                // ignore a trailing slash
-                if (length > rootLength && EndsInDirectorySeparator(path))
-                    length--;
-
-                // find the pivot index between end of string and root
-                for (int pivot = length - 1; pivot >= rootLength; pivot--)
-                {
-                    if (PathInternal.IsDirectorySeparator(path[pivot]))
-                    {
-                        directory = path.Substring(0, pivot);
-                        file = path.Substring(pivot + 1, length - pivot - 1);
-                        return;
-                    }
-                }
-
-                // no pivot, return just the trimmed directory
-                directory = path.Substring(0, length);
             }
         }
 


### PR DESCRIPTION
PR addresses issue #17905, project **System.IO.FileSystem**.

Not really much to do. Most of the red things in [diff](http://tempcoverage.blob.core.windows.net/report2/System.IO.FileSystem.diff.html) file are:

- Classes in `src\Common` folder.
- Methods that are in `*.Unix` files, so I am not sure if they are not used on that platform and therefore they can't be removed.