### PR TITLE
Replace 'enlistment' with 'repo' in a few places

### DIFF
--- a/Documentation/building/cross-platform-testing.md
+++ b/Documentation/building/cross-platform-testing.md
@@ -15,11 +15,11 @@ instructions assume you are building for Linux, but are easily modifiable for OS
    of debug CoreCLR since it is much faster at actually running XUnit, but debug
    will work if you have the time.
 
-   From the root of your CoreCLR enlistment on Linux, run `./build.sh Release` in
+   From the root of your CoreCLR repo on Linux, run `./build.sh Release` in
    order to build.
 2. A corresponding version of System.Private.Corelib.dll. Depending on your platform, this may
    be produced when you run  `build.sh`. Otherwise, this can be produced by
-   running `build.cmd linuxmscorlib Release` (it's `mscorlib` for historical reasons) from a CoreCLR enlistment on
+   running `build.cmd linuxmscorlib Release` (it's `mscorlib` for historical reasons) from a CoreCLR repo on
    Windows. Remember that the runtime and System.Private.Corelib are tightly coupled with
    respect to object sizes and layout so you need to ensure you have either a
    release coreclr and release System.Private.Corelib or debug coreclr and debug System.Private.Corelib.
@@ -30,7 +30,7 @@ instructions assume you are building for Linux, but are easily modifiable for OS
    * Build the managed parts of CoreFX on Windows. To do so run `build-managed.cmd -os=Linux`. It is okay to build a Debug version of CoreFX and run it
    on top of a release CoreCLR (which is exactly what we do in Jenkins).
 
-   * Build the native parts of CoreFX on Linux. To do so run `./build-native.sh` from the root of your CoreFX enlistment.
+   * Build the native parts of CoreFX on Linux. To do so run `./build-native.sh` from the root of your CoreFX repo.
 
 4. The packages folder which contains all the packages restored from NuGet and
    MyGet when building CoreFX.

--- a/dir.targets
+++ b/dir.targets
@@ -3,9 +3,9 @@
 
   <Target Name="CheckForBuildTools">
     <Error Condition="!Exists('$(ToolsDir)') and '$(OverrideToolsDir)'=='true'"
-           Text="The tools directory [$(ToolsDir)] does not exist. Please run sync in your enlistment to ensure the tools are installed before attempting to build an individual project." />
+           Text="The tools directory [$(ToolsDir)] does not exist. Please run sync in your repo to ensure the tools are installed before attempting to build an individual project." />
     <Error Condition="!Exists('$(ToolsDir)') and '$(OverrideToolsDir)'!='true'"
-           Text="The tools directory [$(ToolsDir)] does not exist. Please run init-tools.cmd in your enlistment to ensure the tools are installed before attempting to build an individual project." />
+           Text="The tools directory [$(ToolsDir)] does not exist. Please run init-tools.cmd in your repo to ensure the tools are installed before attempting to build an individual project." />
   </Target>
 
   <Import Project="buildvertical.targets" />

--- a/src/Common/tests/System/Net/Prerequisites/Deployment/config.ps1
+++ b/src/Common/tests/System/Net/Prerequisites/Deployment/config.ps1
@@ -28,7 +28,7 @@ $COREFX_NET_AD_MachineIP = ""           #Example: "192.168.0.1" - must be a Stat
 $COREFX_NET_IISSERVER_Machine = ""      #Example: "TESTIIS"
 $COREFX_NET_IISSERVER_MachineIP = ""    #Example: "192.168.0.1" - must be a Static IPv4 address.
 
-# A Windows Client or Server SKU hosting the corefx enlistment. This machine will be joined to the Domain.
+# A Windows Client or Server SKU hosting the corefx repo. This machine will be joined to the Domain.
 $COREFX_NET_CLIENT_Machine = ""         #Example: "TESTCLIENT"
 
 # -- Test Parameters


### PR DESCRIPTION
"Enlistment" is a MS-internal term from Source Depot days for what in today's git world is now commonly called a "repo".

Updating this in a few places to avoid confusing compiler errors.

