### PR TITLE
Add Synchronous APIs in Syndication for .Net Core

### DIFF
--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
@@ -71,8 +71,10 @@ namespace System.ServiceModel.Syndication
         public override bool CanRead(System.Xml.XmlReader reader) { throw null; }
         protected override System.ServiceModel.Syndication.InlineCategoriesDocument CreateInlineCategoriesDocument() { throw null; }
         protected override System.ServiceModel.Syndication.ReferencedCategoriesDocument CreateReferencedCategoriesDocument() { throw null; }
+        public override void ReadFrom(System.Xml.XmlReader reader) { }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader) { throw null; }
-        public override System.Threading.Tasks.Task WriteTo(System.Xml.XmlWriter writer) { throw null; }
+        public override void WriteTo(System.Xml.XmlWriter writer) { }
+        public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer) { throw null; }
     }
     public partial class AtomPub10ServiceDocumentFormatter : System.ServiceModel.Syndication.ServiceDocumentFormatter
     {
@@ -82,7 +84,9 @@ namespace System.ServiceModel.Syndication
         public override string Version { get { throw null; } }
         public override bool CanRead(System.Xml.XmlReader reader) { throw null; }
         protected override System.ServiceModel.Syndication.ServiceDocument CreateDocumentInstance() { throw null; }
+        public override void ReadFrom(System.Xml.XmlReader reader) { }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader) { throw null; }
+        public override void WriteTo(System.Xml.XmlWriter writer) { }
         public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer) { throw null; }
     }
     public partial class AtomPub10ServiceDocumentFormatter<TServiceDocument> : System.ServiceModel.Syndication.AtomPub10ServiceDocumentFormatter where TServiceDocument : System.ServiceModel.Syndication.ServiceDocument, new()
@@ -102,6 +106,7 @@ namespace System.ServiceModel.Syndication
         public static System.ServiceModel.Syndication.InlineCategoriesDocument Create(System.Collections.ObjectModel.Collection<System.ServiceModel.Syndication.SyndicationCategory> categories, bool isFixed, string scheme) { throw null; }
         public static System.ServiceModel.Syndication.ReferencedCategoriesDocument Create(System.Uri linkToCategoriesDocument) { throw null; }
         public System.ServiceModel.Syndication.CategoriesDocumentFormatter GetFormatter() { throw null; }
+        public static System.ServiceModel.Syndication.CategoriesDocument Load(System.Xml.XmlReader reader) { throw null; }
         public static System.Threading.Tasks.Task<System.ServiceModel.Syndication.CategoriesDocument> LoadAsync(System.Xml.XmlReader reader) { throw null; }
         public void Save(System.Xml.XmlWriter writer) { }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
@@ -111,6 +116,7 @@ namespace System.ServiceModel.Syndication
         protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
+    [System.Runtime.Serialization.DataContractAttribute]
     public abstract partial class CategoriesDocumentFormatter
     {
         protected CategoriesDocumentFormatter() { }
@@ -120,9 +126,11 @@ namespace System.ServiceModel.Syndication
         public abstract bool CanRead(System.Xml.XmlReader reader);
         protected virtual System.ServiceModel.Syndication.InlineCategoriesDocument CreateInlineCategoriesDocument() { throw null; }
         protected virtual System.ServiceModel.Syndication.ReferencedCategoriesDocument CreateReferencedCategoriesDocument() { throw null; }
+        public abstract void ReadFrom(System.Xml.XmlReader reader);
         public abstract System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader);
         protected virtual void SetDocument(System.ServiceModel.Syndication.CategoriesDocument document) { }
-        public abstract System.Threading.Tasks.Task WriteTo(System.Xml.XmlWriter writer);
+        public abstract void WriteTo(System.Xml.XmlWriter writer);
+        public abstract System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer);
     }
     public partial class InlineCategoriesDocument : System.ServiceModel.Syndication.CategoriesDocument
     {
@@ -233,8 +241,11 @@ namespace System.ServiceModel.Syndication
         public System.Collections.ObjectModel.Collection<System.ServiceModel.Syndication.Workspace> Workspaces { get { throw null; } }
         protected internal virtual System.ServiceModel.Syndication.Workspace CreateWorkspace() { throw null; }
         public System.ServiceModel.Syndication.ServiceDocumentFormatter GetFormatter() { throw null; }
+        public static System.ServiceModel.Syndication.ServiceDocument Load(System.Xml.XmlReader reader) { throw null; }
         public static System.Threading.Tasks.Task<TServiceDocument> LoadAsync<TServiceDocument>(System.Xml.XmlReader reader) where TServiceDocument : System.ServiceModel.Syndication.ServiceDocument, new() { throw null; }
-        public System.Threading.Tasks.Task Save(System.Xml.XmlWriter writer) { throw null; }
+        public static TServiceDocument Load<TServiceDocument>(System.Xml.XmlReader reader) where TServiceDocument : System.ServiceModel.Syndication.ServiceDocument, new() { throw null; }
+        public void Save(System.Xml.XmlWriter writer) { }
+        public System.Threading.Tasks.Task SaveAsync(System.Xml.XmlWriter writer) { throw null; }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
         protected internal virtual void WriteAttributeExtensions(System.Xml.XmlWriter writer, string version) { }
@@ -260,6 +271,7 @@ namespace System.ServiceModel.Syndication
         protected static void LoadElementExtensions(System.Xml.XmlReader reader, System.ServiceModel.Syndication.ResourceCollectionInfo collection, int maxExtensionSize) { }
         protected static void LoadElementExtensions(System.Xml.XmlReader reader, System.ServiceModel.Syndication.ServiceDocument document, int maxExtensionSize) { }
         protected static void LoadElementExtensions(System.Xml.XmlReader reader, System.ServiceModel.Syndication.Workspace workspace, int maxExtensionSize) { }
+        public abstract void ReadFrom(System.Xml.XmlReader reader);
         public abstract System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader);
         protected virtual void SetDocument(System.ServiceModel.Syndication.ServiceDocument document) { }
         protected static bool TryParseAttribute(string name, string ns, string value, System.ServiceModel.Syndication.CategoriesDocument categories, string version) { throw null; }
@@ -286,6 +298,7 @@ namespace System.ServiceModel.Syndication
         protected static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.ResourceCollectionInfo collection, string version) { throw null; }
         protected static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.ServiceDocument document, string version) { throw null; }
         protected static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.Workspace workspace, string version) { throw null; }
+        public abstract void WriteTo(System.Xml.XmlWriter writer);
         public abstract System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer);
     }
     public partial class SyndicationCategory
@@ -336,10 +349,15 @@ namespace System.ServiceModel.Syndication
         public SyndicationElementExtension(System.Xml.XmlReader xmlReader) { }
         public string OuterName { get { throw null; } }
         public string OuterNamespace { get { throw null; } }
-        public System.Threading.Tasks.Task<TExtension> GetObject<TExtension>() { throw null; }
-        public System.Threading.Tasks.Task<TExtension> GetObject<TExtension>(System.Runtime.Serialization.XmlObjectSerializer serializer) { throw null; }
-        public System.Threading.Tasks.Task<TExtension> GetObject<TExtension>(System.Xml.Serialization.XmlSerializer serializer) { throw null; }
+        public System.Threading.Tasks.Task<TExtension> GetObjectAsync<TExtension>() { throw null; }
+        public System.Threading.Tasks.Task<TExtension> GetObjectAsync<TExtension>(System.Runtime.Serialization.XmlObjectSerializer serializer) { throw null; }
+        public System.Threading.Tasks.Task<TExtension> GetObjectAsync<TExtension>(System.Xml.Serialization.XmlSerializer serializer) { throw null; }
+        public TExtension GetObject<TExtension>() { throw null; }
+        public TExtension GetObject<TExtension>(System.Runtime.Serialization.XmlObjectSerializer serializer) { throw null; }
+        public TExtension GetObject<TExtension>(System.Xml.Serialization.XmlSerializer serializer) { throw null; }
+        public System.Xml.XmlReader GetReader() { throw null; }
         public System.Threading.Tasks.Task<System.Xml.XmlReader> GetReaderAsync() { throw null; }
+        public void WriteTo(System.Xml.XmlWriter writer) { }
         public System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer) { throw null; }
     }
     public sealed partial class SyndicationElementExtensionCollection : System.Collections.ObjectModel.Collection<System.ServiceModel.Syndication.SyndicationElementExtension>
@@ -350,13 +368,17 @@ namespace System.ServiceModel.Syndication
         public void Add(object xmlSerializerExtension, System.Xml.Serialization.XmlSerializer serializer) { }
         public void Add(string outerName, string outerNamespace, object dataContractExtension) { }
         public void Add(string outerName, string outerNamespace, object dataContractExtension, System.Runtime.Serialization.XmlObjectSerializer dataContractSerializer) { }
-        public void Add(System.Xml.XmlReader reader) { }
+        public void Add(System.Xml.XmlReader xmlReader) { }
         protected override void ClearItems() { }
-        public System.Threading.Tasks.Task<System.Xml.XmlReader> GetReaderAtElementExtensions() { throw null; }
+        public System.Xml.XmlReader GetReaderAtElementExtensions() { throw null; }
+        public System.Threading.Tasks.Task<System.Xml.XmlReader> GetReaderAtElementExtensionsAsync() { throw null; }
         protected override void InsertItem(int index, System.ServiceModel.Syndication.SyndicationElementExtension item) { }
-        public System.Threading.Tasks.Task<System.Collections.ObjectModel.Collection<TExtension>> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace) { throw null; }
-        public System.Threading.Tasks.Task<System.Collections.ObjectModel.Collection<TExtension>> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace, System.Runtime.Serialization.XmlObjectSerializer serializer) { throw null; }
-        public System.Threading.Tasks.Task<System.Collections.ObjectModel.Collection<TExtension>> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace, System.Xml.Serialization.XmlSerializer serializer) { throw null; }
+        public System.Threading.Tasks.Task<System.Collections.ObjectModel.Collection<TExtension>> ReadElementExtensionsAsync<TExtension>(string extensionName, string extensionNamespace) { throw null; }
+        public System.Threading.Tasks.Task<System.Collections.ObjectModel.Collection<TExtension>> ReadElementExtensionsAsync<TExtension>(string extensionName, string extensionNamespace, System.Runtime.Serialization.XmlObjectSerializer serializer) { throw null; }
+        public System.Threading.Tasks.Task<System.Collections.ObjectModel.Collection<TExtension>> ReadElementExtensionsAsync<TExtension>(string extensionName, string extensionNamespace, System.Xml.Serialization.XmlSerializer serializer) { throw null; }
+        public System.Collections.ObjectModel.Collection<TExtension> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace) { throw null; }
+        public System.Collections.ObjectModel.Collection<TExtension> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace, System.Runtime.Serialization.XmlObjectSerializer serializer) { throw null; }
+        public System.Collections.ObjectModel.Collection<TExtension> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace, System.Xml.Serialization.XmlSerializer serializer) { throw null; }
         protected override void RemoveItem(int index) { }
         protected override void SetItem(int index, System.ServiceModel.Syndication.SyndicationElementExtension item) { }
     }
@@ -679,10 +701,14 @@ namespace System.ServiceModel.Syndication
         public System.ServiceModel.Syndication.SyndicationElementExtension Extension { get { throw null; } }
         public override string Type { get { throw null; } }
         public override System.ServiceModel.Syndication.SyndicationContent Clone() { throw null; }
-        public System.Threading.Tasks.Task<System.Xml.XmlDictionaryReader> GetReaderAtContent() { throw null; }
-        public System.Threading.Tasks.Task<TContent> ReadContent<TContent>() { throw null; }
-        public System.Threading.Tasks.Task<TContent> ReadContent<TContent>(System.Runtime.Serialization.XmlObjectSerializer dataContractSerializer) { throw null; }
-        public System.Threading.Tasks.Task<TContent> ReadContent<TContent>(System.Xml.Serialization.XmlSerializer serializer) { throw null; }
+        public System.Xml.XmlDictionaryReader GetReaderAtContent() { throw null; }
+        public System.Threading.Tasks.Task<System.Xml.XmlDictionaryReader> GetReaderAtContentAsync() { throw null; }
+        public System.Threading.Tasks.Task<TContent> ReadContentAsync<TContent>() { throw null; }
+        public System.Threading.Tasks.Task<TContent> ReadContentAsync<TContent>(System.Runtime.Serialization.XmlObjectSerializer dataContractSerializer) { throw null; }
+        public System.Threading.Tasks.Task<TContent> ReadContentAsync<TContent>(System.Xml.Serialization.XmlSerializer serializer) { throw null; }
+        public TContent ReadContent<TContent>() { throw null; }
+        public TContent ReadContent<TContent>(System.Runtime.Serialization.XmlObjectSerializer dataContractSerializer) { throw null; }
+        public TContent ReadContent<TContent>(System.Xml.Serialization.XmlSerializer serializer) { throw null; }
         protected override void WriteContentsTo(System.Xml.XmlWriter writer) { }
     }
 }

--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
@@ -40,7 +40,7 @@ namespace System.ServiceModel.Syndication
         public Atom10FeedFormatter(TSyndicationFeed feedToWrite) { }
         protected override System.ServiceModel.Syndication.SyndicationFeed CreateFeedInstance() { throw null; }
     }
-    public partial class Atom10ItemFormatter : System.ServiceModel.Syndication.SyndicationItemFormatter
+    public partial class Atom10ItemFormatter : System.ServiceModel.Syndication.SyndicationItemFormatter, System.Xml.Serialization.IXmlSerializable
     {
         public Atom10ItemFormatter() { }
         public Atom10ItemFormatter(System.ServiceModel.Syndication.SyndicationItem itemToWrite) { }
@@ -53,6 +53,9 @@ namespace System.ServiceModel.Syndication
         protected override System.ServiceModel.Syndication.SyndicationItem CreateItemInstance() { throw null; }
         public override void ReadFrom(System.Xml.XmlReader reader) { }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader) { throw null; }
+        System.Xml.Schema.XmlSchema System.Xml.Serialization.IXmlSerializable.GetSchema() { throw null; }
+        void System.Xml.Serialization.IXmlSerializable.ReadXml(System.Xml.XmlReader reader) { }
+        void System.Xml.Serialization.IXmlSerializable.WriteXml(System.Xml.XmlWriter writer) { }
         public override void WriteTo(System.Xml.XmlWriter writer) { }
         public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer) { throw null; }
     }
