### PR TITLE
Unroll loop for Utf8Parser unsigned integer parsers

### DIFF
--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.D.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.D.cs
@@ -13,66 +13,64 @@ namespace System.Buffers.Text
 
             int sign = 1;
             int index = 0;
-            uint digit = text[index] - 48u;  // '0'
-            if (digit == unchecked('-' - 48u)) // '0'
+            int num = text[index];
+            if (num == '-')
             {
                 sign = -1;
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                digit = text[index] - 48u; // '0'
+                num = text[index];
             }
-            else if (digit == unchecked('+' - 48u)) // '0'
+            else if (num == '+')
             {
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                digit = text[index] - 48u; // '0'
+                num = text[index];
             }
 
-            uint answer = 0;
+            int answer = 0;
 
-            if (digit <= 9)
+            if (ParserHelpers.IsDigit(num))
             {
-                if (digit == 0)
+                if (num == '0')
                 {
                     do
                     {
                         index++;
                         if ((uint)index >= (uint)text.Length)
                             goto Done;
-                        digit = text[index];
-                    } while (digit == '0');
-
-                    digit = digit - 48u; // '0'
-                    if (digit > 9)
+                        num = text[index];
+                    } while (num == '0');
+                    if (!ParserHelpers.IsDigit(num))
                         goto Done;
                 }
 
-                answer = digit;
+                answer = num - '0';
                 index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 // Potential overflow
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
-
+                answer = answer * 10 + num - '0';
                 // if sign < 0, (-1 * sign + 1) / 2 = 1
                 // else, (-1 * sign + 1) / 2 = 0
-                if (answer > (uint)sbyte.MaxValue + (-1 * sign + 1) / 2)
+                if ((uint)answer > (uint)sbyte.MaxValue + (-1 * sign + 1) / 2)
                     goto FalseExit; // Overflow
+
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
                 if (!ParserHelpers.IsDigit(text[index]))
@@ -100,82 +98,80 @@ Done:
 
             int sign = 1;
             int index = 0;
-            uint digit = text[index] - 48u;  // '0'
-            if (digit == unchecked('-' - 48u)) // '0'
+            int num = text[index];
+            if (num == '-')
             {
                 sign = -1;
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                digit = text[index] - 48u; // '0'
+                num = text[index];
             }
-            else if (digit == unchecked('+' - 48u)) // '0'
+            else if (num == '+')
             {
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                digit = text[index] - 48u; // '0'
+                num = text[index];
             }
 
-            uint answer = 0;
+            int answer = 0;
 
-            if (digit <= 9)
+            if (ParserHelpers.IsDigit(num))
             {
-                if (digit == 0)
+                if (num == '0')
                 {
                     do
                     {
                         index++;
                         if ((uint)index >= (uint)text.Length)
                             goto Done;
-                        digit = text[index];
-                    } while (digit == '0');
-
-                    digit = digit - 48u; // '0'
-                    if (digit > 9)
+                        num = text[index];
+                    } while (num == '0');
+                    if (!ParserHelpers.IsDigit(num))
                         goto Done;
                 }
 
-                answer = digit;
+                answer = num - '0';
                 index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 // Potential overflow
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
-
+                answer = answer * 10 + num - '0';
                 // if sign < 0, (-1 * sign + 1) / 2 = 1
                 // else, (-1 * sign + 1) / 2 = 0
                 if ((uint)answer > (uint)short.MaxValue + (-1 * sign + 1) / 2)
                     goto FalseExit; // Overflow
+
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
                 if (!ParserHelpers.IsDigit(text[index]))
@@ -203,124 +199,122 @@ Done:
 
             int sign = 1;
             int index = 0;
-            uint digit = text[index] - 48u;  // '0'
-            if (digit == unchecked('-' - 48u)) // '0'
+            int num = text[index];
+            if (num == '-')
             {
                 sign = -1;
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                digit = text[index] - 48u; // '0'
+                num = text[index];
             }
