### PR TITLE
EventLog GetEntry Exception

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -14,13 +14,13 @@ namespace System.Diagnostics.Tests
         private void WaitForEventLog(EventLog eventLog, int entriesExpected)
         {
             int tries = 0;
-            while (eventLog.Entries.Count < entriesExpected && tries < 20)
+            while (eventLog.SafeCount() < entriesExpected && tries < 20)
             {
                 Thread.Sleep(100);
                 tries++;
             }
 
-            Assert.Equal(entriesExpected, eventLog.Entries.Count);
+            Assert.Equal(entriesExpected, eventLog.SafeCount());
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
@@ -71,7 +71,7 @@ namespace System.Diagnostics.Tests
                     eventLog.Source = source;
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
                     WaitForEventLog(eventLog, 1);
-                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.SafeCount() - 1]);
                     Assert.False(entry.Equals(null));
                 }
             }
@@ -96,12 +96,12 @@ namespace System.Diagnostics.Tests
                     eventLog.Source = source;
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
                     WaitForEventLog(eventLog, 1);  //There is latency between writing and getting the entry
-                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.SafeCount() - 1]);
                     Assert.True(entry.Equals(entry));
 
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
                     WaitForEventLog(eventLog, 2);
-                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.SafeCount() - 1]);
                     Assert.Equal(entry.Index + 1, secondEntry.Index);
                 }
             }
@@ -127,8 +127,8 @@ namespace System.Diagnostics.Tests
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
                     WaitForEventLog(eventLog, 2);
-                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
-                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 2]);
+                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.SafeCount() - 1]);
+                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.SafeCount() - 2]);
                     Assert.False(entry.Equals(secondEntry));
                 }
             }

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -95,7 +95,7 @@ namespace System.Diagnostics.Tests
                 {
                     eventLog.Source = source;
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
-                    WaitForEventLog(eventLog, 1);
+                    WaitForEventLog(eventLog, 1);  //There is latency between writing and getting the entry
                     EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.True(entry.Equals(entry));
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -10,18 +9,6 @@ namespace System.Diagnostics.Tests
     public class EventLogEntryCollectionTests
     {
         private const string message = "EntryCollectionMessage";
-
-        private void WaitForEventLog(EventLog eventLog, int entriesExpected)
-        {
-            int tries = 0;
-            while (eventLog.SafeCount() < entriesExpected && tries < 20)
-            {
-                Thread.Sleep(100);
-                tries++;
-            }
-
-            Assert.Equal(entriesExpected, eventLog.SafeCount());
-        }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void CopyingEventLogEntryCollection()
@@ -70,8 +57,8 @@ namespace System.Diagnostics.Tests
                 {
                     eventLog.Source = source;
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
-                    WaitForEventLog(eventLog, 1);
-                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.SafeCount() - 1]);
+                    Helpers.WaitForEventLog(eventLog, 1);
+                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.False(entry.Equals(null));
                 }
             }
@@ -95,13 +82,13 @@ namespace System.Diagnostics.Tests
                 {
                     eventLog.Source = source;
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
-                    WaitForEventLog(eventLog, 1);  //There is latency between writing and getting the entry
-                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.SafeCount() - 1]);
+                    Helpers.WaitForEventLog(eventLog, 1);  //There is latency between writing and getting the entry
+                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.True(entry.Equals(entry));
 
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
-                    WaitForEventLog(eventLog, 2);
-                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.SafeCount() - 1]);
+                    Helpers.WaitForEventLog(eventLog, 2);
+                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.Equal(entry.Index + 1, secondEntry.Index);
                 }
             }
@@ -126,9 +113,9 @@ namespace System.Diagnostics.Tests
                     eventLog.Source = source;
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
-                    WaitForEventLog(eventLog, 2);
-                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.SafeCount() - 1]);
-                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.SafeCount() - 2]);
+                    Helpers.WaitForEventLog(eventLog, 2);
+                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 2]);
                     Assert.False(entry.Equals(secondEntry));
                 }
             }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -30,7 +30,7 @@ namespace System.Diagnostics.Tests
                         eventCounter += 1;
                         signal.Set();
                     });
-                    eventLog.EnableRaisingEvents = waitOnEvent;
+                    Helpers.RetryOnWin7(() => eventLog.EnableRaisingEvents = waitOnEvent);
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
                     if (waitOnEvent)
                     {

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -34,9 +34,9 @@ namespace System.Diagnostics.Tests
                 {
                     eventLog.Source = source;
                     eventLog.Clear();
-                    Assert.Equal(0, eventLog.Entries.Count);
+                    Assert.Equal(0, eventLog.SafeCount());
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry("Writing to event log."));
-                    Assert.Equal(1, eventLog.Entries.Count);
+                    Assert.Equal(1, eventLog.SafeCount());
                 }
             }
             finally
