### PR TITLE
Remove dead code from System.Private.DataContractSerialization

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -373,9 +432,6 @@
   <data name="ObjectTableOverflow" xml:space="preserve">
     <value>An internal error has occurred. Object table overflow. This could be caused by serializing or deserializing extremely large object graphs.</value>
   </data>
-  <data name="OrderCannotBeNegative" xml:space="preserve">
-    <value>Property 'Order' in DataMemberAttribute attribute cannot be a negative number.</value>
-  </data>
   <data name="ParameterCountMismatch" xml:space="preserve">
     <value>Invalid number of parameters to call method '{0}'. Expected '{1}' parameters, but '{2}' were provided.</value>
   </data>
@@ -733,9 +789,6 @@
   <data name="XmlMaxBytesPerReadExceeded" xml:space="preserve">
     <value>The 'maximum bytes per Read operation' quota ({0}) has been exceeded while reading XML data. Long element start tags (consisting of the element name, attribute names and attribute values) may trigger this quota. This quota may be increased by changing the MaxBytesPerRead property on the XmlDictionaryReaderQuotas object used when creating the XML reader.</value>
   </data>
-  <data name="XmlMaxNameTableCharCountExceeded" xml:space="preserve">
-    <value>The maximum nametable character count quota ({0}) has been exceeded while reading XML data. The nametable is a data structure used to store strings encountered during XML processing - long XML documents with non-repeating element names, attribute names and attribute values may trigger this quota. This quota may be increased by changing the MaxNameTableCharCount property on the XmlDictionaryReaderQuotas object used when creating the XML reader.</value>
-  </data>
   <data name="XmlMaxDepthExceeded" xml:space="preserve">
     <value>The maximum read depth ({0}) has been exceeded because XML data being read has more levels of nesting than is allowed by the quota. This quota may be increased by changing the MaxDepth property on the XmlDictionaryReaderQuotas object used when creating the XML reader.</value>
   </data>
@@ -850,25 +903,25 @@
   <data name="GenericCallbackException" xml:space="preserve">
     <value>A user callback threw an exception.  Check the exception stack and inner exception to determine the callback that failed.</value>
   </data>
-    <data name="JsonEncounteredUnexpectedCharacter" xml:space="preserve">
+  <data name="JsonEncounteredUnexpectedCharacter" xml:space="preserve">
     <value>Encountered unexpected character '{0}'.</value>
   </data>
-    <data name="JsonOffsetExceedsBufferSize" xml:space="preserve">
+  <data name="JsonOffsetExceedsBufferSize" xml:space="preserve">
     <value>The specified offset exceeds the buffer size ({0} bytes).</value>
   </data>
-    <data name="JsonSizeExceedsRemainingBufferSpace" xml:space="preserve">
+  <data name="JsonSizeExceedsRemainingBufferSpace" xml:space="preserve">
     <value>The specified size exceeds the remaining buffer space ('{0}' bytes).</value>
   </data>
-    <data name="InvalidCharacterEncountered" xml:space="preserve">
+  <data name="InvalidCharacterEncountered" xml:space="preserve">
     <value>Encountered invalid character '{0}'.</value>
   </data>
-    <data name="JsonInvalidFFFE" xml:space="preserve">
+  <data name="JsonInvalidFFFE" xml:space="preserve">
     <value>Characters with hexadecimal values 0xFFFE and 0xFFFF are not valid.</value>
   </data>
-    <data name="JsonDateTimeOutOfRange" xml:space="preserve">
+  <data name="JsonDateTimeOutOfRange" xml:space="preserve">
     <value>DateTime values that are greater than DateTime.MaxValue or smaller than DateTime.MinValue when converted to UTC cannot be serialized to JSON.</value>
   </data>
-    <data name="JsonWriteArrayNotSupported" xml:space="preserve">
+  <data name="JsonWriteArrayNotSupported" xml:space="preserve">
     <value>To write JSON arrays, use XML writer methods to write the attribute type='array' followed by methods like WriteStartElement (with the local name 'item'), WriteAttributeString, and WriteEndElement to write the JSON array items.</value>
   </data>
   <data name="JsonMethodNotSupported" xml:space="preserve">
@@ -889,7 +942,7 @@
   <data name="JsonMustSpecifyDataType" xml:space="preserve">
     <value>You must write an attribute '{0}'='{1}' after writing the attribute with local name '{2}'.</value>
   </data>