@@ -62,7 +65,7 @@ namespace System.ServiceModel.Syndication
         public Atom10ItemFormatter(TSyndicationItem itemToWrite) { }
         protected override System.ServiceModel.Syndication.SyndicationItem CreateItemInstance() { throw null; }
     }
-    public partial class AtomPub10CategoriesDocumentFormatter : System.ServiceModel.Syndication.CategoriesDocumentFormatter
+    public partial class AtomPub10CategoriesDocumentFormatter : System.ServiceModel.Syndication.CategoriesDocumentFormatter, System.Xml.Serialization.IXmlSerializable
     {
         public AtomPub10CategoriesDocumentFormatter() { }
         public AtomPub10CategoriesDocumentFormatter(System.ServiceModel.Syndication.CategoriesDocument documentToWrite) { }
@@ -73,10 +76,13 @@ namespace System.ServiceModel.Syndication
         protected override System.ServiceModel.Syndication.ReferencedCategoriesDocument CreateReferencedCategoriesDocument() { throw null; }
         public override void ReadFrom(System.Xml.XmlReader reader) { }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader) { throw null; }
+        System.Xml.Schema.XmlSchema System.Xml.Serialization.IXmlSerializable.GetSchema() { throw null; }
+        void System.Xml.Serialization.IXmlSerializable.ReadXml(System.Xml.XmlReader reader) { }
+        void System.Xml.Serialization.IXmlSerializable.WriteXml(System.Xml.XmlWriter writer) { }
         public override void WriteTo(System.Xml.XmlWriter writer) { }
         public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer) { throw null; }
     }
-    public partial class AtomPub10ServiceDocumentFormatter : System.ServiceModel.Syndication.ServiceDocumentFormatter
+    public partial class AtomPub10ServiceDocumentFormatter : System.ServiceModel.Syndication.ServiceDocumentFormatter, System.Xml.Serialization.IXmlSerializable
     {
         public AtomPub10ServiceDocumentFormatter() { }
         public AtomPub10ServiceDocumentFormatter(System.ServiceModel.Syndication.ServiceDocument documentToWrite) { }
@@ -86,6 +92,9 @@ namespace System.ServiceModel.Syndication
         protected override System.ServiceModel.Syndication.ServiceDocument CreateDocumentInstance() { throw null; }
         public override void ReadFrom(System.Xml.XmlReader reader) { }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader) { throw null; }
+        System.Xml.Schema.XmlSchema System.Xml.Serialization.IXmlSerializable.GetSchema() { throw null; }
+        void System.Xml.Serialization.IXmlSerializable.ReadXml(System.Xml.XmlReader reader) { }
+        void System.Xml.Serialization.IXmlSerializable.WriteXml(System.Xml.XmlWriter writer) { }
         public override void WriteTo(System.Xml.XmlWriter writer) { }
         public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer) { throw null; }
     }
@@ -171,7 +180,7 @@ namespace System.ServiceModel.Syndication
         protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
-    public partial class Rss20FeedFormatter : System.ServiceModel.Syndication.SyndicationFeedFormatter
+    public partial class Rss20FeedFormatter : System.ServiceModel.Syndication.SyndicationFeedFormatter, System.Xml.Serialization.IXmlSerializable
     {
         public Rss20FeedFormatter() { }
         public Rss20FeedFormatter(System.ServiceModel.Syndication.SyndicationFeed feedToWrite) { }
@@ -191,6 +200,9 @@ namespace System.ServiceModel.Syndication
         protected virtual System.Threading.Tasks.Task<System.ServiceModel.Syndication.SyndicationItem> ReadItemAsync(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed) { throw null; }
         protected virtual System.Collections.Generic.IEnumerable<System.ServiceModel.Syndication.SyndicationItem> ReadItems(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed, out bool areAllItemsRead) { areAllItemsRead = default(bool); throw null; }
         protected internal override void SetFeed(System.ServiceModel.Syndication.SyndicationFeed feed) { }
+        System.Xml.Schema.XmlSchema System.Xml.Serialization.IXmlSerializable.GetSchema() { throw null; }
+        void System.Xml.Serialization.IXmlSerializable.ReadXml(System.Xml.XmlReader reader) { }
+        void System.Xml.Serialization.IXmlSerializable.WriteXml(System.Xml.XmlWriter writer) { }
         protected virtual void WriteItem(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, System.Uri feedBaseUri) { }
         protected virtual System.Threading.Tasks.Task WriteItemAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, System.Uri feedBaseUri) { throw null; }
         protected virtual void WriteItems(System.Xml.XmlWriter writer, System.Collections.Generic.IEnumerable<System.ServiceModel.Syndication.SyndicationItem> items, System.Uri feedBaseUri) { }
@@ -205,7 +217,7 @@ namespace System.ServiceModel.Syndication
         public Rss20FeedFormatter(TSyndicationFeed feedToWrite, bool serializeExtensionsAsAtom) { }
         protected override System.ServiceModel.Syndication.SyndicationFeed CreateFeedInstance() { throw null; }
     }
-    public partial class Rss20ItemFormatter : System.ServiceModel.Syndication.SyndicationItemFormatter
+    public partial class Rss20ItemFormatter : System.ServiceModel.Syndication.SyndicationItemFormatter, System.Xml.Serialization.IXmlSerializable
     {
         public Rss20ItemFormatter() { }
         public Rss20ItemFormatter(System.ServiceModel.Syndication.SyndicationItem itemToWrite) { }
@@ -220,10 +232,13 @@ namespace System.ServiceModel.Syndication
         protected override System.ServiceModel.Syndication.SyndicationItem CreateItemInstance() { throw null; }
         public override void ReadFrom(System.Xml.XmlReader reader) { }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader) { throw null; }
+        System.Xml.Schema.XmlSchema System.Xml.Serialization.IXmlSerializable.GetSchema() { throw null; }
+        void System.Xml.Serialization.IXmlSerializable.ReadXml(System.Xml.XmlReader reader) { }
+        void System.Xml.Serialization.IXmlSerializable.WriteXml(System.Xml.XmlWriter writer) { }
         public override void WriteTo(System.Xml.XmlWriter writer) { }
         public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer) { throw null; }
     }
-    public partial class Rss20ItemFormatter<TSyndicationItem> : System.ServiceModel.Syndication.Rss20ItemFormatter where TSyndicationItem : System.ServiceModel.Syndication.SyndicationItem, new()
+    public partial class Rss20ItemFormatter<TSyndicationItem> : System.ServiceModel.Syndication.Rss20ItemFormatter, System.Xml.Serialization.IXmlSerializable where TSyndicationItem : System.ServiceModel.Syndication.SyndicationItem, new()
     {
         public Rss20ItemFormatter() { }
         public Rss20ItemFormatter(TSyndicationItem itemToWrite) { }

--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
@@ -7,51 +7,7 @@
 
 namespace System.ServiceModel.Syndication
 {
-    public static partial class Atom10Constants
-    {
-        public const string AlternateTag = "alternate";
-        public const string Atom10Namespace = "http://www.w3.org/2005/Atom";
-        public const string Atom10Prefix = "a10";
-        public const string AtomMediaType = "application/atom+xml";
-        public const string AuthorTag = "author";
-        public const string CategoryTag = "category";
-        public const string ContentTag = "content";
-        public const string ContributorTag = "contributor";
-        public const string EmailTag = "email";
-        public const string EntryTag = "entry";
-        public const string FeedTag = "feed";
-        public const string GeneratorTag = "generator";
-        public const string HrefTag = "href";
-        public const string HtmlMediaType = "text/html";
-        public const string HtmlType = "html";
-        public const string IconTag = "icon";
-        public const string IdTag = "id";
-        public const string LabelTag = "label";
-        public const string LengthTag = "length";
-        public const string LinkTag = "link";
-        public const string LogoTag = "logo";
-        public const string NameTag = "name";
-        public const string PlaintextType = "text";
-        public const string PublishedTag = "published";
-        public const string RelativeTag = "rel";
-        public const string RightsTag = "rights";
-        public const string SchemeTag = "scheme";
-        public const string SelfTag = "self";
-        public const string SourceFeedTag = "source";
-        public const string SourceTag = "src";
-        public const string SpecificationLink = "http://atompub.org/2005/08/17/draft-ietf-atompub-format-11.html";
-        public const string SubtitleTag = "subtitle";
-        public const string SummaryTag = "summary";
-        public const string TermTag = "term";
-        public const string TitleTag = "title";
-        public const string TypeTag = "type";
-        public const string UpdatedTag = "updated";
-        public const string UriTag = "uri";
-        public const string XHtmlMediaType = "application/xhtml+xml";
-        public const string XHtmlType = "xhtml";
-        public const string XmlMediaType = "text/xml";
-    }
-    public partial class Atom10FeedFormatter : System.ServiceModel.Syndication.SyndicationFeedFormatter
+    public partial class Atom10FeedFormatter : System.ServiceModel.Syndication.SyndicationFeedFormatter, System.Xml.Serialization.IXmlSerializable
     {
         public Atom10FeedFormatter() { }
         public Atom10FeedFormatter(System.ServiceModel.Syndication.SyndicationFeed feedToWrite) { }
@@ -65,6 +21,9 @@ namespace System.ServiceModel.Syndication
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader, System.Threading.CancellationToken ct) { throw null; }
         protected virtual System.Threading.Tasks.Task<System.ServiceModel.Syndication.SyndicationItem> ReadItemAsync(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed) { throw null; }
         protected virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.ServiceModel.Syndication.SyndicationItem>> ReadItemsAsync(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed) { throw null; }
+        System.Xml.Schema.XmlSchema System.Xml.Serialization.IXmlSerializable.GetSchema() { throw null; }
+        void System.Xml.Serialization.IXmlSerializable.ReadXml(System.Xml.XmlReader reader) { }
+        void System.Xml.Serialization.IXmlSerializable.WriteXml(System.Xml.XmlWriter writer) { }
         protected virtual System.Threading.Tasks.Task WriteItemAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, System.Uri feedBaseUri) { throw null; }
         protected virtual System.Threading.Tasks.Task WriteItemsAsync(System.Xml.XmlWriter writer, System.Collections.Generic.IEnumerable<System.ServiceModel.Syndication.SyndicationItem> items, System.Uri feedBaseUri) { throw null; }
         public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer, System.Threading.CancellationToken ct) { throw null; }
@@ -312,7 +271,9 @@ namespace System.ServiceModel.Syndication
         public virtual System.ServiceModel.Syndication.SyndicationCategory Clone() { throw null; }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
+        protected internal virtual void WriteAttributeExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
+        protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
     public abstract partial class SyndicationContent
@@ -419,7 +380,9 @@ namespace System.ServiceModel.Syndication
         public System.Threading.Tasks.Task SaveAsRss20Async(System.Xml.XmlWriter writer, System.Threading.CancellationToken ct) { throw null; }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
+        protected internal virtual void WriteAttributeExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
+        protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
     [System.Runtime.Serialization.DataContractAttribute]
@@ -460,11 +423,21 @@ namespace System.ServiceModel.Syndication
         protected internal static bool TryParseElement(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationItem item, string version) { throw null; }
         protected internal static bool TryParseElement(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationLink link, string version) { throw null; }
         protected internal static bool TryParseElement(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationPerson person, string version) { throw null; }
-        protected internal static System.Threading.Tasks.Task WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationLink link, string version) { throw null; }
+        protected internal static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationCategory category, string version) { }
+        protected internal static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationFeed feed, string version) { }
+        protected internal static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, string version) { }
+        protected internal static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationLink link, string version) { }
+        protected internal static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationPerson person, string version) { }
         protected internal static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationCategory category, string version) { throw null; }
         protected internal static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationFeed feed, string version) { throw null; }
         protected internal static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, string version) { throw null; }
+        protected internal static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationLink link, string version) { throw null; }
         protected internal static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationPerson person, string version) { throw null; }
+        protected internal static void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationCategory category, string version) { }
+        protected internal static void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationFeed feed, string version) { }
+        protected internal static void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, string version) { }
+        protected internal static void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationLink link, string version) { }
+        protected internal static void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationPerson person, string version) { }
         protected internal static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationCategory category, string version) { throw null; }
         protected internal static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationFeed feed, string version) { throw null; }
         protected internal static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, string version) { throw null; }
@@ -509,7 +482,9 @@ namespace System.ServiceModel.Syndication
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseContent(System.Xml.XmlReader reader, string contentType, string version, out System.ServiceModel.Syndication.SyndicationContent content) { content = default(System.ServiceModel.Syndication.SyndicationContent); throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
+        protected internal virtual void WriteAttributeExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
+        protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
     [System.Runtime.Serialization.DataContractAttribute]
@@ -573,7 +548,9 @@ namespace System.ServiceModel.Syndication
         public System.Uri GetAbsoluteUri() { throw null; }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
+        protected internal virtual void WriteAttributeExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
+        protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
     public partial class SyndicationPerson
@@ -590,7 +567,9 @@ namespace System.ServiceModel.Syndication
         public virtual System.ServiceModel.Syndication.SyndicationPerson Clone() { throw null; }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
+        protected internal virtual void WriteAttributeExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
+        protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
     public partial class SyndicationTextInput

--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
@@ -106,7 +106,9 @@ namespace System.ServiceModel.Syndication
         public void Save(System.Xml.XmlWriter writer) { }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
+        protected internal virtual void WriteAttributeExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
+        protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
     public abstract partial class CategoriesDocumentFormatter
@@ -156,7 +158,9 @@ namespace System.ServiceModel.Syndication
         protected internal virtual System.ServiceModel.Syndication.ReferencedCategoriesDocument CreateReferencedCategoriesDocument() { throw null; }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
+        protected internal virtual void WriteAttributeExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
+        protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
     public partial class Rss20FeedFormatter : System.ServiceModel.Syndication.SyndicationFeedFormatter
@@ -233,7 +237,9 @@ namespace System.ServiceModel.Syndication
         public System.Threading.Tasks.Task Save(System.Xml.XmlWriter writer) { throw null; }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
+        protected internal virtual void WriteAttributeExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
+        protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
     [System.Runtime.Serialization.DataContractAttribute]
@@ -264,10 +270,18 @@ namespace System.ServiceModel.Syndication
         protected static bool TryParseElement(System.Xml.XmlReader reader, System.ServiceModel.Syndication.ResourceCollectionInfo collection, string version) { throw null; }
         protected static bool TryParseElement(System.Xml.XmlReader reader, System.ServiceModel.Syndication.ServiceDocument document, string version) { throw null; }
         protected static bool TryParseElement(System.Xml.XmlReader reader, System.ServiceModel.Syndication.Workspace workspace, string version) { throw null; }
+        protected static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.CategoriesDocument categories, string version) { }
+        protected static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.ResourceCollectionInfo collection, string version) { }
         protected static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.ServiceDocument document, string version) { }
         protected static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.Workspace workspace, string version) { }
         protected static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.CategoriesDocument categories, string version) { throw null; }
         protected static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.ResourceCollectionInfo collection, string version) { throw null; }
