### PR TITLE
Better exception when JScript.NET is targeted

### DIFF
--- a/src/System.Management/src/System/Management/WMIGenerator.cs
+++ b/src/System.Management/src/System/Management/WMIGenerator.cs
@@ -4861,7 +4861,12 @@ namespace System.Management
                         strProvider = "Visual Basic.";
                         cp = new VBCodeProvider();
                         break;
-            
+
+                    case CodeLanguage.JScript:
+                        strProvider = "JScript.NET.";
+                        bSucceeded = false; // JScriptCodeProvider does not exist on CoreFx
+                        break;
+
                     case CodeLanguage.CSharp:
                         strProvider = "C#.";
                         cp= new CSharpCodeProvider() ;


### PR DESCRIPTION
Generates the same exception for the other languages that are not
supported: ArgumentOutOfRangeException.

No tests are being added for these exceptions because failure to
generate the file keeps the file locked, so that would leave files with
size 0 on the test box.