### PR TITLE
Make Microsoft.CSharp.RuntimeBinder.Syntax.NameManager static

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -574,7 +574,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     }
 
                 case TypeKind.TK_VoidType:
-                    ErrAppendName(GetNameManager().Lookup(TokenFacts.GetText(TokenKind.Void)));
+                    ErrAppendName(NameManager.Lookup(TokenFacts.GetText(TokenKind.Void)));
                     break;
 
                 case TypeKind.TK_ParameterModifierType:
@@ -673,11 +673,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             }
 
             return result;
-        }
-
-        private NameManager GetNameManager()
-        {
-            return m_globalSymbols.GetNameManager();
         }
 
         private TypeManager GetTypeManager()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -54,12 +54,10 @@ namespace Microsoft.CSharp.RuntimeBinder
             _semanticChecker = new CSemanticChecker();
 
             BSYMMGR bsymmgr = _semanticChecker.getBSymmgr();
-            NameManager nameManager = _semanticChecker.GetNameManager();
 
             _symbolTable = new SymbolTable(
                 bsymmgr.GetSymbolTable(),
                 bsymmgr.GetSymFactory(),
-                nameManager,
                 _semanticChecker.GetTypeManager(),
                 bsymmgr,
                 _semanticChecker);
@@ -457,7 +455,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 }
                 LocalVariableSymbol local =
                     _semanticChecker.GetGlobalSymbolFactory()
-                        .CreateLocalVar(_semanticChecker.GetNameManager().Add("p" + i), pScope, type);
+                        .CreateLocalVar(NameManager.Add("p" + i), pScope, type);
                 local.fUsedInAnonMeth = true;
                 locals[i] = local;
             }
@@ -474,7 +472,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             // We don't actually need the real delegate type here - we just need SOME delegate type.
             // This is because we never attempt any conversions on the lambda itself.
             AggregateType delegateType = _symbolTable.GetCTypeFromType(typeof(Func<>)) as AggregateType;
-            LocalVariableSymbol thisLocal = _semanticChecker.GetGlobalSymbolFactory().CreateLocalVar(_semanticChecker.GetNameManager().Add("this"), pScope, _symbolTable.GetCTypeFromType(typeof(object)));
+            LocalVariableSymbol thisLocal = _semanticChecker.GetGlobalSymbolFactory().CreateLocalVar(NameManager.Add("this"), pScope, _symbolTable.GetCTypeFromType(typeof(object)));
             thisLocal.isThis = true;
             ExprBoundLambda boundLambda = _exprFactory.CreateAnonymousMethod(delegateType, pScope);
             ExprReturn returnStatement = _exprFactory.CreateReturn(call);
@@ -583,7 +581,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             if (argument.Info.NamedArgument)
             {
                 Debug.Assert(argument.Info.Name != null);
-                arg = _exprFactory.CreateNamedArgumentSpecification(_semanticChecker.GetNameManager().Add(argument.Info.Name), arg);
+                arg = _exprFactory.CreateNamedArgumentSpecification(NameManager.Add(argument.Info.Name), arg);
             }
 
             // If we have an object that was "dynamic" at compile time, we need
@@ -618,7 +616,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             Expr callingObject,
             SYMKIND kind)
         {
-            Name name = _semanticChecker.GetNameManager().Add(Name);
+            Name name = NameManager.Add(Name);
             AggregateType callingType;
 
             CType callingObjectType = callingObject.Type;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversions.cs
@@ -147,9 +147,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     AggregateSymbol aggIReadOnlyList = loader.GetPredefAgg(PredefinedType.PT_G_IREADONLYLIST);
 
                     if ((aggIList == null ||
-                        !loader.IsBaseAggregate(aggIList, aggDst.getAggregate())) &&
+                        !SymbolLoader.IsBaseAggregate(aggIList, aggDst.getAggregate())) &&
                         (aggIReadOnlyList == null ||
-                        !loader.IsBaseAggregate(aggIReadOnlyList, aggDst.getAggregate())))
+                        !SymbolLoader.IsBaseAggregate(aggIReadOnlyList, aggDst.getAggregate())))
                     {
                         return false;
                     }
