### PR TITLE
Remove some redundances from Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -243,8 +243,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 return;
             }
 
-            TypeArray replacementTypeArray = null;
-            ErrAppendMethodParentSym(meth, pctx, out replacementTypeArray);
+            ErrAppendMethodParentSym(meth, pctx, out TypeArray replacementTypeArray);
             if (meth.IsConstructor())
             {
                 // Use the name of the parent class instead of the name "<ctor>".

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
@@ -975,9 +975,9 @@ namespace Microsoft.CSharp.RuntimeBinder
             if (arrinit != null)
             {
                 Expr list = arrinit.OptionalArguments;
-                Expr p = list;
                 while (list != null)
                 {
+                    Expr p;
                     if (list is ExprList pList)
                     {
                         p = pList.OptionalElement;
@@ -988,6 +988,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                         p = list;
                         list = null;
                     }
+
                     expressions.Add(GetExpression(p));
                 }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/ErrorReporting.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/ErrorReporting.cs
@@ -56,7 +56,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return ErrorContext.Error(err, isNested ? new ErrArg[]{field.FieldWithType} : Array.Empty<ErrArg>());
         }
 
-        // Return true if we actually report a failure.
         private void TryReportLvalueFailure(Expr expr, CheckLvalueKind kind)
         {
             Debug.Assert(expr != null);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/ErrorReporting.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/ErrorReporting.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 // everything else
-                if (pObject != null && !pObject.isLvalue() && (expr is ExprField || (!isNested && expr is ExprProperty)))
+                if (pObject != null && !pObject.isLvalue() && (expr is ExprField || !isNested))
                 {
                     Debug.Assert(pObject.Type.isStructOrEnum());
                     expr = pObject;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -1040,7 +1040,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     // If lifting of the source is required, we need to figure out the intermediate conversion
                     // from the type of the source to the type of the UD conversion parameter. Note that typeFrom
                     // is not a nullable type.
-                    Expr pConversionArgument = null;
+                    Expr pConversionArgument;
                     if (typeFrom != typeSrcBase)
                     {
                         // There is an intermediate conversion.
@@ -1060,6 +1060,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             pConversionArgument = exprSrc;
                         }
                     }
+
                     Debug.Assert(pConversionArgument != null);
                     ExprCall pConversionCall = ExprFactory.CreateCall(0, typeDst, pConversionArgument, pMemGroup, mwiBest);
                     pConversionCall.NullableCallLiftKind = NullableCallLiftKind.NotLiftedIntermediateConversion;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -451,7 +451,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(exprTypeDest != null);
             Debug.Assert(exprTypeDest.Type != null);
             CType typeDest = exprTypeDest.Type;
-            pexprDest = null;
             // If the source is a constant, and cast is really simple (no change in fundamental
             // type, no flags), then create a new constant node with the new type instead of
             // creating a cast node. This allows compile-time constants to be easily recognized.
@@ -480,7 +479,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             pexprDest = exprCast;
             Debug.Assert(exprCast.Argument != null);
-            return;
         }
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -504,15 +502,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             pObject = AdjustMemberObject(mwi, pObject, out fConstrained);
             pMemGroup.OptionalObject = pObject;
 
-            CType pReturnType = null;
-            if ((flags & (MemLookFlags.Ctor | MemLookFlags.NewObj)) == (MemLookFlags.Ctor | MemLookFlags.NewObj))
-            {
-                pReturnType = mwi.Ats;
-            }
-            else
-            {
-                pReturnType = GetTypes().SubstType(mwi.Meth().RetType, mwi.GetType(), mwi.TypeArgs);
-            }
+            CType pReturnType =
+                (flags & (MemLookFlags.Ctor | MemLookFlags.NewObj)) == (MemLookFlags.Ctor | MemLookFlags.NewObj)
+                    ? mwi.Ats
+                    : GetTypes().SubstType(mwi.Meth().RetType, mwi.GetType(), mwi.TypeArgs);
 
             ExprCall pResult = GetExprFactory().CreateCall(0, pReturnType, pArguments, pMemGroup, mwi);
 
@@ -659,12 +652,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             bool fConstrained;
             MethWithType mwtGet;
             MethWithType mwtSet;
-            Expr pObjectThrough = null;
 
             // We keep track of the type of the pObject which we're doing the call through so that we can report 
             // protection access errors later, either below when binding the get, or later when checking that
             // the setter is actually an lvalue.
-            pObjectThrough = pObject;
+            Expr pObjectThrough = pObject;
 
             PostBindProperty(pwt, pObject, out mwtGet, out mwtSet);
 
@@ -1765,7 +1757,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             @params.CopyItems(0, @params.Count - 1, prgtype);
 
             CType type = @params[@params.Count - 1];
-            CType elementType = null;
 
             if (!(type is ArrayType arr))
             {
@@ -1775,7 +1766,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // At this point, we have an array sym.
-            elementType = arr.GetElementType();
+            CType elementType = arr.GetElementType();
 
             for (int itype = @params.Count - 1; itype < count; itype++)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -502,10 +502,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             pObject = AdjustMemberObject(mwi, pObject, out fConstrained);
             pMemGroup.OptionalObject = pObject;
 
-            CType pReturnType =
-                (flags & (MemLookFlags.Ctor | MemLookFlags.NewObj)) == (MemLookFlags.Ctor | MemLookFlags.NewObj)
-                    ? mwi.Ats
-                    : GetTypes().SubstType(mwi.Meth().RetType, mwi.GetType(), mwi.TypeArgs);
+            CType pReturnType;
+            if ((flags & (MemLookFlags.Ctor | MemLookFlags.NewObj)) == (MemLookFlags.Ctor | MemLookFlags.NewObj))
+            {
+                pReturnType = mwi.Ats;
+            }
+            else
+            {
+                pReturnType = GetTypes().SubstType(mwi.Meth().RetType, mwi.GetType(), mwi.TypeArgs);
+            }
 
             ExprCall pResult = GetExprFactory().CreateCall(0, pReturnType, pArguments, pMemGroup, mwi);
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -345,11 +345,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     else
                     {
                         // We have some ambiguities, lets sort them out.
-                        CandidateFunctionMember pAmbig1 = null;
-                        CandidateFunctionMember pAmbig2 = null;
-
                         CType pTypeThrough = _pGroup.OptionalObject?.Type;
-                        pmethBest = _pExprBinder.FindBestMethod(_methList, pTypeThrough, _pArguments, out pAmbig1, out pAmbig2);
+                        pmethBest = _pExprBinder.FindBestMethod(_methList, pTypeThrough, _pArguments, out CandidateFunctionMember pAmbig1, out CandidateFunctionMember pAmbig2);
 
                         if (null == pmethBest)
                         {
@@ -543,7 +540,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 CType pParamType = type;
                 CType pRawParamType = type.StripNubs();
 
-                Expr optionalArgument = null;
+                Expr optionalArgument;
                 if (methprop.HasDefaultParameterValue(index))
                 {
                     CType pConstValType = methprop.GetDefaultParameterValueConstValType(index);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return false;
 
             // Loop through symbols.
-            Symbol symCur = null;
+            Symbol symCur;
             for (symCur = GetSymbolLoader().LookupAggMember(_name, typeCur.getAggregate(), symbmask_t.MASK_ALL);
                  symCur != null;
                  symCur = GetSymbolLoader().LookupNextSym(symCur, typeCur.getAggregate(), symbmask_t.MASK_ALL))
@@ -415,9 +415,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 Debug.Assert(!typeCur.isInterfaceType());
 
-                bool fHideByName = false;
-
-                SearchSingleType(typeCur, out fHideByName);
+                SearchSingleType(typeCur, out bool fHideByName);
 
                 if (_swtFirst && !_fMulti)
                 {
@@ -485,9 +483,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 Debug.Assert(typeCur != null && typeCur.isInterfaceType());
 
-                bool fHideByName = false;
-
-                if (!typeCur.fAllHidden && SearchSingleType(typeCur, out fHideByName))
+                if (!typeCur.fAllHidden && SearchSingleType(typeCur, out bool fHideByName))
                 {
                     fHideByName |= !_fMulti;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1669,20 +1669,20 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         /*
             Handles standard binary floating point (float, double) based operators.
         */
-        private ExprOperator BindRealBinOp(ExpressionKind ek, EXPRFLAG flags, Expr arg1, Expr arg2)
+        private ExprOperator BindRealBinOp(ExpressionKind ek, EXPRFLAG _, Expr arg1, Expr arg2)
         {
             Debug.Assert(arg1.Type.isPredefined() && arg2.Type.isPredefined() && arg1.Type.getPredefType() == arg2.Type.getPredefType());
-            return bindFloatOp(ek, flags, arg1, arg2);
+            return bindFloatOp(ek, arg1, arg2);
         }
 
 
         /*
             Handles standard unary floating point (float, double) based operators.
         */
-        private ExprOperator BindRealUnaOp(ExpressionKind ek, EXPRFLAG flags, Expr arg)
+        private ExprOperator BindRealUnaOp(ExpressionKind ek, EXPRFLAG _, Expr arg)
         {
             Debug.Assert(arg.Type.isPredefined());
-            return bindFloatOp(ek, flags, arg, null);
+            return bindFloatOp(ek, arg, null);
         }
 
 
@@ -2409,7 +2409,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
           will be a constant also. op2 can be null for a unary operator. The operands are assumed
           to be already converted to the correct type.
          */
-        private ExprOperator bindFloatOp(ExpressionKind kind, EXPRFLAG flags, Expr op1, Expr op2)
+        private ExprOperator bindFloatOp(ExpressionKind kind, Expr op1, Expr op2)
         {
             //Debug.Assert(kind.isRelational() || kind.isArithmetic());
             Debug.Assert(op2 == null || op1.Type == op2.Type);
@@ -2419,8 +2419,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             CType typeDest = kind.IsRelational() ? GetPredefindType(PredefinedType.PT_BOOL) : op1.Type;
 
             ExprOperator exprRes = GetExprFactory().CreateOperator(kind, typeDest, op1, op2);
-            flags = ~EXPRFLAG.EXF_CHECKOVERFLOW;
-            exprRes.Flags &= flags;
+            exprRes.Flags &= ~EXPRFLAG.EXF_CHECKOVERFLOW;
 
             return exprRes;
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1721,7 +1721,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(ek == ExpressionKind.Add || ek == ExpressionKind.Subtract);
             ConstVal cv;
-            Expr pExprResult = null;
+            Expr pExprResult;
 
             if (type.isEnumType() && type.fundType() > FUNDTYPE.FT_LASTINTEGRAL)
             {
@@ -1752,22 +1752,22 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case FUNDTYPE.FT_U2:
                     typeTmp = GetPredefindType(PredefinedType.PT_INT);
                     cv = ConstVal.Get(1);
-                    pExprResult = LScalar(ek, flags, exprVal, type, cv, pExprResult, typeTmp);
+                    pExprResult = LScalar(ek, flags, exprVal, type, cv, typeTmp);
                     break;
                 case FUNDTYPE.FT_I4:
                 case FUNDTYPE.FT_U4:
                     cv = ConstVal.Get(1);
-                    pExprResult = LScalar(ek, flags, exprVal, type, cv, pExprResult, typeTmp);
+                    pExprResult = LScalar(ek, flags, exprVal, type, cv, typeTmp);
                     break;
                 case FUNDTYPE.FT_I8:
                 case FUNDTYPE.FT_U8:
                     cv = ConstVal.Get((long)1);
-                    pExprResult = LScalar(ek, flags, exprVal, type, cv, pExprResult, typeTmp);
+                    pExprResult = LScalar(ek, flags, exprVal, type, cv, typeTmp);
                     break;
                 case FUNDTYPE.FT_R4:
                 case FUNDTYPE.FT_R8:
                     cv = ConstVal.Get(1.0);
-                    pExprResult = LScalar(ek, flags, exprVal, type, cv, pExprResult, typeTmp);
+                    pExprResult = LScalar(ek, flags, exprVal, type, cv, typeTmp);
                     break;
             }
             Debug.Assert(pExprResult != null);
@@ -1775,20 +1775,17 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return pExprResult;
         }
 
-        private Expr LScalar(ExpressionKind ek, EXPRFLAG flags, Expr exprVal, CType type, ConstVal cv, Expr pExprResult, CType typeTmp)
+        private Expr LScalar(ExpressionKind ek, EXPRFLAG flags, Expr exprVal, CType type, ConstVal cv, CType typeTmp)
         {
             CType typeOne = type;
             if (typeOne.isEnumType())
             {
                 typeOne = typeOne.underlyingEnumType();
             }
-            pExprResult = GetExprFactory().CreateBinop(ek, typeTmp, exprVal, GetExprFactory().CreateConstant(typeOne, cv));
+
+            ExprBinOp pExprResult = GetExprFactory().CreateBinop(ek, typeTmp, exprVal, GetExprFactory().CreateConstant(typeOne, cv));
             pExprResult.Flags |= flags;
-            if (typeTmp != type)
-            {
-                pExprResult = mustCast(pExprResult, type, CONVERTTYPE.NOUDC);
-            }
-            return pExprResult;
+            return typeTmp != type ? mustCast(pExprResult, type, CONVERTTYPE.NOUDC) : pExprResult;
         }
 
         private ExprMulti BindNonliftedIncOp(ExpressionKind ek, EXPRFLAG flags, Expr arg, UnaOpFullSig uofs)
@@ -2088,8 +2085,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         */
         private Expr BindEnumBinOp(ExpressionKind ek, EXPRFLAG flags, Expr arg1, Expr arg2)
         {
-            AggregateType typeEnum = null;
-            AggregateType typeDst = GetEnumBinOpType(ek, arg1.Type, arg2.Type, out typeEnum);
+            AggregateType typeDst = GetEnumBinOpType(ek, arg1.Type, arg2.Type, out AggregateType typeEnum);
 
             Debug.Assert(typeEnum != null);
             PredefinedType ptOp;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -266,10 +266,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             // the CType in which the method is being called has no relationship with the 
             // CType on which the method is defined surely this is NOACCESS and not NOACCESSTHRU
-            if (found == false)
-                return ACCESSERROR.ACCESSERROR_NOACCESS;
-
-            return (atsThru == null) ? ACCESSERROR.ACCESSERROR_NOACCESS : ACCESSERROR.ACCESSERROR_NOACCESSTHRU;
+            return found ? ACCESSERROR.ACCESSERROR_NOACCESSTHRU : ACCESSERROR.ACCESSERROR_NOACCESS;
         }
 
         public static bool CheckBogus(Symbol sym)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 Debug.Assert(iv >= 0);
 
-                TypeParameterType tpt = null;
+                TypeParameterType tpt;
                 if (iv >= this.prgptvs.Count)
                 {
                     TypeParameterSymbol pTypeParameter = new TypeParameterSymbol();
@@ -1124,7 +1124,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             var key = Tuple.Create(assemblyThatDefinesAttribute, assemblyToCheck);
             if (!_internalsVisibleToCalculated.TryGetValue(key, out result))
             {
-                AssemblyName assyName = null;
+                AssemblyName assyName;
 
                 // Assembly.GetName() requires FileIOPermission to FileIOPermissionAccess.PathDiscovery.
                 // If we don't have that (we're in low trust), then we are going to effectively turn off

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -667,9 +667,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 if (o is Type)
                 {
                     Type t = o as Type;
-                    Name name = null;
-                    name = GetName(t);
-                    next = _symbolTable.LookupSym(name, current, symbmask_t.MASK_AggregateSymbol) as AggregateSymbol;
+                    next = _symbolTable.LookupSym(GetName(t), current, symbmask_t.MASK_AggregateSymbol) as AggregateSymbol;
 
                     // Make sure we match arity as well when we find an aggregate.
                     if (next != null)


### PR DESCRIPTION
* Remove dead path from `CheckAccessCore`.

If `aggWhere` was null we return, otherwise last for must happen at least once. Within that if `atsThru` is null we return, therefore later path for `atsThru` being null cannot be hit.

* Remove dead test from `TryReportLvalueFailure`

If `!isNested` we are on the first loop so if `pObject != null` and `!(expr is ExprField)` then we know statically that `expr is ExprProperty` as only paths for it being `ExprField` or `ExprProperty` set `pObject`, so remove redundant test.

* Remove parameter from `bindFloatOp` that is always overwritten.

* Remove parameter from `LScalar` that is always overwritten.

* Reduce duplication in `BindIncOpCore`.

* Remove some unused assignments.