-            else if (digit == unchecked('+' - 48u)) // '0'
+            else if (num == '+')
             {
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                digit = text[index] - 48u; // '0'
+                num = text[index];
             }
 
-            uint answer = 0;
+            int answer = 0;
 
-            if (digit <= 9)
+            if (ParserHelpers.IsDigit(num))
             {
-                if (digit == 0)
+                if (num == '0')
                 {
                     do
                     {
                         index++;
                         if ((uint)index >= (uint)text.Length)
                             goto Done;
-                        digit = text[index];
-                    } while (digit == '0');
-
-                    digit = digit - 48u; // '0'
-                    if (digit > 9)
+                        num = text[index];
+                    } while (num == '0');
+                    if (!ParserHelpers.IsDigit(num))
                         goto Done;
                 }
 
-                answer = digit;
+                answer = num - '0';
                 index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 // Potential overflow
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
                 if (answer > int.MaxValue / 10)
-                    goto FalseExit; // Will overflow our accumulator (and hence, the value)
-                answer = 10 * answer + digit;
-
+                    goto FalseExit; // Overflow
+                answer = answer * 10 + num - '0';
                 // if sign < 0, (-1 * sign + 1) / 2 = 1
                 // else, (-1 * sign + 1) / 2 = 0
-                if (answer > (uint)int.MaxValue + (-1 * sign + 1) / 2)
+                if ((uint)answer > (uint)int.MaxValue + (-1 * sign + 1) / 2)
                     goto FalseExit; // Overflow
+
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
                 if (!ParserHelpers.IsDigit(text[index]))
@@ -337,7 +331,7 @@ FalseExit:
 
 Done:
             bytesConsumed = index;
-            value = ((int)answer) * sign;
+            value = answer * sign;
             return true;
         }
 

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.D.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.D.cs
@@ -66,13 +66,13 @@ namespace System.Buffers.Text
                 digit = text[index] - 48u; // '0';
                 if (digit > 9)
                     goto Done;
+                index++;
                 answer = 10 * answer + digit;
 
                 // if sign < 0, (-1 * sign + 1) / 2 = 1
                 // else, (-1 * sign + 1) / 2 = 0
                 if (answer > (uint)sbyte.MaxValue + (-1 * sign + 1) / 2)
                     goto FalseExit; // Overflow
-                index++;
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
                 if (!ParserHelpers.IsDigit(text[index]))
@@ -169,13 +169,13 @@ Done:
                 digit = text[index] - 48u; // '0';
                 if (digit > 9)
                     goto Done;
+                index++;
                 answer = 10 * answer + digit;
 
                 // if sign < 0, (-1 * sign + 1) / 2 = 1
                 // else, (-1 * sign + 1) / 2 = 0
                 if ((uint)answer > (uint)short.MaxValue + (-1 * sign + 1) / 2)
                     goto FalseExit; // Overflow
-                index++;
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
                 if (!ParserHelpers.IsDigit(text[index]))
@@ -312,9 +312,9 @@ Done:
                 digit = text[index] - 48u; // '0';
                 if (digit > 9)
                     goto Done;
+                index++;
                 if (answer > int.MaxValue / 10)
                     goto FalseExit; // Will overflow our accumulator (and hence, the value)
-                index++;
                 answer = 10 * answer + digit;
 
                 // if sign < 0, (-1 * sign + 1) / 2 = 1

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.D.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.D.cs
@@ -13,64 +13,64 @@ namespace System.Buffers.Text
 
             int sign = 1;
             int index = 0;
-            int num = text[index];
-            if (num == '-')
+            uint digit = text[index] - 48u;  // '0'
+            if (digit == unchecked('-' - 48u)) // '0'
             {
                 sign = -1;
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                num = text[index];
+                digit = text[index] - 48u; // '0'
             }
-            else if (num == '+')
+            else if (digit == unchecked('+' - 48u)) // '0'
             {
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                num = text[index];
+                digit = text[index] - 48u; // '0'
             }
 
