### PR TITLE
Add string support to ReadOnlyMemory<char>

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -115,6 +115,7 @@ namespace System
         public static ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source) where T : struct { throw null; }
         
         public static ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this ReadOnlySpan<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
+
         public static bool TryGetString(this ReadOnlyMemory<char> readOnlyMemory, out string text, out int start, out int length) { throw null; }
     }
 
@@ -356,3 +357,10 @@ namespace System.Buffers.Text
     }
 }
 
+namespace System.Runtime.InteropServices
+{
+    public static class MemoryMarshal
+    {
+        public static Memory<T> AsMemory<T>(ReadOnlyMemory<T> readOnlyMemory) { throw null; }
+    }
+}

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -92,6 +92,8 @@ namespace System
         public static Span<TTo> NonPortableCast<TFrom, TTo>(this Span<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
         
         public static ReadOnlySpan<char> AsReadOnlySpan(this string text) { throw null; }
+        public static ReadOnlyMemory<char> AsReadOnlyMemory(this string text) { throw null; }
+
         public static Span<T> AsSpan<T>(this T[] array) { throw null; }
         public static Span<T> AsSpan<T>(this ArraySegment<T> arraySegment) { throw null; }
         public static ReadOnlySpan<T> AsReadOnlySpan<T>(this T[] array) { throw null; }
@@ -113,6 +115,7 @@ namespace System
         public static ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source) where T : struct { throw null; }
         
         public static ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this ReadOnlySpan<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
+        public static bool TryGetString(this ReadOnlyMemory<char> readOnlyMemory, out string text, out int start, out int length) { throw null; }
     }
 
     public readonly struct ReadOnlyMemory<T>

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -115,6 +115,7 @@
     <Compile Include="System\Buffers\IRetainable.cs" />
     <Compile Include="System\Buffers\MemoryHandle.cs" />
     <Compile Include="System\Buffers\OwnedMemory.cs" />
+    <Compile Include="System\Runtime\InteropServices\MemoryMarshal.cs" />
   </ItemGroup>
   <ItemGroup>
     <!-- Common or Common-branched source files -->

--- a/src/System.Memory/src/System/MemoryDebugView.cs
+++ b/src/System.Memory/src/System/MemoryDebugView.cs
@@ -33,6 +33,13 @@ namespace System
                     Array.Copy(segment.Array, segment.Offset, array, 0, array.Length);
                     return array;
                 }
+
+                if (typeof(T) == typeof(char) &&
+                    ((ReadOnlyMemory<char>)(object)_memory).TryGetString(out string text, out int start, out int length))
+                {
+                    return (T[])(object)text.Substring(start, length).ToCharArray();
+                }
+
                 return SpanHelpers.PerTypeValues<T>.EmptyArray;
             }
         }

--- a/src/System.Memory/src/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/System.Memory/src/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// Provides a collection of methods for interoperating with <see cref="Memory{T}"/>, <see cref="ReadOnlyMemory{T}"/>,
+    /// <see cref="Span{T}"/>, and <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    public static class MemoryMarshal
+    {
+        /// <summary>Creates a <see cref="Memory{T}"/> from a <see cref="ReadOnlyMemory{T}"/>.</summary>
+        /// <param name="readOnlyMemory">The <see cref="ReadOnlyMemory{T}"/>.</param>
+        /// <returns>A <see cref="Memory{T}"/> representing the same memory as the <see cref="ReadOnlyMemory{T}"/>, but writable.</returns>
+        /// <remarks>
+        /// <see cref="AsMemory{T}(ReadOnlyMemory{T})"/> must be used with extreme caution.  <see cref="ReadOnlyMemory{T}"/> is used
+        /// to represent immutable data and other memory that is not meant to be written to; <see cref="Memory{T}"/> instances created
+        /// by <see cref="AsMemory{T}(ReadOnlyMemory{T})"/> should not be written to.  The method exists to enable variables typed
+        /// as <see cref="Memory{T}"/> but only used for reading to store a <see cref="ReadOnlyMemory{T}"/>.
+        /// </remarks>
+        public static Memory<T> AsMemory<T>(ReadOnlyMemory<T> readOnlyMemory) =>
+            Unsafe.As<ReadOnlyMemory<T>, Memory<T>>(ref readOnlyMemory);
+    }
+}

