### PR TITLE
EventLog tests enabled on windows 7

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -141,7 +141,6 @@ namespace System.Diagnostics.Tests
                             eventLog.Clear();
                         }
                     }
-
                 }
             }
             finally

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -22,17 +22,17 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry("Further Testing"));
+                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
+                    Helpers.RetryAvailable(() => eventLog.WriteEntry("Further Testing"));
 
                     EventLogEntryCollection entryCollection = eventLog.Entries;
                     EventLogEntry[] entryCollectionCopied = new EventLogEntry[entryCollection.Count];
 
-                    Helpers.CopyCollection<EventLogEntryCollection>(() => entryCollection.CopyTo(entryCollectionCopied, 0));
+                    Helpers.RetryAvailable(() => entryCollection.CopyTo(entryCollectionCopied, 0));
                     int i = 0;
                     foreach (EventLogEntry entry in entryCollection)
                     {
-                        Assert.Equal(entry.Message, Helpers.RetrieveMessage<EventLogEntry>(() => entryCollectionCopied[i].Message));
+                        Assert.Equal(entry.Message, Helpers.RetrieveEntryOrMessage<string>(() => entryCollectionCopied[i].Message));
                         i += 1;
                     }
                 }
@@ -40,7 +40,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -56,7 +56,7 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
+                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
                     EventLogEntry entry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.False(entry.Equals(null));
                 }
@@ -64,7 +64,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -80,11 +80,11 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
+                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
                     EventLogEntry entry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.True(entry.Equals(entry));
 
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
+                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
                     EventLogEntry secondEntry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.Equal(entry.Index + 1, secondEntry.Index);
                 }
@@ -92,7 +92,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -108,8 +108,8 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
+                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
+                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
                     EventLogEntry entry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     EventLogEntry secondEntry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 2]);
                     Assert.False(entry.Equals(secondEntry));
@@ -118,7 +118,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
     }

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -69,7 +69,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -93,7 +93,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -121,7 +121,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -147,7 +147,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
     }

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -58,12 +58,25 @@ namespace System.Diagnostics.Tests
                         }
                     }
 
-                    int i = 0;
-                    foreach (EventLogEntry entry in entryCollection)
+                    bool entryRetrived = true;
+                    while (entryRetrived)
                     {
-                        Assert.Equal(entry.Message, entryCollectionCopied[i].Message);
-                        i += 1;
+                        try
+                        {
+                            int i = 0;
+                            foreach (EventLogEntry entry in entryCollection)
+                            {
+                                Assert.Equal(entry.Message, entryCollectionCopied[i].Message);
+                                i += 1;
+                            }
+                            entryRetrived = false;
+                        }
+                        catch (Win32Exception)
+                        {
+                            Thread.Sleep(100);
+                        }
                     }
+
                 }
             }
             finally

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -32,7 +32,7 @@ namespace System.Diagnostics.Tests
                     int i = 0;
                     foreach (EventLogEntry entry in entryCollection)
                     {
-                        Assert.Equal(entry.Message, Helpers.RetrieveOnWin7(() => entryCollectionCopied[i].Message));
+                        Assert.Equal(entry.Message, Helpers.RetryOnWin7(() => entryCollectionCopied[i].Message));
                         i += 1;
                     }
                 }
@@ -57,7 +57,7 @@ namespace System.Diagnostics.Tests
                 {
                     eventLog.Source = source;
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
-                    EventLogEntry entry = Helpers.RetrieveOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.False(entry.Equals(null));
                 }
             }
@@ -81,11 +81,11 @@ namespace System.Diagnostics.Tests
                 {
                     eventLog.Source = source;
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
-                    EventLogEntry entry = Helpers.RetrieveOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.True(entry.Equals(entry));
 
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
-                    EventLogEntry secondEntry = Helpers.RetrieveOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.Equal(entry.Index + 1, secondEntry.Index);
                 }
             }
@@ -110,8 +110,8 @@ namespace System.Diagnostics.Tests
                     eventLog.Source = source;
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
-                    EventLogEntry entry = Helpers.RetrieveOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
-                    EventLogEntry secondEntry = Helpers.RetrieveOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 2]);
+                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 2]);
                     Assert.False(entry.Equals(secondEntry));
                 }
             }

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
-using System.Threading;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -30,40 +28,13 @@ namespace System.Diagnostics.Tests
                     EventLogEntryCollection entryCollection = eventLog.Entries;
                     EventLogEntry[] entryCollectionCopied = new EventLogEntry[entryCollection.Count];
 
-                    bool entryCopied = true;
-                    while (entryCopied)
+                    Helpers.CopyCollection<EventLogEntryCollection>(() => entryCollection.CopyTo(entryCollectionCopied, 0));
+                    int i = 0;
+                    foreach (EventLogEntry entry in entryCollection)
                     {
-                        try
-                        {
-                            entryCollection.CopyTo(entryCollectionCopied, 0);
-                            entryCopied = false;
-                        }
-                        catch (Win32Exception)
-                        {
-                            Thread.Sleep(100);
-                            eventLog.Clear();
-                        }
+                        Assert.Equal(entry.Message, Helpers.RetrieveMessage<EventLogEntry>(() => entryCollectionCopied[i].Message));
+                        i += 1;
                     }
-
-                    bool entryRetrived = true;
-                    while (entryRetrived)
-                    {
-                        try
-                        {
-                            int i = 0;
-                            foreach (EventLogEntry entry in entryCollection)
-                            {
-                                Assert.Equal(entry.Message, entryCollectionCopied[i].Message);
-                                i += 1;
-                            }
-                            entryRetrived = false;
-                        }
-                        catch (Win32Exception)
-                        {
-                            Thread.Sleep(100);
-                        }
-                    }
-
                 }
             }
             finally

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -76,7 +76,6 @@ namespace System.Diagnostics.Tests
                             Thread.Sleep(100);
                         }
                     }
-
                 }
             }
             finally

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -57,7 +57,7 @@ namespace System.Diagnostics.Tests
                 {
                     eventLog.Source = source;
                     Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
-                    EventLogEntry entry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry entry = Helpers.RetrieveEntryOrMessage(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.False(entry.Equals(null));
                 }
             }
@@ -81,11 +81,11 @@ namespace System.Diagnostics.Tests
                 {
                     eventLog.Source = source;
                     Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
-                    EventLogEntry entry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry entry = Helpers.RetrieveEntryOrMessage(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.True(entry.Equals(entry));
 
                     Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
-                    EventLogEntry secondEntry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry secondEntry = Helpers.RetrieveEntryOrMessage(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.Equal(entry.Index + 1, secondEntry.Index);
                 }
             }
@@ -110,8 +110,8 @@ namespace System.Diagnostics.Tests
                     eventLog.Source = source;
                     Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
                     Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
-                    EventLogEntry entry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
-                    EventLogEntry secondEntry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 2]);
+                    EventLogEntry entry = Helpers.RetrieveEntryOrMessage(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry secondEntry = Helpers.RetrieveEntryOrMessage(() => eventLog.Entries[eventLog.Entries.Count - 2]);
                     Assert.False(entry.Equals(secondEntry));
                 }
             }

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Threading;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -55,9 +57,22 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    eventLog.WriteEntry(message);
-                    EventLogEntry entry = eventLog.Entries[eventLog.Entries.Count - 1];
-                    Assert.False(entry.Equals(null));
+                    bool entryWritten = true;
+                    while (entryWritten)
+                    {
+                        try
+                        {
+                            eventLog.WriteEntry(message);
+                            EventLogEntry entry = eventLog.Entries[eventLog.Entries.Count - 1];
+                            Assert.False(entry.Equals(null));
+                            entryWritten = false;
+                        }
+                        catch (Win32Exception)
+                        {
+                            Thread.Sleep(100);
+                            eventLog.Clear();
+                        }
+                    }
                 }
             }
             finally
@@ -79,12 +94,26 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    eventLog.WriteEntry(message);
-                    EventLogEntry entry = eventLog.Entries[eventLog.Entries.Count - 1];
-                    Assert.True(entry.Equals(entry));
-                    eventLog.WriteEntry(message);
-                    EventLogEntry secondEntry = eventLog.Entries[eventLog.Entries.Count - 1];
-                    Assert.Equal(entry.Index + 1, secondEntry.Index);
+                    bool entryWritten = true;
+                    while (entryWritten)
+                    {
+                        try
+                        {
+                            eventLog.WriteEntry(message);
+                            EventLogEntry entry = eventLog.Entries[eventLog.Entries.Count - 1];
+                            Assert.True(entry.Equals(entry));
+                            eventLog.WriteEntry(message);
+                            EventLogEntry secondEntry = eventLog.Entries[eventLog.Entries.Count - 1];
+                            Assert.Equal(entry.Index + 1, secondEntry.Index);
+                            entryWritten = false;
+                        }
+                        catch (Win32Exception)
+                        {
+                            Thread.Sleep(100);
+                            eventLog.Clear();
+                        }
+                    }
+
                 }
             }
             finally
