### PR TITLE
 Mark applicable structs as readonly

### DIFF
--- a/src/Common/src/Interop/OSX/System.Native/Interop.ProtocolStatistics.cs
+++ b/src/Common/src/Interop/OSX/System.Native/Interop.ProtocolStatistics.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [StructLayoutAttribute(LayoutKind.Sequential)]
-        public unsafe struct TcpGlobalStatistics
+        public unsafe readonly struct TcpGlobalStatistics
         {
             public readonly ulong ConnectionsAccepted;
             public readonly ulong ConnectionsInitiated;
@@ -27,7 +27,7 @@ internal static partial class Interop
         public static extern unsafe int GetTcpGlobalStatistics(out TcpGlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
-        public unsafe struct IPv4GlobalStatistics
+        public unsafe readonly struct IPv4GlobalStatistics
         {
             public readonly ulong OutboundPackets;
             public readonly ulong OutputPacketsNoRoute;
@@ -49,7 +49,7 @@ internal static partial class Interop
         public static extern unsafe int GetIPv4GlobalStatistics(out IPv4GlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
-        public unsafe struct UdpGlobalStatistics
+        public unsafe readonly struct UdpGlobalStatistics
         {
             public readonly ulong DatagramsReceived;
             public readonly ulong DatagramsSent;
@@ -62,7 +62,7 @@ internal static partial class Interop
         public static extern unsafe int GetUdpGlobalStatistics(out UdpGlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
-        public unsafe struct Icmpv4GlobalStatistics
+        public unsafe readonly struct Icmpv4GlobalStatistics
         {
             public readonly ulong AddressMaskRepliesReceived;
             public readonly ulong AddressMaskRepliesSent;
@@ -92,7 +92,7 @@ internal static partial class Interop
         public static extern unsafe int GetIcmpv4GlobalStatistics(out Icmpv4GlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
-        public unsafe struct Icmpv6GlobalStatistics
+        public unsafe readonly struct Icmpv6GlobalStatistics
         {
             public readonly ulong DestinationUnreachableMessagesReceived;
             public readonly ulong DestinationUnreachableMessagesSent;
@@ -127,7 +127,7 @@ internal static partial class Interop
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIcmpv6GlobalStatistics")]
         public static extern unsafe int GetIcmpv6GlobalStatistics(out Icmpv6GlobalStatistics statistics);
 
-        public struct NativeIPInterfaceStatistics
+        public readonly struct NativeIPInterfaceStatistics
         {
             public readonly ulong SendQueueLength;
             public readonly ulong Mtu;

--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -11,7 +11,7 @@ namespace System.Collections.Generic
     /// Represents a position within a <see cref="LargeArrayBuilder{T}"/>.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal struct CopyPosition
+    internal readonly struct CopyPosition
     {
         /// <summary>
         /// Constructs a new <see cref="CopyPosition"/>.

--- a/src/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
@@ -10,7 +10,7 @@ namespace System.Collections.Generic
     /// Represents a reserved region within a <see cref="SparseArrayBuilder{T}"/>.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal struct Marker
+    internal readonly struct Marker
     {
         /// <summary>
         /// Constructs a new marker.

--- a/src/Common/src/System/Net/ContextFlagsAdapterPal.Unix.cs
+++ b/src/Common/src/System/Net/ContextFlagsAdapterPal.Unix.cs
@@ -8,7 +8,7 @@ namespace System.Net
 {
     internal static class ContextFlagsAdapterPal
     {
-        private struct ContextFlagMapping
+        private readonly struct ContextFlagMapping
         {
             public readonly Interop.NetSecurityNative.GssFlags GssFlags;
             public readonly ContextFlagsPal ContextFlag;

--- a/src/Common/src/System/Net/ContextFlagsAdapterPal.Windows.cs
+++ b/src/Common/src/System/Net/ContextFlagsAdapterPal.Windows.cs
@@ -8,7 +8,7 @@ namespace System.Net
 {
     internal static class ContextFlagsAdapterPal
     {
-        private struct ContextFlagMapping
+        private readonly struct ContextFlagMapping
         {
             public readonly Interop.SspiCli.ContextFlags Win32Flag;
             public readonly ContextFlagsPal ContextFlag;

--- a/src/Common/src/System/Net/SecurityStatusPal.cs
+++ b/src/Common/src/System/Net/SecurityStatusPal.cs
@@ -4,7 +4,7 @@
 
 namespace System.Net
 {
-    internal struct SecurityStatusPal
+    internal readonly struct SecurityStatusPal
     {
         public readonly SecurityStatusPalErrorCode ErrorCode;
         public readonly Exception Exception;

--- a/src/Common/src/System/Runtime/InteropServices/FunctionWrapper.cs
+++ b/src/Common/src/System/Runtime/InteropServices/FunctionWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices
 
     public enum FunctionLoadResultKind { Success, LibraryNotFound, FunctionNotFound }
 
-    public struct FunctionLoadResult<T>
+    public readonly struct FunctionLoadResult<T>
     {
         public FunctionLoadResultKind ResultKind { get; }
         public T Delegate { get; }

--- a/src/Common/src/System/Text/StringOrCharArray.cs
+++ b/src/Common/src/System/Text/StringOrCharArray.cs
@@ -12,7 +12,7 @@ namespace System.Text
     /// allocate/copy the chars into a new string.  This comes at the expense of an extra
     /// reference field + two Int32s per key in the size of the dictionary's Entry array.
     /// </summary>
-    internal struct StringOrCharArray : IEquatable<StringOrCharArray>
+    internal readonly struct StringOrCharArray : IEquatable<StringOrCharArray>
     {
         public readonly string String;
 

--- a/src/Common/src/System/Threading/Tasks/ForceAsyncAwaiter.cs
+++ b/src/Common/src/System/Threading/Tasks/ForceAsyncAwaiter.cs
@@ -21,7 +21,7 @@ namespace System.Threading.Tasks
         }
     }
 
-    internal struct ForceAsyncAwaiter : ICriticalNotifyCompletion
+    internal readonly struct ForceAsyncAwaiter : ICriticalNotifyCompletion
     {
         private readonly Task _task;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ArgumentObject.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ArgumentObject.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CSharp.RuntimeBinder
     // value's type because unless the static time type was dynamic, we want to use the
     // static time type. Also, we may have null values, in which case we would not be 
     // able to get the type.
-    internal struct ArgumentObject
+    internal readonly struct ArgumentObject
     {
         internal readonly object Value;
         internal readonly CSharpArgumentInfo Info;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ConstVal.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ConstVal.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         Boolean
     }
 
-    internal struct ConstVal
+    internal readonly struct ConstVal
     {
         // Pre-boxed common values.
         private static readonly object s_false = false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -256,7 +256,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // 2) Make it so parameter lists can be compared by a simple pointer comparison
         // 3) Allow us to associate a token with each signature for faster metadata emit
 
-        private struct TypeArrayKey : IEquatable<TypeArrayKey>
+        private readonly struct TypeArrayKey : IEquatable<TypeArrayKey>
         {
             private readonly CType[] _types;
             private readonly int _hashCode;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
@@ -10,7 +10,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal struct KeyPair<Key1, Key2> : IEquatable<KeyPair<Key1, Key2>>
+    internal readonly struct KeyPair<Key1, Key2> : IEquatable<KeyPair<Key1, Key2>>
     {
         private readonly Key1 _pKey1;
         private readonly Key2 _pKey2;

--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/shared/TraceLogging/PropertyValue.cs
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/shared/TraceLogging/PropertyValue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
@@ -27,7 +27,7 @@ namespace System.Diagnostics.Tracing
 #else
     internal
 #endif
-    unsafe struct PropertyValue
+    unsafe readonly struct PropertyValue
     {
         /// <summary>
         /// Union of well-known value types, to avoid boxing those types.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
@@ -15,7 +15,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Contains all the key/values in the collection that hash to the same value.
         /// </summary>
-        internal struct HashBucket : IEnumerable<KeyValuePair<TKey, TValue>>
+        internal readonly struct HashBucket : IEnumerable<KeyValuePair<TKey, TValue>>
         {
             /// <summary>
             /// One of the values in this bucket.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.MutationInput.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.MutationInput.cs
@@ -15,7 +15,7 @@ namespace System.Collections.Immutable
         /// Description of the current data structure as input into a
         /// mutating or query method.
         /// </summary>
-        private struct MutationInput
+        private readonly struct MutationInput
         {
             /// <summary>
             /// The root of the data structure for the collection.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.MutationResult.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.MutationResult.cs
@@ -12,7 +12,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Describes the result of a mutation on the immutable data structure.
         /// </summary>
-        private struct MutationResult
+        private readonly struct MutationResult
         {
             /// <summary>
             /// The root node of the data structure after the mutation.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.HashBucket.cs
@@ -31,7 +31,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Contains all the keys in the collection that hash to the same value.
         /// </summary>
-        internal struct HashBucket
+        internal readonly struct HashBucket
         {
             /// <summary>
             /// One of the values in this bucket.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.MutationInput.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.MutationInput.cs
@@ -15,7 +15,7 @@ namespace System.Collections.Immutable
         /// Description of the current data structure as input into a
         /// mutating or query method.
         /// </summary>
-        private struct MutationInput
+        private readonly struct MutationInput
         {
             /// <summary>
             /// The root of the data structure for the collection.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.MutationResult.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.MutationResult.cs
@@ -28,7 +28,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Describes the result of a mutation on the immutable data structure.
         /// </summary>
-        private struct MutationResult
+        private readonly struct MutationResult
         {
             /// <summary>
             /// The root node of the data structure after the mutation.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.NodeEnumerable.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.NodeEnumerable.cs
@@ -15,7 +15,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Enumerates over a sorted dictionary used for hash buckets.
         /// </summary>
-        private struct NodeEnumerable : IEnumerable<T>
+        private readonly struct NodeEnumerable : IEnumerable<T>
         {
             /// <summary>
             /// The root of the sorted dictionary to enumerate.

--- a/src/System.Collections.Specialized/ref/System.Collections.Specialized.cs
+++ b/src/System.Collections.Specialized/ref/System.Collections.Specialized.cs
@@ -25,7 +25,7 @@ namespace System.Collections.Specialized
         public override string ToString() { throw null; }
         public static string ToString(System.Collections.Specialized.BitVector32 value) { throw null; }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct Section
+        public readonly partial struct Section
         {
             public short Mask { get { throw null; } }
             public short Offset { get { throw null; } }

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/BitVector32.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/BitVector32.cs
@@ -230,7 +230,7 @@ namespace System.Collections.Specialized
         ///    <para>
         ///       Represents an section of the vector that can contain a integer number.</para>
         /// </devdoc>
-        public struct Section
+        public readonly struct Section
         {
             private readonly short _mask;
             private readonly short _offset;

--- a/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.cs
+++ b/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.cs
@@ -1438,7 +1438,7 @@ namespace System.ComponentModel.Design.Serialization
         public object Invoke() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MemberRelationship
+    public readonly partial struct MemberRelationship
     {
         public static readonly System.ComponentModel.Design.Serialization.MemberRelationship Empty;
         public MemberRelationship(object owner, System.ComponentModel.MemberDescriptor member) { throw null; }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/MemberRelationshipService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/MemberRelationshipService.cs
@@ -180,7 +180,7 @@ namespace System.ComponentModel.Design.Serialization
     /// <summary>
     ///    This class represents a single relationship between an object and a member.
     /// </summary>
-    public struct MemberRelationship
+    public readonly struct MemberRelationship
     {
         public static readonly MemberRelationship Empty = new MemberRelationship();
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -3273,7 +3273,7 @@ namespace System.ComponentModel
             ///     A type descriptor for extended types.  This type descriptor
             ///     looks at the head node in the linked list.
             /// </summary>
-            private struct DefaultExtendedTypeDescriptor : ICustomTypeDescriptor
+            private readonly struct DefaultExtendedTypeDescriptor : ICustomTypeDescriptor
             {
                 private readonly TypeDescriptionNode _node;
                 private readonly object _instance;
@@ -3584,7 +3584,7 @@ namespace System.ComponentModel
             /// <summary>
             ///     The default type descriptor.
             /// </summary>
-            private struct DefaultTypeDescriptor : ICustomTypeDescriptor
+            private readonly struct DefaultTypeDescriptor : ICustomTypeDescriptor
             {
                 private readonly TypeDescriptionNode _node;
                 private readonly Type _objectType;

--- a/src/System.Console/ref/System.Console.cs
+++ b/src/System.Console/ref/System.Console.cs
@@ -127,7 +127,7 @@ namespace System
         White = 15,
         Yellow = 14,
     }
-    public partial struct ConsoleKeyInfo
+    public readonly partial struct ConsoleKeyInfo
     {
         public ConsoleKeyInfo(char keyChar, ConsoleKey key, bool shift, bool alt, bool control) { }
         public char KeyChar { get { throw null; } }

--- a/src/System.Console/src/System/ConsoleKeyInfo.cs
+++ b/src/System.Console/src/System/ConsoleKeyInfo.cs
@@ -4,7 +4,7 @@
 
 namespace System
 {
-    public struct ConsoleKeyInfo
+    public readonly struct ConsoleKeyInfo
     {
         private readonly char _keyChar;
         private readonly ConsoleKey _key;

--- a/src/System.Console/src/System/TermInfo.cs
+++ b/src/System.Console/src/System/TermInfo.cs
@@ -897,7 +897,7 @@ namespace System
             /// It is a discriminated union of either an integer or a string, 
             /// with characters represented as integers.
             /// </summary>
-            public struct FormatParam
+            public readonly struct FormatParam
             {
                 /// <summary>The integer stored in the parameter.</summary>
                 private readonly int _int32;

--- a/src/System.Data.Common/src/System/Data/DataKey.cs
+++ b/src/System.Data.Common/src/System/Data/DataKey.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Data
 {
-    internal struct DataKey
+    internal readonly struct DataKey
     {
         private const int maxColumns = 32;
 

--- a/src/System.Data.Common/src/System/Data/Filter/ExpressionParser.cs
+++ b/src/System.Data.Common/src/System/Data/Filter/ExpressionParser.cs
@@ -47,7 +47,7 @@ namespace System.Data
         private const int Expr = 2;   /* The previous operand was a complex expression */
 
 
-        private struct ReservedWords
+        private readonly struct ReservedWords
         {
             internal readonly string _word;      // the word
             internal readonly Tokens _token;

--- a/src/System.Data.Common/src/System/Data/RbTree.cs
+++ b/src/System.Data.Common/src/System/Data/RbTree.cs
@@ -1893,7 +1893,7 @@ namespace System.Data
 
 
         /// <summary>Represents the node in the tree and the satellite branch it took to get there.</summary>
-        private struct NodePath
+        private readonly struct NodePath
         {
             /// <summary>Represents the node in the tree</summary>
             internal readonly int _nodeID;

--- a/src/System.Data.Common/src/System/Data/Selection.cs
+++ b/src/System.Data.Common/src/System/Data/Selection.cs
@@ -9,7 +9,7 @@ using System.Threading;
 
 namespace System.Data
 {
-    internal struct IndexField
+    internal readonly struct IndexField
     {
         public readonly DataColumn Column;
         public readonly bool IsDescending; // false = Asc; true = Desc what is default value for this?

--- a/src/System.Data.Odbc/src/System/Data/Odbc/OdbcMetaDataFactory.cs
+++ b/src/System.Data.Odbc/src/System/Data/Odbc/OdbcMetaDataFactory.cs
@@ -12,7 +12,7 @@ namespace System.Data.Odbc
 {
     internal class OdbcMetaDataFactory : DbMetaDataFactory
     {
-        private struct SchemaFunctionName
+        private readonly struct SchemaFunctionName
         {
             internal SchemaFunctionName(string schemaName, ODBC32.SQL_API odbcFunction)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
@@ -144,7 +144,7 @@ namespace System.Data.SqlClient
         }
 
         // Used to hold column metadata for SqlDataReader case
-        private struct SourceColumnMetadata
+        private readonly struct SourceColumnMetadata
         {
             public SourceColumnMetadata(ValueMethod method, bool isSqlType, bool isDataFeed)
             {

--- a/src/System.Diagnostics.PerformanceCounter/ref/System.Diagnostics.PerformanceCounter.cs
+++ b/src/System.Diagnostics.PerformanceCounter/ref/System.Diagnostics.PerformanceCounter.cs
@@ -32,7 +32,7 @@ namespace System.Diagnostics
         public virtual void Remove(System.Diagnostics.CounterCreationData value) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CounterSample
+    public readonly partial struct CounterSample
     {
         public static System.Diagnostics.CounterSample Empty;
         public CounterSample(long rawValue, long baseValue, long counterFrequency, long systemFrequency, long timeStamp, long timeStamp100nSec, System.Diagnostics.PerformanceCounterType counterType) { throw null;}

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/CounterSample.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/CounterSample.cs
@@ -7,7 +7,7 @@ namespace System.Diagnostics
     /// <summary>
     ///     A struct holding the raw data for a performance counter.
     /// </summary>    
-    public struct CounterSample
+    public readonly struct CounterSample
     {
         private readonly long _rawValue;
         private readonly long _baseValue;

--- a/src/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
+++ b/src/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
@@ -173,7 +173,7 @@ namespace System.Diagnostics.SymbolStore
         NativeStackRegister = 8,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct SymbolToken
+    public readonly partial struct SymbolToken
     {
         public SymbolToken(int val) { throw null; }
         public bool Equals(System.Diagnostics.SymbolStore.SymbolToken obj) { throw null; }

--- a/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/SymbolToken.cs
+++ b/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/SymbolToken.cs
@@ -4,7 +4,7 @@
 
 namespace System.Diagnostics.SymbolStore
 {
-    public struct SymbolToken
+    public readonly struct SymbolToken
     {
         private readonly int _token;
         

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/TriState.Serializable.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/TriState.Serializable.cs
@@ -1,11 +1,11 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Drawing.Printing
 {
     [Serializable]
-    partial struct TriState
+    readonly partial struct TriState
     {
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/TriState.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/TriState.cs
@@ -4,9 +4,9 @@
 
 namespace System.Drawing.Printing
 {
-    internal partial struct TriState
+    internal readonly partial struct TriState
     {
-        private byte _value; // 0 is "default", not false
+        private readonly byte _value; // 0 is "default", not false
 
         public static readonly TriState Default = new TriState(0);
         public static readonly TriState False = new TriState(1);

--- a/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.cs
+++ b/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.cs
@@ -7,7 +7,7 @@
 
 namespace System.Drawing
 {
-    public partial struct Color : System.IEquatable<System.Drawing.Color>
+    public readonly partial struct Color : System.IEquatable<System.Drawing.Color>
     {
         public static readonly System.Drawing.Color Empty;
         public byte A { get { throw null; } }

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -11,7 +11,7 @@ namespace System.Drawing
     [DebuggerDisplay("{NameAndARGBValue}")]
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
-    public struct Color : IEquatable<Color>
+    public readonly struct Color : IEquatable<Color>
     {
         public static readonly Color Empty = new Color();
 

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateInput.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateInput.cs
@@ -28,7 +28,7 @@ namespace System.IO.Compression
             StartIndex = state._startIndex;
         }
 
-        internal struct InputState
+        internal readonly struct InputState
         {
             internal readonly int _count;
             internal readonly int _startIndex;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputBuffer.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputBuffer.cs
@@ -106,7 +106,7 @@ namespace System.IO.Compression
             _bitCount = state._bitCount;
         }
 
-        internal struct BufferState
+        internal readonly struct BufferState
         {
             internal readonly int _pos;      // position
             internal readonly uint _bitBuf;  // store uncomplete bits

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -371,7 +371,7 @@ namespace System.IO.Compression
         }
     }
 
-    internal struct ZipLocalFileHeader
+    internal readonly struct ZipLocalFileHeader
     {
         public const uint DataDescriptorSignature = 0x08074B50;
         public const uint SignatureConstant = 0x04034B50;

--- a/src/System.IO.FileSystem/src/System/IO/PathPair.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathPair.cs
@@ -4,7 +4,7 @@
 
 namespace System.IO
 {
-    internal struct PathPair
+    internal readonly struct PathPair
     {
         internal readonly string UserPath;
         internal readonly string FullPath;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/BoundConstants.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/BoundConstants.cs
@@ -24,7 +24,7 @@ namespace System.Linq.Expressions.Compiler
         /// ends up using a JIT temp and defeats the purpose of caching the
         /// value in a local)
         /// </summary>
-        private struct TypedConstant : IEquatable<TypedConstant>
+        private readonly struct TypedConstant : IEquatable<TypedConstant>
         {
             internal readonly object Value;
             internal readonly Type Type;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
@@ -57,7 +57,7 @@ namespace System.Linq.Expressions.Compiler
         /// <summary>
         /// Result of a rewrite operation. Always contains an action and a node.
         /// </summary>
-        private struct Result
+        private readonly struct Result
         {
             internal readonly RewriteAction Action;
             internal readonly Expression Node;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/BranchLabel.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/BranchLabel.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 
 namespace System.Linq.Expressions.Interpreter
 {
-    internal struct RuntimeLabel
+    internal readonly struct RuntimeLabel
     {
         public readonly int Index;
         public readonly int StackDepth;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -15,7 +15,7 @@ namespace System.Linq.Expressions.Interpreter
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
     [DebuggerTypeProxy(typeof(InstructionArray.DebugView))]
-    internal struct InstructionArray
+    internal readonly struct InstructionArray
     {
         internal readonly int MaxStackDepth;
         internal readonly int MaxContinuationDepth;
@@ -142,7 +142,7 @@ namespace System.Linq.Expressions.Interpreter
             }
 
             [DebuggerDisplay("{GetValue(),nq}", Name = "{GetName(),nq}", Type = "{GetDisplayType(), nq}")]
-            internal struct InstructionView
+            internal readonly struct InstructionView
             {
                 private readonly int _index;
                 private readonly int _stackDepth;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -256,7 +256,7 @@ namespace System.Linq.Expressions.Interpreter
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-    internal struct InterpretedFrameInfo
+    internal readonly struct InterpretedFrameInfo
     {
         private readonly string _methodName;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
@@ -46,7 +46,7 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
-    internal struct LocalDefinition
+    internal readonly struct LocalDefinition
     {
         internal LocalDefinition(int localIndex, ParameterExpression parameter)
         {

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
@@ -491,7 +491,7 @@ namespace System.Linq.Parallel
     /// <summary>
     /// A structure to represent a producer in the producer heap.
     /// </summary>
-    internal struct Producer<TKey>
+    internal readonly struct Producer<TKey>
     {
         internal readonly TKey MaxKey; // Order index of the next element from this producer
         internal readonly int ProducerIndex; // Index of the producer, [0..DOP)

--- a/src/System.Linq/src/System/Linq/Buffer.cs
+++ b/src/System.Linq/src/System/Linq/Buffer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,7 +10,7 @@ namespace System.Linq
     /// A buffer into which the contents of an <see cref="IEnumerable{TElement}"/> can be stored.
     /// </summary>
     /// <typeparam name="TElement">The type of the buffer's elements.</typeparam>
-    internal struct Buffer<TElement>
+    internal readonly struct Buffer<TElement>
     {
         /// <summary>
         /// The stored items.

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,7 +10,7 @@ namespace System.Net.Http.Headers
     // if the header is one of our known headers, then it contains a reference to the KnownHeader object;
     // otherwise, for custom headers, it just contains a string for the header name.
     // Use HeaderDescriptor.TryGet to resolve an arbitrary header name to a HeaderDescriptor.
-    internal struct HeaderDescriptor : IEquatable<HeaderDescriptor>
+    internal readonly struct HeaderDescriptor : IEquatable<HeaderDescriptor>
     {
         private readonly string _headerName;
         private readonly KnownHeader _knownHeader;

--- a/src/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -101,7 +101,7 @@ namespace System.Net.Http.Headers
             char this[int index] { get; }
         }
 
-        private struct StringAccessor : IHeaderNameAccessor
+        private readonly struct StringAccessor : IHeaderNameAccessor
         {
             private readonly string _string;
 
@@ -115,7 +115,7 @@ namespace System.Net.Http.Headers
         }
 
         // Can't use Span here as it's unsupported.
-        private unsafe struct BytePtrAccessor : IHeaderNameAccessor
+        private unsafe readonly struct BytePtrAccessor : IHeaderNameAccessor
         {
             private readonly byte* _p;
             private readonly int _length;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
@@ -1,10 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Net.Http
 {
-    internal struct HttpConnectionKey : IEquatable<HttpConnectionKey>
+    internal readonly struct HttpConnectionKey : IEquatable<HttpConnectionKey>
     {
         public readonly bool UsingSSL;
         public readonly string Host;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -487,7 +487,7 @@ namespace System.Net.Http
 
         /// <summary>A cached idle connection and metadata about it.</summary>
         [StructLayout(LayoutKind.Auto)]
-        private struct CachedConnection : IEquatable<CachedConnection>
+        private readonly struct CachedConnection : IEquatable<CachedConnection>
         {
             /// <summary>The cached connection.</summary>
             internal readonly HttpConnection _connection;

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseHeaderReader.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseHeaderReader.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Net.Http
 {
-    internal struct CurlResponseHeaderReader
+    internal readonly struct CurlResponseHeaderReader
     {
         private const string HttpPrefix = "HTTP/";
 
@@ -139,7 +139,7 @@ namespace System.Net.Http
             return c == ' ' || (c >= '\x0009' && c <= '\x000d') || c == '\x00a0' || c == '\x0085';
         }
 
-        private unsafe struct HeaderBufferSpan
+        private unsafe readonly struct HeaderBufferSpan
         {
             private readonly byte* _pointer;
             public readonly int Length;

--- a/src/System.Net.Mail/src/System/Net/Mail/MailHeaderInfo.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/MailHeaderInfo.cs
@@ -9,7 +9,7 @@ namespace System.Net.Mail
     internal static class MailHeaderInfo
     {
         // Structure that wraps information about a single mail header
-        private struct HeaderInfo
+        private readonly struct HeaderInfo
         {
             public readonly string NormalizedName;
             public readonly bool IsSingleton;

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -56,7 +56,7 @@ using System.Text;
 
 namespace System.Net
 {
-    internal struct HeaderVariantInfo
+    internal readonly struct HeaderVariantInfo
     {
         private readonly string _name;
         private readonly CookieVariant _variant;

--- a/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -418,7 +418,7 @@ namespace System.Net
         }
     }
 
-    internal struct CredentialHostKey : IEquatable<CredentialHostKey>
+    internal readonly struct CredentialHostKey : IEquatable<CredentialHostKey>
     {
         public readonly string Host;
         public readonly string AuthenticationType;

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -122,7 +122,7 @@ namespace System.Net.Security
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get { throw null; } set { } }
         public EncryptionPolicy EncryptionPolicy { get { throw null; } set { } }
     }
-    public partial struct SslApplicationProtocol : IEquatable<SslApplicationProtocol>
+    public readonly partial struct SslApplicationProtocol : IEquatable<SslApplicationProtocol>
     {
         public static readonly SslApplicationProtocol Http2;
         public static readonly SslApplicationProtocol Http11;

--- a/src/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace System.Net.Security
 {
-    public struct SslApplicationProtocol : IEquatable<SslApplicationProtocol>
+    public readonly struct SslApplicationProtocol : IEquatable<SslApplicationProtocol>
     {
         private readonly ReadOnlyMemory<byte> _readOnlyProtocol;
         private static readonly Encoding s_utf8 = Encoding.GetEncoding(Encoding.UTF8.CodePage, EncoderFallback.ExceptionFallback, DecoderFallback.ExceptionFallback);

--- a/src/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
@@ -19,7 +19,7 @@ namespace System.Net.Security
         //
         // Uses certificate thumb-print comparison.
         //
-        private struct SslCredKey : IEquatable<SslCredKey>
+        private readonly struct SslCredKey : IEquatable<SslCredKey>
         {
             private readonly byte[] _thumbPrint;
             private readonly int _allowedProtocols;

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.Adapters.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.Adapters.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 using System.Threading;
@@ -15,7 +15,7 @@ namespace System.Net.Security
             Task WriteAsync(byte[] buffer, int offset, int count);
         }
 
-        private struct SslWriteAsync : ISslWriteAdapter
+        private readonly struct SslWriteAsync : ISslWriteAdapter
         {
             private readonly SslState _sslState;
             private readonly CancellationToken _cancellationToken;
@@ -31,7 +31,7 @@ namespace System.Net.Security
             public Task WriteAsync(byte[] buffer, int offset, int count) => _sslState.InnerStream.WriteAsync(buffer, offset, count, _cancellationToken);
         }
 
-        private struct SslWriteSync : ISslWriteAdapter
+        private readonly struct SslWriteSync : ISslWriteAdapter
         {
             private readonly SslState _sslState;
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -16,7 +16,7 @@ namespace System.Net.Sockets
         //
         // Encapsulates a particular SocketAsyncContext object's access to a SocketAsyncEngine.  
         //
-        public struct Token
+        public readonly struct Token
         {
             private readonly SocketAsyncEngine _engine;
             private readonly IntPtr _handle;

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Win32.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Win32.cs
@@ -16,7 +16,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace System.Net.WebSockets
 {
-    internal partial struct WebSocketHandle
+    internal readonly partial struct WebSocketHandle
     {
         private const string WebSocketAvailableApiCheck = "WinHttpWebSocketCompleteUpgrade";
 

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.WinRT.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.WinRT.cs
@@ -19,7 +19,7 @@ using RTWebSocketError = Windows.Networking.Sockets.WebSocketError;
 
 namespace System.Net.WebSockets
 {
-    internal partial struct WebSocketHandle
+    internal readonly partial struct WebSocketHandle
     {
         private readonly WinRTWebSocket _webSocket;
 

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Windows.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Windows.cs
@@ -16,7 +16,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace System.Net.WebSockets
 {
-    internal partial struct WebSocketHandle
+    internal readonly partial struct WebSocketHandle
     {
         #region Properties
         public static bool IsValid(WebSocketHandle handle)

--- a/src/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1448,14 +1448,14 @@ namespace System.Net.WebSockets
         }
 
         /// <summary><see cref="IWebSocketReceiveResultGetter{TResult}"/> implementation for <see cref="WebSocketReceiveResult"/>.</summary>
-        private struct WebSocketReceiveResultGetter : IWebSocketReceiveResultGetter<WebSocketReceiveResult>
+        private readonly struct WebSocketReceiveResultGetter : IWebSocketReceiveResultGetter<WebSocketReceiveResult>
         {
             public WebSocketReceiveResult GetResult(int count, WebSocketMessageType messageType, bool endOfMessage, WebSocketCloseStatus? closeStatus, string closeDescription) =>
                 new WebSocketReceiveResult(count, messageType, endOfMessage, closeStatus, closeDescription);
         }
 
         /// <summary><see cref="IWebSocketReceiveResultGetter{TResult}"/> implementation for <see cref="ValueWebSocketReceiveResult"/>.</summary>
-        private struct ValueWebSocketReceiveResultGetter : IWebSocketReceiveResultGetter<ValueWebSocketReceiveResult>
+        private readonly struct ValueWebSocketReceiveResultGetter : IWebSocketReceiveResultGetter<ValueWebSocketReceiveResult>
         {
             public ValueWebSocketReceiveResult GetResult(int count, WebSocketMessageType messageType, bool endOfMessage, WebSocketCloseStatus? closeStatus, string closeDescription) =>
                 new ValueWebSocketReceiveResult(count, messageType, endOfMessage); // closeStatus/closeDescription are ignored

--- a/src/System.Private.DataContractSerialization/src/System/Xml/BytesWithOffset.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/BytesWithOffset.cs
@@ -4,7 +4,7 @@
 
 namespace System.Xml
 {
-    internal struct BytesWithOffset
+    internal readonly struct BytesWithOffset
     {
         private readonly byte[] _bytes;
         private readonly int _offset;

--- a/src/System.Private.Xml.Linq/src/System/Xml/XPath/XNodeNavigator.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/XPath/XNodeNavigator.cs
@@ -853,7 +853,7 @@ namespace System.Xml.XPath
         }
     }
 
-    internal struct XPathEvaluator
+    internal readonly struct XPathEvaluator
     {
         public object Evaluate<T>(XNode node, string expression, IXmlNamespaceResolver resolver) where T : class
         {

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -3267,7 +3267,7 @@ namespace System.Xml
         // Returns true when the whole value has been parsed. Return false when it needs to be called again to get a next chunk of value.
 
 
-        private struct ParseTextState
+        private readonly struct ParseTextState
         {
             public readonly int outOrChars;
             public readonly char[] chars;

--- a/src/System.Private.Xml/src/System/Xml/Dom/XmlNode.cs
+++ b/src/System.Private.Xml/src/System/Xml/Dom/XmlNode.cs
@@ -1423,7 +1423,7 @@ namespace System.Xml
         private object debuggerDisplayProxy { get { return new DebuggerDisplayXmlNodeProxy(this); } }
 
         [DebuggerDisplay("{ToString()}")]
-        internal struct DebuggerDisplayXmlNodeProxy
+        internal readonly struct DebuggerDisplayXmlNodeProxy
         {
             private readonly XmlNode _node;
 

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/MatcherBuilder.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/MatcherBuilder.cs
@@ -244,7 +244,7 @@ namespace System.Xml.Xsl.Xslt
         }
     }
 
-    internal struct Pattern
+    internal readonly struct Pattern
     {
         public readonly TemplateMatch Match;
 

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGeneratorEnv.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGeneratorEnv.cs
@@ -20,7 +20,7 @@ namespace System.Xml.Xsl.Xslt
         // Everywhere in this code in case of error in the stylesheet we should throw XslLoadException.
         // This helper IErrorHelper implementation is used to wrap XmlException's into XslLoadException's.
 
-        private struct ThrowErrorHelper : IErrorHelper
+        private readonly struct ThrowErrorHelper : IErrorHelper
         {
             public void ReportError(string res, params string[] args)
             {

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XslAstAnalyzer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XslAstAnalyzer.cs
@@ -938,7 +938,7 @@ namespace System.Xml.Xsl.Xslt
         // ------------------------------- XPathAnalyzer --------------------------------
 
         // Ignores all errors and warnings
-        internal struct NullErrorHelper : IErrorHelper
+        internal readonly struct NullErrorHelper : IErrorHelper
         {
             public void ReportError(string res, params string[] args) { }
             public void ReportWarning(string res, params string[] args) { }

--- a/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -83,7 +83,7 @@ namespace System.Reflection
 namespace System.Reflection.Metadata
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ArrayShape
+    public readonly partial struct ArrayShape
     {
         public ArrayShape(int rank, System.Collections.Immutable.ImmutableArray<int> sizes, System.Collections.Immutable.ImmutableArray<int> lowerBounds) { throw null;}
         public System.Collections.Immutable.ImmutableArray<int> LowerBounds { get { throw null; } }
@@ -91,7 +91,7 @@ namespace System.Reflection.Metadata
         public System.Collections.Immutable.ImmutableArray<int> Sizes { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct AssemblyDefinition
+    public readonly partial struct AssemblyDefinition
     {
         public System.Reflection.Metadata.StringHandle Culture { get { throw null; } }
         public System.Reflection.AssemblyFlags Flags { get { throw null; } }
@@ -106,7 +106,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.DeclarativeSecurityAttributeHandleCollection GetDeclarativeSecurityAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct AssemblyDefinitionHandle : System.IEquatable<System.Reflection.Metadata.AssemblyDefinitionHandle>
+    public readonly partial struct AssemblyDefinitionHandle : System.IEquatable<System.Reflection.Metadata.AssemblyDefinitionHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -120,7 +120,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.AssemblyDefinitionHandle left, System.Reflection.Metadata.AssemblyDefinitionHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct AssemblyFile
+    public readonly partial struct AssemblyFile
     {
         public bool ContainsMetadata { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle HashValue { get { throw null; } }
@@ -128,7 +128,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct AssemblyFileHandle : System.IEquatable<System.Reflection.Metadata.AssemblyFileHandle>
+    public readonly partial struct AssemblyFileHandle : System.IEquatable<System.Reflection.Metadata.AssemblyFileHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -142,7 +142,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.AssemblyFileHandle left, System.Reflection.Metadata.AssemblyFileHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct AssemblyFileHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.AssemblyFileHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.AssemblyFileHandle>, System.Collections.IEnumerable
+    public readonly partial struct AssemblyFileHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.AssemblyFileHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.AssemblyFileHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.AssemblyFileHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -159,7 +159,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct AssemblyReference
+    public readonly partial struct AssemblyReference
     {
         public System.Reflection.Metadata.StringHandle Culture { get { throw null; } }
         public System.Reflection.AssemblyFlags Flags { get { throw null; } }
@@ -173,7 +173,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct AssemblyReferenceHandle : System.IEquatable<System.Reflection.Metadata.AssemblyReferenceHandle>
+    public readonly partial struct AssemblyReferenceHandle : System.IEquatable<System.Reflection.Metadata.AssemblyReferenceHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -187,7 +187,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.AssemblyReferenceHandle left, System.Reflection.Metadata.AssemblyReferenceHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct AssemblyReferenceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.AssemblyReferenceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.AssemblyReferenceHandle>, System.Collections.IEnumerable
+    public readonly partial struct AssemblyReferenceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.AssemblyReferenceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.AssemblyReferenceHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.AssemblyReferenceHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -204,7 +204,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct Blob
+    public readonly partial struct Blob
     {
         public bool IsDefault { get { throw null; } }
         public int Length { get { throw null; } }
@@ -282,7 +282,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct BlobContentId : System.IEquatable<System.Reflection.Metadata.BlobContentId>
+    public readonly partial struct BlobContentId : System.IEquatable<System.Reflection.Metadata.BlobContentId>
     {
         public BlobContentId(byte[] id) { throw null;}
         public BlobContentId(System.Collections.Immutable.ImmutableArray<byte> id) { throw null;}
@@ -300,7 +300,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.BlobContentId left, System.Reflection.Metadata.BlobContentId right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct BlobHandle : System.IEquatable<System.Reflection.Metadata.BlobHandle>
+    public readonly partial struct BlobHandle : System.IEquatable<System.Reflection.Metadata.BlobHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -410,14 +410,14 @@ namespace System.Reflection.Metadata
         public void WriteUTF8(string value, bool allowUnpairedSurrogates) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct Constant
+    public readonly partial struct Constant
     {
         public System.Reflection.Metadata.EntityHandle Parent { get { throw null; } }
         public System.Reflection.Metadata.ConstantTypeCode TypeCode { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Value { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ConstantHandle : System.IEquatable<System.Reflection.Metadata.ConstantHandle>
+    public readonly partial struct ConstantHandle : System.IEquatable<System.Reflection.Metadata.ConstantHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -449,7 +449,7 @@ namespace System.Reflection.Metadata
         UInt64 = (byte)11,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomAttribute
+    public readonly partial struct CustomAttribute
     {
         public System.Reflection.Metadata.EntityHandle Constructor { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Parent { get { throw null; } }
@@ -457,7 +457,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeValue<TType> DecodeValue<TType>(System.Reflection.Metadata.ICustomAttributeTypeProvider<TType> provider) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomAttributeHandle : System.IEquatable<System.Reflection.Metadata.CustomAttributeHandle>
+    public readonly partial struct CustomAttributeHandle : System.IEquatable<System.Reflection.Metadata.CustomAttributeHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -471,7 +471,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.CustomAttributeHandle left, System.Reflection.Metadata.CustomAttributeHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomAttributeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.CustomAttributeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.CustomAttributeHandle>, System.Collections.IEnumerable
+    public readonly partial struct CustomAttributeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.CustomAttributeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.CustomAttributeHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -493,7 +493,7 @@ namespace System.Reflection.Metadata
         Property = (byte)84,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomAttributeNamedArgument<TType>
+    public readonly partial struct CustomAttributeNamedArgument<TType>
     {
         public CustomAttributeNamedArgument(string name, System.Reflection.Metadata.CustomAttributeNamedArgumentKind kind, TType type, object value) { throw null;}
         public System.Reflection.Metadata.CustomAttributeNamedArgumentKind Kind { get { throw null; } }
@@ -502,28 +502,28 @@ namespace System.Reflection.Metadata
         public object Value { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomAttributeTypedArgument<TType>
+    public readonly partial struct CustomAttributeTypedArgument<TType>
     {
         public CustomAttributeTypedArgument(TType type, object value) { throw null;}
         public TType Type { get { throw null; } }
         public object Value { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomAttributeValue<TType>
+    public readonly partial struct CustomAttributeValue<TType>
     {
         public CustomAttributeValue(System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeTypedArgument<TType>> fixedArguments, System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeNamedArgument<TType>> namedArguments) { throw null;}
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeTypedArgument<TType>> FixedArguments { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeNamedArgument<TType>> NamedArguments { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomDebugInformation
+    public readonly partial struct CustomDebugInformation
     {
         public System.Reflection.Metadata.GuidHandle Kind { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Parent { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Value { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomDebugInformationHandle : System.IEquatable<System.Reflection.Metadata.CustomDebugInformationHandle>
+    public readonly partial struct CustomDebugInformationHandle : System.IEquatable<System.Reflection.Metadata.CustomDebugInformationHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -537,7 +537,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.CustomDebugInformationHandle left, System.Reflection.Metadata.CustomDebugInformationHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomDebugInformationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.CustomDebugInformationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.CustomDebugInformationHandle>, System.Collections.IEnumerable
+    public readonly partial struct CustomDebugInformationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.CustomDebugInformationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.CustomDebugInformationHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.CustomDebugInformationHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -560,14 +560,14 @@ namespace System.Reflection.Metadata
         public System.Collections.Immutable.ImmutableArray<byte> Id { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct DeclarativeSecurityAttribute
+    public readonly partial struct DeclarativeSecurityAttribute
     {
         public System.Reflection.DeclarativeSecurityAction Action { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Parent { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle PermissionSet { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct DeclarativeSecurityAttributeHandle : System.IEquatable<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle>
+    public readonly partial struct DeclarativeSecurityAttributeHandle : System.IEquatable<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -581,7 +581,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.DeclarativeSecurityAttributeHandle left, System.Reflection.Metadata.DeclarativeSecurityAttributeHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct DeclarativeSecurityAttributeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle>, System.Collections.IEnumerable
+    public readonly partial struct DeclarativeSecurityAttributeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.DeclarativeSecurityAttributeHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -598,7 +598,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct Document
+    public readonly partial struct Document
     {
         public System.Reflection.Metadata.BlobHandle Hash { get { throw null; } }
         public System.Reflection.Metadata.GuidHandle HashAlgorithm { get { throw null; } }
@@ -606,7 +606,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.DocumentNameBlobHandle Name { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct DocumentHandle : System.IEquatable<System.Reflection.Metadata.DocumentHandle>
+    public readonly partial struct DocumentHandle : System.IEquatable<System.Reflection.Metadata.DocumentHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -620,7 +620,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.DocumentHandle left, System.Reflection.Metadata.DocumentHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct DocumentHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.DocumentHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.DocumentHandle>, System.Collections.IEnumerable
+    public readonly partial struct DocumentHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.DocumentHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.DocumentHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.DocumentHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -637,7 +637,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct DocumentNameBlobHandle : System.IEquatable<System.Reflection.Metadata.DocumentNameBlobHandle>
+    public readonly partial struct DocumentNameBlobHandle : System.IEquatable<System.Reflection.Metadata.DocumentNameBlobHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -649,7 +649,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.DocumentNameBlobHandle left, System.Reflection.Metadata.DocumentNameBlobHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct EntityHandle : System.IEquatable<System.Reflection.Metadata.EntityHandle>
+    public readonly partial struct EntityHandle : System.IEquatable<System.Reflection.Metadata.EntityHandle>
     {
         public static readonly System.Reflection.Metadata.AssemblyDefinitionHandle AssemblyDefinition;
         public static readonly System.Reflection.Metadata.ModuleDefinitionHandle ModuleDefinition;
@@ -664,14 +664,14 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.EntityHandle left, System.Reflection.Metadata.EntityHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct EventAccessors
+    public readonly partial struct EventAccessors
     {
         public System.Reflection.Metadata.MethodDefinitionHandle Adder { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Raiser { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Remover { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct EventDefinition
+    public readonly partial struct EventDefinition
     {
         public System.Reflection.EventAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
@@ -680,7 +680,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct EventDefinitionHandle : System.IEquatable<System.Reflection.Metadata.EventDefinitionHandle>
+    public readonly partial struct EventDefinitionHandle : System.IEquatable<System.Reflection.Metadata.EventDefinitionHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -694,7 +694,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.EventDefinitionHandle left, System.Reflection.Metadata.EventDefinitionHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct EventDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.EventDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.EventDefinitionHandle>, System.Collections.IEnumerable
+    public readonly partial struct EventDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.EventDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.EventDefinitionHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.EventDefinitionHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -711,7 +711,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ExceptionRegion
+    public readonly partial struct ExceptionRegion
     {
         public System.Reflection.Metadata.EntityHandle CatchType { get { throw null; } }
         public int FilterOffset { get { throw null; } }
@@ -729,7 +729,7 @@ namespace System.Reflection.Metadata
         Finally = (ushort)2,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ExportedType
+    public readonly partial struct ExportedType
     {
         public System.Reflection.TypeAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Implementation { get { throw null; } }
@@ -740,7 +740,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ExportedTypeHandle : System.IEquatable<System.Reflection.Metadata.ExportedTypeHandle>
+    public readonly partial struct ExportedTypeHandle : System.IEquatable<System.Reflection.Metadata.ExportedTypeHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -754,7 +754,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.ExportedTypeHandle left, System.Reflection.Metadata.ExportedTypeHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ExportedTypeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ExportedTypeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ExportedTypeHandle>, System.Collections.IEnumerable
+    public readonly partial struct ExportedTypeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ExportedTypeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ExportedTypeHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.ExportedTypeHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -771,7 +771,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct FieldDefinition
+    public readonly partial struct FieldDefinition
     {
         public System.Reflection.FieldAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
@@ -785,7 +785,7 @@ namespace System.Reflection.Metadata
         public int GetRelativeVirtualAddress() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct FieldDefinitionHandle : System.IEquatable<System.Reflection.Metadata.FieldDefinitionHandle>
+    public readonly partial struct FieldDefinitionHandle : System.IEquatable<System.Reflection.Metadata.FieldDefinitionHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -799,7 +799,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.FieldDefinitionHandle left, System.Reflection.Metadata.FieldDefinitionHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct FieldDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.FieldDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.FieldDefinitionHandle>, System.Collections.IEnumerable
+    public readonly partial struct FieldDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.FieldDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.FieldDefinitionHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.FieldDefinitionHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -816,7 +816,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct GenericParameter
+    public readonly partial struct GenericParameter
     {
         public System.Reflection.GenericParameterAttributes Attributes { get { throw null; } }
         public int Index { get { throw null; } }
@@ -826,14 +826,14 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct GenericParameterConstraint
+    public readonly partial struct GenericParameterConstraint
     {
         public System.Reflection.Metadata.GenericParameterHandle Parameter { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Type { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct GenericParameterConstraintHandle : System.IEquatable<System.Reflection.Metadata.GenericParameterConstraintHandle>
+    public readonly partial struct GenericParameterConstraintHandle : System.IEquatable<System.Reflection.Metadata.GenericParameterConstraintHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -847,7 +847,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.GenericParameterConstraintHandle left, System.Reflection.Metadata.GenericParameterConstraintHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct GenericParameterConstraintHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.GenericParameterConstraintHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.GenericParameterConstraintHandle>, System.Collections.Generic.IReadOnlyList<System.Reflection.Metadata.GenericParameterConstraintHandle>, System.Collections.IEnumerable
+    public readonly partial struct GenericParameterConstraintHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.GenericParameterConstraintHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.GenericParameterConstraintHandle>, System.Collections.Generic.IReadOnlyList<System.Reflection.Metadata.GenericParameterConstraintHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.GenericParameterConstraintHandle this[int index] { get { throw null; } }
@@ -865,7 +865,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct GenericParameterHandle : System.IEquatable<System.Reflection.Metadata.GenericParameterHandle>
+    public readonly partial struct GenericParameterHandle : System.IEquatable<System.Reflection.Metadata.GenericParameterHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -879,7 +879,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.GenericParameterHandle left, System.Reflection.Metadata.GenericParameterHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct GenericParameterHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.GenericParameterHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.GenericParameterHandle>, System.Collections.Generic.IReadOnlyList<System.Reflection.Metadata.GenericParameterHandle>, System.Collections.IEnumerable
+    public readonly partial struct GenericParameterHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.GenericParameterHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.GenericParameterHandle>, System.Collections.Generic.IReadOnlyList<System.Reflection.Metadata.GenericParameterHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.GenericParameterHandle this[int index] { get { throw null; } }
@@ -897,7 +897,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct GuidHandle : System.IEquatable<System.Reflection.Metadata.GuidHandle>
+    public readonly partial struct GuidHandle : System.IEquatable<System.Reflection.Metadata.GuidHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -909,7 +909,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.GuidHandle left, System.Reflection.Metadata.GuidHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct Handle : System.IEquatable<System.Reflection.Metadata.Handle>
+    public readonly partial struct Handle : System.IEquatable<System.Reflection.Metadata.Handle>
     {
         public static readonly System.Reflection.Metadata.AssemblyDefinitionHandle AssemblyDefinition;
         public static readonly System.Reflection.Metadata.ModuleDefinitionHandle ModuleDefinition;
@@ -1221,7 +1221,7 @@ namespace System.Reflection.Metadata
         public ImageFormatLimitationException(string message, System.Exception innerException) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ImportDefinition
+    public readonly partial struct ImportDefinition
     {
         public System.Reflection.Metadata.BlobHandle Alias { get { throw null; } }
         public System.Reflection.Metadata.ImportDefinitionKind Kind { get { throw null; } }
@@ -1230,7 +1230,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.EntityHandle TargetType { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ImportDefinitionCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ImportDefinition>, System.Collections.IEnumerable
+    public readonly partial struct ImportDefinitionCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ImportDefinition>, System.Collections.IEnumerable
     {
         public System.Reflection.Metadata.ImportDefinitionCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.ImportDefinition> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ImportDefinition>.GetEnumerator() { throw null; }
@@ -1258,14 +1258,14 @@ namespace System.Reflection.Metadata
         ImportXmlNamespace = 4,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ImportScope
+    public readonly partial struct ImportScope
     {
         public System.Reflection.Metadata.BlobHandle ImportsBlob { get { throw null; } }
         public System.Reflection.Metadata.ImportScopeHandle Parent { get { throw null; } }
         public System.Reflection.Metadata.ImportDefinitionCollection GetImports() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ImportScopeCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ImportScopeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ImportScopeHandle>, System.Collections.IEnumerable
+    public readonly partial struct ImportScopeCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ImportScopeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ImportScopeHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.ImportScopeCollection.Enumerator GetEnumerator() { throw null; }
@@ -1282,7 +1282,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ImportScopeHandle : System.IEquatable<System.Reflection.Metadata.ImportScopeHandle>
+    public readonly partial struct ImportScopeHandle : System.IEquatable<System.Reflection.Metadata.ImportScopeHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1296,13 +1296,13 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.ImportScopeHandle left, System.Reflection.Metadata.ImportScopeHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct InterfaceImplementation
+    public readonly partial struct InterfaceImplementation
     {
         public System.Reflection.Metadata.EntityHandle Interface { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct InterfaceImplementationHandle : System.IEquatable<System.Reflection.Metadata.InterfaceImplementationHandle>
+    public readonly partial struct InterfaceImplementationHandle : System.IEquatable<System.Reflection.Metadata.InterfaceImplementationHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1316,7 +1316,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.InterfaceImplementationHandle left, System.Reflection.Metadata.InterfaceImplementationHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct InterfaceImplementationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.InterfaceImplementationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.InterfaceImplementationHandle>, System.Collections.IEnumerable
+    public readonly partial struct InterfaceImplementationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.InterfaceImplementationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.InterfaceImplementationHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.InterfaceImplementationHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -1352,13 +1352,13 @@ namespace System.Reflection.Metadata
         TType GetSZArrayType(TType elementType);
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LocalConstant
+    public readonly partial struct LocalConstant
     {
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Signature { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LocalConstantHandle : System.IEquatable<System.Reflection.Metadata.LocalConstantHandle>
+    public readonly partial struct LocalConstantHandle : System.IEquatable<System.Reflection.Metadata.LocalConstantHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1372,7 +1372,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.LocalConstantHandle left, System.Reflection.Metadata.LocalConstantHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LocalConstantHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalConstantHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.LocalConstantHandle>, System.Collections.IEnumerable
+    public readonly partial struct LocalConstantHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalConstantHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.LocalConstantHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.LocalConstantHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -1389,7 +1389,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LocalScope
+    public readonly partial struct LocalScope
     {
         public int EndOffset { get { throw null; } }
         public System.Reflection.Metadata.ImportScopeHandle ImportScope { get { throw null; } }
@@ -1401,7 +1401,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.LocalVariableHandleCollection GetLocalVariables() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LocalScopeHandle : System.IEquatable<System.Reflection.Metadata.LocalScopeHandle>
+    public readonly partial struct LocalScopeHandle : System.IEquatable<System.Reflection.Metadata.LocalScopeHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1415,7 +1415,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.LocalScopeHandle left, System.Reflection.Metadata.LocalScopeHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LocalScopeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalScopeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.LocalScopeHandle>, System.Collections.IEnumerable
+    public readonly partial struct LocalScopeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalScopeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.LocalScopeHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.LocalScopeHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -1441,7 +1441,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LocalVariable
+    public readonly partial struct LocalVariable
     {
         public System.Reflection.Metadata.LocalVariableAttributes Attributes { get { throw null; } }
         public int Index { get { throw null; } }
@@ -1454,7 +1454,7 @@ namespace System.Reflection.Metadata
         None = 0,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LocalVariableHandle : System.IEquatable<System.Reflection.Metadata.LocalVariableHandle>
+    public readonly partial struct LocalVariableHandle : System.IEquatable<System.Reflection.Metadata.LocalVariableHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1468,7 +1468,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.LocalVariableHandle left, System.Reflection.Metadata.LocalVariableHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LocalVariableHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalVariableHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.LocalVariableHandle>, System.Collections.IEnumerable
+    public readonly partial struct LocalVariableHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalVariableHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.LocalVariableHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.LocalVariableHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -1485,7 +1485,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ManifestResource
+    public readonly partial struct ManifestResource
     {
         public System.Reflection.ManifestResourceAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Implementation { get { throw null; } }
@@ -1494,7 +1494,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ManifestResourceHandle : System.IEquatable<System.Reflection.Metadata.ManifestResourceHandle>
+    public readonly partial struct ManifestResourceHandle : System.IEquatable<System.Reflection.Metadata.ManifestResourceHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1508,7 +1508,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.ManifestResourceHandle left, System.Reflection.Metadata.ManifestResourceHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ManifestResourceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ManifestResourceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ManifestResourceHandle>, System.Collections.IEnumerable
+    public readonly partial struct ManifestResourceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ManifestResourceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ManifestResourceHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.ManifestResourceHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -1525,7 +1525,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MemberReference
+    public readonly partial struct MemberReference
     {
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Parent { get { throw null; } }
@@ -1536,7 +1536,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.MemberReferenceKind GetKind() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MemberReferenceHandle : System.IEquatable<System.Reflection.Metadata.MemberReferenceHandle>
+    public readonly partial struct MemberReferenceHandle : System.IEquatable<System.Reflection.Metadata.MemberReferenceHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1550,7 +1550,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.MemberReferenceHandle left, System.Reflection.Metadata.MemberReferenceHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MemberReferenceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MemberReferenceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MemberReferenceHandle>, System.Collections.IEnumerable
+    public readonly partial struct MemberReferenceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MemberReferenceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MemberReferenceHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.MemberReferenceHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -1687,7 +1687,7 @@ namespace System.Reflection.Metadata
         PrefetchMetadata = 2,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MetadataStringComparer
+    public readonly partial struct MetadataStringComparer
     {
         public bool Equals(System.Reflection.Metadata.DocumentNameBlobHandle handle, string value) { throw null; }
         public bool Equals(System.Reflection.Metadata.DocumentNameBlobHandle handle, string value, bool ignoreCase) { throw null; }
@@ -1719,7 +1719,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.BlobReader GetILReader() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodDebugInformation
+    public readonly partial struct MethodDebugInformation
     {
         public System.Reflection.Metadata.DocumentHandle Document { get { throw null; } }
         public System.Reflection.Metadata.StandaloneSignatureHandle LocalSignature { get { throw null; } }
@@ -1728,7 +1728,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.MethodDefinitionHandle GetStateMachineKickoffMethod() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodDebugInformationHandle : System.IEquatable<System.Reflection.Metadata.MethodDebugInformationHandle>
+    public readonly partial struct MethodDebugInformationHandle : System.IEquatable<System.Reflection.Metadata.MethodDebugInformationHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1743,7 +1743,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.MethodDefinitionHandle ToDefinitionHandle() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodDebugInformationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodDebugInformationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MethodDebugInformationHandle>, System.Collections.IEnumerable
+    public readonly partial struct MethodDebugInformationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodDebugInformationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MethodDebugInformationHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.MethodDebugInformationHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -1760,7 +1760,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodDefinition
+    public readonly partial struct MethodDefinition
     {
         public System.Reflection.MethodAttributes Attributes { get { throw null; } }
         public System.Reflection.MethodImplAttributes ImplAttributes { get { throw null; } }
@@ -1776,7 +1776,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.ParameterHandleCollection GetParameters() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodDefinitionHandle : System.IEquatable<System.Reflection.Metadata.MethodDefinitionHandle>
+    public readonly partial struct MethodDefinitionHandle : System.IEquatable<System.Reflection.Metadata.MethodDefinitionHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1791,7 +1791,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.MethodDebugInformationHandle ToDebugInformationHandle() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MethodDefinitionHandle>, System.Collections.IEnumerable
+    public readonly partial struct MethodDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MethodDefinitionHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -1808,7 +1808,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodImplementation
+    public readonly partial struct MethodImplementation
     {
         public System.Reflection.Metadata.EntityHandle MethodBody { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle MethodDeclaration { get { throw null; } }
@@ -1816,7 +1816,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodImplementationHandle : System.IEquatable<System.Reflection.Metadata.MethodImplementationHandle>
+    public readonly partial struct MethodImplementationHandle : System.IEquatable<System.Reflection.Metadata.MethodImplementationHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1830,7 +1830,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.MethodImplementationHandle left, System.Reflection.Metadata.MethodImplementationHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodImplementationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodImplementationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MethodImplementationHandle>, System.Collections.IEnumerable
+    public readonly partial struct MethodImplementationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodImplementationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MethodImplementationHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.MethodImplementationHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -1847,14 +1847,14 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodImport
+    public readonly partial struct MethodImport
     {
         public System.Reflection.MethodImportAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.ModuleReferenceHandle Module { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodSignature<TType>
+    public readonly partial struct MethodSignature<TType>
     {
         public MethodSignature(System.Reflection.Metadata.SignatureHeader header, TType returnType, int requiredParameterCount, int genericParameterCount, System.Collections.Immutable.ImmutableArray<TType> parameterTypes) { throw null;}
         public int GenericParameterCount { get { throw null; } }
@@ -1864,7 +1864,7 @@ namespace System.Reflection.Metadata
         public TType ReturnType { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodSpecification
+    public readonly partial struct MethodSpecification
     {
         public System.Reflection.Metadata.EntityHandle Method { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Signature { get { throw null; } }
@@ -1872,7 +1872,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodSpecificationHandle : System.IEquatable<System.Reflection.Metadata.MethodSpecificationHandle>
+    public readonly partial struct MethodSpecificationHandle : System.IEquatable<System.Reflection.Metadata.MethodSpecificationHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1886,7 +1886,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.MethodSpecificationHandle left, System.Reflection.Metadata.MethodSpecificationHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ModuleDefinition
+    public readonly partial struct ModuleDefinition
     {
         public System.Reflection.Metadata.GuidHandle BaseGenerationId { get { throw null; } }
         public int Generation { get { throw null; } }
@@ -1895,7 +1895,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ModuleDefinitionHandle : System.IEquatable<System.Reflection.Metadata.ModuleDefinitionHandle>
+    public readonly partial struct ModuleDefinitionHandle : System.IEquatable<System.Reflection.Metadata.ModuleDefinitionHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1909,13 +1909,13 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.ModuleDefinitionHandle left, System.Reflection.Metadata.ModuleDefinitionHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ModuleReference
+    public readonly partial struct ModuleReference
     {
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ModuleReferenceHandle : System.IEquatable<System.Reflection.Metadata.ModuleReferenceHandle>
+    public readonly partial struct ModuleReferenceHandle : System.IEquatable<System.Reflection.Metadata.ModuleReferenceHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1938,7 +1938,7 @@ namespace System.Reflection.Metadata
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.TypeDefinitionHandle> TypeDefinitions { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct NamespaceDefinitionHandle : System.IEquatable<System.Reflection.Metadata.NamespaceDefinitionHandle>
+    public readonly partial struct NamespaceDefinitionHandle : System.IEquatable<System.Reflection.Metadata.NamespaceDefinitionHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1950,7 +1950,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.NamespaceDefinitionHandle left, System.Reflection.Metadata.NamespaceDefinitionHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct Parameter
+    public readonly partial struct Parameter
     {
         public System.Reflection.ParameterAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
@@ -1960,7 +1960,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.BlobHandle GetMarshallingDescriptor() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ParameterHandle : System.IEquatable<System.Reflection.Metadata.ParameterHandle>
+    public readonly partial struct ParameterHandle : System.IEquatable<System.Reflection.Metadata.ParameterHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -1974,7 +1974,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.ParameterHandle left, System.Reflection.Metadata.ParameterHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ParameterHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ParameterHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ParameterHandle>, System.Collections.IEnumerable
+    public readonly partial struct ParameterHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ParameterHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ParameterHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.ParameterHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -2036,13 +2036,13 @@ namespace System.Reflection.Metadata
         Void = (byte)1,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct PropertyAccessors
+    public readonly partial struct PropertyAccessors
     {
         public System.Reflection.Metadata.MethodDefinitionHandle Getter { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Setter { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct PropertyDefinition
+    public readonly partial struct PropertyDefinition
     {
         public System.Reflection.PropertyAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
@@ -2053,7 +2053,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.ConstantHandle GetDefaultValue() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct PropertyDefinitionHandle : System.IEquatable<System.Reflection.Metadata.PropertyDefinitionHandle>
+    public readonly partial struct PropertyDefinitionHandle : System.IEquatable<System.Reflection.Metadata.PropertyDefinitionHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -2067,7 +2067,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.PropertyDefinitionHandle left, System.Reflection.Metadata.PropertyDefinitionHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct PropertyDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.PropertyDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.PropertyDefinitionHandle>, System.Collections.IEnumerable
+    public readonly partial struct PropertyDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.PropertyDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.PropertyDefinitionHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.PropertyDefinitionHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -2084,14 +2084,14 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ReservedBlob<THandle> where THandle : struct
+    public readonly partial struct ReservedBlob<THandle> where THandle : struct
     {
         public System.Reflection.Metadata.Blob Content { get { throw null; } }
         public THandle Handle { get { throw null; } }
         public System.Reflection.Metadata.BlobWriter CreateWriter() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct SequencePoint : System.IEquatable<System.Reflection.Metadata.SequencePoint>
+    public readonly partial struct SequencePoint : System.IEquatable<System.Reflection.Metadata.SequencePoint>
     {
         public const int HiddenLine = 16707566;
         public System.Reflection.Metadata.DocumentHandle Document { get { throw null; } }
@@ -2106,7 +2106,7 @@ namespace System.Reflection.Metadata
         public override int GetHashCode() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct SequencePointCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.SequencePoint>, System.Collections.IEnumerable
+    public readonly partial struct SequencePointCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.SequencePoint>, System.Collections.IEnumerable
     {
         public System.Reflection.Metadata.SequencePointCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.SequencePoint> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.SequencePoint>.GetEnumerator() { throw null; }
@@ -2229,7 +2229,7 @@ namespace System.Reflection.Metadata
         ValueType = (byte)17,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct StandaloneSignature
+    public readonly partial struct StandaloneSignature
     {
         public System.Reflection.Metadata.BlobHandle Signature { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<TType> DecodeLocalSignature<TType, TGenericContext>(System.Reflection.Metadata.ISignatureTypeProvider<TType, TGenericContext> provider, TGenericContext genericContext) { throw null; }
@@ -2238,7 +2238,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.StandaloneSignatureKind GetKind() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct StandaloneSignatureHandle : System.IEquatable<System.Reflection.Metadata.StandaloneSignatureHandle>
+    public readonly partial struct StandaloneSignatureHandle : System.IEquatable<System.Reflection.Metadata.StandaloneSignatureHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -2257,7 +2257,7 @@ namespace System.Reflection.Metadata
         Method = 0,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct StringHandle : System.IEquatable<System.Reflection.Metadata.StringHandle>
+    public readonly partial struct StringHandle : System.IEquatable<System.Reflection.Metadata.StringHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -2269,7 +2269,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.StringHandle left, System.Reflection.Metadata.StringHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct TypeDefinition
+    public readonly partial struct TypeDefinition
     {
         public System.Reflection.TypeAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle BaseType { get { throw null; } }
@@ -2290,7 +2290,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.PropertyDefinitionHandleCollection GetProperties() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct TypeDefinitionHandle : System.IEquatable<System.Reflection.Metadata.TypeDefinitionHandle>
+    public readonly partial struct TypeDefinitionHandle : System.IEquatable<System.Reflection.Metadata.TypeDefinitionHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -2304,7 +2304,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.TypeDefinitionHandle left, System.Reflection.Metadata.TypeDefinitionHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct TypeDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.TypeDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.TypeDefinitionHandle>, System.Collections.IEnumerable
+    public readonly partial struct TypeDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.TypeDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.TypeDefinitionHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.TypeDefinitionHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -2321,7 +2321,7 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct TypeLayout
+    public readonly partial struct TypeLayout
     {
         public TypeLayout(int size, int packingSize) { throw null;}
         public bool IsDefault { get { throw null; } }
@@ -2329,14 +2329,14 @@ namespace System.Reflection.Metadata
         public int Size { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct TypeReference
+    public readonly partial struct TypeReference
     {
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Namespace { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle ResolutionScope { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct TypeReferenceHandle : System.IEquatable<System.Reflection.Metadata.TypeReferenceHandle>
+    public readonly partial struct TypeReferenceHandle : System.IEquatable<System.Reflection.Metadata.TypeReferenceHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -2350,7 +2350,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.TypeReferenceHandle left, System.Reflection.Metadata.TypeReferenceHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct TypeReferenceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.TypeReferenceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.TypeReferenceHandle>, System.Collections.IEnumerable
+    public readonly partial struct TypeReferenceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.TypeReferenceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.TypeReferenceHandle>, System.Collections.IEnumerable
     {
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.TypeReferenceHandleCollection.Enumerator GetEnumerator() { throw null; }
@@ -2367,14 +2367,14 @@ namespace System.Reflection.Metadata
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct TypeSpecification
+    public readonly partial struct TypeSpecification
     {
         public System.Reflection.Metadata.BlobHandle Signature { get { throw null; } }
         public TType DecodeSignature<TType, TGenericContext>(System.Reflection.Metadata.ISignatureTypeProvider<TType, TGenericContext> provider, TGenericContext genericContext) { throw null; }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct TypeSpecificationHandle : System.IEquatable<System.Reflection.Metadata.TypeSpecificationHandle>
+    public readonly partial struct TypeSpecificationHandle : System.IEquatable<System.Reflection.Metadata.TypeSpecificationHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -2388,7 +2388,7 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.TypeSpecificationHandle left, System.Reflection.Metadata.TypeSpecificationHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct UserStringHandle : System.IEquatable<System.Reflection.Metadata.UserStringHandle>
+    public readonly partial struct UserStringHandle : System.IEquatable<System.Reflection.Metadata.UserStringHandle>
     {
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -2403,14 +2403,14 @@ namespace System.Reflection.Metadata
 namespace System.Reflection.Metadata.Ecma335
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ArrayShapeEncoder
+    public readonly partial struct ArrayShapeEncoder
     {
         public ArrayShapeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public void Shape(int rank, System.Collections.Immutable.ImmutableArray<int> sizes, System.Collections.Immutable.ImmutableArray<int> lowerBounds) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct BlobEncoder
+    public readonly partial struct BlobEncoder
     {
         public BlobEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2452,7 +2452,7 @@ namespace System.Reflection.Metadata.Ecma335
         public void AddFinallyRegion(System.Reflection.Metadata.Ecma335.LabelHandle tryStart, System.Reflection.Metadata.Ecma335.LabelHandle tryEnd, System.Reflection.Metadata.Ecma335.LabelHandle handlerStart, System.Reflection.Metadata.Ecma335.LabelHandle handlerEnd) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomAttributeArrayTypeEncoder
+    public readonly partial struct CustomAttributeArrayTypeEncoder
     {
         public CustomAttributeArrayTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2460,7 +2460,7 @@ namespace System.Reflection.Metadata.Ecma335
         public void ObjectArray() { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomAttributeElementTypeEncoder
+    public readonly partial struct CustomAttributeElementTypeEncoder
     {
         public CustomAttributeElementTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2482,21 +2482,21 @@ namespace System.Reflection.Metadata.Ecma335
         public void UInt64() { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomAttributeNamedArgumentsEncoder
+    public readonly partial struct CustomAttributeNamedArgumentsEncoder
     {
         public CustomAttributeNamedArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.NamedArgumentsEncoder Count(int count) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CustomModifiersEncoder
+    public readonly partial struct CustomModifiersEncoder
     {
         public CustomModifiersEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.CustomModifiersEncoder AddModifier(System.Reflection.Metadata.EntityHandle type, bool isOptional) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct EditAndContinueLogEntry : System.IEquatable<System.Reflection.Metadata.Ecma335.EditAndContinueLogEntry>
+    public readonly partial struct EditAndContinueLogEntry : System.IEquatable<System.Reflection.Metadata.Ecma335.EditAndContinueLogEntry>
     {
         public EditAndContinueLogEntry(System.Reflection.Metadata.EntityHandle handle, System.Reflection.Metadata.Ecma335.EditAndContinueOperation operation) { throw null;}
         public System.Reflection.Metadata.EntityHandle Handle { get { throw null; } }
@@ -2515,7 +2515,7 @@ namespace System.Reflection.Metadata.Ecma335
         Default = 0,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ExceptionRegionEncoder
+    public readonly partial struct ExceptionRegionEncoder
     {
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public bool HasSmallFormat { get { throw null; } }
@@ -2532,7 +2532,7 @@ namespace System.Reflection.Metadata.Ecma335
         public static int GetTypeDefinitionId(this System.Reflection.Metadata.ExportedType exportedType) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct FixedArgumentsEncoder
+    public readonly partial struct FixedArgumentsEncoder
     {
         public FixedArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2545,7 +2545,7 @@ namespace System.Reflection.Metadata.Ecma335
         None = 0,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct GenericTypeArgumentsEncoder
+    public readonly partial struct GenericTypeArgumentsEncoder
     {
         public GenericTypeArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2559,7 +2559,7 @@ namespace System.Reflection.Metadata.Ecma335
         UserString = 0,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct InstructionEncoder
+    public readonly partial struct InstructionEncoder
     {
         public InstructionEncoder(System.Reflection.Metadata.BlobBuilder codeBuilder, System.Reflection.Metadata.Ecma335.ControlFlowBuilder controlFlowBuilder=null) { throw null;}
         public System.Reflection.Metadata.BlobBuilder CodeBuilder { get { throw null; } }
@@ -2589,7 +2589,7 @@ namespace System.Reflection.Metadata.Ecma335
         public void Token(System.Reflection.Metadata.EntityHandle handle) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LabelHandle : System.IEquatable<System.Reflection.Metadata.Ecma335.LabelHandle>
+    public readonly partial struct LabelHandle : System.IEquatable<System.Reflection.Metadata.Ecma335.LabelHandle>
     {
         public int Id { get { throw null; } }
         public bool IsNil { get { throw null; } }
@@ -2600,7 +2600,7 @@ namespace System.Reflection.Metadata.Ecma335
         public static bool operator !=(System.Reflection.Metadata.Ecma335.LabelHandle left, System.Reflection.Metadata.Ecma335.LabelHandle right) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LiteralEncoder
+    public readonly partial struct LiteralEncoder
     {
         public LiteralEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2612,21 +2612,21 @@ namespace System.Reflection.Metadata.Ecma335
         public System.Reflection.Metadata.Ecma335.VectorEncoder Vector() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LiteralsEncoder
+    public readonly partial struct LiteralsEncoder
     {
         public LiteralsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.LiteralEncoder AddLiteral() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LocalVariablesEncoder
+    public readonly partial struct LocalVariablesEncoder
     {
         public LocalVariablesEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.LocalVariableTypeEncoder AddVariable() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LocalVariableTypeEncoder
+    public readonly partial struct LocalVariableTypeEncoder
     {
         public LocalVariableTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2801,14 +2801,14 @@ namespace System.Reflection.Metadata.Ecma335
         None = 0,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodBodyStreamEncoder
+    public readonly partial struct MethodBodyStreamEncoder
     {
         public MethodBodyStreamEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.MethodBodyStreamEncoder.MethodBody AddMethodBody(int codeSize, int maxStack=8, int exceptionRegionCount=0, bool hasSmallExceptionRegions=true, System.Reflection.Metadata.StandaloneSignatureHandle localVariablesSignature=default(System.Reflection.Metadata.StandaloneSignatureHandle), System.Reflection.Metadata.Ecma335.MethodBodyAttributes attributes=(System.Reflection.Metadata.Ecma335.MethodBodyAttributes)(1)) { throw null; }
         public int AddMethodBody(System.Reflection.Metadata.Ecma335.InstructionEncoder instructionEncoder, int maxStack=8, System.Reflection.Metadata.StandaloneSignatureHandle localVariablesSignature=default(System.Reflection.Metadata.StandaloneSignatureHandle), System.Reflection.Metadata.Ecma335.MethodBodyAttributes attributes=(System.Reflection.Metadata.Ecma335.MethodBodyAttributes)(1)) { throw null; }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct MethodBody
+        public readonly partial struct MethodBody
         {
             public System.Reflection.Metadata.Ecma335.ExceptionRegionEncoder ExceptionRegions { get { throw null; } }
             public System.Reflection.Metadata.Blob Instructions { get { throw null; } }
@@ -2816,7 +2816,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MethodSignatureEncoder
+    public readonly partial struct MethodSignatureEncoder
     {
         public MethodSignatureEncoder(System.Reflection.Metadata.BlobBuilder builder, bool hasVarArgs) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2825,7 +2825,7 @@ namespace System.Reflection.Metadata.Ecma335
         public void Parameters(int parameterCount, out System.Reflection.Metadata.Ecma335.ReturnTypeEncoder returnType, out System.Reflection.Metadata.Ecma335.ParametersEncoder parameters) { returnType = default(System.Reflection.Metadata.Ecma335.ReturnTypeEncoder); parameters = default(System.Reflection.Metadata.Ecma335.ParametersEncoder); }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct NamedArgumentsEncoder
+    public readonly partial struct NamedArgumentsEncoder
     {
         public NamedArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2833,7 +2833,7 @@ namespace System.Reflection.Metadata.Ecma335
         public void AddArgument(bool isField, out System.Reflection.Metadata.Ecma335.NamedArgumentTypeEncoder type, out System.Reflection.Metadata.Ecma335.NameEncoder name, out System.Reflection.Metadata.Ecma335.LiteralEncoder literal) { type = default(System.Reflection.Metadata.Ecma335.NamedArgumentTypeEncoder); name = default(System.Reflection.Metadata.Ecma335.NameEncoder); literal = default(System.Reflection.Metadata.Ecma335.LiteralEncoder); }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct NamedArgumentTypeEncoder
+    public readonly partial struct NamedArgumentTypeEncoder
     {
         public NamedArgumentTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2842,14 +2842,14 @@ namespace System.Reflection.Metadata.Ecma335
         public System.Reflection.Metadata.Ecma335.CustomAttributeArrayTypeEncoder SZArray() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct NameEncoder
+    public readonly partial struct NameEncoder
     {
         public NameEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public void Name(string name) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ParametersEncoder
+    public readonly partial struct ParametersEncoder
     {
         public ParametersEncoder(System.Reflection.Metadata.BlobBuilder builder, bool hasVarArgs=false) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2858,7 +2858,7 @@ namespace System.Reflection.Metadata.Ecma335
         public System.Reflection.Metadata.Ecma335.ParametersEncoder StartVarArgs() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ParameterTypeEncoder
+    public readonly partial struct ParameterTypeEncoder
     {
         public ParameterTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2867,7 +2867,7 @@ namespace System.Reflection.Metadata.Ecma335
         public void TypedReference() { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct PermissionSetEncoder
+    public readonly partial struct PermissionSetEncoder
     {
         public PermissionSetEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2883,7 +2883,7 @@ namespace System.Reflection.Metadata.Ecma335
         public System.Reflection.Metadata.BlobContentId Serialize(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ReturnTypeEncoder
+    public readonly partial struct ReturnTypeEncoder
     {
         public ReturnTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2893,7 +2893,7 @@ namespace System.Reflection.Metadata.Ecma335
         public void Void() { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ScalarEncoder
+    public readonly partial struct ScalarEncoder
     {
         public ScalarEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -2902,7 +2902,7 @@ namespace System.Reflection.Metadata.Ecma335
         public void SystemType(string serializedTypeName) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct SignatureDecoder<TType, TGenericContext>
+    public readonly partial struct SignatureDecoder<TType, TGenericContext>
     {
         public SignatureDecoder(System.Reflection.Metadata.ISignatureTypeProvider<TType, TGenericContext> provider, System.Reflection.Metadata.MetadataReader metadataReader, TGenericContext genericContext) { throw null;}
         public TType DecodeFieldSignature(ref System.Reflection.Metadata.BlobReader blobReader) { throw null; }
@@ -2912,7 +2912,7 @@ namespace System.Reflection.Metadata.Ecma335
         public TType DecodeType(ref System.Reflection.Metadata.BlobReader blobReader, bool allowTypeSpecifications=false) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct SignatureTypeEncoder
+    public readonly partial struct SignatureTypeEncoder
     {
         public SignatureTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -3002,7 +3002,7 @@ namespace System.Reflection.Metadata.Ecma335
         TypeSpec = (byte)27,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct VectorEncoder
+    public readonly partial struct VectorEncoder
     {
         public VectorEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
@@ -3030,7 +3030,7 @@ namespace System.Reflection.PortableExecutable
         UpSystemOnly = (ushort)16384,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CodeViewDebugDirectoryData
+    public readonly partial struct CodeViewDebugDirectoryData
     {
         public int Age { get { throw null; } }
         public System.Guid Guid { get { throw null; } }
@@ -3081,7 +3081,7 @@ namespace System.Reflection.PortableExecutable
         public void AddReproducibleEntry() { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct DebugDirectoryEntry
+    public readonly partial struct DebugDirectoryEntry
     {
         public DebugDirectoryEntry(uint stamp, ushort majorVersion, ushort minorVersion, System.Reflection.PortableExecutable.DebugDirectoryEntryType type, int dataSize, int dataRelativeVirtualAddress, int dataPointer) { throw null;}
         public int DataPointer { get { throw null; } }
@@ -3102,7 +3102,7 @@ namespace System.Reflection.PortableExecutable
         Unknown = 0,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct DirectoryEntry
+    public readonly partial struct DirectoryEntry
     {
         public readonly int RelativeVirtualAddress;
         public readonly int Size;
@@ -3299,7 +3299,7 @@ namespace System.Reflection.PortableExecutable
         PE32Plus = (ushort)523,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct PEMemoryBlock
+    public readonly partial struct PEMemoryBlock
     {
         public int Length { get { throw null; } }
         public unsafe byte* Pointer { get { throw null; } }
@@ -3395,7 +3395,7 @@ namespace System.Reflection.PortableExecutable
         TypeReg = (uint)0,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct SectionHeader
+    public readonly partial struct SectionHeader
     {
         public string Name { get { throw null; } }
         public ushort NumberOfLineNumbers { get { throw null; } }
@@ -3409,7 +3409,7 @@ namespace System.Reflection.PortableExecutable
         public int VirtualSize { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct SectionLocation
+    public readonly partial struct SectionLocation
     {
         public SectionLocation(int relativeVirtualAddress, int pointerToRawData) { throw null;}
         public int PointerToRawData { get { throw null; } }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamConstraints.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamConstraints.cs
@@ -4,7 +4,7 @@
 
 namespace System.Reflection.Internal
 {
-    internal struct StreamConstraints
+    internal readonly struct StreamConstraints
     {
         public readonly object GuardOpt;
         public readonly long ImageStart;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryBlock.cs
@@ -11,7 +11,7 @@ using System.Text;
 namespace System.Reflection.Internal
 {
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-    internal unsafe struct MemoryBlock
+    internal unsafe readonly struct MemoryBlock
     {
         internal readonly byte* Pointer;
         internal readonly int Length;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Blob.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Blob.cs
@@ -4,7 +4,7 @@
 
 namespace System.Reflection.Metadata
 {
-    public struct Blob
+    public readonly struct Blob
     {
         internal readonly byte[] Buffer;
         internal readonly int Start;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobContentId.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobContentId.cs
@@ -8,7 +8,7 @@ using System.Reflection.Internal;
 
 namespace System.Reflection.Metadata
 {
-    public struct BlobContentId : IEquatable<BlobContentId>
+    public readonly struct BlobContentId : IEquatable<BlobContentId>
     {
         private const int Size = BlobUtilities.SizeOfGuid + sizeof(uint);
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/CustomAttributeDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/CustomAttributeDecoder.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,7 +9,7 @@ namespace System.Reflection.Metadata.Ecma335
     /// <summary>
     /// Decodes custom attribute blobs.
     /// </summary>
-    internal struct CustomAttributeDecoder<TType>
+    internal readonly struct CustomAttributeDecoder<TType>
     {
         private readonly ICustomAttributeTypeProvider<TType> _provider;
         private readonly MetadataReader _reader;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/EditAndContinueLogEntry.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/EditAndContinueLogEntry.cs
@@ -4,7 +4,7 @@
 
 namespace System.Reflection.Metadata.Ecma335
 {
-    public struct EditAndContinueLogEntry : IEquatable<EditAndContinueLogEntry>
+    public readonly struct EditAndContinueLogEntry : IEquatable<EditAndContinueLogEntry>
     {
         public EntityHandle Handle { get; }
         public EditAndContinueOperation Operation { get; }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/BlobEncoders.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/BlobEncoders.cs
@@ -9,7 +9,7 @@ namespace System.Reflection.Metadata.Ecma335
     // TODO: debug metadata blobs
     // TODO: revisit ctors (public vs internal vs static factories)?
 
-    public struct BlobEncoder
+    public readonly struct BlobEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -191,7 +191,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct MethodSignatureEncoder
+    public readonly struct MethodSignatureEncoder
     {
         public BlobBuilder Builder { get; }
         public bool HasVarArgs { get; }
@@ -242,7 +242,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct LocalVariablesEncoder
+    public readonly struct LocalVariablesEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -257,7 +257,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct LocalVariableTypeEncoder
+    public readonly struct LocalVariableTypeEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -292,7 +292,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct ParameterTypeEncoder
+    public readonly struct ParameterTypeEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -322,7 +322,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct PermissionSetEncoder
+    public readonly struct PermissionSetEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -378,7 +378,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct GenericTypeArgumentsEncoder
+    public readonly struct GenericTypeArgumentsEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -393,7 +393,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct FixedArgumentsEncoder
+    public readonly struct FixedArgumentsEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -408,7 +408,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct LiteralEncoder
+    public readonly struct LiteralEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -492,7 +492,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct ScalarEncoder
+    public readonly struct ScalarEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -564,7 +564,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct LiteralsEncoder
+    public readonly struct LiteralsEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -579,7 +579,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct VectorEncoder
+    public readonly struct VectorEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -600,7 +600,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct NameEncoder
+    public readonly struct NameEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -618,7 +618,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct CustomAttributeNamedArgumentsEncoder
+    public readonly struct CustomAttributeNamedArgumentsEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -639,7 +639,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct NamedArgumentsEncoder
+    public readonly struct NamedArgumentsEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -688,7 +688,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct NamedArgumentTypeEncoder
+    public readonly struct NamedArgumentTypeEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -713,7 +713,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct CustomAttributeArrayTypeEncoder
+    public readonly struct CustomAttributeArrayTypeEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -735,7 +735,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct CustomAttributeElementTypeEncoder
+    public readonly struct CustomAttributeElementTypeEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -804,7 +804,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct SignatureTypeEncoder
+    public readonly struct SignatureTypeEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -1057,7 +1057,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct CustomModifiersEncoder
+    public readonly struct CustomModifiersEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -1094,7 +1094,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct ArrayShapeEncoder
+    public readonly struct ArrayShapeEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -1174,7 +1174,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct ReturnTypeEncoder
+    public readonly struct ReturnTypeEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -1209,7 +1209,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    public struct ParametersEncoder
+    public readonly struct ParametersEncoder
     {
         public BlobBuilder Builder { get; }
         public bool HasVarArgs { get; }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/ControlFlowBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/ControlFlowBuilder.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Metadata.Ecma335
     public sealed class ControlFlowBuilder
     {
         // internal for testing:
-        internal struct BranchInfo
+        internal readonly struct BranchInfo
         {
             internal readonly int ILOffset;
             internal readonly LabelHandle Label;
@@ -49,7 +49,7 @@ namespace System.Reflection.Metadata.Ecma335
             }
         }
 
-        internal struct ExceptionHandlerInfo
+        internal readonly struct ExceptionHandlerInfo
         {
             public readonly ExceptionRegionKind Kind;
             public readonly LabelHandle TryStart, TryEnd, HandlerStart, HandlerEnd, FilterStart;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/ExceptionRegionEncoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/ExceptionRegionEncoder.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata.Ecma335
 {
-    public struct ExceptionRegionEncoder
+    public readonly struct ExceptionRegionEncoder
     {
         private const int TableHeaderSize = 4;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/InstructionEncoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/InstructionEncoder.cs
@@ -9,7 +9,7 @@ namespace System.Reflection.Metadata.Ecma335
     /// <summary>
     /// Encodes instructions.
     /// </summary>
-    public struct InstructionEncoder
+    public readonly struct InstructionEncoder
     {
         /// <summary>
         /// Underlying builder where encoded instructions are written to.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/LabelHandle.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/LabelHandle.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata.Ecma335
 {
-    public struct LabelHandle : IEquatable<LabelHandle>
+    public readonly struct LabelHandle : IEquatable<LabelHandle>
     {
         /// <summary>
         /// 1-based id identifying the label within the context of a <see cref="ControlFlowBuilder"/>.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/MethodBodyStreamEncoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/MethodBodyStreamEncoder.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,7 +7,7 @@ namespace System.Reflection.Metadata.Ecma335
     /// <summary>
     /// Encodes method body stream.
     /// </summary>
-    public struct MethodBodyStreamEncoder
+    public readonly struct MethodBodyStreamEncoder
     {
         public BlobBuilder Builder { get; }
 
@@ -75,7 +75,7 @@ namespace System.Reflection.Metadata.Ecma335
             return new MethodBody(bodyOffset, instructions, regionEncoder);
         }
 
-        public struct MethodBody
+        public readonly struct MethodBody
         {
             /// <summary>
             /// Offset of the encoded method body in method body stream.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/SignatureDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/SignatureDecoder.cs
@@ -11,7 +11,7 @@ namespace System.Reflection.Metadata.Ecma335
     /// Decodes signature blobs.
     /// See Metadata Specification section II.23.2: Blobs and signatures.
     /// </summary>
-    public struct SignatureDecoder<TType, TGenericContext>
+    public readonly struct SignatureDecoder<TType, TGenericContext>
     {
         private readonly ISignatureTypeProvider<TType, TGenericContext> _provider;
         private readonly MetadataReader _metadataReaderOpt;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/EntityHandle.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/EntityHandle.cs
@@ -14,7 +14,7 @@ namespace System.Reflection.Metadata
     /// Use <see cref="EntityHandle"/> to store multiple kinds of entity handles.
     /// It has smaller memory footprint than <see cref="Handle"/>.
     /// </remarks>
-    public struct EntityHandle : IEquatable<EntityHandle>
+    public readonly struct EntityHandle : IEquatable<EntityHandle>
     {
         // bits:
         //     31: IsVirtual

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Handle.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Handle.cs
@@ -13,7 +13,7 @@ namespace System.Reflection.Metadata
     /// <remarks>
     /// Use <see cref="Handle"/> to store multiple kinds of handles.
     /// </remarks>
-    public struct Handle : IEquatable<Handle>
+    public readonly struct Handle : IEquatable<Handle>
     {
         private readonly int _value;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/IL/ExceptionRegion.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/IL/ExceptionRegion.cs
@@ -4,7 +4,7 @@
 
 namespace System.Reflection.Metadata
 {
-    public struct ExceptionRegion
+    public readonly struct ExceptionRegion
     {
         private readonly ExceptionRegionKind _kind;
         private readonly int _tryOffset;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/GuidHeap.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/GuidHeap.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,7 +6,7 @@ using System.Reflection.Internal;
 
 namespace System.Reflection.Metadata.Ecma335
 {
-    internal struct GuidHeap
+    internal readonly struct GuidHeap
     {
         internal readonly MemoryBlock Block;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/Tables.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/Tables.cs
@@ -7,7 +7,7 @@ using System.Reflection.Internal;
 
 namespace System.Reflection.Metadata.Ecma335
 {
-    internal struct ModuleTableReader
+    internal readonly struct ModuleTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsStringHeapRefSizeSmall;
@@ -71,7 +71,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct TypeRefTableReader
+    internal readonly struct TypeRefTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsResolutionScopeRefSizeSmall;
@@ -284,7 +284,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct FieldPtrTableReader
+    internal readonly struct FieldPtrTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsFieldTableRowRefSizeSmall;
@@ -318,7 +318,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct FieldTableReader
+    internal readonly struct FieldTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsStringHeapRefSizeSmall;
@@ -366,7 +366,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct MethodPtrTableReader
+    internal readonly struct MethodPtrTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsMethodTableRowRefSizeSmall;
@@ -401,7 +401,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct MethodTableReader
+    internal readonly struct MethodTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsParamRefSizeSmall;
@@ -476,7 +476,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct ParamPtrTableReader
+    internal readonly struct ParamPtrTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsParamTableRowRefSizeSmall;
@@ -505,7 +505,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct ParamTableReader
+    internal readonly struct ParamTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsStringHeapRefSizeSmall;
@@ -550,7 +550,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct InterfaceImplTableReader
+    internal readonly struct InterfaceImplTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsTypeDefTableRowRefSizeSmall;
@@ -675,7 +675,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct ConstantTableReader
+    internal readonly struct ConstantTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsHasConstantRefSizeSmall;
@@ -747,7 +747,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct CustomAttributeTableReader
+    internal readonly struct CustomAttributeTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsHasCustomAttributeRefSizeSmall;
@@ -858,7 +858,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct FieldMarshalTableReader
+    internal readonly struct FieldMarshalTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsHasFieldMarshalRefSizeSmall;
@@ -922,7 +922,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct DeclSecurityTableReader
+    internal readonly struct DeclSecurityTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsHasDeclSecurityRefSizeSmall;
@@ -1072,7 +1072,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct FieldLayoutTableReader
+    internal readonly struct FieldLayoutTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsFieldTableRowRefSizeSmall;
@@ -1135,7 +1135,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct StandAloneSigTableReader
+    internal readonly struct StandAloneSigTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsBlobHeapRefSizeSmall;
@@ -1163,7 +1163,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct EventMapTableReader
+    internal readonly struct EventMapTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsTypeDefTableRowRefSizeSmall;
@@ -1216,7 +1216,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct EventPtrTableReader
+    internal readonly struct EventPtrTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsEventTableRowRefSizeSmall;
@@ -1291,7 +1291,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct PropertyMapTableReader
+    internal readonly struct PropertyMapTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsTypeDefTableRowRefSizeSmall;
@@ -1346,7 +1346,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct PropertyPtrTableReader
+    internal readonly struct PropertyPtrTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsPropertyTableRowRefSizeSmall;
@@ -1378,7 +1378,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct PropertyTableReader
+    internal readonly struct PropertyTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsStringHeapRefSizeSmall;
@@ -1425,7 +1425,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct MethodSemanticsTableReader
+    internal readonly struct MethodSemanticsTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsMethodTableRowRefSizeSmall;
@@ -1521,7 +1521,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct MethodImplTableReader
+    internal readonly struct MethodImplTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsTypeDefTableRowRefSizeSmall;
@@ -1607,7 +1607,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct ModuleRefTableReader
+    internal readonly struct ModuleRefTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsStringHeapRefSizeSmall;
@@ -1636,7 +1636,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct TypeSpecTableReader
+    internal readonly struct TypeSpecTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsBlobHeapRefSizeSmall;
@@ -1665,7 +1665,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct ImplMapTableReader
+    internal readonly struct ImplMapTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsModuleRefTableRowRefSizeSmall;
@@ -1745,7 +1745,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct FieldRVATableReader
+    internal readonly struct FieldRVATableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsFieldTableRowRefSizeSmall;
@@ -1798,7 +1798,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct EnCLogTableReader
+    internal readonly struct EnCLogTableReader
     {
         internal readonly int NumberOfRows;
         private readonly int _TokenOffset;
@@ -1836,7 +1836,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct EnCMapTableReader
+    internal readonly struct EnCMapTableReader
     {
         internal readonly int NumberOfRows;
         private readonly int _TokenOffset;
@@ -1861,7 +1861,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct AssemblyTableReader
+    internal readonly struct AssemblyTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsStringHeapRefSizeSmall;
@@ -1946,7 +1946,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct AssemblyProcessorTableReader
+    internal readonly struct AssemblyProcessorTableReader
     {
         internal readonly int NumberOfRows;
         private readonly int _ProcessorOffset;
@@ -1966,7 +1966,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct AssemblyOSTableReader
+    internal readonly struct AssemblyOSTableReader
     {
         internal readonly int NumberOfRows;
         private readonly int _OSPlatformIdOffset;
@@ -1990,7 +1990,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct AssemblyRefTableReader
+    internal readonly struct AssemblyRefTableReader
     {
         /// <summary>
         /// In CLI metadata equal to the actual number of entries in AssemblyRef table.
@@ -2080,7 +2080,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct AssemblyRefProcessorTableReader
+    internal readonly struct AssemblyRefProcessorTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsAssemblyRefTableRowSizeSmall;
@@ -2105,7 +2105,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct AssemblyRefOSTableReader
+    internal readonly struct AssemblyRefOSTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsAssemblyRefTableRowRefSizeSmall;
@@ -2133,7 +2133,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct FileTableReader
+    internal readonly struct FileTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsStringHeapRefSizeSmall;
@@ -2180,7 +2180,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct ExportedTypeTableReader
+    internal readonly struct ExportedTypeTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsImplementationRefSizeSmall;
@@ -2256,7 +2256,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct ManifestResourceTableReader
+    internal readonly struct ManifestResourceTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsImplementationRefSizeSmall;
@@ -2312,7 +2312,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct NestedClassTableReader
+    internal readonly struct NestedClassTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsTypeDefTableRowRefSizeSmall;
@@ -2378,7 +2378,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct GenericParamTableReader
+    internal readonly struct GenericParamTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsTypeOrMethodDefRefSizeSmall;
@@ -2484,7 +2484,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct MethodSpecTableReader
+    internal readonly struct MethodSpecTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsMethodDefOrRefRefSizeSmall;
@@ -2523,7 +2523,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct GenericParamConstraintTableReader
+    internal readonly struct GenericParamConstraintTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _IsGenericParamTableRowRefSizeSmall;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/UserStringHeap.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/UserStringHeap.cs
@@ -6,7 +6,7 @@ using System.Reflection.Internal;
 
 namespace System.Reflection.Metadata.Ecma335
 {
-    internal struct UserStringHeap
+    internal readonly struct UserStringHeap
     {
         internal readonly MemoryBlock Block;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.WinMD.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.WinMD.cs
@@ -29,7 +29,7 @@ namespace System.Reflection.Metadata
         private static string[] s_projectedTypeNames;
         private static ProjectionInfo[] s_projectionInfos;
 
-        private struct ProjectionInfo
+        private readonly struct ProjectionInfo
         {
             public readonly string WinRTNamespace;
             public readonly StringHandle.VirtualIndex ClrNamespace;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataStringComparer.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataStringComparer.cs
@@ -46,7 +46,7 @@ namespace System.Reflection.Metadata
     ///
     /// The choice between them is therefore one of style and not performance.
     /// </remarks>
-    public struct MetadataStringComparer
+    public readonly struct MetadataStringComparer
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/CustomDebugInformation.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/CustomDebugInformation.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct CustomDebugInformation
+    public readonly struct CustomDebugInformation
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Document.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Document.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Metadata
     /// <remarks>
     /// See also https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md#document-table-0x30.
     /// </remarks>
-    public struct Document
+    public readonly struct Document
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/DocumentNameBlobHandle.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/DocumentNameBlobHandle.cs
@@ -16,7 +16,7 @@ namespace System.Reflection.Metadata
     /// The kind of the handle is <see cref="HandleKind.Blob"/>. 
     /// The handle is a specialization of <see cref="BlobHandle"/> and doesn't have a distinct kind. 
     /// </remarks>
-    public struct DocumentNameBlobHandle : IEquatable<DocumentNameBlobHandle>
+    public readonly struct DocumentNameBlobHandle : IEquatable<DocumentNameBlobHandle>
     {
         // bits:
         // 29..31: 0

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/HandleCollections.Debug.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/HandleCollections.Debug.cs
@@ -9,7 +9,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct DocumentHandleCollection : IReadOnlyCollection<DocumentHandle>
+    public readonly struct DocumentHandleCollection : IReadOnlyCollection<DocumentHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -108,7 +108,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct MethodDebugInformationHandleCollection : IReadOnlyCollection<MethodDebugInformationHandle>
+    public readonly struct MethodDebugInformationHandleCollection : IReadOnlyCollection<MethodDebugInformationHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -207,7 +207,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct LocalScopeHandleCollection : IReadOnlyCollection<LocalScopeHandle>
+    public readonly struct LocalScopeHandleCollection : IReadOnlyCollection<LocalScopeHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -415,7 +415,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct LocalVariableHandleCollection : IReadOnlyCollection<LocalVariableHandle>
+    public readonly struct LocalVariableHandleCollection : IReadOnlyCollection<LocalVariableHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -521,7 +521,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct LocalConstantHandleCollection : IReadOnlyCollection<LocalConstantHandle>
+    public readonly struct LocalConstantHandleCollection : IReadOnlyCollection<LocalConstantHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -627,7 +627,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct ImportScopeCollection : IReadOnlyCollection<ImportScopeHandle>
+    public readonly struct ImportScopeCollection : IReadOnlyCollection<ImportScopeHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -726,7 +726,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct CustomDebugInformationHandleCollection : IReadOnlyCollection<CustomDebugInformationHandle>
+    public readonly struct CustomDebugInformationHandleCollection : IReadOnlyCollection<CustomDebugInformationHandle>
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Handles.Debug.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Handles.Debug.cs
@@ -7,7 +7,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct DocumentHandle : IEquatable<DocumentHandle>
+    public readonly struct DocumentHandle : IEquatable<DocumentHandle>
     {
         private const uint tokenType = TokenTypeIds.Document;
         private const byte tokenTypeSmall = (byte)HandleType.Document;
@@ -90,7 +90,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct MethodDebugInformationHandle : IEquatable<MethodDebugInformationHandle>
+    public readonly struct MethodDebugInformationHandle : IEquatable<MethodDebugInformationHandle>
     {
         private const uint tokenType = TokenTypeIds.MethodDebugInformation;
         private const byte tokenTypeSmall = (byte)HandleType.MethodDebugInformation;
@@ -185,7 +185,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct LocalScopeHandle : IEquatable<LocalScopeHandle>
+    public readonly struct LocalScopeHandle : IEquatable<LocalScopeHandle>
     {
         private const uint tokenType = TokenTypeIds.LocalScope;
         private const byte tokenTypeSmall = (byte)HandleType.LocalScope;
@@ -268,7 +268,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct LocalVariableHandle : IEquatable<LocalVariableHandle>
+    public readonly struct LocalVariableHandle : IEquatable<LocalVariableHandle>
     {
         private const uint tokenType = TokenTypeIds.LocalVariable;
         private const byte tokenTypeSmall = (byte)HandleType.LocalVariable;
@@ -351,7 +351,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct LocalConstantHandle : IEquatable<LocalConstantHandle>
+    public readonly struct LocalConstantHandle : IEquatable<LocalConstantHandle>
     {
         private const uint tokenType = TokenTypeIds.LocalConstant;
         private const byte tokenTypeSmall = (byte)HandleType.LocalConstant;
@@ -434,7 +434,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct ImportScopeHandle : IEquatable<ImportScopeHandle>
+    public readonly struct ImportScopeHandle : IEquatable<ImportScopeHandle>
     {
         private const uint tokenType = TokenTypeIds.ImportScope;
         private const byte tokenTypeSmall = (byte)HandleType.ImportScope;
@@ -517,7 +517,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct CustomDebugInformationHandle : IEquatable<CustomDebugInformationHandle>
+    public readonly struct CustomDebugInformationHandle : IEquatable<CustomDebugInformationHandle>
     {
         private const uint tokenType = TokenTypeIds.CustomDebugInformation;
         private const byte tokenTypeSmall = (byte)HandleType.CustomDebugInformation;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/ImportDefinition.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/ImportDefinition.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct ImportDefinition
+    public readonly struct ImportDefinition
     {
         public ImportDefinitionKind Kind { get; }
         public BlobHandle Alias { get; }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/ImportDefinitionCollection.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/ImportDefinitionCollection.cs
@@ -10,7 +10,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct ImportDefinitionCollection : IEnumerable<ImportDefinition>
+    public readonly struct ImportDefinitionCollection : IEnumerable<ImportDefinition>
     {
         private readonly MemoryBlock _block;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/ImportScope.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/ImportScope.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Metadata
     /// <remarks>
     /// See https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md#importscope-table-0x35
     /// </remarks>
-    public struct ImportScope
+    public readonly struct ImportScope
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/LocalConstant.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/LocalConstant.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Metadata
     /// <remarks>
     /// See https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md#localconstant-table-0x34.
     /// </remarks>
-    public struct LocalConstant
+    public readonly struct LocalConstant
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/LocalScope.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/LocalScope.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Metadata
     /// <remarks>
     /// See https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md#localscope-table-0x32.
     /// </remarks>
-    public struct LocalScope
+    public readonly struct LocalScope
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/LocalVariable.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/LocalVariable.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Metadata
     /// <remarks>
     /// See https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md#localvariable-table-0x33.
     /// </remarks>
-    public struct LocalVariable
+    public readonly struct LocalVariable
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/MethodDebugInformation.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/MethodDebugInformation.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Metadata
     /// <remarks>
     /// See https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md#methoddebuginformation-table-0x31.
     /// </remarks>
-    public struct MethodDebugInformation
+    public readonly struct MethodDebugInformation
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/SequencePoint.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/SequencePoint.cs
@@ -8,7 +8,7 @@ using System.Reflection.Internal;
 namespace System.Reflection.Metadata
 {
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-    public struct SequencePoint : IEquatable<SequencePoint>
+    public readonly struct SequencePoint : IEquatable<SequencePoint>
     {
         public const int HiddenLine = 0xfeefee;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/SequencePointCollection.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/SequencePointCollection.cs
@@ -10,7 +10,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct SequencePointCollection : IEnumerable<SequencePoint>
+    public readonly struct SequencePointCollection : IEnumerable<SequencePoint>
     {
         private readonly MemoryBlock _block;
         private readonly DocumentHandle _document;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Tables.Debug.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Tables.Debug.cs
@@ -6,7 +6,7 @@ using System.Reflection.Internal;
 
 namespace System.Reflection.Metadata.Ecma335
 {
-    internal struct DocumentTableReader
+    internal readonly struct DocumentTableReader
     {
         internal readonly int NumberOfRows;
 
@@ -65,7 +65,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct MethodDebugInformationTableReader
+    internal readonly struct MethodDebugInformationTableReader
     {
         internal readonly int NumberOfRows;
 
@@ -108,7 +108,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct LocalScopeTableReader
+    internal readonly struct LocalScopeTableReader
     {
         internal readonly int NumberOfRows;
 
@@ -236,7 +236,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct LocalVariableTableReader
+    internal readonly struct LocalVariableTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _isStringHeapRefSizeSmall;
@@ -283,7 +283,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct LocalConstantTableReader
+    internal readonly struct LocalConstantTableReader
     {
         internal readonly int NumberOfRows;
         private readonly bool _isStringHeapRefSizeSmall;
@@ -325,7 +325,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct StateMachineMethodTableReader
+    internal readonly struct StateMachineMethodTableReader
     {
         internal readonly int NumberOfRows;
 
@@ -383,7 +383,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct ImportScopeTableReader
+    internal readonly struct ImportScopeTableReader
     {
         internal readonly int NumberOfRows;
 
@@ -426,7 +426,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct CustomDebugInformationTableReader
+    internal readonly struct CustomDebugInformationTableReader
     {
         internal readonly int NumberOfRows;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/ReservedBlob.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/ReservedBlob.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,7 +7,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Represents a handle and a corresponding blob on a metadata heap that was reserved for future content update.
     /// </summary>
-    public struct ReservedBlob<THandle>
+    public readonly struct ReservedBlob<THandle>
         where THandle : struct
     {
         public THandle Handle { get; }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/ArrayShape.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/ArrayShape.cs
@@ -9,7 +9,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Represents the shape of an array type.
     /// </summary>
-    public struct ArrayShape
+    public readonly struct ArrayShape
     {
         /// <summary>
         /// Gets the number of dimensions in the array.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/CustomAttributeNamedArgument.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/CustomAttributeNamedArgument.cs
@@ -1,10 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Reflection.Metadata
 {
-    public struct CustomAttributeNamedArgument<TType>
+    public readonly struct CustomAttributeNamedArgument<TType>
     {
         public string Name { get; }
         public CustomAttributeNamedArgumentKind Kind { get; }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/CustomAttributeTypedArgument.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/CustomAttributeTypedArgument.cs
@@ -1,10 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Reflection.Metadata
 {
-    public struct CustomAttributeTypedArgument<TType>
+    public readonly struct CustomAttributeTypedArgument<TType>
     {
         public TType Type { get; }
         public object Value { get; }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/CustomAttributeValue.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/CustomAttributeValue.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 
 namespace System.Reflection.Metadata
 {
-    public struct CustomAttributeValue<TType>
+    public readonly struct CustomAttributeValue<TType>
     {
         public ImmutableArray<CustomAttributeTypedArgument<TType>> FixedArguments { get; }
         public ImmutableArray<CustomAttributeNamedArgument<TType>> NamedArguments { get; }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/MethodSignature.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/MethodSignature.cs
@@ -11,7 +11,7 @@ namespace System.Reflection.Metadata
     /// Represents a method (definition, reference, or standalone) or property signature.
     /// In the case of properties, the signature matches that of a getter with a distinguishing <see cref="SignatureHeader"/>.
     /// </summary>
-    public struct MethodSignature<TType>
+    public readonly struct MethodSignature<TType>
     {
         /// <summary>
         /// Represents the information in the leading byte of the signature (kind, calling convention, flags).

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyDefinition.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyDefinition.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public partial struct AssemblyDefinition
+    public readonly partial struct AssemblyDefinition
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyDefinition.netstandard.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyDefinition.netstandard.cs
@@ -1,10 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Reflection.Metadata
 {
-    public partial struct AssemblyDefinition
+    public readonly partial struct AssemblyDefinition
     {
         public AssemblyName GetAssemblyName()
         {

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyFile.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyFile.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct AssemblyFile
+    public readonly struct AssemblyFile
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyReference.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyReference.cs
@@ -7,7 +7,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public partial struct AssemblyReference
+    public readonly partial struct AssemblyReference
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyReference.netstandard.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyReference.netstandard.cs
@@ -1,10 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Reflection.Metadata
 {
-    public partial struct AssemblyReference
+    public readonly partial struct AssemblyReference
     {
         public AssemblyName GetAssemblyName()
         {

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/Constant.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/Constant.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct Constant
+    public readonly struct Constant
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/CustomAttribute.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/CustomAttribute.cs
@@ -7,7 +7,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct CustomAttribute
+    public readonly struct CustomAttribute
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/DeclarativeSecurityAttribute.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/DeclarativeSecurityAttribute.cs
@@ -7,7 +7,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct DeclarativeSecurityAttribute
+    public readonly struct DeclarativeSecurityAttribute
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/EventDefinition.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/EventDefinition.cs
@@ -8,7 +8,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct EventDefinition
+    public readonly struct EventDefinition
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/ExportedType.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/ExportedType.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct ExportedType
+    public readonly struct ExportedType
     {
         internal readonly MetadataReader reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/FieldDefinition.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/FieldDefinition.cs
@@ -7,7 +7,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct FieldDefinition
+    public readonly struct FieldDefinition
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/GenericParameter.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/GenericParameter.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct GenericParameter
+    public readonly struct GenericParameter
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/GenericParameterConstraint.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/GenericParameterConstraint.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct GenericParameterConstraint
+    public readonly struct GenericParameterConstraint
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/HandleCollections.TypeSystem.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/HandleCollections.TypeSystem.cs
@@ -13,7 +13,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Represents generic type parameters of a method or type.
     /// </summary>
-    public struct GenericParameterHandleCollection : IReadOnlyList<GenericParameterHandle>
+    public readonly struct GenericParameterHandleCollection : IReadOnlyList<GenericParameterHandle>
     {
         private readonly int _firstRowId;
         private readonly ushort _count;
@@ -121,7 +121,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Represents constraints of a generic type parameter.
     /// </summary>
-    public struct GenericParameterConstraintHandleCollection : IReadOnlyList<GenericParameterConstraintHandle>
+    public readonly struct GenericParameterConstraintHandleCollection : IReadOnlyList<GenericParameterConstraintHandle>
     {
         private readonly int _firstRowId;
         private readonly ushort _count;
@@ -226,7 +226,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct CustomAttributeHandleCollection : IReadOnlyCollection<CustomAttributeHandle>
+    public readonly struct CustomAttributeHandleCollection : IReadOnlyCollection<CustomAttributeHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -346,7 +346,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct DeclarativeSecurityAttributeHandleCollection : IReadOnlyCollection<DeclarativeSecurityAttributeHandle>
+    public readonly struct DeclarativeSecurityAttributeHandleCollection : IReadOnlyCollection<DeclarativeSecurityAttributeHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -453,7 +453,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct MethodDefinitionHandleCollection : IReadOnlyCollection<MethodDefinitionHandle>
+    public readonly struct MethodDefinitionHandleCollection : IReadOnlyCollection<MethodDefinitionHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -573,7 +573,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct FieldDefinitionHandleCollection : IReadOnlyCollection<FieldDefinitionHandle>
+    public readonly struct FieldDefinitionHandleCollection : IReadOnlyCollection<FieldDefinitionHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -693,7 +693,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct PropertyDefinitionHandleCollection : IReadOnlyCollection<PropertyDefinitionHandle>
+    public readonly struct PropertyDefinitionHandleCollection : IReadOnlyCollection<PropertyDefinitionHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -813,7 +813,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct EventDefinitionHandleCollection : IReadOnlyCollection<EventDefinitionHandle>
+    public readonly struct EventDefinitionHandleCollection : IReadOnlyCollection<EventDefinitionHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -933,7 +933,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct MethodImplementationHandleCollection : IReadOnlyCollection<MethodImplementationHandle>
+    public readonly struct MethodImplementationHandleCollection : IReadOnlyCollection<MethodImplementationHandle>
     {
         private readonly int _firstRowId;
         private readonly int _lastRowId;
@@ -1036,7 +1036,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Collection of parameters of a specified method.
     /// </summary>
-    public struct ParameterHandleCollection : IReadOnlyCollection<ParameterHandle>
+    public readonly struct ParameterHandleCollection : IReadOnlyCollection<ParameterHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -1148,7 +1148,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct InterfaceImplementationHandleCollection : IReadOnlyCollection<InterfaceImplementationHandle>
+    public readonly struct InterfaceImplementationHandleCollection : IReadOnlyCollection<InterfaceImplementationHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -1249,7 +1249,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Represents a collection of <see cref="TypeDefinitionHandle"/>.
     /// </summary>
-    public struct TypeDefinitionHandleCollection : IReadOnlyCollection<TypeDefinitionHandle>
+    public readonly struct TypeDefinitionHandleCollection : IReadOnlyCollection<TypeDefinitionHandle>
     {
         private readonly int _lastRowId;
 
@@ -1339,7 +1339,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Represents a collection of <see cref="TypeReferenceHandle"/>.
     /// </summary>
-    public struct TypeReferenceHandleCollection : IReadOnlyCollection<TypeReferenceHandle>
+    public readonly struct TypeReferenceHandleCollection : IReadOnlyCollection<TypeReferenceHandle>
     {
         private readonly int _lastRowId;
 
@@ -1429,7 +1429,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Represents a collection of <see cref="TypeReferenceHandle"/>.
     /// </summary>
-    public struct ExportedTypeHandleCollection : IReadOnlyCollection<ExportedTypeHandle>
+    public readonly struct ExportedTypeHandleCollection : IReadOnlyCollection<ExportedTypeHandle>
     {
         private readonly int _lastRowId;
 
@@ -1519,7 +1519,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Represents a collection of <see cref="MemberReferenceHandle"/>.
     /// </summary>
-    public struct MemberReferenceHandleCollection : IReadOnlyCollection<MemberReferenceHandle>
+    public readonly struct MemberReferenceHandleCollection : IReadOnlyCollection<MemberReferenceHandle>
     {
         private readonly int _lastRowId;
 
@@ -1606,7 +1606,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct PropertyAccessors
+    public readonly struct PropertyAccessors
     {
         // Workaround: JIT doesn't generate good code for nested structures, so use uints.
 
@@ -1626,7 +1626,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct EventAccessors
+    public readonly struct EventAccessors
     {
         // Workaround: JIT doesn't generate good code for nested structures, so use uints.
 
@@ -1652,7 +1652,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Collection of assembly references.
     /// </summary>
-    public struct AssemblyReferenceHandleCollection : IReadOnlyCollection<AssemblyReferenceHandle>
+    public readonly struct AssemblyReferenceHandleCollection : IReadOnlyCollection<AssemblyReferenceHandle>
     {
         private readonly MetadataReader _reader;
 
@@ -1763,7 +1763,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Represents a collection of <see cref="ManifestResourceHandle"/>.
     /// </summary>
-    public struct ManifestResourceHandleCollection : IReadOnlyCollection<ManifestResourceHandle>
+    public readonly struct ManifestResourceHandleCollection : IReadOnlyCollection<ManifestResourceHandle>
     {
         private readonly int _lastRowId;
 
@@ -1853,7 +1853,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// Represents a collection of <see cref="AssemblyFileHandle"/>.
     /// </summary>
-    public struct AssemblyFileHandleCollection : IReadOnlyCollection<AssemblyFileHandle>
+    public readonly struct AssemblyFileHandleCollection : IReadOnlyCollection<AssemblyFileHandle>
     {
         private readonly int _lastRowId;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/Handles.TypeSystem.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/Handles.TypeSystem.cs
@@ -7,7 +7,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct ModuleDefinitionHandle : IEquatable<ModuleDefinitionHandle>
+    public readonly struct ModuleDefinitionHandle : IEquatable<ModuleDefinitionHandle>
     {
         private const uint tokenType = TokenTypeIds.Module;
         private const byte tokenTypeSmall = (byte)HandleType.Module;
@@ -90,7 +90,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct AssemblyDefinitionHandle : IEquatable<AssemblyDefinitionHandle>
+    public readonly struct AssemblyDefinitionHandle : IEquatable<AssemblyDefinitionHandle>
     {
         private const uint tokenType = TokenTypeIds.Assembly;
         private const byte tokenTypeSmall = (byte)HandleType.Assembly;
@@ -173,7 +173,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct InterfaceImplementationHandle : IEquatable<InterfaceImplementationHandle>
+    public readonly struct InterfaceImplementationHandle : IEquatable<InterfaceImplementationHandle>
     {
         private const uint tokenType = TokenTypeIds.InterfaceImpl;
         private const byte tokenTypeSmall = (byte)HandleType.InterfaceImpl;
@@ -256,7 +256,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct MethodDefinitionHandle : IEquatable<MethodDefinitionHandle>
+    public readonly struct MethodDefinitionHandle : IEquatable<MethodDefinitionHandle>
     {
         private const uint tokenType = TokenTypeIds.MethodDef;
         private const byte tokenTypeSmall = (byte)HandleType.MethodDef;
@@ -351,7 +351,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct MethodImplementationHandle : IEquatable<MethodImplementationHandle>
+    public readonly struct MethodImplementationHandle : IEquatable<MethodImplementationHandle>
     {
         private const uint tokenType = TokenTypeIds.MethodImpl;
         private const byte tokenTypeSmall = (byte)HandleType.MethodImpl;
@@ -434,7 +434,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct MethodSpecificationHandle : IEquatable<MethodSpecificationHandle>
+    public readonly struct MethodSpecificationHandle : IEquatable<MethodSpecificationHandle>
     {
         private const uint tokenType = TokenTypeIds.MethodSpec;
         private const byte tokenTypeSmall = (byte)HandleType.MethodSpec;
@@ -517,7 +517,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct TypeDefinitionHandle : IEquatable<TypeDefinitionHandle>
+    public readonly struct TypeDefinitionHandle : IEquatable<TypeDefinitionHandle>
     {
         private const uint tokenType = TokenTypeIds.TypeDef;
         private const byte tokenTypeSmall = (byte)HandleType.TypeDef;
@@ -600,7 +600,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct ExportedTypeHandle : IEquatable<ExportedTypeHandle>
+    public readonly struct ExportedTypeHandle : IEquatable<ExportedTypeHandle>
     {
         private const uint tokenType = TokenTypeIds.ExportedType;
         private const byte tokenTypeSmall = (byte)HandleType.ExportedType;
@@ -683,7 +683,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct TypeReferenceHandle : IEquatable<TypeReferenceHandle>
+    public readonly struct TypeReferenceHandle : IEquatable<TypeReferenceHandle>
     {
         private const uint tokenType = TokenTypeIds.TypeRef;
         private const byte tokenTypeSmall = (byte)HandleType.TypeRef;
@@ -766,7 +766,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct TypeSpecificationHandle : IEquatable<TypeSpecificationHandle>
+    public readonly struct TypeSpecificationHandle : IEquatable<TypeSpecificationHandle>
     {
         private const uint tokenType = TokenTypeIds.TypeSpec;
         private const byte tokenTypeSmall = (byte)HandleType.TypeSpec;
@@ -849,7 +849,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct MemberReferenceHandle : IEquatable<MemberReferenceHandle>
+    public readonly struct MemberReferenceHandle : IEquatable<MemberReferenceHandle>
     {
         private const uint tokenType = TokenTypeIds.MemberRef;
         private const byte tokenTypeSmall = (byte)HandleType.MemberRef;
@@ -932,7 +932,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct FieldDefinitionHandle : IEquatable<FieldDefinitionHandle>
+    public readonly struct FieldDefinitionHandle : IEquatable<FieldDefinitionHandle>
     {
         private const uint tokenType = TokenTypeIds.FieldDef;
         private const byte tokenTypeSmall = (byte)HandleType.FieldDef;
@@ -1015,7 +1015,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct EventDefinitionHandle : IEquatable<EventDefinitionHandle>
+    public readonly struct EventDefinitionHandle : IEquatable<EventDefinitionHandle>
     {
         private const uint tokenType = TokenTypeIds.Event;
         private const byte tokenTypeSmall = (byte)HandleType.Event;
@@ -1098,7 +1098,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct PropertyDefinitionHandle : IEquatable<PropertyDefinitionHandle>
+    public readonly struct PropertyDefinitionHandle : IEquatable<PropertyDefinitionHandle>
     {
         private const uint tokenType = TokenTypeIds.Property;
         private const byte tokenTypeSmall = (byte)HandleType.Property;
@@ -1181,7 +1181,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct StandaloneSignatureHandle : IEquatable<StandaloneSignatureHandle>
+    public readonly struct StandaloneSignatureHandle : IEquatable<StandaloneSignatureHandle>
     {
         private const uint tokenType = TokenTypeIds.Signature;
         private const byte tokenTypeSmall = (byte)HandleType.Signature;
@@ -1264,7 +1264,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct ParameterHandle : IEquatable<ParameterHandle>
+    public readonly struct ParameterHandle : IEquatable<ParameterHandle>
     {
         private const uint tokenType = TokenTypeIds.ParamDef;
         private const byte tokenTypeSmall = (byte)HandleType.ParamDef;
@@ -1347,7 +1347,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct GenericParameterHandle : IEquatable<GenericParameterHandle>
+    public readonly struct GenericParameterHandle : IEquatable<GenericParameterHandle>
     {
         private const uint tokenType = TokenTypeIds.GenericParam;
         private const byte tokenTypeSmall = (byte)HandleType.GenericParam;
@@ -1430,7 +1430,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct GenericParameterConstraintHandle : IEquatable<GenericParameterConstraintHandle>
+    public readonly struct GenericParameterConstraintHandle : IEquatable<GenericParameterConstraintHandle>
     {
         private const uint tokenType = TokenTypeIds.GenericParamConstraint;
         private const byte tokenTypeSmall = (byte)HandleType.GenericParamConstraint;
@@ -1513,7 +1513,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct ModuleReferenceHandle : IEquatable<ModuleReferenceHandle>
+    public readonly struct ModuleReferenceHandle : IEquatable<ModuleReferenceHandle>
     {
         private const uint tokenType = TokenTypeIds.ModuleRef;
         private const byte tokenTypeSmall = (byte)HandleType.ModuleRef;
@@ -1596,7 +1596,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct AssemblyReferenceHandle : IEquatable<AssemblyReferenceHandle>
+    public readonly struct AssemblyReferenceHandle : IEquatable<AssemblyReferenceHandle>
     {
         private const uint tokenType = TokenTypeIds.AssemblyRef;
         private const byte tokenTypeSmall = (byte)HandleType.AssemblyRef;
@@ -1714,7 +1714,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct CustomAttributeHandle : IEquatable<CustomAttributeHandle>
+    public readonly struct CustomAttributeHandle : IEquatable<CustomAttributeHandle>
     {
         private const uint tokenType = TokenTypeIds.CustomAttribute;
         private const byte tokenTypeSmall = (byte)HandleType.CustomAttribute;
@@ -1797,7 +1797,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct DeclarativeSecurityAttributeHandle : IEquatable<DeclarativeSecurityAttributeHandle>
+    public readonly struct DeclarativeSecurityAttributeHandle : IEquatable<DeclarativeSecurityAttributeHandle>
     {
         private const uint tokenType = TokenTypeIds.DeclSecurity;
         private const byte tokenTypeSmall = (byte)HandleType.DeclSecurity;
@@ -1880,7 +1880,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct ConstantHandle : IEquatable<ConstantHandle>
+    public readonly struct ConstantHandle : IEquatable<ConstantHandle>
     {
         private const uint tokenType = TokenTypeIds.Constant;
         private const byte tokenTypeSmall = (byte)HandleType.Constant;
@@ -1963,7 +1963,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct ManifestResourceHandle : IEquatable<ManifestResourceHandle>
+    public readonly struct ManifestResourceHandle : IEquatable<ManifestResourceHandle>
     {
         private const uint tokenType = TokenTypeIds.ManifestResource;
         private const byte tokenTypeSmall = (byte)HandleType.ManifestResource;
@@ -2046,7 +2046,7 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct AssemblyFileHandle : IEquatable<AssemblyFileHandle>
+    public readonly struct AssemblyFileHandle : IEquatable<AssemblyFileHandle>
     {
         private const uint tokenType = TokenTypeIds.File;
         private const byte tokenTypeSmall = (byte)HandleType.File;
@@ -2135,7 +2135,7 @@ namespace System.Reflection.Metadata
     /// <remarks>
     /// The handle is 32-bit wide.
     /// </remarks>
-    public struct UserStringHandle : IEquatable<UserStringHandle>
+    public readonly struct UserStringHandle : IEquatable<UserStringHandle>
     {
         // bits:
         //     31: 0
@@ -2207,7 +2207,7 @@ namespace System.Reflection.Metadata
     }
 
     // #String heap handle
-    public struct StringHandle : IEquatable<StringHandle>
+    public readonly struct StringHandle : IEquatable<StringHandle>
     {
         // bits:
         //     31: IsVirtual
@@ -2430,7 +2430,7 @@ namespace System.Reflection.Metadata
     /// <summary>
     /// A handle that represents a namespace definition. 
     /// </summary>
-    public struct NamespaceDefinitionHandle : IEquatable<NamespaceDefinitionHandle>
+    public readonly struct NamespaceDefinitionHandle : IEquatable<NamespaceDefinitionHandle>
     {
         // Non-virtual (namespace having at least one type or forwarder of its own) 
         // heap offset is to the null-terminated full name of the namespace in the 
@@ -2546,7 +2546,7 @@ namespace System.Reflection.Metadata
     }
 
     // #Blob heap handle
-    public struct BlobHandle : IEquatable<BlobHandle>
+    public readonly struct BlobHandle : IEquatable<BlobHandle>
     {
         // bits:
         //     31: IsVirtual
@@ -2677,7 +2677,7 @@ namespace System.Reflection.Metadata
     }
 
     // #Guid heap handle
-    public struct GuidHandle : IEquatable<GuidHandle>
+    public readonly struct GuidHandle : IEquatable<GuidHandle>
     {
         // The Guid heap is an array of GUIDs, each 16 bytes wide. 
         // Its first element is numbered 1, its second 2, and so on.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/InterfaceImplementation.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/InterfaceImplementation.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct InterfaceImplementation
+    public readonly struct InterfaceImplementation
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/ManifestResource.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/ManifestResource.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct ManifestResource
+    public readonly struct ManifestResource
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/MemberReference.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/MemberReference.cs
@@ -7,7 +7,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct MemberReference
+    public readonly struct MemberReference
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/MethodDefinition.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/MethodDefinition.cs
@@ -7,7 +7,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct MethodDefinition
+    public readonly struct MethodDefinition
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/MethodImplementation.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/MethodImplementation.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct MethodImplementation
+    public readonly struct MethodImplementation
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/MethodImport.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/MethodImport.cs
@@ -4,7 +4,7 @@
 
 namespace System.Reflection.Metadata
 {
-    public struct MethodImport
+    public readonly struct MethodImport
     {
         private readonly MethodImportAttributes _attributes;
         private readonly StringHandle _name;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/MethodSpecification.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/MethodSpecification.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct MethodSpecification
+    public readonly struct MethodSpecification
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/ModuleDefinition.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/ModuleDefinition.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct ModuleDefinition
+    public readonly struct ModuleDefinition
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/ModuleReference.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/ModuleReference.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct ModuleReference
+    public readonly struct ModuleReference
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/Parameter.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/Parameter.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct Parameter
+    public readonly struct Parameter
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/PropertyDefinition.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/PropertyDefinition.cs
@@ -8,7 +8,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct PropertyDefinition
+    public readonly struct PropertyDefinition
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/StandaloneSignature.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/StandaloneSignature.cs
@@ -8,7 +8,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct StandaloneSignature
+    public readonly struct StandaloneSignature
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/TypeDefinition.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/TypeDefinition.cs
@@ -8,7 +8,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct TypeDefinition
+    public readonly struct TypeDefinition
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/TypeLayout.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/TypeLayout.cs
@@ -4,7 +4,7 @@
 
 namespace System.Reflection.Metadata
 {
-    public struct TypeLayout
+    public readonly struct TypeLayout
     {
         private readonly int _size;
         private readonly int _packingSize;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/TypeReference.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/TypeReference.cs
@@ -7,7 +7,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct TypeReference
+    public readonly struct TypeReference
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/TypeSpecification.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/TypeSpecification.cs
@@ -7,7 +7,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
-    public struct TypeSpecification
+    public readonly struct TypeSpecification
     {
         private readonly MetadataReader _reader;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/CodeViewDebugDirectoryData.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/CodeViewDebugDirectoryData.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Reflection.PortableExecutable
 {
-    public struct CodeViewDebugDirectoryData
+    public readonly struct CodeViewDebugDirectoryData
     {
         /// <summary>
         /// GUID (Globally Unique Identifier) of the associated PDB.

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryEntry.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryEntry.cs
@@ -9,7 +9,7 @@ namespace System.Reflection.PortableExecutable
     /// <summary>
     /// Identifies the location, size and format of a block of debug information.
     /// </summary>
-    public struct DebugDirectoryEntry
+    public readonly struct DebugDirectoryEntry
     {
         internal const int Size =
             sizeof(uint) +   // Characteristics

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DirectoryEntry.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DirectoryEntry.cs
@@ -4,7 +4,7 @@
 
 namespace System.Reflection.PortableExecutable
 {
-    public struct DirectoryEntry
+    public readonly struct DirectoryEntry
     {
         public readonly int RelativeVirtualAddress;
         public readonly int Size;

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBinaryReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBinaryReader.cs
@@ -18,7 +18,7 @@ namespace System.Reflection.PortableExecutable
     ///
     /// Only methods that are needed to read PE headers are implemented.
     /// </summary>
-    internal struct PEBinaryReader
+    internal readonly struct PEBinaryReader
     {
         private readonly long _startOffset;
         private readonly long _maxOffset;

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBuilder.cs
@@ -19,7 +19,7 @@ namespace System.Reflection.PortableExecutable
         private readonly Lazy<ImmutableArray<Section>> _lazySections;
         private Blob _lazyChecksum;
 
-        protected struct Section
+        protected readonly struct Section
         {
             public readonly string Name;
             public readonly SectionCharacteristics Characteristics;
@@ -36,7 +36,7 @@ namespace System.Reflection.PortableExecutable
             }
         }
 
-        private struct SerializedSection
+        private readonly struct SerializedSection
         {
             public readonly BlobBuilder Builder;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEMemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEMemoryBlock.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Reflection.PortableExecutable
 {
-    public struct PEMemoryBlock
+    public readonly struct PEMemoryBlock
     {
         private readonly AbstractMemoryBlock _block;
         private readonly int _offset;

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/SectionHeader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/SectionHeader.cs
@@ -4,7 +4,7 @@
 
 namespace System.Reflection.PortableExecutable
 {
-    public struct SectionHeader
+    public readonly struct SectionHeader
     {
         /// <summary>
         /// The name of the section.

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/SectionLocation.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/SectionLocation.cs
@@ -4,7 +4,7 @@
 
 namespace System.Reflection.PortableExecutable
 {
-    public struct SectionLocation
+    public readonly struct SectionLocation
     {
         public int RelativeVirtualAddress { get; }
         public int PointerToRawData { get; }

--- a/src/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
@@ -9,7 +9,7 @@
 namespace System.Runtime.InteropServices
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct OSPlatform : System.IEquatable<System.Runtime.InteropServices.OSPlatform>
+    public readonly partial struct OSPlatform : System.IEquatable<System.Runtime.InteropServices.OSPlatform>
     {
         public static System.Runtime.InteropServices.OSPlatform Linux { get { throw null; } }
         public static System.Runtime.InteropServices.OSPlatform OSX { get { throw null; } }

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
@@ -4,7 +4,7 @@
 
 namespace System.Runtime.InteropServices
 {
-    public struct OSPlatform : IEquatable<OSPlatform>
+    public readonly struct OSPlatform : IEquatable<OSPlatform>
     {
         private readonly string _osPlatform;
 

--- a/src/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
+++ b/src/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
@@ -9,7 +9,7 @@
 namespace System.Numerics
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct BigInteger : System.IComparable, System.IComparable<System.Numerics.BigInteger>, System.IEquatable<System.Numerics.BigInteger>, System.IFormattable
+    public readonly partial struct BigInteger : System.IComparable, System.IComparable<System.Numerics.BigInteger>, System.IEquatable<System.Numerics.BigInteger>, System.IFormattable
     {
         [System.CLSCompliantAttribute(false)]
         public BigInteger(byte[] value) { throw null; }

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -10,7 +10,7 @@ namespace System.Numerics
 {
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Numerics, Version=4.0.0.0, PublicKeyToken=b77a5c561934e089")]
-    public struct BigInteger : IFormattable, IComparable, IComparable<BigInteger>, IEquatable<BigInteger>
+    public readonly struct BigInteger : IFormattable, IComparable, IComparable<BigInteger>, IEquatable<BigInteger>
     {
         private const int knMaskHighBit = int.MinValue;
         private const uint kuMaskHighBit = unchecked((uint)int.MinValue);

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
@@ -15,7 +15,7 @@ namespace System.Numerics
 
         // see https://en.wikipedia.org/wiki/Barrett_reduction
 
-        internal struct FastReducer
+        internal readonly struct FastReducer
         {
             private readonly uint[] _modulus;
             private readonly uint[] _mu;

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -639,7 +639,7 @@ namespace System
     }
     public delegate int Comparison<in T>(T x, T y);
     public delegate TOutput Converter<in TInput, out TOutput>(TInput input);
-    public partial struct DateTime : System.IComparable, System.IComparable<System.DateTime>, System.IConvertible, System.IEquatable<System.DateTime>, System.IFormattable, System.Runtime.Serialization.ISerializable
+    public readonly partial struct DateTime : System.IComparable, System.IComparable<System.DateTime>, System.IConvertible, System.IEquatable<System.DateTime>, System.IFormattable, System.Runtime.Serialization.ISerializable
     {
         public static readonly System.DateTime MaxValue;
         public static readonly System.DateTime MinValue;
@@ -4054,7 +4054,7 @@ namespace System.Collections.Generic
         public static KeyValuePair<TKey, TValue> Create<TKey, TValue>(TKey key, TValue value) { throw null; }        
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct KeyValuePair<TKey, TValue>
+    public readonly partial struct KeyValuePair<TKey, TValue>
     {
         public KeyValuePair(TKey key, TValue value) { throw null; }
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -6165,7 +6165,7 @@ namespace System.Reflection
         public override string ToString() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public struct ParameterModifier
+    public readonly struct ParameterModifier
     {
         public ParameterModifier(int parameterCount) { }
         public bool this[int index] { get { throw null; } set { } }
@@ -6564,10 +6564,10 @@ namespace System.Runtime.CompilerServices
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
         public delegate TValue CreateValueCallback(TKey key);
     }
-    public partial struct ConfiguredValueTaskAwaitable<TResult>
+    public readonly partial struct ConfiguredValueTaskAwaitable<TResult>
     {
         public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<TResult>.ConfiguredValueTaskAwaiter GetAwaiter() { throw null; }
-        public partial struct ConfiguredValueTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+        public readonly partial struct ConfiguredValueTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
             public bool IsCompleted { get { throw null; } }
             public TResult GetResult() { throw null; }
@@ -6751,7 +6751,7 @@ namespace System.Runtime.CompilerServices
         public UnsafeValueTypeAttribute() { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ValueTaskAwaiter<TResult> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+    public readonly partial struct ValueTaskAwaiter<TResult> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
     {
         public bool IsCompleted { get { throw null; } }
         public TResult GetResult() { throw null; }
@@ -7060,7 +7060,7 @@ namespace System.Runtime.Serialization
         public void Reset() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct StreamingContext
+    public readonly partial struct StreamingContext
     {
         public StreamingContext(System.Runtime.Serialization.StreamingContextStates state) { }
         public StreamingContext(System.Runtime.Serialization.StreamingContextStates state, object additional) { }
@@ -7997,7 +7997,7 @@ namespace System.Threading.Tasks
         public void SetObserved() { }
     }
     [System.Runtime.CompilerServices.AsyncMethodBuilderAttribute(typeof(System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder<>))]
-    public partial struct ValueTask<TResult> : System.IEquatable<System.Threading.Tasks.ValueTask<TResult>>
+    public readonly partial struct ValueTask<TResult> : System.IEquatable<System.Threading.Tasks.ValueTask<TResult>>
     {
         public ValueTask(System.Threading.Tasks.Task<TResult> task) { throw null; }
         public ValueTask(TResult result) { throw null; }

--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -103,7 +103,7 @@ namespace System.Security.Cryptography
         protected virtual bool TryHashFinal(Span<byte> destination, out int bytesWritten) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct HashAlgorithmName : System.IEquatable<System.Security.Cryptography.HashAlgorithmName>
+    public readonly partial struct HashAlgorithmName : System.IEquatable<System.Security.Cryptography.HashAlgorithmName>
     {
         public HashAlgorithmName(string name) { throw null; }
         public static System.Security.Cryptography.HashAlgorithmName MD5 { get { throw null; } }

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithmName.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithmName.cs
@@ -20,7 +20,7 @@ namespace System.Security.Cryptography
     ///    * Must recognize at least "MD5", "SHA1", "SHA256", "SHA384", and "SHA512".
     ///    * Should recognize additional CNG IDs for any other hash algorithms that they also support.
     /// </remarks>
-    public struct HashAlgorithmName : IEquatable<HashAlgorithmName>
+    public readonly struct HashAlgorithmName : IEquatable<HashAlgorithmName>
     {
         // Returning a new instance every time is free here since HashAlgorithmName is a struct with
         // a single string field. The optimized codegen should be equivalent to return "MD5".

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/ChainPal.cs
@@ -459,7 +459,7 @@ namespace Internal.Cryptography.Pal
             return new X509ChainElement(cert, statuses.ToArray(), "");
         }
 
-        private struct X509ChainErrorMapping
+        private readonly struct X509ChainErrorMapping
         {
             internal static readonly X509ChainErrorMapping[] s_chainErrorMappings =
             {

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/ChainPal.GetChainStatusInformation.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/ChainPal.GetChainStatusInformation.cs
@@ -77,7 +77,7 @@ namespace Internal.Cryptography.Pal
                 return SR.Unknown_Error;
         }
 
-        private struct X509ChainErrorMapping
+        private readonly struct X509ChainErrorMapping
         {
             public readonly CertTrustErrorStatus Win32Flag;
             public readonly int Win32ErrorCode;

--- a/src/System.ServiceProcess.ServiceController/ref/System.ServiceProcess.ServiceController.cs
+++ b/src/System.ServiceProcess.ServiceController/ref/System.ServiceProcess.ServiceController.cs
@@ -116,7 +116,7 @@ namespace System.ServiceProcess
         Win32ShareProcess = 32,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct SessionChangeDescription
+    public readonly partial struct SessionChangeDescription
     {
         public System.ServiceProcess.SessionChangeReason Reason { get { throw null; } }
         public int SessionId { get { throw null; } }

--- a/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/SessionChangeDescription.cs
+++ b/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/SessionChangeDescription.cs
@@ -4,7 +4,7 @@
 
 namespace System.ServiceProcess
 {
-    public struct SessionChangeDescription
+    public readonly struct SessionChangeDescription
     {
         private readonly SessionChangeReason _reason;
         private readonly int _id;

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/AllowedCharactersBitmap.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/AllowedCharactersBitmap.cs
@@ -8,7 +8,7 @@ using System.Text.Unicode;
 
 namespace System.Text.Internal
 {
-    internal struct AllowedCharactersBitmap
+    internal readonly struct AllowedCharactersBitmap
     {
         private const int ALLOWED_CHARS_BITMAP_LENGTH = 0x10000 / (8 * sizeof(uint));
         private readonly uint[] _allowedCharacters;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -1119,7 +1119,7 @@ namespace System.Text.RegularExpressions
     /*
      * Used as a key for CacheCodeEntry
      */
-    internal struct CachedCodeEntryKey : IEquatable<CachedCodeEntryKey>
+    internal readonly struct CachedCodeEntryKey : IEquatable<CachedCodeEntryKey>
     {
         private readonly RegexOptions _options;
         private readonly string _cultureKey;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1323,7 +1323,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Lower case mapping descriptor.
         /// </summary>
-        private struct LowerCaseMapping
+        private readonly struct LowerCaseMapping
         {
             internal LowerCaseMapping(char chMin, char chMax, int lcOp, int data)
             {
@@ -1359,7 +1359,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// A first/last pair representing a single range of characters.
         /// </summary>
-        private struct SingleRange
+        private readonly struct SingleRange
         {
             internal SingleRange(char first, char last)
             {

--- a/src/System.Threading.Tasks.Dataflow/ref/System.Threading.Tasks.Dataflow.cs
+++ b/src/System.Threading.Tasks.Dataflow/ref/System.Threading.Tasks.Dataflow.cs
@@ -159,7 +159,7 @@ namespace System.Threading.Tasks.Dataflow
         public bool PropagateCompletion { get { throw null; } set { } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct DataflowMessageHeader : System.IEquatable<System.Threading.Tasks.Dataflow.DataflowMessageHeader>
+    public readonly partial struct DataflowMessageHeader : System.IEquatable<System.Threading.Tasks.Dataflow.DataflowMessageHeader>
     {
         public DataflowMessageHeader(long id) { throw null;}
         public long Id { get { throw null; } }

--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowMessageHeader.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowMessageHeader.cs
@@ -19,7 +19,7 @@ namespace System.Threading.Tasks.Dataflow
 {
     /// <summary>Provides a container of data attributes for passing between dataflow blocks.</summary>
     [DebuggerDisplay("Id = {Id}")]
-    public struct DataflowMessageHeader : IEquatable<DataflowMessageHeader>
+    public readonly struct DataflowMessageHeader : IEquatable<DataflowMessageHeader>
     {
         /// <summary>The message ID. Needs to be unique within the source.</summary>
         private readonly long _id;

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/ImmutableArray.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/ImmutableArray.cs
@@ -23,7 +23,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
     /// <summary>Provides a simple, immutable array.</summary>
     /// <typeparam name="T">Specifies the type of the data stored in the array.</typeparam>
     [DebuggerDisplay("Count={Count}")]
-    internal struct ImmutableArray<T>
+    internal readonly struct ImmutableArray<T>
     {
         /// <summary>An empty array.</summary>
         private static readonly ImmutableArray<T> s_empty = new ImmutableArray<T>(new T[0]);

--- a/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -10,7 +10,7 @@ namespace System.Runtime.CompilerServices
     /// <summary>Provides an awaitable type that enables configured awaits on a <see cref="ValueTask{TResult}"/>.</summary>
     /// <typeparam name="TResult">The type of the result produced.</typeparam>
     [StructLayout(LayoutKind.Auto)]
-    public struct ConfiguredValueTaskAwaitable<TResult>
+    public readonly struct ConfiguredValueTaskAwaitable<TResult>
     {
         /// <summary>The wrapped <see cref="ValueTask{TResult}"/>.</summary>
         private readonly ValueTask<TResult> _value;
@@ -34,7 +34,7 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Provides an awaiter for a <see cref="ConfiguredValueTaskAwaitable{TResult}"/>.</summary>
         [StructLayout(LayoutKind.Auto)]
-        public struct ConfiguredValueTaskAwaiter : ICriticalNotifyCompletion
+        public readonly struct ConfiguredValueTaskAwaiter : ICriticalNotifyCompletion
         {
             /// <summary>The value being awaited.</summary>
             private readonly ValueTask<TResult> _value;

--- a/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace System.Runtime.CompilerServices
 {
     /// <summary>Provides an awaiter for a <see cref="ValueTask{TResult}"/>.</summary>
-    public struct ValueTaskAwaiter<TResult> : ICriticalNotifyCompletion
+    public readonly struct ValueTaskAwaiter<TResult> : ICriticalNotifyCompletion
     {
         /// <summary>The value being awaited.</summary>
         private readonly ValueTask<TResult> _value;

--- a/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
@@ -50,7 +50,7 @@ namespace System.Threading.Tasks
     /// </remarks>
     [AsyncMethodBuilder(typeof(AsyncValueTaskMethodBuilder<>))]
     [StructLayout(LayoutKind.Auto)]
-    public struct ValueTask<TResult> : IEquatable<ValueTask<TResult>>
+    public readonly struct ValueTask<TResult> : IEquatable<ValueTask<TResult>>
     {
         /// <summary>The task to be used if the operation completed asynchronously or if it completed synchronously but non-successfully.</summary>
         internal readonly Task<TResult> _task;

--- a/src/System.Transactions.Local/src/System/Transactions/EnlistmentTraceIdentifier.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/EnlistmentTraceIdentifier.cs
@@ -9,7 +9,7 @@ namespace System.Transactions
     /// enlistments.  This identifier is only unique within
     /// a given AppDomain.
     /// </summary>
-    internal struct EnlistmentTraceIdentifier : IEquatable<EnlistmentTraceIdentifier>
+    internal readonly struct EnlistmentTraceIdentifier : IEquatable<EnlistmentTraceIdentifier>
     {
         public static readonly EnlistmentTraceIdentifier Empty = new EnlistmentTraceIdentifier();
 

--- a/src/System.Transactions.Local/src/System/Transactions/TransactionTraceIdentifier.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/TransactionTraceIdentifier.cs
@@ -9,7 +9,7 @@ namespace System.Transactions
     /// of transaction objects.  This identifier is only unique within
     /// a given AppDomain.
     /// </summary>
-    internal struct TransactionTraceIdentifier : IEquatable<TransactionTraceIdentifier>
+    internal readonly struct TransactionTraceIdentifier : IEquatable<TransactionTraceIdentifier>
     {
         public static readonly TransactionTraceIdentifier Empty = new TransactionTraceIdentifier();
 


### PR DESCRIPTION
Fixes #24900
Related to https://github.com/dotnet/coreclr/pull/14789
Related to https://github.com/dotnet/corert/pull/4855

cc: @jkotas, @jaredpar, @VSadov, @tmat for System.Reflection.Metadata (which has the bulk of the changes)