--- a/src/System.Memory/src/System/SpanExtensions.Fast.cs
+++ b/src/System.Memory/src/System/SpanExtensions.Fast.cs
@@ -47,6 +47,20 @@ namespace System
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is null.</exception>
         public static ReadOnlySpan<char> AsReadOnlySpan(this string text) => Span.AsReadOnlySpan(text);
 
+        /// <summary>Creates a new <see cref="ReadOnlyMemory{T}"/> over the portion of the target string.</summary>
+        /// <param name="text">The target string.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is a null reference (Nothing in Visual Basic).</exception>
+        public static ReadOnlyMemory<char> AsReadOnlyMemory(this string text) => Span.AsReadOnlyMemory(text);
+
+        /// <summary>Attempts to get the underlying <see cref="string"/> from a <see cref="ReadOnlyMemory{T}"/>.</summary>
+        /// <param name="readOnlyMemory">The memory that may be wrapping a <see cref="string"/> object.</param>
+        /// <param name="text">The string.</param>
+        /// <param name="start">The starting location in <paramref name="text"/>.</param>
+        /// <param name="length">The number of items in <paramref name="text"/>.</param>
+        /// <returns></returns>
+        public static bool TryGetString(this ReadOnlyMemory<char> readOnlyMemory, out string text, out int start, out int length) =>
+            Span.TryGetString(readOnlyMemory, out text, out start, out length);
+
         /// <summary>
         /// Casts a Span of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
         /// These types may not contain pointers or references. This is checked at runtime in order to preserve type safety.

--- a/src/System.Memory/src/System/SpanExtensions.Portable.cs
+++ b/src/System.Memory/src/System/SpanExtensions.Portable.cs
@@ -70,6 +70,43 @@ namespace System
             return new ReadOnlySpan<char>(Unsafe.As<Pinnable<char>>(text), StringAdjustment, text.Length);
         }
 
+        /// <summary>Creates a new <see cref="ReadOnlyMemory{T}"/> over the portion of the target string.</summary>
+        /// <param name="text">The target string.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is a null reference (Nothing in Visual Basic).</exception>
+        public static ReadOnlyMemory<char> AsReadOnlyMemory(this string text)
+        {
+            if (text == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
+            }
+
+            return new ReadOnlyMemory<char>(text, 0, text.Length);
+        }
+
+        /// <summary>Attempts to get the underlying <see cref="string"/> from a <see cref="ReadOnlyMemory{T}"/>.</summary>
+        /// <param name="readOnlyMemory">The memory that may be wrapping a <see cref="string"/> object.</param>
+        /// <param name="text">The string.</param>
+        /// <param name="start">The starting location in <paramref name="text"/>.</param>
+        /// <param name="length">The number of items in <paramref name="text"/>.</param>
+        /// <returns></returns>
+        public static bool TryGetString(this ReadOnlyMemory<char> readOnlyMemory, out string text, out int start, out int length)
+        {
+            if (readOnlyMemory.GetObjectStartLength(out int offset, out int count) is string s)
+            {
+                text = s;
+                start = offset;
+                length = count;
+                return true;
+            }
+            else
+            {
+                text = null;
+                start = 0;
+                length = 0;
+                return false;
+            }
+        }
+
         /// <summary>
         /// Casts a Span of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
         /// These types may not contain pointers or references. This is checked at runtime in order to preserve type safety.
@@ -129,7 +166,7 @@ namespace System
         }
 
 