-            int answer = 0;
+            uint answer = 0;
 
-            if (ParserHelpers.IsDigit(num))
+            if (digit <= 9)
             {
-                if (num == '0')
+                if (digit == 0)
                 {
                     do
                     {
                         index++;
                         if ((uint)index >= (uint)text.Length)
                             goto Done;
-                        num = text[index];
-                    } while (num == '0');
-                    if (!ParserHelpers.IsDigit(num))
+                        digit = text[index];
+                    } while (digit == '0');
+
+                    digit = digit - 48u; // '0'
+                    if (digit > 9)
                         goto Done;
                 }
 
-                answer = num - '0';
+                answer = digit;
                 index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 // Potential overflow
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
-                if (answer > SByte.MaxValue / 10 + 1)
-                    goto FalseExit; // Overflow
-                answer = answer * 10 + num - '0';
+                answer = 10 * answer + digit;
 
                 // if sign < 0, (-1 * sign + 1) / 2 = 1
                 // else, (-1 * sign + 1) / 2 = 0
-                if ((uint)answer > (uint)SByte.MaxValue + (-1 * sign + 1) / 2)
+                if (answer > (uint)sbyte.MaxValue + (-1 * sign + 1) / 2)
                     goto FalseExit; // Overflow
                 index++;
                 if ((uint)index >= (uint)text.Length)
@@ -89,7 +89,7 @@ FalseExit:
 
 Done:
             bytesConsumed = index;
-            value = (SByte)(answer * sign);
+            value = (sbyte)(answer * sign);
             return true;
         }
 
@@ -100,80 +100,80 @@ Done:
 
             int sign = 1;
             int index = 0;
-            int num = text[index];
-            if (num == '-')
+            uint digit = text[index] - 48u;  // '0'
+            if (digit == unchecked('-' - 48u)) // '0'
             {
                 sign = -1;
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                num = text[index];
+                digit = text[index] - 48u; // '0'
             }
-            else if (num == '+')
+            else if (digit == unchecked('+' - 48u)) // '0'
             {
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                num = text[index];
+                digit = text[index] - 48u; // '0'
             }
 
-            int answer = 0;
+            uint answer = 0;
 
-            if (ParserHelpers.IsDigit(num))
+            if (digit <= 9)
             {
-                if (num == '0')
+                if (digit == 0)
                 {
                     do
                     {
                         index++;
                         if ((uint)index >= (uint)text.Length)
                             goto Done;
-                        num = text[index];
-                    } while (num == '0');
-                    if (!ParserHelpers.IsDigit(num))
+                        digit = text[index];
+                    } while (digit == '0');
+
+                    digit = digit - 48u; // '0'
+                    if (digit > 9)
                         goto Done;
                 }
 
-                answer = num - '0';
+                answer = digit;
                 index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 // Potential overflow
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
-                if (answer > Int16.MaxValue / 10 + 1)
-                    goto FalseExit; // Overflow
-                answer = answer * 10 + num - '0';
+                answer = 10 * answer + digit;
 
                 // if sign < 0, (-1 * sign + 1) / 2 = 1
                 // else, (-1 * sign + 1) / 2 = 0
-                if ((uint)answer > (uint)Int16.MaxValue + (-1 * sign + 1) / 2)
+                if ((uint)answer > (uint)short.MaxValue + (-1 * sign + 1) / 2)
                     goto FalseExit; // Overflow
                 index++;
                 if ((uint)index >= (uint)text.Length)
@@ -203,122 +203,124 @@ Done:
 
             int sign = 1;
             int index = 0;
-            int num = text[index];
-            if (num == '-')
+            uint digit = text[index] - 48u;  // '0'
+            if (digit == unchecked('-' - 48u)) // '0'
             {
                 sign = -1;
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                num = text[index];
+                digit = text[index] - 48u; // '0'
             }