-    <data name="JsonXmlProcessingInstructionNotSupported" xml:space="preserve">
+  <data name="JsonXmlProcessingInstructionNotSupported" xml:space="preserve">
     <value>Processing instructions (other than the XML declaration) are not supported.</value>
   </data>
   <data name="JsonXmlInvalidDeclaration" xml:space="preserve">
@@ -993,7 +1046,7 @@
   </data>
   <data name="FactoryObjectContainsSelfReference" xml:space="preserve">
     <value>Object graph of type '{0}' with Id '{2}' contains a reference to itself. The object has been replaced with a new object of type '{1}' either because it implements IObjectReference or because it is surrogated. The serializer does not support fixing up the nested reference to the new object and cannot deserialize this object. Consider changing the object to remove the nested self-reference.</value>
-  </data>  
+  </data>
   <data name="RecursiveCollectionType" xml:space="preserve">
     <value>Type '{0}' is a recursive collection data contract which is not supported. Consider modifying the definition of collection '{0}' to remove references to itself.</value>
   </data>
@@ -1005,30 +1058,6 @@
   </data>
   <data name="DupTypeContractInDataContractSet" xml:space="preserve">
     <value>DataContract for type '{0}' cannot be added to DataContractSet since type '{1}' with the same data contract name '{2}' in namespace '{3}' is already present and the contracts are not equivalent.</value>
-  </data>
-  <data name="ReferencedTypesCannotContainNull" xml:space="preserve">
-    <value>ReferencedTypes specified via ImportOptions must contain valid types. Cannot contain null.</value>
-  </data>
-  <data name="ReferencedCollectionTypesCannotContainNull" xml:space="preserve">
-    <value>ReferencedCollectionTypes specified via ImportOptions must contain valid types. Cannot contain null.</value>
-  </data>
-  <data name="ReferencedTypeMatchingMessage" xml:space="preserve">
-    <value>(matching)</value>
-  </data>
-  <data name="ReferencedTypeNotMatchingMessage" xml:space="preserve">
-    <value>(not matching)</value>
-  </data>
-  <data name="AmbiguousReferencedTypes1" xml:space="preserve">
-    <value>List of referenced types contains more than one type with same data contract name. Need to exclude all but one of the following types. Only matching types can be valid references: {0}</value>
-  </data>
-  <data name="AmbiguousReferencedTypes3" xml:space="preserve">
-    <value>List of referenced types contains more than one type with data contract name '{0}' in namespace '{1}'. Need to exclude all but one of the following types. Only matching types can be valid references: {2}</value>
-  </data>
-  <data name="AmbiguousReferencedCollectionTypes1" xml:space="preserve">
-    <value>List of referenced collection types contains more than one type with same data contract name. Include only one of the following types. Only matching types can be valid references: {0}</value>
-  </data>
-  <data name="AmbiguousReferencedCollectionTypes3" xml:space="preserve">
-    <value>List of referenced collection types contains more than one type with data contract name '{0}' in namespace '{1}'. Include only one of the following types. Only matching types can be valid references: {2}</value>
   </data>
   <data name="GenericTypeNotExportable" xml:space="preserve">
     <value>Type '{0}' cannot be exported as a schema type because it is an open generic type. You can only export a generic type if all its generic parameter types are actual types.</value>
@@ -1098,7 +1127,7 @@
   </data>
   <data name="PlatformNotSupported_NetDataContractSerializer" xml:space="preserve">
     <value>System.Runtime.Serialization.NetDataContractSerializer is not supported on this platform.</value>
-  </data>  
+  </data>
   <data name="PlatformNotSupported_IDataContractSurrogate" xml:space="preserve">
     <value>The implementation of the function requires System.Runtime.Serialization.IDataContractSurrogate which is not supported on this platform.</value>
   </data>

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -97,7 +97,7 @@ namespace System.Runtime.Serialization
 
 #if uapaot
         // This method returns adapter types used to get DataContract from
