### PR TITLE
update parameter parsing to be more flexible and be closer to coreclr and native build

### DIFF
--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -7,17 +7,19 @@ usage()
     echo "If you plan to only run this script, be sure to pass those parameters."
     echo "For more information type build-native.sh -? at the root of the repo."
     echo
-    echo "Usage: $0 [runParameters][verbose] [clangx.y] [cross] [staticLibLink] [cmakeargs] [makeargs]"
-    echo "runParameters: buildArch, buildType, buildOS, --numProc <numproc value>"
-    echo "verbose - optional argument to enable verbose build output."
-    echo "clangx.y - optional argument to build using clang version x.y."
-    echo "cross - optional argument to signify cross compilation,"
-    echo "      - will use ROOTFS_DIR environment variable if set."
-    echo "staticLibLink - Optional argument to statically link any native library."
-    echo "portable - Optional argument to build native libraries portable over GLIBC based Linux distros."
-    echo "stripSymbols - Optional argument to strip native symbols during the build."
-    echo "generateversion - Pass this in to get a version on the build output."
-    echo "cmakeargs - user-settable additional arguments passed to CMake."
+    echo "Usage: $0 [runParameters][-verbose] [-clangx.y] [-cross] [-staticLibLink] [-cmakeargs] [-makeargs]"
+    echo "runParameters: buildArch, buildType, buildOS, -numProc <numproc value>"
+    echo "BuildArch can be: -x64, -x86, -arm, -armel, -arm64"
+    echo "BuildType can be: -debug, -checked, -release"
+    echo "-verbose - optional argument to enable verbose build output."
+    echo "-clangx.y - optional argument to build using clang version x.y."
+    echo "-cross - optional argument to signify cross compilation,"
+    echo "       - will use ROOTFS_DIR environment variable if set."
+    echo "-staticLibLink - Optional argument to statically link any native library."
+    echo "-portable - Optional argument to build native libraries portable over GLIBC based Linux distros."
+    echo "-stripSymbols - Optional argument to strip native symbols during the build."
+    echo "-generateversion - Pass this in to get a version on the build output."
+    echo "-cmakeargs - user-settable additional arguments passed to CMake."
     exit 1
 }
 
@@ -228,64 +230,64 @@ while :; do
             usage
             exit 1
             ;;
-        x86)
+        x86|-x86)
             __BuildArch=x86
             ;;
-        x64)
+        x64|-x64)
             __BuildArch=x64
             ;;
-        arm)
+        arm|-arm)
             __BuildArch=arm
             ;;
-        armel)
+        armel|-armel)
             __BuildArch=armel
             ;;
-        arm64)
+        arm64|-arm64)
             __BuildArch=arm64
             ;;
-        debug)
+        debug|-debug)
             __BuildType=Debug
             ;;
-        release)
+        release|-release)
             __BuildType=Release
             __CMakeArgs=RELEASE
             ;;
-        freebsd)
+        freebsd|-freebsd)
             __BuildOS=FreeBSD
             ;;
-        linux)
+        linux|-linux)
             __BuildOS=Linux
             ;;
-        netbsd)
+        netbsd|-netbsd)
             __BuildOS=NetBSD
             ;;
-        osx)
+        osx|-osx)
             __BuildOS=OSX
             ;;
-        stripsymbols)
+        stripsymbols|-stripsymbols)
             __CMakeExtraArgs="$__CMakeExtraArgs -DSTRIP_SYMBOLS=true"
             ;;
         --targetgroup)
             shift
             __TargetGroup=$1
             ;;
-        --numproc)
+        --numproc|-numproc|numproc)
             shift
             __NumProc=$1
             ;;
-        verbose)
+        verbose|-verbose)
             __VerboseBuild=1
             ;;
-        staticliblink)
+        staticliblink|-staticliblink)
             __StaticLibLink=1
             ;;
-        -portable)
+        -portable|-portable)
             # Portable native components are only supported on Linux
             if [ "$__HostOS" == "Linux" ]; then
                 __PortableBuild=1
             fi
             ;;
-        generateversion)
+        generateversion|-generateversion)
             __generateversionsource=true
             ;;
         --clang*)
@@ -294,30 +296,34 @@ while :; do
                 __ClangMajorVersion=`echo $v | cut -d '.' -f1`
                 __ClangMinorVersion=`echo $v | cut -d '.' -f2`
             ;;
-        clang3.5)
+        clang3.5|-clang3.5)
             __ClangMajorVersion=3
             __ClangMinorVersion=5
             ;;
-        clang3.6)
+        clang3.6|-clang3.6)
             __ClangMajorVersion=3
             __ClangMinorVersion=6
             ;;
-        clang3.7)
+        clang3.7|-clang3.7)
             __ClangMajorVersion=3
             __ClangMinorVersion=7
             ;;
-        clang3.8)
+        clang3.8|-clang3.8)
             __ClangMajorVersion=3
             __ClangMinorVersion=8
             ;;
-        clang3.9)
+        clang3.9|-clang3.9)
             __ClangMajorVersion=3
             __ClangMinorVersion=9
             ;;
-        cross)
+        clang4.0|-clang4.0)
+            __ClangMajorVersion=4
+            __ClangMinorVersion=0
+            ;;
+        cross|-cross)
             __CrossBuild=1
             ;;
-        cmakeargs)
+        cmakeargs|-cmakeargs)
             if [ -n "$2" ]; then
                 __CMakeExtraArgs="$__CMakeExtraArgs $2"
                 shift
@@ -326,7 +332,7 @@ while :; do
                 exit 1
             fi
             ;;
-        makeargs)
+        makeargs|-makeargs)
             if [ -n "$2" ]; then
                 __MakeExtraArgs="$__MakeExtraArgs $2"
                 shift
@@ -335,7 +341,7 @@ while :; do
                 exit 1
             fi
             ;;
-        useservergc)
+        useservergc|-useservergc)
             __ServerGC=1
             ;;
         *)


### PR DESCRIPTION
allow keyword variants with and without leading '-'. e.g. both 'release' and  '-release' are valid. 