-            else if (num == '+')
+            else if (digit == unchecked('+' - 48u)) // '0'
             {
                 index++;
                 if ((uint)index >= (uint)text.Length)
                     goto FalseExit;
-                num = text[index];
+                digit = text[index] - 48u; // '0'
             }
 
-            int answer = 0;
+            uint answer = 0;
 
-            if (ParserHelpers.IsDigit(num))
+            if (digit <= 9)
             {
-                if (num == '0')
+                if (digit == 0)
                 {
                     do
                     {
                         index++;
                         if ((uint)index >= (uint)text.Length)
                             goto Done;
-                        num = text[index];
-                    } while (num == '0');
-                    if (!ParserHelpers.IsDigit(num))
+                        digit = text[index];
+                    } while (digit == '0');
+
+                    digit = digit - 48u; // '0'
+                    if (digit > 9)
                         goto Done;
                 }
 
-                answer = num - '0';
+                answer = digit;
                 index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
                 index++;
-                answer = 10 * answer + num - '0';
+                answer = 10 * answer + digit;
 
                 // Potential overflow
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                num = text[index];
-                if (!ParserHelpers.IsDigit(num))
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
                     goto Done;
-                if (answer > Int32.MaxValue / 10 + 1)
-                    goto FalseExit; // Overflow
-                answer = answer * 10 + num - '0';
+                if (answer > int.MaxValue / 10)
+                    goto FalseExit; // Will overflow our accumulator (and hence, the value)
+                index++;
+                answer = 10 * answer + digit;
 
                 // if sign < 0, (-1 * sign + 1) / 2 = 1
                 // else, (-1 * sign + 1) / 2 = 0
-                if ((uint)answer > (uint)Int32.MaxValue + (-1 * sign + 1) / 2)
+                if (answer > (uint)int.MaxValue + (-1 * sign + 1) / 2)
                     goto FalseExit; // Overflow
-                index++;
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
                 if (!ParserHelpers.IsDigit(text[index]))
@@ -335,7 +337,7 @@ FalseExit:
 
 Done:
             bytesConsumed = index;
-            value = answer * sign;
+            value = ((int)answer) * sign;
             return true;
         }
 

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
@@ -12,46 +12,44 @@ namespace System.Buffers.Text
                 goto FalseExit;
 
             int index = 0;
-            uint digit = text[index] - 48u; // '0'
-            uint answer = 0;
+            int num = text[index];
+            int answer = 0;
 
-            if (digit <= 9)
+            if (ParserHelpers.IsDigit(num))
             {
-                if (digit == 0)
+                if (num == '0')
                 {
                     do
                     {
                         index++;
                         if ((uint)index >= (uint)text.Length)
                             goto Done;
-                        digit = text[index];
-                    } while (digit == '0');
-
-                    digit = digit - 48u; // '0'
-                    if (digit > 9)
+                        num = text[index];
+                    } while (num == '0');
+                    if (!ParserHelpers.IsDigit(num))
                         goto Done;
                 }
 
-                answer = digit;
+                answer = num - '0';
                 index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 // Potential overflow
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
-                if (answer > byte.MaxValue)
+                answer = answer * 10 + num - '0';
+                if ((uint)answer > byte.MaxValue)
                     goto FalseExit; // Overflow
 
                 if ((uint)index >= (uint)text.Length)
@@ -80,62 +78,60 @@ Done:
                 goto FalseExit;
 
             int index = 0;
-            uint digit = text[index] - 48u; // '0'
-            uint answer = 0;
+            int num = text[index];
+            int answer = 0;
 
-            if (digit <= 9)
+            if (ParserHelpers.IsDigit(num))
             {
-                if (digit == 0)
+                if (num == '0')
                 {
                     do
                     {
                         index++;
                         if ((uint)index >= (uint)text.Length)
                             goto Done;
-                        digit = text[index];
-                    } while (digit == '0');
-
-                    digit = digit - 48u; // '0'
-                    if (digit > 9)
+                        num = text[index];
+                    } while (num == '0');
+                    if (!ParserHelpers.IsDigit(num))
                         goto Done;
                 }
 
