### PR TITLE
Improve RegexInterpreter.Go code gen size

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -455,12 +455,6 @@ namespace System.Text.RegularExpressions
             int advance = -1;
             for (; ;)
             {
-#if DEBUG
-                if (runmatch.Debug)
-                {
-                    DumpState();
-                }
-#endif
                 if (advance >= 0)
                 {
                     // https://github.com/dotnet/coreclr/pull/14850#issuecomment-342256447
@@ -468,6 +462,12 @@ namespace System.Text.RegularExpressions
                     Advance(advance);
                     advance = -1;
                 }
+#if DEBUG
+                if (runmatch.Debug)
+                {
+                    DumpState();
+                }
+#endif
 
                 CheckTimeout();
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -34,11 +34,6 @@ namespace System.Text.RegularExpressions
             runtrackcount = _code._trackcount;
         }
 
-        private void Advance()
-        {
-            Advance(0);
-        }
-
         private void Advance(int i)
         {
             _codepos += (i + 1);
@@ -457,6 +452,7 @@ namespace System.Text.RegularExpressions
         {
             Goto(0);
 
+            int advance = -1;
             for (; ;)
             {
 #if DEBUG
@@ -465,6 +461,13 @@ namespace System.Text.RegularExpressions
                     DumpState();
                 }
 #endif
+                if (advance >= 0)
+                {
+                    // https://github.com/dotnet/coreclr/pull/14850#issuecomment-342256447
+                    // Single common Advance call to reduce method size; and single method inline point
+                    Advance(advance);
+                    advance = -1;
+                }
 
                 CheckTimeout();
 
@@ -483,12 +486,12 @@ namespace System.Text.RegularExpressions
                     case RegexCode.Testref:
                         if (!IsMatched(Operand(0)))
                             break;
-                        Advance(1);
+                        advance = 1;
                         continue;
 
                     case RegexCode.Lazybranch:
                         TrackPush(Textpos());
-                        Advance(1);
+                        advance = 1;
                         continue;
 
                     case RegexCode.Lazybranch | RegexCode.Back:
@@ -500,13 +503,13 @@ namespace System.Text.RegularExpressions
                     case RegexCode.Setmark:
                         StackPush(Textpos());
                         TrackPush();
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.Nullmark:
                         StackPush(-1);
                         TrackPush();
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.Setmark | RegexCode.Back:
@@ -518,7 +521,7 @@ namespace System.Text.RegularExpressions
                         StackPop();
                         TrackPush(StackPeek());
                         Textto(StackPeek());
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.Getmark | RegexCode.Back:
@@ -536,7 +539,7 @@ namespace System.Text.RegularExpressions
                             Capture(Operand(0), StackPeek(), Textpos());
                         TrackPush(StackPeek());
 
-                        Advance(2);
+                        advance = 2;
 
                         continue;
 
@@ -565,7 +568,7 @@ namespace System.Text.RegularExpressions
                             else
                             {                                  // Empty match -> straight now
                                 TrackPush2(StackPeek());            // Save old mark
-                                Advance(1);                         // Straight
+                                advance = 1;                        // Straight
                             }
                             continue;
                         }
@@ -575,7 +578,7 @@ namespace System.Text.RegularExpressions
                         StackPop();
                         Textto(TrackPeek(1));                       // Recall position
                         TrackPush2(TrackPeek());                    // Save old mark
-                        Advance(1);                                 // Straight
+                        advance = 1;                                // Straight
                         continue;
 
                     case RegexCode.Branchmark | RegexCode.Back2:
@@ -609,7 +612,7 @@ namespace System.Text.RegularExpressions
 
                                 TrackPush2(StackPeek());                // Save old mark
                             }
-                            Advance(1);
+                            advance = 1;
                             continue;
                         }
 
@@ -642,13 +645,13 @@ namespace System.Text.RegularExpressions
                     case RegexCode.Setcount:
                         StackPush(Textpos(), Operand(0));
                         TrackPush();
-                        Advance(1);
+                        advance = 1;
                         continue;
 
                     case RegexCode.Nullcount:
                         StackPush(-1, Operand(0));
                         TrackPush();
-                        Advance(1);
+                        advance = 1;
                         continue;
 
                     case RegexCode.Setcount | RegexCode.Back:
@@ -672,7 +675,7 @@ namespace System.Text.RegularExpressions
                             if (count >= Operand(1) || (matched == 0 && count >= 0))
                             {                                   // Max loops or empty match -> straight now
                                 TrackPush2(mark, count);            // Save old mark, count
-                                Advance(2);                         // Straight
+                                advance = 2;                        // Straight
                             }
                             else
                             {                                  // Nonempty match -> count+loop now
@@ -695,7 +698,7 @@ namespace System.Text.RegularExpressions
                         {                         // Positive -> can go straight
                             Textto(StackPeek());                        // Zap to mark
                             TrackPush2(TrackPeek(), StackPeek(1) - 1);  // Save old mark, old count
-                            Advance(2);                                 // Straight
+                            advance = 2;                                // Straight
                             continue;
                         }
                         StackPush(TrackPeek(), StackPeek(1) - 1);       // recall old mark, old count
@@ -728,7 +731,7 @@ namespace System.Text.RegularExpressions
                             else
                             {                                  // Nonneg count -> straight now
                                 TrackPush(mark, count, Textpos());  // Save mark, count, position
-                                Advance(2);                         // Straight
+                                advance = 2;                        // Straight
                             }
                             continue;
                         }
