### PR TITLE
Re-enabling previously disabled tests for uapaot due to Retain bug

### DIFF
--- a/src/System.Memory/tests/Memory/Retain.cs
+++ b/src/System.Memory/tests/Memory/Retain.cs
@@ -110,7 +110,6 @@ namespace System.MemoryTests
             handle.Dispose();
         }
 
-        [ActiveIssue(24384, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void OwnedMemoryRetainWithPinningAndSlice()
         {

--- a/src/System.Memory/tests/ReadOnlyMemory/Retain.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Retain.cs
@@ -110,7 +110,6 @@ namespace System.MemoryTests
             handle.Dispose();
         }
 
-        [ActiveIssue(24384, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void OwnedMemoryRetainWithPinningAndSlice()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/24384

The tests that were disabled in https://github.com/dotnet/corefx/pull/24385 can now be re-enabled since the bugs have been fixed for uapaot.

cc @jkotas, @KrzysztofCwalina, @stephentoub, @safern, @leekir