### PR TITLE
Removing Span<byte> extension methods and using the generic ones

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -76,20 +76,16 @@ namespace System
     
     public static class SpanExtensions
     {
-        public static int IndexOf<T>(this Span<T> span, T value) where T:struct, IEquatable<T> { throw null; }
-        public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : struct, IEquatable<T> { throw null; }
-        public static int IndexOf(this Span<byte> span, byte value) { throw null; }
-        public static int IndexOf(this Span<byte> span, ReadOnlySpan<byte> value) { throw null; }
+        public static int IndexOf<T>(this Span<T> span, T value) where T : IEquatable<T> { throw null; }
+        public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
 
         public static int IndexOfAny(this Span<byte> span, byte value0, byte value1) { throw null; }
         public static int IndexOfAny(this Span<byte> span, byte value0, byte value1, byte value2) { throw null; }
         public static int IndexOfAny(this Span<byte> span, ReadOnlySpan<byte> values) { throw null; }
 
-        public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second) where T:struct, IEquatable<T> { throw null; }
-        public static bool SequenceEqual(this Span<byte> first, ReadOnlySpan<byte> second) { throw null; }
+        public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second) where T : IEquatable<T> { throw null; }
         
-        public static bool StartsWith<T>(this Span<T> span, ReadOnlySpan<T> value) where T : struct, IEquatable<T> { throw null; }
-        public static bool StartsWith(this Span<byte> span, ReadOnlySpan<byte> value) { throw null; }
+        public static bool StartsWith<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
 
         public static Span<byte> AsBytes<T>(this Span<T> source) where T : struct { throw null; }
 
@@ -103,20 +99,16 @@ namespace System
 
         public static void CopyTo<T>(this T[] array, Span<T> destination) { throw null; }
 
-        public static int IndexOf<T>(this ReadOnlySpan<T> span, T value) where T : struct, IEquatable<T> { throw null; }
-        public static int IndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value) where T : struct, IEquatable<T> { throw null; }
-        public static int IndexOf(this ReadOnlySpan<byte> span, byte value) { throw null; }
-        public static int IndexOf(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> value) { throw null; }
+        public static int IndexOf<T>(this ReadOnlySpan<T> span, T value) where T : IEquatable<T> { throw null; }
+        public static int IndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
 
         public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1) { throw null; }
         public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2) { throw null; }
         public static int IndexOfAny(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> values) { throw null; }
 
-        public static bool SequenceEqual<T>(this ReadOnlySpan<T> first, ReadOnlySpan<T> second) where T : struct, IEquatable<T> { throw null; }
-        public static bool SequenceEqual(this ReadOnlySpan<byte> first, ReadOnlySpan<byte> second) { throw null; }
+        public static bool SequenceEqual<T>(this ReadOnlySpan<T> first, ReadOnlySpan<T> second) where T : IEquatable<T> { throw null; }
 
-        public static bool StartsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value) where T : struct, IEquatable<T> { throw null; }
-        public static bool StartsWith(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> value) { throw null; }
+        public static bool StartsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
 
         public static ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source) where T : struct { throw null; }
         

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -21,7 +21,12 @@ namespace System
         public static int IndexOf<T>(this Span<T> span, T value)
             where T : IEquatable<T>
         {
-            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), ref value, span.Length);
+            if (typeof(T) == typeof(byte)) 
+                return SpanHelpers.IndexOf(
+                    ref Unsafe.As<T, byte>(ref span.DangerousGetPinnableReference()), 
+                    Unsafe.As<T, byte>(ref value), 
+                    span.Length);
+            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), value, span.Length);
         }
 
         /// <summary>
@@ -33,6 +38,12 @@ namespace System
         public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value)
             where T : IEquatable<T>
         {
+            if (typeof(T) == typeof(byte)) 
+                return SpanHelpers.IndexOf(
+                    ref Unsafe.As<T, byte>(ref span.DangerousGetPinnableReference()), 
+                    span.Length, 
+                    ref Unsafe.As<T, byte>(ref value.DangerousGetPinnableReference()), 
+                    value.Length);
             return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
         }
 
@@ -56,7 +67,12 @@ namespace System
         public static int IndexOf<T>(this ReadOnlySpan<T> span, T value)
             where T : IEquatable<T>
         {
-            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), ref value, span.Length);
+            if (typeof(T) == typeof(byte)) 
+                return SpanHelpers.IndexOf(
+                    ref Unsafe.As<T, byte>(ref span.DangerousGetPinnableReference()), 
+                    Unsafe.As<T, byte>(ref value), 
+                    span.Length);
+            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), value, span.Length);
         }
 
         /// <summary>
@@ -68,6 +84,12 @@ namespace System
         public static int IndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value)
             where T : IEquatable<T>
         {
+            if (typeof(T) == typeof(byte)) 
+                return SpanHelpers.IndexOf(
+                    ref Unsafe.As<T, byte>(ref span.DangerousGetPinnableReference()), 
+                    span.Length, 
+                    ref Unsafe.As<T, byte>(ref value.DangerousGetPinnableReference()), 
+                    value.Length);
             return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
         }
 

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -19,20 +19,9 @@ namespace System
         /// <param name="value">The value to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf<T>(this Span<T> span, T value)
-            where T:struct, IEquatable<T>
+            where T : IEquatable<T>
         {
-            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), value, span.Length);
-        }
-
-        /// <summary>
-        /// Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. 
-        /// </summary>
-        /// <param name="span">The span to search.</param>
-        /// <param name="value">The value to search for.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this Span<byte> span, byte value)
-        {
-            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value, span.Length);
+            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), ref value, span.Length);
         }
 
         /// <summary>