@@ -179,9 +179,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     AggregateSymbol aggIReadOnlyList = loader.GetPredefAgg(PredefinedType.PT_G_IREADONLYLIST);
 
                     if ((aggIList == null ||
-                        !loader.IsBaseAggregate(aggIList, aggtypeSrc.getAggregate())) &&
+                        !SymbolLoader.IsBaseAggregate(aggIList, aggtypeSrc.getAggregate())) &&
                         (aggIReadOnlyList == null ||
-                        !loader.IsBaseAggregate(aggIReadOnlyList, aggtypeSrc.getAggregate())))
+                        !SymbolLoader.IsBaseAggregate(aggIReadOnlyList, aggtypeSrc.getAggregate())))
                     {
                         return false;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -247,9 +247,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 AggregateSymbol aggIReadOnlyList = GetSymbolLoader().GetPredefAgg(PredefinedType.PT_G_IREADONLYLIST);
 
                 if ((aggIList == null ||
-                    !GetSymbolLoader().IsBaseAggregate(aggIList, aggDest.getAggregate())) &&
+                    !SymbolLoader.IsBaseAggregate(aggIList, aggDest.getAggregate())) &&
                     (aggIReadOnlyList == null ||
-                    !GetSymbolLoader().IsBaseAggregate(aggIReadOnlyList, aggDest.getAggregate())))
+                    !SymbolLoader.IsBaseAggregate(aggIReadOnlyList, aggDest.getAggregate())))
                 {
                     return false;
                 }
