### PR TITLE
Enable support package build on release/2.0.0 for the 4.7.1 changes

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -24,6 +24,10 @@
     <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.Private.CoreFx.NETCoreApp\Microsoft.Private.CoreFx.NETCoreApp.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <!-- Servicing support package to include the changes required for 4.7.1 -->
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\NETStandard.Library.NETFramework\NETStandard.Library.NETFramework.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <UsingTask TaskName="GenerateNetStandardSupportTable" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll" />


### PR DESCRIPTION
cc: @weshaggard @Petermarcu @AlexGhiondea 

In order to build a package with my previous changes, it is required to enable the build of the Support package for servicing. No need to make it stable.