### PR TITLE
Add Span<T> Base64 conversion APIs that support UTF-8

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -200,6 +200,14 @@ namespace System.Buffers
         public abstract void Retain();
         protected internal abstract bool TryGetArray(out ArraySegment<T> arraySegment);
     }
+
+    public enum OperationStatus
+    {
+        Done,
+        DestinationTooSmall,
+        NeedMoreData,
+        InvalidData,
+    }
 }
 
 namespace System.Buffers.Binary
@@ -276,5 +284,18 @@ namespace System.Buffers.Binary
         public static bool TryWriteUInt16BigEndian(Span<byte> buffer, ushort value) { throw null; }
         public static bool TryWriteUInt32BigEndian(Span<byte> buffer, uint value) { throw null; }
         public static bool TryWriteUInt64BigEndian(Span<byte> buffer, ulong value) { throw null; }
+    }
+}
+
+namespace System.Buffers.Text
+{
+    public static class Base64
+    {
+        public static OperationStatus EncodeToUtf8(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int consumed, out int written, bool isFinalBlock = true) { throw null; }
+        public static OperationStatus EncodeToUtf8InPlace(Span<byte> buffer, int dataLength, out int written) { throw null; }
+        public static int GetMaxEncodedToUtf8Length(int length) { throw null; }
+        public static OperationStatus DecodeFromUtf8(ReadOnlySpan<byte> utf8, Span<byte> bytes, out int consumed, out int written, bool isFinalBlock = true) { throw null; }
+        public static OperationStatus DecodeFromUtf8InPlace(Span<byte> buffer, out int written) { throw null; }
+        public static int GetMaxDecodedFromUtf8Length(int length) { throw null; }
     }
 }

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -25,12 +25,15 @@
     <Compile Include="System\SpanExtensions.cs" />
     <Compile Include="System\SpanHelpers.T.cs" />
     <Compile Include="System\SpanHelpers.byte.cs" />
+    <Compile Include="System\Buffers\OperationStatus.cs" />
     <Compile Include="System\Buffers\Binary\Reader.cs" />
     <Compile Include="System\Buffers\Binary\ReaderBigEndian.cs" />
     <Compile Include="System\Buffers\Binary\ReaderLittleEndian.cs" />
     <Compile Include="System\Buffers\Binary\Writer.cs" />
     <Compile Include="System\Buffers\Binary\WriterBigEndian.cs" />
     <Compile Include="System\Buffers\Binary\WriterLittleEndian.cs" />
+    <Compile Include="System\Buffers\Text\Base64Decoder.cs" />
+    <Compile Include="System\Buffers\Text\Base64Encoder.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\ReadOnlySpan.cs" />

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -25,6 +25,7 @@
     <Compile Include="System\SpanExtensions.cs" />
     <Compile Include="System\SpanHelpers.T.cs" />
     <Compile Include="System\SpanHelpers.byte.cs" />
+    <Compile Include="System\ThrowHelper.cs" />
     <Compile Include="System\Buffers\OperationStatus.cs" />
     <Compile Include="System\Buffers\Binary\Reader.cs" />
     <Compile Include="System\Buffers\Binary\ReaderBigEndian.cs" />
@@ -42,7 +43,6 @@
     <Compile Include="System\SpanExtensions.Portable.cs" />
     <Compile Include="System\SpanHelpers.cs" />
     <Compile Include="System\Pinnable.cs" />
-    <Compile Include="System\ThrowHelper.cs" />
     <Compile Include="System\SpanHelpers.Clear.cs" />
     <Compile Include="System\Memory.cs" />
     <Compile Include="System\MemoryDebugView.cs" />

--- a/src/System.Memory/src/System/Buffers/Binary/Reader.cs
+++ b/src/System.Memory/src/System/Buffers/Binary/Reader.cs
@@ -106,12 +106,12 @@ namespace System.Buffers.Binary
 #else
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                throw new ArgumentException(SR.Format(SR.Argument_InvalidTypeWithPointersNotSupported, typeof(T)));
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             }
 #endif
             if (Unsafe.SizeOf<T>() > buffer.Length)
             {
-                throw new ArgumentOutOfRangeException();
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
             }
             return Unsafe.ReadUnaligned<T>(ref buffer.DangerousGetPinnableReference());
         }
@@ -132,7 +132,7 @@ namespace System.Buffers.Binary
 #else
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                throw new ArgumentException(SR.Format(SR.Argument_InvalidTypeWithPointersNotSupported, typeof(T)));
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             }
 #endif
             if (Unsafe.SizeOf<T>() > (uint)buffer.Length)

--- a/src/System.Memory/src/System/Buffers/Binary/Writer.cs
+++ b/src/System.Memory/src/System/Buffers/Binary/Writer.cs
@@ -24,12 +24,12 @@ namespace System.Buffers.Binary
 #else
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                throw new ArgumentException(SR.Format(SR.Argument_InvalidTypeWithPointersNotSupported, typeof(T)));
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             }
 #endif
             if ((uint)Unsafe.SizeOf<T>() > (uint)buffer.Length)
             {
-                throw new ArgumentOutOfRangeException();
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
             }
             Unsafe.WriteUnaligned<T>(ref buffer.DangerousGetPinnableReference(), value);
         }
@@ -50,7 +50,7 @@ namespace System.Buffers.Binary
 #else
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                throw new ArgumentException(SR.Format(SR.Argument_InvalidTypeWithPointersNotSupported, typeof(T)));
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             }
 #endif
             if (Unsafe.SizeOf<T>() > (uint)buffer.Length)

--- a/src/System.Memory/src/System/Buffers/OperationStatus.cs
+++ b/src/System.Memory/src/System/Buffers/OperationStatus.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// This enum defines the various potential status that can be returned from Span-based operations
+    /// that support processing of input contained in multiple discontiguous buffers.
+    /// </summary>
+    public enum OperationStatus
+    {
+        /// <summary>
+        /// The entire input buffer has been processed and the operation is complete.
+        /// </summary>
+        Done,
+        /// <summary>
+        /// The input is partially processed, up to what could fit into the destination buffer.
+        /// The caller can enlarge the destination buffer, slice the buffers appropriately, and retry.
+        /// </summary>
+        DestinationTooSmall,
+        /// <summary>
+        /// The input is partially processed, up to the last valid chunk of the input that could be consumed.
+        /// The caller can stitch the remaining unprocessed input with more data, slice the buffers appropriately, and retry.
+        /// </summary>
+        NeedMoreData,
+        /// <summary>
+        /// The input contained invalid bytes which could not be processed. If the input is partially processed,
+        /// the destination contains the partial result. This guarantees that no additional data appended to the input
+        /// will make the invalid sequence valid.
+        /// </summary>
+        InvalidData,
+    }
+}

--- a/src/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
@@ -169,18 +169,19 @@ namespace System.Buffers.Text
         /// </summary> 
         public static OperationStatus DecodeFromUtf8InPlace(Span<byte> buffer, out int written)
         {
+            int bufferLength = buffer.Length;
             int sourceIndex = 0;
             int destIndex = 0;
 
             // only decode input if it is a multiple of 4
-            if (buffer.Length % 4 != 0) goto InvalidExit;
-            if (buffer.Length == 0) goto DoneExit;
+            if (bufferLength != ((bufferLength >> 2) * 4)) goto InvalidExit;
+            if (bufferLength == 0) goto DoneExit;
 
             ref byte bufferBytes = ref buffer.DangerousGetPinnableReference();
 
             ref sbyte decodingMap = ref s_decodingMap[0];
 
-            while (sourceIndex < buffer.Length - 4)
+            while (sourceIndex < bufferLength - 4)
             {
                 int result = Decode(ref Unsafe.Add(ref bufferBytes, sourceIndex), ref decodingMap);
                 if (result < 0) goto InvalidExit;
@@ -189,10 +190,10 @@ namespace System.Buffers.Text
                 sourceIndex += 4;
             }
 
-            int i0 = Unsafe.Add(ref bufferBytes, buffer.Length - 4);
-            int i1 = Unsafe.Add(ref bufferBytes, buffer.Length - 3);
-            int i2 = Unsafe.Add(ref bufferBytes, buffer.Length - 2);
-            int i3 = Unsafe.Add(ref bufferBytes, buffer.Length - 1);
+            int i0 = Unsafe.Add(ref bufferBytes, bufferLength - 4);
+            int i1 = Unsafe.Add(ref bufferBytes, bufferLength - 3);
+            int i2 = Unsafe.Add(ref bufferBytes, bufferLength - 2);
+            int i3 = Unsafe.Add(ref bufferBytes, bufferLength - 1);
 
             i0 = Unsafe.Add(ref decodingMap, i0);
             i1 = Unsafe.Add(ref decodingMap, i1);

--- a/src/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
@@ -297,7 +297,7 @@ namespace System.Buffers.Text
         }
 
         // Pre-computing this table using a custom string(s_characters) and GenerateDecodingMapAndVerify (found in tests)