-        private static readonly IntPtr StringAdjustment = MeasureStringAdjustment();
+        internal static readonly IntPtr StringAdjustment = MeasureStringAdjustment();
 
         private static IntPtr MeasureStringAdjustment()
         {

--- a/src/System.Memory/tests/Memory/OwnedMemory.cs
+++ b/src/System.Memory/tests/Memory/OwnedMemory.cs
@@ -20,6 +20,27 @@ namespace System.MemoryTests
             OwnedMemory<int> owner = new CustomMemoryForTest<int>(a);
             Memory<int> memory = owner.Memory;
             memory.Validate(91, 92, -93, 94);
+            memory.Slice(0, 4).Validate(91, 92, -93, 94);
+            memory.Slice(1, 0).Validate();
+            memory.Slice(1, 1).Validate(92);
+            memory.Slice(1, 2).Validate(92, -93);
+            memory.Slice(2, 2).Validate(-93, 94);
+            memory.Slice(4, 0).Validate();
+        }
+
+        [Fact]
+        public static void ReadOnlyMemoryFromMemoryFromOwnedMemoryInt()
+        {
+            int[] a = { 91, 92, -93, 94 };
+            OwnedMemory<int> owner = new CustomMemoryForTest<int>(a);
+            ReadOnlyMemory<int> readOnlyMemory = owner.Memory;
+            readOnlyMemory.Validate(91, 92, -93, 94);
+            readOnlyMemory.Slice(0, 4).Validate(91, 92, -93, 94);
+            readOnlyMemory.Slice(1, 0).Validate();
+            readOnlyMemory.Slice(1, 1).Validate(92);
+            readOnlyMemory.Slice(1, 2).Validate(92, -93);
+            readOnlyMemory.Slice(2, 2).Validate(-93, 94);
+            readOnlyMemory.Slice(4, 0).Validate();
         }
 
         [Fact]
@@ -29,6 +50,12 @@ namespace System.MemoryTests
             OwnedMemory<long> owner = new CustomMemoryForTest<long>(a);
             Memory<long> memory = owner.Memory;
             memory.Validate(91, -92, 93, 94, -95);
+            memory.Slice(0, 5).Validate(91, -92, 93, 94, -95);
+            memory.Slice(1, 0).Validate();
+            memory.Slice(1, 1).Validate(-92);
+            memory.Slice(1, 2).Validate(-92, 93);
+            memory.Slice(2, 3).Validate(93, 94, -95);
+            memory.Slice(5, 0).Validate();
         }
 
         [Fact]