-        // generated assembly.
+        // generated assembly. 
         private static Type GetDataContractAdapterTypeForGeneratedAssembly(Type type)
         {
             if (type == Globals.TypeOfDateTimeOffset)
@@ -1233,6 +1233,11 @@ namespace System.Runtime.Serialization
             {
                 get { return _ns; }
                 set { _ns = value; }
+            }
+
+            internal virtual bool CanContainReferences
+            {
+                get { return true; }
             }
 
             internal virtual bool IsPrimitive

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -97,7 +97,7 @@ namespace System.Runtime.Serialization
 
 #if uapaot
         // This method returns adapter types used to get DataContract from
-        // generated assembly. 
+        // generated assembly.
         private static Type GetDataContractAdapterTypeForGeneratedAssembly(Type type)
         {
             if (type == Globals.TypeOfDateTimeOffset)
@@ -1233,11 +1233,6 @@ namespace System.Runtime.Serialization
             {
                 get { return _ns; }
                 set { _ns = value; }
-            }
-
-            internal virtual bool CanContainReferences
-            {
-                get { return true; }
             }
 
             internal virtual bool IsPrimitive

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataMember.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataMember.cs
@@ -31,11 +31,6 @@ namespace System.Runtime.Serialization
             _helper = new CriticalHelper(memberInfo);
         }
 
-        internal DataMember(DataContract memberTypeContract, string name, bool isNullable, bool isRequired, bool emitDefaultValue, int order)
-        {
-            _helper = new CriticalHelper(memberTypeContract, name, isNullable, isRequired, emitDefaultValue, order);
-        }
-
         internal MemberInfo MemberInfo
         {
             get
@@ -64,7 +59,7 @@ namespace System.Runtime.Serialization
         {
             get
             { return _helper.IsRequired; }
-            
+
             set
             { _helper.IsRequired = value; }
         }
@@ -73,7 +68,7 @@ namespace System.Runtime.Serialization
         {
             get
             { return _helper.EmitDefaultValue; }
-            
+
             set
             { _helper.EmitDefaultValue = value; }
         }
@@ -184,16 +179,6 @@ namespace System.Runtime.Serialization
             {
                 _emitDefaultValue = Globals.DefaultEmitDefaultValue;
                 _memberInfo = memberInfo;
-            }
-
-            internal CriticalHelper(DataContract memberTypeContract, string name, bool isNullable, bool isRequired, bool emitDefaultValue, int order)
-            {
-                this.MemberTypeContract = memberTypeContract;
-                this.Name = name;
-                this.IsNullable = isNullable;
-                this.IsRequired = isRequired;
-                this.EmitDefaultValue = emitDefaultValue;
-                this.Order = order;
             }
 
             internal MemberInfo MemberInfo

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DiagnosticUtility.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DiagnosticUtility.cs
@@ -73,11 +73,6 @@ namespace System.Runtime.Serialization
                 return new ArgumentException(message);
             }
 
-            public static Exception ThrowHelperArgument(string paramName, string message)
-            {
-                return new ArgumentException(message, paramName);
-            }
-
             internal static Exception ThrowHelperFatal(string message, Exception innerException)
             {
                 return ThrowHelperError(new Exception(message, innerException));

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
@@ -41,7 +41,6 @@ namespace System.Runtime.Serialization
         private XmlNodeReader _xmlNodeReader;
 #pragma warning restore 0649
 
-        private Queue<IDataNode> _deserializedDataNodes;
         private XmlObjectSerializerReadContext _context;
 
         private static Dictionary<string, string> s_nsToPrefixTable;
@@ -63,29 +62,11 @@ namespace System.Runtime.Serialization
             _context = context;
         }
 
-        internal void SetDeserializedValue(object obj)
-        {
-            IDataNode deserializedDataNode = (_deserializedDataNodes == null || _deserializedDataNodes.Count == 0) ? null : _deserializedDataNodes.Dequeue();
-            if (deserializedDataNode != null && !(obj is IDataNode))
-            {
-                deserializedDataNode.Value = obj;
-                deserializedDataNode.IsFinalValue = true;
-            }
-        }
-
         internal IDataNode GetCurrentNode()
         {
             IDataNode retVal = _element.dataNode;
             Skip();
             return retVal;
-        }
-
-        internal void SetDataNode(IDataNode dataNode, string name, string ns)
-        {
-            SetNextElement(dataNode, name, ns, null);
-            _element = _nextElement;
-            _nextElement = null;
-            SetElement();
         }
 
         internal void Reset()
@@ -100,7 +81,6 @@ namespace System.Runtime.Serialization
             _element = null;
             _nextElement = null;
             _elements = null;
-            _deserializedDataNodes = null;
         }
 
         private bool IsXmlDataNode { get { return (_internalNodeType == ExtensionDataNodeType.Xml); } }
