### PR TITLE
Increase tolerance on SendTimesOut_Throws

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
@@ -127,7 +127,8 @@ namespace System.Net.Sockets.Tests
                 Assert.True(acceptedSocket.Connected);
 
                 // Try to ensure that the elapsed timeout is reasonably correct
-                Assert.InRange(elapsed, Timeout * 0.5, Timeout * 2);
+                // Sometimes test machines run slowly
+                Assert.InRange(elapsed, Timeout * 0.5, Timeout * 3);
             }
         }
     }

--- a/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
@@ -82,7 +82,8 @@ namespace System.Net.Sockets.Tests
                 Assert.True(acceptedSocket.Connected);
 
                 // Try to ensure that the elapsed timeout is reasonably correct
-                Assert.InRange(elapsed, Timeout * 0.75, Timeout * 1.5);
+                // Sometimes test machines run slowly
+                Assert.InRange(elapsed, Timeout * 0.75, Timeout * 2);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/24804

(assuming it's just because the machine is slow)