### PR TITLE
Share EventSource tests with Microsoft.Diagnostics.Tracing.EventSource.Redist Package

### DIFF
--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/tests/Configurations.props
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/tests/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netfx;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/tests/Microsoft.Diagnostics.Tracing.EventSource.Redist.Tests.csproj
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/tests/Microsoft.Diagnostics.Tracing.EventSource.Redist.Tests.csproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{0657A043-0AEE-445E-9BE4-0B3A9D80318F}</ProjectGuid>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_ETLEVENTS</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_EVENTCOUNTER_DISPOSE</DefineConstants>
+    <DefineConstants>$(DefineConstants);USE_MDT_EVENTSOURCE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SDTTestDir>..\..\System.Diagnostics.Tracing\tests</SDTTestDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\Harness\EventTestHarness.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\FuzzyTests.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\Harness\Listeners.cs" />
+    <!-- <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestEventCounter.cs" /> -->
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestFilter.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestShutdown.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestsEventSourceLifetime.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestsManifestGeneration.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestsManifestNegative.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestsTraits.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestsWriteEvent.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestsWriteEventToListener.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\EventSourceTestParser.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\LoudListener.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestsWrite.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestsUserErrors.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\TestUtilities.cs" />
+    <Compile Include="$(SDTTestDir)\BasicEventSourceTest\XUnitAssemblyAttributes.cs" />
+    <!--EventSources for testing-->
+    <Compile Include="$(SDTTestDir)\CustomEventSources\EventSourceTest.cs" />
+    <Compile Include="$(SDTTestDir)\CustomEventSources\InvalidCallsToWriteEvent.cs" />
+    <Compile Include="$(SDTTestDir)\CustomEventSources\InvalidEventSources.cs" />
+    <Compile Include="$(SDTTestDir)\CustomEventSources\SimpleEventSource.cs" />
+    <Compile Include="$(SDTTestDir)\CustomEventSources\UseAbstractEventSource.cs" />
+    <Compile Include="$(SDTTestDir)\CustomEventSources\UseInterfaceEventSource.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/EventSourceTestParser.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/EventSourceTestParser.cs
@@ -4,9 +4,12 @@
 
 using System;
 using System.Diagnostics;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using System.Text;
-//using System.Diagnostics.Tracing;
 using Address = System.UInt64;
 
 #pragma warning disable 1591        // disable warnings on XML comments not being present

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
@@ -7,7 +7,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using Xunit;
 #if USE_ETW // TODO: Enable when TraceEvent is available on CoreCLR. GitHub issue #4864.
 using Microsoft.Diagnostics.Tracing.Session;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EventTestHarness.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EventTestHarness.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using Xunit;
 using System;
 using System.Collections.Generic;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
@@ -8,7 +8,11 @@ using Microsoft.Diagnostics.Tracing.Session;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using System.IO;
 using System.Text;
 using System.Threading;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/LoudListener.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/LoudListener.cs