@@ -447,11 +427,6 @@ namespace System.Runtime.Serialization
         }
 
         private void MoveNext(IDataNode dataNode)
-        {
-            throw NotImplemented.ByDesign;
-        }
-
-        private void SetNextElement(IDataNode node, string name, string ns, string prefix)
         {
             throw NotImplemented.ByDesign;
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -759,17 +759,6 @@ namespace System.Runtime.Serialization
             }
         }
 
-        private static Type s_typeOfListGeneric;
-        internal static Type TypeOfListGeneric
-        {
-            get
-            {
-                if (s_typeOfListGeneric == null)
-                    s_typeOfListGeneric = typeof(List<>);
-                return s_typeOfListGeneric;
-            }
-        }
-
         private static Type s_typeOfXmlElement;
         internal static Type TypeOfXmlElement
         {
@@ -855,8 +844,6 @@ namespace System.Runtime.Serialization
         #endregion
 
         private static Type s_typeOfScriptObject;
-        private static Func<object, string> s_serializeFunc;
-        private static Func<string, object> s_deserializeFunc;
 
         internal static ClassDataContract CreateScriptObjectClassDataContract()
         {
@@ -867,25 +854,6 @@ namespace System.Runtime.Serialization
         internal static bool TypeOfScriptObject_IsAssignableFrom(Type type)
         {
             return s_typeOfScriptObject != null && s_typeOfScriptObject.IsAssignableFrom(type);
-        }
-
-        internal static void SetScriptObjectJsonSerializer(Type typeOfScriptObject, Func<object, string> serializeFunc, Func<string, object> deserializeFunc)
-        {
-            Globals.s_typeOfScriptObject = typeOfScriptObject;
-            Globals.s_serializeFunc = serializeFunc;
-            Globals.s_deserializeFunc = deserializeFunc;
-        }
-
-        internal static string ScriptObjectJsonSerialize(object obj)
-        {
-            Debug.Assert(s_serializeFunc != null);
-            return Globals.s_serializeFunc(obj);
-        }
-
-        internal static object ScriptObjectJsonDeserialize(string json)
-        {
-            Debug.Assert(s_deserializeFunc != null);
-            return Globals.s_deserializeFunc(json);
         }
 
         public const bool DefaultIsRequired = false;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
@@ -106,8 +106,8 @@ namespace System.Runtime.Serialization.Json
                 if (this.knownDataContracts == null && this.knownTypeList != null)
                 {
                     // This assignment may be performed concurrently and thus is a race condition.
-                    // It's safe, however, because at worse a new (and identical) dictionary of 
-                    // data contracts will be created and re-assigned to this field.  Introduction 
+                    // It's safe, however, because at worse a new (and identical) dictionary of
+                    // data contracts will be created and re-assigned to this field.  Introduction
                     // of a lock here could lead to deadlocks.
                     this.knownDataContracts = XmlObjectSerializerContext.GetDataContractsForKnownTypes(this.knownTypeList);
                 }
@@ -118,13 +118,6 @@ namespace System.Runtime.Serialization.Json
         public int MaxItemsInObjectGraph
         {
             get { return _maxItemsInObjectGraph; }
-        }
-        internal bool AlwaysEmitTypeInformation
-        {
-            get
-            {
-                return _emitTypeInformation == EmitTypeInformation.Always;
-            }
         }
 
         public DateTimeFormat DateTimeFormat
@@ -527,7 +520,7 @@ namespace System.Runtime.Serialization.Json
         {
         }
 
-        internal DataContractJsonSerializerImpl(Type type, 
+        internal DataContractJsonSerializerImpl(Type type,
             XmlDictionaryString rootName,
             IEnumerable<Type> knownTypes,
             int maxItemsInObjectGraph,
@@ -576,8 +569,8 @@ namespace System.Runtime.Serialization.Json
                 if (this.knownDataContracts == null && this.knownTypeList != null)
                 {
                     // This assignment may be performed concurrently and thus is a race condition.
-                    // It's safe, however, because at worse a new (and identical) dictionary of 
-                    // data contracts will be created and re-assigned to this field.  Introduction 
+                    // It's safe, however, because at worse a new (and identical) dictionary of
+                    // data contracts will be created and re-assigned to this field.  Introduction
                     // of a lock here could lead to deadlocks.
                     this.knownDataContracts = XmlObjectSerializerContext.GetDataContractsForKnownTypes(this.knownTypeList);
                 }
@@ -705,7 +698,7 @@ namespace System.Runtime.Serialization.Json
         public override void WriteObject(Stream stream, object graph)
         {
             CheckNull(stream, nameof(stream));
-            XmlDictionaryWriter jsonWriter = JsonReaderWriterFactory.CreateJsonWriter(stream, Encoding.UTF8, false); //  ownsStream 
+            XmlDictionaryWriter jsonWriter = JsonReaderWriterFactory.CreateJsonWriter(stream, Encoding.UTF8, false); //  ownsStream
             WriteObject(jsonWriter, graph);
             jsonWriter.Flush();
         }
@@ -804,7 +797,7 @@ namespace System.Runtime.Serialization.Json
 
         internal static void WriteJsonNull(XmlWriterDelegator writer)
         {
-            writer.WriteAttributeString(null, JsonGlobals.typeString, null, JsonGlobals.nullString); //  prefix //  namespace 
+            writer.WriteAttributeString(null, JsonGlobals.typeString, null, JsonGlobals.nullString); //  prefix //  namespace
         }
 
         internal static void WriteJsonValue(JsonDataContract contract, XmlWriterDelegator writer, object graph, XmlObjectSerializerWriteContextComplexJson context, RuntimeTypeHandle declaredTypeHandle)
@@ -900,12 +893,12 @@ namespace System.Runtime.Serialization.Json
                     if (contract.CanContainReferences)
                     {
                         XmlObjectSerializerWriteContextComplexJson context = XmlObjectSerializerWriteContextComplexJson.CreateContext(this, contract);
-                        context.OnHandleReference(writer, graph, true); //  canContainReferences 
+                        context.OnHandleReference(writer, graph, true); //  canContainReferences
                         context.SerializeWithoutXsiType(contract, writer, graph, declaredType.TypeHandle);
                     }
                     else
                     {
-                        DataContractJsonSerializerImpl.WriteJsonValue(JsonDataContract.GetJsonDataContract(contract), writer, graph, null, declaredType.TypeHandle); //  XmlObjectSerializerWriteContextComplexJson 
+                        DataContractJsonSerializerImpl.WriteJsonValue(JsonDataContract.GetJsonDataContract(contract), writer, graph, null, declaredType.TypeHandle); //  XmlObjectSerializerWriteContextComplexJson
                     }
                 }
                 else
@@ -914,7 +907,7 @@ namespace System.Runtime.Serialization.Json
                     contract = DataContractJsonSerializerImpl.GetDataContract(contract, declaredType, graphType);
                     if (contract.CanContainReferences)
                     {
-                        context.OnHandleReference(writer, graph, true); //  canContainCyclicReference 
+                        context.OnHandleReference(writer, graph, true); //  canContainCyclicReference
                         context.SerializeWithXsiTypeAtTopLevel(contract, writer, graph, declaredType.TypeHandle, graphType);
                     }
                     else

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaHelper.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaHelper.cs
@@ -10,24 +10,6 @@ using System.Collections.Generic;
 
 namespace System.Runtime.Serialization
 {
-    using SchemaObjectDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, SchemaObjectInfo>;
-
-    internal class SchemaObjectInfo
-    {
-        internal XmlSchemaType type;
-        internal XmlSchemaElement element;
-        internal XmlSchema schema;
-        internal List<XmlSchemaType> knownTypes;
-
-        internal SchemaObjectInfo(XmlSchemaType type, XmlSchemaElement element, XmlSchema schema, List<XmlSchemaType> knownTypes)
-        {
-            this.type = type;
-            this.element = element;
-            this.schema = schema;
-            this.knownTypes = knownTypes;
-        }
-    }
-
     internal static class SchemaHelper
     {
 
@@ -62,36 +44,6 @@ namespace System.Runtime.Serialization
             return null;
         }
 
-        internal static XmlSchemaType GetSchemaType(SchemaObjectDictionary schemaInfo, XmlQualifiedName typeName)
-        {
-            SchemaObjectInfo schemaObjectInfo;
-            if (schemaInfo.TryGetValue(typeName, out schemaObjectInfo))
-            {
-                return schemaObjectInfo.type;
-            }
-            return null;
-        }
-
-        internal static XmlSchema GetSchemaWithType(SchemaObjectDictionary schemaInfo, XmlSchemaSet schemas, XmlQualifiedName typeName)
-        {
-            SchemaObjectInfo schemaObjectInfo;
-            if (schemaInfo.TryGetValue(typeName, out schemaObjectInfo))
-            {
-                if (schemaObjectInfo.schema != null)
-                    return schemaObjectInfo.schema;
-            }
-            ICollection currentSchemas = schemas.Schemas();
-            string ns = typeName.Namespace;
-            foreach (XmlSchema schema in currentSchemas)
-            {
-                if (NamespacesEqual(ns, schema.TargetNamespace))
-                {
-                    return schema;
-                }
-            }
-            return null;
-        }
-
         internal static XmlSchemaElement GetSchemaElement(XmlSchemaSet schemas, XmlQualifiedName elementQName, out XmlSchema outSchema)
         {
             outSchema = null;
@@ -111,16 +63,6 @@ namespace System.Runtime.Serialization
                         }
                     }
                 }
-            }
-            return null;
-        }
-
-        internal static XmlSchemaElement GetSchemaElement(SchemaObjectDictionary schemaInfo, XmlQualifiedName elementName)
-        {
-            SchemaObjectInfo schemaObjectInfo;
-            if (schemaInfo.TryGetValue(elementName, out schemaObjectInfo))
-            {
-                return schemaObjectInfo.element;
             }
             return null;
         }
