### PR TITLE
Crypto: Expose SSL_set_tlsext_host_name

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -127,6 +127,9 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslAddExtraChainCert")]
         internal static extern bool SslAddExtraChainCert(SafeSslHandle ssl, SafeX509Handle x509);
 
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetTlsExtHostName")]
+        private static extern int SslSetTlsExtHostName(SafeSslHandle ssl);
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetClientCAList")]
         private static extern SafeSharedX509NameStackHandle SslGetClientCAList_private(SafeSslHandle ssl);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -573,3 +573,8 @@ extern "C" void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const uint8_t** proto
         *len = 0;
     }
 }
+
+extern "C" int32_t CryptoNative_SslSetTlsExtHostName(SSL *ssl, const char *name)
+{
+    return int SSL_set_tlsext_host_name(ssl, name);
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
@@ -389,3 +389,8 @@ extern "C" int32_t CryptoNative_SslCtxSetAlpnProtos(SSL_CTX* ctx, const uint8_t*
 Shims the ssl_get0_alpn_selected method.
 */
 extern "C" void CryptoNative_SslGet0AlpnSelected(SSL* ssl, const uint8_t** protocol, uint32_t* len);
+
+/*
+Shims the SSL_set_tlsext_host_name method.
+*/
+extern "C" int32_t CryptoNative_SslSetTlsExtHostName(SSL *ssl, const char *name);


### PR DESCRIPTION
This PR adds `SSL_set_tlsext_host_name` and exposes it as `SslSetTlsExtHostName`. 

Should serve as a start for fixing #23731; where `ClientWebSocket` does not correctly set the host name on SSL connections.