+        protected static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.ServiceDocument document, string version) { throw null; }
+        protected static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.Workspace workspace, string version) { throw null; }
+        protected static void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.CategoriesDocument categories, string version) { }
+        protected static void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.ResourceCollectionInfo collection, string version) { }
+        protected static void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.ServiceDocument document, string version) { }
+        protected static void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.Workspace workspace, string version) { }
         protected static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.CategoriesDocument categories, string version) { throw null; }
         protected static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.ResourceCollectionInfo collection, string version) { throw null; }
         protected static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.ServiceDocument document, string version) { throw null; }
@@ -307,8 +321,9 @@ namespace System.ServiceModel.Syndication
         public static System.ServiceModel.Syndication.XmlSyndicationContent CreateXmlContent(object dataContractObject) { throw null; }
         public static System.ServiceModel.Syndication.XmlSyndicationContent CreateXmlContent(object dataContractObject, System.Runtime.Serialization.XmlObjectSerializer dataContractSerializer) { throw null; }
         public static System.ServiceModel.Syndication.XmlSyndicationContent CreateXmlContent(object xmlSerializerObject, System.Xml.Serialization.XmlSerializer serializer) { throw null; }
-        public static System.ServiceModel.Syndication.XmlSyndicationContent CreateXmlContent(System.Xml.XmlReader XmlReaderWrapper) { throw null; }
+        public static System.ServiceModel.Syndication.XmlSyndicationContent CreateXmlContent(System.Xml.XmlReader xmlReader) { throw null; }
         protected abstract void WriteContentsTo(System.Xml.XmlWriter writer);
+        public void WriteTo(System.Xml.XmlWriter writer, string outerElementName, string outerElementNamespace) { }
         public System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer, string outerElementName, string outerElementNamespace) { throw null; }
     }
     public partial class SyndicationElementExtension
@@ -318,7 +333,7 @@ namespace System.ServiceModel.Syndication
         public SyndicationElementExtension(object xmlSerializerExtension, System.Xml.Serialization.XmlSerializer serializer) { }
         public SyndicationElementExtension(string outerName, string outerNamespace, object dataContractExtension) { }
         public SyndicationElementExtension(string outerName, string outerNamespace, object dataContractExtension, System.Runtime.Serialization.XmlObjectSerializer dataContractSerializer) { }
-        public SyndicationElementExtension(System.Xml.XmlReader reader) { }
+        public SyndicationElementExtension(System.Xml.XmlReader xmlReader) { }
         public string OuterName { get { throw null; } }
         public string OuterNamespace { get { throw null; } }
         public System.Threading.Tasks.Task<TExtension> GetObject<TExtension>() { throw null; }
@@ -375,7 +390,6 @@ namespace System.ServiceModel.Syndication
         public System.Collections.ObjectModel.Collection<System.ServiceModel.Syndication.SyndicationLink> Links { get { throw null; } }
         public System.Collections.ObjectModel.Collection<string> SkipDays { get { throw null; } }
         public System.Collections.ObjectModel.Collection<int> SkipHours { get { throw null; } }
-        public System.ServiceModel.Syndication.SyndicationTextInput TextInput { get { throw null; } set { } }
         public int TimeToLive { get { throw null; } set { } }
         public System.ServiceModel.Syndication.TextSyndicationContent Title { get { throw null; } set { } }
         public virtual System.ServiceModel.Syndication.SyndicationFeed Clone(bool cloneItems) { throw null; }
@@ -393,7 +407,9 @@ namespace System.ServiceModel.Syndication
         public static System.Threading.Tasks.Task<System.ServiceModel.Syndication.SyndicationFeed> LoadAsync(System.Xml.XmlReader reader, System.Threading.CancellationToken ct) { throw null; }
         public static System.Threading.Tasks.Task<TSyndicationFeed> LoadAsync<TSyndicationFeed>(System.Xml.XmlReader reader, System.Threading.CancellationToken ct) where TSyndicationFeed : System.ServiceModel.Syndication.SyndicationFeed, new() { throw null; }
         public static TSyndicationFeed Load<TSyndicationFeed>(System.Xml.XmlReader reader) where TSyndicationFeed : System.ServiceModel.Syndication.SyndicationFeed, new() { throw null; }
+        public void SaveAsAtom10(System.Xml.XmlWriter writer) { }
         public System.Threading.Tasks.Task SaveAsAtom10Async(System.Xml.XmlWriter writer, System.Threading.CancellationToken ct) { throw null; }
+        public void SaveAsRss20(System.Xml.XmlWriter writer) { }
         public System.Threading.Tasks.Task SaveAsRss20Async(System.Xml.XmlWriter writer, System.Threading.CancellationToken ct) { throw null; }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
@@ -494,10 +510,14 @@ namespace System.ServiceModel.Syndication
         public System.ServiceModel.Syndication.Atom10ItemFormatter GetAtom10Formatter() { throw null; }
         public System.ServiceModel.Syndication.Rss20ItemFormatter GetRss20Formatter() { throw null; }
         public System.ServiceModel.Syndication.Rss20ItemFormatter GetRss20Formatter(bool serializeExtensionsAsAtom) { throw null; }
+        public static System.ServiceModel.Syndication.SyndicationItem Load(System.Xml.XmlReader reader) { throw null; }
         public static System.Threading.Tasks.Task<System.ServiceModel.Syndication.SyndicationItem> LoadAsync(System.Xml.XmlReader reader) { throw null; }
         public static System.Threading.Tasks.Task<TSyndicationItem> LoadAsync<TSyndicationItem>(System.Xml.XmlReader reader) where TSyndicationItem : System.ServiceModel.Syndication.SyndicationItem, new() { throw null; }
-        public System.Threading.Tasks.Task SaveAsAtom10(System.Xml.XmlWriter writer) { throw null; }
-        public System.Threading.Tasks.Task SaveAsRss20(System.Xml.XmlWriter writer) { throw null; }
+        public static TSyndicationItem Load<TSyndicationItem>(System.Xml.XmlReader reader) where TSyndicationItem : System.ServiceModel.Syndication.SyndicationItem, new() { throw null; }
+        public void SaveAsAtom10(System.Xml.XmlWriter writer) { }
+        public System.Threading.Tasks.Task SaveAsAtom10Async(System.Xml.XmlWriter writer) { throw null; }
+        public void SaveAsRss20(System.Xml.XmlWriter writer) { }
+        public System.Threading.Tasks.Task SaveAsRss20Async(System.Xml.XmlWriter writer) { throw null; }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseContent(System.Xml.XmlReader reader, string contentType, string version, out System.ServiceModel.Syndication.SyndicationContent content) { content = default(System.ServiceModel.Syndication.SyndicationContent); throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
@@ -535,10 +555,18 @@ namespace System.ServiceModel.Syndication
         protected static bool TryParseElement(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationItem item, string version) { throw null; }
         protected static bool TryParseElement(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationLink link, string version) { throw null; }
         protected static bool TryParseElement(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationPerson person, string version) { throw null; }
+        protected static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationCategory category, string version) { }
+        protected static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, string version) { }
+        protected static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationLink link, string version) { }
+        protected static void WriteAttributeExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationPerson person, string version) { }
         protected static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationCategory category, string version) { throw null; }
         protected static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, string version) { throw null; }
         protected static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationLink link, string version) { throw null; }
         protected static System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationPerson person, string version) { throw null; }
+        protected void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationCategory category, string version) { }
+        protected static void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, string version) { }
+        protected void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationLink link, string version) { }
+        protected void WriteElementExtensions(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationPerson person, string version) { }
         protected System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationCategory category, string version) { throw null; }
         protected static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, string version) { throw null; }
         protected System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationLink link, string version) { throw null; }
@@ -593,14 +621,6 @@ namespace System.ServiceModel.Syndication
         protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
-    public partial class SyndicationTextInput
-    {
-        public string Description;
-        public System.ServiceModel.Syndication.SyndicationLink link;
-        public string name;
-        public string title;
-        public SyndicationTextInput() { }
-    }
     public static partial class SyndicationVersions
     {
         public const string Atom10 = "Atom10";
@@ -644,7 +664,9 @@ namespace System.ServiceModel.Syndication
         protected internal virtual System.ServiceModel.Syndication.ResourceCollectionInfo CreateResourceCollection() { throw null; }
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version) { throw null; }
         protected internal virtual bool TryParseElement(System.Xml.XmlReader reader, string version) { throw null; }
-        protected internal virtual System.Threading.Tasks.Task WriteAttributeExtensions(System.Xml.XmlWriter writer, string version) { throw null; }
+        protected internal virtual void WriteAttributeExtensions(System.Xml.XmlWriter writer, string version) { }
+        protected internal virtual System.Threading.Tasks.Task WriteAttributeExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
+        protected internal virtual void WriteElementExtensions(System.Xml.XmlWriter writer, string version) { }
         protected internal virtual System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, string version) { throw null; }
     }
     public partial class XmlSyndicationContent : System.ServiceModel.Syndication.SyndicationContent

--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
@@ -51,7 +51,9 @@ namespace System.ServiceModel.Syndication
         public override string Version { get { throw null; } }
         public override bool CanRead(System.Xml.XmlReader reader) { throw null; }
         protected override System.ServiceModel.Syndication.SyndicationItem CreateItemInstance() { throw null; }
+        public override void ReadFrom(System.Xml.XmlReader reader) { }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader) { throw null; }
+        public override void WriteTo(System.Xml.XmlWriter writer) { }
         public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer) { throw null; }
     }
     public partial class Atom10ItemFormatter<TSyndicationItem> : System.ServiceModel.Syndication.Atom10ItemFormatter where TSyndicationItem : System.ServiceModel.Syndication.SyndicationItem, new()
@@ -66,7 +68,7 @@ namespace System.ServiceModel.Syndication
         public AtomPub10CategoriesDocumentFormatter(System.ServiceModel.Syndication.CategoriesDocument documentToWrite) { }
         public AtomPub10CategoriesDocumentFormatter(System.Type inlineDocumentType, System.Type referencedDocumentType) { }
         public override string Version { get { throw null; } }
-        public override System.Threading.Tasks.Task<bool> CanReadAsync(System.Xml.XmlReader reader) { throw null; }
+        public override bool CanRead(System.Xml.XmlReader reader) { throw null; }
         protected override System.ServiceModel.Syndication.InlineCategoriesDocument CreateInlineCategoriesDocument() { throw null; }
         protected override System.ServiceModel.Syndication.ReferencedCategoriesDocument CreateReferencedCategoriesDocument() { throw null; }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader) { throw null; }
@@ -78,7 +80,7 @@ namespace System.ServiceModel.Syndication
         public AtomPub10ServiceDocumentFormatter(System.ServiceModel.Syndication.ServiceDocument documentToWrite) { }
         public AtomPub10ServiceDocumentFormatter(System.Type documentTypeToCreate) { }
         public override string Version { get { throw null; } }
-        public override System.Threading.Tasks.Task<bool> CanReadAsync(System.Xml.XmlReader reader) { throw null; }
+        public override bool CanRead(System.Xml.XmlReader reader) { throw null; }
         protected override System.ServiceModel.Syndication.ServiceDocument CreateDocumentInstance() { throw null; }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader) { throw null; }
         public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer) { throw null; }
@@ -113,7 +115,7 @@ namespace System.ServiceModel.Syndication
         protected CategoriesDocumentFormatter(System.ServiceModel.Syndication.CategoriesDocument documentToWrite) { }
         public System.ServiceModel.Syndication.CategoriesDocument Document { get { throw null; } }
         public abstract string Version { get; }
-        public abstract System.Threading.Tasks.Task<bool> CanReadAsync(System.Xml.XmlReader reader);
+        public abstract bool CanRead(System.Xml.XmlReader reader);
         protected virtual System.ServiceModel.Syndication.InlineCategoriesDocument CreateInlineCategoriesDocument() { throw null; }
         protected virtual System.ServiceModel.Syndication.ReferencedCategoriesDocument CreateReferencedCategoriesDocument() { throw null; }
         public abstract System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader);
@@ -204,7 +206,9 @@ namespace System.ServiceModel.Syndication
         public override string Version { get { throw null; } }
         public override bool CanRead(System.Xml.XmlReader reader) { throw null; }
         protected override System.ServiceModel.Syndication.SyndicationItem CreateItemInstance() { throw null; }
+        public override void ReadFrom(System.Xml.XmlReader reader) { }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader) { throw null; }
+        public override void WriteTo(System.Xml.XmlWriter writer) { }
         public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer) { throw null; }
     }
     public partial class Rss20ItemFormatter<TSyndicationItem> : System.ServiceModel.Syndication.Rss20ItemFormatter where TSyndicationItem : System.ServiceModel.Syndication.SyndicationItem, new()
@@ -239,7 +243,7 @@ namespace System.ServiceModel.Syndication
         protected ServiceDocumentFormatter(System.ServiceModel.Syndication.ServiceDocument documentToWrite) { }
         public System.ServiceModel.Syndication.ServiceDocument Document { get { throw null; } }
         public abstract string Version { get; }
-        public abstract System.Threading.Tasks.Task<bool> CanReadAsync(System.Xml.XmlReader reader);
+        public abstract bool CanRead(System.Xml.XmlReader reader);
         protected static System.ServiceModel.Syndication.SyndicationCategory CreateCategory(System.ServiceModel.Syndication.InlineCategoriesDocument inlineCategories) { throw null; }
         protected static System.ServiceModel.Syndication.ResourceCollectionInfo CreateCollection(System.ServiceModel.Syndication.Workspace workspace) { throw null; }
         protected virtual System.ServiceModel.Syndication.ServiceDocument CreateDocumentInstance() { throw null; }
