### PR TITLE
Remove tests that expect exception for long env vars

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -19,7 +19,6 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentNullException>("variable", () => Environment.GetEnvironmentVariable(null));
             AssertExtensions.Throws<ArgumentNullException>("variable", () => Environment.SetEnvironmentVariable(null, "test"));
             AssertExtensions.Throws<ArgumentException>("variable", () => Environment.SetEnvironmentVariable("", "test"));
-            AssertExtensions.Throws<ArgumentException>("value", null, () => Environment.SetEnvironmentVariable("test", new string('s', 65 * 1024)));
 
             AssertExtensions.Throws<ArgumentException>("variable", () => Environment.SetEnvironmentVariable("", "test", EnvironmentVariableTarget.Machine));
             AssertExtensions.Throws<ArgumentNullException>("variable", () => Environment.SetEnvironmentVariable(null, "test", EnvironmentVariableTarget.User));

--- a/src/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
@@ -11,7 +11,6 @@ namespace System.Tests
 {
     public class SetEnvironmentVariable
     {
-        private const int MAX_VAR_LENGTH_ALLOWED = 32767;
         private const string NullString = "\u0000";
 
         internal static bool IsSupportedTarget(EnvironmentVariableTarget target)
@@ -31,9 +30,6 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentException>("variable", () => Environment.SetEnvironmentVariable(string.Empty, "test"));
             AssertExtensions.Throws<ArgumentException>("variable", () => Environment.SetEnvironmentVariable(NullString, "test"));
             AssertExtensions.Throws<ArgumentException>("variable", null, () => Environment.SetEnvironmentVariable("Variable=Something", "test"));
-
-            string varWithLenLongerThanAllowed = new string('c', MAX_VAR_LENGTH_ALLOWED + 1);
-            AssertExtensions.Throws<ArgumentException>("variable", null, () => Environment.SetEnvironmentVariable(varWithLenLongerThanAllowed, "test"));
         }
 
         private static void ExecuteAgainstTarget(


### PR DESCRIPTION
Reacting to PR https://github.com/dotnet/coreclr/pull/14872 in corefx tests

Cherry-picked from https://github.com/dotnet/corefx/pull/25131/commits/5ba5d54218496b5667689581a9732b4ddc821542
cc: @weshaggard 