@@ -106,11 +135,24 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    eventLog.WriteEntry(message);
-                    eventLog.WriteEntry(message);
-                    EventLogEntry entry = eventLog.Entries[eventLog.Entries.Count - 1];
-                    EventLogEntry secondEntry = eventLog.Entries[eventLog.Entries.Count - 2];
-                    Assert.False(entry.Equals(secondEntry));
+                    bool entryWritten = true;
+                    while (entryWritten)
+                    {
+                        try
+                        {
+                            eventLog.WriteEntry(message);
+                            eventLog.WriteEntry(message);
+                            EventLogEntry entry = eventLog.Entries[eventLog.Entries.Count - 1];
+                            EventLogEntry secondEntry = eventLog.Entries[eventLog.Entries.Count - 2];
+                            Assert.False(entry.Equals(secondEntry));
+                            entryWritten = false;
+                        }
+                        catch (Win32Exception)
+                        {
+                            Thread.Sleep(100);
+                            eventLog.Clear();
+                        }
+                    }
                 }
             }
             finally

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -24,11 +24,39 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    eventLog.WriteEntry(message);
-                    eventLog.WriteEntry("Further Testing");
+                    bool entryWritten = true;
+                    while (entryWritten)
+                    {
+                        try
+                        {
+                            eventLog.WriteEntry(message);
+                            eventLog.WriteEntry("Further Testing");
+                            entryWritten = false;
+                        }
+                        catch (Win32Exception)
+                        {
+                            Thread.Sleep(100);
+                            eventLog.Clear();
+                        }
+                    }
+
                     EventLogEntryCollection entryCollection = eventLog.Entries;
                     EventLogEntry[] entryCollectionCopied = new EventLogEntry[entryCollection.Count];
-                    entryCollection.CopyTo(entryCollectionCopied, 0);
+
+                    bool entryCopied = true;
+                    while (entryCopied)
+                    {
+                        try
+                        {
+                            entryCollection.CopyTo(entryCollectionCopied, 0);
+                            entryCopied = false;
+                        }
+                        catch (Win32Exception)
+                        {
+                            Thread.Sleep(100);
+                            eventLog.Clear();
+                        }
+                    }
 
                     int i = 0;
                     foreach (EventLogEntry entry in entryCollection)

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -24,21 +24,8 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    bool entryWritten = true;
-                    while (entryWritten)
-                    {
-                        try
-                        {
-                            eventLog.WriteEntry(message);
-                            eventLog.WriteEntry("Further Testing");
-                            entryWritten = false;
-                        }
-                        catch (Win32Exception)
-                        {
-                            Thread.Sleep(100);
-                            eventLog.Clear();
-                        }
-                    }
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry("Further Testing"));
 
                     EventLogEntryCollection entryCollection = eventLog.Entries;
                     EventLogEntry[] entryCollectionCopied = new EventLogEntry[entryCollection.Count];
@@ -76,6 +63,7 @@ namespace System.Diagnostics.Tests
                             Thread.Sleep(100);
                         }
                     }
+
                 }
             }
             finally
@@ -97,22 +85,9 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    bool entryWritten = true;
-                    while (entryWritten)
-                    {
-                        try
-                        {
-                            eventLog.WriteEntry(message);
-                            EventLogEntry entry = eventLog.Entries[eventLog.Entries.Count - 1];
-                            Assert.False(entry.Equals(null));
-                            entryWritten = false;
-                        }
-                        catch (Win32Exception)
-                        {
-                            Thread.Sleep(100);
-                            eventLog.Clear();
-                        }
-                    }
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
+                    EventLogEntry entry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    Assert.False(entry.Equals(null));
                 }
             }
             finally
@@ -134,25 +109,13 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    bool entryWritten = true;
-                    while (entryWritten)
-                    {
-                        try
-                        {
-                            eventLog.WriteEntry(message);
-                            EventLogEntry entry = eventLog.Entries[eventLog.Entries.Count - 1];
-                            Assert.True(entry.Equals(entry));
-                            eventLog.WriteEntry(message);
-                            EventLogEntry secondEntry = eventLog.Entries[eventLog.Entries.Count - 1];
-                            Assert.Equal(entry.Index + 1, secondEntry.Index);
-                            entryWritten = false;
-                        }
-                        catch (Win32Exception)
-                        {
-                            Thread.Sleep(100);
-                            eventLog.Clear();
-                        }
-                    }
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
+                    EventLogEntry entry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    Assert.True(entry.Equals(entry));
+
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
+                    EventLogEntry secondEntry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    Assert.Equal(entry.Index + 1, secondEntry.Index);
                 }
             }
             finally
@@ -174,24 +137,11 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    bool entryWritten = true;
-                    while (entryWritten)
-                    {
-                        try
-                        {
-                            eventLog.WriteEntry(message);
-                            eventLog.WriteEntry(message);
-                            EventLogEntry entry = eventLog.Entries[eventLog.Entries.Count - 1];
-                            EventLogEntry secondEntry = eventLog.Entries[eventLog.Entries.Count - 2];
-                            Assert.False(entry.Equals(secondEntry));
-                            entryWritten = false;
-                        }
-                        catch (Win32Exception)
-                        {
-                            Thread.Sleep(100);
-                            eventLog.Clear();
-                        }
-                    }
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
+                    EventLogEntry entry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry secondEntry = Helpers.RetrieveEntry<EventLog>(() => eventLog.Entries[eventLog.Entries.Count - 2]);
+                    Assert.False(entry.Equals(secondEntry));
                 }
             }
             finally

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -22,17 +22,17 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
-                    Helpers.RetryAvailable(() => eventLog.WriteEntry("Further Testing"));
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry("Further Testing"));
 
                     EventLogEntryCollection entryCollection = eventLog.Entries;
                     EventLogEntry[] entryCollectionCopied = new EventLogEntry[entryCollection.Count];
 
-                    Helpers.RetryAvailable(() => entryCollection.CopyTo(entryCollectionCopied, 0));
+                    Helpers.RetryOnWin7(() => entryCollection.CopyTo(entryCollectionCopied, 0));
                     int i = 0;
                     foreach (EventLogEntry entry in entryCollection)
                     {
-                        Assert.Equal(entry.Message, Helpers.RetrieveEntryOrMessage<string>(() => entryCollectionCopied[i].Message));
+                        Assert.Equal(entry.Message, Helpers.RetrieveOnWin7(() => entryCollectionCopied[i].Message));
                         i += 1;
                     }
                 }
@@ -40,7 +40,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -56,15 +56,15 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
-                    EventLogEntry entry = Helpers.RetrieveEntryOrMessage(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
+                    EventLogEntry entry = Helpers.RetrieveOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.False(entry.Equals(null));
                 }
             }
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -80,19 +80,19 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
-                    EventLogEntry entry = Helpers.RetrieveEntryOrMessage(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
+                    EventLogEntry entry = Helpers.RetrieveOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.True(entry.Equals(entry));
 
-                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
-                    EventLogEntry secondEntry = Helpers.RetrieveEntryOrMessage(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
+                    EventLogEntry secondEntry = Helpers.RetrieveOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.Equal(entry.Index + 1, secondEntry.Index);
                 }
             }
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -108,17 +108,17 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
-                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
-                    EventLogEntry entry = Helpers.RetrieveEntryOrMessage(() => eventLog.Entries[eventLog.Entries.Count - 1]);
-                    EventLogEntry secondEntry = Helpers.RetrieveEntryOrMessage(() => eventLog.Entries[eventLog.Entries.Count - 2]);
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
+                    EventLogEntry entry = Helpers.RetrieveOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry secondEntry = Helpers.RetrieveOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 2]);
                     Assert.False(entry.Equals(secondEntry));
                 }
             }
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
     }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -50,7 +50,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Threading;
 using Xunit;
 
@@ -31,7 +32,19 @@ namespace System.Diagnostics.Tests
                         signal.Set();
                     });
                     eventLog.EnableRaisingEvents = waitOnEvent;
