### PR TITLE
Change lifetime of Socket used in NamedPipeServerStream on Unix

### DIFF
--- a/src/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes/src/Resources/Strings.resx
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -210,5 +269,8 @@
   </data>
   <data name="PlatformNotSupported_OperatingSystemError" xml:space="preserve">
     <value>The operating system returned error '{0}' indicating that the operation is not supported.</value>
+  </data>
+  <data name="IO_AllPipeInstancesAreBusy" xml:space="preserve">
+    <value>All pipe instances are busy.</value>
   </data>
 </root>

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -245,6 +245,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Collections" />
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
@@ -33,10 +33,7 @@ namespace System.IO.Pipes
             }
             catch (SocketException e)
             {
-                if (clientHandle != null)
-                {
-                    clientHandle.Dispose();
-                }
+                clientHandle?.Dispose();
                 socket.Dispose();
 
                 switch (e.SocketErrorCode)

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -49,10 +49,14 @@ namespace System.IO.Pipes
                 throw new PlatformNotSupportedException(SR.PlatformNotSupproted_InvalidNameChars);
             }
 
-            // Return the pipe path.  The pipe is created directly under %TMPDIR%.  We don't bother
-            // putting it into subdirectories, as the pipe will only exist on disk for the
-            // duration between when the server starts listening and the client connects, after
-            // which the pipe will be deleted.
+            // Return the pipe path.  The pipe is created directly under %TMPDIR%.  We previously
+            // didn't put it into a subdirectory because it only existed on disk for the duration
+            // between when the server started listening in WaitForConnection and when the client
+            // connected, after which the pipe was deleted.  We now create the pipe when the
+            // server stream is created, which leaves it on disk longer, but we can't change the
+            // naming scheme used as that breaks the ability for code running on an older
+            // runtime to connect to code running on the newer runtime.  That means we're stuck
+            // with a tmp file for the lifetime of the server stream.
             return s_pipePrefix + pipeName;
         }
 
@@ -83,7 +87,7 @@ namespace System.IO.Pipes
             // nop
         }
 
-        private void UninitializeAsyncHandle()
+        internal virtual void DisposeCore(bool disposing)
         {
             // nop
         }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -47,10 +47,12 @@ namespace System.IO.Pipes
             _threadPoolBinding = ThreadPoolBoundHandle.BindHandle(handle);
         }
 
-        private void UninitializeAsyncHandle()
+        private void DisposeCore(bool disposing)
         {
-            if (_threadPoolBinding != null)
-                _threadPoolBinding.Dispose();
+            if (disposing)
+            {
+                _threadPoolBinding?.Dispose();
+            }
         }
 
         [SecurityCritical]

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -6,7 +6,6 @@ using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using System.Runtime.InteropServices;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -395,7 +394,7 @@ namespace System.IO.Pipes
                     _handle.Dispose();
                 }
 
-                UninitializeAsyncHandle();
+                DisposeCore(disposing);
             }
             finally
             {


### PR DESCRIPTION
We currently create and destroy the unix domain socket each time WaitForConnection{Async} is called, and it lives until the client connects.  This causes problems when multiple clients try to connect before WaitForConnection{Async} is called; any number that's under the min listen limit applied by the OS will have their connections completed, even though Accept hasn't been called, and then when the socket is closed, the connections will all fail.  This change moves the UDS creation to when the NamedPipeServerStream is created, deleting it when the NPSS is disposed.

cc: @pjanotti, @JeremyKuhne, @jaredpar, @khyperia