### PR TITLE
Implement cancellation token for SslStream new AuthenticateAs*Async methods

### DIFF
--- a/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
+++ b/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
@@ -53,7 +53,7 @@ namespace System.Net
                 int remainingCount = request.Count, offset = request.Offset;
                 do
                 {
-                    int bytes = await transport.ReadAsync(request.Buffer, offset, remainingCount, CancellationToken.None).ConfigureAwait(false);
+                    int bytes = await transport.ReadAsync(request.Buffer, offset, remainingCount, request.CancellationToken).ConfigureAwait(false);
                     if (bytes == 0)
                     {
                         if (remainingCount != request.Count)

--- a/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
+++ b/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
@@ -21,7 +21,7 @@ namespace System.Net
     internal class AsyncProtocolRequest
     {
 #if DEBUG
-        internal object _DebugAsyncChain;         // Optionally used to track chains of async calls.
+        internal object _debugAsyncChain;         // Optionally used to track chains of async calls.
 #endif
 
         private AsyncProtocolCallback _callback;
@@ -34,12 +34,15 @@ namespace System.Net
         public LazyAsyncResult UserAsyncResult;
         public int Result;
         public object AsyncState;
+        public readonly CancellationToken CancellationToken;
 
         public byte[] Buffer; // Temporary buffer reused by a protocol.
         public int Offset;
         public int Count;
 
-        public AsyncProtocolRequest(LazyAsyncResult userAsyncResult)
+        public AsyncProtocolRequest(LazyAsyncResult userAsyncResult) : this(userAsyncResult, CancellationToken.None) { }
+
+        public AsyncProtocolRequest(LazyAsyncResult userAsyncResult, CancellationToken cancellationToken)
         {
             if (userAsyncResult == null)
             {
@@ -49,7 +52,9 @@ namespace System.Net
             {
                 NetEventSource.Fail(this, "userAsyncResult is already completed.");
             }
+
             UserAsyncResult = userAsyncResult;
+            CancellationToken = cancellationToken;
         }
 
         public void Reset(LazyAsyncResult userAsyncResult)
@@ -72,7 +77,7 @@ namespace System.Net
             Offset = 0;
             Count = 0;
 #if DEBUG
-            _DebugAsyncChain = 0;
+            _debugAsyncChain = 0;
 #endif
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -642,7 +642,7 @@ namespace System.Net.Security
             if (asyncRequest != null && asyncRequest.CancellationToken.IsCancellationRequested)
             {
                 // Cancel async operation, before I/O starts.
-                asyncRequest.CompleteUserWithError(new TaskCanceledException());
+                asyncRequest.CompleteUserWithError(new OperationCanceledException(asyncRequest.CancellationToken));
                 return;
             }
 
@@ -752,8 +752,8 @@ namespace System.Net.Security
         {
             if (asyncRequest != null && asyncRequest.CancellationToken.IsCancellationRequested)
             {
-                // Return async operation if cancellation requested.
-                asyncRequest.CompleteUserWithError(new TaskCanceledException());
+                // Cancel async operation if cancellation requested.
+                asyncRequest.CompleteUserWithError(new OperationCanceledException(asyncRequest.CancellationToken));
                 return;
             }
 
@@ -813,8 +813,8 @@ namespace System.Net.Security
         {
             if (asyncRequest != null && asyncRequest.CancellationToken.IsCancellationRequested)
             {
-                // Return async operation if cancellation requested.
-                asyncRequest.CompleteUserWithError(new TaskCanceledException());
+                // Cancel async operation if cancellation requested.
+                asyncRequest.CompleteUserWithError(new OperationCanceledException(asyncRequest.CancellationToken));
                 return;
             }
 
@@ -849,7 +849,7 @@ namespace System.Net.Security
         {
             if (asyncRequest != null && asyncRequest.CancellationToken.IsCancellationRequested)
             {
-                asyncRequest.CompleteUserWithError(new TaskCanceledException());
+                asyncRequest.CompleteUserWithError(new OperationCanceledException(asyncRequest.CancellationToken));
                 return;
             }
 
@@ -895,7 +895,7 @@ namespace System.Net.Security
         {
             if (asyncRequest != null && asyncRequest.CancellationToken.IsCancellationRequested)
             {
-                asyncRequest.CompleteUserWithError(new TaskCanceledException());
+                asyncRequest.CompleteUserWithError(new OperationCanceledException(asyncRequest.CancellationToken));
                 return;
             }
 
@@ -953,7 +953,7 @@ namespace System.Net.Security
         {
             if (asyncRequest != null && asyncRequest.CancellationToken.IsCancellationRequested)
             {
-                asyncRequest.CompleteUserWithError(new TaskCanceledException());
+                asyncRequest.CompleteUserWithError(new OperationCanceledException(asyncRequest.CancellationToken));
                 return;
             }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -655,7 +655,7 @@ namespace System.Net.Security
 
             // This will tell that we don't know the framing yet (what SSL version is)
             _Framing = Framing.Unknown;
-            
+
             try
             {
                 if (receiveFirst)

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -185,7 +185,7 @@ namespace System.Net.Security
             _sslState.ValidateCreateContext(sslClientAuthenticationOptions);
 
             LazyAsyncResult result = new LazyAsyncResult(_sslState, asyncState, asyncCallback);
-            _sslState.ProcessAuthentication(result);
+            _sslState.ProcessAuthentication(result, cancellationToken);
             return result;
         }
 
@@ -239,7 +239,7 @@ namespace System.Net.Security
             _sslState.ValidateCreateContext(sslServerAuthenticationOptions);
 
             LazyAsyncResult result = new LazyAsyncResult(_sslState, asyncState, asyncCallback);
-            _sslState.ProcessAuthentication(result);
+            _sslState.ProcessAuthentication(result, cancellationToken);
             return result;
         }
 
@@ -307,7 +307,7 @@ namespace System.Net.Security
             sslClientAuthenticationOptions._certSelectionDelegate = _certSelectionDelegate;
 
             _sslState.ValidateCreateContext(sslClientAuthenticationOptions);
-            _sslState.ProcessAuthentication(null);
+            _sslState.ProcessAuthentication(null, CancellationToken.None);
         }
 
         public virtual void AuthenticateAsServer(X509Certificate serverCertificate)
@@ -343,7 +343,7 @@ namespace System.Net.Security
             sslServerAuthenticationOptions._certValidationDelegate = _certValidationDelegate;
 
             _sslState.ValidateCreateContext(sslServerAuthenticationOptions);
-            _sslState.ProcessAuthentication(null);
+            _sslState.ProcessAuthentication(null, CancellationToken.None);
         }
         #endregion
 

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -79,7 +79,7 @@ namespace System.Net.Security.Tests
                 serverOptions.RemoteCertificateValidationCallback = AllowAnyServerCertificate;
 
                 CancellationTokenSource cts = new CancellationTokenSource();
-                Task clientTask = Assert.ThrowsAsync<TaskCanceledException>(() => client.AuthenticateAsClientAsync(clientOptions, cts.Token));
+                Task clientTask = Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.AuthenticateAsClientAsync(clientOptions, cts.Token));
                 Task serverTask = Assert.ThrowsAsync<TimeoutException>(() => server.AuthenticateAsServerAsync(serverOptions, CancellationToken.None));
 
                 cts.Cancel();
@@ -107,7 +107,7 @@ namespace System.Net.Security.Tests
 
                 CancellationTokenSource cts = new CancellationTokenSource();
                 Task clientTask = Assert.ThrowsAsync<TimeoutException>(() => client.AuthenticateAsClientAsync(clientOptions, CancellationToken.None));
-                Task serverTask = Assert.ThrowsAsync<TaskCanceledException>(() => server.AuthenticateAsServerAsync(serverOptions, cts.Token));
+                Task serverTask = Assert.ThrowsAnyAsync<OperationCanceledException>(() => server.AuthenticateAsServerAsync(serverOptions, cts.Token));
 
                 cts.Cancel();
                 Assert.True(Task.WaitAll(new[] { clientTask, serverTask }, TestConfiguration.PassingTestTimeoutMilliseconds));

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -76,13 +76,13 @@ namespace System.Net.Security.Tests
 
                 SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions();
                 serverOptions.ServerCertificate = certificate;
-                serverOptions.RemoteCertificateValidationCallback = AllowAnyServerCertificate;
 
                 CancellationTokenSource cts = new CancellationTokenSource();
+                cts.Cancel();
+
                 Task clientTask = Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.AuthenticateAsClientAsync(clientOptions, cts.Token));
                 Task serverTask = Assert.ThrowsAsync<TimeoutException>(() => server.AuthenticateAsServerAsync(serverOptions, CancellationToken.None));
 
-                cts.Cancel();
                 Assert.True(Task.WaitAll(new[] { clientTask, serverTask }, TestConfiguration.PassingTestTimeoutMilliseconds));
             }
         }
@@ -103,13 +103,13 @@ namespace System.Net.Security.Tests
 
                 SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions();
                 serverOptions.ServerCertificate = certificate;
-                serverOptions.RemoteCertificateValidationCallback = AllowAnyServerCertificate;
 
                 CancellationTokenSource cts = new CancellationTokenSource();
+                cts.Cancel();
+
                 Task clientTask = Assert.ThrowsAsync<TimeoutException>(() => client.AuthenticateAsClientAsync(clientOptions, CancellationToken.None));
                 Task serverTask = Assert.ThrowsAnyAsync<OperationCanceledException>(() => server.AuthenticateAsServerAsync(serverOptions, cts.Token));
 
-                cts.Cancel();
                 Assert.True(Task.WaitAll(new[] { clientTask, serverTask }, TestConfiguration.PassingTestTimeoutMilliseconds));
             }
         }

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -194,8 +194,8 @@ namespace System.Net.Security.Tests
                     ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 },
                     ServerCertificate = certificate,
                 };
-                
-                Task t1 = Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(clientOptions, CancellationToken.None));
+
+                Task t1 = Assert.ThrowsAsync<TimeoutException>(() => client.AuthenticateAsClientAsync(clientOptions, CancellationToken.None));
                 Task t2 = Assert.ThrowsAsync<AuthenticationException>(() => server.AuthenticateAsServerAsync(serverOptions, CancellationToken.None));
 
                 Assert.True(Task.WaitAll(new[] { t1, t2 }, TestConfiguration.PassingTestTimeoutMilliseconds));

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
@@ -183,7 +183,7 @@ namespace System.Net.Security
         // This method assumes that a SSPI context is already in a good shape.
         // For example it is either a fresh context or already authenticated context that needs renegotiation.
         //
-        internal void ProcessAuthentication(LazyAsyncResult lazyResult)
+        internal void ProcessAuthentication(LazyAsyncResult lazyResult, CancellationToken cancellationToken)
         {
         }
 


### PR DESCRIPTION
also fixes #24853 

cc @stephentoub @Tratcher @Drawaes 