### PR TITLE
Defer calculation of AggregateType.GetBaseClass() in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -191,7 +191,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 ErrAppendParentSym(meth, pctx);
 
                 // Get the type args from the explicit impl type and substitute using pctx (if there is one).
-                SubstContext ctx = new SubstContext(GetTypeManager().SubstType(meth.swtSlot.GetType(), pctx) as AggregateType);
+                SubstContext ctx = new SubstContext(GetTypeManager().SubstType(meth.swtSlot.GetType(), pctx));
                 ErrAppendSym(meth.swtSlot.Sym, ctx, fArgs);
 
                 // args already added
@@ -308,7 +308,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             ErrAppendParentSym(prop, pctx);
             if (prop.IsExpImpl() && prop.swtSlot.Sym != null)
             {
-                SubstContext ctx = new SubstContext(GetTypeManager().SubstType(prop.swtSlot.GetType(), pctx) as AggregateType);
+                SubstContext ctx = new SubstContext(GetTypeManager().SubstType(prop.swtSlot.GetType(), pctx));
                 ErrAppendSym(prop.swtSlot.Sym, ctx);
             }
             else if (prop.IsExpImpl())

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 TypeManager manager = GetOwningAggregate().GetTypeManager();
                 AggregateType baseClass = manager.SymbolTable.GetCTypeFromType(baseSysType) as AggregateType;
                 Debug.Assert(baseClass != null);
-                _baseType = manager.SubstType(baseClass, GetTypeArgsAll()) as AggregateType;
+                _baseType = manager.SubstType(baseClass, GetTypeArgsAll());
             }
 
             return _baseType;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -46,8 +47,35 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public AggregateType GetBaseClass()
         {
-            return _baseType ??
-                (_baseType = getAggregate().GetTypeManager().SubstType(getAggregate().GetBaseClass(), GetTypeArgsAll()) as AggregateType);
+            if (_baseType == null)
+            {
+                Type baseSysType = AssociatedSystemType.BaseType;
+                if (baseSysType == null)
+                {
+                    return null;
+                }
+
+                // If we have a generic type definition, then we need to set the
+                // base class to be our current base type, and use that to calculate 
+                // our agg type and its base, then set it to be the generic version of the
+                // base type. This is because:
+                //
+                // Suppose we have Foo<T> : IFoo<T>
+                //
+                // Initially, the BaseType will be IFoo<Foo.T>, which gives us the substitution
+                // that we want to use for our agg type's base type. However, in the Symbol chain,
+                // we want the base type to be IFoo<IFoo.T>. So we need to substitute.
+                //
+                // If we don't have a generic type definition, then we just need to set our base
+                // class. This is so that if we have a base type that's generic, we'll be
+                // getting the correctly instantiated base type.
+                TypeManager manager = GetOwningAggregate().GetTypeManager();
+                AggregateType baseClass = manager.SymbolTable.GetCTypeFromType(baseSysType) as AggregateType;
+                Debug.Assert(baseClass != null);
+                _baseType = manager.SubstType(baseClass, GetTypeArgsAll()) as AggregateType;
+            }
+
+            return _baseType;
         }
 
         public IEnumerable<AggregateType> TypeHierarchy

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -56,6 +56,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _symbolTable = table;
         }
 
+        public SymbolTable SymbolTable => _symbolTable;
+
         private sealed class StdTypeVarColl
         {
             private readonly List<TypeParameterType> prgptvs;
@@ -171,33 +173,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 pAggregate.SetErrors(false);
                 _typeTable.InsertAggregate(agg, atsOuter, typeArgs, pAggregate);
-
-                // If we have a generic type definition, then we need to set the
-                // base class to be our current base type, and use that to calculate 
-                // our agg type and its base, then set it to be the generic version of the
-                // base type. This is because:
-                //
-                // Suppose we have Foo<T> : IFoo<T>
-                //
-                // Initially, the BaseType will be IFoo<Foo.T>, which gives us the substitution
-                // that we want to use for our agg type's base type. However, in the Symbol chain,
-                // we want the base type to be IFoo<IFoo.T>. Thats why we need to do this little trick.
-                //
-                // If we don't have a generic type definition, then we just need to set our base
-                // class. This is so that if we have a base type that's generic, we'll be
-                // getting the correctly instantiated base type.
-
-                var baseType = pAggregate.AssociatedSystemType?.BaseType;
-                if (baseType != null)
-                {
-                    // Store the old base class.
-
-                    AggregateType oldBaseType = agg.GetBaseClass();
-                    agg.SetBaseClass(_symbolTable.GetCTypeFromType(baseType) as AggregateType);
-                    pAggregate.GetBaseClass(); // Get the base type for the new agg type we're making.
-
-                    agg.SetBaseClass(oldBaseType);
-                }
             }
             else
             {

--- a/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             Assert.True(res);
         }
 
-        [Fact, ActiveIssue(7527)]
+        [Fact]
         public void CyclicTypeDefinition()
         {
             dynamic x = new Third<int>();

--- a/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
@@ -215,5 +215,22 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             result = "xyz" + d;
             Assert.Equal("xyzabc", result);
         }
+
+        [Fact]
+        public void DynamicArgumentToCyclicTypeDefinition()
+        {
+            dynamic arg = 5;
+            new Builder<object>().SomeMethod(arg);
+        }
+
+        public class Builder<TItem> : BuilderBaseEx<Builder<TItem>>
+        {
+            public Builder<TItem> SomeMethod(object arg)
+            {
+                return this;
+            }
+        }
+        public class BuilderBaseEx<T> : BuilderBase<T> where T : BuilderBaseEx<T> { }
+        public class BuilderBase<T> where T : BuilderBase<T> { }
     }
 }

--- a/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -232,5 +233,36 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
         public class BuilderBaseEx<T> : BuilderBase<T> where T : BuilderBaseEx<T> { }
         public class BuilderBase<T> where T : BuilderBase<T> { }
+
+        [Fact]
+        public void CircularOnOwnNested()
+        {
+            dynamic d = new Generic<string>.Inner
+            {
+                Foo = "expected"
+            };
+
+            Assert.Equal("expected", d.Foo);
+        }
+
+
+        [Fact]
+        public void CircularOnOwnNestedAbsentMember()
+        {
+            dynamic d = new Generic<string>.Inner
+            {
+                Foo = "expected"
+            };
+
+            Assert.Throws<RuntimeBinderException>(() => d.Bar);
+        }
+
+        class Generic<T> : BindingList<Generic<T>.Inner>
+        {
+            public class Inner
+            {
+                public object Foo { get; set; }
+            }
+        }
     }
 }


### PR DESCRIPTION
Push logic for calculating the substitution necessary on base types when type or the base are generic into `AggregateType` and defer it until first call.

This allows cycling chains of derivation and type parameters.

Fixes #7527

* Add test for variant of cyclic type definitions.

Confirms fix for #7527 also fixes #23706

* Overrides for `SubstType` and `SubstTypeCore` for `AggregateType` when used

In one case replaces the equivalent existing override completely.

Allows type-checking and casting to be avoided.