@@ -42,20 +31,9 @@ namespace System
         /// <param name="value">The sequence to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value)
-            where T : struct, IEquatable<T>
+            where T : IEquatable<T>
         {
             return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
-        }
-
-        /// <summary>
-        /// Searches for the specified sequence and returns the index of its first occurrence. If not found, returns -1.
-        /// </summary>
-        /// <param name="span">The span to search.</param>
-        /// <param name="value">The sequence to search for.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this Span<byte> span, ReadOnlySpan<byte> value)
-        {
-            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
         }
 
         /// <summary>
@@ -63,17 +41,7 @@ namespace System
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second)
-            where T:struct, IEquatable<T>
-        {
-            int length = first.Length;
-            return length == second.Length && SpanHelpers.SequenceEqual(ref first.DangerousGetPinnableReference(), ref second.DangerousGetPinnableReference(), length);
-        }
-
-        /// <summary>
-        /// Determines whether two sequences are equal by comparing the elements.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool SequenceEqual(this Span<byte> first, ReadOnlySpan<byte> second)
+            where T : IEquatable<T>
         {
             int length = first.Length;
             return length == second.Length && SpanHelpers.SequenceEqual(ref first.DangerousGetPinnableReference(), ref second.DangerousGetPinnableReference(), length);
@@ -86,20 +54,9 @@ namespace System
         /// <param name="value">The value to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf<T>(this ReadOnlySpan<T> span, T value)
-            where T : struct, IEquatable<T>
+            where T : IEquatable<T>
         {
-            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), value, span.Length);
-        }
-
-        /// <summary>
-        /// Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. 
-        /// </summary>
-        /// <param name="span">The span to search.</param>
-        /// <param name="value">The value to search for.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this ReadOnlySpan<byte> span, byte value)
-        {
-            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value, span.Length);
+            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), ref value, span.Length);
         }
 
         /// <summary>
@@ -109,22 +66,10 @@ namespace System
         /// <param name="value">The sequence to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value)
-            where T : struct, IEquatable<T>
+            where T : IEquatable<T>
         {
             return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
         }
-
-        /// <summary>
-        /// Searches for the specified sequence and returns the index of its first occurrence. If not found, returns -1.
-        /// </summary>
-        /// <param name="span">The span to search.</param>
-        /// <param name="value">The sequence to search for.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> value)
-        {
-            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
-        }
-
 
         /// <summary>
         /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1.
@@ -203,30 +148,10 @@ namespace System
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool SequenceEqual<T>(this ReadOnlySpan<T> first, ReadOnlySpan<T> second)
-            where T : struct, IEquatable<T>
+            where T : IEquatable<T>
         {
             int length = first.Length;
             return length == second.Length && SpanHelpers.SequenceEqual(ref first.DangerousGetPinnableReference(), ref second.DangerousGetPinnableReference(), length);
-        }
-
-        /// <summary>
-        /// Determines whether two sequences are equal by comparing the elements.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool SequenceEqual(this ReadOnlySpan<byte> first, ReadOnlySpan<byte> second)
-        {
-            int length = first.Length;
-            return length == second.Length && SpanHelpers.SequenceEqual(ref first.DangerousGetPinnableReference(), ref second.DangerousGetPinnableReference(), length);
-        }
-
-        /// <summary>
-        /// Determines whether the specified sequence appears at the start of the span.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool StartsWith(this Span<byte> span, ReadOnlySpan<byte> value)
-        {
-            int valueLength = value.Length;
-            return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref span.DangerousGetPinnableReference(), ref value.DangerousGetPinnableReference(), valueLength);
         }
 
         /// <summary>
@@ -234,17 +159,7 @@ namespace System
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool StartsWith<T>(this Span<T> span, ReadOnlySpan<T> value)
-            where T : struct, IEquatable<T>
-        {
-            int valueLength = value.Length;
-            return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref span.DangerousGetPinnableReference(), ref value.DangerousGetPinnableReference(), valueLength);
-        }
-
-        /// <summary>
-        /// Determines whether the specified sequence appears at the start of the span.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool StartsWith(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> value)
+            where T : IEquatable<T>
         {
             int valueLength = value.Length;
             return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref span.DangerousGetPinnableReference(), ref value.DangerousGetPinnableReference(), valueLength);
@@ -255,7 +170,7 @@ namespace System
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool StartsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value)
-            where T : struct, IEquatable<T>
+            where T : IEquatable<T>
         {
             int valueLength = value.Length;
             return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref span.DangerousGetPinnableReference(), ref value.DangerousGetPinnableReference(), valueLength);

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -55,6 +55,12 @@ namespace System
             where T : IEquatable<T>
         {
             int length = first.Length;
+            if (typeof(T) == typeof(byte))
+                return length == second.Length &&
+                SpanHelpers.SequenceEqual(
+                    ref Unsafe.As<T, byte>(ref first.DangerousGetPinnableReference()),
+                    ref Unsafe.As<T, byte>(ref second.DangerousGetPinnableReference()),
+                    length);
             return length == second.Length && SpanHelpers.SequenceEqual(ref first.DangerousGetPinnableReference(), ref second.DangerousGetPinnableReference(), length);
         }
 