-                    eventLog.WriteEntry(message, EventLogEntryType.Information);
+                    bool entryWritten = true;
+                    while (entryWritten)
+                    {
+                        try
+                        {
+                            eventLog.WriteEntry(message, EventLogEntryType.Information);
+                            entryWritten = false;
+                        }
+                        catch (Win32Exception)
+                        {
+                            Thread.Sleep(100);
+                        }
+                    }                  
                     if (waitOnEvent)
                     {
                         if (!signal.WaitOne(6000))

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -32,7 +32,7 @@ namespace System.Diagnostics.Tests
                     });
                     eventLog.EnableRaisingEvents = waitOnEvent;
 
-                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
 
                     if (waitOnEvent)
                     {
@@ -50,7 +50,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -31,9 +31,7 @@ namespace System.Diagnostics.Tests
                         signal.Set();
                     });
                     eventLog.EnableRaisingEvents = waitOnEvent;
-
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
-
                     if (waitOnEvent)
                     {
                         if (!signal.WaitOne(6000))

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -32,7 +32,7 @@ namespace System.Diagnostics.Tests
                     });
                     eventLog.EnableRaisingEvents = waitOnEvent;
 
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
+                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
 
                     if (waitOnEvent)
                     {
@@ -50,7 +50,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
 using System.Threading;
 using Xunit;
 
@@ -32,19 +31,9 @@ namespace System.Diagnostics.Tests
                         signal.Set();
                     });
                     eventLog.EnableRaisingEvents = waitOnEvent;
-                    bool entryWritten = true;
-                    while (entryWritten)
-                    {
-                        try
-                        {
-                            eventLog.WriteEntry(message, EventLogEntryType.Information);
-                            entryWritten = false;
-                        }
-                        catch (Win32Exception)
-                        {
-                            Thread.Sleep(100);
-                        }
-                    }                  
+
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
+
                     if (waitOnEvent)
                     {
                         if (!signal.WaitOne(6000))

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -21,7 +21,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
 
             Assert.False(EventLog.SourceExists(source));
@@ -96,7 +96,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -21,7 +21,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
 
             Assert.False(EventLog.SourceExists(source));
@@ -96,7 +96,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -21,7 +21,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
 
             Assert.False(EventLog.SourceExists(source));
@@ -96,7 +96,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
 using System.Globalization;
 using System.IO;
-using System.Threading;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -37,19 +35,7 @@ namespace System.Diagnostics.Tests
                     eventLog.Source = source;
                     eventLog.Clear();
                     Assert.Equal(0, eventLog.Entries.Count);
-                    bool entryWritten = true;
-                    while (entryWritten)
-                    {
-                        try
-                        {
-                            eventLog.WriteEntry("Writing to event log.");
-                            entryWritten = false;
-                        }
-                        catch (Win32Exception)
-                        {
-                            Thread.Sleep(100);
-                        }
-                    }
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry("Writing to event log."));
                     Assert.Equal(1, eventLog.Entries.Count);
                 }
             }
@@ -355,19 +341,7 @@ namespace System.Diagnostics.Tests
             {
                 eventlog.Source = "Security";
                 EventLogEntry eventLogEntry = null;
-                bool entryRetrieved = true;
-                while (entryRetrieved)
-                {
-                    try
-                    {
-                        eventLogEntry = eventlog.Entries[0];
-                        entryRetrieved = false;
-                    }
-                    catch (Win32Exception)
-                    {
-                        Thread.Sleep(100);
-                    }
-                }
+                eventLogEntry = Helpers.RetrieveEntry<EventLog>(() => eventlog.Entries[0]);
                 Assert.Contains("", eventLogEntry.Message);
             }
         }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
+using System.Threading;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -35,7 +37,19 @@ namespace System.Diagnostics.Tests
                     eventLog.Source = source;
                     eventLog.Clear();
                     Assert.Equal(0, eventLog.Entries.Count);
-                    eventLog.WriteEntry("Writing to event log.");
+                    bool entryWritten = true;
+                    while (entryWritten)
+                    {
+                        try
+                        {
+                            eventLog.WriteEntry("Writing to event log.");
+                            entryWritten = false;
+                        }
+                        catch (Win32Exception)
+                        {
+                            Thread.Sleep(100);
+                        }
+                    }
                     Assert.Equal(1, eventLog.Entries.Count);
                 }
             }
@@ -340,7 +354,20 @@ namespace System.Diagnostics.Tests
             using (EventLog eventlog = new EventLog("Security"))
             {
                 eventlog.Source = "Security";
-                EventLogEntry eventLogEntry = eventlog.Entries[0];
+                EventLogEntry eventLogEntry = null;
+                bool entryRetrieved = true;
+                while (entryRetrieved)
+                {
+                    try
+                    {
+                        eventLogEntry = eventlog.Entries[0];
+                        entryRetrieved = false;
+                    }
+                    catch (Win32Exception)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
                 Assert.Contains("", eventLogEntry.Message);
             }
         }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -35,14 +35,14 @@ namespace System.Diagnostics.Tests
                     eventLog.Source = source;
                     eventLog.Clear();
                     Assert.Equal(0, eventLog.Entries.Count);
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry("Writing to event log."));
+                    Helpers.RetryAvailable(() => eventLog.WriteEntry("Writing to event log."));
                     Assert.Equal(1, eventLog.Entries.Count);
                 }
             }
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -69,7 +69,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
                 Assert.False(EventLog.Exists(log));
             }
         }
@@ -141,7 +141,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -180,7 +180,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -207,7 +207,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -267,7 +267,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -325,7 +325,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -42,7 +42,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -69,7 +69,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
                 Assert.False(EventLog.Exists(log));
             }
         }
@@ -141,7 +141,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -180,7 +180,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -207,7 +207,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -267,7 +267,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -325,7 +325,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -340,7 +340,7 @@ namespace System.Diagnostics.Tests
             using (EventLog eventlog = new EventLog("Security"))
             {
                 eventlog.Source = "Security";
-                EventLogEntry eventLogEntry = null;
+                EventLogEntry eventLogEntry;
                 eventLogEntry = Helpers.RetrieveEntry<EventLog>(() => eventlog.Entries[0]);
                 Assert.Contains("", eventLogEntry.Message);
             }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -341,7 +341,7 @@ namespace System.Diagnostics.Tests
             {
                 eventlog.Source = "Security";
                 EventLogEntry eventLogEntry;
-                eventLogEntry = Helpers.RetrieveOnWin7(() => eventlog.Entries[0]);
+                eventLogEntry = Helpers.RetryOnWin7(() => eventlog.Entries[0]);
                 Assert.Contains("", eventLogEntry.Message);
             }
         }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -35,14 +35,14 @@ namespace System.Diagnostics.Tests
                     eventLog.Source = source;
                     eventLog.Clear();
                     Assert.Equal(0, eventLog.Entries.Count);
-                    Helpers.RetryAvailable(() => eventLog.WriteEntry("Writing to event log."));
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry("Writing to event log."));
                     Assert.Equal(1, eventLog.Entries.Count);
                 }
             }
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -69,7 +69,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
                 Assert.False(EventLog.Exists(log));
             }
         }