@@ -518,6 +522,7 @@ namespace System.ServiceModel.Syndication
         protected static void LoadElementExtensions(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationItem item, int maxExtensionSize) { }
         protected static void LoadElementExtensions(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationLink link, int maxExtensionSize) { }
         protected static void LoadElementExtensions(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationPerson person, int maxExtensionSize) { }
+        public abstract void ReadFrom(System.Xml.XmlReader reader);
         public abstract System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader);
         protected internal virtual void SetItem(System.ServiceModel.Syndication.SyndicationItem item) { }
         public override string ToString() { throw null; }
@@ -538,6 +543,7 @@ namespace System.ServiceModel.Syndication
         protected static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, string version) { throw null; }
         protected System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationLink link, string version) { throw null; }
         protected System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationPerson person, string version) { throw null; }
+        public abstract void WriteTo(System.Xml.XmlWriter writer);
         public abstract System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer);
     }
     public partial class SyndicationLink

--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
@@ -193,7 +193,6 @@ namespace System.ServiceModel.Syndication
         public override string Version { get { throw null; } }
         public override bool CanRead(System.Xml.XmlReader reader) { throw null; }
         protected override System.ServiceModel.Syndication.SyndicationFeed CreateFeedInstance() { throw null; }
-        public static System.DateTimeOffset DefaultDateParser(string dateTimeString, string localName, string ns) { throw null; }
         public override void ReadFrom(System.Xml.XmlReader reader) { }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader, System.Threading.CancellationToken ct) { throw null; }
         protected virtual System.ServiceModel.Syndication.SyndicationItem ReadItem(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed) { throw null; }
@@ -461,9 +460,9 @@ namespace System.ServiceModel.Syndication
         protected SyndicationFeedFormatter() { }
         protected SyndicationFeedFormatter(System.ServiceModel.Syndication.SyndicationFeed feedToWrite) { }
         public System.Func<string, string, string, System.DateTimeOffset> DateTimeParser { get { throw null; } set { } }
+        public System.ServiceModel.Syndication.SyndicationFeed Feed { get { throw null; } }
         public System.Func<string, string, string, string> StringParser { get { throw null; } set { } }
         public System.Func<string, System.UriKind, string, string, System.Uri> UriParser { get { throw null; } set { } }
-        public System.ServiceModel.Syndication.SyndicationFeed Feed { get { throw null; } }
         public abstract string Version { get; }
         public abstract bool CanRead(System.Xml.XmlReader reader);
         protected internal static System.ServiceModel.Syndication.SyndicationCategory CreateCategory(System.ServiceModel.Syndication.SyndicationFeed feed) { throw null; }

--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
@@ -18,14 +18,20 @@ namespace System.ServiceModel.Syndication
         public override string Version { get { throw null; } }
         public override bool CanRead(System.Xml.XmlReader reader) { throw null; }
         protected override System.ServiceModel.Syndication.SyndicationFeed CreateFeedInstance() { throw null; }
+        public override void ReadFrom(System.Xml.XmlReader reader) { }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader, System.Threading.CancellationToken ct) { throw null; }
+        protected virtual System.ServiceModel.Syndication.SyndicationItem ReadItem(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed) { throw null; }
         protected virtual System.Threading.Tasks.Task<System.ServiceModel.Syndication.SyndicationItem> ReadItemAsync(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed) { throw null; }
+        protected virtual System.Collections.Generic.IEnumerable<System.ServiceModel.Syndication.SyndicationItem> ReadItems(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed, out bool areAllItemsRead) { areAllItemsRead = default(bool); throw null; }
         protected virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.ServiceModel.Syndication.SyndicationItem>> ReadItemsAsync(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed) { throw null; }
         System.Xml.Schema.XmlSchema System.Xml.Serialization.IXmlSerializable.GetSchema() { throw null; }
         void System.Xml.Serialization.IXmlSerializable.ReadXml(System.Xml.XmlReader reader) { }
         void System.Xml.Serialization.IXmlSerializable.WriteXml(System.Xml.XmlWriter writer) { }
+        protected virtual void WriteItem(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, System.Uri feedBaseUri) { }
         protected virtual System.Threading.Tasks.Task WriteItemAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, System.Uri feedBaseUri) { throw null; }
+        protected virtual void WriteItems(System.Xml.XmlWriter writer, System.Collections.Generic.IEnumerable<System.ServiceModel.Syndication.SyndicationItem> items, System.Uri feedBaseUri) { }
         protected virtual System.Threading.Tasks.Task WriteItemsAsync(System.Xml.XmlWriter writer, System.Collections.Generic.IEnumerable<System.ServiceModel.Syndication.SyndicationItem> items, System.Uri feedBaseUri) { throw null; }
+        public override void WriteTo(System.Xml.XmlWriter writer) { }
         public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer, System.Threading.CancellationToken ct) { throw null; }
     }
     public partial class Atom10FeedFormatter<TSyndicationFeed> : System.ServiceModel.Syndication.Atom10FeedFormatter where TSyndicationFeed : System.ServiceModel.Syndication.SyndicationFeed, new()
@@ -164,11 +170,18 @@ namespace System.ServiceModel.Syndication
         public override string Version { get { throw null; } }
         public override bool CanRead(System.Xml.XmlReader reader) { throw null; }
         protected override System.ServiceModel.Syndication.SyndicationFeed CreateFeedInstance() { throw null; }
+        public static System.DateTimeOffset DefaultDateParser(string dateTimeString, string localName, string ns) { throw null; }
+        public override void ReadFrom(System.Xml.XmlReader reader) { }
         public override System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader, System.Threading.CancellationToken ct) { throw null; }
+        protected virtual System.ServiceModel.Syndication.SyndicationItem ReadItem(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed) { throw null; }
         protected virtual System.Threading.Tasks.Task<System.ServiceModel.Syndication.SyndicationItem> ReadItemAsync(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed) { throw null; }
+        protected virtual System.Collections.Generic.IEnumerable<System.ServiceModel.Syndication.SyndicationItem> ReadItems(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationFeed feed, out bool areAllItemsRead) { areAllItemsRead = default(bool); throw null; }
         protected internal override void SetFeed(System.ServiceModel.Syndication.SyndicationFeed feed) { }
+        protected virtual void WriteItem(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, System.Uri feedBaseUri) { }
         protected virtual System.Threading.Tasks.Task WriteItemAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, System.Uri feedBaseUri) { throw null; }
+        protected virtual void WriteItems(System.Xml.XmlWriter writer, System.Collections.Generic.IEnumerable<System.ServiceModel.Syndication.SyndicationItem> items, System.Uri feedBaseUri) { }
         protected virtual System.Threading.Tasks.Task WriteItemsAsync(System.Xml.XmlWriter writer, System.Collections.Generic.IEnumerable<System.ServiceModel.Syndication.SyndicationItem> items, System.Uri feedBaseUri) { throw null; }
+        public override void WriteTo(System.Xml.XmlWriter writer) { }
         public override System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer, System.Threading.CancellationToken ct) { throw null; }
     }
     public partial class Rss20FeedFormatter<TSyndicationFeed> : System.ServiceModel.Syndication.Rss20FeedFormatter where TSyndicationFeed : System.ServiceModel.Syndication.SyndicationFeed, new()
@@ -409,6 +422,7 @@ namespace System.ServiceModel.Syndication
         protected internal static void LoadElementExtensions(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationItem item, int maxExtensionSize) { }
         protected internal static void LoadElementExtensions(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationLink link, int maxExtensionSize) { }
         protected internal static void LoadElementExtensions(System.Xml.XmlReader reader, System.ServiceModel.Syndication.SyndicationPerson person, int maxExtensionSize) { }
+        public abstract void ReadFrom(System.Xml.XmlReader reader);
         public abstract System.Threading.Tasks.Task ReadFromAsync(System.Xml.XmlReader reader, System.Threading.CancellationToken ct);
         protected internal virtual void SetFeed(System.ServiceModel.Syndication.SyndicationFeed feed) { }
         public override string ToString() { throw null; }
@@ -443,6 +457,7 @@ namespace System.ServiceModel.Syndication
         protected internal static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationItem item, string version) { throw null; }
         protected internal static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationLink link, string version) { throw null; }
         protected internal static System.Threading.Tasks.Task WriteElementExtensionsAsync(System.Xml.XmlWriter writer, System.ServiceModel.Syndication.SyndicationPerson person, string version) { throw null; }