@@ -173,6 +179,12 @@ namespace System
             where T : IEquatable<T>
         {
             int length = first.Length;
+            if (typeof(T) == typeof(byte))
+                return length == second.Length &&
+                SpanHelpers.SequenceEqual(
+                    ref Unsafe.As<T, byte>(ref first.DangerousGetPinnableReference()),
+                    ref Unsafe.As<T, byte>(ref second.DangerousGetPinnableReference()),
+                    length);
             return length == second.Length && SpanHelpers.SequenceEqual(ref first.DangerousGetPinnableReference(), ref second.DangerousGetPinnableReference(), length);
         }
 
@@ -184,6 +196,12 @@ namespace System
             where T : IEquatable<T>
         {
             int valueLength = value.Length;
+            if (typeof(T) == typeof(byte))
+                return valueLength <= span.Length && 
+                SpanHelpers.SequenceEqual(
+                    ref Unsafe.As<T, byte>(ref span.DangerousGetPinnableReference()),
+                    ref Unsafe.As<T, byte>(ref value.DangerousGetPinnableReference()),
+                    valueLength);
             return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref span.DangerousGetPinnableReference(), ref value.DangerousGetPinnableReference(), valueLength);
         }
 
@@ -195,6 +213,12 @@ namespace System
             where T : IEquatable<T>
         {
             int valueLength = value.Length;
+            if (typeof(T) == typeof(byte))
+                return valueLength <= span.Length && 
+                SpanHelpers.SequenceEqual(
+                    ref Unsafe.As<T, byte>(ref span.DangerousGetPinnableReference()),
+                    ref Unsafe.As<T, byte>(ref value.DangerousGetPinnableReference()),
+                    valueLength);
             return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref span.DangerousGetPinnableReference(), ref value.DangerousGetPinnableReference(), valueLength);
         }
 

--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -10,15 +10,15 @@ namespace System
     internal static partial class SpanHelpers
     {
         public static int IndexOf<T>(ref T searchSpace, int searchSpaceLength, ref T value, int valueLength)
-            where T : struct, IEquatable<T>
+            where T : IEquatable<T>
         {
+            if (typeof(T) == typeof(byte)) return IndexOf(ref Unsafe.As<T, byte>(ref searchSpace), searchSpaceLength, ref Unsafe.As<T, byte>(ref value), valueLength);
             Debug.Assert(searchSpaceLength >= 0);
             Debug.Assert(valueLength >= 0);
 
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
-            T valueHead = value;
             ref T valueTail = ref Unsafe.Add(ref value, 1);
             int valueTailLength = valueLength - 1;
 
@@ -31,7 +31,7 @@ namespace System
                     break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Do a quick search for the first element of "value".
-                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
+                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), ref value, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
                     break;
                 index += relativeIndex;
@@ -45,9 +45,10 @@ namespace System
             return -1;
         }
 
-        public static unsafe int IndexOf<T>(ref T searchSpace, T value, int length)
-            where T : struct, IEquatable<T>
+        public static unsafe int IndexOf<T>(ref T searchSpace, ref T value, int length)
+            where T : IEquatable<T>
         {
+            if (typeof(T) == typeof(byte)) return IndexOf(ref Unsafe.As<T, byte>(ref searchSpace), ref Unsafe.As<T, byte>(ref value), length);
             Debug.Assert(length >= 0);
 
             IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
@@ -120,8 +121,9 @@ namespace System
         }
 
         public static bool SequenceEqual<T>(ref T first, ref T second, int length)
