### PR TITLE
WIP: Move OpenCommPort to api set

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -30,6 +30,5 @@ internal static partial class Interop
         internal const string WinHttp = "winhttp.dll";
         internal const string Ws2_32 = "ws2_32.dll";
         internal const string Zlib = "clrcompression.dll";
-
     }
 }

--- a/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -8,12 +8,12 @@ internal static partial class Interop
     {
         internal const string Advapi32 = "advapi32.dll";
         internal const string BCrypt = "BCrypt.dll";
+        internal const string CoreComm_L1_1_1 = "api-ms-win-core-comm-l1-1-1.dll";
         internal const string Crypt32 = "crypt32.dll";
         internal const string Error_L1 = "api-ms-win-core-winrt-error-l1-1-0.dll";
         internal const string HttpApi = "httpapi.dll";
         internal const string IpHlpApi = "iphlpapi.dll";
         internal const string Kernel32 = "kernel32.dll";
-        internal const string KernelBase = "kernelbase.dll";
         internal const string Memory_L1_3 = "api-ms-win-core-memory-l1-1-3.dll";
         internal const string Mswsock = "mswsock.dll";
         internal const string NCrypt = "ncrypt.dll";
@@ -30,5 +30,6 @@ internal static partial class Interop
         internal const string WinHttp = "winhttp.dll";
         internal const string Ws2_32 = "ws2_32.dll";
         internal const string Zlib = "clrcompression.dll";
+
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.OpenCommPort.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.OpenCommPort.cs
@@ -9,9 +9,9 @@ using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
-    internal partial class KernelBase
+    internal partial class mincore
     {
-        [DllImport(Libraries.KernelBase, SetLastError = true)]
+        [DllImport(Libraries.CoreComm_L1_1_1, SetLastError = true)]
         internal static extern SafeFileHandle OpenCommPort(
              uint uPortNumber,
              int dwDesiredAccess,

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -112,8 +112,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FileTypes.cs">
       <Link>Common\Interop\Windows\Interop.FileTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernelbase\Interop.OpenCommPort.cs">
-      <Link>Common\Interop\Windows\kernelbase\Interop.OpenCommPort.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.OpenCommPort.cs">
+      <Link>Common\Interop\Windows\mincore\Interop.OpenCommPort.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
       <Link>Common\System\IO\PathInternal.Windows.cs</Link>

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -112,9 +112,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FileTypes.cs">
       <Link>Common\Interop\Windows\Interop.FileTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.OpenCommPort.cs">
-      <Link>Common\Interop\Windows\mincore\Interop.OpenCommPort.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
       <Link>Common\System\IO\PathInternal.Windows.cs</Link>
     </Compile>
@@ -137,6 +134,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.OpenCommPort.cs">
+      <Link>Common\Interop\Windows\mincore\Interop.OpenCommPort.cs</Link>
+    </Compile>
     <Compile Include="System\IO\Ports\SerialPort.Uap.cs" />
     <Compile Include="System\IO\Ports\SerialStream.Uap.cs" />
   </ItemGroup>

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Uap.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Uap.cs
@@ -10,7 +10,7 @@ namespace System.IO.Ports
     {
         public SafeFileHandle OpenPort(uint portNumber)
         {
-            return Interop.KernelBase.OpenCommPort(
+            return Interop.mincore.OpenCommPort(
                 portNumber,
                 Interop.Kernel32.GenericOperations.GENERIC_READ | Interop.Kernel32.GenericOperations.GENERIC_WRITE,
                 NativeMethods.FILE_FLAG_OVERLAPPED);


### PR DESCRIPTION
It will fail until changes in buildtools (https://github.com/dotnet/buildtools/pull/1766) reach corefx.