@@ -288,9 +288,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 AggregateSymbol aggIReadOnlyList = GetSymbolLoader().GetPredefAgg(PredefinedType.PT_G_IREADONLYLIST);
 
                 if ((aggIList == null ||
-                    !GetSymbolLoader().IsBaseAggregate(aggIList, aggSrc.getAggregate())) &&
+                    !SymbolLoader.IsBaseAggregate(aggIList, aggSrc.getAggregate())) &&
                     (aggIReadOnlyList == null ||
-                    !GetSymbolLoader().IsBaseAggregate(aggIReadOnlyList, aggSrc.getAggregate())))
+                    !SymbolLoader.IsBaseAggregate(aggIReadOnlyList, aggSrc.getAggregate())))
                 {
                     return false;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -799,7 +799,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // Find the next operator.
                 methCur = methCur == null
                     ? GetSymbolLoader().LookupAggMember(pName, atsCur.getAggregate(), symbmask_t.MASK_MethodSymbol) as MethodSymbol
-                    : GetSymbolLoader().LookupNextSym(methCur, atsCur.getAggregate(), symbmask_t.MASK_MethodSymbol) as MethodSymbol;
+                    : SymbolLoader.LookupNextSym(methCur, atsCur.getAggregate(), symbmask_t.MASK_MethodSymbol) as MethodSymbol;
 
                 if (methCur == null)
                 {
@@ -1425,7 +1425,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 for (Symbol symT = symbolLoader.LookupAggMember(pswt.Sym.name, atsObj.getAggregate(), mask);
                      symT != null;
-                     symT = symbolLoader.LookupNextSym(symT, atsObj.getAggregate(), mask))
+                     symT = SymbolLoader.LookupNextSym(symT, atsObj.getAggregate(), mask))
                 {
                     if (symT.IsOverride() && (symT.SymBaseVirtual() == pswt.Sym || symT.SymBaseVirtual() == pswt.Sym.SymBaseVirtual()))
                     {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GlobalSymbolContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GlobalSymbolContext.cs
@@ -14,22 +14,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     internal sealed class GlobalSymbolContext
     {
         private readonly PredefinedTypes _predefTypes;
-        private readonly NameManager _nameManager;
 
-        public GlobalSymbolContext(NameManager namemgr)
+        public GlobalSymbolContext()
         {
-            GlobalSymbols = new BSYMMGR(namemgr);
+            GlobalSymbols = new BSYMMGR();
             _predefTypes = new PredefinedTypes(GlobalSymbols);
             TypeManager = new TypeManager(GlobalSymbols, _predefTypes);
-
-            _nameManager = namemgr;
         }
 
         public TypeManager TypeManager { get; }
         public TypeManager GetTypes() { return TypeManager; }
         private BSYMMGR GlobalSymbols { get; }
         public BSYMMGR GetGlobalSymbols() { return GlobalSymbols; }
-        public NameManager GetNameManager() { return _nameManager; }
         public PredefinedTypes GetPredefTypes() { return _predefTypes; }
 
         public SymFactory GetGlobalSymbolFactory()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -694,7 +694,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     for (MethodOrPropertySymbol meth = symbolLoader.LookupAggMember(method.name, pAggregate, symbmask_t.MASK_MethodSymbol | symbmask_t.MASK_PropertySymbol) as MethodOrPropertySymbol;
                             meth != null;
-                            meth = symbolLoader.LookupNextSym(meth, pAggregate, symbmask_t.MASK_MethodSymbol | symbmask_t.MASK_PropertySymbol) as MethodOrPropertySymbol)
+                            meth = SymbolLoader.LookupNextSym(meth, pAggregate, symbmask_t.MASK_MethodSymbol | symbmask_t.MASK_PropertySymbol) as MethodOrPropertySymbol)
                     {
                         if (!meth.isOverride)
                         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Symbol symCur = null;
             for (symCur = GetSymbolLoader().LookupAggMember(_name, typeCur.getAggregate(), symbmask_t.MASK_ALL);
                  symCur != null;
-                 symCur = GetSymbolLoader().LookupNextSym(symCur, typeCur.getAggregate(), symbmask_t.MASK_ALL))
+                 symCur = SymbolLoader.LookupNextSym(symCur, typeCur.getAggregate(), symbmask_t.MASK_ALL))
             {
                 // Check for arity.
                 switch (symCur.getKind())

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     else
                     {
-                        _pCurrentSym = GetSymbolLoader().LookupNextSym(
+                        _pCurrentSym = SymbolLoader.LookupNextSym(
                                 _pCurrentSym, _pCurrentType.getAggregate(), _mask) as MethodOrPropertySymbol;
                     }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -2639,7 +2639,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             bool foundSome = false;
             for (MethodSymbol methCur = GetSymbolLoader().LookupAggMember(name, type.getAggregate(), symbmask_t.MASK_MethodSymbol) as MethodSymbol;
                 methCur != null;
-                methCur = GetSymbolLoader().LookupNextSym(methCur, type.getAggregate(), symbmask_t.MASK_MethodSymbol) as MethodSymbol)
+                methCur = SymbolLoader.LookupNextSym(methCur, type.getAggregate(), symbmask_t.MASK_MethodSymbol) as MethodSymbol)
             {
                 if (UserDefinedBinaryOperatorIsApplicable(candidateList, ek, methCur, type, arg1, arg2, fDontLift))
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -443,7 +443,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             for (Symbol sym = GetSymbolLoader().LookupAggMember(methodName, type, symbmask_t.MASK_ALL);
                  sym != null;
-                 sym = GetSymbolLoader().LookupNextSym(sym, type, symbmask_t.MASK_ALL))
+                 sym = SymbolLoader.LookupNextSym(sym, type, symbmask_t.MASK_ALL))
             {
                 if (sym is MethodSymbol methsym)
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -124,7 +124,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public ErrorHandling ErrorContext => SymbolLoader.ErrorContext;
 
-        public NameManager GetNameManager() { return SymbolLoader.GetNameManager(); }
         public TypeManager GetTypeManager() { return SymbolLoader.GetTypeManager(); }
         public BSYMMGR getBSymmgr() { return SymbolLoader.getBSymmgr(); }
         public SymFactory GetGlobalSymbolFactory() { return SymbolLoader.GetGlobalSymbolFactory(); }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private readonly NamespaceSymbol _rootNS;         // The "root" (unnamed) namespace.
 
-        private NameManager m_nameTable;
         private SYMTBL tableGlobal;
 
         // The hash table for type arrays.
@@ -29,14 +28,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private static readonly TypeArray s_taEmpty = new TypeArray(Array.Empty<CType>());
 
-        public BSYMMGR(NameManager nameMgr)
+        public BSYMMGR()
         {
-            this.m_nameTable = nameMgr;
             this.tableGlobal = new SYMTBL();
             _symFactory = new SymFactory(this.tableGlobal);
 
             this.tableTypeArrays = new Dictionary<TypeArrayKey, TypeArray>();
-            _rootNS = _symFactory.CreateNamespace(m_nameTable.Lookup(""), null);
+            _rootNS = _symFactory.CreateNamespace(NameManager.Lookup(""), null);
             GetNsAid(_rootNS);
 
             ////////////////////////////////////////////////////////////////////////////////
@@ -55,17 +53,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if (iDot == -1)
                         break;
                     string sub = (iDot > start) ? name.Substring(start, iDot - start) : name.Substring(start);
-                    Name nm = this.GetNameManager().Add(sub);
+                    Name nm = NameManager.Add(sub);
                     ns = LookupGlobalSymCore(nm, ns, symbmask_t.MASK_NamespaceSymbol) as NamespaceSymbol ?? _symFactory.CreateNamespace(nm, ns);
                     start += sub.Length + 1;
                 }
             }
-        }
-
-
-        public NameManager GetNameManager()
-        {
-            return m_nameTable;
         }
 
         public SYMTBL GetSymbolTable()
@@ -183,7 +175,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     int iDot = name.IndexOf('.', start);
                     if (iDot == -1) break;
                     string sub = (iDot > start) ? name.Substring(start, iDot - start) : name.Substring(start);
-                    Name nm = this.GetNameManager().Add(sub);
+                    Name nm = NameManager.Add(sub);
                     ns = LookupGlobalSymCore(nm, ns, symbmask_t.MASK_NamespaceSymbol) as NamespaceSymbol ?? _symFactory.CreateNamespace(nm, ns);
                     start += sub.Length + 1;
                 }
@@ -225,11 +217,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // Note: this won't produce the same names as the native logic
             if (u2 != null)
             {
-                return this.m_nameTable.Add(string.Format(CultureInfo.InvariantCulture, "{0:X}-{1:X}", u1.GetHashCode(), u2.GetHashCode()));
+                return NameManager.Add(string.Format(CultureInfo.InvariantCulture, "{0:X}-{1:X}", u1.GetHashCode(), u2.GetHashCode()));
             }
             else
             {
-                return this.m_nameTable.Add(string.Format(CultureInfo.InvariantCulture, "{0:X}", u1.GetHashCode()));
+                return NameManager.Add(string.Format(CultureInfo.InvariantCulture, "{0:X}", u1.GetHashCode()));
             }
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // If we have generated an identity cast or reference cast to a base class
             // we can omit the cast.
             if (pArgument.Type == pExpr.Type ||
-                    GetSymbolLoader().IsBaseClassOfClass(pArgument.Type, pExpr.Type) ||
+                    SymbolLoader.IsBaseClassOfClass(pArgument.Type, pExpr.Type) ||
                     CConversions.FImpRefConv(GetSymbolLoader(), pArgument.Type, pExpr.Type))
             {
                 return Visit(pArgument);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     name = NameManager.GetPredefinedName(PredefinedName.PN_ARRAY0 + args);
                     break;
                 default:
-                    name = _BSymmgr.GetNameManager().Add("[X" + args + 1);
+                    name = NameManager.Add("[X" + args + 1);
                     break;
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -25,7 +25,6 @@ namespace Microsoft.CSharp.RuntimeBinder
         // Members from the managed binder.
         private readonly SYMTBL _symbolTable;
         private readonly SymFactory _symFactory;
-        private readonly NameManager _nameManager;
         private readonly TypeManager _typeManager;
         private readonly BSYMMGR _bsymmgr;
         private readonly CSemanticChecker _semanticChecker;
@@ -67,14 +66,12 @@ namespace Microsoft.CSharp.RuntimeBinder
         internal SymbolTable(
             SYMTBL symTable,
             SymFactory symFactory,
-            NameManager nameManager,
             TypeManager typeManager,
             BSYMMGR bsymmgr,
             CSemanticChecker semanticChecker)
         {
             _symbolTable = symTable;
             _symFactory = symFactory;
-            _nameManager = nameManager;
             _typeManager = typeManager;
             _bsymmgr = bsymmgr;
             _semanticChecker = semanticChecker;
@@ -341,7 +338,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private Name GetName(string p)
         {
-            return _nameManager.Add(p ?? "");
+            return NameManager.Add(p ?? "");
         }
 
         /////////////////////////////////////////////////////////////////////////////////
@@ -354,11 +351,11 @@ namespace Microsoft.CSharp.RuntimeBinder
                 int idx = name.IndexOf('`');
                 if (idx >= 0)
                 {
-                    return _nameManager.Add(name, idx);
+                    return NameManager.Add(name, idx);
                 }
             }
 
-            return _nameManager.Add(name);
+            return NameManager.Add(name);
         }
 
         #endregion
@@ -1385,7 +1382,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     }
 
                     prevProp = prop;
-                    prop = _semanticChecker.SymbolLoader.LookupNextSym(prop, prop.parent, symbmask_t.MASK_PropertySymbol) as PropertySymbol;
+                    prop = SymbolLoader.LookupNextSym(prop, prop.parent, symbmask_t.MASK_PropertySymbol) as PropertySymbol;
                 }
 
                 prop = prevProp;