@@ -772,7 +775,7 @@ namespace System.Text.RegularExpressions
                     case RegexCode.Setjump:
                         StackPush(Trackpos(), Crawlpos());
                         TrackPush();
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.Setjump | RegexCode.Back:
@@ -798,7 +801,7 @@ namespace System.Text.RegularExpressions
                         StackPop(2);
                         Trackto(StackPeek());
                         TrackPush(StackPeek(1));
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.Forejump | RegexCode.Back:
@@ -814,82 +817,82 @@ namespace System.Text.RegularExpressions
                     case RegexCode.Bol:
                         if (Leftchars() > 0 && CharAt(Textpos() - 1) != '\n')
                             break;
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.Eol:
                         if (Rightchars() > 0 && CharAt(Textpos()) != '\n')
                             break;
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.Boundary:
                         if (!IsBoundary(Textpos(), runtextbeg, runtextend))
                             break;
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.Nonboundary:
                         if (IsBoundary(Textpos(), runtextbeg, runtextend))
                             break;
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.ECMABoundary:
                         if (!IsECMABoundary(Textpos(), runtextbeg, runtextend))
                             break;
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.NonECMABoundary:
                         if (IsECMABoundary(Textpos(), runtextbeg, runtextend))
                             break;
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.Beginning:
                         if (Leftchars() > 0)
                             break;
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.Start:
                         if (Textpos() != Textstart())
                             break;
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.EndZ:
                         if (Rightchars() > 1 || Rightchars() == 1 && CharAt(Textpos()) != '\n')
                             break;
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.End:
                         if (Rightchars() > 0)
                             break;
-                        Advance();
+                        advance = 0;
                         continue;
 
                     case RegexCode.One:
                         if (Forwardchars() < 1 || Forwardcharnext() != (char)Operand(0))
                             break;
 
-                        Advance(1);
+                        advance = 1;
                         continue;
 
                     case RegexCode.Notone:
                         if (Forwardchars() < 1 || Forwardcharnext() == (char)Operand(0))
                             break;
 
-                        Advance(1);
+                        advance = 1;
                         continue;
 
                     case RegexCode.Set:
                         if (Forwardchars() < 1 || !RegexCharClass.CharInClass(Forwardcharnext(), _code._strings[Operand(0)]))
                             break;
 
-                        Advance(1);
+                        advance = 1;
                         continue;
 
                     case RegexCode.Multi:
@@ -897,7 +900,7 @@ namespace System.Text.RegularExpressions
                             if (!Stringmatch(_code._strings[Operand(0)]))
                                 break;
 
-                            Advance(1);
+                            advance = 1;
                             continue;
                         }
 
@@ -916,7 +919,7 @@ namespace System.Text.RegularExpressions
                                     break;
                             }
 
-                            Advance(1);
+                            advance = 1;
                             continue;
                         }
 
@@ -933,7 +936,7 @@ namespace System.Text.RegularExpressions
                                 if (Forwardcharnext() != ch)
                                     goto BreakBackward;
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -950,7 +953,7 @@ namespace System.Text.RegularExpressions
                                 if (Forwardcharnext() == ch)
                                     goto BreakBackward;
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -967,7 +970,7 @@ namespace System.Text.RegularExpressions
                                 if (!RegexCharClass.CharInClass(Forwardcharnext(), set))
                                     goto BreakBackward;
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -993,7 +996,7 @@ namespace System.Text.RegularExpressions
                             if (c > i)
                                 TrackPush(c - i - 1, Textpos() - Bump());
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -1019,7 +1022,7 @@ namespace System.Text.RegularExpressions
                             if (c > i)
                                 TrackPush(c - i - 1, Textpos() - Bump());
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -1045,7 +1048,7 @@ namespace System.Text.RegularExpressions
                             if (c > i)
                                 TrackPush(c - i - 1, Textpos() - Bump());
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -1061,7 +1064,7 @@ namespace System.Text.RegularExpressions
                             if (i > 0)
                                 TrackPush(i - 1, pos - Bump());
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -1076,7 +1079,7 @@ namespace System.Text.RegularExpressions
                             if (i > 0)
                                 TrackPush(i - 1, pos - Bump());
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -1091,7 +1094,7 @@ namespace System.Text.RegularExpressions
                             if (c > 0)
                                 TrackPush(c - 1, Textpos());
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -1105,7 +1108,7 @@ namespace System.Text.RegularExpressions
                             if (c > 0)
                                 TrackPush(c - 1, Textpos());
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -1123,7 +1126,7 @@ namespace System.Text.RegularExpressions
                             if (i > 0)
                                 TrackPush(i - 1, pos + Bump());
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -1141,7 +1144,7 @@ namespace System.Text.RegularExpressions
                             if (i > 0)
                                 TrackPush(i - 1, pos + Bump());
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 
@@ -1159,7 +1162,7 @@ namespace System.Text.RegularExpressions
                             if (i > 0)
                                 TrackPush(i - 1, pos + Bump());
 
-                            Advance(2);
+                            advance = 2;
                             continue;
                         }
 


### PR DESCRIPTION
When the Advance call is inlined it causes considerable code gen size increase (as there are so many occurrences in a single method). 

This can be reduced to a single call to resolve it.

From: https://github.com/dotnet/coreclr/pull/14850#issuecomment-342256447

@AndyAyersMS PTAL