@@ -51,7 +51,7 @@ namespace System.Diagnostics.Tests
         {
             using (EventLog eventLog = new EventLog("Application"))
             {
-                Assert.InRange(eventLog.Entries.Count, 1, Int32.MaxValue);
+                Assert.InRange(eventLog.SafeCount(), 1, Int32.MaxValue);
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -34,9 +34,10 @@ namespace System.Diagnostics.Tests
                 {
                     eventLog.Source = source;
                     eventLog.Clear();
-                    Assert.Equal(0, eventLog.SafeCount());
+                    Assert.Equal(0, Helpers.RetryOnWin7((() => eventLog.Entries.Count)));
                     Helpers.RetryOnWin7(() => eventLog.WriteEntry("Writing to event log."));
-                    Assert.Equal(1, eventLog.SafeCount());
+                    Helpers.WaitForEventLog(eventLog, 1);
+                    Assert.Equal(1, Helpers.RetryOnWin7((() => eventLog.Entries.Count)));
                 }
             }
             finally
@@ -51,7 +52,7 @@ namespace System.Diagnostics.Tests
         {
             using (EventLog eventLog = new EventLog("Application"))
             {
-                Assert.InRange(eventLog.SafeCount(), 1, Int32.MaxValue);
+                Assert.InRange(Helpers.RetryOnWin7((() => eventLog.Entries.Count)), 1, Int32.MaxValue);
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -403,7 +403,7 @@ namespace System.Diagnostics.Tests
                 return Helpers.RetryOnWin7(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
 
             int retries = 0;
-            while (retries < 20 && PlatformDetection.IsWindows7)
+            while (retries < 20)
             {
                 try
                 {

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Threading;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -399,25 +398,7 @@ namespace System.Diagnostics.Tests
     {
         internal static EventLogEntry LastOrDefault(this EventLogEntryCollection elec)
         {
-            if (!PlatformDetection.IsWindows7)
-                return Helpers.RetryOnWin7(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
-
-            int retries = 0;
-            while (retries < 20)
-            {
-                try
-                {
-                    return Helpers.RetryOnWin7(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
-                }
-                catch (ArgumentException)
-                {
-                    Thread.Sleep(100);
-                    retries++;
-                }
-            }
-            // on windows 7 the count is incremented but the entry is not added to the list
-            Assert.NotEqual(20, retries);
-            return null;
+            return Helpers.RetryOnWin7(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
         }
     }
 }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -359,7 +359,7 @@ namespace System.Diagnostics.Tests
         public void WriteEventInstanceNull()
         {
             string source = "Source_" + nameof(WriteEventInstanceNull);
-            Assert.Throws<ArgumentNullException>(() => EventLog.WriteEvent(source, null, insertStrings));
+            Assert.Throws<ArgumentNullException>(() => Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, null, insertStrings)));
         }
 
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
@@ -368,7 +368,7 @@ namespace System.Diagnostics.Tests
             string source = "Source_" + nameof(WriteEventMessageValues_OutOfRange);
             string[] message = new string[1];
             message[0] = new string('c', 32767);
-            Assert.Throws<ArgumentException>(() => EventLog.WriteEvent(source, eventInstance, message));
+            Assert.Throws<ArgumentException>(() => Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, eventInstance, message)));
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
@@ -377,7 +377,7 @@ namespace System.Diagnostics.Tests
             string source = "Source_" + nameof(WriteWithoutExistingSource);
             try
             {
-                EventLog.WriteEvent(source, eventInstance, rawData, null);
+                Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, eventInstance, rawData, null));
                 Assert.Equal("Application", EventLog.LogNameFromSourceName(source, "."));
             }
             finally

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -416,6 +416,7 @@ namespace System.Diagnostics.Tests
                 }
             }
             // on windows 7 the count is incremented but the entry is not added to the list
+            Assert.NotEqual(20, retries);
             return null;
         }
     }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Threading;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -398,8 +399,24 @@ namespace System.Diagnostics.Tests
     {
         internal static EventLogEntry LastOrDefault(this EventLogEntryCollection elec)
         {
-            return Helpers.RetryOnWin7(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
+            if (!PlatformDetection.IsWindows7)
+                return Helpers.RetryOnWin7(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
+
+            int retries = 0;
+            while (retries < 20 && PlatformDetection.IsWindows7)
+            {
+                try
+                {
+                    return Helpers.RetryOnWin7(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
+                }
+                catch (ArgumentException)
+                {
+                    Thread.Sleep(100);
+                    retries++;
+                }
+            }
+            // on windows 7 the count is incremented but the entry is not added to the list
+            return null;
         }
     }
-
 }

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -46,5 +46,14 @@ namespace System.Diagnostics.Tests
             Assert.NotEqual(0, retries);
             return entry;
         }
+
+    }
+
+    internal static class EventLogExtentions
+    {
+        internal static int SafeCount(this EventLog eventLog)
+        {
+            return Helpers.RetryOnWin7(() => eventLog.Entries.Count);
+        }
     }
 }

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics.Tests
             RetryOnWin7<object>(() => { func(); return null; });
         }
 
-        public static T RetryOnWin7<T>(Func<T> func, bool tryOnAllPlatforms = true)
+        public static T RetryOnWin7<T>(Func<T> func)
         {
             if (!PlatformDetection.IsWindows7)
             {

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -28,7 +28,7 @@ namespace System.Diagnostics.Tests
 
             // We are retrying on windows 7 because it throws win32exception while some operations like Writing,Retrieveing and Deleting log.
             // So We just try to do the operation again in case of this exception 
-            int retries = 10;
+            int retries = 20;
             while (retries > 0)
             {
                 try

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -46,6 +46,11 @@ namespace System.Diagnostics.Tests
                     Thread.Sleep(100);
                     retries--;
                 }
+                catch (ArgumentException)
+                {
+                    Thread.Sleep(100);
+                    retries--;
+                }
             }
 
             Assert.NotEqual(0, retries);


### PR DESCRIPTION
This Pr deals with the issue of system.argument exception while retrieving entry from the eventlog.

Fixes #24874 