-        static readonly sbyte[] s_decodingMap = {
+        private static readonly sbyte[] s_decodingMap = {
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,         //62 is placed at index 43 (for +), 63 at index 47 (for /)

--- a/src/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
@@ -1,0 +1,300 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Buffers.Text
+{
+    public static partial class Base64
+    {
+        /// <summary>
+        /// Decode the span of UTF-8 encoded text represented as base 64 into binary data.
+        /// If the input is not a multiple of 4, it will decode as much as it can, to the closest multiple of 4.
+        ///
+        /// <param name="utf8">The input span which contains UTF-8 encoded text in base 64 that needs to be decoded.</param>
+        /// <param name="bytes">The output span which contains the result of the operation, i.e. the decoded binary data.</param>
+        /// <param name="consumed">The number of input bytes consumed during the operation. This can be used to slice the input for subsequent calls, if necessary.</param>
+        /// <param name="written">The number of bytes written into the output span. This can be used to slice the output for subsequent calls, if necessary.</param>
+        /// <param name="isFinalBlock">True (default) when the input span contains the entire data to decode. 
+        /// Set to false only if it is known that the input span contains partial data with more data to follow.</param>
+        /// <returns>It returns the OperationStatus enum values:
+        /// - Done - on successful processing of the entire input span
+        /// - DestinationTooSmall - if there is not enough space in the output span to fit the decoded input
+        /// - NeedMoreData - only if isFinalBlock is false and the input is not a multiple of 4, otherwise the partial input would be considered as InvalidData
+        /// - InvalidData - if the input contains bytes outside of the expected base 64 range, or if it contains invalid/more than two padding characters,
+        ///   or if the input is incomplete (i.e. not a multiple of 4) and isFinalBlock is true.</returns>
+        /// </summary> 
+        public static OperationStatus DecodeFromUtf8(ReadOnlySpan<byte> utf8, Span<byte> bytes, out int consumed, out int written, bool isFinalBlock = true)
+        {
+            ref byte srcBytes = ref utf8.DangerousGetPinnableReference();
+            ref byte destBytes = ref bytes.DangerousGetPinnableReference();
+
+            int srcLength = utf8.Length & ~0x3;  // only decode input up to the closest multiple of 4.
+            int destLength = bytes.Length;
+
+            int sourceIndex = 0;
+            int destIndex = 0;
+
+            if (utf8.Length == 0) goto DoneExit;
+
+            ref sbyte decodingMap = ref s_decodingMap[0];
+
+            // Last bytes could have padding characters, so process them separately and treat them as valid only if isFinalBlock is true
+            // if isFinalBlock is false, padding characters are considered invalid
+            int skipLastChunk = isFinalBlock ? 4 : 0;
+
+            while (sourceIndex < srcLength - skipLastChunk)
+            {
+                int result = Decode(ref Unsafe.Add(ref srcBytes, sourceIndex), ref decodingMap);
+                if (result < 0) goto InvalidExit;
+                if (destIndex > destLength - 3) goto DestinationSmallExit;
+                WriteThreeLowOrderBytes(ref Unsafe.Add(ref destBytes, destIndex), result);
+                destIndex += 3;
+                sourceIndex += 4;
+            }
+
+            // If input is less than 4 bytes, srcLength == sourceIndex == 0
+            // If input is not a multiple of 4, sourceIndex == srcLength != 0
+            if (sourceIndex == srcLength)
+            {
+                if (isFinalBlock) goto InvalidExit;
+                goto NeedMoreExit;
+            }
+
+            // if isFinalBlock is false, we will never reach this point
+            
+            int i0 = Unsafe.Add(ref srcBytes, srcLength - 4);
+            int i1 = Unsafe.Add(ref srcBytes, srcLength - 3);
+            int i2 = Unsafe.Add(ref srcBytes, srcLength - 2);
+            int i3 = Unsafe.Add(ref srcBytes, srcLength - 1);
+
+            i0 = Unsafe.Add(ref decodingMap, i0);
+            i1 = Unsafe.Add(ref decodingMap, i1);
+
+            i0 <<= 18;
+            i1 <<= 12;
+
+            i0 |= i1;
+
+            if (i3 != s_encodingPad)
+            {
+                i2 = Unsafe.Add(ref decodingMap, i2);
+                i3 = Unsafe.Add(ref decodingMap, i3);
+
+                i2 <<= 6;
+
+                i0 |= i3;
+                i0 |= i2;
+
+                if (i0 < 0) goto InvalidExit;
+                if (destIndex > destLength - 3) goto DestinationSmallExit;
+                WriteThreeLowOrderBytes(ref Unsafe.Add(ref destBytes, destIndex), i0);
+                destIndex += 3;
+            }
+            else if (i2 != s_encodingPad)
+            {
+                i2 = Unsafe.Add(ref decodingMap, i2);
+
+                i2 <<= 6;
+
+                i0 |= i2;
+
+                if (i0 < 0) goto InvalidExit;
+                if (destIndex > destLength - 2) goto DestinationSmallExit;
+                Unsafe.Add(ref destBytes, destIndex) = (byte)(i0 >> 16);
+                Unsafe.Add(ref destBytes, destIndex + 1) = (byte)(i0 >> 8);
+                destIndex += 2;
+            }
+            else
+            {
+                if (i0 < 0) goto InvalidExit;
+                if (destIndex > destLength - 1) goto DestinationSmallExit;
+                Unsafe.Add(ref destBytes, destIndex) = (byte)(i0 >> 16);
+                destIndex += 1;
+            }
+
+            sourceIndex += 4;
+
+            if (srcLength != utf8.Length) goto InvalidExit;
+
+            DoneExit:
+            consumed = sourceIndex;
+            written = destIndex;
+            return OperationStatus.Done;
+
+            DestinationSmallExit:
+            if (srcLength != utf8.Length && isFinalBlock) goto InvalidExit; // if input is not a multiple of 4, and there is no more data, return invalid data instead
+            consumed = sourceIndex;
+            written = destIndex;
+            return OperationStatus.DestinationTooSmall;
+
+            NeedMoreExit:
+            consumed = sourceIndex;
+            written = destIndex;
+            return OperationStatus.NeedMoreData;
+
+            InvalidExit:
+            consumed = sourceIndex;
+            written = destIndex;
+            return OperationStatus.InvalidData;
+        }
+
+        /// <summary>
+        /// Returns the maximum length (in bytes) of the result if you were to deocde base 64 encoded text within a byte span of size "length".
+        /// </summary> 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetMaxDecodedFromUtf8Length(int length)
+        {
+            Debug.Assert(length >= 0);
+            return (length >> 2) * 3;
+        }
+
+        /// <summary>
+        /// Decode the span of UTF-8 encoded text in base 64 (in-place) into binary data.
+        /// The decoded binary output is smaller than the text data contained in the input (the operation deflates the data).
+        /// If the input is not a multiple of 4, it will not decode any.
+        ///
+        /// <param name="buffer">The input span which contains the base 64 text data that needs to be decoded.</param>
+        /// <param name="written">The number of bytes written into the buffer.</param>
+        /// <returns>It returns the OperationStatus enum values:
+        /// - Done - on successful processing of the entire input span
+        /// - InvalidData - if the input contains bytes outside of the expected base 64 range, or if it contains invalid/more than two padding characters, 
+        ///   or if the input is incomplete (i.e. not a multiple of 4).
+        /// It does not return DestinationTooSmall since that is not possible for base 64 decoding.
+        /// It does not return NeedMoreData since this method tramples the data in the buffer and 
+        /// hence can only be called once with all the data in the buffer.</returns>
+        /// </summary> 
+        public static OperationStatus DecodeFromUtf8InPlace(Span<byte> buffer, out int written)
+        {
+            int sourceIndex = 0;
+            int destIndex = 0;
+
+            // only decode input if it is a multiple of 4
+            if (buffer.Length % 4 != 0) goto InvalidExit;
+            if (buffer.Length == 0) goto DoneExit;
+
+            ref byte bufferBytes = ref buffer.DangerousGetPinnableReference();
+
+            ref sbyte decodingMap = ref s_decodingMap[0];
+
+            while (sourceIndex < buffer.Length - 4)
+            {
+                int result = Decode(ref Unsafe.Add(ref bufferBytes, sourceIndex), ref decodingMap);
+                if (result < 0) goto InvalidExit;
+                WriteThreeLowOrderBytes(ref Unsafe.Add(ref bufferBytes, destIndex), result);
+                destIndex += 3;
+                sourceIndex += 4;
+            }
+
+            int i0 = Unsafe.Add(ref bufferBytes, buffer.Length - 4);
+            int i1 = Unsafe.Add(ref bufferBytes, buffer.Length - 3);
+            int i2 = Unsafe.Add(ref bufferBytes, buffer.Length - 2);
+            int i3 = Unsafe.Add(ref bufferBytes, buffer.Length - 1);
+
+            i0 = Unsafe.Add(ref decodingMap, i0);
+            i1 = Unsafe.Add(ref decodingMap, i1);
+
+            i0 <<= 18;
+            i1 <<= 12;
+
+            i0 |= i1;
+
+            if (i3 != s_encodingPad)
+            {
+                i2 = Unsafe.Add(ref decodingMap, i2);
+                i3 = Unsafe.Add(ref decodingMap, i3);
+
+                i2 <<= 6;
+
+                i0 |= i3;
+                i0 |= i2;
+
+                if (i0 < 0) goto InvalidExit;
+                WriteThreeLowOrderBytes(ref Unsafe.Add(ref bufferBytes, destIndex), i0);
+                destIndex += 3;
+            }
+            else if (i2 != s_encodingPad)
+            {
+                i2 = Unsafe.Add(ref decodingMap, i2);
+
+                i2 <<= 6;
+
+                i0 |= i2;
+
+                if (i0 < 0) goto InvalidExit;
+                Unsafe.Add(ref bufferBytes, destIndex) = (byte)(i0 >> 16);
+                Unsafe.Add(ref bufferBytes, destIndex + 1) = (byte)(i0 >> 8);
+                destIndex += 2;
+            }
+            else
+            {
+                if (i0 < 0) goto InvalidExit;
+                Unsafe.Add(ref bufferBytes, destIndex) = (byte)(i0 >> 16);
+                destIndex += 1;
+            }
+
+            DoneExit:
+            written = destIndex;
+            return OperationStatus.Done;
+
+            InvalidExit:
+            written = destIndex;
+            return OperationStatus.InvalidData;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int Decode(ref byte encodedBytes, ref sbyte decodingMap)
+        {
+            int i0 = encodedBytes;
+            int i1 = Unsafe.Add(ref encodedBytes, 1);
+            int i2 = Unsafe.Add(ref encodedBytes, 2);
+            int i3 = Unsafe.Add(ref encodedBytes, 3);
+
+            i0 = Unsafe.Add(ref decodingMap, i0);
+            i1 = Unsafe.Add(ref decodingMap, i1);
+            i2 = Unsafe.Add(ref decodingMap, i2);
+            i3 = Unsafe.Add(ref decodingMap, i3);
+
+            i0 <<= 18;
+            i1 <<= 12;
+            i2 <<= 6;
+
+            i0 |= i3;
+            i1 |= i2;
+
+            i0 |= i1;
+            return i0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WriteThreeLowOrderBytes(ref byte destination, int value)
+        {
+            destination = (byte)(value >> 16);
+            Unsafe.Add(ref destination, 1) = (byte)(value >> 8);
+            Unsafe.Add(ref destination, 2) = (byte)value;
+        }
+
+        // Pre-computing this table using a custom string(s_characters) and GenerateDecodingMapAndVerify (found in tests)
+        static readonly sbyte[] s_decodingMap = {
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,         //62 is placed at index 43 (for +), 63 at index 47 (for /)
+            52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1,         //52-61 are placed at index 48-57 (for 0-9), 64 at index 61 (for =)
+            -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,         //0-25 are placed at index 65-90 (for A-Z)
+            -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1,         //26-51 are placed at index 97-122 (for a-z)
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,         // Bytes over 122 ('z') are invalid and cannot be decoded
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,         // Hence, padding the map with 255, which indicates invalid input
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        };
+    }
+}

--- a/src/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
@@ -79,7 +79,7 @@ namespace System.Buffers.Text
 
             i0 |= i1;
 
-            if (i3 != s_encodingPad)
+            if (i3 != EncodingPad)
             {
                 i2 = Unsafe.Add(ref decodingMap, i2);
                 i3 = Unsafe.Add(ref decodingMap, i3);
@@ -94,7 +94,7 @@ namespace System.Buffers.Text
                 WriteThreeLowOrderBytes(ref Unsafe.Add(ref destBytes, destIndex), i0);
                 destIndex += 3;
             }
-            else if (i2 != s_encodingPad)
+            else if (i2 != EncodingPad)
             {
                 i2 = Unsafe.Add(ref decodingMap, i2);
 
@@ -144,11 +144,16 @@ namespace System.Buffers.Text
 
         /// <summary>
         /// Returns the maximum length (in bytes) of the result if you were to deocde base 64 encoded text within a byte span of size "length".
-        /// </summary> 
+        /// </summary>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="length"/> is less than 0.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetMaxDecodedFromUtf8Length(int length)
         {
-            Debug.Assert(length >= 0);
+            if (length < 0)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+
             return (length >> 2) * 3;
         }
 
@@ -203,7 +208,7 @@ namespace System.Buffers.Text
 
             i0 |= i1;
 
-            if (i3 != s_encodingPad)
+            if (i3 != EncodingPad)
             {
                 i2 = Unsafe.Add(ref decodingMap, i2);
                 i3 = Unsafe.Add(ref decodingMap, i3);
@@ -217,7 +222,7 @@ namespace System.Buffers.Text
                 WriteThreeLowOrderBytes(ref Unsafe.Add(ref bufferBytes, destIndex), i0);
                 destIndex += 3;
             }
-            else if (i2 != s_encodingPad)
+            else if (i2 != EncodingPad)
             {
                 i2 = Unsafe.Add(ref decodingMap, i2);
 

--- a/src/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
@@ -209,7 +209,7 @@ namespace System.Buffers.Text
         }
 
         // Pre-computing this table using a custom string(s_characters) and GenerateEncodingMapAndVerify (found in tests)
-        static readonly byte[] s_encodingMap = {
+        private static readonly byte[] s_encodingMap = {
             65, 66, 67, 68, 69, 70, 71, 72,         //A..H
             73, 74, 75, 76, 77, 78, 79, 80,         //I..P
             81, 82, 83, 84, 85, 86, 87, 88,         //Q..X

--- a/src/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
@@ -1,0 +1,233 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Buffers.Text
+{
+    /// <summary>
+    /// Convert between binary data and UTF-8 encoded text that is represented in base 64.
+    /// </summary>
+    public static partial class Base64
+    {
+        /// <summary>
+        /// Encode the span of binary data into UTF-8 encoded text represented as base 64.
+        ///
+        /// <param name="bytes">The input span which contains binary data that needs to be encoded.</param>
+        /// <param name="utf8">The output span which contains the result of the operation, i.e. the UTF-8 encoded text in base 64.</param>
+        /// <param name="consumed">The number of input bytes consumed during the operation. This can be used to slice the input for subsequent calls, if necessary.</param>
+        /// <param name="written">The number of bytes written into the output span. This can be used to slice the output for subsequent calls, if necessary.</param>
+        /// <param name="isFinalBlock">True (default) when the input span contains the entire data to decode. 
+        /// Set to false only if it is known that the input span contains partial data with more data to follow.</param>
+        /// <returns>It returns the OperationStatus enum values:
+        /// - Done - on successful processing of the entire input span
+        /// - DestinationTooSmall - if there is not enough space in the output span to fit the encoded input
+        /// - NeedMoreData - only if isFinalBlock is false, otherwise the output is padded if the input is not a multiple of 3
+        /// It does not return InvalidData since that is not possible for base 64 encoding.</returns>
+        /// </summary> 
+        public static OperationStatus EncodeToUtf8(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int consumed, out int written, bool isFinalBlock = true)
+        {
+            ref byte srcBytes = ref bytes.DangerousGetPinnableReference();
+            ref byte destBytes = ref utf8.DangerousGetPinnableReference();
+
+            int srcLength = bytes.Length;
+            int destLength = utf8.Length;
+
+            int sourceIndex = 0;
+            int destIndex = 0;
+            int result = 0;
+
+            while (sourceIndex < srcLength - 2)
+            {
+                result = Encode(ref Unsafe.Add(ref srcBytes, sourceIndex));
+                if (destIndex > destLength - 4) goto DestinationSmallExit;
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref destBytes, destIndex), result);
+                destIndex += 4;
+                sourceIndex += 3;
+            }
+            
+            if (isFinalBlock != true) goto NeedMoreDataExit;
+
+            if (sourceIndex == srcLength - 1)
+            {
+                result = EncodeAndPadTwo(ref Unsafe.Add(ref srcBytes, sourceIndex));
+                if (destIndex > destLength - 4) goto DestinationSmallExit;
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref destBytes, destIndex), result);
+                destIndex += 4;
+                sourceIndex += 1;
+            }
+            else if (sourceIndex == srcLength - 2)
+            {
+                result = EncodeAndPadOne(ref Unsafe.Add(ref srcBytes, sourceIndex));
+                if (destIndex > destLength - 4) goto DestinationSmallExit;
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref destBytes, destIndex), result);
+                destIndex += 4;
+                sourceIndex += 2;
+            }
+
+            consumed = sourceIndex;
+            written = destIndex;
+            return OperationStatus.Done;
+
+            NeedMoreDataExit:
+            consumed = sourceIndex;
+            written = destIndex;
+            return OperationStatus.NeedMoreData;
+
+            DestinationSmallExit:
+            consumed = sourceIndex;
+            written = destIndex;
+            return OperationStatus.DestinationTooSmall;
+        }
+
+        /// <summary>
+        /// Returns the maximum length (in bytes) of the result if you were to encode binary data within a byte span of size "length".
+        /// </summary> 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetMaxEncodedToUtf8Length(int length)
+        {
+            Debug.Assert(length >= 0);
+            checked
+            {
+                return (((length + 2) / 3) * 4);
+            }
+        }
+
+        /// <summary>
+        /// Encode the span of binary data (in-place) into UTF-8 encoded text represented as base 64. 
+        /// The encoded text output is larger than the binary data contained in the input (the operation inflates the data).
+        ///
+        /// <param name="buffer">The input span which contains binary data that needs to be encoded. 
+        /// It needs to be large enough to fit the result of the operation.</param>
+        /// <param name="dataLength">The amount of binary data contained within the buffer that needs to be encoded 
+        /// (and needs to be smaller than the buffer length).</param>
+        /// <param name="written">The number of bytes written into the buffer.</param>
+        /// <returns>It returns the OperationStatus enum values:
+        /// - Done - on successful processing of the entire buffer
+        /// - DestinationTooSmall - if there is not enough space in the buffer beyond dataLength to fit the result of encoding the input
+        /// It does not return NeedMoreData since this method tramples the data in the buffer and hence can only be called once with all the data in the buffer.
+        /// It does not return InvalidData since that is not possible for base 64 encoding.</returns>
+        /// </summary> 
+        public static OperationStatus EncodeToUtf8InPlace(Span<byte> buffer, int dataLength, out int written)
+        {
+            var encodedLength = GetMaxEncodedToUtf8Length(dataLength);
+            if (buffer.Length < encodedLength) goto FalseExit;
+
+            var leftover = dataLength - dataLength / 3 * 3; // how many bytes after packs of 3
+
+            var destinationIndex = encodedLength - 4;
+            var sourceIndex = dataLength - leftover;
+
+            // encode last pack to avoid conditional in the main loop
+            if (leftover != 0)
+            {
+                var sourceSlice = buffer.Slice(sourceIndex, leftover);
+                var desitnationSlice = buffer.Slice(destinationIndex, 4);
+                destinationIndex -= 4;
+                var result = EncodeToUtf8(sourceSlice, desitnationSlice, out _, out int tempWritten);
+                Debug.Assert(result == OperationStatus.Done);
+            }
+
+            for (int index = sourceIndex - 3; index >= 0; index -= 3)
+            {
+                var sourceSlice = buffer.Slice(index, 3);
+                var desitnationSlice = buffer.Slice(destinationIndex, 4);
+                destinationIndex -= 4;
+                var result = EncodeToUtf8(sourceSlice, desitnationSlice, out _, out int tempWritten);
+                Debug.Assert(result == OperationStatus.Done);
+            }
+
+            written = encodedLength;
+            return OperationStatus.Done;
+
+            FalseExit:
+            written = 0;
+            return OperationStatus.DestinationTooSmall;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Encode(byte b0, byte b1, byte b2, out byte r0, out byte r1, out byte r2, out byte r3)
+        {
+            int i0 = b0 >> 2;
+            r0 = s_encodingMap[i0];
+
+            int i1 = (b0 & 0x3) << 4 | (b1 >> 4);
+            r1 = s_encodingMap[i1];
+
+            int i2 = (b1 & 0xF) << 2 | (b2 >> 6);
+            r2 = s_encodingMap[i2];
+
+            int i3 = b2 & 0x3F;
+            r3 = s_encodingMap[i3];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Encode(byte b0, byte b1, byte b2, out byte r0, out byte r1, out byte r2)
+        {
+            int i0 = b0 >> 2;
+            r0 = s_encodingMap[i0];
+
+            int i1 = (b0 & 0x3) << 4 | (b1 >> 4);
+            r1 = s_encodingMap[i1];
+
+            int i2 = (b1 & 0xF) << 2 | (b2 >> 6);
+            r2 = s_encodingMap[i2];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Encode(byte b0, byte b1, out byte r0, out byte r1)
+        {
+            int i0 = b0 >> 2;
+            r0 = s_encodingMap[i0];
+
+            int i1 = (b0 & 0x3) << 4 | (b1 >> 4);
+            r1 = s_encodingMap[i1];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int Encode(ref byte threeBytes)
+        {
+            byte b0 = threeBytes;
+            byte b1 = Unsafe.Add(ref threeBytes, 1);
+            byte b2 = Unsafe.Add(ref threeBytes, 2);
+
+            Encode(b0, b1, b2, out byte r0, out byte r1, out byte r2, out byte r3);
+
+            int result = r3 << 24 | r2 << 16 | r1 << 8 | r0;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int EncodeAndPadOne(ref byte twoBytes)
+        {
+            Encode(twoBytes, Unsafe.Add(ref twoBytes, 1), 0, out byte r0, out byte r1, out byte r2);
+            int result = s_encodingPad << 24 | r2 << 16 | r1 << 8 | r0;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int EncodeAndPadTwo(ref byte oneByte)
+        {
+            Encode(oneByte, 0, out byte r0, out byte r1);
+            int result = s_encodingPad << 24 | s_encodingPad << 16 | r1 << 8 | r0;
+            return result;
+        }
+
+        // Pre-computing this table using a custom string(s_characters) and GenerateEncodingMapAndVerify (found in tests)
+        static readonly byte[] s_encodingMap = {
+            65, 66, 67, 68, 69, 70, 71, 72,         //A..H
+            73, 74, 75, 76, 77, 78, 79, 80,         //I..P
+            81, 82, 83, 84, 85, 86, 87, 88,         //Q..X
+            89, 90, 97, 98, 99, 100, 101, 102,      //Y..Z, a..f
+            103, 104, 105, 106, 107, 108, 109, 110, //g..n
+            111, 112, 113, 114, 115, 116, 117, 118, //o..v
+            119, 120, 121, 122, 48, 49, 50, 51,     //w..z, 0..3
+            52, 53, 54, 55, 56, 57, 43, 47          //4..9, +, /
+        };
+
+        const byte s_encodingPad = (byte)'='; // '=', for padding
+    }
+}

--- a/src/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
+++ b/src/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
@@ -1,0 +1,536 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Text;
+using Xunit;
+
+namespace System.Buffers.Text.Tests
+{
+    public class Base64DecoderUnitTests
+    {
+        [Fact]
+        public void BasicDecoding()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes = rnd.Next(100, 1000 * 1000);
+                while (numBytes % 4 != 0)
+                {
+                    numBytes = rnd.Next(100, 1000 * 1000);
+                }
+                Span<byte> source = new byte[numBytes];
+                Base64TestHelper.InitalizeDecodableBytes(source, numBytes);
+
+                Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+                Assert.Equal(OperationStatus.Done, 
+                    Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+                Assert.Equal(source.Length, consumed);
+                Assert.Equal(decodedBytes.Length, decodedByteCount);
+                Assert.True(Base64TestHelper.VerifyDecodingCorrectness(source.Length, decodedBytes.Length, source, decodedBytes));
+            }
+        }
+
+        [Fact]
+        public void DecodeEmptySpan()
+        {
+            Span<byte> source = Span<byte>.Empty;
+            Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+
+            Assert.Equal(OperationStatus.Done, 
+                Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+            Assert.Equal(source.Length, consumed);
+            Assert.Equal(decodedBytes.Length, decodedByteCount);
+            Assert.True(Base64TestHelper.VerifyDecodingCorrectness(source.Length, decodedBytes.Length, source, decodedBytes));
+        }
+
+        [Fact]
+        public void BasicDecodingWithFinalBlockFalse()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes = rnd.Next(100, 1000 * 1000);
+                while (numBytes % 4 != 0)
+                {
+                    numBytes = rnd.Next(100, 1000 * 1000);
+                }
+                Span<byte> source = new byte[numBytes];
+                Base64TestHelper.InitalizeDecodableBytes(source, numBytes);
+
+                Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+                int expectedConsumed = source.Length / 4 * 4; // only consume closest multiple of four since isFinalBlock is false
+
+                Assert.Equal(OperationStatus.NeedMoreData, 
+                    Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount, isFinalBlock: false));
+                Assert.Equal(expectedConsumed, consumed);
+                Assert.Equal(decodedBytes.Length, decodedByteCount);
+                Assert.True(Base64TestHelper.VerifyDecodingCorrectness(expectedConsumed, decodedBytes.Length, source, decodedBytes));
+            }
+        }
+
+        [Theory]
+        [InlineData("A", 0, 0)]
+        [InlineData("AQ", 0, 0)]
+        [InlineData("AQI", 0, 0)]
+        [InlineData("AQIDBA", 4, 3)]
+        [InlineData("AQIDBAU", 4, 3)]
+        [InlineData("AQID", 4, 3)]
+        [InlineData("AQIDBAUG", 8, 6)]
+        public void BasicDecodingWithFinalBlockFalseKnownInputNeedMoreData(string inputString, int expectedConsumed, int expectedWritten)
+        {
+            Span<byte> source = Encoding.ASCII.GetBytes(inputString);
+            Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+
+            Assert.Equal(OperationStatus.NeedMoreData, Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount, isFinalBlock: false));
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(expectedWritten, decodedByteCount); // expectedWritten == decodedBytes.Length
+            Assert.True(Base64TestHelper.VerifyDecodingCorrectness(expectedConsumed, decodedBytes.Length, source, decodedBytes));
+        }
+
+        [Theory]
+        [InlineData("AQ==", 0, 0)]
+        [InlineData("AQI=", 0, 0)]
+        [InlineData("AQIDBA==", 4, 3)]
+        [InlineData("AQIDBAU=", 4, 3)]
+        public void BasicDecodingWithFinalBlockFalseKnownInputInvalid(string inputString, int expectedConsumed, int expectedWritten)
+        {
+            Span<byte> source = Encoding.ASCII.GetBytes(inputString);
+            Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+
+            Assert.Equal(OperationStatus.InvalidData, Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount, isFinalBlock: false));
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(expectedWritten, decodedByteCount);
+            Assert.True(Base64TestHelper.VerifyDecodingCorrectness(expectedConsumed, expectedWritten, source, decodedBytes));
+        }
+
+        [Theory]
+        [InlineData("A", 0, 0)]
+        [InlineData("AQ", 0, 0)]
+        [InlineData("AQI", 0, 0)]
+        [InlineData("AQIDBA", 4, 3)]
+        [InlineData("AQIDBAU", 4, 3)]
+        public void BasicDecodingWithFinalBlockTrueKnownInputInvalid(string inputString, int expectedConsumed, int expectedWritten)
+        {
+            Span<byte> source = Encoding.ASCII.GetBytes(inputString);
+            Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+
+            Assert.Equal(OperationStatus.InvalidData, Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(expectedWritten, decodedByteCount); // expectedWritten == decodedBytes.Length
+            Assert.True(Base64TestHelper.VerifyDecodingCorrectness(expectedConsumed, decodedBytes.Length, source, decodedBytes));
+        }
+
+        [Theory]
+        [InlineData("AQ==", 4, 1)]
+        [InlineData("AQI=", 4, 2)]
+        [InlineData("AQID", 4, 3)]
+        [InlineData("AQIDBA==", 8, 4)]
+        [InlineData("AQIDBAU=", 8, 5)]
+        [InlineData("AQIDBAUG", 8, 6)]
+        public void BasicDecodingWithFinalBlockTrueKnownInputDone(string inputString, int expectedConsumed, int expectedWritten)
+        {
+            Span<byte> source = Encoding.ASCII.GetBytes(inputString);
+            Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+
+            Assert.Equal(OperationStatus.Done, Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(expectedWritten, decodedByteCount);
+            Assert.True(Base64TestHelper.VerifyDecodingCorrectness(expectedConsumed, expectedWritten, source, decodedBytes));
+        }
+
+        [Fact]
+        public void DecodingInvalidBytes()
+        {
+            // Invalid Bytes:
+            // 0-42
+            // 44-46
+            // 58-64
+            // 91-96
+            // 123-255
+            byte[] invalidBytes = Base64TestHelper.InvalidBytes;
+            Assert.Equal(byte.MaxValue + 1 - 64, invalidBytes.Length); // 192
+            
+            for (int j = 0; j < 8; j++)
+            {
+                Span<byte> source = new byte[8] { 50, 50, 50, 50, 80, 80, 80, 80 }; // valid input - "2222PPPP"
+                Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+
+                for (int i = 0; i < invalidBytes.Length; i++)
+                {
+                    // Don't test padding (byte 61 i.e. '='), which is tested in DecodingInvalidBytesPadding
+                    if (invalidBytes[i] == Base64TestHelper.s_encodingPad) continue;
+
+                    // replace one byte with an invalid input
+                    source[j] = invalidBytes[i];
+
+                    Assert.Equal(OperationStatus.InvalidData,
+                        Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+                    
+                    if (j < 4)
+                    {
+                        Assert.Equal(0, consumed);
+                        Assert.Equal(0, decodedByteCount);
+                    }
+                    else
+                    {
+                        Assert.Equal(4, consumed);
+                        Assert.Equal(3, decodedByteCount);
+                        Assert.True(Base64TestHelper.VerifyDecodingCorrectness(4, 3, source, decodedBytes));
+                    }
+                }
+            }
+
+            // Input that is not a multiple of 4 is considered invalid
+            {
+                Span<byte> source = new byte[7] { 50, 50, 50, 50, 80, 80, 80 }; // incomplete input - "2222PPP"
+                Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+                Assert.Equal(OperationStatus.InvalidData,
+                        Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+                Assert.Equal(4, consumed);
+                Assert.Equal(3, decodedByteCount);
+                Assert.True(Base64TestHelper.VerifyDecodingCorrectness(4, 3, source, decodedBytes));
+            }
+        }
+
+        [Fact]
+        public void DecodingInvalidBytesPadding()
+        {
+            // Only last 2 bytes can be padding, all other occurrence of padding is invalid
+            for (int j = 0; j < 7; j++)
+            {
+                Span<byte> source = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 }; // valid input - "2222PPPP"
+                Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+                source[j] = Base64TestHelper.s_encodingPad;
+                Assert.Equal(OperationStatus.InvalidData,
+                    Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+
+                if (j < 4)
+                {
+                    Assert.Equal(0, consumed);
+                    Assert.Equal(0, decodedByteCount);
+                }
+                else
+                {
+                    Assert.Equal(4, consumed);
+                    Assert.Equal(3, decodedByteCount);
+                    Assert.True(Base64TestHelper.VerifyDecodingCorrectness(4, 3, source, decodedBytes));
+                }
+            }
+
+            // Invalid input with valid padding
+            {
+                Span<byte> source = new byte[] { 50, 50, 50, 50, 80, 42, 42, 42 };
+                Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+                source[6] = Base64TestHelper.s_encodingPad;
+                source[7] = Base64TestHelper.s_encodingPad; // invalid input - "2222P*=="
+                Assert.Equal(OperationStatus.InvalidData,
+                    Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+
+                Assert.Equal(4, consumed);
+                Assert.Equal(3, decodedByteCount);
+                Assert.True(Base64TestHelper.VerifyDecodingCorrectness(4, 3, source, decodedBytes));
+
+                source = new byte[] { 50, 50, 50, 50, 80, 42, 42, 42 };
+                decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+                source[7] = Base64TestHelper.s_encodingPad; // invalid input - "2222PP**="
+                Assert.Equal(OperationStatus.InvalidData,
+                    Base64.DecodeFromUtf8(source, decodedBytes, out consumed, out decodedByteCount));
+
+                Assert.Equal(4, consumed);
+                Assert.Equal(3, decodedByteCount);
+                Assert.True(Base64TestHelper.VerifyDecodingCorrectness(4, 3, source, decodedBytes));
+            }
+
+            // The last byte or the last 2 bytes being the padding character is valid
+            {
+                Span<byte> source = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 };
+                Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+                source[6] = Base64TestHelper.s_encodingPad;
+                source[7] = Base64TestHelper.s_encodingPad; // valid input - "2222PP=="
+                Assert.Equal(OperationStatus.Done,
+                    Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+
+                Assert.Equal(source.Length, consumed);
+                Assert.Equal(4, decodedByteCount);
+                Assert.True(Base64TestHelper.VerifyDecodingCorrectness(source.Length, 4, source, decodedBytes));
+
+                source = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 };
+                decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+                source[7] = Base64TestHelper.s_encodingPad; // valid input - "2222PPP="
+                Assert.Equal(OperationStatus.Done,
+                    Base64.DecodeFromUtf8(source, decodedBytes, out consumed, out decodedByteCount));
+
+                Assert.Equal(source.Length, consumed);
+                Assert.Equal(5, decodedByteCount);
+                Assert.True(Base64TestHelper.VerifyDecodingCorrectness(source.Length, 5, source, decodedBytes));
+            }
+        }
+
+        [Fact]
+        public void DecodingOutputTooSmall()
+        {
+            for (int numBytes = 5; numBytes < 20; numBytes++)
+            {
+                Span<byte> source = new byte[numBytes];
+                Base64TestHelper.InitalizeDecodableBytes(source, numBytes);
+
+                Span<byte> decodedBytes = new byte[3];
+                int consumed, written;
+                if (numBytes % 4 != 0)
+                {
+                    Assert.True(OperationStatus.InvalidData ==
+                        Base64.DecodeFromUtf8(source, decodedBytes, out consumed, out written), "Number of Input Bytes: " + numBytes);
+                }
+                else
+                {
+                    Assert.True(OperationStatus.DestinationTooSmall ==
+                        Base64.DecodeFromUtf8(source, decodedBytes, out consumed, out written), "Number of Input Bytes: " + numBytes);
+                }
+                int expectedConsumed = 4;
+                Assert.Equal(expectedConsumed, consumed);
+                Assert.Equal(decodedBytes.Length, written);
+                Assert.True(Base64TestHelper.VerifyDecodingCorrectness(expectedConsumed, decodedBytes.Length, source, decodedBytes));
+            }
+
+            // Output too small even with padding characters in the input
+            {
+                Span<byte> source = new byte[12];
+                Base64TestHelper.InitalizeDecodableBytes(source);
+                source[10] = Base64TestHelper.s_encodingPad;
+                source[11] = Base64TestHelper.s_encodingPad;
+
+                Span<byte> decodedBytes = new byte[6];
+                Assert.Equal(OperationStatus.DestinationTooSmall, 
+                    Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int written));
+                int expectedConsumed = 8;
+                Assert.Equal(expectedConsumed, consumed);
+                Assert.Equal(decodedBytes.Length, written);
+                Assert.True(Base64TestHelper.VerifyDecodingCorrectness(expectedConsumed, decodedBytes.Length, source, decodedBytes));
+            }
+
+            {
+                Span<byte> source = new byte[12];
+                Base64TestHelper.InitalizeDecodableBytes(source);
+                source[11] = Base64TestHelper.s_encodingPad;
+
+                Span<byte> decodedBytes = new byte[7];
+                Assert.Equal(OperationStatus.DestinationTooSmall, 
+                    Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int written));
+                int expectedConsumed = 8;
+                Assert.Equal(expectedConsumed, consumed);
+                Assert.Equal(6, written);
+                Assert.True(Base64TestHelper.VerifyDecodingCorrectness(expectedConsumed, 6, source, decodedBytes));
+            }
+        }
+
+        [Fact]
+        public void DecodingOutputTooSmallRetry()
+        {
+            Span<byte> source = new byte[1000];
+            Base64TestHelper.InitalizeDecodableBytes(source);
+
+            int outputSize = 240;
+            int requiredSize = Base64.GetMaxDecodedFromUtf8Length(source.Length);
+
+            Span<byte> decodedBytes = new byte[outputSize];
+            Assert.Equal(OperationStatus.DestinationTooSmall, 
+                Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+            int expectedConsumed = decodedBytes.Length / 3 * 4;
+            Assert.Equal(expectedConsumed, consumed);             
+            Assert.Equal(decodedBytes.Length, decodedByteCount);
+            Assert.True(Base64TestHelper.VerifyDecodingCorrectness(expectedConsumed, decodedBytes.Length, source, decodedBytes));
+
+            decodedBytes = new byte[requiredSize - outputSize];
+            source = source.Slice(consumed);
+            Assert.Equal(OperationStatus.Done,
+                Base64.DecodeFromUtf8(source, decodedBytes, out consumed, out decodedByteCount));
+            expectedConsumed = decodedBytes.Length / 3 * 4;
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(decodedBytes.Length, decodedByteCount);
+            Assert.True(Base64TestHelper.VerifyDecodingCorrectness(expectedConsumed, decodedBytes.Length, source, decodedBytes));
+        }
+
+        [Fact]
+        public void GetMaxDecodedLength()
+        {
+            Span<byte> sourceEmpty = Span<byte>.Empty;
+            Assert.Equal(0, Base64.GetMaxDecodedFromUtf8Length(0));
+
+            // int.MaxValue - (int.MaxValue % 4) => 2147483644, largest multiple of 4 less than int.MaxValue
+            int[] input = { 0, 4, 8, 12, 16, 20, 2000000000, 2147483640, 2147483644 };
+            int[] expected = { 0, 3, 6, 9, 12, 15, 1500000000, 1610612730, 1610612733 };
+
+            for (int i = 0; i < input.Length; i++)
+            {
+                Assert.Equal(expected[i], Base64.GetMaxDecodedFromUtf8Length(input[i]));
+            }
+
+            // Lengths that are not a multiple of 4.
+            int[] lengthsNotMultipleOfFour = { 1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15, 1001, 1002, 1003, 2147483645, 2147483646, 2147483647 };
+            int[] expectedOutput = { 0, 0, 0, 3, 3, 3, 6, 6, 6, 9, 9, 9, 750, 750, 750, 1610612733, 1610612733, 1610612733 };
+            for (int i = 0; i < lengthsNotMultipleOfFour.Length; i++)
+            {
+                Assert.Equal(expectedOutput[i], Base64.GetMaxDecodedFromUtf8Length(lengthsNotMultipleOfFour[i]));
+            }
+        }
+
+        
+        [Fact]
+        public void DecodeInPlace()
+        {
+            const int numberOfBytes = 15;
+
+            for (int numberOfBytesToTest = 0; numberOfBytesToTest <= numberOfBytes; numberOfBytesToTest += 4)
+            {
+                Span<byte> testBytes = new byte[numberOfBytes];
+                Base64TestHelper.InitalizeDecodableBytes(testBytes);
+                string sourceString = Encoding.ASCII.GetString(testBytes.Slice(0, numberOfBytesToTest).ToArray());
+                Span<byte> expectedBytes = Convert.FromBase64String(sourceString);
+
+                Assert.Equal(OperationStatus.Done, Base64.DecodeFromUtf8InPlace(testBytes.Slice(0, numberOfBytesToTest), out int bytesWritten));
+                Assert.Equal(Base64.GetMaxDecodedFromUtf8Length(numberOfBytesToTest), bytesWritten);
+                Assert.True(expectedBytes.SequenceEqual(testBytes.Slice(0, bytesWritten)));
+            }
+        }
+
+        [Fact]
+        public void EncodeAndDecodeInPlace()
+        {
+            byte[] testBytes = new byte[256];
+            for (int i = 0; i < 256; i++)
+            {
+                testBytes[i] = (byte)i;
+            }
+
+            for (int value = 0; value < 256; value++)
+            {
+                Span<byte> sourceBytes = testBytes.AsSpan().Slice(0, value + 1);
+                Span<byte> buffer = new byte[Base64.GetMaxEncodedToUtf8Length(sourceBytes.Length)];
+
+                Assert.Equal(OperationStatus.Done, Base64.EncodeToUtf8(sourceBytes, buffer, out int consumed, out int written));
+
+                var encodedText = Encoding.ASCII.GetString(buffer.ToArray());
+                var expectedText = Convert.ToBase64String(testBytes, 0, value + 1);
+                Assert.Equal(expectedText, encodedText);
+
+                Assert.Equal(OperationStatus.Done, Base64.DecodeFromUtf8InPlace(buffer, out int bytesWritten));
+                Assert.Equal(sourceBytes.Length, bytesWritten);
+                Assert.True(sourceBytes.SequenceEqual(buffer.Slice(0, bytesWritten)));
+            }
+        }
+
+        [Fact]
+        public void DecodeInPlaceInvalidBytes()
+        {
+            byte[] invalidBytes = Base64TestHelper.InvalidBytes;
+            
+            for (int j = 0; j < 8; j++)
+            {
+                for (int i = 0; i < invalidBytes.Length; i++)
+                {
+                    Span<byte> buffer = new byte[8] { 50, 50, 50, 50, 80, 80, 80, 80 }; // valid input - "2222PPPP"
+
+                    // Don't test padding (byte 61 i.e. '='), which is tested in DecodeInPlaceInvalidBytesPadding
+                    if (invalidBytes[i] == Base64TestHelper.s_encodingPad) continue;
+
+                    // replace one byte with an invalid input
+                    buffer[j] = invalidBytes[i];
+                    string sourceString = Encoding.ASCII.GetString(buffer.Slice(0, 4).ToArray());
+
+                    Assert.Equal(OperationStatus.InvalidData, Base64.DecodeFromUtf8InPlace(buffer, out int bytesWritten));
+                    
+                    if (j < 4)
+                    {
+                        Assert.Equal(0, bytesWritten);
+                    }
+                    else
+                    {
+                        Assert.Equal(3, bytesWritten);
+                        Span<byte> expectedBytes = Convert.FromBase64String(sourceString);
+                        Assert.True(expectedBytes.SequenceEqual(buffer.Slice(0, bytesWritten)));
+                    }
+                }
+            }
+
+            // Input that is not a multiple of 4 is considered invalid
+            {
+                Span<byte> buffer = new byte[7] { 50, 50, 50, 50, 80, 80, 80 }; // incomplete input - "2222PPP"
+                Assert.Equal(OperationStatus.InvalidData, Base64.DecodeFromUtf8InPlace(buffer, out int bytesWritten));
+                Assert.Equal(0, bytesWritten);
+            }
+        }
+
+        [Fact]
+        public void DecodeInPlaceInvalidBytesPadding()
+        {
+            // Only last 2 bytes can be padding, all other occurrence of padding is invalid
+            for (int j = 0; j < 7; j++)
+            {
+                Span<byte> buffer = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 }; // valid input - "2222PPPP"
+                buffer[j] = Base64TestHelper.s_encodingPad;
+                string sourceString = Encoding.ASCII.GetString(buffer.Slice(0, 4).ToArray());
+
+                Assert.Equal(OperationStatus.InvalidData, Base64.DecodeFromUtf8InPlace(buffer, out int bytesWritten));
+
+                if (j < 4)
+                {
+                    Assert.Equal(0, bytesWritten);
+                }
+                else
+                {
+                    Assert.Equal(3, bytesWritten);
+                    Span<byte> expectedBytes = Convert.FromBase64String(sourceString);
+                    Assert.True(expectedBytes.SequenceEqual(buffer.Slice(0, bytesWritten)));
+                }
+            }
+
+            // Invalid input with valid padding
+            {
+                Span<byte> buffer = new byte[] { 50, 50, 50, 50, 80, 42, 42, 42 };
+                buffer[6] = Base64TestHelper.s_encodingPad;
+                buffer[7] = Base64TestHelper.s_encodingPad; // invalid input - "2222P*=="
+                string sourceString = Encoding.ASCII.GetString(buffer.Slice(0, 4).ToArray());
+                Assert.Equal(OperationStatus.InvalidData, Base64.DecodeFromUtf8InPlace(buffer, out int bytesWritten));
+                Assert.Equal(3, bytesWritten);
+                Span<byte> expectedBytes = Convert.FromBase64String(sourceString);
+                Assert.True(expectedBytes.SequenceEqual(buffer.Slice(0, bytesWritten)));
+            }
+
+            {
+                Span<byte> buffer = new byte[] { 50, 50, 50, 50, 80, 42, 42, 42 };
+                buffer[7] = Base64TestHelper.s_encodingPad; // invalid input - "2222P**="
+                string sourceString = Encoding.ASCII.GetString(buffer.Slice(0, 4).ToArray());
+                Assert.Equal(OperationStatus.InvalidData, Base64.DecodeFromUtf8InPlace(buffer, out int bytesWritten));
+                Assert.Equal(3, bytesWritten);
+                Span<byte> expectedBytes = Convert.FromBase64String(sourceString);
+                Assert.True(expectedBytes.SequenceEqual(buffer.Slice(0, bytesWritten)));
+            }
+
+            // The last byte or the last 2 bytes being the padding character is valid
+            {
+                Span<byte> buffer = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 };
+                buffer[6] = Base64TestHelper.s_encodingPad;
+                buffer[7] = Base64TestHelper.s_encodingPad; // valid input - "2222PP=="
+                string sourceString = Encoding.ASCII.GetString(buffer.ToArray());
+                Assert.Equal(OperationStatus.Done, Base64.DecodeFromUtf8InPlace(buffer, out int bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Span<byte> expectedBytes = Convert.FromBase64String(sourceString);
+                Assert.True(expectedBytes.SequenceEqual(buffer.Slice(0, bytesWritten)));
+            }
+            
+            {
+                Span<byte> buffer = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 };
+                buffer[7] = Base64TestHelper.s_encodingPad; // valid input - "2222PPP="
+                string sourceString = Encoding.ASCII.GetString(buffer.ToArray());
+                Assert.Equal(OperationStatus.Done, Base64.DecodeFromUtf8InPlace(buffer, out int bytesWritten));
+                Assert.Equal(5, bytesWritten);
+                Span<byte> expectedBytes = Convert.FromBase64String(sourceString);
+                Assert.True(expectedBytes.SequenceEqual(buffer.Slice(0, bytesWritten)));
+            }
+        }
+
+    }
+}

--- a/src/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
+++ b/src/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
@@ -375,6 +375,10 @@ namespace System.Buffers.Text.Tests
             {
                 Assert.Equal(expectedOutput[i], Base64.GetMaxDecodedFromUtf8Length(lengthsNotMultipleOfFour[i]));
             }
+
+            // negative input
+            Assert.Throws<ArgumentOutOfRangeException>(() => Base64.GetMaxDecodedFromUtf8Length(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Base64.GetMaxDecodedFromUtf8Length(int.MinValue));
         }
 
         

--- a/src/System.Memory/tests/Base64/Base64EncoderUnitTests.cs
+++ b/src/System.Memory/tests/Base64/Base64EncoderUnitTests.cs
@@ -1,0 +1,245 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Text;
+using Xunit;
+
+namespace System.Buffers.Text.Tests
+{
+    public class Base64EncoderUnitTests
+    {
+        [Fact]
+        public void BasicEncodingAndDecoding()
+        {
+            var bytes = new byte[byte.MaxValue + 1];
+            for (int i = 0; i < byte.MaxValue + 1; i++)
+            {
+                bytes[i] = (byte)i;
+            }
+
+            for (int value = 0; value < 256; value++)
+            {
+                Span<byte> sourceBytes = bytes.AsSpan().Slice(0, value + 1);
+                Span<byte> encodedBytes = new byte[Base64.GetMaxEncodedToUtf8Length(sourceBytes.Length)];
+                Assert.Equal(OperationStatus.Done, Base64.EncodeToUtf8(sourceBytes, encodedBytes, out int consumed, out int encodedBytesCount));
+                Assert.Equal(sourceBytes.Length, consumed);
+                Assert.Equal(encodedBytes.Length, encodedBytesCount);
+
+                string encodedText = Encoding.ASCII.GetString(encodedBytes.ToArray());
+                string expectedText = Convert.ToBase64String(bytes, 0, value + 1);
+                Assert.Equal(expectedText, encodedText);
+
+                if (encodedBytes.Length % 4 == 0)
+                {
+                    Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(encodedBytes.Length)];
+                    Assert.Equal(OperationStatus.Done, Base64.DecodeFromUtf8(encodedBytes, decodedBytes, out consumed, out int decodedByteCount));
+                    Assert.Equal(encodedBytes.Length, consumed);
+                    Assert.Equal(sourceBytes.Length, decodedByteCount);
+                    Assert.True(sourceBytes.SequenceEqual(decodedBytes.Slice(0, decodedByteCount)));
+                }
+            }
+        }
+
+        [Fact]
+        public void BasicEncoding()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes = rnd.Next(100, 1000 * 1000);
+                Span<byte> source = new byte[numBytes];
+                Base64TestHelper.InitalizeBytes(source, numBytes);
+
+                Span<byte> encodedBytes = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+                Assert.Equal(OperationStatus.Done, Base64.EncodeToUtf8(source, encodedBytes, out int consumed, out int encodedBytesCount));
+                Assert.Equal(source.Length, consumed);
+                Assert.Equal(encodedBytes.Length, encodedBytesCount);
+                Assert.True(Base64TestHelper.VerifyEncodingCorrectness(source.Length, encodedBytes.Length, source, encodedBytes));
+            }
+        }
+
+        [Fact]
+        public void EncodeEmptySpan()
+        {
+            Span<byte> source = Span<byte>.Empty;
+            Span<byte> encodedBytes = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            
+            Assert.Equal(OperationStatus.Done, Base64.EncodeToUtf8(source, encodedBytes, out int consumed, out int encodedBytesCount));
+            Assert.Equal(source.Length, consumed);
+            Assert.Equal(encodedBytes.Length, encodedBytesCount);
+            Assert.True(Base64TestHelper.VerifyEncodingCorrectness(source.Length, encodedBytes.Length, source, encodedBytes));
+        }
+
+        [Fact]
+        public void BasicEncodingWithFinalBlockFalse()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes = rnd.Next(100, 1000 * 1000);
+                Span<byte> source = new byte[numBytes];
+                Base64TestHelper.InitalizeBytes(source, numBytes);
+                Span<byte> encodedBytes = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+                int expectedConsumed = source.Length / 3 * 3; // only consume closest multiple of three since isFinalBlock is false
+                int expectedWritten = source.Length / 3 * 4;
+
+                Assert.Equal(OperationStatus.NeedMoreData, Base64.EncodeToUtf8(source, encodedBytes, out int consumed, out int encodedBytesCount, isFinalBlock: false));
+                Assert.Equal(expectedConsumed, consumed);
+                Assert.Equal(expectedWritten, encodedBytesCount);
+                Assert.True(Base64TestHelper.VerifyEncodingCorrectness(expectedConsumed, expectedWritten, source, encodedBytes));
+            }
+        }
+
+        [Theory]
+        [InlineData(1, "", 0, 0)]
+        [InlineData(2, "", 0, 0)]
+        [InlineData(3, "AQID", 3, 4)]
+        [InlineData(4, "AQID", 3, 4)]
+        [InlineData(5, "AQID", 3, 4)]
+        [InlineData(6, "AQIDBAUG", 6, 8)]
+        [InlineData(7, "AQIDBAUG", 6, 8)]
+        public void BasicEncodingWithFinalBlockFalseKnownInput(int numBytes, string expectedText, int expectedConsumed, int expectedWritten)
+        {
+            Span<byte> source = new byte[numBytes];
+            for (int i = 0; i < numBytes; i++)
+            {
+                source[i] = (byte)(i + 1);
+            }
+            Span<byte> encodedBytes = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+
+            Assert.Equal(OperationStatus.NeedMoreData, Base64.EncodeToUtf8(source, encodedBytes, out int consumed, out int encodedBytesCount, isFinalBlock: false));
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(expectedWritten, encodedBytesCount);
+
+            string encodedText = Encoding.ASCII.GetString(encodedBytes.Slice(0, expectedWritten).ToArray());
+            Assert.Equal(expectedText, encodedText);
+        }
+
+        [Theory]
+        [InlineData(1, "AQ==", 1, 4)]
+        [InlineData(2, "AQI=", 2, 4)]
+        [InlineData(3, "AQID", 3, 4)]
+        [InlineData(4, "AQIDBA==", 4, 8)]
+        [InlineData(5, "AQIDBAU=", 5, 8)]
+        [InlineData(6, "AQIDBAUG", 6, 8)]
+        [InlineData(7, "AQIDBAUGBw==", 7, 12)]
+        public void BasicEncodingWithFinalBlockTrueKnownInput(int numBytes, string expectedText, int expectedConsumed, int expectedWritten)
+        {
+            Span<byte> source = new byte[numBytes];
+            for (int i = 0; i < numBytes; i++)
+            {
+                source[i] = (byte)(i + 1);
+            }
+            Span<byte> encodedBytes = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+
+            Assert.Equal(OperationStatus.Done, Base64.EncodeToUtf8(source, encodedBytes, out int consumed, out int encodedBytesCount, isFinalBlock: true));
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(expectedWritten, encodedBytesCount);
+
+            string encodedText = Encoding.ASCII.GetString(encodedBytes.Slice(0, expectedWritten).ToArray());
+            Assert.Equal(expectedText, encodedText);
+        }
+
+        [Fact]
+        public void EncodingOutputTooSmall()
+        {
+            for (int numBytes = 4; numBytes < 20; numBytes++)
+            {
+                Span<byte> source = new byte[numBytes];
+                Base64TestHelper.InitalizeBytes(source, numBytes);
+
+                Span<byte> encodedBytes = new byte[4];
+                Assert.Equal(OperationStatus.DestinationTooSmall,
+                    Base64.EncodeToUtf8(source, encodedBytes, out int consumed, out int written));
+                int expectedConsumed = 3;
+                Assert.Equal(expectedConsumed, consumed);
+                Assert.Equal(encodedBytes.Length, written);
+                Assert.True(Base64TestHelper.VerifyEncodingCorrectness(expectedConsumed, encodedBytes.Length, source, encodedBytes));
+            }
+        }
+
+        [Fact]
+        public void EncodingOutputTooSmallRetry()
+        {
+            Span<byte> source = new byte[750];
+            Base64TestHelper.InitalizeBytes(source);
+
+            int outputSize = 320;
+            int requiredSize = Base64.GetMaxEncodedToUtf8Length(source.Length);
+
+            Span<byte> encodedBytes = new byte[outputSize];
+            Assert.Equal(OperationStatus.DestinationTooSmall,
+                Base64.EncodeToUtf8(source, encodedBytes, out int consumed, out int written));
+            int expectedConsumed = encodedBytes.Length / 4 * 3;
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(encodedBytes.Length, written);
+            Assert.True(Base64TestHelper.VerifyEncodingCorrectness(expectedConsumed, encodedBytes.Length, source, encodedBytes));
+
+            encodedBytes = new byte[requiredSize - outputSize];
+            source = source.Slice(consumed);
+            Assert.Equal(OperationStatus.Done,
+                Base64.EncodeToUtf8(source, encodedBytes, out consumed, out written));
+            expectedConsumed = encodedBytes.Length / 4 * 3;
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(encodedBytes.Length, written);
+            Assert.True(Base64TestHelper.VerifyEncodingCorrectness(expectedConsumed, encodedBytes.Length, source, encodedBytes));
+        }
+
+        [Fact]
+        public void GetMaxEncodedLength()
+        {
+            // (int.MaxValue - 4)/(4/3) => 1610612733, otherwise integer overflow
+            int[] input = { 0, 1, 2, 3, 4, 5, 6, 1610612728, 1610612729, 1610612730, 1610612731, 1610612732, 1610612733 };
+            int[] expected = { 0, 4, 4, 4, 8, 8, 8, 2147483640, 2147483640, 2147483640, 2147483644, 2147483644, 2147483644 };
+            for (int i = 0; i < input.Length; i++)
+            {
+                Assert.Equal(expected[i], Base64.GetMaxEncodedToUtf8Length(input[i]));
+            }
+
+            // integer overflow
+            Assert.Throws<OverflowException>(() => Base64.GetMaxEncodedToUtf8Length(1610612734));
+            Assert.Throws<OverflowException>(() => Base64.GetMaxEncodedToUtf8Length(int.MaxValue));
+        }
+
+        [Fact]
+        public void EncodeInPlace()
+        {
+            const int numberOfBytes = 15;
+            Span<byte> testBytes = new byte[numberOfBytes / 3 * 4]; // slack since encoding inflates the data
+            Base64TestHelper.InitalizeBytes(testBytes);
+
+            for (int numberOfBytesToTest = 0; numberOfBytesToTest <= numberOfBytes; numberOfBytesToTest++)
+            {
+                var expectedText = Convert.ToBase64String(testBytes.Slice(0, numberOfBytesToTest).ToArray());
+
+                Assert.Equal(OperationStatus.Done, Base64.EncodeToUtf8InPlace(testBytes, numberOfBytesToTest, out int bytesWritten));
+                Assert.Equal(Base64.GetMaxEncodedToUtf8Length(numberOfBytesToTest), bytesWritten);
+
+                var encodedText = Encoding.ASCII.GetString(testBytes.Slice(0, bytesWritten).ToArray());
+                Assert.Equal(expectedText, encodedText);
+            }
+        }
+
+        [Fact]
+        public void EncodeInPlaceOutputTooSmall()
+        {
+            byte[] testBytes = {1, 2, 3};
+
+            for (int numberOfBytesToTest = 1; numberOfBytesToTest <= testBytes.Length; numberOfBytesToTest++)
+            {
+                Assert.Equal(OperationStatus.DestinationTooSmall, Base64.EncodeToUtf8InPlace(testBytes, numberOfBytesToTest, out int bytesWritten));
+                Assert.Equal(0, bytesWritten);
+            }
+        }
+
+        [Fact]
+        public void EncodeInPlaceDataLengthTooLarge()
+        {
+            byte[] testBytes = {1, 2, 3};
+            Assert.Equal(OperationStatus.DestinationTooSmall, Base64.EncodeToUtf8InPlace(testBytes, testBytes.Length + 1, out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+        }
+    }
+}

--- a/src/System.Memory/tests/Base64/Base64TestHelper.cs
+++ b/src/System.Memory/tests/Base64/Base64TestHelper.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace System.Buffers.Text.Tests
+{
+    public static class Base64TestHelper
+    {
+        public static string s_characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+        // Pre-computing this table using a custom string(s_characters) and GenerateEncodingMapAndVerify (found in tests)
+        public static readonly byte[] s_encodingMap = {
+            65, 66, 67, 68, 69, 70, 71, 72,         //A..H
+            73, 74, 75, 76, 77, 78, 79, 80,         //I..P
+            81, 82, 83, 84, 85, 86, 87, 88,         //Q..X
+            89, 90, 97, 98, 99, 100, 101, 102,      //Y..Z, a..f
+            103, 104, 105, 106, 107, 108, 109, 110, //g..n
+            111, 112, 113, 114, 115, 116, 117, 118, //o..v
+            119, 120, 121, 122, 48, 49, 50, 51,     //w..z, 0..3
+            52, 53, 54, 55, 56, 57, 43, 47          //4..9, +, /
+        };
+
+        // Pre-computing this table using a custom string(s_characters) and GenerateDecodingMapAndVerify (found in tests)
+        public static readonly sbyte[] s_decodingMap = {
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,         //62 is placed at index 43 (for +), 63 at index 47 (for /)
+            52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1,         //52-61 are placed at index 48-57 (for 0-9), 64 at index 61 (for =)
+            -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,         //0-25 are placed at index 65-90 (for A-Z)
+            -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1,         //26-51 are placed at index 97-122 (for a-z)
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,         // Bytes over 122 ('z') are invalid and cannot be decoded
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,         // Hence, padding the map with 255, which indicates invalid input
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        };
+
+        public static readonly byte s_encodingPad = (byte)'=';              // '=', for padding
+
+        public static readonly sbyte s_invalidByte = -1;                    // Designating -1 for invalid bytes in the decoding map
+
+        public static byte[] InvalidBytes
+        {
+            get
+            {
+                int[] indices = s_decodingMap.FindAllIndexOf(s_invalidByte);
+                // Workaroudn for indices.Cast<byte>().ToArray() since it throws
+                // InvalidCastException: Unable to cast object of type 'System.Int32' to type 'System.Byte'
+                byte[] bytes = new byte[indices.Length];
+                for(int i = 0; i < indices.Length; i++)
+                {
+                    bytes[i] = (byte)indices[i];
+                }
+                return bytes;
+            }
+        }
+
+        public static void InitalizeBytes(Span<byte> bytes, int seed = 100)
+        {
+            var rnd = new Random(seed);
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                bytes[i] = (byte)rnd.Next(0, byte.MaxValue + 1);
+            }
+        }
+
+        public static void InitalizeDecodableBytes(Span<byte> bytes, int seed = 100)
+        {
+            var rnd = new Random(seed);
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                int index = (byte)rnd.Next(0, s_encodingMap.Length - 1);    // Do not pick '='
+                bytes[i] = s_encodingMap[index];
+            }
+        }
+
+        [Fact]
+        public static void GenerateEncodingMapAndVerify()
+        {
+            var data = new byte[64]; // Base64
+            for (int i = 0; i < s_characters.Length; i++)
+            {
+                data[i] = (byte)s_characters[i];
+            }
+            Assert.True(s_encodingMap.AsSpan().SequenceEqual(data));
+        }
+
+        [Fact]
+        public static void GenerateDecodingMapAndVerify()
+        {
+            var data = new sbyte[256]; // 0 to byte.MaxValue (255)
+            for (int i = 0; i < data.Length; i++)
+            {
+                data[i] = s_invalidByte;
+            }
+            for (int i = 0; i < s_characters.Length; i++)
+            {
+                data[s_characters[i]] = (sbyte)i;
+            }
+            Assert.True(s_decodingMap.AsSpan().SequenceEqual(data));
+        }
+
+        public static int[] FindAllIndexOf<T>(this IEnumerable<T> values, T valueToFind)
+        {
+            return values.Select((element, index) => Equals(element, valueToFind) ? index : -1).Where(index => index != -1).ToArray();
+        }
+
+        public static bool VerifyEncodingCorrectness(int expectedConsumed, int expectedWritten, Span<byte> source, Span<byte> encodedBytes)
+        {
+            string expectedText = Convert.ToBase64String(source.Slice(0, expectedConsumed).ToArray());
+            string encodedText = Encoding.ASCII.GetString(encodedBytes.Slice(0, expectedWritten).ToArray());
+            return expectedText.Equals(encodedText);
+        }
+
+        public static bool VerifyDecodingCorrectness(int expectedConsumed, int expectedWritten, Span<byte> source, Span<byte> decodedBytes)
+        {
+            string sourceString = Encoding.ASCII.GetString(source.Slice(0, expectedConsumed).ToArray());
+            byte[] expectedBytes = Convert.FromBase64String(sourceString);
+            return expectedBytes.AsSpan().SequenceEqual(decodedBytes.Slice(0, expectedWritten));
+        }
+    }
+}
+

