### PR TITLE
Fix handling of unary operations on nullable enums in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UnaOpSig.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UnaOpSig.cs
@@ -68,13 +68,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // This is a unary operator, so the second argument should be neither lifted nor converted.
                 Debug.Assert((_grflt & LiftFlags.Lift2) == 0);
                 Debug.Assert((_grflt & LiftFlags.Convert2) == 0);
-                if (_grflt == LiftFlags.None)
-                {
-                    return false;
-                }
-                // We can't both convert and lift.
-                Debug.Assert(((_grflt & LiftFlags.Lift1) == 0) || ((_grflt & LiftFlags.Convert1) == 0));
-                return true;
+                return (_grflt & LiftFlags.Lift1) != 0;
             }
             public bool Convert()
             {

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -14,6 +14,7 @@
     <Compile Include="IndexingTests.cs" />
     <Compile Include="IntegerBinaryOperationTests.cs" />
     <Compile Include="IntegerUnaryOperationTests.cs" />
+    <Compile Include="NullableEnumUnaryOperationTest.cs" />
     <Compile Include="RuntimeBinderExceptionTests.cs" />
     <Compile Include="RuntimeBinderInternalCompilerExceptionTests.cs" />
     <Compile Include="RuntimeBinderTests.cs" />

--- a/src/Microsoft.CSharp/tests/NullableEnumUnaryOperationTest.cs
+++ b/src/Microsoft.CSharp/tests/NullableEnumUnaryOperationTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
 
         public static IEnumerable<object[]> Int32NullableEnums() => Int32Enums().Append(new object[] {null});
 
-        [Theory, MemberData(nameof(Int32NullableEnums))]
+        [Theory, MemberData(nameof(Int32NullableEnums)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "25067 is not fixed in NetFX")]
         public void ComplementInt32NullableEnum(StringComparison? value)
         {
             CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);

--- a/src/Microsoft.CSharp/tests/NullableEnumUnaryOperationTest.cs
+++ b/src/Microsoft.CSharp/tests/NullableEnumUnaryOperationTest.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public class NullableEnumUnaryOperationTest
+    {
+        public static IEnumerable<object[]> Int32Enums() => Enum.GetValues(typeof(StringComparison))
+            .Cast<StringComparison>()
+            .Select(x => new object[] {x});
+
+        public static IEnumerable<object[]> Int32NullableEnums() => Int32Enums().Append(new object[] {null});
+
+        [Theory, MemberData(nameof(Int32NullableEnums))]
+        public void ComplementInt32NullableEnum(StringComparison? value)
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.OnesComplement,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, StringComparison?, object>> site = CallSite<Func<CallSite, StringComparison?, object>>.Create(binder);
+            Func<CallSite, StringComparison?, object> targ = site.Target;
+            object result = targ(site, value);
+            Assert.Equal(~value, result);
+        }
+
+        [Theory, MemberData(nameof(Int32Enums))]
+        public void IncrementInt32NullableEnum(StringComparison? value)
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.Increment,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, StringComparison?, object>> site = CallSite<Func<CallSite, StringComparison?, object>>.Create(binder);
+            Func<CallSite, StringComparison?, object> targ = site.Target;
+            object result = targ(site, value);
+            Assert.Equal(++value, result); // Note that there is no writeback to value.
+        }
+
+        [Theory, MemberData(nameof(Int32Enums))]
+        public void DecrementInt32NullableEnum(StringComparison? value)
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.Decrement,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, StringComparison?, object>> site = CallSite<Func<CallSite, StringComparison?, object>>.Create(binder);
+            Func<CallSite, StringComparison?, object> targ = site.Target;
+            object result = targ(site, value);
+            Assert.Equal(--value, result); // Note that there is no writeback to value.
+        }
+
+        [Fact]
+        public void CannotIncrementNullNullableEnum()
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.Increment,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, StringComparison?, object>> site = CallSite<Func<CallSite, StringComparison?, object>>.Create(binder);
+            Func<CallSite, StringComparison?, object> targ = site.Target;
+            Assert.Throws<RuntimeBinderException>(() => targ(site, default));
+        }
+
+        [Fact]
+        public void CannotDecrementNullNullableEnum()
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.Decrement,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, StringComparison?, object>> site = CallSite<Func<CallSite, StringComparison?, object>>.Create(binder);
+            Func<CallSite, StringComparison?, object> targ = site.Target;
+            Assert.Throws<RuntimeBinderException>(() => targ(site, default));
+        }
+    }
+}


### PR DESCRIPTION
The code that covered this case would put a `NullableType` where an `AggregateType` would then be expected, and throw on an `as AggregateType` it would hit. There was also no code to handle the necessary cast, then lifted operation, then cast back.

Have the underlying type passed to where the `AggregateType` is expected, and then handle the case of a lifted enum unary operation.

Fixes #25067