--- a/src/System.Memory/tests/MemoryMarshal/AsMemory.cs
+++ b/src/System.Memory/tests/MemoryMarshal/AsMemory.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.MemoryTests
+{
+    public static partial class MemoryMarshalTests
+    {
+        public static IEnumerable<object[]> ReadOnlyMemoryInt32Instances()
+        {
+            yield return new object[] { ReadOnlyMemory<int>.Empty };
+            yield return new object[] { new ReadOnlyMemory<int>(new int[0]) };
+            yield return new object[] { new ReadOnlyMemory<int>(new int[10]) };
+            yield return new object[] { new ReadOnlyMemory<int>(new int[10], 1, 3) };
+            yield return new object[] { (ReadOnlyMemory<int>)new CustomMemoryForTest<int>(new int[10]).Memory };
+        }
+
+        public static IEnumerable<object[]> ReadOnlyMemoryObjectInstances()
+        {
+            yield return new object[] { ReadOnlyMemory<object>.Empty };
+            yield return new object[] { new ReadOnlyMemory<object>(new object[0]) };
+            yield return new object[] { new ReadOnlyMemory<object>(new object[10]) };
+            yield return new object[] { new ReadOnlyMemory<object>(new object[10], 1, 3) };
+            yield return new object[] { (ReadOnlyMemory<object>)new CustomMemoryForTest<object>(new object[10]).Memory };
+        }
+
+        public static IEnumerable<object[]> ReadOnlyMemoryCharInstances()
+        {
+            yield return new object[] { ReadOnlyMemory<char>.Empty };
+            yield return new object[] { new ReadOnlyMemory<char>(new char[10], 1, 3) };
+            yield return new object[] { (ReadOnlyMemory<char>)new CustomMemoryForTest<char>(new char[10]).Memory };
+            yield return new object[] { "12345".AsReadOnlyMemory() };
+        }
+
+        [Theory]
+        [MemberData(nameof(ReadOnlyMemoryInt32Instances))]
+        public static void AsMemory_Roundtrips(ReadOnlyMemory<int> readOnlyMemory) => AsMemory_Roundtrips_Core(readOnlyMemory);
+
+        [Theory]
+        [MemberData(nameof(ReadOnlyMemoryObjectInstances))]
+        public static void AsMemory_Roundtrips(ReadOnlyMemory<object> readOnlyMemory) => AsMemory_Roundtrips_Core(readOnlyMemory);
+
+        [Theory]
+        [MemberData(nameof(ReadOnlyMemoryCharInstances))]
+        public static void AsMemory_Roundtrips(ReadOnlyMemory<char> readOnlyMemory)
+        {
+            AsMemory_Roundtrips_Core(readOnlyMemory);
+
+            Memory<char> memory = MemoryMarshal.AsMemory(readOnlyMemory);
+            ReadOnlyMemory<char> readOnlyClone = memory;
+
+            // TryGetString
+            bool gotString1 = readOnlyMemory.TryGetString(out string text1, out int start1, out int length1);
+            Assert.Equal(gotString1, readOnlyClone.TryGetString(out string text2, out int start2, out int length2));
+            Assert.Same(text1, text2);
+            Assert.Equal(start1, start2);
+            Assert.Equal(length1, length2);
+            if (gotString1)
+            {
+                Assert.False(memory.TryGetArray(out ArraySegment<char> array));
+            }
+        }
+
+        private static unsafe void AsMemory_Roundtrips_Core<T>(ReadOnlyMemory<T> readOnlyMemory)
+        {
+            Memory<T> memory = MemoryMarshal.AsMemory(readOnlyMemory);
+            ReadOnlyMemory<T> readOnlyClone = memory;
+
+            // Equals
+            Assert.True(readOnlyMemory.Equals(readOnlyClone));
+            Assert.True(readOnlyMemory.Equals((object)readOnlyClone));
+            Assert.True(readOnlyMemory.Equals((object)memory));
+
+            // Span
+            Assert.True(readOnlyMemory.Span == readOnlyClone.Span);
+            Assert.True(readOnlyMemory.Span == memory.Span);
+
+            // TryGetArray
+            Assert.True(readOnlyMemory.DangerousTryGetArray(out ArraySegment<T> array1) == memory.TryGetArray(out ArraySegment<T> array2));
+            Assert.Same(array1.Array, array2.Array);
+            Assert.Equal(array1.Offset, array2.Offset);
+            Assert.Equal(array1.Count, array2.Count);
+
+            // Retain
+            using (MemoryHandle readOnlyMemoryHandle = readOnlyMemory.Retain())
+            using (MemoryHandle readOnlyCloneHandle = readOnlyMemory.Retain())
+            using (MemoryHandle memoryHandle = readOnlyMemory.Retain())
+            {
+                Assert.Equal((IntPtr)readOnlyMemoryHandle.Pointer, (IntPtr)readOnlyCloneHandle.Pointer);
+                Assert.Equal((IntPtr)readOnlyMemoryHandle.Pointer, (IntPtr)memoryHandle.Pointer);
+            }
+        }
+    }
+}

--- a/src/System.Memory/tests/Performance/Perf.MemorySlice.cs
+++ b/src/System.Memory/tests/Performance/Perf.MemorySlice.cs
@@ -15,12 +15,12 @@ namespace System.Memory.Tests
         [Benchmark(InnerIterationCount = InnerCount)]
         [InlineData(1000)]
         [InlineData(1000 * 1000)]