@@ -141,7 +141,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -180,7 +180,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -207,7 +207,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -267,7 +267,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -325,7 +325,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -341,7 +341,7 @@ namespace System.Diagnostics.Tests
             {
                 eventlog.Source = "Security";
                 EventLogEntry eventLogEntry;
-                eventLogEntry = Helpers.RetrieveEntryOrMessage(() => eventlog.Entries[0]);
+                eventLogEntry = Helpers.RetrieveOnWin7(() => eventlog.Entries[0]);
                 Assert.Contains("", eventLogEntry.Message);
             }
         }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -341,7 +341,7 @@ namespace System.Diagnostics.Tests
             {
                 eventlog.Source = "Security";
                 EventLogEntry eventLogEntry;
-                eventLogEntry = Helpers.RetrieveEntry<EventLog>(() => eventlog.Entries[0]);
+                eventLogEntry = Helpers.RetrieveEntryOrMessage(() => eventlog.Entries[0]);
                 Assert.Contains("", eventLogEntry.Message);
             }
         }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Threading;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -399,20 +398,8 @@ namespace System.Diagnostics.Tests
     {
         internal static EventLogEntry LastOrDefault(this EventLogEntryCollection elec)
         {
-            bool entryRetrieved = true;
             EventLogEntry eventLogEntry = null;
-            while (entryRetrieved)
-            {
-                try
-                {
-                    eventLogEntry = elec.Count > 0 ? elec[elec.Count - 1] : null;
-                    entryRetrieved = false;
-                }
-                catch (Win32Exception)
-                {
-                    Thread.Sleep(100);
-                }
-            }
+            eventLogEntry = Helpers.RetrieveEntryFromCollection<EventLogEntryCollection>(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
             return eventLogEntry;
         }
     }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Threading;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -394,7 +395,21 @@ namespace System.Diagnostics.Tests
     {
         internal static EventLogEntry LastOrDefault(this EventLogEntryCollection elec)
         {
-            return elec.Count > 0 ? elec[elec.Count - 1] : null;
+            bool entryRetrieved = true;
+            EventLogEntry eventLogEntry = null;
+            while (entryRetrieved)
+            {
+                try
+                {
+                    eventLogEntry = elec.Count > 0 ? elec[elec.Count - 1] : null;
+                    entryRetrieved = false;
+                }
+                catch (Win32Exception)
+                {
+                    Thread.Sleep(100);
+                }
+            }
+            return eventLogEntry;
         }
     }
 }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -25,27 +25,27 @@ namespace System.Diagnostics.Tests
                     EventLog.WriteEvent(source, eventInstance);
                     if (data)
                     {
-                        Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
+                        Helpers.RetryAvailable(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
-                        Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
+                        Helpers.RetryAvailable(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
-                        Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
+                        Helpers.RetryAvailable(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
                         return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
                 {
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning));
+                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message, EventLogEntryType.Warning));
                 }
                 else
                 {
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
+                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
                 }
 
                 return eventLog.Entries.LastOrDefault();
@@ -62,27 +62,27 @@ namespace System.Diagnostics.Tests
                     EventLog.WriteEvent(source, eventInstance);
                     if (data)
                     {
-                        Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
+                        Helpers.RetryAvailable(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
-                        Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
+                        Helpers.RetryAvailable(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
-                        Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
+                        Helpers.RetryAvailable(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
                         return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
                 {
-                    Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning));
+                    Helpers.RetryAvailable(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning));
                 }
                 else
                 {
-                    Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message));
+                    Helpers.RetryAvailable(() => EventLog.WriteEntry(source, message));
                 }
 
                 return eventLog.Entries.LastOrDefault();
@@ -93,11 +93,11 @@ namespace System.Diagnostics.Tests
         {
             if (data)
             {
-                Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEvent(source, eventInstance, rawData, insertStrings));
+                Helpers.RetryAvailable(() => EventLog.WriteEvent(source, eventInstance, rawData, insertStrings));
             }
             else
             {
-                Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEvent(source, eventInstance, insertStrings));
+                Helpers.RetryAvailable(() => EventLog.WriteEvent(source, eventInstance, insertStrings));
             }
             using (EventLog eventLog = new EventLog())
             {
@@ -113,9 +113,9 @@ namespace System.Diagnostics.Tests
                 string[] insertStringsSingleton = { "ExtraText" };
                 eventLog.Source = source;
                 if (data)
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton));
+                    Helpers.RetryAvailable(() => eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton));
                 else
-                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEvent(eventInstance, insertStringsSingleton));
+                    Helpers.RetryAvailable(() => eventLog.WriteEvent(eventInstance, insertStringsSingleton));
 
                 return eventLog.Entries.LastOrDefault();
             }
@@ -149,7 +149,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -178,7 +178,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -207,7 +207,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -242,7 +242,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -271,7 +271,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -324,7 +324,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -351,7 +351,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
+                Helpers.RetryAvailable(() => EventLog.Delete(log));
             }
         }
 
@@ -399,7 +399,7 @@ namespace System.Diagnostics.Tests
         internal static EventLogEntry LastOrDefault(this EventLogEntryCollection elec)
         {
             EventLogEntry eventLogEntry = null;
-            eventLogEntry = Helpers.RetrieveEntryFromCollection<EventLogEntryCollection>(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
+            eventLogEntry = Helpers.RetrieveEntryOrMessage<EventLogEntry>(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
             return eventLogEntry;
         }
     }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -26,46 +26,27 @@ namespace System.Diagnostics.Tests
                     EventLog.WriteEvent(source, eventInstance);
                     if (data)
                     {
-                        if (PlatformDetection.IsWindows7)
-                            RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
-                        else
-                            eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData);
-
+                        Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
-                        if (PlatformDetection.IsWindows7)
-                            RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
-                        else
-                            eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId);
-
+                        Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
-                        if (PlatformDetection.IsWindows7)
-                            RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
-                        else
-                            eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId);
-
+                        Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
                         return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
                 {
-                    if (PlatformDetection.IsWindows7)
-                        RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning));
-                    else
-                        eventLog.WriteEntry(message, EventLogEntryType.Warning);
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning));
                 }
                 else
                 {
-                    if (PlatformDetection.IsWindows7)
-                        RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
-                    else
-                        eventLog.WriteEntry(message);
-
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
                 }
 
                 return eventLog.Entries.LastOrDefault();
@@ -82,45 +63,27 @@ namespace System.Diagnostics.Tests
                     EventLog.WriteEvent(source, eventInstance);
                     if (data)
                     {
-                        if (PlatformDetection.IsWindows7)
-                            RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
-                        else
-                            EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData);
-
+                        Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
-                        if (PlatformDetection.IsWindows7)
-                            RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
-                        else
-                            EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId);
-
+                        Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
-                        if (PlatformDetection.IsWindows7)
-                            RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
-                        else
-                            EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId);
-
+                        Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
                         return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
                 {
-                    if (PlatformDetection.IsWindows7)
-                        RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning));
-                    else
-                        EventLog.WriteEntry(source, message, EventLogEntryType.Warning);
+                    Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning));
                 }
                 else
                 {
-                    if (PlatformDetection.IsWindows7)
-                        RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message));
-                    else
-                        EventLog.WriteEntry(source, message);
+                    Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message));
                 }
 
                 return eventLog.Entries.LastOrDefault();
@@ -131,17 +94,11 @@ namespace System.Diagnostics.Tests
         {
             if (data)
             {
-                if (PlatformDetection.IsWindows7)
-                    RetryAvailable<EventLog>(() => EventLog.WriteEvent(source, eventInstance, rawData, insertStrings));
-                else
-                    EventLog.WriteEvent(source, eventInstance, rawData, insertStrings);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEvent(source, eventInstance, rawData, insertStrings));
             }
             else
             {
-                if (PlatformDetection.IsWindows7)
-                    RetryAvailable<EventLog>(() => EventLog.WriteEvent(source, eventInstance, insertStrings));
-                else
-                    EventLog.WriteEvent(source, eventInstance, insertStrings);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.WriteEvent(source, eventInstance, insertStrings));
             }
             using (EventLog eventLog = new EventLog())
             {
@@ -157,38 +114,12 @@ namespace System.Diagnostics.Tests
                 string[] insertStringsSingleton = { "ExtraText" };
                 eventLog.Source = source;
                 if (data)
-                {
-                    if (PlatformDetection.IsWindows7)
-                        RetryAvailable<EventLog>(() => eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton));
-                    else
-                        eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton);
-                }
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton));
                 else
-                {
-                    eventLog.WriteEvent(eventInstance, insertStringsSingleton);
-                }
+                    Helpers.RetryAvailable<EventLog>(() => eventLog.WriteEvent(eventInstance, insertStringsSingleton));
 
                 return eventLog.Entries.LastOrDefault();
             }
-        }
-
-        static void RetryAvailable<EventLog>(Action func)
-        {
-            int retries = 3;
-            while (retries > 0)
-            {
-                try
-                {
-                    func();
-                    break;
-                }
-                catch (Win32Exception)
-                {
-                    Thread.Sleep(100);
-                    retries--;
-                }
-            }
-            return;
         }
 
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -22,30 +22,30 @@ namespace System.Diagnostics.Tests
                 eventLog.Source = source;
                 if (instance)
                 {
-                    Helpers.RetryAvailable(() => EventLog.WriteEvent(source, eventInstance));
+                    Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, eventInstance));
                     if (data)
                     {
-                        Helpers.RetryAvailable(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
+                        Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
-                        Helpers.RetryAvailable(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
+                        Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
-                        Helpers.RetryAvailable(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
+                        Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
                         return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
                 {
-                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message, EventLogEntryType.Warning));
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Warning));
                 }
                 else
                 {
-                    Helpers.RetryAvailable(() => eventLog.WriteEntry(message));
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
                 }
 
                 return eventLog.Entries.LastOrDefault();