-                answer = digit;
+                answer = num - '0';
                 index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 // Potential overflow
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
-                if (answer > ushort.MaxValue)
+                answer = answer * 10 + num - '0';
+                if ((uint)answer > ushort.MaxValue)
                     goto FalseExit; // Overflow
 
                 if ((uint)index >= (uint)text.Length)
@@ -164,103 +160,101 @@ Done:
                 goto FalseExit;
 
             int index = 0;
-            uint digit = text[index] - 48u; // '0'
-            uint answer = 0;
+            int num = text[index];
+            int answer = 0;
 
-            if (digit <= 9)
+            if (ParserHelpers.IsDigit(num))
             {
-                if (digit == 0)
+                if (num == '0')
                 {
                     do
                     {
                         index++;
                         if ((uint)index >= (uint)text.Length)
                             goto Done;
-                        digit = text[index];
-                    } while (digit == '0');
-
-                    digit = digit - 48u; // '0'
-                    if (digit > 9)
+                        num = text[index];
+                    } while (num == '0');
+                    if (!ParserHelpers.IsDigit(num))
                         goto Done;
                 }
 
-                answer = digit;
+                answer = num - '0';
                 index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                answer = 10 * answer + digit;
+                answer = 10 * answer + num - '0';
 
                 // Potential overflow
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
-                digit = text[index] - 48u; // '0';
-                if (digit > 9)
+                num = text[index];
+                if (!ParserHelpers.IsDigit(num))
                     goto Done;
                 index++;
-                if (answer > uint.MaxValue / 10 || (answer == uint.MaxValue / 10 && digit > 5))
+                if (((uint)answer) > uint.MaxValue / 10 || (((uint)answer) == uint.MaxValue / 10 && num > '5'))
                     goto FalseExit; // Overflow
-                answer = 10 * answer + digit;
+                answer = answer * 10 + num - '0';
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
@@ -278,7 +272,7 @@ FalseExit:
 
 Done:
             bytesConsumed = index;
-            value = answer;
+            value = (uint)answer;
             return true;
         }
 

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
@@ -49,10 +49,10 @@ namespace System.Buffers.Text
                 digit = text[index] - 48u; // '0';
                 if (digit > 9)
                     goto Done;
+                index++;
                 answer = 10 * answer + digit;
                 if (answer > byte.MaxValue)
                     goto FalseExit; // Overflow
-                index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
@@ -133,10 +133,10 @@ Done:
                 digit = text[index] - 48u; // '0';
                 if (digit > 9)
                     goto Done;
+                index++;
                 answer = 10 * answer + digit;
                 if (answer > ushort.MaxValue)
                     goto FalseExit; // Overflow
-                index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;
@@ -257,10 +257,10 @@ Done:
                 digit = text[index] - 48u; // '0';
                 if (digit > 9)
                     goto Done;
+                index++;
                 if (answer > uint.MaxValue / 10 || (answer == uint.MaxValue / 10 && digit > 5))
                     goto FalseExit; // Overflow
                 answer = 10 * answer + digit;