+        public abstract void WriteTo(System.Xml.XmlWriter writer);
         public abstract System.Threading.Tasks.Task WriteToAsync(System.Xml.XmlWriter writer, System.Threading.CancellationToken ct);
     }
     public partial class SyndicationItem

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10Constants.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10Constants.cs
@@ -6,7 +6,7 @@
 
 namespace System.ServiceModel.Syndication
 {
-    public static class Atom10Constants
+    static class Atom10Constants
     {
         public const string AlternateTag = "alternate";
         public const string Atom10Namespace = "http://www.w3.org/2005/Atom";

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10Constants.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10Constants.cs
@@ -6,7 +6,7 @@
 
 namespace System.ServiceModel.Syndication
 {
-    static class Atom10Constants
+    internal static class Atom10Constants
     {
         public const string AlternateTag = "alternate";
         public const string Atom10Namespace = "http://www.w3.org/2005/Atom";

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -7,16 +7,18 @@ namespace System.ServiceModel.Syndication
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Runtime.CompilerServices;
     using System.ServiceModel.Channels;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Xml;
+    using System.Xml.Schema;
     using System.Xml.Serialization;
 
     [XmlRoot(ElementName = Atom10Constants.FeedTag, Namespace = Atom10Constants.Atom10Namespace)]
-    public class Atom10FeedFormatter : SyndicationFeedFormatter
+    public class Atom10FeedFormatter : SyndicationFeedFormatter, IXmlSerializable
     {
         internal static readonly TimeSpan zeroOffset = new TimeSpan(0, 0, 0);
         internal const string XmlNs = "http://www.w3.org/XML/1998/namespace";
@@ -97,6 +99,34 @@ namespace System.ServiceModel.Syndication
             }
 
             return reader.IsStartElement(Atom10Constants.FeedTag, Atom10Constants.Atom10Namespace);
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        XmlSchema IXmlSerializable.GetSchema()
+        {
+            return null;
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        void IXmlSerializable.ReadXml(XmlReader reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            ReadFromAsync(reader, CancellationToken.None).Wait();
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            WriteFeedAsync(writer).Wait();
         }
 
         public override async Task ReadFromAsync(XmlReader reader, CancellationToken ct)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -115,7 +115,7 @@ namespace System.ServiceModel.Syndication
                 throw new ArgumentNullException(nameof(reader));
             }
 
-            ReadFromAsync(reader, CancellationToken.None).Wait();
+            ReadFromAsync(reader, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
@@ -126,17 +126,17 @@ namespace System.ServiceModel.Syndication
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            WriteFeedAsync(writer).Wait();
+            WriteFeedAsync(writer).GetAwaiter().GetResult();
         }
 
         public override void ReadFrom(XmlReader reader)
         {
-            ReadFromAsync(reader, CancellationToken.None).Wait();
+            ReadFromAsync(reader, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         public override void WriteTo(XmlWriter writer)
         {
-            WriteToAsync(writer, CancellationToken.None).Wait();
+            WriteToAsync(writer, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         public override async Task ReadFromAsync(XmlReader reader, CancellationToken ct)
@@ -565,13 +565,13 @@ namespace System.ServiceModel.Syndication
 
         protected virtual SyndicationItem ReadItem(XmlReader reader, SyndicationFeed feed)
         {
-            return ReadItemAsync(reader, feed).Result;
+            return ReadItemAsync(reader, feed).GetAwaiter().GetResult();
         }
 
         [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "The out parameter is needed to enable implementations that read in items from the stream on demand")]
         protected virtual IEnumerable<SyndicationItem> ReadItems(XmlReader reader, SyndicationFeed feed, out bool areAllItemsRead)
         {
-            IEnumerable<SyndicationItem> result = ReadItemsAsync(reader, feed).Result;
+            IEnumerable<SyndicationItem> result = ReadItemsAsync(reader, feed).GetAwaiter().GetResult();
             areAllItemsRead = true;
             return result;
         }
@@ -620,12 +620,12 @@ namespace System.ServiceModel.Syndication
 
         protected virtual void WriteItem(XmlWriter writer, SyndicationItem item, Uri feedBaseUri)
         {
-            WriteItemAsync(writer, item, feedBaseUri).Wait();
+            WriteItemAsync(writer, item, feedBaseUri).GetAwaiter().GetResult();
         }
 
         protected virtual void WriteItems(XmlWriter writer, IEnumerable<SyndicationItem> items, Uri feedBaseUri)
         {
-            WriteItemsAsync(writer, items, feedBaseUri).Wait();
+            WriteItemsAsync(writer, items, feedBaseUri).GetAwaiter().GetResult();
         }
 
         protected virtual async Task WriteItemAsync(XmlWriter writer, SyndicationItem item, Uri feedBaseUri)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -101,13 +101,11 @@ namespace System.ServiceModel.Syndication
             return reader.IsStartElement(Atom10Constants.FeedTag, Atom10Constants.Atom10Namespace);
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         XmlSchema IXmlSerializable.GetSchema()
         {
             return null;
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
             if (reader == null)
@@ -118,7 +116,6 @@ namespace System.ServiceModel.Syndication
             ReadFromAsync(reader, CancellationToken.None).GetAwaiter().GetResult();
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
             if (writer == null)
@@ -568,7 +565,6 @@ namespace System.ServiceModel.Syndication
             return ReadItemAsync(reader, feed).GetAwaiter().GetResult();
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "The out parameter is needed to enable implementations that read in items from the stream on demand")]
         protected virtual IEnumerable<SyndicationItem> ReadItems(XmlReader reader, SyndicationFeed feed, out bool areAllItemsRead)
         {
             IEnumerable<SyndicationItem> result = ReadItemsAsync(reader, feed).GetAwaiter().GetResult();

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -7,7 +7,6 @@ namespace System.ServiceModel.Syndication
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Runtime.CompilerServices;
     using System.ServiceModel.Channels;

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -129,6 +129,16 @@ namespace System.ServiceModel.Syndication
             WriteFeedAsync(writer).Wait();
         }
 
+        public override void ReadFrom(XmlReader reader)
+        {
+            ReadFromAsync(reader, CancellationToken.None).Wait();
+        }
+
+        public override void WriteTo(XmlWriter writer)
+        {
+            WriteToAsync(writer, CancellationToken.None).Wait();
+        }
+
         public override async Task ReadFromAsync(XmlReader reader, CancellationToken ct)
         {
             if (!CanRead(reader))
@@ -553,6 +563,19 @@ namespace System.ServiceModel.Syndication
             return SyndicationFeedFormatter.CreateFeedInstance(_feedType);
         }
 
+        protected virtual SyndicationItem ReadItem(XmlReader reader, SyndicationFeed feed)
+        {
+            return ReadItemAsync(reader, feed).Result;
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "The out parameter is needed to enable implementations that read in items from the stream on demand")]
+        protected virtual IEnumerable<SyndicationItem> ReadItems(XmlReader reader, SyndicationFeed feed, out bool areAllItemsRead)
+        {
+            IEnumerable<SyndicationItem> result = ReadItemsAsync(reader, feed).Result;
+            areAllItemsRead = true;
+            return result;
+        }
+
         protected virtual async Task<SyndicationItem> ReadItemAsync(XmlReader reader, SyndicationFeed feed)
         {
             if (feed == null)
@@ -593,6 +616,16 @@ namespace System.ServiceModel.Syndication
             }
 
             return items;
+        }
+
+        protected virtual void WriteItem(XmlWriter writer, SyndicationItem item, Uri feedBaseUri)
+        {
+            WriteItemAsync(writer, item, feedBaseUri).Wait();
+        }
+
+        protected virtual void WriteItems(XmlWriter writer, IEnumerable<SyndicationItem> items, Uri feedBaseUri)
+        {
+            WriteItemsAsync(writer, items, feedBaseUri).Wait();
         }
 
         protected virtual async Task WriteItemAsync(XmlWriter writer, SyndicationItem item, Uri feedBaseUri)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10ItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10ItemFormatter.cs
@@ -19,7 +19,7 @@ namespace System.ServiceModel.Syndication
     using System.Xml.Serialization;
 
     [XmlRoot(ElementName = Atom10Constants.EntryTag, Namespace = Atom10Constants.Atom10Namespace)]
-    public class Atom10ItemFormatter : SyndicationItemFormatter
+    public class Atom10ItemFormatter : SyndicationItemFormatter, IXmlSerializable
     {
         private Atom10FeedFormatter _feedSerializer;
         private Type _itemType;
@@ -98,6 +98,33 @@ namespace System.ServiceModel.Syndication
                 throw new ArgumentNullException(nameof(reader));
             }
             return reader.IsStartElement(Atom10Constants.EntryTag, Atom10Constants.Atom10Namespace);
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        XmlSchema IXmlSerializable.GetSchema()
+        {
+            return null;
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        void IXmlSerializable.ReadXml(XmlReader reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+            ReadItemAsync(reader).GetAwaiter().GetResult();
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            WriteItemAsync(writer).GetAwaiter().GetResult();
         }
 
         public override void ReadFrom(XmlReader reader)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10ItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10ItemFormatter.cs
@@ -102,12 +102,12 @@ namespace System.ServiceModel.Syndication
 
         public override void ReadFrom(XmlReader reader)
         {
-            ReadFromAsync(reader).Wait();
+            ReadFromAsync(reader).GetAwaiter().GetResult();
         }
 
         public override void WriteTo(XmlWriter writer)
         {
-            WriteToAsync(writer).Wait();
+            WriteToAsync(writer).GetAwaiter().GetResult();
         }
 
         public override Task ReadFromAsync(XmlReader reader)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10ItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10ItemFormatter.cs
@@ -100,6 +100,16 @@ namespace System.ServiceModel.Syndication
             return reader.IsStartElement(Atom10Constants.EntryTag, Atom10Constants.Atom10Namespace);
         }
 
+        public override void ReadFrom(XmlReader reader)
+        {
+            ReadFromAsync(reader).Wait();
+        }
+
+        public override void WriteTo(XmlWriter writer)
+        {
+            WriteToAsync(writer).Wait();
+        }
+
         public override Task ReadFromAsync(XmlReader reader)
         {
             if (!CanRead(reader))

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10ItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10ItemFormatter.cs
@@ -11,7 +11,6 @@
 namespace System.ServiceModel.Syndication
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using System.Xml;

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10ItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10ItemFormatter.cs
@@ -100,13 +100,11 @@ namespace System.ServiceModel.Syndication
             return reader.IsStartElement(Atom10Constants.EntryTag, Atom10Constants.Atom10Namespace);
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         XmlSchema IXmlSerializable.GetSchema()
         {
             return null;
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
             if (reader == null)
@@ -116,7 +114,6 @@ namespace System.ServiceModel.Syndication
             ReadItemAsync(reader).GetAwaiter().GetResult();
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
             if (writer == null)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatter.cs
@@ -115,6 +115,16 @@ namespace System.ServiceModel.Syndication
             return WriteDocumentAsync(writer);
         }
 
+        public override void ReadFrom(XmlReader reader)
+        {
+            ReadFromAsync(reader).GetAwaiter().GetResult();
+        }
+
+        public override void WriteTo(XmlWriter writer)
+        {
+            WriteToAsync(writer).GetAwaiter().GetResult();
+        }
+
         public override async Task ReadFromAsync(XmlReader reader)
         {
             if (reader == null)
@@ -130,7 +140,7 @@ namespace System.ServiceModel.Syndication
             await ReadDocumentAsync(XmlReaderWrapper.CreateFromReader(reader));
         }
 
-        public override async Task WriteTo(XmlWriter writer)
+        public override async Task WriteToAsync(XmlWriter writer)
         {
             if (writer == null)
             {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatter.cs
@@ -79,7 +79,7 @@ namespace System.ServiceModel.Syndication
             get { return App10Constants.Namespace; }
         }
 
-        public override Task<bool> CanReadAsync(XmlReader reader)
+        public override bool CanRead(XmlReader reader)
         {
             if (reader == null)
             {
@@ -122,7 +122,7 @@ namespace System.ServiceModel.Syndication
                 throw new ArgumentNullException(nameof(reader));
             }
 
-            if (!await CanReadAsync(reader))
+            if (!CanRead(reader))
             {
                 throw new XmlException(SR.Format(SR.UnknownDocumentXml, reader.LocalName, reader.NamespaceURI));
             }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatter.cs
@@ -6,7 +6,6 @@
 namespace System.ServiceModel.Syndication
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using System.Xml;

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatter.cs
@@ -89,16 +89,14 @@ namespace System.ServiceModel.Syndication
             }
 
             reader = XmlReaderWrapper.CreateFromReader(reader);
-            return reader.IsStartElementAsync(App10Constants.Categories, App10Constants.Namespace);
+            return reader.IsStartElement(App10Constants.Categories, App10Constants.Namespace);
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         XmlSchema IXmlSerializable.GetSchema()
         {
             return null;
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
             if (reader == null)
@@ -109,7 +107,6 @@ namespace System.ServiceModel.Syndication
             ReadDocumentAsync(XmlReaderWrapper.CreateFromReader(reader)).GetAwaiter().GetResult();
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
             if (writer == null)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatter.cs
@@ -6,13 +6,15 @@
 namespace System.ServiceModel.Syndication
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using System.Xml;
+    using System.Xml.Schema;
     using System.Xml.Serialization;
 
     [XmlRoot(ElementName = App10Constants.Categories, Namespace = App10Constants.Namespace)]
-    public class AtomPub10CategoriesDocumentFormatter : CategoriesDocumentFormatter
+    public class AtomPub10CategoriesDocumentFormatter : CategoriesDocumentFormatter, IXmlSerializable
     {
         private Type _inlineDocumentType;
         private int _maxExtensionSize;
@@ -90,29 +92,36 @@ namespace System.ServiceModel.Syndication
             return reader.IsStartElementAsync(App10Constants.Categories, App10Constants.Namespace);
         }
 
-        Task ReadXmlAsync(XmlReader reader)
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        XmlSchema IXmlSerializable.GetSchema()
+        {
+            return null;
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        void IXmlSerializable.ReadXml(XmlReader reader)
         {
             if (reader == null)
             {
                 throw new ArgumentNullException(nameof(reader));
             }
 
-            return ReadDocumentAsync(reader);
+            ReadDocumentAsync(XmlReaderWrapper.CreateFromReader(reader)).GetAwaiter().GetResult();
         }
 
-        private Task WriteXmlAsync(XmlWriter writer)
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        void IXmlSerializable.WriteXml(XmlWriter writer)
         {
             if (writer == null)
             {
                 throw new ArgumentNullException(nameof(writer));
             }
-
             if (Document == null)
             {
                 throw new InvalidOperationException(SR.DocumentFormatterDoesNotHaveDocument);
             }
 
-            return WriteDocumentAsync(writer);
+            WriteDocumentAsync(XmlWriterWrapper.CreateFromWriter(writer)).GetAwaiter().GetResult();
         }
 
         public override void ReadFrom(XmlReader reader)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
@@ -16,7 +16,7 @@ namespace System.ServiceModel.Syndication
     internal delegate ReferencedCategoriesDocument CreateReferencedCategoriesDelegate();
 
     [XmlRoot(ElementName = App10Constants.Service, Namespace = App10Constants.Namespace)]
-    public class AtomPub10ServiceDocumentFormatter : ServiceDocumentFormatter
+    public class AtomPub10ServiceDocumentFormatter : ServiceDocumentFormatter, IXmlSerializable
     {
         private Type _documentType;
         private int _maxExtensionSize;
@@ -71,14 +71,36 @@ namespace System.ServiceModel.Syndication
             return reader.IsStartElementAsync(App10Constants.Service, App10Constants.Namespace);
         }
 
-        Task ReadXml(XmlReader reader)
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        XmlSchema IXmlSerializable.GetSchema()
+        {
+            return null;
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        void IXmlSerializable.ReadXml(XmlReader reader)
         {
             if (reader == null)
             {
                 throw new ArgumentNullException(nameof(reader));
             }
 
-            return ReadDocumentAsync(reader);
+            ReadDocumentAsync(XmlReaderWrapper.CreateFromReader(reader)).GetAwaiter().GetResult();
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+            if (this.Document == null)
+            {
+                throw new InvalidOperationException(SR.DocumentFormatterDoesNotHaveDocument);
+            }
+
+            WriteDocumentAsync(XmlWriterWrapper.CreateFromWriter(writer)).GetAwaiter().GetResult();
         }
 
         public override void ReadFrom(XmlReader reader)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
@@ -81,6 +81,16 @@ namespace System.ServiceModel.Syndication
             return ReadDocumentAsync(reader);
         }
 
+        public override void ReadFrom(XmlReader reader)
+        {
+            ReadFromAsync(reader).GetAwaiter().GetResult();
+        }
+
+        public override void WriteTo(XmlWriter writer)
+        {
+            WriteToAsync(writer).GetAwaiter().GetResult();
+        }
+
         private Task WriteXml(XmlWriter writer)
         {
             if (writer == null)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
@@ -60,7 +60,7 @@ namespace System.ServiceModel.Syndication
             get { return App10Constants.Namespace; }
         }
 
-        public override Task<bool> CanReadAsync(XmlReader reader)
+        public override bool CanRead(XmlReader reader)
         {
             if (reader == null)
             {
@@ -106,7 +106,7 @@ namespace System.ServiceModel.Syndication
             reader = XmlReaderWrapper.CreateFromReader(reader);
             await reader.MoveToContentAsync();
 
-            if (!await CanReadAsync(reader))
+            if (!CanRead(reader))
             {
                 throw new XmlException(SR.Format(SR.UnknownDocumentXml, reader.LocalName, reader.NamespaceURI));
             }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
@@ -68,16 +68,14 @@ namespace System.ServiceModel.Syndication
             }
 
             reader = XmlReaderWrapper.CreateFromReader(reader);
-            return reader.IsStartElementAsync(App10Constants.Service, App10Constants.Namespace);
+            return reader.IsStartElement(App10Constants.Service, App10Constants.Namespace);
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         XmlSchema IXmlSerializable.GetSchema()
         {
             return null;
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
             if (reader == null)
@@ -88,7 +86,6 @@ namespace System.ServiceModel.Syndication
             ReadDocumentAsync(XmlReaderWrapper.CreateFromReader(reader)).GetAwaiter().GetResult();
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
             if (writer == null)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
@@ -5,7 +5,6 @@
 namespace System.ServiceModel.Syndication
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using System.Xml;

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
@@ -406,7 +406,7 @@ namespace System.ServiceModel.Syndication
             writer.WriteAttributeString("xml", "lang", Atom10FeedFormatter.XmlNs, lang);
         }
 
-        private async Task<ResourceCollectionInfo> ReadCollection(XmlReader reader, Workspace workspace)
+        private async Task<ResourceCollectionInfo> ReadCollectionAsync(XmlReader reader, Workspace workspace)
         {
             ResourceCollectionInfo result = CreateCollection(workspace);
             result.BaseUri = workspace.BaseUri;
@@ -557,7 +557,7 @@ namespace System.ServiceModel.Syndication
                         {
                             if (await reader.IsStartElementAsync(App10Constants.Workspace, App10Constants.Namespace))
                             {
-                                result.Workspaces.Add(ReadWorkspace(reader, result).Result);
+                                result.Workspaces.Add(await ReadWorkspaceAsync(reader, result));
                             }
                             else if (!TryParseElement(reader, result, Version))
                             {
@@ -599,7 +599,7 @@ namespace System.ServiceModel.Syndication
             SetDocument(result);
         }
 
-        private async Task<Workspace> ReadWorkspace(XmlReader reader, ServiceDocument document)
+        private async Task<Workspace> ReadWorkspaceAsync(XmlReader reader, ServiceDocument document)
         {
             Workspace result = CreateWorkspace(document);
             result.BaseUri = document.BaseUri;
@@ -645,7 +645,7 @@ namespace System.ServiceModel.Syndication
                     }
                     else if (await reader.IsStartElementAsync(App10Constants.Collection, App10Constants.Namespace))
                     {
-                        result.Collections.Add(ReadCollection(reader, result).Result);
+                        result.Collections.Add(await ReadCollectionAsync(reader, result));
                     }
                     else if (!TryParseElement(reader, result, Version))
                     {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/CategoriesDocument.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/CategoriesDocument.cs
@@ -96,6 +96,16 @@ namespace System.ServiceModel.Syndication
             return false;
         }
 
+        protected internal virtual void WriteAttributeExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteAttributeExtensions(writer);
+        }
+
+        protected internal virtual void WriteElementExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteElementExtensions(writer);
+        }
+
         protected internal virtual Task WriteAttributeExtensionsAsync(XmlWriter writer, string version)
         {
             return _extensions.WriteAttributeExtensionsAsync(writer);

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/CategoriesDocument.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/CategoriesDocument.cs
@@ -88,7 +88,7 @@ namespace System.ServiceModel.Syndication
 
         public void Save(XmlWriter writer)
         {
-            GetFormatter().WriteToAsync(writer);
+            GetFormatter().WriteTo(writer);
         }
 
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/CategoriesDocument.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/CategoriesDocument.cs
@@ -69,6 +69,11 @@ namespace System.ServiceModel.Syndication
             return new ReferencedCategoriesDocument(linkToCategoriesDocument);
         }
 
+        public static CategoriesDocument Load(XmlReader reader)
+        {
+            return LoadAsync(reader).GetAwaiter().GetResult();
+        }
+
         public static async Task<CategoriesDocument> LoadAsync(XmlReader reader)
         {
             AtomPub10CategoriesDocumentFormatter formatter = new AtomPub10CategoriesDocumentFormatter();
@@ -83,7 +88,7 @@ namespace System.ServiceModel.Syndication
 
         public void Save(XmlWriter writer)
         {
-            GetFormatter().WriteTo(writer);
+            GetFormatter().WriteToAsync(writer);
         }
 
         protected internal virtual bool TryParseAttribute(string name, string ns, string value, string version)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/CategoriesDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/CategoriesDocumentFormatter.cs
@@ -34,7 +34,7 @@ namespace System.ServiceModel.Syndication
         public abstract string Version
         { get; }
 
-        public abstract Task<bool> CanReadAsync(XmlReader reader);
+        public abstract bool CanRead(XmlReader reader);
         public abstract Task ReadFromAsync(XmlReader reader);
         public abstract Task WriteTo(XmlWriter writer);
 

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/CategoriesDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/CategoriesDocumentFormatter.cs
@@ -10,6 +10,7 @@ namespace System.ServiceModel.Syndication
     using System.Threading.Tasks;
     using System.Xml;
 
+    [DataContract]
     public abstract class CategoriesDocumentFormatter
     {
         private CategoriesDocument _document;
@@ -35,8 +36,10 @@ namespace System.ServiceModel.Syndication
         { get; }
 
         public abstract bool CanRead(XmlReader reader);
+        public abstract void ReadFrom(XmlReader reader);
+        public abstract void WriteTo(XmlWriter writer);
         public abstract Task ReadFromAsync(XmlReader reader);
-        public abstract Task WriteTo(XmlWriter writer);
+        public abstract Task WriteToAsync(XmlWriter writer);
 
         protected virtual InlineCategoriesDocument CreateInlineCategoriesDocument()
         {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ExtensibleSyndicationObject.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ExtensibleSyndicationObject.cs
@@ -102,6 +102,16 @@ namespace System.ServiceModel.Syndication
             _elementExtensions = new SyndicationElementExtensionCollection(buffer);
         }
 
+        internal void WriteAttributeExtensions(XmlWriter writer)
+        {
+            WriteAttributeExtensionsAsync(writer).Wait();
+        }
+
+        internal void WriteElementExtensions(XmlWriter writer)
+        {
+            WriteElementExtensionsAsync(writer).Wait();
+        }
+
         internal async Task WriteAttributeExtensionsAsync(XmlWriter writer)
         {
             if (writer == null)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ExtensibleSyndicationObject.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ExtensibleSyndicationObject.cs
@@ -104,12 +104,12 @@ namespace System.ServiceModel.Syndication
 
         internal void WriteAttributeExtensions(XmlWriter writer)
         {
-            WriteAttributeExtensionsAsync(writer).Wait();
+            WriteAttributeExtensionsAsync(writer).GetAwaiter().GetResult();
         }
 
         internal void WriteElementExtensions(XmlWriter writer)
         {
-            WriteElementExtensionsAsync(writer).Wait();
+            WriteElementExtensionsAsync(writer).GetAwaiter().GetResult();
         }
 
         internal async Task WriteAttributeExtensionsAsync(XmlWriter writer)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ResourceCollectionInfo.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ResourceCollectionInfo.cs
@@ -148,6 +148,16 @@ namespace System.ServiceModel.Syndication
             return false;
         }
 
+        protected internal virtual void WriteAttributeExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteAttributeExtensions(writer);
+        }
+
+        protected internal virtual void WriteElementExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteElementExtensions(writer);
+        }
+
         protected internal virtual Task WriteAttributeExtensionsAsync(XmlWriter writer, string version)
         {
             return _extensions.WriteAttributeExtensionsAsync(writer);

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -135,13 +135,11 @@ namespace System.ServiceModel.Syndication
             return reader.IsStartElement(Rss20Constants.RssTag, Rss20Constants.Rss20Namespace);
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         XmlSchema IXmlSerializable.GetSchema()
         {
             return null;
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
             if (reader == null)
@@ -152,7 +150,6 @@ namespace System.ServiceModel.Syndication
             ReadFeedAsync(reader).GetAwaiter().GetResult();
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
             if (writer == null)
@@ -446,7 +443,6 @@ namespace System.ServiceModel.Syndication
             return ReadItemAsync(reader, feed).GetAwaiter().GetResult();
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "The out parameter is needed to enable implementations that read in items from the stream on demand")]
         protected virtual IEnumerable<SyndicationItem> ReadItems(XmlReader reader, SyndicationFeed feed, out bool areAllItemsRead)
         {
             if (feed == null)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -158,12 +158,12 @@ namespace System.ServiceModel.Syndication
 
         public override void ReadFrom(XmlReader reader)
         {
-            ReadFromAsync(reader, CancellationToken.None).Wait();
+            ReadFromAsync(reader, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         public override void WriteTo(XmlWriter writer)
         {
-            WriteToAsync(writer, CancellationToken.None).Wait();
+            WriteToAsync(writer, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         public override async Task WriteToAsync(XmlWriter writer, CancellationToken ct)
@@ -346,7 +346,7 @@ namespace System.ServiceModel.Syndication
 
                         if (notHandled)
                         {
-                            bool parsedExtension = _serializeExtensionsAsAtom && _atomSerializer.TryParseItemElementFromAsync(reader, result).Result;
+                            bool parsedExtension = _serializeExtensionsAsAtom && _atomSerializer.TryParseItemElementFromAsync(reader, result).GetAwaiter().GetResult();
 
                             if (!parsedExtension)
                             {
@@ -414,7 +414,7 @@ namespace System.ServiceModel.Syndication
 
         protected virtual SyndicationItem ReadItem(XmlReader reader, SyndicationFeed feed)
         {
-            return ReadItemAsync(reader, feed).Result;
+            return ReadItemAsync(reader, feed).GetAwaiter().GetResult();
         }
 
         [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "The out parameter is needed to enable implementations that read in items from the stream on demand")]
@@ -456,12 +456,12 @@ namespace System.ServiceModel.Syndication
 
         protected virtual void WriteItem(XmlWriter writer, SyndicationItem item, Uri feedBaseUri)
         {
-            WriteItemAsync(writer, item, feedBaseUri).Wait();
+            WriteItemAsync(writer, item, feedBaseUri).GetAwaiter().GetResult();
         }
 
         protected virtual void WriteItems(XmlWriter writer, IEnumerable<SyndicationItem> items, Uri feedBaseUri)
         {
-            WriteItemsAsync(writer, items, feedBaseUri).Wait();
+            WriteItemsAsync(writer, items, feedBaseUri).GetAwaiter().GetResult();
         }
 
         protected virtual async Task WriteItemAsync(XmlWriter writer, SyndicationItem item, Uri feedBaseUri)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -7,7 +7,6 @@ namespace System.ServiceModel.Syndication
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Text;
     using System.Threading;

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20ItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20ItemFormatter.cs
@@ -113,14 +113,14 @@ namespace System.ServiceModel.Syndication
             return reader.IsStartElement(Rss20Constants.ItemTag, Rss20Constants.Rss20Namespace);
         }
 
-
-        private async Task WriteXml(XmlWriter writer)
+        public override void ReadFrom(XmlReader reader)
         {
-            if (writer == null)
-            {
-                throw new ArgumentNullException(nameof(writer));
-            }
-            await WriteItem(writer);
+            ReadFromAsync(reader).Wait();
+        }
+
+        public override void WriteTo(XmlWriter writer)
+        {
+            WriteToAsync(writer).Wait();
         }
 
         public override Task ReadFromAsync(XmlReader reader)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20ItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20ItemFormatter.cs
@@ -115,12 +115,12 @@ namespace System.ServiceModel.Syndication
 
         public override void ReadFrom(XmlReader reader)
         {
-            ReadFromAsync(reader).Wait();
+            ReadFromAsync(reader).GetAwaiter().GetResult();
         }
 
         public override void WriteTo(XmlWriter writer)
         {
-            WriteToAsync(writer).Wait();
+            WriteToAsync(writer).GetAwaiter().GetResult();
         }
 
         public override Task ReadFromAsync(XmlReader reader)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20ItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20ItemFormatter.cs
@@ -113,13 +113,11 @@ namespace System.ServiceModel.Syndication
             return reader.IsStartElement(Rss20Constants.ItemTag, Rss20Constants.Rss20Namespace);
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         XmlSchema IXmlSerializable.GetSchema()
         {
             return null;
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
             if (reader == null)
@@ -130,7 +128,6 @@ namespace System.ServiceModel.Syndication
             ReadItemAsync(XmlReaderWrapper.CreateFromReader(reader)).GetAwaiter().GetResult();
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
             if (writer == null)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20ItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20ItemFormatter.cs
@@ -5,7 +5,6 @@
 namespace System.ServiceModel.Syndication
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using System.Xml;

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20ItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20ItemFormatter.cs
@@ -13,7 +13,7 @@ namespace System.ServiceModel.Syndication
     using System.Xml.Serialization;
 
     [XmlRoot(ElementName = Rss20Constants.ItemTag, Namespace = Rss20Constants.Rss20Namespace)]
-    public class Rss20ItemFormatter : SyndicationItemFormatter
+    public class Rss20ItemFormatter : SyndicationItemFormatter, IXmlSerializable
     {
         private Rss20FeedFormatter _feedSerializer;
         private Type _itemType;
@@ -113,6 +113,34 @@ namespace System.ServiceModel.Syndication
             return reader.IsStartElement(Rss20Constants.ItemTag, Rss20Constants.Rss20Namespace);
         }
 
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        XmlSchema IXmlSerializable.GetSchema()
+        {
+            return null;
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        void IXmlSerializable.ReadXml(XmlReader reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            ReadItemAsync(XmlReaderWrapper.CreateFromReader(reader)).GetAwaiter().GetResult();
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "The IXmlSerializable implementation is only for exposing under WCF DataContractSerializer. The funcionality is exposed to derived class through the ReadFrom\\WriteTo methods")]
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            WriteItem(writer);
+        }
+
         public override void ReadFrom(XmlReader reader)
         {
             ReadFromAsync(reader).GetAwaiter().GetResult();
@@ -170,7 +198,7 @@ namespace System.ServiceModel.Syndication
     }
 
     [XmlRoot(ElementName = Rss20Constants.ItemTag, Namespace = Rss20Constants.Rss20Namespace)]
-    public class Rss20ItemFormatter<TSyndicationItem> : Rss20ItemFormatter
+    public class Rss20ItemFormatter<TSyndicationItem> : Rss20ItemFormatter, IXmlSerializable
         where TSyndicationItem : SyndicationItem, new()
     {
         public Rss20ItemFormatter()

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ServiceDocument.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ServiceDocument.cs
@@ -101,6 +101,16 @@ namespace System.ServiceModel.Syndication
             return false;
         }
 
+        protected internal virtual void WriteAttributeExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteAttributeExtensions(writer);
+        }
+
+        protected internal virtual void WriteElementExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteElementExtensions(writer);
+        }
+
         protected internal virtual Task WriteAttributeExtensionsAsync(XmlWriter writer, string version)
         {
             return _extensions.WriteAttributeExtensionsAsync(writer);

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ServiceDocument.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ServiceDocument.cs
@@ -68,6 +68,17 @@ namespace System.ServiceModel.Syndication
             }
         }
 
+        public static ServiceDocument Load(XmlReader reader)
+        {
+            return Load<ServiceDocument>(reader);
+        }
+
+        public static TServiceDocument Load<TServiceDocument>(XmlReader reader)
+            where TServiceDocument : ServiceDocument, new()
+        {
+            return LoadAsync<TServiceDocument>(reader).GetAwaiter().GetResult();
+        }
+
         public static async Task<TServiceDocument> LoadAsync<TServiceDocument>(XmlReader reader)
             where TServiceDocument : ServiceDocument, new()
         {
@@ -81,7 +92,12 @@ namespace System.ServiceModel.Syndication
             return new AtomPub10ServiceDocumentFormatter(this);
         }
 
-        public Task Save(XmlWriter writer)
+        public void Save(XmlWriter writer)
+        {
+            SaveAsync(writer).GetAwaiter().GetResult();
+        }
+
+        public Task SaveAsync(XmlWriter writer)
         {
             return new AtomPub10ServiceDocumentFormatter(this).WriteToAsync(writer);
         }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ServiceDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ServiceDocumentFormatter.cs
@@ -35,7 +35,7 @@ namespace System.ServiceModel.Syndication
         public abstract string Version
         { get; }
 
-        public abstract Task<bool> CanReadAsync(XmlReader reader);
+        public abstract bool CanRead(XmlReader reader);
         public abstract Task ReadFromAsync(XmlReader reader);
         public abstract Task WriteToAsync(XmlWriter writer);
 

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ServiceDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ServiceDocumentFormatter.cs
@@ -242,8 +242,7 @@ namespace System.ServiceModel.Syndication
             {
                 throw new ArgumentNullException(nameof(document));
             }
-
-            document.WriteAttributeExtensionsAsync(writer, version);
+            document.WriteAttributeExtensions(writer, version);
         }
 
         protected static void WriteAttributeExtensions(XmlWriter writer, Workspace workspace, string version)
@@ -252,8 +251,81 @@ namespace System.ServiceModel.Syndication
             {
                 throw new ArgumentNullException(nameof(workspace));
             }
-
             workspace.WriteAttributeExtensions(writer, version);
+        }
+
+        protected static void WriteAttributeExtensions(XmlWriter writer, ResourceCollectionInfo collection, string version)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+            collection.WriteAttributeExtensions(writer, version);
+        }
+
+        protected static void WriteAttributeExtensions(XmlWriter writer, CategoriesDocument categories, string version)
+        {
+            if (categories == null)
+            {
+                throw new ArgumentNullException(nameof(categories));
+            }
+            categories.WriteAttributeExtensions(writer, version);
+        }
+
+        protected static void WriteElementExtensions(XmlWriter writer, ServiceDocument document, string version)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+            document.WriteElementExtensions(writer, version);
+        }
+
+        protected static void WriteElementExtensions(XmlWriter writer, Workspace workspace, string version)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+            workspace.WriteElementExtensions(writer, version);
+        }
+
+        protected static void WriteElementExtensions(XmlWriter writer, ResourceCollectionInfo collection, string version)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+            collection.WriteElementExtensions(writer, version);
+        }
+
+        protected static void WriteElementExtensions(XmlWriter writer, CategoriesDocument categories, string version)
+        {
+            if (categories == null)
+            {
+                throw new ArgumentNullException(nameof(categories));
+            }
+            categories.WriteElementExtensions(writer, version);
+        }
+
+        protected static Task WriteAttributeExtensionsAsync(XmlWriter writer, ServiceDocument document, string version)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            return document.WriteAttributeExtensionsAsync(writer, version);
+        }
+
+        protected static Task WriteAttributeExtensionsAsync(XmlWriter writer, Workspace workspace, string version)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            return workspace.WriteAttributeExtensionsAsync(writer, version);
         }
 
         protected static Task WriteAttributeExtensionsAsync(XmlWriter writer, ResourceCollectionInfo collection, string version)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ServiceDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ServiceDocumentFormatter.cs
@@ -36,6 +36,8 @@ namespace System.ServiceModel.Syndication
         { get; }
 
         public abstract bool CanRead(XmlReader reader);
+        public abstract void ReadFrom(System.Xml.XmlReader reader);
+        public abstract void WriteTo(System.Xml.XmlWriter writer);
         public abstract Task ReadFromAsync(XmlReader reader);
         public abstract Task WriteToAsync(XmlWriter writer);
 

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationCategory.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationCategory.cs
@@ -90,6 +90,16 @@ namespace System.ServiceModel.Syndication
             return false;
         }
 
+        protected internal virtual void WriteAttributeExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteAttributeExtensions(writer);
+        }
+
+        protected internal virtual void WriteElementExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteElementExtensions(writer);
+        }
+
         protected internal virtual Task WriteAttributeExtensionsAsync(XmlWriter writer, string version)
         {
             return _extensions.WriteAttributeExtensionsAsync(writer);

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationContent.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationContent.cs
@@ -72,9 +72,9 @@ namespace System.ServiceModel.Syndication
             return new XmlSyndicationContent(Atom10Constants.XmlMediaType, dataContractObject, dataContractSerializer);
         }
 