-        private static void MemorySliceThenGetSpan(int numberOfBytes)
+        private static void Memory_Byte_SliceThenGetSpan(int numberOfBytes)
         {
             Memory<byte> memory = new byte[numberOfBytes];
             int numberOfSlices = numberOfBytes / 10 - 1;
 
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 int localInt = 0;
                 using (iteration.StartMeasurement())
@@ -41,12 +41,12 @@ namespace System.Memory.Tests
         [Benchmark(InnerIterationCount = InnerCount)]
         [InlineData(1000)]
         [InlineData(1000 * 1000)]
-        private static void MemoryGetSpanThenSlice(int numberOfBytes)
+        private static void Memory_Byte_GetSpanThenSlice(int numberOfBytes)
         {
             Memory<byte> memory = new byte[numberOfBytes];
             int numberOfSlices = numberOfBytes / 10 - 1;
 
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 int localInt = 0;
                 using (iteration.StartMeasurement())
@@ -64,5 +64,100 @@ namespace System.Memory.Tests
             }
         }
 
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void ReadOnlyMemory_Byte_GetSpanThenSlice(int numberOfBytes)
+        {
+            ReadOnlyMemory<byte> memory = new byte[numberOfBytes];
+            int numberOfSlices = numberOfBytes / 10 - 1;
+
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                int localInt = 0;
+                long iters = Benchmark.InnerIterationCount;
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < iters; i++)
+                    {
+                        for (int j = 0; j < numberOfSlices; j++)
+                        {
+                            var span = memory.Span.Slice(10, 1);
+                            localInt ^= span[0];
+                        }
+                    }
+                }
+                volatileInt = localInt;
+            }
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void ReadOnlyMemory_Char_GetSpanThenSlice(int numberOfChars)
+        {
+            ReadOnlyMemory<char> memory = new char[numberOfChars];
+            int numberOfSlices = numberOfChars / 10 - 1;
+
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                int localInt = 0;
+                long iters = Benchmark.InnerIterationCount;
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < iters; i++)
+                    {
+                        for (int j = 0; j < numberOfSlices; j++)
+                        {
+                            var span = memory.Span.Slice(10, 1);
+                            localInt ^= span[0];
+                        }
+                    }
+                }
+                volatileInt = localInt;
+            }
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        public static void ReadOnlyMemory_Byte_TryGetArray()
+        {
+            ReadOnlyMemory<byte> memory = new byte[1];
+            ArraySegment<byte> result;
+
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                long iters = Benchmark.InnerIterationCount;
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < iters; i++)
+                    {
+                        memory.DangerousTryGetArray(out result);
+                    }
+                }
+            }
+
+            volatileInt = result.Count;
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        public static void ReadOnlyMemory_Char_TryGetArray()
+        {
+            ReadOnlyMemory<char> memory = new char[1];
+            ArraySegment<char> result;
+
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
+            {
+                long iters = Benchmark.InnerIterationCount;
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < iters; i++)
+                    {
+                        memory.DangerousTryGetArray(out result);
+                    }
+                }
+            }
+
+            volatileInt = result.Count;
+        }
     }
 }

--- a/src/System.Memory/tests/ReadOnlyMemory/Strings.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Strings.cs
@@ -49,10 +49,7 @@ namespace System.MemoryTests
             ReadOnlyMemory<char> m = input.AsReadOnlyMemory();
             Assert.Equal(input.Substring(offset, count), new string(m.Slice(offset, count).ToArray()));
             Assert.Equal(input.Substring(offset, count), new string(m.Slice(offset, count).Span.ToArray()));
-            if (offset + count == input.Length)
-            {
-                Assert.Equal(input.Substring(offset), new string(m.Slice(offset).ToArray()));
-            }
+            Assert.Equal(input.Substring(offset), new string(m.Slice(offset).ToArray()));
         }
 
         [Fact]