@@ -59,30 +59,30 @@ namespace System.Diagnostics.Tests
                 eventLog.Source = source;
                 if (instance)
                 {
-                    Helpers.RetryAvailable(() => EventLog.WriteEvent(source, eventInstance));
+                    Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, eventInstance));
                     if (data)
                     {
-                        Helpers.RetryAvailable(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
+                        Helpers.RetryOnWin7(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
-                        Helpers.RetryAvailable(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
+                        Helpers.RetryOnWin7(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
-                        Helpers.RetryAvailable(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
+                        Helpers.RetryOnWin7(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
                         return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
                 {
-                    Helpers.RetryAvailable(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning));
+                    Helpers.RetryOnWin7(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning));
                 }
                 else
                 {
-                    Helpers.RetryAvailable(() => EventLog.WriteEntry(source, message));
+                    Helpers.RetryOnWin7(() => EventLog.WriteEntry(source, message));
                 }
 
                 return eventLog.Entries.LastOrDefault();
@@ -93,11 +93,11 @@ namespace System.Diagnostics.Tests
         {
             if (data)
             {
-                Helpers.RetryAvailable(() => EventLog.WriteEvent(source, eventInstance, rawData, insertStrings));
+                Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, eventInstance, rawData, insertStrings));
             }
             else
             {
-                Helpers.RetryAvailable(() => EventLog.WriteEvent(source, eventInstance, insertStrings));
+                Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, eventInstance, insertStrings));
             }
             using (EventLog eventLog = new EventLog())
             {
@@ -113,9 +113,9 @@ namespace System.Diagnostics.Tests
                 string[] insertStringsSingleton = { "ExtraText" };
                 eventLog.Source = source;
                 if (data)
-                    Helpers.RetryAvailable(() => eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton));
+                    Helpers.RetryOnWin7(() => eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton));
                 else
-                    Helpers.RetryAvailable(() => eventLog.WriteEvent(eventInstance, insertStringsSingleton));
+                    Helpers.RetryOnWin7(() => eventLog.WriteEvent(eventInstance, insertStringsSingleton));
 
                 return eventLog.Entries.LastOrDefault();
             }
@@ -149,7 +149,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -178,7 +178,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -207,7 +207,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -242,7 +242,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -271,7 +271,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -324,7 +324,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -351,7 +351,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryAvailable(() => EventLog.Delete(log));
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
             }
         }
 
@@ -398,9 +398,7 @@ namespace System.Diagnostics.Tests
     {
         internal static EventLogEntry LastOrDefault(this EventLogEntryCollection elec)
         {
-            EventLogEntry eventLogEntry = null;
-            eventLogEntry = Helpers.RetrieveEntryOrMessage<EventLogEntry>(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
-            return eventLogEntry;
+            return Helpers.RetrieveOnWin7(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
         }
     }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -478,7 +478,7 @@ namespace System.Diagnostics.Tests
         }
     }
 
-    internal static class eventLogEntries
+    internal static class EventLogEntryCollectionExtensions
     {
         internal static EventLogEntry LastOrDefault(this EventLogEntryCollection elec)
         {

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -22,7 +22,7 @@ namespace System.Diagnostics.Tests
                 eventLog.Source = source;
                 if (instance)
                 {
-                    EventLog.WriteEvent(source, eventInstance);
+                    Helpers.RetryAvailable(() => EventLog.WriteEvent(source, eventInstance));
                     if (data)
                     {
                         Helpers.RetryAvailable(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
@@ -59,7 +59,7 @@ namespace System.Diagnostics.Tests
                 eventLog.Source = source;
                 if (instance)
                 {
-                    EventLog.WriteEvent(source, eventInstance);
+                    Helpers.RetryAvailable(() => EventLog.WriteEvent(source, eventInstance));
                     if (data)
                     {
                         Helpers.RetryAvailable(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -150,7 +150,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -179,7 +179,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -208,7 +208,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -243,7 +243,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -272,7 +272,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -325,7 +325,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 
@@ -352,7 +352,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
+                Helpers.RetryAvailable<EventLog>(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -129,11 +129,25 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry;
-                if (sourceFlag)
-                    eventLogEntry = WriteLogEntry(source);
-                else
-                    eventLogEntry = WriteLogEntryWithSource(source);
+                EventLogEntry eventLogEntry = null;
+                bool entryWritten = true;
+
+                while (entryWritten)
+                {
+                    try
+                    {
+                        if (sourceFlag)
+                            eventLogEntry = WriteLogEntry(source);
+                        else
+                            eventLogEntry = WriteLogEntryWithSource(source);
+
+                        entryWritten = false;
+                    }
+                    catch (Win32Exception)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
 
                 if (eventLogEntry != null)
                 {
@@ -160,12 +174,24 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry;
-                if (sourceFlag)
-                    eventLogEntry = WriteLogEntry(source, type: true);
-                else
-                    eventLogEntry = WriteLogEntryWithSource(source, type: true);
+                EventLogEntry eventLogEntry = null;
+                bool entryWritten = true;
+                while (entryWritten)
+                {
+                    try
+                    {
+                        if (sourceFlag)
+                            eventLogEntry = WriteLogEntry(source, type: true);
+                        else
+                            eventLogEntry = WriteLogEntryWithSource(source, type: true);
 
+                        entryWritten = false;
+                    }
+                    catch (Win32Exception)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
                 if (eventLogEntry != null)
                 {
                     Assert.Contains(message, eventLogEntry.Message);
@@ -189,11 +215,24 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry;
-                if (sourceFlag)
-                    eventLogEntry = WriteLogEntry(source, type: true, instance: true);
-                else
-                    eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true);
+                EventLogEntry eventLogEntry = null;
+                bool entryWritten = true;
+                while (entryWritten)
+                {
+                    try
+                    {
+                        if (sourceFlag)
+                            eventLogEntry = WriteLogEntry(source, type: true, instance: true);
+                        else
+                            eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true);
+
+                        entryWritten = false;
+                    }
+                    catch (Win32Exception)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
 
                 if (eventLogEntry != null)
                 {
@@ -218,12 +257,24 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry;
-                if (sourceFlag)
-                    eventLogEntry = WriteLogEntry(source, type: true, instance: true, category: true);
-                else
-                    eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true, category: true);
+                EventLogEntry eventLogEntry = null;
+                bool entryWritten = true;
+                while (entryWritten)
+                {
+                    try
+                    {
+                        if (sourceFlag)
+                            eventLogEntry = WriteLogEntry(source, type: true, instance: true, category: true);
+                        else
+                            eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true, category: true);
 
+                        entryWritten = false;
+                    }
+                    catch (Win32Exception)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
                 // There is some prefix string already attached to the message passed
                 // The description for Event ID '0' in Source 'SourceWriteEntryWithTypeIDAndCategory' cannot be found.  The local computer may not have the necessary registry information or message DLL files to display the message, or you may not have permission
                 // to access them.  The following information is part of the event:'EventLogWriteEntryTestsMessage'
@@ -253,12 +304,24 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry;
-                if (sourceFlag)
-                    eventLogEntry = WriteLogEntry(source, type: true, instance: true, category: true, data: true);
-                else
-                    eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true, category: true, data: true);
+                EventLogEntry eventLogEntry = null;
+                bool entryWritten = true;
+                while (entryWritten)
+                {
+                    try
+                    {
+                        if (sourceFlag)
+                            eventLogEntry = WriteLogEntry(source, type: true, instance: true, category: true, data: true);
+                        else
+                            eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true, category: true, data: true);
 
+                        entryWritten = false;
+                    }
+                    catch (Win32Exception)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
                 if (eventLogEntry != null)
                 {
                     Assert.Contains(message, eventLogEntry.Message);
@@ -309,15 +372,26 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry;
-                if (SourceFlag)
-                    eventLogEntry = WriteLogEntryEventSource(source);
-                else
-                    eventLogEntry = WriteLogEntryEvent(source);
+                EventLogEntry eventLogEntry = null;
+                bool entryWritten = true;
+                while (entryWritten)
+                {
+                    try
+                    {
+                        if (SourceFlag)
+                            eventLogEntry = WriteLogEntryEventSource(source);
+                        else
+                            eventLogEntry = WriteLogEntryEvent(source);
 
+                        entryWritten = false;
+                    }
+                    catch (Win32Exception)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
                 if (eventLogEntry != null)
                     Assert.All(insertStrings, message => eventLogEntry.Message.Contains(message));
-
             }
             finally
             {
@@ -336,11 +410,24 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry;
-                if (SourceFlag)
-                    eventLogEntry = WriteLogEntryEventSource(source, data: true);
-                else
-                    eventLogEntry = WriteLogEntryEvent(source, data: true);
+                EventLogEntry eventLogEntry = null;
+                bool entryWritten = true;
+                while (entryWritten)
+                {
+                    try
+                    {
+                        if (SourceFlag)
+                            eventLogEntry = WriteLogEntryEventSource(source, data: true);
+                        else
+                            eventLogEntry = WriteLogEntryEvent(source, data: true);
+
+                        entryWritten = false;
+                    }
+                    catch (Win32Exception)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
 
                 if (eventLogEntry != null)
                     Assert.Equal(rawData, eventLogEntry.Data);

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -26,17 +26,17 @@ namespace System.Diagnostics.Tests
                     if (data)
                     {
                         eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData);
-                        return EventLogEntryCollectionExtensions.LastOrDefault(eventLog.Entries);
+                        return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
                         eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId);
-                        return EventLogEntryCollectionExtensions.LastOrDefault(eventLog.Entries);
+                        return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
                         eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId);
-                        return EventLogEntryCollectionExtensions.LastOrDefault(eventLog.Entries);
+                        return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
@@ -48,7 +48,7 @@ namespace System.Diagnostics.Tests
                     eventLog.WriteEntry(message);
                 }
 
-                return EventLogEntryCollectionExtensions.LastOrDefault(eventLog.Entries);
+                return eventLog.Entries.LastOrDefault();
             }
         }
 
@@ -63,17 +63,17 @@ namespace System.Diagnostics.Tests
                     if (data)
                     {
                         EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData);
-                        return EventLogEntryCollectionExtensions.LastOrDefault(eventLog.Entries);
+                        return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
                         EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId);
-                        return EventLogEntryCollectionExtensions.LastOrDefault(eventLog.Entries);
+                        return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
                         EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId);
-                        return EventLogEntryCollectionExtensions.LastOrDefault(eventLog.Entries);
+                        return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
@@ -85,7 +85,7 @@ namespace System.Diagnostics.Tests
                     EventLog.WriteEntry(source, message);
                 }
 
-                return EventLogEntryCollectionExtensions.LastOrDefault(eventLog.Entries);
+                return eventLog.Entries.LastOrDefault();
             }
         }
 
@@ -99,7 +99,7 @@ namespace System.Diagnostics.Tests
             using (EventLog eventLog = new EventLog())
             {
                 eventLog.Source = source;
-                return EventLogEntryCollectionExtensions.LastOrDefault(eventLog.Entries);
+                return eventLog.Entries.LastOrDefault();
             }
         }
 
@@ -114,7 +114,7 @@ namespace System.Diagnostics.Tests
                 else
                     eventLog.WriteEvent(eventInstance, insertStringsSingleton);
 
-                return EventLogEntryCollectionExtensions.LastOrDefault(eventLog.Entries);
+                return eventLog.Entries.LastOrDefault();
             }
         }
 
@@ -390,7 +390,7 @@ namespace System.Diagnostics.Tests
         }
     }
 