--- a/src/System.Memory/tests/Performance/Perf.Base64EncodeDecode.cs
+++ b/src/System.Memory/tests/Performance/Perf.Base64EncodeDecode.cs
@@ -1,0 +1,211 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using System.Text;
+using Xunit;
+
+namespace System.Buffers.Text.Tests
+{
+    public class Base64EncodeDecodeTests
+    {
+        private const int InnerCount = 1000;
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void Base64Encode(int numberOfBytes)
+        {
+            Span<byte> source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source);
+            Span<byte> destination = new byte[Base64.GetMaxEncodedToUtf8Length(numberOfBytes)];
+
+            foreach (var iteration in Benchmark.Iterations) {
+                using (iteration.StartMeasurement()) {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        Base64.EncodeToUtf8(source, destination, out int consumed, out int written);
+                }
+            }
+
+            Span<byte> backToSource = new byte[numberOfBytes];
+            Base64.DecodeFromUtf8(destination, backToSource, out _, out _);
+            Assert.True(source.SequenceEqual(backToSource));
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void Base64EncodeBaseline(int numberOfBytes)
+        {
+            var source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source.AsSpan());
+            var destination = new char[Base64.GetMaxEncodedToUtf8Length(numberOfBytes)];
+
+            foreach (var iteration in Benchmark.Iterations) {
+                using (iteration.StartMeasurement()) {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        Convert.ToBase64CharArray(source, 0, source.Length, destination, 0);
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void Base64Decode(int numberOfBytes)
+        {
+            Span<byte> source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source);
+            Span<byte> encoded = new byte[Base64.GetMaxEncodedToUtf8Length(numberOfBytes)];
+            Base64.EncodeToUtf8(source, encoded, out _, out _);
+
+            foreach (var iteration in Benchmark.Iterations) {
+                using (iteration.StartMeasurement()) {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        Base64.DecodeFromUtf8(encoded, source, out int bytesConsumed, out int bytesWritten);
+                }
+            }
+
+            Span<byte> backToEncoded = encoded.ToArray();
+            Base64.EncodeToUtf8(source, encoded, out _, out _);
+            Assert.True(backToEncoded.SequenceEqual(encoded));
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void Base64DecodeBaseline(int numberOfBytes)
+        {
+            var source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source.AsSpan());
+            char[] encoded = Convert.ToBase64String(source).ToCharArray();
+
+            foreach (var iteration in Benchmark.Iterations) {
+                using (iteration.StartMeasurement()) {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        Convert.FromBase64CharArray(encoded, 0, encoded.Length);
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void Base64EncodeInPlace(int numberOfBytes)
+        {
+            Span<byte> source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source);
+            int length = Base64.GetMaxEncodedToUtf8Length(numberOfBytes);
+            Span<byte> decodedSpan = new byte[length];
+            source.CopyTo(decodedSpan);
+            Span<byte> backupSpan = decodedSpan.ToArray();
+
+            int bytesWritten = 0;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        backupSpan.CopyTo(decodedSpan);
+                        Base64.EncodeToUtf8InPlace(decodedSpan, numberOfBytes, out bytesWritten);
+                    }
+                }
+            }
+
+            Span<byte> backToSource = new byte[numberOfBytes];
+            Base64.DecodeFromUtf8(decodedSpan, backToSource, out _, out _);
+            Assert.True(backupSpan.Slice(0, numberOfBytes).SequenceEqual(backToSource));
+        }
+
+        [Benchmark]
+        [InlineData(1000 * 1000)]
+        private static void Base64EncodeInPlaceOnce(int numberOfBytes)
+        {
+            Span<byte> source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source);
+            int length = Base64.GetMaxEncodedToUtf8Length(numberOfBytes);
+            Span<byte> decodedSpan = new byte[length];
+            source.CopyTo(decodedSpan);
+            Span<byte> backupSpan = decodedSpan.ToArray();
+
+            int bytesWritten = 0;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                backupSpan.CopyTo(decodedSpan);
+                using (iteration.StartMeasurement())
+                {
+                    Base64.EncodeToUtf8InPlace(decodedSpan, numberOfBytes, out bytesWritten);
+                }
+            }
+
+            Span<byte> backToSource = new byte[numberOfBytes];
+            Base64.DecodeFromUtf8(decodedSpan, backToSource, out _, out _);
+            Assert.True(backupSpan.Slice(0, numberOfBytes).SequenceEqual(backToSource));
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void Base64DecodeInPlace(int numberOfBytes)
+        {
+            Span<byte> source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source);
+            int length = Base64.GetMaxEncodedToUtf8Length(numberOfBytes);
+            Span<byte> encodedSpan = new byte[length];
+            Base64.EncodeToUtf8(source, encodedSpan, out _, out _);
+            
+            Span<byte> backupSpan = encodedSpan.ToArray();
+
+            int bytesWritten = 0;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        backupSpan.CopyTo(encodedSpan);
+                        Base64.DecodeFromUtf8InPlace(encodedSpan, out bytesWritten);
+                    }
+                }
+            }
+
+            Assert.True(source.SequenceEqual(encodedSpan.Slice(0, bytesWritten)));
+        }
+
+        [Benchmark]
+        [InlineData(1000 * 1000)]
+        private static void Base64DecodeInPlaceOnce(int numberOfBytes)
+        {
+            Span<byte> source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source);
+            int length = Base64.GetMaxEncodedToUtf8Length(numberOfBytes);
+            Span<byte> encodedSpan = new byte[length];
+
+            int bytesWritten = 0;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                Base64.EncodeToUtf8(source, encodedSpan, out _, out _);
+                using (iteration.StartMeasurement())
+                {
+                    Base64.DecodeFromUtf8InPlace(encodedSpan, out bytesWritten);
+                }
+            }
+
+            Assert.True(source.SequenceEqual(encodedSpan.Slice(0, bytesWritten)));
+        }
+    }
+}

