### PR TITLE
Microsoft.CSharp: Don't allocate in SubstTypeArray unless necessary.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -391,36 +391,37 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return SubstType(typeSrc, typeArgsCls, typeArgsMeth, SubstTypeFlags.NormNone);
         }
 
-        public TypeArray SubstTypeArray(TypeArray taSrc, SubstContext pctx)
+        public TypeArray SubstTypeArray(TypeArray taSrc, SubstContext ctx)
         {
-            if (taSrc == null || taSrc.Count == 0 || pctx == null || pctx.FNop())
-                return taSrc;
-
-            CType[] prgpts = new CType[taSrc.Count];
-            for (int ipts = 0; ipts < taSrc.Count; ipts++)
+            if (taSrc != null && taSrc.Count != 0 && ctx != null && !ctx.FNop())
             {
-                prgpts[ipts] = this.SubstTypeCore(taSrc[ipts], pctx);
+                CType[] srcs = taSrc.Items;
+                for (int i = 0; i < srcs.Length; i++)
+                {
+                    CType src = srcs[i];
+                    CType dst = SubstTypeCore(src, ctx);
+                    if (src != dst)
+                    {
+                        CType[] dsts = new CType[srcs.Length];
+                        Array.Copy(srcs, dsts, i);
+                        dsts[i] = dst;
+                        while (++i < srcs.Length)
+                        {
+                            dsts[i] = SubstTypeCore(srcs[i], ctx);
+                        }
+
+                        return _BSymmgr.AllocParams(dsts);
+                    }
+                }
             }
-            return _BSymmgr.AllocParams(taSrc.Count, prgpts);
+
+            return taSrc;
         }
 
         private TypeArray SubstTypeArray(TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
-        {
-            if (taSrc == null || taSrc.Count == 0)
-                return taSrc;
-
-            var ctx = new SubstContext(typeArgsCls, typeArgsMeth, grfst);
-
-            if (ctx.FNop())
-                return taSrc;
-
-            CType[] prgpts = new CType[taSrc.Count];
-            for (int ipts = 0; ipts < taSrc.Count; ipts++)
-            {
-                prgpts[ipts] = SubstTypeCore(taSrc[ipts], ctx);
-            }
-            return _BSymmgr.AllocParams(taSrc.Count, prgpts);
-        }
+            => taSrc == null || taSrc.Count == 0
+            ? taSrc
+            : SubstTypeArray(taSrc, new SubstContext(typeArgsCls, typeArgsMeth, grfst));
 
         public TypeArray SubstTypeArray(TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -418,20 +418,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return taSrc;
         }
 
-        private TypeArray SubstTypeArray(TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
+        public TypeArray SubstTypeArray(TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth)
             => taSrc == null || taSrc.Count == 0
             ? taSrc
-            : SubstTypeArray(taSrc, new SubstContext(typeArgsCls, typeArgsMeth, grfst));
+            : SubstTypeArray(taSrc, new SubstContext(typeArgsCls, typeArgsMeth, SubstTypeFlags.NormNone));
 
-        public TypeArray SubstTypeArray(TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth)
-        {
-            return this.SubstTypeArray(taSrc, typeArgsCls, typeArgsMeth, SubstTypeFlags.NormNone);
-        }
-
-        public TypeArray SubstTypeArray(TypeArray taSrc, TypeArray typeArgsCls)
-        {
-            return this.SubstTypeArray(taSrc, typeArgsCls, (TypeArray)null, SubstTypeFlags.NormNone);
-        }
+        public TypeArray SubstTypeArray(TypeArray taSrc, TypeArray typeArgsCls) => SubstTypeArray(taSrc, typeArgsCls, null);
 
         private CType SubstTypeCore(CType type, SubstContext pctx)
         {


### PR DESCRIPTION
As long as `SubstTypeArray` attempts a substitution, it will always allocate and return a new `TypeArray` even if the contents are identical to the source.

This in turn will cause calling substitutions to substitute an identical `CType`.

Change so as not to allocate unless at least one substitution makes a change.

* Refactor `SubstTypeArray` overrides for always-same parameter.

`grfst` is always passed `SubstTypeFlags.NormNone` so remove that parameter and the overload that now clashes.