-    internal static class EventLogEntryCollectionExtensions
+    internal static class eventLogEntries
     {
         internal static EventLogEntry LastOrDefault(this EventLogEntryCollection elec)
         {

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Reflection;
 using System.Threading;
 using Xunit;
 
@@ -27,34 +26,46 @@ namespace System.Diagnostics.Tests
                     EventLog.WriteEvent(source, eventInstance);
                     if (data)
                     {
-                        eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData);
+                        if (PlatformDetection.IsWindows7)
+                            RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
+                        else
+                            eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData);
+
                         return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
-                        eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId);
+                        if (PlatformDetection.IsWindows7)
+                            RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
+                        else
+                            eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId);
+
                         return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
-                        eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId);
+                        if (PlatformDetection.IsWindows7)
+                            RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
+                        else
+                            eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId);
+
                         return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
                 {
-                    eventLog.WriteEntry(message, EventLogEntryType.Warning);
+                    if (PlatformDetection.IsWindows7)
+                        RetryAvailable<EventLog>(() => eventLog.WriteEntry(message, EventLogEntryType.Warning));
+                    else
+                        eventLog.WriteEntry(message, EventLogEntryType.Warning);
                 }
                 else
                 {
                     if (PlatformDetection.IsWindows7)
-                    {
-                        WriteEventWin7<EventLog>(() => eventLog.WriteEntry(message));
-                    }
+                        RetryAvailable<EventLog>(() => eventLog.WriteEntry(message));
                     else
-                    {
                         eventLog.WriteEntry(message);
-                    }
+
                 }
 
                 return eventLog.Entries.LastOrDefault();
@@ -71,27 +82,45 @@ namespace System.Diagnostics.Tests
                     EventLog.WriteEvent(source, eventInstance);
                     if (data)
                     {
-                        EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData);
+                        if (PlatformDetection.IsWindows7)
+                            RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
+                        else
+                            EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData);
+
                         return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
-                        EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId);
+                        if (PlatformDetection.IsWindows7)
+                            RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
+                        else
+                            EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId);
+
                         return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
-                        EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId);
+                        if (PlatformDetection.IsWindows7)
+                            RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
+                        else
+                            EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId);
+
                         return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
                 {
-                    EventLog.WriteEntry(source, message, EventLogEntryType.Warning);
+                    if (PlatformDetection.IsWindows7)
+                        RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning));
+                    else
+                        EventLog.WriteEntry(source, message, EventLogEntryType.Warning);
                 }
                 else
                 {
-                    EventLog.WriteEntry(source, message);
+                    if (PlatformDetection.IsWindows7)
+                        RetryAvailable<EventLog>(() => EventLog.WriteEntry(source, message));
+                    else
+                        EventLog.WriteEntry(source, message);
                 }
 
                 return eventLog.Entries.LastOrDefault();
@@ -101,10 +130,19 @@ namespace System.Diagnostics.Tests
         private EventLogEntry WriteLogEntryEventSource(string source, bool data = false)
         {
             if (data)
-                EventLog.WriteEvent(source, eventInstance, rawData, insertStrings);
+            {
+                if (PlatformDetection.IsWindows7)
+                    RetryAvailable<EventLog>(() => EventLog.WriteEvent(source, eventInstance, rawData, insertStrings));
+                else
+                    EventLog.WriteEvent(source, eventInstance, rawData, insertStrings);
+            }
             else
-                EventLog.WriteEvent(source, eventInstance, insertStrings);
-
+            {
+                if (PlatformDetection.IsWindows7)
+                    RetryAvailable<EventLog>(() => EventLog.WriteEvent(source, eventInstance, insertStrings));
+                else
+                    EventLog.WriteEvent(source, eventInstance, insertStrings);
+            }
             using (EventLog eventLog = new EventLog())
             {
                 eventLog.Source = source;
@@ -119,35 +157,22 @@ namespace System.Diagnostics.Tests
                 string[] insertStringsSingleton = { "ExtraText" };
                 eventLog.Source = source;
                 if (data)
-                    eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton);
+                {
+                    if (PlatformDetection.IsWindows7)
+                        RetryAvailable<EventLog>(() => eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton));
+                    else
+                        eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton);
+                }
                 else
+                {
                     eventLog.WriteEvent(eventInstance, insertStringsSingleton);
+                }
 
                 return eventLog.Entries.LastOrDefault();
             }
         }
 
-        private void WriteEventWin71(Type type, string name, Type[] argumentTypes, BindingFlags flags, object[] argumentValues, EventLog eventLog, int retries = 3)
-        {
-            while (retries > 0)
-            {
-                try
-                {
-                    MethodInfo methodInfo = type.GetMethod(name, flags, null, CallingConventions.Any, argumentTypes, null);
-                    methodInfo.Invoke(eventLog, argumentValues);
-                    break;
-                }
-                catch (Win32Exception)
-                {
-                    Thread.Sleep(100);
-                    retries--;
-                }
-            }
-            return;
-
-        }
-
-        static void WriteEventWin7<EventLog>(Action func)
+        static void RetryAvailable<EventLog>(Action func)
         {
             int retries = 3;
             while (retries > 0)
@@ -166,26 +191,6 @@ namespace System.Diagnostics.Tests
             return;
         }
 