@@ -183,51 +125,5 @@ namespace System.Runtime.Serialization
                 import.Namespace = ns;
             schema.Includes.Add(import);
         }
-
-        internal static XmlSchema GetSchemaWithGlobalElementDeclaration(XmlSchemaElement element, XmlSchemaSet schemas)
-        {
-            ICollection currentSchemas = schemas.Schemas();
-            foreach (XmlSchema schema in currentSchemas)
-            {
-                foreach (XmlSchemaObject schemaObject in schema.Items)
-                {
-                    XmlSchemaElement schemaElement = schemaObject as XmlSchemaElement;
-                    if (schemaElement == null)
-                        continue;
-
-                    if (schemaElement == element)
-                    {
-                        return schema;
-                    }
-                }
-            }
-            return null;
-        }
-
-        internal static XmlQualifiedName GetGlobalElementDeclaration(XmlSchemaSet schemas, XmlQualifiedName typeQName, out bool isNullable)
-        {
-            ICollection currentSchemas = schemas.Schemas();
-            string ns = typeQName.Namespace;
-            if (ns == null)
-                ns = string.Empty;
-            isNullable = false;
-            foreach (XmlSchema schema in currentSchemas)
-            {
-                foreach (XmlSchemaObject schemaObject in schema.Items)
-                {
-                    XmlSchemaElement schemaElement = schemaObject as XmlSchemaElement;
-                    if (schemaElement == null)
-                        continue;
-
-                    if (schemaElement.SchemaTypeName.Equals(typeQName))
-                    {
-                        isNullable = schemaElement.IsNillable;
-                        return new XmlQualifiedName(schemaElement.Name, schema.TargetNamespace);
-                    }
-                }
-            }
-            return null;
-        }
-
     }
 }

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
@@ -1836,7 +1836,6 @@ namespace System.Xml
             private int _attributeCount;
             private XmlSpace _space;
             private string _lang;
