### PR TITLE
Generate debuginfo on all builds on unix platforms

### DIFF
--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -20,6 +20,7 @@ add_compile_options(-fPIC)
 add_compile_options(-I${CMAKE_CURRENT_SOURCE_DIR}/Common)
 add_compile_options(-I${CMAKE_CURRENT_BINARY_DIR}/Common)
 add_compile_options(-Wno-c99-extensions)
+add_compile_options(-g)
 
 if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.5)
     add_compile_options(-Wno-unreachable-code)
@@ -60,7 +61,7 @@ endif ()
 
 string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_CMAKE_BUILD_TYPE)
 if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
-    add_compile_options(-g -O0)
+    add_compile_options(-O0)
     add_definitions(-DDEBUG)
 
     # obtain settings from running coreclr\enablesanitizers.sh


### PR DESCRIPTION
The windows build already includes `/Zi /Zl` as part of commit 920fd2f3 (PR #7840). It looks like it was simply missed on Unix.

This change also makes the native debug information closer to what CoreCLR does on all platforms. See https://github.com/dotnet/coreclr/pull/3445 for more information.

This is also needed for the end-to-end debuginfo generation as part of source-build. See https://github.com/dotnet/source-build/issues/267