-            where T : struct, IEquatable<T>
+            where T : IEquatable<T>
         {
+            //if (typeof(T) == typeof(byte)) return SequenceEqual(ref Unsafe.As<T, byte>(ref first), ref Unsafe.As<T, byte>(ref second), length);
             Debug.Assert(length >= 0);
 
             if (Unsafe.AreSame(ref first, ref second))

--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -48,7 +48,6 @@ namespace System
         public static unsafe int IndexOf<T>(ref T searchSpace, T value, int length)
             where T : IEquatable<T>
         {
-            
             Debug.Assert(length >= 0);
 
             IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
@@ -123,7 +122,6 @@ namespace System
         public static bool SequenceEqual<T>(ref T first, ref T second, int length)
             where T : IEquatable<T>
         {
-            if (typeof(T) == typeof(byte)) return SequenceEqual(ref Unsafe.As<T, byte>(ref first), ref Unsafe.As<T, byte>(ref second), length);
             Debug.Assert(length >= 0);
 
             if (Unsafe.AreSame(ref first, ref second))

--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -12,13 +12,13 @@ namespace System
         public static int IndexOf<T>(ref T searchSpace, int searchSpaceLength, ref T value, int valueLength)
             where T : IEquatable<T>
         {
-            if (typeof(T) == typeof(byte)) return IndexOf(ref Unsafe.As<T, byte>(ref searchSpace), searchSpaceLength, ref Unsafe.As<T, byte>(ref value), valueLength);
             Debug.Assert(searchSpaceLength >= 0);
             Debug.Assert(valueLength >= 0);
 
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
+            T valueHead = value;
             ref T valueTail = ref Unsafe.Add(ref value, 1);
             int valueTailLength = valueLength - 1;
 
@@ -31,7 +31,7 @@ namespace System
                     break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Do a quick search for the first element of "value".
-                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), ref value, remainingSearchSpaceLength);
+                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
                     break;
                 index += relativeIndex;
@@ -45,10 +45,10 @@ namespace System
             return -1;
         }
 
-        public static unsafe int IndexOf<T>(ref T searchSpace, ref T value, int length)
+        public static unsafe int IndexOf<T>(ref T searchSpace, T value, int length)
             where T : IEquatable<T>
         {
-            if (typeof(T) == typeof(byte)) return IndexOf(ref Unsafe.As<T, byte>(ref searchSpace), ref Unsafe.As<T, byte>(ref value), length);
+            
             Debug.Assert(length >= 0);
 
             IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
@@ -123,7 +123,7 @@ namespace System
         public static bool SequenceEqual<T>(ref T first, ref T second, int length)
             where T : IEquatable<T>
         {
-            //if (typeof(T) == typeof(byte)) return SequenceEqual(ref Unsafe.As<T, byte>(ref first), ref Unsafe.As<T, byte>(ref second), length);
+            if (typeof(T) == typeof(byte)) return SequenceEqual(ref Unsafe.As<T, byte>(ref first), ref Unsafe.As<T, byte>(ref second), length);
             Debug.Assert(length >= 0);
 
             if (Unsafe.AreSame(ref first, ref second))

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -21,7 +21,6 @@ namespace System
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
-            byte valueHead = value;
             ref byte valueTail = ref Unsafe.Add(ref value, 1);
             int valueTailLength = valueLength - 1;
 
@@ -34,7 +33,7 @@ namespace System
                     break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Do a quick search for the first element of "value".
-                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
+                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), ref value, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
                     break;
                 index += relativeIndex;
@@ -59,7 +58,7 @@ namespace System
             int index = -1;
             for (int i = 0; i < valueLength; i++)
             {
-                var tempIndex = IndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
+                var tempIndex = IndexOf(ref searchSpace, ref Unsafe.Add(ref value, i), searchSpaceLength);
                 if (tempIndex != -1)
                 {
                     index = (index == -1 || index > tempIndex) ? tempIndex : index;
@@ -68,7 +67,7 @@ namespace System
             return index;
         }
 
-        public static unsafe int IndexOf(ref byte searchSpace, byte value, int length)
+        public static unsafe int IndexOf(ref byte searchSpace, ref byte value, int length)
         {
             Debug.Assert(length >= 0);
 

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -21,6 +21,7 @@ namespace System
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
+            byte valueHead = value;
             ref byte valueTail = ref Unsafe.Add(ref value, 1);
             int valueTailLength = valueLength - 1;
 
@@ -33,7 +34,7 @@ namespace System
                     break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Do a quick search for the first element of "value".
-                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), ref value, remainingSearchSpaceLength);
+                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
                     break;
                 index += relativeIndex;
@@ -58,7 +59,7 @@ namespace System
             int index = -1;
             for (int i = 0; i < valueLength; i++)
             {
-                var tempIndex = IndexOf(ref searchSpace, ref Unsafe.Add(ref value, i), searchSpaceLength);
+                var tempIndex = IndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
                 if (tempIndex != -1)
                 {
                     index = (index == -1 || index > tempIndex) ? tempIndex : index;
@@ -67,7 +68,7 @@ namespace System
             return index;
         }
 
-        public static unsafe int IndexOf(ref byte searchSpace, ref byte value, int length)
+        public static unsafe int IndexOf(ref byte searchSpace, byte value, int length)
         {
             Debug.Assert(length >= 0);
 

--- a/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
@@ -53,7 +53,7 @@ namespace System.Memory.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        index |= byteSpan.IndexOf(53);        // '5' = 53
+                        index |= byteSpan.IndexOf<byte>(53);        // '5' = 53
                     }
                 }
             }

--- a/src/System.Memory/tests/Performance/Perf.Span.StartsWith.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.StartsWith.cs
@@ -9,7 +9,7 @@ namespace System.Memory.Tests
 {
     public class Perf_Span_StartsWith
     {
-        [Benchmark]
+        [Benchmark(InnerIterationCount = 10000)]
         [InlineData(1, 1)]
         [InlineData(10, 1)]
         [InlineData(100, 1)]
@@ -46,7 +46,7 @@ namespace System.Memory.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < 10000; i++)
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
                         bool result = span.StartsWith(value);
                     }
@@ -54,7 +54,7 @@ namespace System.Memory.Tests
             }
         }
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = 1000000)]
         [InlineData(1, 1)]
         [InlineData(10, 1)]
         [InlineData(100, 1)]
@@ -91,7 +91,52 @@ namespace System.Memory.Tests
             {
                 using (iteration.StartMeasurement())
                 {
-                    for (int i = 0; i < 10000; i++)
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        bool result = span.StartsWith(value);
+                    }
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = 10000)]
+        [InlineData(1, 1)]
+        [InlineData(10, 1)]
+        [InlineData(100, 1)]
+        [InlineData(1000, 1)]
+        [InlineData(10000, 1)]
+        [InlineData(10, 10)]
+        [InlineData(100, 10)]
+        [InlineData(1000, 10)]
+        [InlineData(10000, 10)]
+        [InlineData(100, 100)]
+        [InlineData(1000, 100)]
+        [InlineData(10000, 100)]
+        [InlineData(1000, 1000)]
+        [InlineData(10000, 1000)]
+        [InlineData(10000, 10000)]
+        public void String(int size, int valSize)
+        {
+            var a = new string[size];
+            for (int i = 0; i < size; i++)
+            {
+                int num = 65 + i % 26;
+                a[i] = ((char)num).ToString();
+            }
+
+            var b = new string[valSize];
+            for (int i = 0; i < valSize; i++)
+            {
+                int num = 65 + i % 26;
+                b[i] = ((char)num).ToString();
+            }
+            var span = new Span<string>(a);
+            var value = new Span<string>(b);
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
                         bool result = span.StartsWith(value);
                     }

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
@@ -14,7 +14,7 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOf_Byte()
         {
             ReadOnlySpan<byte> sp = new ReadOnlySpan<byte>(Array.Empty<byte>());
-            int idx = sp.IndexOf(0);
+            int idx = sp.IndexOf<byte>(0);
             Assert.Equal(-1, idx);
         }
 
