### PR TITLE
Conditioning the reference to PlatformAbstractions to fix uapaot test runs

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -50,7 +50,7 @@
     <PackageReference Include="Microsoft.3rdpartytools.MarkdownLog">
       <Version>0.10.0-alpha-experimental</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions">
+    <PackageReference Condition="'$(TargetGroup)' != 'uapaot'" Include="Microsoft.DotNet.PlatformAbstractions">
       <Version>$(MicrosoftDotNetPlatformAbstractionsPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="CommandLineParser">
@@ -98,7 +98,7 @@
     <PackageToInclude Include="xunit.runner.utility"/>
     <PackageToInclude Include="Microsoft.xunit.netcore.extensions"/>
     <PackageToInclude Include="Newtonsoft.Json"/>
-    <PackageToInclude Include="Microsoft.DotNet.PlatformAbstractions" />
+    <PackageToInclude Condition="'$(TargetGroup)' != 'uapaot'" Include="Microsoft.DotNet.PlatformAbstractions" />
     <PackageToInclude Include="$(XUnitRunnerPackageId)" />
   </ItemGroup>
 

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -57,7 +57,7 @@
     <ReferenceFromRuntime Include="xunit.core" />
     <ReferenceFromRuntime Include="Xunit.NetCore.Extensions" />
     <ReferenceFromRuntime Include="xunit.assert" />
-    <ReferenceFromRuntime Include="Microsoft.DotNet.PlatformAbstractions" />
+    <ReferenceFromRuntime Condition="'$(TargetGroup)' != 'uapaot'" Include="Microsoft.DotNet.PlatformAbstractions" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Reference Include="System.Security.Principal.Windows" />


### PR DESCRIPTION
cc: @MattGal @krwq 

Microsoft.DotNet.PlatformAbstractions.dll has a dependency to libc.dll so when it was added it broke all of uapaot tests since they should not depend on a library that won't be available at runtime.