### PR TITLE
Fixed Bugs with DateTime Parsing

### DIFF
--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -31,8 +31,6 @@ namespace System.ServiceModel.Syndication
         private static readonly XmlQualifiedName s_atom10Title = new XmlQualifiedName(Atom10Constants.TitleTag, string.Empty);
         private static readonly XmlQualifiedName s_atom10Type = new XmlQualifiedName(Atom10Constants.TypeTag, string.Empty);
         private static readonly UriGenerator s_idGenerator = new UriGenerator();
-        private const string Rfc3339LocalDateTimeFormat = "yyyy-MM-ddTHH:mm:sszzz";
-        private const string Rfc3339UTCDateTimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
         private Type _feedType;
         private int _maxExtensionSize;
         private bool _preserveAttributeExtensions;
@@ -717,11 +715,11 @@ namespace System.ServiceModel.Syndication
         {
             if (dateTime.Offset == zeroOffset)
             {
-                return dateTime.ToUniversalTime().ToString(Rfc3339UTCDateTimeFormat, CultureInfo.InvariantCulture);
+                return dateTime.ToUniversalTime().ToString(DateTimeHelper.Rfc3339UTCDateTimeFormat, CultureInfo.InvariantCulture);
             }
             else
             {
-                return dateTime.ToString(Rfc3339LocalDateTimeFormat, CultureInfo.InvariantCulture);
+                return dateTime.ToString(DateTimeHelper.Rfc3339LocalDateTimeFormat, CultureInfo.InvariantCulture);
             }
         }
 

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -31,6 +31,8 @@ namespace System.ServiceModel.Syndication
         private static readonly XmlQualifiedName s_atom10Title = new XmlQualifiedName(Atom10Constants.TitleTag, string.Empty);
         private static readonly XmlQualifiedName s_atom10Type = new XmlQualifiedName(Atom10Constants.TypeTag, string.Empty);
         private static readonly UriGenerator s_idGenerator = new UriGenerator();
+        private const string Rfc3339LocalDateTimeFormat = "yyyy-MM-ddTHH:mm:sszzz";
+        private const string Rfc3339UTCDateTimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
         private Type _feedType;
         private int _maxExtensionSize;
         private bool _preserveAttributeExtensions;
