### PR TITLE
Exlude CustomMemoryForTest from being reflected on to unblock tests on ILC

### DIFF
--- a/src/System.Memory/tests/Resources/System.Memory.Tests.rd.xml
+++ b/src/System.Memory/tests/Resources/System.Memory.Tests.rd.xml
@@ -1,0 +1,6 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library>
+    <!-- Needed because OwnedMemory is reflection blocked and xunit tries to reflect on this concrete type during discovery -->
+    <Type Name="System.MemoryTests.CustomMemoryForTest{T}" Dynamic="Excluded" Browse="Excluded" Serialize="Excluded" />
+  </Library>
+</Directives>

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -103,5 +103,8 @@
     <Compile Include="Binary\BinaryReaderUnitTests.cs" />
     <Compile Include="Binary\BinaryWriterUnitTests.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Span and friends (such as OwnedMemory) are reflection blocked.
During test discovery, xunit tries to reflect on CustomMemoryForTest (the concrete implementation of OwnedMemory) and gets stuck which results in test failures.

https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Filc~2F/build/20171020.02/workItem/System.Memory.Tests/wilogs
> 2017-10-20 13:43:06,224: ERROR: executor(376): _execute_command: Executor timed out after 1200 seconds and was killed.
2017-10-20 13:43:06,224: INFO: event(43): send: Sending event type WorkItemTimeout


Tyvm for helping resolve this issue, @morganbr! 

@AtsushiKan, what is required to add these types to the contract and stop them from being reflection blocked?

cc @stephentoub, @KrzysztofCwalina, @safern, @danmosemsft, @leekir