-        //[Fact]
-        public void dummyWrite()
-        {
-            string log = "DummyEntry";
-            string source = "Source" + nameof(dummyWrite);
-            try
-            {
-                EventLog.CreateEventSource(source, log);
-                EventLog eventLog = new EventLog();
-                eventLog.Source = source;
-                WriteEventWin71(typeof(EventLog), "WriteEntry", new Type[] { typeof(string) }, BindingFlags.Instance | BindingFlags.Public, new object[] { "A789541278" }, eventLog);
-                Console.WriteLine(eventLog.Entries[0].Message);
-            }
-            finally
-            {
-                EventLog.DeleteEventSource(source);
-                EventLog.Delete(log);
-            }
-        }
-
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(false)]
         [InlineData(true)]
@@ -196,25 +201,12 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry = null;
-                bool entryWritten = true;
+                EventLogEntry eventLogEntry;
 
-                while (entryWritten)
-                {
-                    try
-                    {
-                        if (sourceFlag)
-                            eventLogEntry = WriteLogEntry(source);
-                        else
-                            eventLogEntry = WriteLogEntryWithSource(source);
-
-                        entryWritten = false;
-                    }
-                    catch (Win32Exception)
-                    {
-                        Thread.Sleep(100);
-                    }
-                }
+                if (sourceFlag)
+                    eventLogEntry = WriteLogEntry(source);
+                else
+                    eventLogEntry = WriteLogEntryWithSource(source);
 
                 if (eventLogEntry != null)
                 {
@@ -241,24 +233,12 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry = null;
-                bool entryWritten = true;
-                while (entryWritten)
-                {
-                    try
-                    {
-                        if (sourceFlag)
-                            eventLogEntry = WriteLogEntry(source, type: true);
-                        else
-                            eventLogEntry = WriteLogEntryWithSource(source, type: true);
+                EventLogEntry eventLogEntry;
+                if (sourceFlag)
+                    eventLogEntry = WriteLogEntry(source, type: true);
+                else
+                    eventLogEntry = WriteLogEntryWithSource(source, type: true);
 
-                        entryWritten = false;
-                    }
-                    catch (Win32Exception)
-                    {
-                        Thread.Sleep(100);
-                    }
-                }
                 if (eventLogEntry != null)
                 {
                     Assert.Contains(message, eventLogEntry.Message);
@@ -282,24 +262,11 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry = null;
-                bool entryWritten = true;
-                while (entryWritten)
-                {
-                    try
-                    {
-                        if (sourceFlag)
-                            eventLogEntry = WriteLogEntry(source, type: true, instance: true);
-                        else
-                            eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true);
-
-                        entryWritten = false;
-                    }
-                    catch (Win32Exception)
-                    {
-                        Thread.Sleep(100);
-                    }
-                }
+                EventLogEntry eventLogEntry;
+                if (sourceFlag)
+                    eventLogEntry = WriteLogEntry(source, type: true, instance: true);
+                else
+                    eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true);
 
                 if (eventLogEntry != null)
                 {
@@ -324,24 +291,12 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry = null;
-                bool entryWritten = true;
-                while (entryWritten)
-                {
-                    try
-                    {
-                        if (sourceFlag)
-                            eventLogEntry = WriteLogEntry(source, type: true, instance: true, category: true);
-                        else
-                            eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true, category: true);
+                EventLogEntry eventLogEntry;
+                if (sourceFlag)
+                    eventLogEntry = WriteLogEntry(source, type: true, instance: true, category: true);
+                else
+                    eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true, category: true);
 
-                        entryWritten = false;
-                    }
-                    catch (Win32Exception)
-                    {
-                        Thread.Sleep(100);
-                    }
-                }
                 // There is some prefix string already attached to the message passed
                 // The description for Event ID '0' in Source 'SourceWriteEntryWithTypeIDAndCategory' cannot be found.  The local computer may not have the necessary registry information or message DLL files to display the message, or you may not have permission
                 // to access them.  The following information is part of the event:'EventLogWriteEntryTestsMessage'
@@ -371,24 +326,12 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry = null;
-                bool entryWritten = true;
-                while (entryWritten)
-                {
-                    try
-                    {
-                        if (sourceFlag)
-                            eventLogEntry = WriteLogEntry(source, type: true, instance: true, category: true, data: true);
-                        else
-                            eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true, category: true, data: true);
+                EventLogEntry eventLogEntry;
+                if (sourceFlag)
+                    eventLogEntry = WriteLogEntry(source, type: true, instance: true, category: true, data: true);
+                else
+                    eventLogEntry = WriteLogEntryWithSource(source, type: true, instance: true, category: true, data: true);
 
-                        entryWritten = false;
-                    }
-                    catch (Win32Exception)
-                    {
-                        Thread.Sleep(100);
-                    }
-                }
                 if (eventLogEntry != null)
                 {
                     Assert.Contains(message, eventLogEntry.Message);
@@ -439,24 +382,12 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry = null;
-                bool entryWritten = true;
-                while (entryWritten)
-                {
-                    try
-                    {
-                        if (SourceFlag)
-                            eventLogEntry = WriteLogEntryEventSource(source);
-                        else
-                            eventLogEntry = WriteLogEntryEvent(source);
+                EventLogEntry eventLogEntry;
+                if (SourceFlag)
+                    eventLogEntry = WriteLogEntryEventSource(source);
+                else
+                    eventLogEntry = WriteLogEntryEvent(source);
 
-                        entryWritten = false;
-                    }
-                    catch (Win32Exception)
-                    {
-                        Thread.Sleep(100);
-                    }
-                }
                 if (eventLogEntry != null)
                     Assert.All(insertStrings, message => eventLogEntry.Message.Contains(message));
             }
