### PR TITLE
Remove redundant check from flaky test

### DIFF
--- a/src/System.Management/tests/System.Management.Tests.csproj
+++ b/src/System.Management/tests/System.Management.Tests.csproj
@@ -7,15 +7,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
-      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.ProcessOptions.cs">
-      <Link>Common\Interop\Windows\advapi32\Interop.ProcessOptions.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.OpenProcess.cs">
-      <Link>Common\Interop\Windows\kernel32\Interop.OpenProcess.cs</Link>
-    </Compile>
     <Compile Include="MofHelpers\MofCollection.cs" />
     <Compile Include="MofHelpers\MofFixture.cs" />
     <Compile Include="System\Management\ManagementClassTestsMofRequired.cs" />

--- a/src/System.Management/tests/System/Management/ManagementObjectTests.cs
+++ b/src/System.Management/tests/System/Management/ManagementObjectTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
 using Xunit;
 
@@ -73,10 +72,6 @@ namespace System.Management.Tests
             var processId = (uint)methodArgs[3];
             Assert.True(0u != processId, $"Unexpected process ID: {processId}");
 
-            // Before terminating the process open a handle to it so the processId cannot be re-used until
-            // it is disposed. This ensures that the processId is not re-used right after the call to Terminate
-            // and the expected exception is always thrown.
-            using (SafeProcessHandle processHandle = Interop.Kernel32.OpenProcess(Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION, false, (int)processId))
             using (Process targetProcess = Process.GetProcessById((int)processId))
             using (var process = new ManagementObject($"Win32_Process.Handle=\"{processId}\""))
             {
@@ -87,9 +82,6 @@ namespace System.Management.Tests
                 Assert.Equal(0u, resultCode);
 
                 Assert.True(targetProcess.HasExited);
-
-                ManagementException managementException = Assert.Throws<ManagementException>(() => process.Get());
-                Assert.Equal(ManagementStatus.NotFound, managementException.ErrorCode);
             }
         }
     }


### PR DESCRIPTION
That check for expected exception is already present in other tests but
it is very flaky in this specific test. The point of this test is about
method invocations and as long as the target process was terminated that
is verified so I'm simply removing the problematic step of the test.

Fixes #24961 