--- a/src/System.Memory/tests/Performance/Perf.Base64EncodeDecode.cs
+++ b/src/System.Memory/tests/Performance/Perf.Base64EncodeDecode.cs
@@ -85,14 +85,14 @@ namespace System.Buffers.Text.Tests
         [InlineData(1000 * 1000)]
         private static void Base64DecodeBaseline(int numberOfBytes)
         {
-            var source = new byte[numberOfBytes];
-            Base64TestHelper.InitalizeBytes(source.AsSpan());
-            char[] encoded = Convert.ToBase64String(source).ToCharArray();
+            Span<byte> source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source);
+            ReadOnlySpan<char> encoded = Convert.ToBase64String(source.ToArray()).ToCharArray();
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                        Convert.FromBase64CharArray(encoded, 0, encoded.Length);
+                        Convert.TryFromBase64Chars(encoded, source, out int bytesWritten);
                 }
             }
         }

--- a/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
+++ b/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
@@ -8,12 +8,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="Perf.Base64EncodeDecode.cs" />
     <Compile Include="Perf.Span.BinaryReadAndWrite.cs" />
     <Compile Include="Perf.Span.Clear.cs" />
     <Compile Include="Perf.Span.Fill.cs" />
     <Compile Include="Perf.Span.IndexOf.cs" />
     <Compile Include="Perf.Span.StartsWith.cs" />
     <Compile Include="Perf.MemorySlice.cs" />
