### PR TITLE
SSLStream Check for deallocated GCHandle

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -115,6 +115,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue(24722, TestPlatforms.Linux)]
         [PlatformSpecific(~TestPlatforms.OSX)]
         public void SslStream_StreamToStream_Alpn_NonMatchingProtocols_Fail()
         {


### PR DESCRIPTION
The GCHandle can easily be deallocated (by closing the SSlStream or if it's cancelled) before OpenSsl calls back due to the otherside sending the Client Hello. Therefore if I am not mistaken we should check that the GCHandle is still allocated when we rehydrate it from a pointer handed in from unmanaged code?

Also if it is null or deallocated, we don't want to throw an exception inside a Native callback because it can cause all kinds of havoc.