-            private int _namespaceBoundary;
             private int _nsTop;
             private Namespace _defaultNamespace;
 
@@ -1879,26 +1878,6 @@ namespace System.Xml
                 _space = XmlSpace.None;
                 _lang = null;
                 _lastNameSpace = null;
-                _namespaceBoundary = 0;
-            }
-
-            public int NamespaceBoundary
-            {
-                get
-                {
-                    return _namespaceBoundary;
-                }
-                set
-                {
-                    int i;
-                    for (i = 0; i < _nsCount; i++)
-                        if (_namespaces[i].Depth >= value)
-                            break;
-
-                    _nsTop = i;
-                    _namespaceBoundary = value;
-                    _lastNameSpace = null;
-                }
             }
 
             public void Close()

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
@@ -824,13 +824,6 @@ namespace System.Xml
             return _nsMgr.LookupPrefix(ns);
         }
 
-        internal string LookupNamespace(string prefix)
-        {
-            if (prefix == null)
-                return null;
-            return _nsMgr.LookupNamespace(prefix);
-        }
-
         private string GetQualifiedNamePrefix(string namespaceUri, XmlDictionaryString xNs)
         {
             string prefix = _nsMgr.LookupPrefix(namespaceUri);
@@ -921,7 +914,7 @@ namespace System.Xml
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.XmlInvalidDeclaration)));
 
             // The only thing the text can legitimately contain is version, encoding, and standalone.