@@ -29,7 +29,7 @@ namespace System.SpanTests
                 for (int i = 0; i < length; i++)
                 {
                     byte target0 = default(byte);
-                    int idx = span.IndexOf(target0);
+                    int idx = span.IndexOf<byte>(target0);
                     Assert.Equal(0, idx);
                 }
             }
@@ -50,7 +50,7 @@ namespace System.SpanTests
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
                 {
                     byte target = a[targetIndex];
-                    int idx = span.IndexOf(target);
+                    int idx = span.IndexOf<byte>(target);
                     Assert.Equal(targetIndex, idx);
                 }
             }
@@ -71,7 +71,7 @@ namespace System.SpanTests
                 }
                 ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
 
-                int idx = span.IndexOf(target);
+                int idx = span.IndexOf<byte>(target);
                 Assert.Equal(-1, idx);
             }
         }
@@ -83,11 +83,11 @@ namespace System.SpanTests
             for (var i = 0; i < Vector<byte>.Count; i++)
             {
                 var span = new ReadOnlySpan<byte>(array, i, 3 * Vector<byte>.Count);
-                int idx = span.IndexOf((byte)'1');
+                int idx = span.IndexOf<byte>((byte)'1');
                 Assert.Equal(-1, idx);
 
                 span = new ReadOnlySpan<byte>(array, i, 3 * Vector<byte>.Count - 3);
-                idx = span.IndexOf((byte)'1');
+                idx = span.IndexOf<byte>((byte)'1');
                 Assert.Equal(-1, idx);
             }
         }
@@ -103,11 +103,11 @@ namespace System.SpanTests
             for (var i = 0; i < Vector<byte>.Count; i++)
             {
                 var span = new ReadOnlySpan<byte>(array, i, 3 * Vector<byte>.Count);
-                int idx = span.IndexOf(5);
+                int idx = span.IndexOf<byte>(5);
                 Assert.Equal(0, idx);
 
                 span = new ReadOnlySpan<byte>(array, i, 3 * Vector<byte>.Count - 3);
-                idx = span.IndexOf(5);
+                idx = span.IndexOf<byte>(5);
                 Assert.Equal(0, idx);
             }
         }
@@ -128,7 +128,7 @@ namespace System.SpanTests
                 a[length - 2] = 200;
 
                 ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
-                int idx = span.IndexOf(200);
+                int idx = span.IndexOf<byte>(200);
                 Assert.Equal(length - 2, idx);
             }
         }
@@ -142,7 +142,7 @@ namespace System.SpanTests
                 a[0] = 99;
                 a[length + 1] = 99;
                 ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
-                int index = span.IndexOf(99);
+                int index = span.IndexOf<byte>(99);
                 Assert.Equal(-1, index);
             }
         }
@@ -177,7 +177,7 @@ namespace System.SpanTests
             var index = -1;
             if (searchFor.Length == 1)
             {
-                index = span.IndexOf((byte)searchFor[0]);
+                index = span.IndexOf<byte>((byte)searchFor[0]);
             }
             else if (searchFor.Length == 2)
             {

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOfSequence.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOfSequence.byte.cs
@@ -13,7 +13,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 5, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 5, 1, 77 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(0, index);
         }
 
@@ -22,7 +22,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 1, 2, 3, 1, 2, 3, 1, 2, 3 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 2, 3 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(1, index);
         }
 
@@ -31,7 +31,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 77, 77, 88 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(10, index);
         }
 
@@ -40,7 +40,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 77, 77, 88, 99 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(-1, index);
         }
 
@@ -49,7 +49,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 100, 77, 88, 99 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(-1, index);
         }
 
@@ -58,7 +58,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 3, 4, 5 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(3, index);
         }
 
@@ -67,7 +67,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 3, 4, 5 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(-1, index);
         }
 
@@ -77,7 +77,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(Array.Empty<byte>());
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(0, index);
         }
 
@@ -86,7 +86,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(Array.Empty<byte>());
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 1, 2, 3 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(-1, index);
         }
 
@@ -96,7 +96,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 2 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(2, index);
         }
 
@@ -106,7 +106,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 5 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(5, index);
         }
 
@@ -116,7 +116,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 5 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(-1, index);
         }
     }

--- a/src/System.Memory/tests/ReadOnlySpan/SequenceEqual.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/SequenceEqual.byte.cs
@@ -15,7 +15,7 @@ namespace System.SpanTests
 
             ReadOnlySpan<byte> first = new ReadOnlySpan<byte>(a, 1, 0);
             ReadOnlySpan<byte> second = new ReadOnlySpan<byte>(a, 2, 0);
-            bool b = first.SequenceEqual(second);
+            bool b = first.SequenceEqual<byte>(second);
             Assert.True(b);
         }
 
@@ -24,7 +24,7 @@ namespace System.SpanTests
         {
             byte[] a = { 4, 5, 6 };
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
-            bool b = span.SequenceEqual(span);
+            bool b = span.SequenceEqual<byte>(span);
             Assert.True(b);
         }
 