@@ -4,7 +4,11 @@
 
 using System;
 using System.Diagnostics;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 
 namespace BasicEventSourceTests
 {

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
@@ -2,7 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 #if USE_ETW // TODO: Enable when TraceEvent is available on CoreCLR. GitHub issue https://github.com/dotnet/corefx/issues/4864 
 using Microsoft.Diagnostics.Tracing.Session;
 #endif

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestFilter.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestFilter.cs
@@ -4,7 +4,11 @@
 
 using System;
 using System.Collections.ObjectModel;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using Xunit;
 
 namespace BasicEventSourceTests

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestShutdown.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestShutdown.cs
@@ -7,7 +7,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using Xunit;
 #if USE_ETW // TODO: Enable when TraceEvent is available on CoreCLR. GitHub issue #4864.
 using Microsoft.Diagnostics.Tracing.Session;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using System.Diagnostics;
 using Xunit;
 using System;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsEventSourceLifetime.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsEventSourceLifetime.cs
@@ -8,7 +8,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using System.Reflection;
 
 namespace BasicEventSourceTests

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.cs
@@ -7,12 +7,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using Xunit;
 using System.Reflection;
 
-//using Mdt = MdtEventSources;
-using Sdt = SdtEventSources;
+using SdtEventSources;
 using System.Diagnostics;
 using System.Threading;
 using System.Text.RegularExpressions;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestNegative.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestNegative.cs
@@ -9,7 +9,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using Xunit;
 
 using Sdt = SdtEventSources;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsTraits.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsTraits.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using Xunit;
 using System;
 

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using Xunit;
 using System;
 using System.Collections.Generic;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
@@ -7,7 +7,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using Xunit;
 #if USE_ETW // TODO: Enable when TraceEvent is available on CoreCLR. GitHub issue #4864.
 using Microsoft.Diagnostics.Tracing.Session;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
@@ -11,7 +11,11 @@ using System.Threading.Tasks;
 using System.Threading;
 using Xunit;
 
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using System.Text.RegularExpressions;
 using System.Diagnostics;
 using SdtEventSources;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
@@ -8,7 +8,11 @@ using System.Linq;
 using System.Text;
 using Xunit;
 using System.Threading;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using SdtEventSources;
 
 namespace BasicEventSourceTests

--- a/src/System.Diagnostics.Tracing/tests/CustomEventSources/EventSourceTest.cs
+++ b/src/System.Diagnostics.Tracing/tests/CustomEventSources/EventSourceTest.cs
@@ -5,7 +5,11 @@
 using System;
 using System.Linq;
 using System.Diagnostics;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 
 // We wish to test both Microsoft.Diagnostics.Tracing (Nuget)
 // and System.Diagnostics.Tracing (Framework), we use this Ifdef make each kind 

--- a/src/System.Diagnostics.Tracing/tests/CustomEventSources/InvalidCallsToWriteEvent.cs
+++ b/src/System.Diagnostics.Tracing/tests/CustomEventSources/InvalidCallsToWriteEvent.cs
@@ -3,7 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 
 // We wish to test both Microsoft.Diagnostics.Tracing (Nuget)
 // and System.Diagnostics.Tracing (Framework), we use this Ifdef make each kind 

--- a/src/System.Diagnostics.Tracing/tests/CustomEventSources/InvalidEventSources.cs
+++ b/src/System.Diagnostics.Tracing/tests/CustomEventSources/InvalidEventSources.cs
@@ -3,7 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 
 // We wish to test both Microsoft.Diagnostics.Tracing (Nuget)
 // and System.Diagnostics.Tracing (Framework), we use this Ifdef make each kind 

--- a/src/System.Diagnostics.Tracing/tests/CustomEventSources/SimpleEventSource.cs
+++ b/src/System.Diagnostics.Tracing/tests/CustomEventSources/SimpleEventSource.cs
@@ -5,7 +5,11 @@
 // #define FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
 
 using System;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 
 // We wish to test both Microsoft.Diagnostics.Tracing (Nuget)
 // and System.Diagnostics.Tracing (Framework), we use this Ifdef make each kind 
@@ -17,7 +21,11 @@ namespace SdtEventSources
     namespace DontPollute
     {
         public sealed class EventSource :
+#if USE_MDT_EVENTSOURCE
+            Microsoft.Diagnostics.Tracing.EventSource
+#else
             System.Diagnostics.Tracing.EventSource
+#endif
         {
             [Event(1)]
             public void EventWrite(int i) { this.WriteEvent(1, i); }

--- a/src/System.Diagnostics.Tracing/tests/CustomEventSources/UseAbstractEventSource.cs
+++ b/src/System.Diagnostics.Tracing/tests/CustomEventSources/UseAbstractEventSource.cs
@@ -4,7 +4,11 @@
 
 using System;
 
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 
 // We wish to test both Microsoft.Diagnostics.Tracing (Nuget)
 // and System.Diagnostics.Tracing (Framework), we use this Ifdef make each kind 

--- a/src/System.Diagnostics.Tracing/tests/CustomEventSources/UseInterfaceEventSource.cs
+++ b/src/System.Diagnostics.Tracing/tests/CustomEventSources/UseInterfaceEventSource.cs
@@ -4,7 +4,11 @@
 
 using System;
 
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 
 // We wish to test both Microsoft.Diagnostics.Tracing (Nuget)
 // and System.Diagnostics.Tracing (Framework), we use this Ifdef make each kind 


### PR DESCRIPTION
Run System.Diagnostics.Tracing tests against Microsoft.Diagnostics.Tracing.EventSource.Redist package.

There are two parts to this PR:
 - Create a csproj to run the tests.
 - Re-direct the tests themselves to use Microsoft.Diagnostics.Tracing instead of System.Diagnostics.Tracing.
