### PR TITLE
Cleanup Windows 10 version detection

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -82,9 +82,9 @@ namespace System
         public static bool IsUbuntu1704 { get { throw null; } }
         public static bool IsUbuntu1710 { get { throw null; } }
         public static bool IsWindows { get { throw null; } }
-        public static bool IsWindows10Version1607OrGreater { get { throw null; } }
-        public static bool IsWindows10Version1703OrGreater { get { throw null; } }
-        public static bool IsWindows10Version1709OrGreater { get { throw null; } }
+        public static bool IsWindows10Version1607OrGreater { get { throw null; } } // >= Windows 10 Anniversary Update
+        public static bool IsWindows10Version1703OrGreater { get { throw null; } } // >= Windows 10 Creators Update
+        public static bool IsWindows10Version1709OrGreater { get { throw null; } } // >= Windows 10 Fall Creators Update
         public static bool IsWindows7 { get { throw null; } }
         public static bool IsWindows8x { get { throw null; } }
         public static bool IsWindowsAndElevated { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -82,11 +82,9 @@ namespace System
         public static bool IsUbuntu1704 { get { throw null; } }
         public static bool IsUbuntu1710 { get { throw null; } }
         public static bool IsWindows { get { throw null; } }
-        public static bool IsWindows10InsiderPreviewBuild16215OrGreater { get { throw null; } }
         public static bool IsWindows10Version1607OrGreater { get { throw null; } }
-        public static bool IsWindows10Version16251OrGreater { get { throw null; } }
         public static bool IsWindows10Version1703OrGreater { get { throw null; } }
-        public static bool IsWindowsRedStone2 { get { throw null; } }
+        public static bool IsWindows10Version1709OrGreater { get { throw null; } }
         public static bool IsWindows7 { get { throw null; } }
         public static bool IsWindows8x { get { throw null; } }
         public static bool IsWindowsAndElevated { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/Net/PlatformDetection.Networking.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Net/PlatformDetection.Networking.cs
@@ -9,6 +9,6 @@ namespace System
         // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
         // ClientWebSocket.ReceiveAsync to consume partial message data as it arrives, without having to wait
         // for "end of message" to be signaled.
-        public static bool ClientWebSocketPartialMessagesSupported => !IsUap || IsWindows10InsiderPreviewBuild16215OrGreater;
+        public static bool ClientWebSocketPartialMessagesSupported => !IsUap || IsWindows10Version1709OrGreater;
     }
 }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -19,8 +19,7 @@ namespace System
         public static bool IsWindows8x => false;
         public static bool IsWindows10Version1607OrGreater => false;
         public static bool IsWindows10Version1703OrGreater => false;
-        public static bool IsWindows10InsiderPreviewBuild16215OrGreater => false;
-        public static bool IsWindows10Version16251OrGreater => false;
+        public static bool IsWindows10Version1709OrGreater => false;
         public static bool IsNotOneCoreUAP =>  true;
         public static bool IsNetfx462OrNewer() { return false; }
         public static bool IsNetfx470OrNewer() { return false; }
@@ -41,7 +40,6 @@ namespace System
         public static bool IsWindowsNanoServer => false;
         public static bool IsWindowsServerCore => false;
         public static bool IsWindowsAndElevated => false;
-        public static bool IsWindowsRedStone2 => false;
 
         // RedHat family covers RedHat and CentOS
         public static bool IsRedHatFamily => IsRedHatFamilyAndVersion();

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -42,12 +42,8 @@ namespace System
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
         public static bool IsWindows10Version1703OrGreater => 
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 15063;
-        public static bool IsWindows10InsiderPreviewBuild16215OrGreater => 
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16215;
-        public static bool IsWindows10Version16251OrGreater => 
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16251;
-        public static bool IsWindowsRedStone2 => // Creators Update version 
-            GetWindowsVersion() == 10 && (GetWindowsBuildNumber() / 1000) == 15; // any build with 15xxx. e.g 15063
+        public static bool IsWindows10Version1709OrGreater => 
+            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16299;
 
         // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool IsNotOneCoreUAP =>  

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -155,7 +155,7 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
             string newTitle = new string('a', int.Parse(lengthOfTitleString));
             Console.Title = newTitle;
 
