### PR TITLE
Make ServicePointManager tests run out of proc

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-02125-0
+2.0.0-prerelease-02124-02

--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-02124-02
+2.0.0-prerelease-02125-0

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.cs
@@ -43,7 +43,7 @@ namespace RemoteExecutorConsoleApp
             Type t = null;
             MethodInfo mi = null;
             object instance = null;
-            int? exitCode = null;
+            int exitCode = 0;
             try
             {
                 // Create the test class if necessary
@@ -96,9 +96,6 @@ namespace RemoteExecutorConsoleApp
                 (instance as IDisposable)?.Dispose();
             }
 
-            if (!exitCode.HasValue)
-                exitCode = 0;
-
             // Environment.Exit not supported on .Net Native - don't even call it to avoid the nuisance exception.
             if (!RuntimeInformation.FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase))
             {
@@ -107,13 +104,13 @@ namespace RemoteExecutorConsoleApp
                 // end up keeping the process alive potentially indefinitely.
                 try
                 {
-                    Environment.Exit(exitCode.Value);
+                    Environment.Exit(exitCode);
                 }
                 catch (PlatformNotSupportedException)
                 {
                 }
             }
-            return exitCode.Value;
+            return exitCode;
         }
 
         private static MethodInfo GetMethod(this Type type, string methodName)

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -128,6 +128,7 @@ namespace System.Diagnostics
         public const int SuccessExitCode = 42;
         protected static readonly string TestConsoleApp;
         protected RemoteExecutorTestBase() { }
+        public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Action method, System.Diagnostics.RemoteInvokeOptions options=null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<int> method, System.Diagnostics.RemoteInvokeOptions options=null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<string, int> method, string arg, System.Diagnostics.RemoteInvokeOptions options=null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<string, string, int> method, string arg1, string arg2, System.Diagnostics.RemoteInvokeOptions options=null) { throw null; }

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
@@ -24,9 +24,9 @@ namespace System.Diagnostics
         {
             options = options ?? new RemoteInvokeOptions();
 
-            // Verify the specified method is and that it returns an int (the exit code),
+            // Verify the specified method returns an int (the exit code) or nothing,
             // and that if it accepts any arguments, they're all strings.
-            Assert.True(method.ReturnType == typeof(int) || method.ReturnType == typeof(Task<int>));
+            Assert.True(method.ReturnType == typeof(void) || method.ReturnType == typeof(int) || method.ReturnType == typeof(Task<int>));
             Assert.All(method.GetParameters(), pi => Assert.Equal(typeof(string), pi.ParameterType));
 
             // And make sure it's in this assembly.  This isn't critical, but it helps with deployment to know

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -29,8 +29,9 @@ namespace System.Diagnostics
             Action method,
             RemoteInvokeOptions options = null)
         {
-            if (options != null)
-                options.CheckExitCode = false;
+            // There's no exit code to check
+            options = options ?? new RemoteInvokeOptions();
+            options.CheckExitCode = false;
 
             return RemoteInvoke(GetMethodInfo(method), Array.Empty<string>(), options);
         }

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -26,6 +26,19 @@ namespace System.Diagnostics
         /// <param name="method">The method to invoke.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle RemoteInvoke(
