### PR TITLE
ManagedHandler: move Debug.Assert(_writeOffset == 0) after code trying to handle that case

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -1076,7 +1076,6 @@ namespace System.Net.Http
 
         private void ReturnConnectionToPool()
         {
-            Debug.Assert(_writeOffset == 0, "Everything in write buffer should have been flushed.");
             Debug.Assert(_readAheadTask == null, "Expected a previous initial read to already be consumed.");
             Debug.Assert(_currentRequest != null, "Expected the connection to be associated with a request.");
 
@@ -1117,6 +1116,7 @@ namespace System.Net.Http
         private void ReturnConnectionToPoolCore()
         {
             Debug.Assert(_sendRequestContentTask == null || _sendRequestContentTask.IsCompleted);
+            Debug.Assert(_writeOffset == 0, "Everything in write buffer should have been flushed.");
 
             if (NetEventSource.IsEnabled)
             {

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -1109,7 +1109,6 @@ namespace System.Net.Http
                     sendRequestContentTask.GetAwaiter().GetResult();
                 }
             }
-            Debug.Assert(_writeOffset == 0, "Everything in write buffer should have been flushed.");
 
             ReturnConnectionToPoolCore();
         }
@@ -1117,6 +1116,7 @@ namespace System.Net.Http
         private void ReturnConnectionToPoolCore()
         {
             Debug.Assert(_sendRequestContentTask == null || _sendRequestContentTask.IsCompleted);
+            Debug.Assert(_writeOffset == 0, "Everything in write buffer should have been flushed.");
 
             if (NetEventSource.IsEnabled)
             {

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -1109,6 +1109,7 @@ namespace System.Net.Http
                     sendRequestContentTask.GetAwaiter().GetResult();
                 }
             }
+            Debug.Assert(_writeOffset == 0, "Everything in write buffer should have been flushed.");
 
             ReturnConnectionToPoolCore();
         }
@@ -1116,7 +1117,6 @@ namespace System.Net.Http
         private void ReturnConnectionToPoolCore()
         {
             Debug.Assert(_sendRequestContentTask == null || _sendRequestContentTask.IsCompleted);
-            Debug.Assert(_writeOffset == 0, "Everything in write buffer should have been flushed.");
 
             if (NetEventSource.IsEnabled)
             {


### PR DESCRIPTION
There is code in ReturnConnectionToPool() to finish pending write. 
However the assert was executed before that. 

With this change I could run HTTP unit tests for while without hitting the assert. 
Before the change, I would hit this every 1-2 hours. 
