### PR TITLE
Enable official builds for Alpine Linux

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -224,6 +224,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Create Helix Test Jobs",
+      "condition": "ne(variables['PB_EnableCloudTest'], 'false')",
       "timeoutInMinutes": 0,
       "refName": "Task11",
       "task": {

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -55,8 +55,9 @@
             "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
             "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -Outerloop -RuntimeOS=alpine.3.6 -- /p:ArchiveTests=false /p:EnableDumpling=true /p:PortableBuild=false",
             "PB_SyncArguments": "-p -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false",
-            "PB_TargetQueue": "Alpine.3.6.Amd64",
-            "PB_CreateHelixArguments": "/p:EnableCloudTest=false /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
+            "PB_TargetQueue": "Alpine.36.Amd64",
+            "PB_EnableCloudTest" : "false",
+            "PB_CreateHelixArguments": "/p:EnableCloudTest=$(PB_EnableCloudTest) /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
           },
           "ReportingParameters": {
             "OperatingSystem": "Alpine3.6",
@@ -400,8 +401,9 @@
             "PB_BuildArguments": "-buildArch=x64 -Debug -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
             "PB_BuildTestsArguments": "-buildArch=x64 -Debug -SkipTests -Outerloop -RuntimeOS=alpine.3.6 -- /p:ArchiveTests=false /p:EnableDumpling=true /p:PortableBuild=false",
             "PB_SyncArguments": "-p -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false",
-            "PB_TargetQueue": "Alpine.3.6.Amd64",
-            "PB_CreateHelixArguments": "/p:EnableCloudTest=false /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
+            "PB_TargetQueue": "Alpine.36.Amd64",
+            "PB_EnableCloudTest" : "false",
+            "PB_CreateHelixArguments": "/p:EnableCloudTest=$(PB_EnableCloudTest) /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
           },
           "ReportingParameters": {
             "OperatingSystem": "Alpine3.6",

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -49,6 +49,23 @@
           }
         },
         {
+          "Name": "DotNet-CoreFx-Trusted-Linux",
+          "Parameters": {
+            "PB_DockerTag": "alpine-3.6-3148f11-20171119021156",
+            "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
+            "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -Outerloop -RuntimeOS=alpine.3.6 -- /p:ArchiveTests=false /p:EnableDumpling=true /p:PortableBuild=false",
+            "PB_SyncArguments": "-p -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false",
+            "PB_TargetQueue": "Alpine.3.6.Amd64",
+            "PB_CreateHelixArguments": "/p:EnableCloudTest=false /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Alpine3.6",
+            "Platform": "x64",
+            "Type": "build/product/",
+            "ConfigurationGroup": "Release"
+          }
+        },
+        {
           "Name": "DotNet-CoreFx-Trusted-Linux-Crossbuild",
           "Parameters": {
             "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20170319080304",
@@ -371,6 +388,23 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "RedHat6",
+            "Platform": "x64",
+            "Type": "build/product/",
+            "ConfigurationGroup": "Debug"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Linux",
+          "Parameters": {
+            "PB_DockerTag": "alpine-3.6-3148f11-20171119021156",
+            "PB_BuildArguments": "-buildArch=x64 -Debug -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
+            "PB_BuildTestsArguments": "-buildArch=x64 -Debug -SkipTests -Outerloop -RuntimeOS=alpine.3.6 -- /p:ArchiveTests=false /p:EnableDumpling=true /p:PortableBuild=false",
+            "PB_SyncArguments": "-p -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false",
+            "PB_TargetQueue": "Alpine.3.6.Amd64",
+            "PB_CreateHelixArguments": "/p:EnableCloudTest=false /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Alpine3.6",
             "Platform": "x64",
             "Type": "build/product/",
             "ConfigurationGroup": "Debug"


### PR DESCRIPTION
This change enables official builds for Alpine 3.6. It doesn't enable
tests since we don't have a way to create Alpine queue.