+            Action method,
+            RemoteInvokeOptions options = null)
+        {
+            if (options != null)
+                options.CheckExitCode = false;
+
+            return RemoteInvoke(GetMethodInfo(method), Array.Empty<string>(), options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle RemoteInvoke(
             Func<int> method, 
             RemoteInvokeOptions options = null)
         {

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.uap.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.uap.cs
@@ -27,7 +27,7 @@ namespace System.Diagnostics
         {
             options = options ?? new RemoteInvokeOptions();
 
-            // Verify the specified method is and that it returns an int (the exit code),
+            // Verify the specified method returns an int (the exit code) or nothing,
             // and that if it accepts any arguments, they're all strings.
             Assert.True(method.ReturnType == typeof(void) || method.ReturnType == typeof(int) || method.ReturnType == typeof(Task<int>));
             Assert.All(method.GetParameters(), pi => Assert.Equal(typeof(string), pi.ParameterType));

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.uap.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.uap.cs
@@ -29,7 +29,7 @@ namespace System.Diagnostics
 
             // Verify the specified method is and that it returns an int (the exit code),
             // and that if it accepts any arguments, they're all strings.
-            Assert.True(method.ReturnType == typeof(int) || method.ReturnType == typeof(Task<int>));
+            Assert.True(method.ReturnType == typeof(void) || method.ReturnType == typeof(int) || method.ReturnType == typeof(Task<int>));
             Assert.All(method.GetParameters(), pi => Assert.Equal(typeof(string), pi.ParameterType));
 
             // And make sure it's in this assembly.  This isn't critical, but it helps with deployment to know
@@ -66,7 +66,7 @@ namespace System.Diagnostics
 
                 Assert.True(response.Status == AppServiceResponseStatus.Success, $"response.Status = {response.Status}");
                 int res = (int)response.Message["Results"];
-                Assert.True(res == options.ExpectedExitCode, (string)response.Message["Log"] + Environment.NewLine + $"Returned Error code: {res}");
+                Assert.True(!options.CheckExitCode || res == options.ExpectedExitCode, (string)response.Message["Log"] + Environment.NewLine + $"Returned Error code: {res}");
             }
 
             // RemoteInvokeHandle is not really needed in the UAP scenario but we use it just to have consistent interface as non UAP

--- a/src/System.Net.ServicePoint/tests/ServicePointManagerTest.cs
+++ b/src/System.Net.ServicePoint/tests/ServicePointManagerTest.cs
@@ -3,327 +3,382 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using Xunit;
 
 namespace System.Net.Tests
 {
-    public class ServicePointManagerTest
+    public class ServicePointManagerTest : RemoteExecutorTestBase
     {
         [Fact]
         public static void RequireEncryption_ExpectedDefault()
         {
-            Assert.Equal(EncryptionPolicy.RequireEncryption, ServicePointManager.EncryptionPolicy);
+            RemoteInvoke(() => Assert.Equal(EncryptionPolicy.RequireEncryption, ServicePointManager.EncryptionPolicy));
         }
 
         [Fact]
         public static void CheckCertificateRevocationList_Roundtrips()
         {
-            Assert.False(ServicePointManager.CheckCertificateRevocationList);
+            RemoteInvoke(() =>
+            {
+                Assert.False(ServicePointManager.CheckCertificateRevocationList);
 
-            ServicePointManager.CheckCertificateRevocationList = true;
-            Assert.True(ServicePointManager.CheckCertificateRevocationList);
+                ServicePointManager.CheckCertificateRevocationList = true;
+                Assert.True(ServicePointManager.CheckCertificateRevocationList);
 
-            ServicePointManager.CheckCertificateRevocationList = false;
-            Assert.False(ServicePointManager.CheckCertificateRevocationList);
+                ServicePointManager.CheckCertificateRevocationList = false;
+                Assert.False(ServicePointManager.CheckCertificateRevocationList);
+            });
         }
 
         [Fact]
         public static void DefaultConnectionLimit_Roundtrips()
         {
-            Assert.Equal(2, ServicePointManager.DefaultConnectionLimit);
+            RemoteInvoke(() =>
+            {
+                Assert.Equal(2, ServicePointManager.DefaultConnectionLimit);
 
-            ServicePointManager.DefaultConnectionLimit = 20;
-            Assert.Equal(20, ServicePointManager.DefaultConnectionLimit);
+                ServicePointManager.DefaultConnectionLimit = 20;
+                Assert.Equal(20, ServicePointManager.DefaultConnectionLimit);
 
-            ServicePointManager.DefaultConnectionLimit = 2;
-            Assert.Equal(2, ServicePointManager.DefaultConnectionLimit);
+                ServicePointManager.DefaultConnectionLimit = 2;
+                Assert.Equal(2, ServicePointManager.DefaultConnectionLimit);
+            });
         }
 
         [Fact]
         public static void DnsRefreshTimeout_Roundtrips()
         {
-            Assert.Equal(120000, ServicePointManager.DnsRefreshTimeout);
+            RemoteInvoke(() =>
+            {
+                Assert.Equal(120000, ServicePointManager.DnsRefreshTimeout);
 
-            ServicePointManager.DnsRefreshTimeout = 42;
-            Assert.Equal(42, ServicePointManager.DnsRefreshTimeout);
+                ServicePointManager.DnsRefreshTimeout = 42;
+                Assert.Equal(42, ServicePointManager.DnsRefreshTimeout);
 
-            ServicePointManager.DnsRefreshTimeout = 120000;
-            Assert.Equal(120000, ServicePointManager.DnsRefreshTimeout);
+                ServicePointManager.DnsRefreshTimeout = 120000;
+                Assert.Equal(120000, ServicePointManager.DnsRefreshTimeout);
+            });
         }
 
         [Fact]
         public static void EnableDnsRoundRobin_Roundtrips()
         {
-            Assert.False(ServicePointManager.EnableDnsRoundRobin);
+            RemoteInvoke(() =>
+            {
+                Assert.False(ServicePointManager.EnableDnsRoundRobin);
 
-            ServicePointManager.EnableDnsRoundRobin = true;
-            Assert.True(ServicePointManager.EnableDnsRoundRobin);
+                ServicePointManager.EnableDnsRoundRobin = true;
+                Assert.True(ServicePointManager.EnableDnsRoundRobin);
 
-            ServicePointManager.EnableDnsRoundRobin = false;
-            Assert.False(ServicePointManager.EnableDnsRoundRobin);
+                ServicePointManager.EnableDnsRoundRobin = false;
+                Assert.False(ServicePointManager.EnableDnsRoundRobin);
+            });
         }
 
         [Fact]
         public static void Expect100Continue_Roundtrips()
         {
-            Assert.True(ServicePointManager.Expect100Continue);
+            RemoteInvoke(() =>
+            {
+                Assert.True(ServicePointManager.Expect100Continue);
 
-            ServicePointManager.Expect100Continue = false;
-            Assert.False(ServicePointManager.Expect100Continue);
+                ServicePointManager.Expect100Continue = false;
+                Assert.False(ServicePointManager.Expect100Continue);
 
-            ServicePointManager.Expect100Continue = true;
-            Assert.True(ServicePointManager.Expect100Continue);
+                ServicePointManager.Expect100Continue = true;
+                Assert.True(ServicePointManager.Expect100Continue);
+            });
         }
 
         [Fact]
         public static void MaxServicePointIdleTime_Roundtrips()
         {
-            Assert.Equal(100000, ServicePointManager.MaxServicePointIdleTime);
+            RemoteInvoke(() =>
+            {
+                Assert.Equal(100000, ServicePointManager.MaxServicePointIdleTime);
 
-            ServicePointManager.MaxServicePointIdleTime = 42;
-            Assert.Equal(42, ServicePointManager.MaxServicePointIdleTime);
+                ServicePointManager.MaxServicePointIdleTime = 42;
+                Assert.Equal(42, ServicePointManager.MaxServicePointIdleTime);
 
-            ServicePointManager.MaxServicePointIdleTime = 100000;
-            Assert.Equal(100000, ServicePointManager.MaxServicePointIdleTime);
+                ServicePointManager.MaxServicePointIdleTime = 100000;
+                Assert.Equal(100000, ServicePointManager.MaxServicePointIdleTime);
+            });
         }
 
         [Fact]
         public static void MaxServicePoints_Roundtrips()
         {
-            Assert.Equal(0, ServicePointManager.MaxServicePoints);
+            RemoteInvoke(() =>
+            {
+                Assert.Equal(0, ServicePointManager.MaxServicePoints);
 
-            ServicePointManager.MaxServicePoints = 42;
-            Assert.Equal(42, ServicePointManager.MaxServicePoints);
+                ServicePointManager.MaxServicePoints = 42;
+                Assert.Equal(42, ServicePointManager.MaxServicePoints);
 
-            ServicePointManager.MaxServicePoints = 0;
-            Assert.Equal(0, ServicePointManager.MaxServicePoints);
+                ServicePointManager.MaxServicePoints = 0;
+                Assert.Equal(0, ServicePointManager.MaxServicePoints);
+            });
         }
 
         [Fact]
         public static void ReusePort_Roundtrips()
         {
-            Assert.False(ServicePointManager.ReusePort);
+            RemoteInvoke(() =>
+            {
+                Assert.False(ServicePointManager.ReusePort);
 
-            ServicePointManager.ReusePort = true;
-            Assert.True(ServicePointManager.ReusePort);
+                ServicePointManager.ReusePort = true;
+                Assert.True(ServicePointManager.ReusePort);
 
-            ServicePointManager.ReusePort = false;
-            Assert.False(ServicePointManager.ReusePort);
+                ServicePointManager.ReusePort = false;
+                Assert.False(ServicePointManager.ReusePort);
+            });
         }
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop default SecurityProtocol to Ssl3; explicitly changed to SystemDefault for core.")]
         public static void SecurityProtocol_Roundtrips()
         {
-            var orig = (SecurityProtocolType)0; // SystemDefault.
-            Assert.Equal(orig, ServicePointManager.SecurityProtocol);
+            RemoteInvoke(() =>
+            {
+                var orig = (SecurityProtocolType)0; // SystemDefault.
+                Assert.Equal(orig, ServicePointManager.SecurityProtocol);
 
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11;
-            Assert.Equal(SecurityProtocolType.Tls11, ServicePointManager.SecurityProtocol);
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11;
+                Assert.Equal(SecurityProtocolType.Tls11, ServicePointManager.SecurityProtocol);
 
-            ServicePointManager.SecurityProtocol = orig;
-            Assert.Equal(orig, ServicePointManager.SecurityProtocol);
+                ServicePointManager.SecurityProtocol = orig;
+                Assert.Equal(orig, ServicePointManager.SecurityProtocol);
+            });
         }
 
         [Fact]
         public static void ServerCertificateValidationCallback_Roundtrips()
         {
-            Assert.Null(ServicePointManager.ServerCertificateValidationCallback);
+            RemoteInvoke(() =>
+            {
+                Assert.Null(ServicePointManager.ServerCertificateValidationCallback);
 
-            RemoteCertificateValidationCallback callback = delegate { return true; };
-            ServicePointManager.ServerCertificateValidationCallback = callback;
-            Assert.Same(callback, ServicePointManager.ServerCertificateValidationCallback);
+                RemoteCertificateValidationCallback callback = delegate { return true; };
+                ServicePointManager.ServerCertificateValidationCallback = callback;
+                Assert.Same(callback, ServicePointManager.ServerCertificateValidationCallback);
 
-            ServicePointManager.ServerCertificateValidationCallback = null;
-            Assert.Null(ServicePointManager.ServerCertificateValidationCallback);
+                ServicePointManager.ServerCertificateValidationCallback = null;
+                Assert.Null(ServicePointManager.ServerCertificateValidationCallback);
+            });
         }
 
         [Fact]
         public static void UseNagleAlgorithm_Roundtrips()
         {
-            Assert.True(ServicePointManager.UseNagleAlgorithm);
+            RemoteInvoke(() =>
+            {
+                Assert.True(ServicePointManager.UseNagleAlgorithm);
 
-            ServicePointManager.UseNagleAlgorithm = false;
-            Assert.False(ServicePointManager.UseNagleAlgorithm);
+                ServicePointManager.UseNagleAlgorithm = false;
+                Assert.False(ServicePointManager.UseNagleAlgorithm);
 
-            ServicePointManager.UseNagleAlgorithm = true;
-            Assert.True(ServicePointManager.UseNagleAlgorithm);
+                ServicePointManager.UseNagleAlgorithm = true;
+                Assert.True(ServicePointManager.UseNagleAlgorithm);
+            });
         }
 
         [Fact]
         public static void InvalidArguments_Throw()
         {
-            const int ssl2Client = 0x00000008;
-            const int ssl2Server = 0x00000004;
-            const SecurityProtocolType ssl2 = (SecurityProtocolType)(ssl2Client | ssl2Server);
-            Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = ssl2);
+            RemoteInvoke(() =>
+            {
+                const int ssl2Client = 0x00000008;
+                const int ssl2Server = 0x00000004;
+                const SecurityProtocolType ssl2 = (SecurityProtocolType)(ssl2Client | ssl2Server);
+                Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = ssl2);
 
-            AssertExtensions.Throws<ArgumentNullException>("uriString", () => ServicePointManager.FindServicePoint((string)null, null));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.MaxServicePoints = -1);
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.DefaultConnectionLimit = 0);
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.MaxServicePointIdleTime = -2);
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("keepAliveTime", () => ServicePointManager.SetTcpKeepAlive(true, -1, 1));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("keepAliveInterval", () => ServicePointManager.SetTcpKeepAlive(true, 1, -1));
-            AssertExtensions.Throws<ArgumentNullException>("address", () => ServicePointManager.FindServicePoint(null));
-            AssertExtensions.Throws<ArgumentNullException>("uriString", () => ServicePointManager.FindServicePoint((string)null, null));
-            AssertExtensions.Throws<ArgumentNullException>("address", () => ServicePointManager.FindServicePoint((Uri)null, null));
-            Assert.Throws<NotSupportedException>(() => ServicePointManager.FindServicePoint("http://anything", new FixedWebProxy("https://anything")));
+                AssertExtensions.Throws<ArgumentNullException>("uriString", () => ServicePointManager.FindServicePoint((string)null, null));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.MaxServicePoints = -1);
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.DefaultConnectionLimit = 0);
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.MaxServicePointIdleTime = -2);
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("keepAliveTime", () => ServicePointManager.SetTcpKeepAlive(true, -1, 1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("keepAliveInterval", () => ServicePointManager.SetTcpKeepAlive(true, 1, -1));
+                AssertExtensions.Throws<ArgumentNullException>("address", () => ServicePointManager.FindServicePoint(null));
+                AssertExtensions.Throws<ArgumentNullException>("uriString", () => ServicePointManager.FindServicePoint((string)null, null));
+                AssertExtensions.Throws<ArgumentNullException>("address", () => ServicePointManager.FindServicePoint((Uri)null, null));
+                Assert.Throws<NotSupportedException>(() => ServicePointManager.FindServicePoint("http://anything", new FixedWebProxy("https://anything")));
 
-            ServicePoint sp = ServicePointManager.FindServicePoint("http://" + Guid.NewGuid().ToString("N"), null);
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => sp.ConnectionLeaseTimeout = -2);
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => sp.ConnectionLimit = 0);
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => sp.MaxIdleTime = -2);
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => sp.ReceiveBufferSize = -2);
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("keepAliveTime", () => sp.SetTcpKeepAlive(true, -1, 1));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("keepAliveInterval", () => sp.SetTcpKeepAlive(true, 1, -1));
+                ServicePoint sp = ServicePointManager.FindServicePoint("http://" + Guid.NewGuid().ToString("N"), null);
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => sp.ConnectionLeaseTimeout = -2);
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => sp.ConnectionLimit = 0);
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => sp.MaxIdleTime = -2);
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => sp.ReceiveBufferSize = -2);
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("keepAliveTime", () => sp.SetTcpKeepAlive(true, -1, 1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("keepAliveInterval", () => sp.SetTcpKeepAlive(true, 1, -1));
+            });
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Ssl3 is supported by desktop but explicitly not by core")]
         [Fact]
         public static void SecurityProtocol_Ssl3_NotSupported()
         {
-            const int ssl2Client = 0x00000008;
-            const int ssl2Server = 0x00000004;
-            const SecurityProtocolType ssl2 = (SecurityProtocolType)(ssl2Client | ssl2Server);
+            RemoteInvoke(() =>
+            {
+                const int ssl2Client = 0x00000008;
+                const int ssl2Server = 0x00000004;
+                const SecurityProtocolType ssl2 = (SecurityProtocolType)(ssl2Client | ssl2Server);
 
 #pragma warning disable 0618 // Ssl2, Ssl3 are deprecated.
-            Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3);
-            Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | ssl2);
+                Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3);
+                Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | ssl2);
 #pragma warning restore