-                index++;
 
                 if ((uint)index >= (uint)text.Length)
                     goto Done;

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
@@ -9,225 +9,276 @@ namespace System.Buffers.Text
         private static bool TryParseByteD(ReadOnlySpan<byte> text, out byte value, out int bytesConsumed)
         {
             if (text.Length < 1)
+                goto FalseExit;
+
+            int index = 0;
+            uint digit = text[index] - 48u; // '0'
+            uint answer = 0;
+
+            if (digit <= 9)
             {
-                bytesConsumed = 0;
-                value = default;
-                return false;
+                if (digit == 0)
+                {
+                    do
+                    {
+                        index++;
+                        if ((uint)index >= (uint)text.Length)
+                            goto Done;
+                        digit = text[index];
+                    } while (digit == '0');
+
+                    digit = digit - 48u; // '0'
+                    if (digit > 9)
+                        goto Done;
+                }
+
+                answer = digit;
+                index++;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                // Potential overflow
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                answer = 10 * answer + digit;
+                if (answer > byte.MaxValue)
+                    goto FalseExit; // Overflow
+                index++;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                if (!ParserHelpers.IsDigit(text[index]))
+                    goto Done;
+
+                // Guaranteed overflow
+                goto FalseExit;
             }
 
-            // Parse the first digit separately. If invalid here, we need to return false.
-            uint firstDigit = text[0] - 48u; // '0'
-            if (firstDigit > 9)
-            {
-                bytesConsumed = 0;
-                value = default;
-                return false;
-            }
-            uint parsedValue = firstDigit;
+FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
 
-            if (text.Length < ParserHelpers.ByteOverflowLength)
-            {
-                // Length is less than Parsers.ByteOverflowLength; overflow is not possible
-                for (int index = 1; index < text.Length; index++)
-                {
-                    uint nextDigit = text[index] - 48u; // '0'
-                    if (nextDigit > 9)
-                    {
-                        bytesConsumed = index;
-                        value = (byte)(parsedValue);
-                        return true;
-                    }
-                    parsedValue = parsedValue * 10 + nextDigit;
-                }
-            }
-            else
-            {
-                // Length is greater than Parsers.ByteOverflowLength; overflow is only possible after Parsers.ByteOverflowLength
-                // digits. There may be no overflow after Parsers.ByteOverflowLength if there are leading zeroes.
-                for (int index = 1; index < ParserHelpers.ByteOverflowLength - 1; index++)
-                {
-                    uint nextDigit = text[index] - 48u; // '0'
-                    if (nextDigit > 9)
-                    {
-                        bytesConsumed = index;
-                        value = (byte)(parsedValue);
-                        return true;
-                    }
-                    parsedValue = parsedValue * 10 + nextDigit;
-                }
-                for (int index = ParserHelpers.ByteOverflowLength - 1; index < text.Length; index++)
-                {
-                    uint nextDigit = text[index] - 48u; // '0'
-                    if (nextDigit > 9)
-                    {
-                        bytesConsumed = index;
-                        value = (byte)(parsedValue);
-                        return true;
-                    }
-                    // If parsedValue > (byte.MaxValue / 10), any more appended digits will cause overflow.
-                    // if parsedValue == (byte.MaxValue / 10), any nextDigit greater than 5 implies overflow.
-                    if (parsedValue > byte.MaxValue / 10 || (parsedValue == byte.MaxValue / 10 && nextDigit > 5))
-                    {
-                        bytesConsumed = 0;
-                        value = default;
-                        return false;
-                    }
-                    parsedValue = parsedValue * 10 + nextDigit;
-                }
-            }
-
-            bytesConsumed = text.Length;
-            value = (byte)(parsedValue);
+Done:
+            bytesConsumed = index;
+            value = (byte)answer;
             return true;
         }
 
         private static bool TryParseUInt16D(ReadOnlySpan<byte> text, out ushort value, out int bytesConsumed)
         {
             if (text.Length < 1)
+                goto FalseExit;
+
+            int index = 0;
+            uint digit = text[index] - 48u; // '0'
+            uint answer = 0;
+
+            if (digit <= 9)
             {
-                bytesConsumed = 0;
-                value = default;
-                return false;
+                if (digit == 0)
+                {
+                    do
+                    {
+                        index++;
+                        if ((uint)index >= (uint)text.Length)
+                            goto Done;
+                        digit = text[index];
+                    } while (digit == '0');
+
+                    digit = digit - 48u; // '0'
+                    if (digit > 9)
+                        goto Done;
+                }
+
+                answer = digit;
+                index++;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                // Potential overflow
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                answer = 10 * answer + digit;
+                if (answer > ushort.MaxValue)
+                    goto FalseExit; // Overflow
+                index++;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                if (!ParserHelpers.IsDigit(text[index]))
+                    goto Done;
+
+                // Guaranteed overflow
+                goto FalseExit;
             }
 
-            // Parse the first digit separately. If invalid here, we need to return false.
-            uint firstDigit = text[0] - 48u; // '0'
-            if (firstDigit > 9)
-            {
-                bytesConsumed = 0;
-                value = default;
-                return false;
-            }
-            uint parsedValue = firstDigit;
+FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
 
-            if (text.Length < ParserHelpers.Int16OverflowLength)
-            {
-                // Length is less than Parsers.Int16OverflowLength; overflow is not possible
-                for (int index = 1; index < text.Length; index++)
-                {
-                    uint nextDigit = text[index] - 48u; // '0'
-                    if (nextDigit > 9)
-                    {
-                        bytesConsumed = index;
-                        value = (ushort)(parsedValue);
-                        return true;
-                    }
-                    parsedValue = parsedValue * 10 + nextDigit;
-                }
-            }
-            else
-            {
-                // Length is greater than Parsers.Int16OverflowLength; overflow is only possible after Parsers.Int16OverflowLength
-                // digits. There may be no overflow after Parsers.Int16OverflowLength if there are leading zeroes.
-                for (int index = 1; index < ParserHelpers.Int16OverflowLength - 1; index++)
-                {
-                    uint nextDigit = text[index] - 48u; // '0'
-                    if (nextDigit > 9)
-                    {
-                        bytesConsumed = index;
-                        value = (ushort)(parsedValue);
-                        return true;
-                    }
-                    parsedValue = parsedValue * 10 + nextDigit;
-                }
-                for (int index = ParserHelpers.Int16OverflowLength - 1; index < text.Length; index++)
-                {
-                    uint nextDigit = text[index] - 48u; // '0'
-                    if (nextDigit > 9)
-                    {
-                        bytesConsumed = index;
-                        value = (ushort)(parsedValue);
-                        return true;
-                    }
-                    // If parsedValue > (ushort.MaxValue / 10), any more appended digits will cause overflow.
-                    // if parsedValue == (ushort.MaxValue / 10), any nextDigit greater than 5 implies overflow.
-                    if (parsedValue > ushort.MaxValue / 10 || (parsedValue == ushort.MaxValue / 10 && nextDigit > 5))
-                    {
-                        bytesConsumed = 0;
-                        value = default;
-                        return false;
-                    }
-                    parsedValue = parsedValue * 10 + nextDigit;
-                }
-            }
-
-            bytesConsumed = text.Length;
-            value = (ushort)(parsedValue);
+Done:
+            bytesConsumed = index;
+            value = (ushort)answer;
             return true;
         }
 
         private static bool TryParseUInt32D(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed)
         {
             if (text.Length < 1)
+                goto FalseExit;
+
+            int index = 0;
+            uint digit = text[index] - 48u; // '0'
+            uint answer = 0;
+
+            if (digit <= 9)
             {
-                bytesConsumed = 0;
-                value = default;
-                return false;
+                if (digit == 0)
+                {
+                    do
+                    {
+                        index++;
+                        if ((uint)index >= (uint)text.Length)
+                            goto Done;
+                        digit = text[index];
+                    } while (digit == '0');
+
+                    digit = digit - 48u; // '0'
+                    if (digit > 9)
+                        goto Done;
+                }
+
+                answer = digit;
+                index++;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                index++;
+                answer = 10 * answer + digit;
+
+                // Potential overflow
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                digit = text[index] - 48u; // '0';
+                if (digit > 9)
+                    goto Done;
+                if (answer > uint.MaxValue / 10 || (answer == uint.MaxValue / 10 && digit > 5))
+                    goto FalseExit; // Overflow
+                answer = 10 * answer + digit;
+                index++;
+
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                if (!ParserHelpers.IsDigit(text[index]))
+                    goto Done;
+
+                // Guaranteed overflow
+                goto FalseExit;
             }
 
-            // Parse the first digit separately. If invalid here, we need to return false.
-            uint firstDigit = text[0] - 48u; // '0'
-            if (firstDigit > 9)
-            {
-                bytesConsumed = 0;
-                value = default;
-                return false;
-            }
-            uint parsedValue = firstDigit;
+FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
 
-            if (text.Length < ParserHelpers.Int32OverflowLength)
-            {
-                // Length is less than Parsers.Int32OverflowLength; overflow is not possible
-                for (int index = 1; index < text.Length; index++)
-                {
-                    uint nextDigit = text[index] - 48u; // '0'
-                    if (nextDigit > 9)
-                    {
-                        bytesConsumed = index;
-                        value = parsedValue;
-                        return true;
-                    }
-                    parsedValue = parsedValue * 10 + nextDigit;
-                }
-            }
-            else
-            {
-                // Length is greater than Parsers.Int32OverflowLength; overflow is only possible after Parsers.Int32OverflowLength
-                // digits. There may be no overflow after Parsers.Int32OverflowLength if there are leading zeroes.
-                for (int index = 1; index < ParserHelpers.Int32OverflowLength - 1; index++)
-                {
-                    uint nextDigit = text[index] - 48u; // '0'
-                    if (nextDigit > 9)
-                    {
-                        bytesConsumed = index;
-                        value = parsedValue;
-                        return true;
-                    }
-                    parsedValue = parsedValue * 10 + nextDigit;
-                }
-                for (int index = ParserHelpers.Int32OverflowLength - 1; index < text.Length; index++)
-                {
-                    uint nextDigit = text[index] - 48u; // '0'
-                    if (nextDigit > 9)
-                    {
-                        bytesConsumed = index;
-                        value = parsedValue;
-                        return true;
-                    }
-                    // If parsedValue > (uint.MaxValue / 10), any more appended digits will cause overflow.
-                    // if parsedValue == (uint.MaxValue / 10), any nextDigit greater than 5 implies overflow.
-                    if (parsedValue > uint.MaxValue / 10 || (parsedValue == uint.MaxValue / 10 && nextDigit > 5))
-                    {
-                        bytesConsumed = 0;
-                        value = default;
-                        return false;
-                    }
-                    parsedValue = parsedValue * 10 + nextDigit;
-                }
-            }
-
-            bytesConsumed = text.Length;
-            value = parsedValue;
+Done:
+            bytesConsumed = index;
+            value = answer;
             return true;
         }
 

