### PR TITLE
MS.CSharp: Avoid allocation in AllocParams(int, TypeArray, int)

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -295,6 +295,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public TypeArray AllocParams(int ctype, TypeArray array, int offset)
         {
+            if (ctype == 0)
+            {
+                return s_taEmpty;
+            }
+
+            if (ctype == array.Count)
+            {
+                return array;
+            }
+
             CType[] types = array.Items;
             CType[] newTypes = new CType[ctype];
             Array.ConstrainedCopy(types, offset, newTypes, 0, ctype);


### PR DESCRIPTION
This is called to split the type arguments for nested classes between those for the type itself and those for the outer type.

The most common case will return the empty array or the source array (only really splitting for a type both within a generic type, that also adds further type parameters), but getting there will allocate an array and possibly do a lookup.

Catch and short-circuit on these cases.