@@ -477,24 +408,12 @@ namespace System.Diagnostics.Tests
             try
             {
                 EventLog.CreateEventSource(source, log);
-                EventLogEntry eventLogEntry = null;
-                bool entryWritten = true;
-                while (entryWritten)
-                {
-                    try
-                    {
-                        if (SourceFlag)
-                            eventLogEntry = WriteLogEntryEventSource(source, data: true);
-                        else
-                            eventLogEntry = WriteLogEntryEvent(source, data: true);
+                EventLogEntry eventLogEntry;
 
-                        entryWritten = false;
-                    }
-                    catch (Win32Exception)
-                    {
-                        Thread.Sleep(100);
-                    }
-                }
+                if (SourceFlag)
+                    eventLogEntry = WriteLogEntryEventSource(source, data: true);
+                else
+                    eventLogEntry = WriteLogEntryEvent(source, data: true);
 
                 if (eventLogEntry != null)
                     Assert.Equal(rawData, eventLogEntry.Data);

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -398,7 +398,7 @@ namespace System.Diagnostics.Tests
     {
         internal static EventLogEntry LastOrDefault(this EventLogEntryCollection elec)
         {
-            return Helpers.RetrieveOnWin7(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
+            return Helpers.RetryOnWin7(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
         }
     }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -49,7 +49,7 @@ namespace System.Diagnostics.Tests
                 {
                     if (PlatformDetection.IsWindows7)
                     {
-                        WriteEventWin7(typeof(EventLog), "WriteEntry", new Type[] { typeof(string) }, BindingFlags.Instance | BindingFlags.Public, new object[] { "A789541278" }, eventLog);
+                        WriteEventWin7<EventLog>(() => eventLog.WriteEntry(message));
                     }
                     else
                     {
@@ -127,7 +127,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        private void WriteEventWin7(Type type, string name, Type[] argumentTypes, BindingFlags flags, object[] argumentValues, EventLog eventLog, int retries = 3)
+        private void WriteEventWin71(Type type, string name, Type[] argumentTypes, BindingFlags flags, object[] argumentValues, EventLog eventLog, int retries = 3)
         {
             while (retries > 0)
             {
@@ -147,7 +147,26 @@ namespace System.Diagnostics.Tests
 
         }
 
-        [Fact]
+        static void WriteEventWin7<EventLog>(Action func)
+        {
+            int retries = 3;
+            while (retries > 0)
+            {
+                try
+                {
+                    func();
+                    break;
+                }
+                catch (Win32Exception)
+                {
+                    Thread.Sleep(100);
+                    retries--;
+                }
+            }
+            return;
+        }
+
+        //[Fact]
         public void dummyWrite()
         {
             string log = "DummyEntry";
@@ -157,7 +176,7 @@ namespace System.Diagnostics.Tests
                 EventLog.CreateEventSource(source, log);
                 EventLog eventLog = new EventLog();
                 eventLog.Source = source;
-                WriteEventWin7(typeof(EventLog), "WriteEntry", new Type[] { typeof(string) }, BindingFlags.Instance | BindingFlags.Public, new object[] { "A789541278" }, eventLog);
+                WriteEventWin71(typeof(EventLog), "WriteEntry", new Type[] { typeof(string) }, BindingFlags.Instance | BindingFlags.Public, new object[] { "A789541278" }, eventLog);
                 Console.WriteLine(eventLog.Entries[0].Message);
             }
             finally

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -37,6 +37,31 @@ namespace System.Diagnostics.Tests
             return;
         }
 
+        public static void CopyCollection<EventLogEntryCollection>(Action func)
+        {
+            if (!PlatformDetection.IsWindows7)
+            {
+                func();
+                return;
+            }
+
+            int retries = 3;
+            while (retries > 0)
+            {
+                try
+                {
+                    func();
+                    break;
+                }
+                catch (Win32Exception)
+                {
+                    Thread.Sleep(100);
+                    retries--;
+                }
+            }
+            return;
+        }
+
         public static EventLogEntry RetrieveEntry<EventLog>(Func<EventLogEntry> func)
         {
             EventLogEntry eventLogEntry = null;
@@ -60,6 +85,56 @@ namespace System.Diagnostics.Tests
                 }
             }
             return eventLogEntry;
+        }
+
+        public static EventLogEntry RetrieveEntryFromCollection<EventLog>(Func<EventLogEntry> func)
+        {
+            EventLogEntry eventLogEntry = null;
+            if (!PlatformDetection.IsWindows7)
+            {
+                return func();
+            }
+
+            int retries = 3;
+            while (retries > 0)
+            {
+                try
+                {
+                    eventLogEntry = func();
+                    break;
+                }
+                catch (Win32Exception)
+                {
+                    Thread.Sleep(100);
+                    retries--;
+                }
+            }
+            return eventLogEntry;
+        }
+
+        public static string RetrieveMessage<EventLogEntry>(Func<string> func)
+        {
+            string message = null;
+            if (!PlatformDetection.IsWindows7)
+            {
+                return func();
+            }
+
+            int retries = 3;
+            while (retries > 0)
+            {
+                try
+                {
+                    message = func();
+                    break;
+                }
+                catch (Win32Exception)
+                {
+                    Thread.Sleep(100);
+                    retries--;
+                }
+            }
+            return message;
         }
     }
 }

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -2,11 +2,64 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Threading;
+
 namespace System.Diagnostics.Tests
 {
     internal class Helpers
     {
         public static bool IsElevatedAndSupportsEventLogs { get => AdminHelpers.IsProcessElevated() && SupportsEventLogs; }
         public static bool SupportsEventLogs { get => PlatformDetection.IsNotWindowsNanoServer; }
+
+        public static void RetryAvailable<EventLog>(Action func)
+        {
+            if (!PlatformDetection.IsWindows7)
+            {
+                func();
+                return;
+            }
+
+            int retries = 3;
+            while (retries > 0)
+            {
+                try
+                {
+                    func();
+                    break;
+                }
+                catch (Win32Exception)
+                {
+                    Thread.Sleep(100);
+                    retries--;
+                }
+            }
+            return;
+        }
+
+        public static EventLogEntry RetrieveEntry<EventLog>(Func<EventLogEntry> func)
+        {
+            EventLogEntry eventLogEntry = null;
+            if (!PlatformDetection.IsWindows7)
+            {
+                return func();
+            }
+
+            int retries = 3;
+            while (retries > 0)
+            {
+                try
+                {
+                    eventLogEntry = func();
+                    break;
+                }
+                catch (Win32Exception)
+                {
+                    Thread.Sleep(100);
+                    retries--;
+                }
+            }
+            return eventLogEntry;
+        }
     }
 }

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -7,6 +7,6 @@ namespace System.Diagnostics.Tests
     internal class Helpers
     {
         public static bool IsElevatedAndSupportsEventLogs { get => AdminHelpers.IsProcessElevated() && SupportsEventLogs; }
-        public static bool SupportsEventLogs { get => PlatformDetection.IsNotWindowsNanoServer && !PlatformDetection.IsWindows7; }
+        public static bool SupportsEventLogs { get => PlatformDetection.IsNotWindowsNanoServer; }
     }
 }

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -12,32 +12,7 @@ namespace System.Diagnostics.Tests
         public static bool IsElevatedAndSupportsEventLogs { get => AdminHelpers.IsProcessElevated() && SupportsEventLogs; }
         public static bool SupportsEventLogs { get => PlatformDetection.IsNotWindowsNanoServer; }
 
-        public static void RetryAvailable<EventLog>(Action func)
-        {
-            if (!PlatformDetection.IsWindows7)
-            {
-                func();
-                return;
-            }
-
-            int retries = 3;
-            while (retries > 0)
-            {
-                try
-                {
-                    func();
-                    break;
-                }
-                catch (Win32Exception)
-                {
-                    Thread.Sleep(100);
-                    retries--;
-                }
-            }
-            return;
-        }
-
-        public static void CopyCollection<EventLogEntryCollection>(Action func)
+        public static void RetryAvailable(Action func)
         {
             if (!PlatformDetection.IsWindows7)
             {
@@ -87,9 +62,9 @@ namespace System.Diagnostics.Tests
             return eventLogEntry;
         }
 
-        public static EventLogEntry RetrieveEntryFromCollection<EventLog>(Func<EventLogEntry> func)
+        public static T RetrieveEntryOrMessage<T>(Func<T> func)
         {
-            EventLogEntry eventLogEntry = null;
+            T entry = default(T);
             if (!PlatformDetection.IsWindows7)
             {
                 return func();
@@ -100,7 +75,7 @@ namespace System.Diagnostics.Tests
             {
                 try
                 {
-                    eventLogEntry = func();
+                    entry = func();
                     break;
                 }
                 catch (Win32Exception)
@@ -109,32 +84,7 @@ namespace System.Diagnostics.Tests
                     retries--;
                 }
             }
-            return eventLogEntry;
-        }
-
-        public static string RetrieveMessage<EventLogEntry>(Func<string> func)
-        {
-            string message = null;
-            if (!PlatformDetection.IsWindows7)
-            {
-                return func();
-            }
-
-            int retries = 3;
-            while (retries > 0)
-            {
-                try
-                {
-                    message = func();
-                    break;
-                }
-                catch (Win32Exception)
-                {
-                    Thread.Sleep(100);
-                    retries--;
-                }
-            }
-            return message;
+            return entry;
         }
     }
 }

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -15,17 +15,16 @@ namespace System.Diagnostics.Tests
 
         public static void RetryOnWin7(Action func)
         {
-            RetrieveOnWin7<object>(() => { func(); return null; });
+            RetryOnWin7<object>(() => { func(); return null; });
         }
 
-        public static T RetrieveOnWin7<T>(Func<T> func)
+        public static T RetryOnWin7<T>(Func<T> func)
         {
             T entry = default(T);
             if (!PlatformDetection.IsWindows7)
             {
                 return func();
             }
-
 
             // We are retrying on windows 7 because it throws win32exception while some operations like Writing,Retrieveing and Deleting log.
             // So We just try to do the operation again in case of this exception 

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -26,7 +26,7 @@ namespace System.Diagnostics.Tests
                 try
                 {
                     func();
-                    break;
+                    retries = -1;
                 }
                 catch (Win32Exception)
                 {
@@ -35,31 +35,6 @@ namespace System.Diagnostics.Tests
                 }
             }
             return;
-        }
-
-        public static EventLogEntry RetrieveEntry<EventLog>(Func<EventLogEntry> func)
-        {
-            EventLogEntry eventLogEntry = null;
-            if (!PlatformDetection.IsWindows7)
-            {
-                return func();
-            }
-
-            int retries = 3;
-            while (retries > 0)
-            {
-                try
-                {
-                    eventLogEntry = func();
-                    break;
-                }
-                catch (Win32Exception)
-                {
-                    Thread.Sleep(100);
-                    retries--;
-                }
-            }
-            return eventLogEntry;
         }
 
         public static T RetrieveEntryOrMessage<T>(Func<T> func)
@@ -76,7 +51,7 @@ namespace System.Diagnostics.Tests
                 try
                 {
                     entry = func();
-                    break;
+                    retries = -1;
                 }
                 catch (Win32Exception)
                 {


### PR DESCRIPTION
Fixes #24874 
The EventLog tests were failing on windows 7. It was throwing win32exception. In order to solve the problem we wait  and retry the job after some time.