--- a/src/System.Memory/tests/ReadOnlyMemory/Strings.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Strings.cs
@@ -1,0 +1,175 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Buffers;
+using System.Collections.Generic;
+
+namespace System.MemoryTests
+{
+    public static partial class ReadOnlyMemoryTests
+    {
+        public static IEnumerable<object[]> StringInputs()
+        {
+            yield return new object[] { "" };
+            yield return new object[] { "a" };
+            yield return new object[] { "a\0bcdefghijklmnopqrstuvwxyz" };
+        }
+
+        [Theory]
+        [MemberData(nameof(StringInputs))]
+        public static void AsReadOnlyMemory_ToArray_Roundtrips(string input)
+        {
+            ReadOnlyMemory<char> m = input.AsReadOnlyMemory();
+            Assert.Equal(input, new string(m.ToArray()));
+        }
+
+        [Theory]
+        [MemberData(nameof(StringInputs))]
+        public static void AsReadOnlyMemory_Span_Roundtrips(string input)
+        {
+            ReadOnlyMemory<char> m = input.AsReadOnlyMemory();
+            ReadOnlySpan<char> s = m.Span;
+            Assert.Equal(input, new string(s.ToArray()));
+        }
+
+        [Theory]
+        [InlineData("", 0, 0)]
+        [InlineData("0123456789", 0, 0)]
+        [InlineData("0123456789", 10, 0)]
+        [InlineData("0123456789", 0, 10)]
+        [InlineData("0123456789", 1, 9)]
+        [InlineData("0123456789", 2, 8)]
+        [InlineData("0123456789", 9, 1)]
+        [InlineData("0123456789", 1, 8)]
+        [InlineData("0123456789", 5, 3)]
+        public static void AsReadOnlyMemory_Slice_MatchesSubstring(string input, int offset, int count)
+        {
+            ReadOnlyMemory<char> m = input.AsReadOnlyMemory();
+            Assert.Equal(input.Substring(offset, count), new string(m.Slice(offset, count).ToArray()));
+            Assert.Equal(input.Substring(offset, count), new string(m.Slice(offset, count).Span.ToArray()));
+            if (offset + count == input.Length)
+            {
+                Assert.Equal(input.Substring(offset), new string(m.Slice(offset).ToArray()));
+            }
+        }
+
+        [Fact]
+        public static void AsReadOnlyMemory_NullString_Throws()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("text", () => ((string)null).AsReadOnlyMemory());
+        }
+
+        [Fact]
+        public static void AsReadOnlyMemory_TryGetString_Roundtrips()
+        {
+            string input = "0123456789";
+            ReadOnlyMemory<char> m = input.AsReadOnlyMemory();
+            Assert.False(m.IsEmpty);
+
+            string text;
+            int start;
+            int length;
+
+            Assert.True(m.TryGetString(out text, out start, out length));
+            Assert.Same(input, text);
+            Assert.Equal(0, start);
+            Assert.Equal(input.Length, length);
+
+            m = m.Slice(1);
+            Assert.True(m.TryGetString(out text, out start, out length));
+            Assert.Same(input, text);
+            Assert.Equal(1, start);
+            Assert.Equal(input.Length - 1, length);
+
+            m = m.Slice(1);
+            Assert.True(m.TryGetString(out text, out start, out length));
+            Assert.Same(input, text);
+            Assert.Equal(2, start);
+            Assert.Equal(input.Length - 2, length);
+
+            m = m.Slice(3, 2);
+            Assert.True(m.TryGetString(out text, out start, out length));
+            Assert.Same(input, text);
+            Assert.Equal(5, start);
+            Assert.Equal(2, length);
+
+            m = m.Slice(m.Length);
+            Assert.True(m.TryGetString(out text, out start, out length));
+            Assert.Same(input, text);
+            Assert.Equal(7, start);
+            Assert.Equal(0, length);
+
+            m = m.Slice(0);
+            Assert.True(m.TryGetString(out text, out start, out length));
+            Assert.Same(input, text);
+            Assert.Equal(7, start);
+            Assert.Equal(0, length);
+
+            m = m.Slice(0, 0);
+            Assert.True(m.TryGetString(out text, out start, out length));
+            Assert.Same(input, text);
+            Assert.Equal(7, start);
+            Assert.Equal(0, length);
+
+            Assert.True(m.IsEmpty);
+        }
+
+        [Fact]
+        public static void Array_TryGetString_ReturnsFalse()
+        {
+            ReadOnlyMemory<char> m = new char[10];
+            Assert.False(m.TryGetString(out string text, out int start, out int length));
+            Assert.Null(text);
+            Assert.Equal(0, start);
+            Assert.Equal(0, length);
+        }
+
+        [Fact]
+        public static void AsReadOnlyMemory_TryGetArray_ReturnsFalse()
+        {
+            ReadOnlyMemory<char> m = "0123456789".AsReadOnlyMemory();
+            Assert.False(m.DangerousTryGetArray(out ArraySegment<char> array));
+            Assert.Null(array.Array);
+            Assert.Equal(0, array.Offset);
+            Assert.Equal(0, array.Count);
+        }
+
+        [Fact]
+        public static unsafe void AsReadOnlyMemory_Retain_ExpectedPointerValue()
+        {
+            string input = "0123456789";
+            ReadOnlyMemory<char> m = input.AsReadOnlyMemory();
+
+            using (MemoryHandle h = m.Retain(pin: false))
+            {
+                Assert.Equal(IntPtr.Zero, (IntPtr)h.Pointer);
+            }
+
+            using (MemoryHandle h = m.Retain(pin: true))
+            {
+                GC.Collect();
+                fixed (char* ptr = input)
+                {
+                    Assert.Equal((IntPtr)ptr, (IntPtr)h.Pointer);
+                }
+            }
+        }
+
+        [Fact]
+        public static void AsReadOnlyMemory_EqualsAndGetHashCode_ExpectedResults()
+        {
+            ReadOnlyMemory<char> m1 = new string('a', 4).AsReadOnlyMemory();
+            ReadOnlyMemory<char> m2 = new string('a', 4).AsReadOnlyMemory();
+
+            Assert.True(m1.Span.SequenceEqual(m2.Span));
+            Assert.True(m1.Equals(m1));
+            Assert.True(m1.Equals((object)m1));
+            Assert.False(m1.Equals(m2));
+            Assert.False(m1.Equals((object)m2));
+
+            Assert.Equal(m1.GetHashCode(), m1.GetHashCode());
+        }
+    }
+}

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AllocationHelper.cs" />
+    <Compile Include="ReadOnlyMemory\Strings.cs" />
     <Compile Include="TInt.cs" />
     <Compile Include="TestException.cs" />
     <Compile Include="TestHelpers.cs" />

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -9,7 +9,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AllocationHelper.cs" />
-    <Compile Include="ReadOnlyMemory\Strings.cs" />
     <Compile Include="TInt.cs" />
     <Compile Include="TestException.cs" />
     <Compile Include="TestHelpers.cs" />
@@ -71,6 +70,7 @@
     <Compile Include="ReadOnlySpan\Slice.cs" />
     <Compile Include="ReadOnlySpan\StartsWith.T.cs" />
     <Compile Include="ReadOnlySpan\StartsWith.byte.cs" />
+    <Compile Include="ReadOnlyMemory\Strings.cs" />
     <Compile Include="ReadOnlySpan\ToArray.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -87,6 +87,9 @@
     <Compile Include="Memory\Span.cs" />
     <Compile Include="Memory\ToArray.cs" />
     <Compile Include="Memory\TryGetArray.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MemoryMarshal\AsMemory.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ReadOnlyMemory\CtorArray.cs" />


### PR DESCRIPTION
Ports {ReadOnly}Memory changes from coreclr, exposes new methods from the refs, and adds tests.

Depends on https://github.com/dotnet/coreclr/pull/14906
Fixes https://github.com/dotnet/coreclr/pull/14906
cc: @ahsonkhan, @KrzysztofCwalina, @jkotas 