+            });
         }
 
         [Fact]
         public static void FindServicePoint_ReturnsCachedServicePoint()
         {
-            const string Localhost = "http://localhost";
-            string address1 = "http://" + Guid.NewGuid().ToString("N");
-            string address2 = "http://" + Guid.NewGuid().ToString("N");
+            RemoteInvoke(() =>
+            {
+                const string Localhost = "http://localhost";
+                string address1 = "http://" + Guid.NewGuid().ToString("N");
+                string address2 = "http://" + Guid.NewGuid().ToString("N");
 
-            Assert.NotNull(ServicePointManager.FindServicePoint(new Uri(address1)));
+                Assert.NotNull(ServicePointManager.FindServicePoint(new Uri(address1)));
 
-            Assert.Same(
-                ServicePointManager.FindServicePoint(address1, null),
-                ServicePointManager.FindServicePoint(address1, null));
-            Assert.Same(
-                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)),
-                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)));
-            Assert.Same(
-                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)),
-                ServicePointManager.FindServicePoint(address2, new FixedWebProxy(address1)));
-            Assert.Same(
-                ServicePointManager.FindServicePoint(Localhost, new FixedWebProxy(address1)),
-                ServicePointManager.FindServicePoint(Localhost, new FixedWebProxy(address2)));
+                Assert.Same(
+                    ServicePointManager.FindServicePoint(address1, null),
+                    ServicePointManager.FindServicePoint(address1, null));
+                Assert.Same(
+                    ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)),
+                    ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)));
+                Assert.Same(
+                    ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)),
+                    ServicePointManager.FindServicePoint(address2, new FixedWebProxy(address1)));
+                Assert.Same(
+                    ServicePointManager.FindServicePoint(Localhost, new FixedWebProxy(address1)),
+                    ServicePointManager.FindServicePoint(Localhost, new FixedWebProxy(address2)));
 
