### PR TITLE
Support loading libgdiplus from NuGet packages

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -5,6 +5,7 @@
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Drawing.Text;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace System.Drawing
@@ -21,10 +22,12 @@ namespace System.Drawing
 
             private static IntPtr LoadNativeLibrary()
             {
+                string libraryName = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libgdiplus.dylib" : "libgdiplus.so";
+
                 IntPtr lib = IntPtr.Zero;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    lib = Interop.Libdl.dlopen("libgdiplus.dylib", Interop.Libdl.RTLD_NOW);
+                    lib = Interop.Libdl.dlopen(libraryName, Interop.Libdl.RTLD_NOW);
                 }
                 else
                 {
@@ -32,10 +35,32 @@ namespace System.Drawing
                     // The mono project, where libgdiplus originated, allowed both of the names below to be used, via
                     // a global configuration setting. We prefer the "unversioned" shared object name, and fallback to
                     // the name suffixed with ".0".
-                    lib = Interop.Libdl.dlopen("libgdiplus.so", Interop.Libdl.RTLD_NOW);
+                    lib = Interop.Libdl.dlopen(libraryName, Interop.Libdl.RTLD_NOW);
                     if (lib == IntPtr.Zero)
                     {
                         lib = Interop.Libdl.dlopen("libgdiplus.so.0", Interop.Libdl.RTLD_NOW);
+                    }
+                }
+
+                // If we couldn't find libgdiplus in the system search path, try to look for libgdiplus in the
+                // NuGet package folders. This matches the DllImport behavior.
+                if (lib == IntPtr.Zero)
+                {
+                    string[] searchDirectories = ((string)AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES")).Split(':');
+
+                    foreach (var searchDirectory in searchDirectories)
+                    {
+                        var searchPath = Path.Combine(searchDirectory, libraryName);
+
+                        if (File.Exists(searchPath))
+                        {
+                            lib = Interop.Libdl.dlopen(searchPath, Interop.Libdl.RTLD_NOW);
+                        }
+
+                        if (lib != IntPtr.Zero)
+                        {
+                            break;
+                        }
                     }
                 }
 

--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -22,11 +22,12 @@ namespace System.Drawing
 
             private static IntPtr LoadNativeLibrary()
             {
-                string libraryName = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libgdiplus.dylib" : "libgdiplus.so";
+                string libraryName = null;
 
                 IntPtr lib = IntPtr.Zero;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
+                    libraryName = "libgdiplus.dylib";
                     lib = Interop.Libdl.dlopen(libraryName, Interop.Libdl.RTLD_NOW);
                 }
                 else
@@ -35,6 +36,7 @@ namespace System.Drawing
                     // The mono project, where libgdiplus originated, allowed both of the names below to be used, via
                     // a global configuration setting. We prefer the "unversioned" shared object name, and fallback to
                     // the name suffixed with ".0".
+                    libraryName = "libgdiplus.so";
                     lib = Interop.Libdl.dlopen(libraryName, Interop.Libdl.RTLD_NOW);
                     if (lib == IntPtr.Zero)
                     {

--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -22,7 +22,7 @@ namespace System.Drawing
 
             private static IntPtr LoadNativeLibrary()
             {
-                string libraryName = null;
+                string libraryName;
 
                 IntPtr lib = IntPtr.Zero;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -52,10 +52,7 @@ namespace System.Drawing
                     {
                         var searchPath = Path.Combine(searchDirectory, libraryName);
 
-                        if (File.Exists(searchPath))
-                        {
-                            lib = Interop.Libdl.dlopen(searchPath, Interop.Libdl.RTLD_NOW);
-                        }
+                        lib = Interop.Libdl.dlopen(searchPath, Interop.Libdl.RTLD_NOW);
 
                         if (lib != IntPtr.Zero)
                         {


### PR DESCRIPTION
This PR updates System.Drawing.Common so that it uses a logic very similar to that of `DllImport` when loading the `libgdiplus` native library.

This allows NuGet packages to ship native versions of `libgdiplus` which can then be distributed as part of a self-contained application.

We currently use this approach for `libgdiplus.dylib` on macOS, lifting the requirement for users to do `brew install mono-libgdiplus`. If we ever manage to create a portable version of `libgdiplus.so`, this approach could also work for Linux.

With this change, `GdiplusNative.LoadNativeLibrary` will first attempt to open `libgdiplus.so` and  `libgdiplus.so.0`. 

If neither of those two files are found in the default search path, it iterates over all directories in `AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES")` and will attempt to load `libgdiplus.so` from those directories.

Fixes #24213