### PR TITLE
Fixing a bad typo in PhysicalMemoryMonitor

### DIFF
--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
@@ -78,9 +78,9 @@ namespace System.Runtime.Caching
 
         protected override int GetCurrentPressure()
         {
-            Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx;
+            Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx = default;
             memoryStatusEx.dwLength = (uint)Marshal.SizeOf(typeof(Interop.Kernel32.MEMORYSTATUSEX));
-            if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) != 0)
+            if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) == 0)
             {
                 return 0;
             }


### PR DESCRIPTION
copy-paste error that would disable physical memory monitor :|