-            Assert.NotSame(
-                ServicePointManager.FindServicePoint(address1, null),
-                ServicePointManager.FindServicePoint(address2, null));
-            Assert.NotSame(
-                ServicePointManager.FindServicePoint(address1, null),
-                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)));
-            Assert.NotSame(
-                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)),
-                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address2)));
+                Assert.NotSame(
+                    ServicePointManager.FindServicePoint(address1, null),
+                    ServicePointManager.FindServicePoint(address2, null));
+                Assert.NotSame(
+                    ServicePointManager.FindServicePoint(address1, null),
+                    ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)));
+                Assert.NotSame(
+                    ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)),
+                    ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address2)));
+            });
         }
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop ServicePoint lifetime is slightly longer due to implementation details of real implementation")]
         public static void FindServicePoint_Collectible()
         {
-            string address = "http://" + Guid.NewGuid().ToString("N");
+            RemoteInvoke(() =>
+            {
+                string address = "http://" + Guid.NewGuid().ToString("N");
 
-            bool initial = GetExpect100Continue(address);
-            SetExpect100Continue(address, !initial);
+                bool initial = GetExpect100Continue(address);
+                SetExpect100Continue(address, !initial);
 
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
 
-            Assert.Equal(initial, GetExpect100Continue(address));
+                Assert.Equal(initial, GetExpect100Continue(address));
+            });
         }
 
         [Fact]
         public static void FindServicePoint_ReturnedServicePointMatchesExpectedValues()
         {
-            string address = "http://" + Guid.NewGuid().ToString("N");
+            RemoteInvoke(() =>
+            {
+                string address = "http://" + Guid.NewGuid().ToString("N");
 
-            DateTime start = DateTime.Now;
-            ServicePoint sp = ServicePointManager.FindServicePoint(address, null);
+                DateTime start = DateTime.Now;
+                ServicePoint sp = ServicePointManager.FindServicePoint(address, null);
 
-            Assert.InRange(sp.IdleSince, start, DateTime.MaxValue);
-            Assert.Equal(new Uri(address), sp.Address);
-            Assert.Null(sp.BindIPEndPointDelegate);
-            Assert.Null(sp.Certificate);
-            Assert.Null(sp.ClientCertificate);
-            Assert.Equal(-1, sp.ConnectionLeaseTimeout);
-            Assert.Equal("http", sp.ConnectionName);
-            Assert.Equal(0, sp.CurrentConnections);
-            Assert.Equal(true, sp.Expect100Continue);
-            Assert.Equal(100000, sp.MaxIdleTime);
-            Assert.Equal(new Version(1, 1), sp.ProtocolVersion);
-            Assert.Equal(-1, sp.ReceiveBufferSize);
-            Assert.True(sp.SupportsPipelining, "SupportsPipelining");
-            Assert.True(sp.UseNagleAlgorithm, "UseNagleAlgorithm");
+                Assert.InRange(sp.IdleSince, start, DateTime.MaxValue);
+                Assert.Equal(new Uri(address), sp.Address);
+                Assert.Null(sp.BindIPEndPointDelegate);
+                Assert.Null(sp.Certificate);
+                Assert.Null(sp.ClientCertificate);
+                Assert.Equal(-1, sp.ConnectionLeaseTimeout);
+                Assert.Equal("http", sp.ConnectionName);
+                Assert.Equal(0, sp.CurrentConnections);
+                Assert.Equal(true, sp.Expect100Continue);
+                Assert.Equal(100000, sp.MaxIdleTime);
+                Assert.Equal(new Version(1, 1), sp.ProtocolVersion);
+                Assert.Equal(-1, sp.ReceiveBufferSize);
+                Assert.True(sp.SupportsPipelining, "SupportsPipelining");
+                Assert.True(sp.UseNagleAlgorithm, "UseNagleAlgorithm");
+            });
         }
 
         [Fact]
         public static void FindServicePoint_PropertiesRoundtrip()
         {
-            string address = "http://" + Guid.NewGuid().ToString("N");
+            RemoteInvoke(() =>
+            {
+                string address = "http://" + Guid.NewGuid().ToString("N");
 
-            BindIPEndPoint expectedBindIPEndPointDelegate = delegate { return null; };
-            int expectedConnectionLeaseTimeout = 42;
-            int expectedConnectionLimit = 84;
-            bool expected100Continue = false;
-            int expectedMaxIdleTime = 200000;
-            int expectedReceiveBufferSize = 123;
-            bool expectedUseNagleAlgorithm = false;
+                BindIPEndPoint expectedBindIPEndPointDelegate = delegate { return null; };
+                int expectedConnectionLeaseTimeout = 42;
+                int expectedConnectionLimit = 84;
+                bool expected100Continue = false;
+                int expectedMaxIdleTime = 200000;
+                int expectedReceiveBufferSize = 123;
+                bool expectedUseNagleAlgorithm = false;
 
-            ServicePoint sp1 = ServicePointManager.FindServicePoint(address, null);
-            sp1.BindIPEndPointDelegate = expectedBindIPEndPointDelegate;
-            sp1.ConnectionLeaseTimeout = expectedConnectionLeaseTimeout;
-            sp1.ConnectionLimit = expectedConnectionLimit;
-            sp1.Expect100Continue = expected100Continue;
-            sp1.MaxIdleTime = expectedMaxIdleTime;
-            sp1.ReceiveBufferSize = expectedReceiveBufferSize;
-            sp1.UseNagleAlgorithm = expectedUseNagleAlgorithm;
+                ServicePoint sp1 = ServicePointManager.FindServicePoint(address, null);
+                sp1.BindIPEndPointDelegate = expectedBindIPEndPointDelegate;
+                sp1.ConnectionLeaseTimeout = expectedConnectionLeaseTimeout;
+                sp1.ConnectionLimit = expectedConnectionLimit;
+                sp1.Expect100Continue = expected100Continue;
+                sp1.MaxIdleTime = expectedMaxIdleTime;
+                sp1.ReceiveBufferSize = expectedReceiveBufferSize;
+                sp1.UseNagleAlgorithm = expectedUseNagleAlgorithm;
 
-            ServicePoint sp2 = ServicePointManager.FindServicePoint(address, null);
-            Assert.Same(expectedBindIPEndPointDelegate, sp2.BindIPEndPointDelegate);
-            Assert.Equal(expectedConnectionLeaseTimeout, sp2.ConnectionLeaseTimeout);
-            Assert.Equal(expectedConnectionLimit, sp2.ConnectionLimit);
-            Assert.Equal(expected100Continue, sp2.Expect100Continue);
-            Assert.Equal(expectedMaxIdleTime, sp2.MaxIdleTime);
-            Assert.Equal(expectedReceiveBufferSize, sp2.ReceiveBufferSize);
-            Assert.Equal(expectedUseNagleAlgorithm, sp2.UseNagleAlgorithm);
+                ServicePoint sp2 = ServicePointManager.FindServicePoint(address, null);
+                Assert.Same(expectedBindIPEndPointDelegate, sp2.BindIPEndPointDelegate);
+                Assert.Equal(expectedConnectionLeaseTimeout, sp2.ConnectionLeaseTimeout);
+                Assert.Equal(expectedConnectionLimit, sp2.ConnectionLimit);
+                Assert.Equal(expected100Continue, sp2.Expect100Continue);
+                Assert.Equal(expectedMaxIdleTime, sp2.MaxIdleTime);
+                Assert.Equal(expectedReceiveBufferSize, sp2.ReceiveBufferSize);
+                Assert.Equal(expectedUseNagleAlgorithm, sp2.UseNagleAlgorithm);
+            });
         }
 
         [Fact]
         public static void FindServicePoint_NewServicePointsInheritCurrentValues()
         {
-            string address1 = "http://" + Guid.NewGuid().ToString("N");
-            string address2 = "http://" + Guid.NewGuid().ToString("N");
+            RemoteInvoke(() =>
+            {
+                string address1 = "http://" + Guid.NewGuid().ToString("N");
+                string address2 = "http://" + Guid.NewGuid().ToString("N");
 
-            bool orig100Continue = ServicePointManager.Expect100Continue;
-            bool origNagle = ServicePointManager.UseNagleAlgorithm;
+                bool orig100Continue = ServicePointManager.Expect100Continue;
+                bool origNagle = ServicePointManager.UseNagleAlgorithm;
 
-            ServicePointManager.Expect100Continue = false;
-            ServicePointManager.UseNagleAlgorithm = false;
-            ServicePoint sp1 = ServicePointManager.FindServicePoint(address1, null);
-            Assert.False(sp1.Expect100Continue);
-            Assert.False(sp1.UseNagleAlgorithm);
+                ServicePointManager.Expect100Continue = false;
+                ServicePointManager.UseNagleAlgorithm = false;
+                ServicePoint sp1 = ServicePointManager.FindServicePoint(address1, null);
+                Assert.False(sp1.Expect100Continue);
+                Assert.False(sp1.UseNagleAlgorithm);
 
-            ServicePointManager.Expect100Continue = true;
-            ServicePointManager.UseNagleAlgorithm = true;
-            ServicePoint sp2 = ServicePointManager.FindServicePoint(address2, null);
-            Assert.True(sp2.Expect100Continue);
-            Assert.True(sp2.UseNagleAlgorithm);
-            Assert.False(sp1.Expect100Continue);
-            Assert.False(sp1.UseNagleAlgorithm);
+                ServicePointManager.Expect100Continue = true;
+                ServicePointManager.UseNagleAlgorithm = true;
+                ServicePoint sp2 = ServicePointManager.FindServicePoint(address2, null);
+                Assert.True(sp2.Expect100Continue);
+                Assert.True(sp2.UseNagleAlgorithm);
+                Assert.False(sp1.Expect100Continue);
+                Assert.False(sp1.UseNagleAlgorithm);
 
-            ServicePointManager.Expect100Continue = orig100Continue;
-            ServicePointManager.UseNagleAlgorithm = origNagle;
+                ServicePointManager.Expect100Continue = orig100Continue;
+                ServicePointManager.UseNagleAlgorithm = origNagle;
+            });
         }
 
         // Separated out to avoid the JIT in debug builds interfering with object lifetimes