@@ -33,7 +33,7 @@ namespace System.SpanTests
         {
             byte[] a = { 4, 5, 6 };
             ReadOnlySpan<byte> first = new ReadOnlySpan<byte>(a, 0, 3);
-            bool b = first.SequenceEqual(a);
+            bool b = first.SequenceEqual<byte>(a);
             Assert.True(b);
         }
 
@@ -45,7 +45,7 @@ namespace System.SpanTests
             var segment = new ArraySegment<byte>(dst, 1, 3);
 
             ReadOnlySpan<byte> first = new ReadOnlySpan<byte>(src, 0, 3);
-            bool b = first.SequenceEqual(segment);
+            bool b = first.SequenceEqual<byte>(segment);
             Assert.True(b);
         }
 
@@ -55,7 +55,7 @@ namespace System.SpanTests
             byte[] a = { 4, 5, 6 };
             ReadOnlySpan<byte> first = new ReadOnlySpan<byte>(a, 0, 3);
             ReadOnlySpan<byte> second = new ReadOnlySpan<byte>(a, 0, 2);
-            bool b = first.SequenceEqual(second);
+            bool b = first.SequenceEqual<byte>(second);
             Assert.False(b);
         }
 
@@ -77,7 +77,7 @@ namespace System.SpanTests
 
                     ReadOnlySpan<byte> firstSpan = new ReadOnlySpan<byte>(first);
                     ReadOnlySpan<byte> secondSpan = new ReadOnlySpan<byte>(second);
-                    bool b = firstSpan.SequenceEqual(secondSpan);
+                    bool b = firstSpan.SequenceEqual<byte>(secondSpan);
                     Assert.False(b);
                 }
             }
@@ -96,7 +96,7 @@ namespace System.SpanTests
                 second[length + 1] = 100;
                 ReadOnlySpan<byte> span1 = new ReadOnlySpan<byte>(first, 1, length);
                 ReadOnlySpan<byte> span2 = new ReadOnlySpan<byte>(second, 1, length);
-                bool b = span1.SequenceEqual(span2);
+                bool b = span1.SequenceEqual<byte>(span2);
                 Assert.True(b);
             }
         }

--- a/src/System.Memory/tests/ReadOnlySpan/StartsWith.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/StartsWith.byte.cs
@@ -15,7 +15,7 @@ namespace System.SpanTests
 
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
             ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(a, 2, 0);
-            bool b = span.StartsWith(slice);
+            bool b = span.StartsWith<byte>(slice);
             Assert.True(b);
         }
 
@@ -24,7 +24,7 @@ namespace System.SpanTests
         {
             byte[] a = { 4, 5, 6 };
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
-            bool b = span.StartsWith(span);
+            bool b = span.StartsWith<byte>(span);
             Assert.True(b);
         }
 
@@ -34,7 +34,7 @@ namespace System.SpanTests
             byte[] a = { 4, 5, 6 };
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 0, 2);
             ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(a, 0, 3);
-            bool b = span.StartsWith(slice);
+            bool b = span.StartsWith<byte>(slice);
             Assert.False(b);
         }
 
@@ -44,7 +44,7 @@ namespace System.SpanTests
             byte[] a = { 4, 5, 6 };
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 0, 3);
             ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(a, 0, 2);
-            bool b = span.StartsWith(slice);
+            bool b = span.StartsWith<byte>(slice);
             Assert.True(b);
         }
 
@@ -55,7 +55,7 @@ namespace System.SpanTests
             byte[] b = { 4, 5, 6 };
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 0, 3);
             ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(b, 0, 3);
-            bool c = span.StartsWith(slice);
+            bool c = span.StartsWith<byte>(slice);
             Assert.True(c);
         }
 
@@ -77,7 +77,7 @@ namespace System.SpanTests
 
                     ReadOnlySpan<byte> firstSpan = new ReadOnlySpan<byte>(first);
                     ReadOnlySpan<byte> secondSpan = new ReadOnlySpan<byte>(second);
-                    bool b = firstSpan.StartsWith(secondSpan);
+                    bool b = firstSpan.StartsWith<byte>(secondSpan);
                     Assert.False(b);
                 }
             }
@@ -96,7 +96,7 @@ namespace System.SpanTests
                 second[length + 1] = 100;
                 ReadOnlySpan<byte> span1 = new ReadOnlySpan<byte>(first, 1, length);
                 ReadOnlySpan<byte> span2 = new ReadOnlySpan<byte>(second, 1, length);
-                bool b = span1.StartsWith(span2);
+                bool b = span1.StartsWith<byte>(span2);
                 Assert.True(b);
             }
         }

--- a/src/System.Memory/tests/Span/IndexOf.byte.cs
+++ b/src/System.Memory/tests/Span/IndexOf.byte.cs
@@ -14,7 +14,7 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOf_Byte()
         {
             Span<byte> sp = new Span<byte>(Array.Empty<byte>());
-            int idx = sp.IndexOf(0);
+            int idx = sp.IndexOf<byte>(0);
             Assert.Equal(-1, idx);
         }
 
@@ -29,7 +29,7 @@ namespace System.SpanTests
                 for (int i = 0; i < length; i++)
                 {
                     byte target0 = default(byte);
-                    int idx = span.IndexOf(target0);
+                    int idx = span.IndexOf<byte>(target0);
                     Assert.Equal(0, idx);
                 }
             }
@@ -50,7 +50,7 @@ namespace System.SpanTests
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
                 {
                     byte target = a[targetIndex];
-                    int idx = span.IndexOf(target);
+                    int idx = span.IndexOf<byte>(target);
                     Assert.Equal(targetIndex, idx);
                 }
             }
