### PR TITLE
Add a simple way to test wmi remote

### DIFF
--- a/src/System.Management/tests/System/Management/SelectQueryTests.cs
+++ b/src/System.Management/tests/System/Management/SelectQueryTests.cs
@@ -13,7 +13,7 @@ namespace System.Management.Tests
         public void Select_Win32_LogicalDisk_ClassName()
         {
             var query = new SelectQuery("Win32_LogicalDisk");
-            var scope = new ManagementScope($@"\\{Environment.MachineName}\root\cimv2");
+            var scope = new ManagementScope($@"\\{WmiTestHelper.TargetMachine}\root\cimv2");
             scope.Connect();
 
             using (var searcher = new ManagementObjectSearcher(scope, query))
@@ -32,7 +32,7 @@ namespace System.Management.Tests
         public void Select_Win32_LogicalDisk_ClassName_Condition()
         {
             var query = new SelectQuery("Win32_LogicalDisk", "DriveType=3");
-            var scope = new ManagementScope($@"\\{Environment.MachineName}\root\cimv2");
+            var scope = new ManagementScope($@"\\{WmiTestHelper.TargetMachine}\root\cimv2");
             scope.Connect();
 
             using (var searcher = new ManagementObjectSearcher(scope, query))
@@ -46,11 +46,12 @@ namespace System.Management.Tests
             }
         }
 
-        [ConditionalFact(typeof(WmiTestHelper), nameof(WmiTestHelper.IsWmiSupported))]
-        public void Select_All_Win32_LogicalDisk_Wql()
+        [ConditionalTheory(typeof(WmiTestHelper), nameof(WmiTestHelper.IsWmiSupported))]
+        [MemberData(nameof(WmiTestHelper.ScopeRoots), MemberType = typeof(WmiTestHelper))]
+        public void Select_All_Win32_LogicalDisk_Wql(string scopeRoot)
         {
             var query = new SelectQuery("select * from Win32_LogicalDisk");
-            var scope = new ManagementScope(@"root\cimv2");
+            var scope = new ManagementScope(scopeRoot + @"root\cimv2");
             scope.Connect();
 
             using (var searcher = new ManagementObjectSearcher(scope, query))

--- a/src/System.Management/tests/WmiTestHelper.cs
+++ b/src/System.Management/tests/WmiTestHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.IO;
 
 namespace System.Management.Tests
@@ -12,9 +13,21 @@ namespace System.Management.Tests
         private static readonly bool s_isWmiSupported = PlatformDetection.IsWindows && PlatformDetection.IsNotWindowsNanoServer && !PlatformDetection.IsUap;
         private static readonly string s_systemDriveId = Path.GetPathRoot(Environment.GetEnvironmentVariable("SystemDrive"));
 
+        // Use the environment variable below to do manual runs against remote boxes: just ensure that the credentials running the tests have
+        // rights to query the box (use wbemtest tool to validate).
+        private static readonly string s_targetMachine = Environment.GetEnvironmentVariable("WmiTestTargetMachine") ?? Environment.MachineName;
+        private static readonly object[][] s_scopeRoots = new[]
+        {
+            new [] { $@"\\{s_targetMachine}\" },
+            new [] { @"\\.\" },
+            new [] { string.Empty }
+        };
+
         public static string Namespace => "root/WmiEBvt";
         public static string SystemDriveId => s_systemDriveId;
         public static bool IsWmiSupported => s_isWmiSupported;
         public static bool IsElevatedAndSupportsWmi => s_isElevated && IsWmiSupported;
+        public static string TargetMachine => s_targetMachine;
+        public static IEnumerable<object[]> ScopeRoots => s_scopeRoots;
     }
 }


### PR DESCRIPTION
Simply using an environment variable, WmiTestTargetMachine, to specify
the target machine. When running the tests ensure that the account
running the tests has rights on the target machine.

There is not much value in adding similar scope to other tests since
regarding remote connectivity they actually end up hitting the same
code, so keep this just for some key tests.