### PR TITLE
[Infrastructure] Add clean.cmd -h and -? help arguments, streamliene VBCSCompiler.exe kill logic

### DIFF
--- a/clean.cmd
+++ b/clean.cmd
@@ -1,19 +1,28 @@
 @if not defined _echo @echo off
 setlocal EnableDelayedExpansion
 
-echo Stop VBCSCompiler.exe execution.
-for /f "tokens=2 delims=," %%F in ('tasklist /nh /fi "imagename eq VBCSCompiler.exe" /fo csv') do taskkill /f /PID %%~F
+set NO_DASHES_ARG=%1
+if /I [%NO_DASHES_ARG:-=%] == [?] goto Usage
+if /I [%NO_DASHES_ARG:-=%] == [h] goto Usage
+
+:: Check if VBCSCompiler.exe is running
+tasklist /fi "imagename eq VBCSCompiler.exe" |find ":" > nul
+:: Compiler is running if errorlevel == 1
+if errorlevel 1 (
+  echo Stop VBCSCompiler.exe execution.
+  for /f "tokens=2 delims=," %%F in ('tasklist /nh /fi "imagename eq VBCSCompiler.exe" /fo csv') do taskkill /f /PID %%~F
+)
 
 :: Strip all dashes off the argument and use invariant
 :: compare to match as many versions of "all" that we can
 :: All other argument validation happens inside Run.exe
-set NO_DASHES_ARG=%1
 if not defined NO_DASHES_ARG goto no_args
 if /I [%NO_DASHES_ARG:-=%] == [all] (
   echo Cleaning entire working directory ...
   call git clean -xdf
   exit /b !ERRORLEVEL!
 )
+
 :no_args
 if [%1]==[] set __args=-b
 call %~dp0run.cmd clean %__args% %*

--- a/clean.sh
+++ b/clean.sh
@@ -18,6 +18,8 @@ if [ "$1" == "-?" ] || [ "$1" == "-h" ]; then
     usage
 fi
 
+# Implement VBCSCompiler.exe kill logic once VBCSCompiler.exe is ported to unixes
+
 __working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ "$*" == "-all" ]


### PR DESCRIPTION
Updating clean.{cmd|sh} according to changes introduced to coreclr
in PR https://github.com/dotnet/coreclr/pull/14882