### PR TITLE
Reenabling disabled Memory test for uapaot that was previously missed

### DIFF
--- a/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
@@ -24,7 +24,6 @@ namespace System.SpanTests
             spanLong.Validate(1, -3, 7, -15, 31);
         }
 
-        [ActiveIssue(23952, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public static void ObjectArrayAsReadOnlySpan()
         {


### PR DESCRIPTION
The tests that were disabled in https://github.com/dotnet/corefx/pull/23905 can now be re-enabled since the bugs have been fixed for uapaot.

Missed this one when enabling the tests as part of https://github.com/dotnet/corefx/pull/24385

Fixes https://github.com/dotnet/corefx/issues/23952

cc @safern, @KrzysztofCwalina, @leekir