### PR TITLE
Allow passing null to JsonArray.Add()

### DIFF
--- a/src/System.Json/src/System/Json/JsonArray.cs
+++ b/src/System.Json/src/System/Json/JsonArray.cs
@@ -41,11 +41,6 @@ namespace System.Json
 
         public void Add(JsonValue item)
         {
-            if (item == null)
-            {
-                throw new ArgumentNullException(nameof(item));
-            }
-
             _list.Add(item);
         }
 

--- a/src/System.Json/tests/JsonArrayTests.cs
+++ b/src/System.Json/tests/JsonArrayTests.cs
@@ -118,10 +118,11 @@ namespace System.Json.Tests
         }
 
         [Fact]
-        public void Add_NullItem_ThrowsArgumentNullException()
+        public void Add_NullItem()
         {
             JsonArray array = new JsonArray();
-            AssertExtensions.Throws<ArgumentNullException>("item", () => array.Add(null));
+            array.Add(null);
+            Assert.Equal(1, array.Count);
         }
 
         [Fact]

--- a/src/System.Json/tests/JsonValueTests.cs
+++ b/src/System.Json/tests/JsonValueTests.cs
@@ -88,6 +88,8 @@ namespace System.Json.Tests
                 Assert.Equal(4, value.Count);
                 Assert.Equal(JsonType.Array, value.JsonType);
                 Assert.Equal("[1, 2, 3, null]", value.ToString());
+                ((JsonArray) value).Add(null);
+                Assert.Equal("[1, 2, 3, null, null]", value.ToString());
             });
         }
         


### PR DESCRIPTION
null is a valid value in a JSON array, so there is no reason to forbid adding null to the array.

JsonArray.Save() already handles null values in the array.

--

Port of https://github.com/mono/mono/pull/5609, I'll remove System.Json source from Mono once this is in so we have a single source of truth :)

/cc @steffen-kiess 