@@ -71,7 +71,7 @@ namespace System.SpanTests
                 }
                 Span<byte> span = new Span<byte>(a);
 
-                int idx = span.IndexOf(target);
+                int idx = span.IndexOf<byte>(target);
                 Assert.Equal(-1, idx);
             }
         }
@@ -83,11 +83,11 @@ namespace System.SpanTests
             for (var i = 0; i < Vector<byte>.Count; i++)
             {
                 var span = new Span<byte>(array, i, 3 * Vector<byte>.Count);
-                int idx = span.IndexOf((byte)'1');
+                int idx = span.IndexOf<byte>((byte)'1');
                 Assert.Equal(-1, idx);
 
                 span = new Span<byte>(array, i, 3 * Vector<byte>.Count - 3);
-                idx = span.IndexOf((byte)'1');
+                idx = span.IndexOf<byte>((byte)'1');
                 Assert.Equal(-1, idx);
             }
         }
@@ -103,11 +103,11 @@ namespace System.SpanTests
             for (var i = 0; i < Vector<byte>.Count; i++)
             {
                 var span = new Span<byte>(array, i, 3 * Vector<byte>.Count);
-                int idx = span.IndexOf(5);
+                int idx = span.IndexOf<byte>(5);
                 Assert.Equal(0, idx);
 
                 span = new Span<byte>(array, i, 3 * Vector<byte>.Count - 3);
-                idx = span.IndexOf(5);
+                idx = span.IndexOf<byte>(5);
                 Assert.Equal(0, idx);
             }
         }
@@ -128,7 +128,7 @@ namespace System.SpanTests
                 a[length - 2] = 200;
 
                 Span<byte> span = new Span<byte>(a);
-                int idx = span.IndexOf(200);
+                int idx = span.IndexOf<byte>(200);
                 Assert.Equal(length - 2, idx);
             }
         }
@@ -142,7 +142,7 @@ namespace System.SpanTests
                 a[0] = 99;
                 a[length + 1] = 99;
                 Span<byte> span = new Span<byte>(a, 1, length);
-                int index = span.IndexOf(99);
+                int index = span.IndexOf<byte>(99);
                 Assert.Equal(-1, index);
             }
         }
@@ -177,7 +177,7 @@ namespace System.SpanTests
             var index = -1;
             if (searchFor.Length == 1)
             {
-                index = span.IndexOf((byte)searchFor[0]);
+                index = span.IndexOf<byte>((byte)searchFor[0]);
             }
             else if (searchFor.Length == 2)
             {

--- a/src/System.Memory/tests/Span/IndexOfSequence.byte.cs
+++ b/src/System.Memory/tests/Span/IndexOfSequence.byte.cs
@@ -13,7 +13,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 5, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<byte> value = new Span<byte>(new byte[] { 5, 1, 77 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(0, index);
         }
 
@@ -22,7 +22,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 1, 2, 3, 1, 2, 3, 1, 2, 3 });
             Span<byte> value = new Span<byte>(new byte[] { 2, 3 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(1, index);
         }
 
@@ -31,7 +31,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<byte> value = new Span<byte>(new byte[] { 77, 77, 88 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(10, index);
         }
 
@@ -40,7 +40,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<byte> value = new Span<byte>(new byte[] { 77, 77, 88, 99 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(-1, index);
         }
 
@@ -49,7 +49,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<byte> value = new Span<byte>(new byte[] { 100, 77, 88, 99 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(-1, index);
         }
 
@@ -58,7 +58,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             Span<byte> value = new Span<byte>(new byte[] { 3, 4, 5 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(3, index);
         }
 
@@ -67,7 +67,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             Span<byte> value = new Span<byte>(new byte[] { 3, 4, 5 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(-1, index);
         }
 
@@ -77,7 +77,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<byte> value = new Span<byte>(Array.Empty<byte>());
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(0, index);
         }
 
@@ -86,7 +86,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(Array.Empty<byte>());
             Span<byte> value = new Span<byte>(new byte[] { 1, 2, 3 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(-1, index);
         }
 
@@ -96,7 +96,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             Span<byte> value = new Span<byte>(new byte[] { 2 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(2, index);
         }
 
@@ -106,7 +106,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             Span<byte> value = new Span<byte>(new byte[] { 5 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(5, index);
         }
 
@@ -116,7 +116,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             Span<byte> value = new Span<byte>(new byte[] { 5 });
-            int index = span.IndexOf(value);
+            int index = span.IndexOf<byte>(value);
             Assert.Equal(-1, index);
         }
     }

--- a/src/System.Memory/tests/Span/SequenceEqual.byte.cs
+++ b/src/System.Memory/tests/Span/SequenceEqual.byte.cs
@@ -15,7 +15,7 @@ namespace System.SpanTests
 
             Span<byte> first = new Span<byte>(a, 1, 0);
             Span<byte> second = new Span<byte>(a, 2, 0);
-            bool b = first.SequenceEqual(second);
+            bool b = first.SequenceEqual<byte>(second);
             Assert.True(b);
         }
 
@@ -24,7 +24,7 @@ namespace System.SpanTests
         {
             byte[] a = { 4, 5, 6 };
             Span<byte> span = new Span<byte>(a);
-            bool b = span.SequenceEqual(span);
+            bool b = span.SequenceEqual<byte>(span);
             Assert.True(b);
         }
 
@@ -33,7 +33,7 @@ namespace System.SpanTests
         {
             byte[] a = { 4, 5, 6 };
             Span<byte> first = new Span<byte>(a, 0, 3);
-            bool b = first.SequenceEqual(a);
+            bool b = first.SequenceEqual<byte>(a);
             Assert.True(b);
         }
 
@@ -45,7 +45,7 @@ namespace System.SpanTests
             var segment = new ArraySegment<byte>(dst, 1, 3);
 
             Span<byte> first = new Span<byte>(src, 0, 3);
-            bool b = first.SequenceEqual(segment);
+            bool b = first.SequenceEqual<byte>(segment);
             Assert.True(b);
         }
 
@@ -55,7 +55,7 @@ namespace System.SpanTests
             byte[] a = { 4, 5, 6 };
             Span<byte> first = new Span<byte>(a, 0, 3);
             Span<byte> second = new Span<byte>(a, 0, 2);
-            bool b = first.SequenceEqual(second);
+            bool b = first.SequenceEqual<byte>(second);
             Assert.False(b);
         }
 
@@ -77,7 +77,7 @@ namespace System.SpanTests
 
                     Span<byte> firstSpan = new Span<byte>(first);
                     ReadOnlySpan<byte> secondSpan = new ReadOnlySpan<byte>(second);
-                    bool b = firstSpan.SequenceEqual(secondSpan);
+                    bool b = firstSpan.SequenceEqual<byte>(secondSpan);
                     Assert.False(b);
                 }
             }
@@ -96,7 +96,7 @@ namespace System.SpanTests
                 second[length + 1] = 100;
                 Span<byte> span1 = new Span<byte>(first, 1, length);
                 ReadOnlySpan<byte> span2 = new ReadOnlySpan<byte>(second, 1, length);
-                bool b = span1.SequenceEqual(span2);
+                bool b = span1.SequenceEqual<byte>(span2);
                 Assert.True(b);
             }
         }