@@ -715,11 +717,11 @@ namespace System.ServiceModel.Syndication
         {
             if (dateTime.Offset == zeroOffset)
             {
-                return dateTime.ToUniversalTime().ToString(DateTimeHelper.Rfc3339UTCDateTimeFormat, CultureInfo.InvariantCulture);
+                return dateTime.ToUniversalTime().ToString(Rfc3339UTCDateTimeFormat, CultureInfo.InvariantCulture);
             }
             else
             {
-                return dateTime.ToString(DateTimeHelper.Rfc3339LocalDateTimeFormat, CultureInfo.InvariantCulture);
+                return dateTime.ToString(Rfc3339LocalDateTimeFormat, CultureInfo.InvariantCulture);
             }
         }
 

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
@@ -44,24 +44,6 @@ namespace System.ServiceModel.Syndication
         {
             return (dateTimeString, localName, ns) =>
             {
-                dateTimeString = dateTimeString.Trim();
-                if (dateTimeString.Length < 20)
-                {
-                    throw new FormatException(SR.ErrorParsingDateTime);
-                }
-
-                if (dateTimeString[19] == '.')
-                {
-                    // remove any fractional seconds, we choose to ignore them
-                    int i = 20;
-                    while (dateTimeString.Length > i && char.IsDigit(dateTimeString[i]))
-                    {
-                        ++i;
-                    }
-
-                    dateTimeString = dateTimeString.Substring(0, 19) + dateTimeString.Substring(i);
-                }
-
                 if (Rfc3339DateTimeParser(dateTimeString, out DateTimeOffset dto))
                 {
                     return dto;
@@ -73,6 +55,24 @@ namespace System.ServiceModel.Syndication
 
         private static bool Rfc3339DateTimeParser(string dateTimeString, out DateTimeOffset dto)
         {
+            dateTimeString = dateTimeString.Trim();
+            if (dateTimeString.Length < 20)
+            {
+                return false;
+            }
+
+            if (dateTimeString[19] == '.')
+            {
+                // remove any fractional seconds, we choose to ignore them
+                int i = 20;
+                while (dateTimeString.Length > i && char.IsDigit(dateTimeString[i]))
+                {
+                    ++i;
+                }
+
+                dateTimeString = dateTimeString.Substring(0, 19) + dateTimeString.Substring(i);
+            }
+
             return DateTimeOffset.TryParseExact(dateTimeString, Rfc3339DateTimeFormat,CultureInfo.InvariantCulture.DateTimeFormat,DateTimeStyles.None, out dto);
         }
 

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
@@ -9,7 +9,7 @@ namespace System.ServiceModel.Syndication
 {
     internal static class DateTimeHelper
     {
-        internal const string Rfc3339DateTimeFormat = "yyyy-MM-ddTHH:mm:ssK";
+        private const string Rfc3339DateTimeFormat = "yyyy-MM-ddTHH:mm:ssK";
 
         public static Func<string, string, string, DateTimeOffset> CreateRss20DateTimeParser()
         {
@@ -62,10 +62,7 @@ namespace System.ServiceModel.Syndication
                     dateTimeString = dateTimeString.Substring(0, 19) + dateTimeString.Substring(i);
                 }
 
-                DateTimeOffset dto;
-                if (DateTimeOffset.TryParseExact(dateTimeString, Rfc3339DateTimeFormat,
-                    CultureInfo.InvariantCulture.DateTimeFormat,
-                    DateTimeStyles.None, out dto))
+                if (Rfc3339DateTimeParser(dateTimeString, out DateTimeOffset dto))
                 {
                     return dto;
                 }
@@ -76,8 +73,7 @@ namespace System.ServiceModel.Syndication
 
         private static bool Rfc3339DateTimeParser(string dateTimeString, out DateTimeOffset dto)
         {
-            // RFC3339 uses the W3C Profile of ISO 8601 so using the date time format string "O" will achieve this.
-            return DateTimeOffset.TryParseExact(dateTimeString, "O", null as IFormatProvider, DateTimeStyles.AllowWhiteSpaces, out dto);
+            return DateTimeOffset.TryParseExact(dateTimeString, Rfc3339DateTimeFormat,CultureInfo.InvariantCulture.DateTimeFormat,DateTimeStyles.None, out dto);
         }
 
         private static bool Rfc822DateTimeParser(string dateTimeString, out DateTimeOffset dto)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
@@ -4,14 +4,12 @@
 
 using System.Globalization;
 using System.Text;
-using System.Xml;
 
 namespace System.ServiceModel.Syndication
 {
     internal static class DateTimeHelper
     {
-        internal const string Rfc3339LocalDateTimeFormat = "yyyy-MM-ddTHH:mm:sszzz";
-        internal const string Rfc3339UTCDateTimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
+        internal const string Rfc3339DateTimeFormat = "yyyy-MM-ddTHH:mm:ssK";
 
         public static Func<string, string, string, DateTimeOffset> CreateRss20DateTimeParser()
         {
@@ -49,7 +47,7 @@ namespace System.ServiceModel.Syndication
                 dateTimeString = dateTimeString.Trim();
                 if (dateTimeString.Length < 20)
                 {
-                    throw new XmlException(SR.ErrorParsingDateTime);
+                    throw new FormatException(SR.ErrorParsingDateTime);
                 }
 
                 if (dateTimeString[19] == '.')
@@ -64,23 +62,15 @@ namespace System.ServiceModel.Syndication
                     dateTimeString = dateTimeString.Substring(0, 19) + dateTimeString.Substring(i);
                 }
 
-                DateTimeOffset localTime;
-                if (DateTimeOffset.TryParseExact(dateTimeString, Rfc3339LocalDateTimeFormat,
+                DateTimeOffset dto;
+                if (DateTimeOffset.TryParseExact(dateTimeString, Rfc3339DateTimeFormat,
                     CultureInfo.InvariantCulture.DateTimeFormat,
-                    DateTimeStyles.None, out localTime))
+                    DateTimeStyles.None, out dto))
                 {
-                    return localTime;
+                    return dto;
                 }
 
-                DateTimeOffset utcTime;
-                if (DateTimeOffset.TryParseExact(dateTimeString, Rfc3339UTCDateTimeFormat,
-                    CultureInfo.InvariantCulture.DateTimeFormat,
-                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out utcTime))
-                {
-                    return utcTime;
-                }
-
-                throw new XmlException(SR.ErrorParsingDateTime);
+                throw new FormatException(SR.ErrorParsingDateTime);
             };
         }
 

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -485,8 +485,14 @@ namespace System.ServiceModel.Syndication.Tests
                 {
                     if (!file.StartsWith("#"))
                     {
+                        file = file.Trim();
                         if (File.Exists(file))
                         {
+                            string filename = Path.GetFileName(Path.GetFullPath(file));
+                            if (!file.Equals(filename))
+                            {
+                                Assert.True(false, $"file: {file} - filename: {filename}");
+                            }
                             fileList.Add(Path.GetFullPath(file));
                         }
                         else

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -491,7 +491,7 @@ namespace System.ServiceModel.Syndication.Tests
                         }
                         else
                         {
-                            throw new FileNotFoundException("File not found!",file);
+                            throw new FileNotFoundException($"File `{file}` was not found!");
                         }
                     }
                 }

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -300,7 +300,6 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
-        [ActiveIssue(24894)]
         public static void AtomEntryPositiveTest()
         {
             string filePath = @"brief-entry-noerror.xml";
@@ -335,7 +334,6 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
-        [ActiveIssue(24894)]
         public static void AtomEntryPositiveTest_write()
         {
             string filePath = @"AtomEntryTest.xml";
@@ -343,7 +341,7 @@ namespace System.ServiceModel.Syndication.Tests
 
             SyndicationItem item = new SyndicationItem("SyndicationFeed released for .net Core", "A lot of text describing the release of .net core feature", new Uri("http://contoso.com/news/path"));
             item.Id = "uuid:43481a10-d881-40d1-adf2-99b438c57e21;id=1";
-            item.LastUpdatedTime = new DateTimeOffset(Convert.ToDateTime("2017-10-11T11:25:55Z"));
+            item.LastUpdatedTime = new DateTimeOffset(Convert.ToDateTime("2017-10-11T11:25:55Z")).UtcDateTime;
 
             try
             {
@@ -367,7 +365,6 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
-        [ActiveIssue(24894)]
         public static void AtomFeedPositiveTest()
         {
             string dataFile = @"atom_feeds.dat";

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -488,11 +488,6 @@ namespace System.ServiceModel.Syndication.Tests
                         file = file.Trim();
                         if (File.Exists(file))
                         {
-                            string filename = Path.GetFileName(Path.GetFullPath(file));
-                            if (!file.Equals(filename))
-                            {
-                                Assert.True(false, $"file: {file} - filename: {filename}");
-                            }
                             fileList.Add(Path.GetFullPath(file));
                         }
                         else


### PR DESCRIPTION
The bug was that `Rfc3339DateTimeParser` couldn't parse string like `2003-12-13T18:30:02Z`. The fix was to use the original `Atom10FeedFormatter.DateFromString`.

Fix #24894