### PR TITLE
Add retry logic for setup of dotnet cli

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -46,6 +46,8 @@ display_error_message()
 # Executes a command and retries if it fails.
 execute() {
     local count=0
+    local retries=${retries:-5}
+    local waitFactor=${waitFactor:-6} 
     until "$@"; do
         local exit=$?
         count=$(( $count + 1 ))
@@ -117,11 +119,10 @@ if [ ! -e $__DOTNET_PATH ]; then
 
     echo "Installing dotnet cli..."
     __DOTNET_LOCATION="https://dotnetcli.azureedge.net/dotnet/Sdk/${__DOTNET_TOOLS_VERSION}/${__DOTNET_PKG}.tar.gz"
-    retries=5
-    waitFactor=6 
+
     installDotNetCLI() {
-        echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> $__init_tools_log
-        rm -rf -- $__DOTNET_PATH/*
+        echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> "$__init_tools_log"
+        rm -rf -- "$__DOTNET_PATH/*"
         # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
         if command -v curl > /dev/null; then
             curl --retry 10 -sSL --create-dirs -o $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
@@ -131,7 +132,7 @@ if [ ! -e $__DOTNET_PATH ]; then
         cd $__DOTNET_PATH
         tar -xf $__DOTNET_PATH/dotnet.tar
     }
-    execute installDotNetCLI >> $__init_tools_log 2>&1
+    execute installDotNetCLI >> "$__init_tools_log" 2>&1
 
     cd $__scriptpath
 fi

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -44,7 +44,7 @@ display_error_message()
 }
 
 # Executes a command and retries if it fails.
-executeWithRetry() {
+execute_with_retry() {
     local count=0
     local retries=${retries:-5}
     local waitFactor=${waitFactor:-6} 
@@ -120,7 +120,7 @@ if [ ! -e $__DOTNET_PATH ]; then
     echo "Installing dotnet cli..."
     __DOTNET_LOCATION="https://dotnetcli.azureedge.net/dotnet/Sdk/${__DOTNET_TOOLS_VERSION}/${__DOTNET_PKG}.tar.gz"
 
-    installDotNetCLI() {
+    install_dotnet_cli() {
         echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> "$__init_tools_log"
         rm -rf -- "$__DOTNET_PATH/*"
         # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
@@ -132,7 +132,7 @@ if [ ! -e $__DOTNET_PATH ]; then
         cd $__DOTNET_PATH
         tar -xf $__DOTNET_PATH/dotnet.tar
     }
-    executeWithRetry installDotNetCLI >> "$__init_tools_log" 2>&1
+    execute_with_retry install_dotnet_cli >> "$__init_tools_log" 2>&1
 
     cd $__scriptpath
 fi

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -117,11 +117,12 @@ if [ ! -e $__DOTNET_PATH ]; then
 
     echo "Installing dotnet cli..."
     __DOTNET_LOCATION="https://dotnetcli.azureedge.net/dotnet/Sdk/${__DOTNET_TOOLS_VERSION}/${__DOTNET_PKG}.tar.gz"
-    # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
     retries=5
     waitFactor=6 
     installDotNetCLI() {
         echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> $__init_tools_log
+        rm -rf -- $__DOTNET_PATH/*
+        # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
         if command -v curl > /dev/null; then
             curl --retry 10 -sSL --create-dirs -o $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
         else
@@ -129,11 +130,6 @@ if [ ! -e $__DOTNET_PATH ]; then
         fi
         cd $__DOTNET_PATH
         tar -xf $__DOTNET_PATH/dotnet.tar
-        local tarResult=$?
-        if [ $tarResult -ne 0 ]; then
-            rm -f $__DOTNET_PATH/*
-        fi
-        return $tarResult
     }
     execute installDotNetCLI >> $__init_tools_log 2>&1
 

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -44,7 +44,7 @@ display_error_message()
 }
 
 # Executes a command and retries if it fails.
-execute() {
+executeWithRetry() {
     local count=0
     local retries=${retries:-5}
     local waitFactor=${waitFactor:-6} 
@@ -132,7 +132,7 @@ if [ ! -e $__DOTNET_PATH ]; then
         cd $__DOTNET_PATH
         tar -xf $__DOTNET_PATH/dotnet.tar
     }
-    execute installDotNetCLI >> "$__init_tools_log" 2>&1
+    executeWithRetry installDotNetCLI >> "$__init_tools_log" 2>&1
 
     cd $__scriptpath
 fi

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -129,6 +129,11 @@ if [ ! -e $__DOTNET_PATH ]; then
         fi
         cd $__DOTNET_PATH
         tar -xf $__DOTNET_PATH/dotnet.tar
+        local tarResult=$?
+        if [ $tarResult -ne 0 ]; then
+            rm -f $__DOTNET_PATH/*
+        fi
+        return $tarResult
     }
     execute installDotNetCLI >> $__init_tools_log 2>&1
 


### PR DESCRIPTION
Fixes intermittent build issues where curl returns: curl: (56) GnuTLS recv error (-54): Error in the pull function.
 Retry added to re-download if the tar command fails to extract.