--- a/src/System.Memory/tests/Span/StartsWith.byte.cs
+++ b/src/System.Memory/tests/Span/StartsWith.byte.cs
@@ -15,7 +15,7 @@ namespace System.SpanTests
 
             Span<byte> span = new Span<byte>(a);
             ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(a, 2, 0);
-            bool b = span.StartsWith(slice);
+            bool b = span.StartsWith<byte>(slice);
             Assert.True(b);
         }
 
@@ -24,7 +24,7 @@ namespace System.SpanTests
         {
             byte[] a = { 4, 5, 6 };
             Span<byte> span = new Span<byte>(a);
-            bool b = span.StartsWith(span);
+            bool b = span.StartsWith<byte>(span);
             Assert.True(b);
         }
 
@@ -34,7 +34,7 @@ namespace System.SpanTests
             byte[] a = { 4, 5, 6 };
             Span<byte> span = new Span<byte>(a, 0, 2);
             ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(a, 0, 3);
-            bool b = span.StartsWith(slice);
+            bool b = span.StartsWith<byte>(slice);
             Assert.False(b);
         }
 
@@ -44,7 +44,7 @@ namespace System.SpanTests
             byte[] a = { 4, 5, 6 };
             Span<byte> span = new Span<byte>(a, 0, 3);
             ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(a, 0, 2);
-            bool b = span.StartsWith(slice);
+            bool b = span.StartsWith<byte>(slice);
             Assert.True(b);
         }
 
@@ -55,7 +55,7 @@ namespace System.SpanTests
             byte[] b = { 4, 5, 6 };
             Span<byte> span = new Span<byte>(a, 0, 3);
             ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(b, 0, 3);
-            bool c = span.StartsWith(slice);
+            bool c = span.StartsWith<byte>(slice);
             Assert.True(c);
         }
 
@@ -77,7 +77,7 @@ namespace System.SpanTests
 
                     Span<byte> firstSpan = new Span<byte>(first);
                     ReadOnlySpan<byte> secondSpan = new ReadOnlySpan<byte>(second);
-                    bool b = firstSpan.StartsWith(secondSpan);
+                    bool b = firstSpan.StartsWith<byte>(secondSpan);
                     Assert.False(b);
                 }
             }
@@ -96,7 +96,7 @@ namespace System.SpanTests
                 second[length + 1] = 100;
                 Span<byte> span1 = new Span<byte>(first, 1, length);
                 ReadOnlySpan<byte> span2 = new ReadOnlySpan<byte>(second, 1, length);
-                bool b = span1.StartsWith(span2);
+                bool b = span1.StartsWith<byte>(span2);
                 Assert.True(b);
             }
         }


### PR DESCRIPTION
From https://github.com/dotnet/corefx/issues/24840#issuecomment-339074798 and related to https://github.com/dotnet/corefx/issues/24839.
> We should consider removing the `Span<byte>` as we believe we can specialize the implementation without performance loss.
- No longer exposing Span\<byte\> specific methods. Just adding a type check within the generic methods and routing to the faster implementation when `typeof(T) == typeof(byte)`.

**There is no performance regression. For example, here is the comparison for StartsWith for Span\<byte\>:**

![image](https://user-images.githubusercontent.com/6527137/32084977-4a4d0eb2-ba81-11e7-856d-e98936bbae9f.png)

- Also removing the struct constraint on \<T\> for IndexOf, StartsWith, SequenceEqual. I am not sure why we had those constraints to begin with.

cc @KrzysztofCwalina, @jkotas, @stephentoub, @eerhardt, @benaadams, @dotnet/corefxlab-contrib 