+    <Compile Include="..\Base64\Base64TestHelper.cs" />
     <Compile Include="..\TestHelpers.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>

--- a/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
+++ b/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
@@ -9,12 +9,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Perf.Base64EncodeDecode.cs" />
-    <!-- <Compile Include="Perf.Span.BinaryReadAndWrite.cs" />
+    <Compile Include="Perf.Span.BinaryReadAndWrite.cs" />
     <Compile Include="Perf.Span.Clear.cs" />
     <Compile Include="Perf.Span.Fill.cs" />
     <Compile Include="Perf.Span.IndexOf.cs" />
     <Compile Include="Perf.Span.StartsWith.cs" />
-    <Compile Include="Perf.MemorySlice.cs" /> -->
+    <Compile Include="Perf.MemorySlice.cs" />
     <Compile Include="..\Base64\Base64TestHelper.cs" />
     <Compile Include="..\TestHelpers.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">

--- a/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
+++ b/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
@@ -9,12 +9,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Perf.Base64EncodeDecode.cs" />
-    <Compile Include="Perf.Span.BinaryReadAndWrite.cs" />
+    <!-- <Compile Include="Perf.Span.BinaryReadAndWrite.cs" />
     <Compile Include="Perf.Span.Clear.cs" />
     <Compile Include="Perf.Span.Fill.cs" />
     <Compile Include="Perf.Span.IndexOf.cs" />
     <Compile Include="Perf.Span.StartsWith.cs" />