--- a/src/System.Net.ServicePoint/tests/System.Net.ServicePoint.Tests.csproj
+++ b/src/System.Net.ServicePoint/tests/System.Net.ServicePoint.Tests.csproj
@@ -15,5 +15,11 @@
     <!-- TODO #13070: Add net463 to the condition after the TFM gets updated to the actual .Net 4.6.3.-->
     <Compile Include="TlsSystemDefault.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.ServicePoint/tests/TlsSystemDefault.cs
+++ b/src/System.Net.ServicePoint/tests/TlsSystemDefault.cs
@@ -2,22 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Net.Tests
 {
-    public class TlsSystemDefault
+    public class TlsSystemDefault : RemoteExecutorTestBase
     {
         [Fact]
         public void ServicePointManager_SecurityProtocolDefault_Ok()
         {
-            Assert.Equal(SecurityProtocolType.SystemDefault, ServicePointManager.SecurityProtocol);
+            RemoteInvoke(() => Assert.Equal(SecurityProtocolType.SystemDefault, ServicePointManager.SecurityProtocol));
         }
 
         [Fact]
         public void ServicePointManager_CheckAllowedProtocols_SystemDefault_Allowed()
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.SystemDefault;
+            RemoteInvoke(() => ServicePointManager.SecurityProtocol = SecurityProtocolType.SystemDefault);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/24875

Also allows RemoteExec() to accept delegates that do not return a value. If an exception (such as an assert failure) occurs within the delegate, the RemoteExec() infrastructure will cause the test to fail. There is no need to return an error code if it would be redundant.

Depends on https://github.com/dotnet/buildtools/pull/1759

