### PR TITLE
Merge CheckedConstant & CheckedNormal in MS.CSharp's BindingContext

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -276,7 +276,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 bindingContext.ContextForMemberLookup = null;
             }
 
-            bindingContext.CheckedConstant = bindingContext.CheckedNormal = payload.IsChecked;
+            bindingContext.Checked = payload.IsChecked;
         }
 
         /////////////////////////////////////////////////////////////////////////////////

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BindingContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BindingContext.cs
@@ -22,15 +22,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         public BindingContext(BindingContext parent)
+            : this(parent.SemanticChecker, parent.ExprFactory)
         {
-            Debug.Assert(parent.SemanticChecker != null);
-            ExprFactory = parent.ExprFactory;
             ContextForMemberLookup = parent.ContextForMemberLookup;
-            CheckedNormal = parent.CheckedNormal;
-            CheckedConstant = parent.CheckedConstant;
-            SymbolLoader = (SemanticChecker = parent.SemanticChecker).SymbolLoader;
+            Checked = parent.Checked;
         }
-
 
         //The SymbolLoader can be retrieved from SemanticChecker,
         //but that is a virtual call that is showing up on the profiler. Retrieve
@@ -45,8 +41,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public ExprFactory ExprFactory { get; }
 
-        public bool CheckedNormal { get; set; }
-
-        public bool CheckedConstant { get; set; }
+        public bool Checked { get; set; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -490,7 +490,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         // Decimal is a SimpleType represented in a FT_STRUCT
                         throw ErrorContext.Error(ErrorCode.ERR_ConstOutOfRange, ((ExprConstant)exprConst).Val.DecimalVal.ToString(CultureInfo.InvariantCulture), dest);
                     }
-                    else if (simpleConstToSimpleDestination && Context.CheckedConstant)
+
+                    if (simpleConstToSimpleDestination && Context.Checked)
                     {
                         // check if we failed because we are in checked mode...
                         bool okNow = canExplicitConversionBeBoundInUncheckedContext(expr, expr.Type, destExpr, flags | CONVERTTYPE.NOUDC);
@@ -1173,7 +1174,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return ConstCastResult.Success;
             }
 
-            if (explicitConversion && Context.CheckedConstant && !isConstantInRange(constSrc, typeDest, true))
+            if (explicitConversion && Context.Checked && !isConstantInRange(constSrc, typeDest, true))
             {
                 return ConstCastResult.CheckFailure;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -460,7 +460,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // as the original tree for the constant. Otherwise, return the cast expr.
 
             ExprCast exprCast = GetExprFactory().CreateCast(exprFlags, exprTypeDest, exprSrc);
-            if (Context.CheckedNormal)
+            if (Context.Checked)
             {
                 exprCast.Flags |= EXPRFLAG.EXF_CHECKOVERFLOW;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1229,7 +1229,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (pArgument.Type == null ||
                 !CalculateExprAndUnaryOpKinds(
                            op,
-                           Context.CheckedNormal,
+                           Context.Checked,
                            out ek/*out*/,
                            out unaryOpKind/*out*/,
                            out flags/*out*/))
@@ -2245,14 +2245,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             switch (ek)
             {
                 case ExpressionKind.Add:
-                    if (Context.CheckedNormal)
+                    if (Context.Checked)
                     {
                         flags |= EXPRFLAG.EXF_CHECKOVERFLOW;
                     }
                     pBinopKind = BinOpKind.Add;
                     break;
                 case ExpressionKind.Subtract:
-                    if (Context.CheckedNormal)
+                    if (Context.Checked)
                     {
                         flags |= EXPRFLAG.EXF_CHECKOVERFLOW;
                     }
@@ -2263,14 +2263,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     // EXPRKIND.EK_DIV and EXPRKIND.EK_MOD need to be treated special for hasSideEffects, 
                     // hence the EXPRFLAG.EXF_ASSGOP. Yes, this is a hack.
                     flags |= EXPRFLAG.EXF_ASSGOP;
-                    if (Context.CheckedNormal)
+                    if (Context.Checked)
                     {
                         flags |= EXPRFLAG.EXF_CHECKOVERFLOW;
                     }
                     pBinopKind = BinOpKind.Mul;
                     break;
                 case ExpressionKind.Multiply:
-                    if (Context.CheckedNormal)
+                    if (Context.Checked)
                     {
                         flags |= EXPRFLAG.EXF_CHECKOVERFLOW;
                     }


### PR DESCRIPTION
Always set to the same value (and indeed the distinction isn't meaningful in dynamic code), so just have one such property.