--- a/src/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
@@ -114,6 +114,10 @@ namespace System.Buffers.Text.Tests
                 // Code coverage
                 yield return new ParserTestData<int>("5$", 5, 'x', expectedSuccess: true) { ExpectedBytesConsumed = 1 };
                 yield return new ParserTestData<int>("5faaccbbf", 0, 'x', expectedSuccess: false);
+
+                // This value will overflow a UInt32 accumulator upon assimilating the 0 in a way such that the wrapped-around value still looks like
+                // it's in the range of an Int32. Unless, of course, the implementation had the foresight to check before assimilating. 
+                yield return new ParserTestData<int>("9999999990", 0, 'D', expectedSuccess: false);
             }
         }
 


### PR DESCRIPTION
This optimizes the Byte/UInt16/UInt32 parsers in the same
way that their signed counterparts already were.

Also, tuned up the signed counterparts before copy-pasting them:

- Just subtract the '0' once rather than doing it once in IsDigit()
  and then again to add to the accumulator.

- Eliminate the pre-overflow checks in the case where
  the accumulator is already a larger sized int than the value
  being parsed. The accumulator will never overflow as long
  we're under the digit count limit for the type.

- Fix the Int32 parser's potential overflow comparison
  from "int.MaxValue/10 - 1" to "int.MaxValue/10" (the older
  value works with an unsigned accumulator but in a "by accident" type
  of way.)


Perf improvement:

  +2.6% Int32  (int.MaxValue)
  +7.0% UInt32 (uint.MaxValue)