-        public static XmlSyndicationContent CreateXmlContent(XmlReader XmlReaderWrapper)
+        public static XmlSyndicationContent CreateXmlContent(XmlReader xmlReader)
         {
-            return new XmlSyndicationContent(XmlReaderWrapper);
+            return new XmlSyndicationContent(xmlReader);
         }
 
         public static XmlSyndicationContent CreateXmlContent(object xmlSerializerObject, XmlSerializer serializer)
@@ -83,6 +83,11 @@ namespace System.ServiceModel.Syndication
         }
 
         public abstract SyndicationContent Clone();
+
+        public void WriteTo(XmlWriter writer, string outerElementName, string outerElementNamespace)
+        {
+            WriteToAsync(writer, outerElementName, outerElementNamespace).GetAwaiter().GetResult();
+        }
 
         public async Task WriteToAsync(XmlWriter writer, string outerElementName, string outerElementNamespace)
         {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationElementExtension.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationElementExtension.cs
@@ -23,20 +23,20 @@ namespace System.ServiceModel.Syndication
         private string _outerName;
         private string _outerNamespace;
 
-        public SyndicationElementExtension(XmlReader reader)
+        public SyndicationElementExtension(XmlReader xmlReader)
         {
-            if (reader == null)
+            if (xmlReader == null)
             {
-                throw new ArgumentNullException(nameof(reader));
+                throw new ArgumentNullException(nameof(xmlReader));
             }
-            SyndicationFeedFormatter.MoveToStartElement(reader);
-            _outerName = reader.LocalName;
-            _outerNamespace = reader.NamespaceURI;
+            SyndicationFeedFormatter.MoveToStartElement(xmlReader);
+            _outerName = xmlReader.LocalName;
+            _outerNamespace = xmlReader.NamespaceURI;
             _buffer = new XmlBuffer(int.MaxValue);
             using (XmlDictionaryWriter writer = _buffer.OpenSection(XmlDictionaryReaderQuotas.Max))
             {
                 writer.WriteStartElement(Rss20Constants.ExtensionWrapperTag);
-                writer.WriteNode(reader, false);
+                writer.WriteNode(xmlReader, false);
                 writer.WriteEndElement();
             }
             _buffer.CloseSection();

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationElementExtension.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationElementExtension.cs
@@ -125,12 +125,37 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        public Task<TExtension> GetObject<TExtension>()
+        public TExtension GetObject<TExtension>()
         {
             return GetObject<TExtension>(new DataContractSerializer(typeof(TExtension)));
         }
 
-        public async Task<TExtension> GetObject<TExtension>(XmlObjectSerializer serializer)
+        public TExtension GetObject<TExtension>(XmlObjectSerializer serializer)
+        {
+            return GetObjectAsync<TExtension>(serializer).GetAwaiter().GetResult();
+        }
+
+        public TExtension GetObject<TExtension>(XmlSerializer serializer)
+        {
+            return GetObjectAsync<TExtension>(serializer).GetAwaiter().GetResult();
+        }
+
+        public XmlReader GetReader()
+        {
+            return GetReaderAsync().GetAwaiter().GetResult();
+        }
+
+        public void WriteTo(XmlWriter writer)
+        {
+            WriteToAsync(writer).GetAwaiter().GetResult();
+        }
+
+        public Task<TExtension> GetObjectAsync<TExtension>()
+        {
+            return GetObjectAsync<TExtension>(new DataContractSerializer(typeof(TExtension)));
+        }
+
+        public async Task<TExtension> GetObjectAsync<TExtension>(XmlObjectSerializer serializer)
         {
             if (serializer == null)
             {
@@ -147,7 +172,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        public async Task<TExtension> GetObject<TExtension>(XmlSerializer serializer)
+        public async Task<TExtension> GetObjectAsync<TExtension>(XmlSerializer serializer)
         {
             if (serializer == null)
             {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationElementExtensionCollection.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationElementExtensionCollection.cs
@@ -94,16 +94,36 @@ namespace System.ServiceModel.Syndication
             base.Add(new SyndicationElementExtension(xmlSerializerExtension, serializer));
         }
 
-        public void Add(XmlReader reader)
+        public void Add(XmlReader xmlReader)
         {
-            if (reader == null)
+            if (xmlReader == null)
             {
-                throw new ArgumentNullException(nameof(reader));
+                throw new ArgumentNullException(nameof(xmlReader));
             }
-            base.Add(new SyndicationElementExtension(reader));
+            base.Add(new SyndicationElementExtension(xmlReader));
         }
 
-        public async Task<XmlReader> GetReaderAtElementExtensions()
+        public XmlReader GetReaderAtElementExtensions()
+        {
+            return GetReaderAtElementExtensionsAsync().GetAwaiter().GetResult();
+        }
+
+        public Collection<TExtension> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace)
+        {
+            return ReadElementExtensions<TExtension>(extensionName, extensionNamespace, new DataContractSerializer(typeof(TExtension)));
+        }
+
+        public Collection<TExtension> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace, XmlObjectSerializer serializer)
+        {
+            return ReadElementExtensionsAsync<TExtension>(extensionName, extensionNamespace, serializer).GetAwaiter().GetResult();
+        }
+
+        public Collection<TExtension> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace, XmlSerializer serializer)
+        {
+            return ReadElementExtensionsAsync<TExtension>(extensionName, extensionNamespace, serializer).GetAwaiter().GetResult();
+        }
+
+        public async Task<XmlReader> GetReaderAtElementExtensionsAsync()
         {
             XmlBuffer extensionsBuffer = await GetOrCreateBufferOverExtensions();
             XmlReader reader = extensionsBuffer.GetReader(0);
@@ -111,12 +131,12 @@ namespace System.ServiceModel.Syndication
             return reader;
         }
 
-        public Task<Collection<TExtension>> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace)
+        public Task<Collection<TExtension>> ReadElementExtensionsAsync<TExtension>(string extensionName, string extensionNamespace)
         {
-            return ReadElementExtensions<TExtension>(extensionName, extensionNamespace, new DataContractSerializer(typeof(TExtension)));
+            return ReadElementExtensionsAsync<TExtension>(extensionName, extensionNamespace, new DataContractSerializer(typeof(TExtension)));
         }
 
-        public Task<Collection<TExtension>> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace, XmlObjectSerializer serializer)
+        public Task<Collection<TExtension>> ReadElementExtensionsAsync<TExtension>(string extensionName, string extensionNamespace, XmlObjectSerializer serializer)
         {
             if (serializer == null)
             {
@@ -125,7 +145,7 @@ namespace System.ServiceModel.Syndication
             return ReadExtensions<TExtension>(extensionName, extensionNamespace, serializer, null);
         }
 
-        public Task<Collection<TExtension>> ReadElementExtensions<TExtension>(string extensionName, string extensionNamespace, XmlSerializer serializer)
+        public Task<Collection<TExtension>> ReadElementExtensionsAsync<TExtension>(string extensionName, string extensionNamespace, XmlSerializer serializer)
         {
             if (serializer == null)
             {
@@ -264,11 +284,11 @@ namespace System.ServiceModel.Syndication
 
                 if (dcSerializer != null)
                 {
-                    results.Add(await this[i].GetObject<TExtension>(dcSerializer));
+                    results.Add(await this[i].GetObjectAsync<TExtension>(dcSerializer));
                 }
                 else
                 {
-                    results.Add(await this[i].GetObject<TExtension>(xmlSerializer));
+                    results.Add(await this[i].GetObjectAsync<TExtension>(xmlSerializer));
                 }
             }
             return results;

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
@@ -492,6 +492,16 @@ namespace System.ServiceModel.Syndication
             return _extensions.WriteElementExtensionsAsync(writer);
         }
 
+        protected internal virtual void WriteAttributeExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteAttributeExtensions(writer);
+        }
+
+        protected internal virtual void WriteElementExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteElementExtensions(writer);
+        }
+
         internal void LoadElementExtensions(XmlReader readerOverUnparsedExtensions, int maxExtensionSize)
         {
             _extensions.LoadElementExtensions(readerOverUnparsedExtensions, maxExtensionSize);

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
@@ -59,7 +59,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        public SyndicationTextInput TextInput
+        internal SyndicationTextInput TextInput
         {
             get
             {
@@ -440,6 +440,16 @@ namespace System.ServiceModel.Syndication
         public Rss20FeedFormatter GetRss20Formatter(bool serializeExtensionsAsAtom)
         {
             return new Rss20FeedFormatter(this, serializeExtensionsAsAtom);
+        }
+
+        public void SaveAsAtom10(XmlWriter writer)
+        {
+            SaveAsAtom10Async(writer, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        public void SaveAsRss20(XmlWriter writer)
+        {
+            SaveAsRss20Async(writer, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         public Task SaveAsAtom10Async(XmlWriter writer, CancellationToken ct)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
@@ -51,12 +51,16 @@ namespace System.ServiceModel.Syndication
 
         public abstract bool CanRead(XmlReader reader);
 
+        public abstract void ReadFrom(XmlReader reader);
+
         public abstract Task ReadFromAsync(XmlReader reader, CancellationToken ct);
 
         public override string ToString()
         {
             return string.Format(CultureInfo.CurrentCulture, "{0}, SyndicationVersion={1}", GetType(), Version);
         }
+
+        public abstract void WriteTo(XmlWriter writer);
 
         public abstract Task WriteToAsync(XmlWriter writer, CancellationToken ct);
 

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
@@ -286,6 +286,96 @@ namespace System.ServiceModel.Syndication
             return person.TryParseElement(reader, version);
         }
 
+        internal static protected void WriteAttributeExtensions(XmlWriter writer, SyndicationFeed feed, string version)
+        {
+            if (feed == null)
+            {
+                throw new ArgumentNullException(nameof(feed));
+            }
+            feed.WriteAttributeExtensions(writer, version);
+        }
+
+        internal static protected void WriteAttributeExtensions(XmlWriter writer, SyndicationItem item, string version)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+            item.WriteAttributeExtensions(writer, version);
+        }
+
+        internal static protected void WriteAttributeExtensions(XmlWriter writer, SyndicationCategory category, string version)
+        {
+            if (category == null)
+            {
+                throw new ArgumentNullException(nameof(category));
+            }
+            category.WriteAttributeExtensions(writer, version);
+        }
+
+        internal static protected void WriteAttributeExtensions(XmlWriter writer, SyndicationLink link, string version)
+        {
+            if (link == null)
+            {
+                throw new ArgumentNullException(nameof(link));
+            }
+            link.WriteAttributeExtensions(writer, version);
+        }
+
+        internal static protected void WriteAttributeExtensions(XmlWriter writer, SyndicationPerson person, string version)
+        {
+            if (person == null)
+            {
+                throw new ArgumentNullException(nameof(person));
+            }
+            person.WriteAttributeExtensions(writer, version);
+        }
+
+        internal static protected void WriteElementExtensions(XmlWriter writer, SyndicationFeed feed, string version)
+        {
+            if (feed == null)
+            {
+                throw new ArgumentNullException(nameof(feed));
+            }
+            feed.WriteElementExtensions(writer, version);
+        }
+
+        internal static protected void WriteElementExtensions(XmlWriter writer, SyndicationItem item, string version)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+            item.WriteElementExtensions(writer, version);
+        }
+
+        internal static protected void WriteElementExtensions(XmlWriter writer, SyndicationCategory category, string version)
+        {
+            if (category == null)
+            {
+                throw new ArgumentNullException(nameof(category));
+            }
+            category.WriteElementExtensions(writer, version);
+        }
+
+        internal static protected void WriteElementExtensions(XmlWriter writer, SyndicationLink link, string version)
+        {
+            if (link == null)
+            {
+                throw new ArgumentNullException(nameof(link));
+            }
+            link.WriteElementExtensions(writer, version);
+        }
+
+        internal static protected void WriteElementExtensions(XmlWriter writer, SyndicationPerson person, string version)
+        {
+            if (person == null)
+            {
+                throw new ArgumentNullException(nameof(person));
+            }
+            person.WriteElementExtensions(writer, version);
+        }
+
         internal static protected async Task WriteAttributeExtensionsAsync(XmlWriter writer, SyndicationFeed feed, string version)
         {
             if (feed == null)
@@ -313,7 +403,7 @@ namespace System.ServiceModel.Syndication
             return category.WriteAttributeExtensionsAsync(writer, version);
         }
 
-        internal static protected Task WriteAttributeExtensions(XmlWriter writer, SyndicationLink link, string version)
+        internal static protected Task WriteAttributeExtensionsAsync(XmlWriter writer, SyndicationLink link, string version)
         {
             if (link == null)
             {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
@@ -53,14 +53,14 @@ namespace System.ServiceModel.Syndication
 
         public abstract void ReadFrom(XmlReader reader);
 
+        public abstract void WriteTo(XmlWriter writer);
+
         public abstract Task ReadFromAsync(XmlReader reader, CancellationToken ct);
 
         public override string ToString()
         {
             return string.Format(CultureInfo.CurrentCulture, "{0}, SyndicationVersion={1}", GetType(), Version);
         }
-
-        public abstract void WriteTo(XmlWriter writer);
 
         public abstract Task WriteToAsync(XmlWriter writer, CancellationToken ct);
 

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItem.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItem.cs
@@ -197,6 +197,17 @@ namespace System.ServiceModel.Syndication
             set { _title = value; }
         }
 
+        public static SyndicationItem Load(XmlReader reader)
+        {
+            return LoadAsync(reader).GetAwaiter().GetResult();
+        }
+
+        public static TSyndicationItem Load<TSyndicationItem>(XmlReader reader)
+            where TSyndicationItem : SyndicationItem, new()
+        {
+            return LoadAsync<TSyndicationItem>(reader).GetAwaiter().GetResult();
+        }
+
         public static Task<SyndicationItem> LoadAsync(XmlReader reader)
         {
             return LoadAsync<SyndicationItem>(reader);
@@ -252,12 +263,22 @@ namespace System.ServiceModel.Syndication
             return new Rss20ItemFormatter(this, serializeExtensionsAsAtom);
         }
 
-        public Task SaveAsAtom10(XmlWriter writer)
+        public void SaveAsAtom10(XmlWriter writer)
+        {
+            SaveAsAtom10Async(writer).GetAwaiter().GetResult();
+        }
+
+        public void SaveAsRss20(XmlWriter writer)
+        {
+            SaveAsRss20Async(writer).GetAwaiter().GetResult();
+        }
+
+        public Task SaveAsAtom10Async(XmlWriter writer)
         {
             return GetAtom10Formatter().WriteToAsync(writer);
         }
 
-        public Task SaveAsRss20(XmlWriter writer)
+        public Task SaveAsRss20Async(XmlWriter writer)
         {
             return GetRss20Formatter().WriteToAsync(writer);
         }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItem.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItem.cs
@@ -293,6 +293,16 @@ namespace System.ServiceModel.Syndication
             return false;
         }
 
+        protected internal virtual void WriteAttributeExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteAttributeExtensions(writer);
+        }
+
+        protected internal virtual void WriteElementExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteElementExtensions(writer);
+        }
+
         protected internal virtual Task WriteAttributeExtensionsAsync(XmlWriter writer, string version)
         {
             return _extensions.WriteAttributeExtensionsAsync(writer);

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItemFormatter.cs
@@ -179,6 +179,46 @@ namespace System.ServiceModel.Syndication
             return SyndicationFeedFormatter.TryParseElement(reader, person, version);
         }
 
+        protected static void WriteAttributeExtensions(XmlWriter writer, SyndicationItem item, string version)
+        {
+            SyndicationFeedFormatter.WriteAttributeExtensions(writer, item, version);
+        }
+
+        protected static void WriteAttributeExtensions(XmlWriter writer, SyndicationCategory category, string version)
+        {
+            SyndicationFeedFormatter.WriteAttributeExtensions(writer, category, version);
+        }
+
+        protected static void WriteAttributeExtensions(XmlWriter writer, SyndicationLink link, string version)
+        {
+            SyndicationFeedFormatter.WriteAttributeExtensions(writer, link, version);
+        }
+
+        protected static void WriteAttributeExtensions(XmlWriter writer, SyndicationPerson person, string version)
+        {
+            SyndicationFeedFormatter.WriteAttributeExtensions(writer, person, version);
+        }
+
+        protected static void WriteElementExtensions(XmlWriter writer, SyndicationItem item, string version)
+        {
+            SyndicationFeedFormatter.WriteElementExtensions(writer, item, version);
+        }
+
+        protected void WriteElementExtensions(XmlWriter writer, SyndicationCategory category, string version)
+        {
+            SyndicationFeedFormatter.WriteElementExtensions(writer, category, version);
+        }
+
+        protected void WriteElementExtensions(XmlWriter writer, SyndicationLink link, string version)
+        {
+            SyndicationFeedFormatter.WriteElementExtensions(writer, link, version);
+        }
+
+        protected void WriteElementExtensions(XmlWriter writer, SyndicationPerson person, string version)
+        {
+            SyndicationFeedFormatter.WriteElementExtensions(writer, person, version);
+        }
+
         protected static async Task WriteAttributeExtensionsAsync(XmlWriter writer, SyndicationItem item, string version)
         {
             await SyndicationFeedFormatter.WriteAttributeExtensionsAsync(writer, item, version);

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItemFormatter.cs
@@ -43,6 +43,10 @@ namespace System.ServiceModel.Syndication
 
         public abstract bool CanRead(XmlReader reader);
 
+        public abstract void ReadFrom(XmlReader reader);
+
+        public abstract void WriteTo(XmlWriter writer);
+
         public abstract Task ReadFromAsync(XmlReader reader);
 
         public override string ToString()

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItemFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItemFormatter.cs
@@ -187,7 +187,7 @@ namespace System.ServiceModel.Syndication
 
         protected static async Task WriteAttributeExtensionsAsync(XmlWriter writer, SyndicationLink link, string version)
         {
-            await SyndicationFeedFormatter.WriteAttributeExtensions(writer, link, version);
+            await SyndicationFeedFormatter.WriteAttributeExtensionsAsync(writer, link, version);
         }
 
         protected static async Task WriteAttributeExtensionsAsync(XmlWriter writer, SyndicationPerson person, string version)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationLink.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationLink.cs
@@ -176,6 +176,16 @@ namespace System.ServiceModel.Syndication
             return false;
         }
 
+        protected internal virtual void WriteAttributeExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteAttributeExtensions(writer);
+        }
+
+        protected internal virtual void WriteElementExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteElementExtensions(writer);
+        }
+
         protected internal virtual Task WriteAttributeExtensionsAsync(XmlWriter writer, string version)
         {
             return _extensions.WriteAttributeExtensionsAsync(writer);

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationPerson.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationPerson.cs
@@ -93,6 +93,16 @@ namespace System.ServiceModel.Syndication
             return false;
         }
 
