### PR TITLE
Throw exception if SysConf fails in Environment.ProcessorCount

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
@@ -358,11 +358,11 @@ namespace System
             return num;
         }
 
-        public static int ProcessorCount => (int)Interop.Sys.SysConf(Interop.Sys.SysConfName._SC_NPROCESSORS_ONLN);
+        public static int ProcessorCount => CheckedSysConf(Interop.Sys.SysConfName._SC_NPROCESSORS_ONLN);
 
         public static string SystemDirectory => GetFolderPathCore(SpecialFolder.System, SpecialFolderOption.None);
 
-        public static int SystemPageSize => (int)Interop.Sys.SysConf(Interop.Sys.SysConfName._SC_PAGESIZE);
+        public static int SystemPageSize => CheckedSysConf(Interop.Sys.SysConfName._SC_PAGESIZE);
 
         public static unsafe string UserName
         {
@@ -433,5 +433,19 @@ namespace System
         }
 
         public static string UserDomainName => MachineName;
+
+        /// <summary>Invoke <see cref="Interop.Sys.SysConf"/>, throwing if it fails.</summary>
+        private static int CheckedSysConf(Interop.Sys.SysConfName name)
+        {
+            long result = Interop.Sys.SysConf(name);
+            if (result == -1)
+            {
+                Interop.ErrorInfo errno = Interop.Sys.GetLastErrorInfo();
+                throw errno.Error == Interop.Error.EINVAL ?
+                    new ArgumentOutOfRangeException(nameof(name), name, errno.GetErrorMessage()) :
+                    Interop.GetIOException(errno);
+            }
+            return (int)result;
+        }
     }
 }


### PR DESCRIPTION
This shouldn't happen in a valid configuration, but adding the exception to help highlight the problem with an invalid configuration.

Related to https://github.com/dotnet/corefx/issues/24663
cc: @joperezr, @AlexGhiondea 