@@ -1946,7 +1943,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 symbmask_t.MASK_MethodSymbol) as MethodSymbol;
             for (;
                     meth != null && !meth.AssociatedMemberInfo.IsEquivalentTo(baseMemberInfo);
-                    meth = _semanticChecker.SymbolLoader.LookupNextSym(meth, aggregate, symbmask_t.MASK_MethodSymbol) as MethodSymbol)
+                    meth = SymbolLoader.LookupNextSym(meth, aggregate, symbmask_t.MASK_MethodSymbol) as MethodSymbol)
                 ;
 
             return meth;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameManager.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace Microsoft.CSharp.RuntimeBinder.Syntax
 {
-    internal class NameManager
+    internal static class NameManager
     {
         private static readonly Name[] s_predefinedNames = {
             new Name(".ctor"),
@@ -133,7 +133,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
             new Name("")
         };
 
-        private static readonly NameTable s_knownNames = GetKnownNames();
+        private static readonly NameTable s_names = GetKnownNames();
 
         private static NameTable GetKnownNames()
         {
@@ -147,33 +147,27 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
             return table;
         }
 
-        private readonly NameTable _names = new NameTable();
-
-        internal Name Add(string key)
+        internal static Name Add(string key)
         {
             if (key == null)
             {
                 throw Error.InternalCompilerError();
             }
 
-            return s_knownNames.Lookup(key) ?? _names.Add(key);
+            return s_names.Add(key);
         }
 
-        internal Name Add(string key, int length)
+        internal static Name Add(string key, int length)
         {
             Debug.Assert(key != null);
             Debug.Assert(key.Length >= length);
-            return s_knownNames.Lookup(key, length) ?? _names.Add(key, length);
+            return s_names.Add(key, length);
         }
 
-        internal Name Lookup(string key)
+        internal static Name Lookup(string key)
         {
-            if (key == null)
-            {
-                throw Error.InternalCompilerError();
-            }
-
-            return s_knownNames.Lookup(key) ?? _names.Lookup(key);
+            Debug.Assert(key != null);
+            return s_names.Lookup(key);
         }
 
         internal static Name GetPredefinedName(PredefinedName id)


### PR DESCRIPTION
State is only ever cleared in rare `ResetBindException` case, and will then fill with same contents as before, so it does not need to reset.

Making static avoids waste and delays in the rare case, and reduces passing around of per-context singleton in the common case, reducing coupling.