-    <Compile Include="Perf.MemorySlice.cs" />
+    <Compile Include="Perf.MemorySlice.cs" /> -->
     <Compile Include="..\Base64\Base64TestHelper.cs" />
     <Compile Include="..\TestHelpers.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -104,6 +104,11 @@
     <Compile Include="Binary\BinaryWriterUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Base64\Base64DecoderUnitTests.cs" />
+    <Compile Include="Base64\Base64EncoderUnitTests.cs" />
+    <Compile Include="Base64\Base64TestHelper.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/24568 (part of https://github.com/dotnet/corefx/issues/24174).

```C#
namespace System.Buffers.Text {
    public static class Base64 {
        public static OperationStatus DecodeFromUtf8(ReadOnlySpan<byte> utf8, Span<byte> bytes, out int consumed, out int written, bool isFinalBlock=true);
        public static OperationStatus DecodeFromUtf8InPlace(Span<byte> buffer, out int written);
        public static OperationStatus EncodeToUtf8(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int consumed, out int written, bool isFinalBlock=true);
        public static OperationStatus EncodeToUtf8InPlace(Span<byte> buffer, int dataLength, out int written);
        public static int GetMaxDecodedFromUtf8Length(int length);
        public static int GetMaxEncodedToUtf8Length(int length);
    }
}

namespace System.Buffers {
    public enum OperationStatus {
        DestinationTooSmall = 1,
        Done = 0,
        InvalidData = 3,
        NeedMoreData = 2,
    }
}
```

