### PR TITLE
Fix offical Alpine build - sync arguments

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -52,9 +52,9 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "alpine-3.6-3148f11-20171119021156",
-            "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
+            "PB_BuildArguments": "-buildArch=x64 -Release -SkipTests -stripSymbols -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
             "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -Outerloop -RuntimeOS=alpine.3.6 -- /p:ArchiveTests=false /p:EnableDumpling=true /p:PortableBuild=false",
-            "PB_SyncArguments": "-p -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false",
+            "PB_SyncArguments": "-p -SkipTests -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false /p:OverridePackageSource=$(PB_AzureFeedUrl)",
             "PB_TargetQueue": "Alpine.36.Amd64",
             "PB_EnableCloudTest" : "false",
             "PB_CreateHelixArguments": "/p:EnableCloudTest=$(PB_EnableCloudTest) /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
@@ -398,9 +398,9 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "alpine-3.6-3148f11-20171119021156",
-            "PB_BuildArguments": "-buildArch=x64 -Debug -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
+            "PB_BuildArguments": "-buildArch=x64 -Debug -SkipTests -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
             "PB_BuildTestsArguments": "-buildArch=x64 -Debug -SkipTests -Outerloop -RuntimeOS=alpine.3.6 -- /p:ArchiveTests=false /p:EnableDumpling=true /p:PortableBuild=false",
-            "PB_SyncArguments": "-p -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false",
+            "PB_SyncArguments": "-p -SkipTests -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false /p:OverridePackageSource=$(PB_AzureFeedUrl)",
             "PB_TargetQueue": "Alpine.36.Amd64",
             "PB_EnableCloudTest" : "false",
             "PB_CreateHelixArguments": "/p:EnableCloudTest=$(PB_EnableCloudTest) /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -52,9 +52,9 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "alpine-3.6-3148f11-20171119021156",
-            "PB_BuildArguments": "-buildArch=x64 -Release -SkipTests -stripSymbols -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
+            "PB_BuildArguments": "-buildArch=x64 -Release -BuildTests=false -stripSymbols -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
             "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -Outerloop -RuntimeOS=alpine.3.6 -- /p:ArchiveTests=false /p:EnableDumpling=true /p:PortableBuild=false",
-            "PB_SyncArguments": "-p -SkipTests -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false /p:OverridePackageSource=$(PB_AzureFeedUrl)",
+            "PB_SyncArguments": "-p -BuildTests=false -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false /p:OverridePackageSource=$(PB_AzureFeedUrl)",
             "PB_TargetQueue": "Alpine.36.Amd64",
             "PB_EnableCloudTest" : "false",
             "PB_CreateHelixArguments": "/p:EnableCloudTest=$(PB_EnableCloudTest) /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
@@ -398,9 +398,9 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "alpine-3.6-3148f11-20171119021156",
-            "PB_BuildArguments": "-buildArch=x64 -Debug -SkipTests -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
+            "PB_BuildArguments": "-buildArch=x64 -Debug -BuildTests=false -RuntimeOS=alpine.3.6 -- /p:PortableBuild=false",
             "PB_BuildTestsArguments": "-buildArch=x64 -Debug -SkipTests -Outerloop -RuntimeOS=alpine.3.6 -- /p:ArchiveTests=false /p:EnableDumpling=true /p:PortableBuild=false",
-            "PB_SyncArguments": "-p -SkipTests -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false /p:OverridePackageSource=$(PB_AzureFeedUrl)",
+            "PB_SyncArguments": "-p -BuildTests=false -RuntimeOS=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false /p:OverridePackageSource=$(PB_AzureFeedUrl)",
             "PB_TargetQueue": "Alpine.36.Amd64",
             "PB_EnableCloudTest" : "false",
             "PB_CreateHelixArguments": "/p:EnableCloudTest=$(PB_EnableCloudTest) /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"


### PR DESCRIPTION
It turns out that the sync.sh command needs to be passed the -BuildTests=false
option too so that it doesn't try to sync core-setup packages that
are used only for running tests. Since there are no core-setup packages
for Alpine yet, the sync was failing.
I have also noticed that there was a recent change in the sync arguments
that I have not discovered after rebase of my changes to master. So I
have added the new option there.