### PR TITLE
Simplify Microsoft.CSharp's NameManager and root namespace symbol

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -572,7 +572,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     }
 
                 case TypeKind.TK_VoidType:
-                    ErrAppendName(NameManager.Lookup(TokenFacts.GetText(TokenKind.Void)));
+                    ErrAppendName(NameManager.GetPredefinedName(PredefinedName.PN_VOID));
                     break;
 
                 case TypeKind.TK_ParameterModifierType:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -152,11 +152,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
         private void ErrAppendParentCore(Symbol parent, SubstContext pctx)
         {
-            if (null == parent)
+            if (parent == null || parent == NamespaceSymbol.Root)
+            {
                 return;
-
-            if (parent == getBSymmgr().GetRootNS())
-                return;
+            }
 
             if (pctx != null && !pctx.FNop() && parent is AggregateSymbol agg && 0 != agg.GetTypeVarsAll().Count)
             {
@@ -391,7 +390,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     break;
 
                 case SYMKIND.SK_NamespaceSymbol:
-                    if (sym == getBSymmgr().GetRootNS())
+                    if (sym == NamespaceSymbol.Root)
                     {
                         ErrAppendId(MessageID.GlobalNamespace);
                     }
@@ -676,16 +675,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         private TypeManager GetTypeManager()
         {
             return m_globalSymbols.GetTypes();
-        }
-
-        private BSYMMGR getBSymmgr()
-        {
-            return m_globalSymbols.GetGlobalSymbols();
-        }
-
-        private int GetTypeID(CType type)
-        {
-            return 0;
         }
 
         private void ErrId(out string s, MessageID id)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceSymbol.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
@@ -31,5 +32,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
     internal sealed class NamespaceSymbol : NamespaceOrAggregateSymbol
     {
+        /// <summary>The "root" (unnamed) namespace.</summary>
+        public static readonly NamespaceSymbol Root = GetRootNamespaceSymbol();
+
+        private static NamespaceSymbol GetRootNamespaceSymbol()
+        {
+            NamespaceSymbol root = new NamespaceSymbol
+            {
+                name = NameManager.GetPredefinedName(PredefinedName.PN_VOID)
+            };
+
+            root.setKind(SYMKIND.SK_NamespaceSymbol);
+            return root;
+        }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -19,8 +19,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private readonly SymFactory _symFactory;
 
-        private readonly NamespaceSymbol _rootNS;         // The "root" (unnamed) namespace.
-
         private SYMTBL tableGlobal;
 
         // The hash table for type arrays.
@@ -34,7 +32,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _symFactory = new SymFactory(this.tableGlobal);
 
             this.tableTypeArrays = new Dictionary<TypeArrayKey, TypeArray>();
-            _rootNS = _symFactory.CreateNamespace(NameManager.GetPredefinedName(PredefinedName.PN_EMPTY), null);
 
             ////////////////////////////////////////////////////////////////////////////////
             // Build the data structures needed to make FPreLoad fast. Make sure the 
@@ -43,7 +40,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             for (int i = 0; i < (int)PredefinedType.PT_COUNT; ++i)
             {
-                NamespaceSymbol ns = GetRootNS();
+                NamespaceSymbol ns = NamespaceSymbol.Root;
                 string name = PredefinedTypeFacts.GetName((PredefinedType)i);
                 int start = 0;
                 while (start < name.Length)
@@ -67,11 +64,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public static TypeArray EmptyTypeArray()
         {
             return s_taEmpty;
-        }
-
-        public NamespaceSymbol GetRootNS()
-        {
-            return _rootNS;
         }
 
         public BetterType CompareTypes(TypeArray ta1, TypeArray ta2)
@@ -150,30 +142,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public SymFactory GetSymFactory()
         {
             return _symFactory;
-        }
-
-        ////////////////////////////////////////////////////////////////////////////////
-        // Build the data structures needed to make FPreLoad fast. Make sure the 
-        // namespaces are created. Compute and sort hashes of the NamespaceSymbol * value and type
-        // name (sans arity indicator).
-
-        private void InitPreLoad()
-        {
-            for (int i = 0; i < (int)PredefinedType.PT_COUNT; ++i)
-            {
-                NamespaceSymbol ns = GetRootNS();
-                string name = PredefinedTypeFacts.GetName((PredefinedType)i);
-                int start = 0;
-                while (start < name.Length)
-                {
-                    int iDot = name.IndexOf('.', start);
-                    if (iDot == -1) break;
-                    string sub = (iDot > start) ? name.Substring(start, iDot - start) : name.Substring(start);
-                    Name nm = NameManager.Add(sub);
-                    ns = LookupGlobalSymCore(nm, ns, symbmask_t.MASK_NamespaceSymbol) as NamespaceSymbol ?? _symFactory.CreateNamespace(nm, ns);
-                    start += sub.Length + 1;
-                }
-            }
         }
 
         public Symbol LookupGlobalSymCore(Name name, ParentSymbol parent, symbmask_t kindmask)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _symFactory = new SymFactory(this.tableGlobal);
 
             this.tableTypeArrays = new Dictionary<TypeArrayKey, TypeArray>();
-            _rootNS = _symFactory.CreateNamespace(NameManager.Lookup(""), null);
+            _rootNS = _symFactory.CreateNamespace(NameManager.GetPredefinedName(PredefinedName.PN_EMPTY), null);
 
             ////////////////////////////////////////////////////////////////////////////////
             // Build the data structures needed to make FPreLoad fast. Make sure the 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -29,8 +29,6 @@ namespace Microsoft.CSharp.RuntimeBinder
         private readonly BSYMMGR _bsymmgr;
         private readonly CSemanticChecker _semanticChecker;
 
-        private NamespaceSymbol _rootNamespace;
-
         /////////////////////////////////////////////////////////////////////////////////
 
         private sealed class NameHashKey : IEquatable<NameHashKey>
@@ -75,7 +73,6 @@ namespace Microsoft.CSharp.RuntimeBinder
             _typeManager = typeManager;
             _bsymmgr = bsymmgr;
             _semanticChecker = semanticChecker;
-            _rootNamespace = _bsymmgr.GetRootNS();
 
             // Now populate object.
             LoadSymbolsFromType(typeof(object));
@@ -653,7 +650,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 type = type.GetElementType();
             }
 
-            NamespaceOrAggregateSymbol current = _rootNamespace;
+            NamespaceOrAggregateSymbol current = NamespaceSymbol.Root;
 
             // Go through the declaration chain and add namespaces and types for
             // each element in the chain.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameManager.cs
@@ -112,6 +112,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
             new Name("RemoveEventHandler"),
             new Name("InvocationList"),
             new Name("GetOrCreateEventRegistrationTokenTable"),
+            new Name("void"),
+            new Name(""),
             /* Above here corresponds with PredefinedName enum */
             new Name("true"),
             new Name("false"),
@@ -128,9 +130,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
             new Name("checked"),
             new Name("is"),
             new Name("typeof"),
-            new Name("unchecked"),
-            new Name("void"),
-            new Name("")
+            new Name("unchecked")
         };
 
         private static readonly NameTable s_names = GetKnownNames();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameManager.cs
@@ -164,12 +164,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
             return s_names.Add(key, length);
         }
 
-        internal static Name Lookup(string key)
-        {
-            Debug.Assert(key != null);
-            return s_names.Lookup(key);
-        }
-
         internal static Name GetPredefinedName(PredefinedName id)
         {
             Debug.Assert(id < PredefinedName.PN_COUNT);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameTable.cs
@@ -65,24 +65,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
         {
             int hashCode = ComputeHashCode(name.Text);
             // make sure it doesn't already exist
-            Debug.Assert(Lookup(name.Text) == null);
             Debug.Assert(_entries.All(e => e?.Name.Text != name.Text));
 
             AddEntry(name, hashCode);
-        }
-
-        public Name Lookup(string key)
-        {
-            int hashCode = ComputeHashCode(key);
-            for (Entry e = _entries[hashCode & _mask]; e != null; e = e.Next)
-            {
-                if (e.HashCode == hashCode && e.Name.Text.Equals(key))
-                {
-                    return e.Name;
-                }
-            }
-
-            return null;
         }
 
         private static int ComputeHashCode(string key)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameTable.cs
@@ -85,20 +85,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
             return null;
         }
 
-        public Name Lookup(string key, int length)
-        {
-            int hashCode = ComputeHashCode(key, length);
-            for (Entry e = _entries[hashCode & _mask]; e != null; e = e.Next)
-            {
-                if (e.HashCode == hashCode && Equals(e.Name.Text, key, length))
-                {
-                    return e.Name;
-                }
-            }
-
-            return null;
-        }
-
         private static int ComputeHashCode(string key)
         {
             unchecked

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/PredefinedName.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/PredefinedName.cs
@@ -117,6 +117,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
         PN_INVOCATIONLIST,
         PN_GETORCREATEEVENTREGISTRATIONTOKENTABLE,
 
+        PN_VOID,
+        PN_EMPTY,
+
         PN_COUNT,  // Not a name, this is the total count of predefined names
     }
 }


### PR DESCRIPTION
Now that it's static a few further simplifications are possible.

* Remove `NameTable.Lookup(key, length)`

No longer used.

* Make "void" and the empty string predefined names.

Use `GetPredefinedName` rather than Lookup to retrieve them.

* Remove `NameManager.Lookup` and `NameTable.Lookup`

Former no longer used after the above. Latter only used in an assertion that another assertion duplicates.

* Make root namespace's `NamespaceSymbol` singleton in `NamespaceSymbol`

Since it has no parent and isn't stored in the symbol table, and since name management is now static, it need no longer hang off `BSYMMGR`.