**Note:**
OperationStatus (previously TransformationStatus) can be updated base on API review and doesn't need to block this PR (https://github.com/dotnet/corefx/issues/22412).

**Code Coverage:**
100% line and branch coverage
![image](https://user-images.githubusercontent.com/6527137/32033468-901c1002-b9c1-11e7-90d7-c1cacb24c8cc.png)

**Performance Test Results (duration):**

Test   Name | AVERAGE
-- | --
Base64Decode(numberOfBytes: 10) | 0.019
Base64Decode(numberOfBytes: 100) | 0.110
Base64Decode(numberOfBytes: 1000) | 0.950
Base64Decode(numberOfBytes: 1000000) | 954.361
Base64DecodeBaseline(numberOfBytes: 10) | 0.072
Base64DecodeBaseline(numberOfBytes: 100) | 0.420
Base64DecodeBaseline(numberOfBytes: 1000) | 3.819
Base64DecodeBaseline(numberOfBytes:   1000000) | 8529.559
Base64DecodeDetinationTooSmall(numberOfBytes:   10) | 0.018
Base64DecodeDetinationTooSmall(numberOfBytes:   100) | 0.115
Base64DecodeDetinationTooSmall(numberOfBytes:   1000) | 0.948
Base64DecodeDetinationTooSmall(numberOfBytes:   1000000) | 954.096
Base64DecodeInPlace(numberOfBytes: 10) | 0.020
Base64DecodeInPlace(numberOfBytes: 100) | 0.113
Base64DecodeInPlace(numberOfBytes: 1000) | 0.981
Base64DecodeInPlace(numberOfBytes:   1000000) | 1023.155
Base64DecodeInPlaceOnce(numberOfBytes:   1000000) | 0.950
Base64Encode(numberOfBytes: 10) | 0.020
Base64Encode(numberOfBytes: 100) | 0.129
Base64Encode(numberOfBytes: 1000) | 1.158
Base64Encode(numberOfBytes: 1000000) | 1170.335
Base64EncodeBaseline(numberOfBytes: 10) | 0.029
Base64EncodeBaseline(numberOfBytes: 100) | 0.145
Base64EncodeBaseline(numberOfBytes: 1000) | 1.351
Base64EncodeBaseline(numberOfBytes:   1000000) | 1303.068
Base64EncodeDestinationTooSmall(numberOfBytes:   10) | 0.018
Base64EncodeDestinationTooSmall(numberOfBytes:   100) | 0.128
Base64EncodeDestinationTooSmall(numberOfBytes:   1000) | 1.162
Base64EncodeDestinationTooSmall(numberOfBytes:   1000000) | 1163.685
Base64EncodeInPlace(numberOfBytes: 10) | 0.023
Base64EncodeInPlace(numberOfBytes: 100) | 0.133
Base64EncodeInPlace(numberOfBytes: 1000) | 1.171
Base64EncodeInPlace(numberOfBytes:   1000000) | 1247.834
Base64EncodeInPlaceOnce(numberOfBytes:   1000000) | 1.176

<details> 
<summary>Out-dated performance results 1</summary>

Test   Name | AVERAGE
-- | --
Base64Decode(numberOfBytes: 10) | 0.018
Base64Decode(numberOfBytes: 100) | 0.113
Base64Decode(numberOfBytes: 1000) | 1.005
Base64Decode(numberOfBytes: 1000000) | 1011.903
Base64DecodeBaseline(numberOfBytes: 10) | 0.083
Base64DecodeBaseline(numberOfBytes: 100) | 0.452
Base64DecodeBaseline(numberOfBytes: 1000) | 4.077
Base64DecodeBaseline(numberOfBytes:   1000000) | 8977.842
Base64DecodeInPlace(numberOfBytes: 10) | 0.022
Base64DecodeInPlace(numberOfBytes: 100) | 0.114
Base64DecodeInPlace(numberOfBytes: 1000) | 0.983
Base64DecodeInPlace(numberOfBytes:   1000000) | 1055.159
Base64DecodeInPlaceOnce(numberOfBytes:   1000000) | 0.985
Base64Encode(numberOfBytes: 10) | 0.024
Base64Encode(numberOfBytes: 100) | 0.171
Base64Encode(numberOfBytes: 1000) | 1.631
Base64Encode(numberOfBytes: 1000000) | 1659.814
Base64EncodeBaseline(numberOfBytes: 10) | 0.034
Base64EncodeBaseline(numberOfBytes: 100) | 0.149
Base64EncodeBaseline(numberOfBytes: 1000) | 1.342
Base64EncodeBaseline(numberOfBytes:   1000000) | 1340.315
Base64EncodeInPlace(numberOfBytes: 10) | 0.068
Base64EncodeInPlace(numberOfBytes: 100) | 0.406
Base64EncodeInPlace(numberOfBytes: 1000) | 3.782
Base64EncodeInPlace(numberOfBytes:   1000000) | 3983.673
Base64EncodeInPlaceOnce(numberOfBytes:   1000000) | 3.854
</details> 

<details> 
<summary>Out-dated performance results 2</summary>

Test   Name | AVERAGE
-- | --
Base64Decode(numberOfBytes: 10) | 0.019
Base64Decode(numberOfBytes: 100) | 0.118
Base64Decode(numberOfBytes: 1000) | 1.001
Base64Decode(numberOfBytes: 1000000) | 1000.071
Base64DecodeBaseline(numberOfBytes: 10) | 0.075
Base64DecodeBaseline(numberOfBytes: 100) | 0.428
Base64DecodeBaseline(numberOfBytes: 1000) | 3.872
Base64DecodeBaseline(numberOfBytes:   1000000) | 8725.017
Base64DecodeInPlace(numberOfBytes: 10) | 0.022
Base64DecodeInPlace(numberOfBytes: 100) | 0.117
Base64DecodeInPlace(numberOfBytes: 1000) | 0.986
Base64DecodeInPlace(numberOfBytes:   1000000) | 1068.851
Base64DecodeInPlaceOnce(numberOfBytes:   1000000) | 0.993
Base64Encode(numberOfBytes: 10) | 0.023
Base64Encode(numberOfBytes: 100) | 0.159
Base64Encode(numberOfBytes: 1000) | 1.437
Base64Encode(numberOfBytes: 1000000) | 1473.720
Base64EncodeBaseline(numberOfBytes: 10) | 0.036
Base64EncodeBaseline(numberOfBytes: 100) | 0.149
Base64EncodeBaseline(numberOfBytes: 1000) | 1.602
Base64EncodeBaseline(numberOfBytes:   1000000) | 1357.203
Base64EncodeInPlace(numberOfBytes: 10) | 0.027
Base64EncodeInPlace(numberOfBytes: 100) | 0.157
Base64EncodeInPlace(numberOfBytes: 1000) | 1.399
Base64EncodeInPlace(numberOfBytes:   1000000) | 1466.058
Base64EncodeInPlaceOnce(numberOfBytes:   1000000) | 1.402
</details> 

<details> 
<summary>Out-dated performance results 3</summary>

Test   Name | AVERAGE
-- | --
Base64Decode(numberOfBytes: 10) | 0.017
Base64Decode(numberOfBytes: 100) | 0.110
Base64Decode(numberOfBytes: 1000) | 0.984
Base64Decode(numberOfBytes: 1000000) | 1007.293
Base64DecodeBaseline(numberOfBytes: 10) | 0.069
Base64DecodeBaseline(numberOfBytes: 100) | 0.410
Base64DecodeBaseline(numberOfBytes: 1000) | 3.941
Base64DecodeBaseline(numberOfBytes:   1000000) | 8593.280
Base64DecodeInPlace(numberOfBytes: 10) | 0.021
Base64DecodeInPlace(numberOfBytes: 100) | 0.116
Base64DecodeInPlace(numberOfBytes: 1000) | 1.008
Base64DecodeInPlace(numberOfBytes:   1000000) | 1045.012
Base64DecodeInPlaceOnce(numberOfBytes:   1000000) | 0.955
Base64Encode(numberOfBytes: 10) | 0.020
Base64Encode(numberOfBytes: 100) | 0.132
Base64Encode(numberOfBytes: 1000) | 1.585
Base64Encode(numberOfBytes: 1000000) | 1169.956
Base64EncodeBaseline(numberOfBytes: 10) | 0.029
Base64EncodeBaseline(numberOfBytes: 100) | 0.153
Base64EncodeBaseline(numberOfBytes: 1000) | 1.293
Base64EncodeBaseline(numberOfBytes:   1000000) | 1316.709
Base64EncodeInPlace(numberOfBytes: 10) | 0.023
Base64EncodeInPlace(numberOfBytes: 100) | 0.158
Base64EncodeInPlace(numberOfBytes: 1000) | 1.207
Base64EncodeInPlace(numberOfBytes:   1000000) | 1252.556
Base64EncodeInPlaceOnce(numberOfBytes:   1000000) | 1.166
</details> 

Encode is about  10% faster ~20% slower~ ~10% slower (for input larger than 100 bytes)~. Decode is at least 4x faster (even when compared to the new non-allocating variant TryFromBase64Chars). ~This is probably because the Convert.FromBase64CharArray allocates (approximately n bytes, where n is input size + around 24 byte overhead).~

**Edit 0:** Made encode a bit faster for the common case.
**Edit 1:** Compared against TryFromBase64Chars, there is still a large perf difference.
**Edit 2:** Added new performance numbers based on additional optimizations suggested by @jkotas.
**Edit 3:** Added performance tests for when destination buffer is too small.

cc @KrzysztofCwalina, @stephentoub, @GrabYourPitchforks, @jkotas, @dotnet/corefxlab-contrib 