-            // We only support version 1.0, we can only write whatever encoding we were supplied, 
+            // We only support version 1.0, we can only write whatever encoding we were supplied,
             // and we don't support DTDs, so whatever values are supplied in the text argument are irrelevant.
             _writer.WriteDeclaration();
         }
@@ -950,18 +943,6 @@ namespace System.Xml
             FinishDocument();
             _writeState = WriteState.Start;
             _documentState = DocumentState.End;
-        }
-
-        protected int NamespaceBoundary
-        {
-            get
-            {
-                return _nsMgr.NamespaceBoundary;
-            }
-            set
-            {
-                _nsMgr.NamespaceBoundary = value;
-            }
         }
 
         public override void WriteEntityRef(string name)

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -676,13 +676,6 @@ namespace System.Xml
             return new string(chars, 0, charCount);
         }
 
-        public string GetEscapedString(int offset, int length, XmlNameTable nameTable)
-        {
-            char[] chars = GetCharBuffer(length);
-            int charCount = GetEscapedChars(offset, length, chars);
-            return nameTable.Add(chars, 0, charCount);
-        }
-
         private int GetLessThanCharEntity(int offset, int length)
         {
             byte[] buffer = _buffer;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlExceptionHelper.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlExceptionHelper.cs
@@ -132,11 +132,6 @@ namespace System.Xml
             ThrowXmlException(reader, SR.XmlMaxBytesPerReadExceeded, maxBytesPerRead.ToString(NumberFormatInfo.CurrentInfo));
         }
 
-        public static void ThrowMaxNameTableCharCountExceeded(XmlDictionaryReader reader, int maxNameTableCharCount)
-        {
-            ThrowXmlException(reader, SR.XmlMaxNameTableCharCountExceeded, maxNameTableCharCount.ToString(NumberFormatInfo.CurrentInfo));
-        }
-
         public static void ThrowMaxDepthExceeded(XmlDictionaryReader reader, int maxDepth)
         {
             ThrowXmlException(reader, SR.XmlMaxDepthExceeded, maxDepth.ToString());

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
@@ -33,19 +33,6 @@ namespace System.Xml
             _encoding = encoding;
         }
 
-        // Getting/Setting the Stream exists for fragmenting
-        public Stream Stream
-        {
-            get
-            {
-                return _stream;
-            }
-            set
-            {
-                _stream = value;
-            }
-        }
-
         // StreamBuffer/BufferOffset exists only for the BinaryWriter to fix up nodes
         public byte[] StreamBuffer
         {

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
@@ -115,14 +115,6 @@ namespace System.Xml
             _inAttribute = false;
         }
 
-        public Encoding Encoding
-        {
-            get
-            {
-                return _encoding;
-            }
-        }
-
         private byte[] GetCharEntityBuffer()
         {
             if (_entityChars == null)


### PR DESCRIPTION
PR addresses issue #17905, project **System.Private.DataContractSerialization**.

**Notes**

Some of the red issues in [diff file](http://tempcoverage.blob.core.windows.net/report2/System.Private.DataContractSerialization.diff.html) are already used somewhere, so they were not deleted. For example `Write*` methods in `XmlNodeWriter`, which take `byte[]` as first argument.

Some of the issues are used in conditional compilation, so I did not remove them: `IDataNode`, `NMTOKENSDataContract`, `JsonReadWriteDelegates`, `XmlFormatGeneratorStatics`.

I deleted `NamespaceManager.NamespaceBoundary` property because it is not used anywhere. But it sets `_nsTop` field. This field is used in some `for` loops, but now it is never set, so its value is always 0. So maybe here somebody with greater understanding shoud decide what to do with it.