### PR TITLE
Rename PlatformDetection.OSXKernelVersion to PlatformDetection.OSXVersion

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -97,7 +97,7 @@ namespace System
         public static bool IsInAppContainer { get { throw null; } }
         public static bool IsWinRTSupported { get { throw null; } }
         public static bool IsXmlDsigXsltTransformSupported { get { throw null; } }
-        public static System.Version OSXKernelVersion { get { throw null; } }
+        public static System.Version OSXVersion { get { throw null; } }
         public static int WindowsVersion { get { throw null; } }
         public static string GetDistroVersionString() { throw null; }
         public static bool IsNetfx462OrNewer() { throw null; }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -51,7 +51,7 @@ namespace System
         public static bool IsRedHatFamily7 => IsRedHatFamilyAndVersion(7);
         public static bool IsNotFedoraOrRedHatFamily => !IsFedora && !IsRedHatFamily;
 
-        public static Version OSXKernelVersion { get; } = ToVersion(Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.OperatingSystemVersion);
+        public static Version OSXVersion { get; } = ToVersion(Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.OperatingSystemVersion);
 
         public static string GetDistroVersionString()
         {

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -14,7 +14,7 @@ namespace System
 {
     public static partial class PlatformDetection
     {
-        public static Version OSXKernelVersion => throw new PlatformNotSupportedException();
+        public static Version OSXVersion => throw new PlatformNotSupportedException();
         public static bool IsSuperUser => throw new PlatformNotSupportedException();
         public static bool IsOpenSUSE => false;
         public static bool IsUbuntu => false;

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
@@ -30,7 +30,7 @@ namespace System.Globalization.Tests
         public static string[] FrFRDayNames()
         {
 #if !uap
-            if (PlatformDetection.IsOSX && PlatformDetection.OSXKernelVersion < new Version(10, 12))
+            if (PlatformDetection.IsOSX && PlatformDetection.OSXVersion < new Version(10, 12))
             {
                 return new string[] { "Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi" };
             }
@@ -41,7 +41,7 @@ namespace System.Globalization.Tests
         public static string[] FrFRAbbreviatedDayNames()
         {
 #if !uap
-            if (PlatformDetection.IsOSX  && PlatformDetection.OSXKernelVersion < new Version(10, 12))
+            if (PlatformDetection.IsOSX  && PlatformDetection.OSXVersion < new Version(10, 12))
             {
                 return new string[] { "Dim.", "Lun.", "Mar.", "Mer.", "Jeu.", "Ven.", "Sam." };
             }


### PR DESCRIPTION
This is addressing feedback which was missed in https://github.com/dotnet/corefx/pull/24531

Background: My previous PR has changed underlying implementation of OSXKernelVersion to use core-setup implementation which uses OSX versioning system instead of OSX kernel versioning system. I've changed tests to use new numbers but did not update the name of the property

cc: @tarekgh