### PR TITLE
Delete forced GC during System.Drawing.Common shutdown

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -78,23 +78,10 @@ namespace System.Drawing
                     }
                     Marshal.FreeHGlobal(buf);
                 }
-
-                // under MS 1.x this event is raised only for the default application domain
-#if !NETSTANDARD1_6
-                AppDomain.CurrentDomain.ProcessExit += new EventHandler(ProcessExit);
-#endif
             }
 
             [DllImport("libc")]
             static extern int uname(IntPtr buf);
-
-            private static void ProcessExit(object sender, EventArgs e)
-            {
-                // Called all pending objects and claim any pending handle before
-                // shutting down
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-            }
 
             private static void LoadFunctionPointers()
             {


### PR DESCRIPTION
This is potential reliability and performance and problem. The forced GC is only going to collect unreachable objects, and so it is not providing any sort of guarantees that there are no outstanding GDI references. It should not be required.

Fixes #25159