### PR TITLE
Improve throughput of Enumerable.Contains for default comparer

### DIFF
--- a/src/System.Linq/src/System/Linq/Contains.cs
+++ b/src/System.Linq/src/System/Linq/Contains.cs
@@ -9,27 +9,34 @@ namespace System.Linq
     public static partial class Enumerable
     {
         public static bool Contains<TSource>(this IEnumerable<TSource> source, TSource value) =>
-            source is ICollection<TSource> collection
-            ? collection.Contains(value)
-            : Contains(source, value, null);
+            source is ICollection<TSource> collection ? collection.Contains(value) :
+            Contains(source, value, null);
 
         public static bool Contains<TSource>(this IEnumerable<TSource> source, TSource value, IEqualityComparer<TSource> comparer)
         {
-            if (comparer == null)
-            {
-                comparer = EqualityComparer<TSource>.Default;
-            }
-
             if (source == null)
             {
                 throw Error.ArgumentNull(nameof(source));
             }
 
-            foreach (TSource element in source)
+            if (comparer == null)
             {
-                if (comparer.Equals(element, value))
+                foreach (TSource element in source)
                 {
-                    return true;
+                    if (EqualityComparer<TSource>.Default.Equals(element, value)) // benefits from devirtualization and likely inlining
+                    {
+                        return true;
+                    }
+                }
+            }
+            else
+            {
+                foreach (TSource element in source)
+                {
+                    if (comparer.Equals(element, value))
+                    {
+                        return true;
+                    }
                 }
             }
 

--- a/src/System.Linq/tests/Performance/Perf.Linq.cs
+++ b/src/System.Linq/tests/Performance/Perf.Linq.cs
@@ -195,6 +195,42 @@ namespace System.Linq.Tests
             Perf_LinqTestBase.MeasureMaterializationToDictionary<int>(Perf_LinqTestBase.Wrap(array, wrapType), iteration);
         }
 
+        [Benchmark]
+        [MemberData(nameof(IterationSizeWrapperData))]
+        public void Contains_ElementNotFound(int size, int iterationCount, Perf_LinqTestBase.WrapperType wrapType)
+        {
+            IEnumerable<int> source = Perf_LinqTestBase.Wrap(Enumerable.Range(0, size).ToArray(), wrapType);
+
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < iterationCount; i++)
+                    {
+                        source.Contains(size + 1);
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        [MemberData(nameof(IterationSizeWrapperData))]
+        public void Contains_FirstElementMatches(int size, int iterationCount, Perf_LinqTestBase.WrapperType wrapType)
+        {
+            IEnumerable<int> source = Perf_LinqTestBase.Wrap(Enumerable.Range(0, size).ToArray(), wrapType);
+
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < iterationCount; i++)
+                    {
+                        source.Contains(0);
+                    }
+                }
+            }
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
When no comparer or a null comparer is specified to Enumerable.Contains with a non-collection enumerable, `EqualityComparer<TSource>.Default` is used.  However, with recent improvements to the JIT around devirtualization and inlining of `EqualityComparer<TSource>.Default`, we can do much better for this case by having a loop dedicated to the comparer==null case.  For an enumerable of ints, this speeds up Contains in my measurements by up to 33% (which logically makes sense, as we're effectively eliminating one of three interface calls invoked per element).

cc: @VSadov, @OmarTawfik, @AndyAyersMS 