+        protected internal virtual void WriteAttributeExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteAttributeExtensions(writer);
+        }
+
+        protected internal virtual void WriteElementExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteElementExtensions(writer);
+        }
+
         protected internal virtual Task WriteAttributeExtensionsAsync(XmlWriter writer, string version)
         {
             return _extensions.WriteAttributeExtensionsAsync(writer);

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationPerson.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationPerson.cs
@@ -6,7 +6,6 @@ namespace System.ServiceModel.Syndication
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using System.Xml;
@@ -29,7 +28,6 @@ namespace System.ServiceModel.Syndication
         {
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings", MessageId = "2#", Justification = "The Uri represents a unique category and not a network location")]
         public SyndicationPerson(string email, string name, string uri)
         {
             _name = name;
@@ -71,7 +69,6 @@ namespace System.ServiceModel.Syndication
             set { _name = value; }
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings", Scope = "property", Justification = "The Uri represents a unique category and not a network location")]
         public string Uri
         {
             get { return _uri; }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationTextInput.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationTextInput.cs
@@ -4,7 +4,7 @@
 
 namespace System.ServiceModel.Syndication
 {
-    public class SyndicationTextInput
+    class SyndicationTextInput
     {
         public string Description;
         public string title;

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationTextInput.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationTextInput.cs
@@ -4,7 +4,7 @@
 
 namespace System.ServiceModel.Syndication
 {
-    class SyndicationTextInput
+    internal class SyndicationTextInput
     {
         public string Description;
         public string title;

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Workspace.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Workspace.cs
@@ -95,7 +95,17 @@ namespace System.ServiceModel.Syndication
             return false;
         }
 
-        protected internal virtual Task WriteAttributeExtensions(XmlWriter writer, string version)
+        protected internal virtual void WriteAttributeExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteAttributeExtensions(writer);
+        }
+
+        protected internal virtual void WriteElementExtensions(XmlWriter writer, string version)
+        {
+            _extensions.WriteElementExtensions(writer);
+        }
+
+        protected internal virtual Task WriteAttributeExtensionsAsync(XmlWriter writer, string version)
         {
             return _extensions.WriteAttributeExtensionsAsync(writer);
         }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/XmlSyndicationContent.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/XmlSyndicationContent.cs
@@ -108,18 +108,38 @@ namespace System.ServiceModel.Syndication
             return new XmlSyndicationContent(this);
         }
 
-        public async Task<XmlDictionaryReader> GetReaderAtContent()
+        public XmlDictionaryReader GetReaderAtContent()
+        {
+            return GetReaderAtContentAsync().GetAwaiter().GetResult();
+        }
+
+        public TContent ReadContent<TContent>()
+        {
+            return ReadContent<TContent>((DataContractSerializer)null);
+        }
+
+        public TContent ReadContent<TContent>(XmlObjectSerializer dataContractSerializer)
+        {
+            return ReadContentAsync<TContent>(dataContractSerializer).GetAwaiter().GetResult();
+        }
+
+        public TContent ReadContent<TContent>(XmlSerializer serializer)
+        {
+            return ReadContentAsync<TContent>(serializer).GetAwaiter().GetResult();
+        }
+
+        public async Task<XmlDictionaryReader> GetReaderAtContentAsync()
         {
             await EnsureContentBufferAsync();
             return _contentBuffer.GetReader(0);
         }
 
-        public Task<TContent> ReadContent<TContent>()
+        public Task<TContent> ReadContentAsync<TContent>()
         {
-            return ReadContent<TContent>((DataContractSerializer)null);
+            return ReadContentAsync<TContent>((DataContractSerializer)null);
         }
 
-        public async Task<TContent> ReadContent<TContent>(XmlObjectSerializer dataContractSerializer)
+        public async Task<TContent> ReadContentAsync<TContent>(XmlObjectSerializer dataContractSerializer)
         {
             if (dataContractSerializer == null)
             {
@@ -127,7 +147,7 @@ namespace System.ServiceModel.Syndication
             }
             if (_extension != null)
             {
-                return await _extension.GetObject<TContent>(dataContractSerializer);
+                return await _extension.GetObjectAsync<TContent>(dataContractSerializer);
             }
             else
             {
@@ -141,7 +161,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        public Task<TContent> ReadContent<TContent>(XmlSerializer serializer)
+        public Task<TContent> ReadContentAsync<TContent>(XmlSerializer serializer)
         {
             if (serializer == null)
             {
@@ -149,7 +169,7 @@ namespace System.ServiceModel.Syndication
             }
             if (_extension != null)
             {
-                return _extension.GetObject<TContent>(serializer);
+                return _extension.GetObjectAsync<TContent>(serializer);
             }
             else
             {

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -631,11 +631,11 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.False(string.IsNullOrEmpty(name));
                 switch (name)
                 {
-                    case Atom10Constants.IdTag:
+                    case "id":
                         return "No id!";
-                    case Atom10Constants.NameTag:
+                    case "name":
                         return "new name";
-                    case Atom10Constants.TitleTag:
+                    case "title":
                         return "new title";
                     default:
                         return "Custom Text";

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -524,37 +524,6 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
-        public static async Task SyndicationFeed_RSS_Optional_TextInput()
-        {
-            // *** SETUP *** \\
-            XmlReaderSettings setting = new XmlReaderSettings();
-            setting.Async = true;
-            XmlReader reader = null;
-            Task<SyndicationFeed> rss = null;
-            CancellationToken ct = new CancellationToken();
-
-            try
-            {
-                // *** EXECUTE *** \\
-                reader = XmlReader.Create(@"rssSpecExample.xml", setting);
-                rss = SyndicationFeed.LoadAsync(reader, ct);
-                await Task.WhenAll(rss);
-
-                // *** ASSERT *** \\
-                Assert.True(rss.Result.TextInput.Description == "Search Online");
-                Assert.True(rss.Result.TextInput.title == "Search");
-                Assert.True(rss.Result.TextInput.name == "input Name");
-                Assert.True(rss.Result.TextInput.link.GetAbsoluteUri().ToString() == "http://www.contoso.no/search?");
-            }
-            finally
-            {
-                // *** CLEANUP *** \\
-                Assert.True(rss.Result.Items != null);
-                reader.Close();
-            }
-        }
-
-        [Fact]
         public static async Task SyndicationFeed__Atom_Optional_Icon()
         {
             // *** SETUP *** \\


### PR DESCRIPTION
Syndication on .Net Core currently does not have synchronous APIs, which is not compatible with full framework. The PR added the missing APIs. After this PR, all APIs available on desktop are are available on Net Core.

This PR didn't add any tests for the sync version APIs. I will add the tests in the next PR.

Fix #24665