-            if (newTitle.Length > 513 && PlatformDetection.IsWindowsRedStone2)
+            if (newTitle.Length > 513 && PlatformDetection.IsWindows10Version1703OrGreater)
             {
                 // RS2 has a bug when getting the window title when the title length is longer than 513 character
                 Assert.Throws<IOException>(() => Console.Title);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -97,6 +97,7 @@ namespace System.Net.Http.Functional.Tests
             GetMethods("HEAD", "TRACE");
 
         private static bool IsWindows10Version1607OrGreater => PlatformDetection.IsWindows10Version1607OrGreater;
+        private static bool NotWindowsUAPOrBeforeVersion1709 => !PlatformDetection.IsUap || PlatformDetection.IsWindows10Version1709OrGreater;
 
         private static IEnumerable<object[]> GetMethods(params string[] methods)
         {
@@ -1001,16 +1002,9 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Theory, MemberData(nameof(HeaderWithEmptyValueAndUris))]
+        [ConditionalTheory(nameof(NotWindowsUAPOrBeforeVersion1709)), MemberData(nameof(HeaderWithEmptyValueAndUris))]
         public async Task GetAsync_RequestHeadersAddCustomHeaders_HeaderAndEmptyValueSent(string name, string value, Uri uri)
         {
-            if (PlatformDetection.IsWindows && !PlatformDetection.IsWindows10Version1709OrGreater)
-            {
-                // Skip this test if running on Windows but on a release prior to Windows 10 Fall Creators Update.
-                _output.WriteLine("Skipping test due to Windows 10 version prior to Version 1709.");
-                return;
-            }
-
             using (HttpClient client = CreateHttpClient())
             {
                 _output.WriteLine($"name={name}, value={value}");

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1000,11 +1000,17 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(22187, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(HeaderWithEmptyValueAndUris))]
         public async Task GetAsync_RequestHeadersAddCustomHeaders_HeaderAndEmptyValueSent(string name, string value, Uri uri)
         {
+            if (PlatformDetection.IsWindows && !PlatformDetection.IsWindows10Version1709OrGreater)
+            {
+                // Skip this test if running on Windows but on a release prior to Windows 10 Fall Creators Update.
+                _output.WriteLine("Skipping test due to Windows 10 version prior to Version 1709.");
+                return;
+            }
+
             using (HttpClient client = CreateHttpClient())
             {
                 _output.WriteLine($"name={name}, value={value}");

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -25,10 +25,10 @@ namespace System.Net.WebSockets.Client.Tests
         public static bool CanTestClientCertificates =>
             CanTestCertificates && BackendSupportsCustomCertificateHandling;
 
-        // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
+        // Windows 10 Version 1709 introduced the necessary APIs for the UAP version of
         // ClientWebSocket.ConnectAsync to carry out mutual TLS authentication.
         public static bool ClientCertificatesSupported =>
-            !PlatformDetection.IsUap || PlatformDetection.IsWindows10InsiderPreviewBuild16215OrGreater;
+            !PlatformDetection.IsUap || PlatformDetection.IsWindows10Version1709OrGreater;
 
         public ClientWebSocketOptionsTests(ITestOutputHelper output) : base(output) { }
 

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -275,7 +275,7 @@ namespace System.Tests
         }
 
         // Requires recent RS3 builds and needs to run inside AppContainer
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version16251OrGreater), nameof(PlatformDetection.IsInAppContainer))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1709OrGreater), nameof(PlatformDetection.IsInAppContainer))]
         [InlineData(Environment.SpecialFolder.LocalApplicationData)]
         [InlineData(Environment.SpecialFolder.Cookies)]
         [InlineData(Environment.SpecialFolder.History)]
@@ -291,7 +291,7 @@ namespace System.Tests
         }
 
         // Requires recent RS3 builds and needs to run inside AppContainer
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version16251OrGreater), nameof(PlatformDetection.IsInAppContainer))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1709OrGreater), nameof(PlatformDetection.IsInAppContainer))]
         [InlineData(Environment.SpecialFolder.ApplicationData)]
         [InlineData(Environment.SpecialFolder.MyMusic)]
         [InlineData(Environment.SpecialFolder.MyPictures)]


### PR DESCRIPTION
Windows 10 Version 1709 ("Fall Creators Update") has been released. This
PR cleans up the version detection to use the latest RTM build numbers
and removes obsolete InsiderPreview detection for those tests.

Also, removed ActiveIssue for tests that are now fixed due to Windows 10
fixes.

Fixes #22187