### PR TITLE
Key AggregateType lookup on triple of symbol, outer type and type args

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -504,14 +504,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     ErrorType err = (ErrorType)pType;
                     if (err.HasParent)
                     {
-                        Debug.Assert(err.nameText != null && err.typeArgs != null);
+                        Debug.Assert(err.nameText != null);
                         ErrAppendName(err.nameText);
-                        ErrAppendTypeParameters(err.typeArgs, pctx, true);
                     }
                     else
                     {
                         // Load the string "<error>".
-                        Debug.Assert(null == err.typeArgs);
                         ErrAppendId(MessageID.ERRORSYM);
                     }
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -194,9 +194,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                 }
 
-                _pFixedResults[iParam] = GetTypeManager().GetErrorType(
-                                        ((TypeParameterType)_pMethodTypeParameters[iParam]).GetName(),
-                                        BSYMMGR.EmptyTypeArray());
+                _pFixedResults[iParam] = GetTypeManager()
+                    .GetErrorType(((TypeParameterType)_pMethodTypeParameters[iParam]).GetName());
             }
             return GetGlobalSymbols().AllocParams(_pMethodTypeParameters.Count, _pFixedResults);
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -206,19 +206,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return null;
         }
 
-        public Name GetNameFromPtrs(object u1, object u2)
-        {
-            // Note: this won't produce the same names as the native logic
-            if (u2 != null)
-            {
-                return NameManager.Add(string.Format(CultureInfo.InvariantCulture, "{0:X}-{1:X}", u1.GetHashCode(), u2.GetHashCode()));
-            }
-            else
-            {
-                return NameManager.Add(string.Format(CultureInfo.InvariantCulture, "{0:X}", u1.GetHashCode()));
-            }
-        }
-
         ////////////////////////////////////////////////////////////////////////////////
         // Allocate a type array; used to represent a parameter list.
         // We use a hash table to make sure that allocating the same type array twice 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     internal sealed class ErrorType : CType
     {
         public Name nameText;
-        public TypeArray typeArgs;
 
         // ErrorTypes are always either the per-TypeManager singleton ErrorType
         // that has a null nameText and no namespace parent, or else have a

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
@@ -11,7 +11,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     {
         // Aggregate
         public AggregateType CreateAggregateType(
-            Name name,
             AggregateSymbol parent,
             TypeArray typeArgsThis,
             AggregateType outerType)
@@ -21,8 +20,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             type.outerType = outerType;
             type.SetOwningAggregate(parent);
             type.SetTypeArgsThis(typeArgsThis);
-            type.SetName(name);
-
             type.SetTypeKind(TypeKind.TK_AggregateType);
             return type;
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
@@ -66,16 +66,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return type;
         }
 
-        public ErrorType CreateError(
-            Name name,
-            Name nameText,
-            TypeArray typeArgs)
+        public ErrorType CreateError(Name nameText)
         {
             ErrorType e = new ErrorType();
-            e.SetName(name);
             e.nameText = nameText;
-            e.typeArgs = typeArgs;
-
             e.SetTypeKind(TypeKind.TK_ErrorType);
             return e;
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _typeTable = new TypeTable();
 
             // special types with their own symbol kind.
-            _errorType = _typeFactory.CreateError(null, null, null);
+            _errorType = _typeFactory.CreateError(null);
             _voidType = _typeFactory.CreateVoid();
             _nullType = _typeFactory.CreateNull();
             _typeMethGrp = _typeFactory.CreateMethodGroup();
@@ -308,33 +308,21 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return pParamModifier;
         }
 
-        public ErrorType GetErrorType(
-                Name nameText,
-                TypeArray typeArgs)
+        public ErrorType GetErrorType(Name nameText)
         {
             Debug.Assert(nameText != null);
-            if (typeArgs == null)
-            {
-                typeArgs = BSYMMGR.EmptyTypeArray();
-            }
-
-            Name name = _BSymmgr.GetNameFromPtrs(nameText, typeArgs);
-            Debug.Assert(name != null);
-
-            ErrorType pError = _typeTable.LookupError(name);
-
+            ErrorType pError = _typeTable.LookupError(nameText);
             if (pError == null)
             {
                 // No existing error symbol. Create a new one.
-                pError = _typeFactory.CreateError(name, nameText, typeArgs);
+                pError = _typeFactory.CreateError(nameText);
                 pError.SetErrors(true);
-                _typeTable.InsertError(name, pError);
+                _typeTable.InsertError(nameText, pError);
             }
             else
             {
                 Debug.Assert(pError.HasErrors());
                 Debug.Assert(pError.nameText == nameText);
-                Debug.Assert(pError.typeArgs == typeArgs);
             }
 
             return pError;
@@ -435,6 +423,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case TypeKind.TK_VoidType:
                 case TypeKind.TK_MethodGroupType:
                 case TypeKind.TK_ArgumentListType:
+                case TypeKind.TK_ErrorType:
                     return type;
 
                 case TypeKind.TK_ParameterModifierType:
@@ -463,20 +452,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         if (ats.GetTypeArgsAll() != typeArgs)
                             return GetAggregate(ats.getAggregate(), typeArgs);
                     }
-                    return type;
-
-                case TypeKind.TK_ErrorType:
-                    ErrorType err = (ErrorType)type;
-                    if (err.HasParent)
-                    {
-                        Debug.Assert(err.nameText != null && err.typeArgs != null);
-                        TypeArray typeArgs = SubstTypeArray(err.typeArgs, pctx);
-                        if (typeArgs != err.typeArgs)
-                        {
-                            return GetErrorType(err.nameText, typeArgs);
-                        }
-                    }
-
                     return type;
 
                 case TypeKind.TK_TypeParameterType:
@@ -616,28 +591,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 case TypeKind.TK_ErrorType:
                     ErrorType errSrc = (ErrorType)typeSrc;
-                    if (!(typeDst is ErrorType errDst) || !errSrc.HasParent || !errDst.HasParent)
-                        return false;
-
-                {
-                    Debug.Assert(errSrc.nameText != null && errSrc.typeArgs != null);
-                    Debug.Assert(errDst.nameText != null && errDst.typeArgs != null);
-
-                    if (errSrc.nameText != errDst.nameText || errSrc.typeArgs.Count != errDst.typeArgs.Count
-                        || errSrc.HasParent != errDst.HasParent)
+                    if (!(typeDst is ErrorType errDst))
                     {
                         return false;
                     }
 
-                    // All the args must unify.
-                    for (int i = 0; i < errSrc.typeArgs.Count; i++)
-                    {
-                        if (!SubstEqualTypesCore(errDst.typeArgs[i], errSrc.typeArgs[i], pctx))
-                            return false;
-                    }
-                }
-
-                    return true;
+                    Name srcName = errSrc.nameText;
+                    return srcName != null && errSrc.nameText == errDst.nameText;
 
                 case TypeKind.TK_TypeParameterType:
                     { // BLOCK
@@ -721,20 +681,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
 
                 case TypeKind.TK_ErrorType:
-                    ErrorType err = (ErrorType)type;
-                    if (err.HasParent)
-                    {
-                        Debug.Assert(err.nameText != null && err.typeArgs != null);
-
-                        for (int i = 0; i < err.typeArgs.Count; i++)
-                        {
-                            if (TypeContainsType(err.typeArgs[i], typeFind))
-                                return true;
-                        }
-                    }
-
-                    return false;
-
                 case TypeKind.TK_TypeParameterType:
                     return false;
             }
@@ -752,6 +698,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case TypeKind.TK_NullType:
                 case TypeKind.TK_VoidType:
                 case TypeKind.TK_MethodGroupType:
+                case TypeKind.TK_ErrorType:
                     return false;
 
                 case TypeKind.TK_ArrayType:
@@ -773,23 +720,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             }
                         }
                     }
-                    return false;
-
-                case TypeKind.TK_ErrorType:
-                    ErrorType err = (ErrorType)type;
-                    if (err.HasParent)
-                    {
-                        Debug.Assert(err.nameText != null && err.typeArgs != null);
-
-                        for (int i = 0; i < err.typeArgs.Count; i++)
-                        {
-                            if (TypeContainsTyVars(err.typeArgs[i], typeVars))
-                            {
-                                return true;
-                            }
-                        }
-                    }
-
                     return false;
 
                 case TypeKind.TK_TypeParameterType:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -158,15 +158,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             Debug.Assert(agg.GetTypeVars().Count == typeArgs.Count);
-
-            Name name = _BSymmgr.GetNameFromPtrs(typeArgs, atsOuter);
-            Debug.Assert(name != null);
-
-            AggregateType pAggregate = _typeTable.LookupAggregate(name, agg);
+            AggregateType pAggregate = _typeTable.LookupAggregate(agg, atsOuter, typeArgs);
             if (pAggregate == null)
             {
                 pAggregate = _typeFactory.CreateAggregateType(
-                          name,
                           agg,
                           typeArgs,
                           atsOuter
@@ -175,7 +170,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(!pAggregate.fConstraintsChecked && !pAggregate.fConstraintError);
 
                 pAggregate.SetErrors(false);
-                _typeTable.InsertAggregate(name, agg, pAggregate);
+                _typeTable.InsertAggregate(agg, atsOuter, typeArgs, pAggregate);
 
                 // If we have a generic type definition, then we need to set the
                 // base class to be our current base type, and use that to calculate 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
@@ -23,8 +23,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool Equals(KeyPair<Key1, Key2> other)
         {
-            return Equals(_pKey1, other._pKey1)
-                && Equals(_pKey2, other._pKey2);
+            return EqualityComparer<Key1>.Default.Equals(_pKey1, other._pKey1)
+                && EqualityComparer<Key2>.Default.Equals(_pKey2, other._pKey2);
         }
 
 #if  DEBUG 
@@ -47,7 +47,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     internal sealed class TypeTable
     {
         // Two way hashes
-        private readonly Dictionary<KeyPair<AggregateSymbol, Name>, AggregateType> _pAggregateTable;
+        private readonly Dictionary<KeyPair<AggregateSymbol, KeyPair<AggregateType, TypeArray>>, AggregateType> _aggregateTable;
         private readonly Dictionary<KeyPair<CType, Name>, ArrayType> _pArrayTable;
         private readonly Dictionary<KeyPair<CType, Name>, ParameterModifierType> _pParameterModifierTable;
 
@@ -59,7 +59,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public TypeTable()
         {
-            _pAggregateTable = new Dictionary<KeyPair<AggregateSymbol, Name>, AggregateType>();
+            _aggregateTable = new Dictionary<KeyPair<AggregateSymbol, KeyPair<AggregateType, TypeArray>>, AggregateType>();
             _pErrorWithNamespaceParentTable = new Dictionary<Name, ErrorType>();
             _pArrayTable = new Dictionary<KeyPair<CType, Name>, ArrayType>();
             _pParameterModifierTable = new Dictionary<KeyPair<CType, Name>, ParameterModifierType>();
@@ -68,24 +68,20 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _pTypeParameterTable = new Dictionary<TypeParameterSymbol, TypeParameterType>();
         }
 
-        public AggregateType LookupAggregate(Name pName, AggregateSymbol pAggregate)
+        private static KeyPair<TKey1, TKey2> MakeKey<TKey1, TKey2>(TKey1 key1, TKey2 key2) =>
+            new KeyPair<TKey1, TKey2>(key1, key2);
+
+        public AggregateType LookupAggregate(AggregateSymbol aggregate, AggregateType outer, TypeArray args)
         {
-            var key = new KeyPair<AggregateSymbol, Name>(pAggregate, pName);
-            AggregateType result;
-            if (_pAggregateTable.TryGetValue(key, out result))
-            {
-                return result;
-            }
-            return null;
+            _aggregateTable.TryGetValue(MakeKey(aggregate, MakeKey(outer, args)), out AggregateType result);
+            return result;
         }
 
         public void InsertAggregate(
-                Name pName,
-                AggregateSymbol pAggregateSymbol,
-                AggregateType pAggregate)
+            AggregateSymbol aggregate, AggregateType outer, TypeArray args, AggregateType pAggregate)
         {
-            Debug.Assert(LookupAggregate(pName, pAggregateSymbol) == null);
-            _pAggregateTable.Add(new KeyPair<AggregateSymbol, Name>(pAggregateSymbol, pName), pAggregate);
+            Debug.Assert(LookupAggregate(aggregate, outer, args) == null);
+            _aggregateTable.Add(MakeKey(aggregate, MakeKey(outer, args)), pAggregate);
         }
 
         public ErrorType LookupError(Name pName) =>

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
@@ -39,8 +39,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public override int GetHashCode()
         {
-            return (_pKey1 == null ? 0 : _pKey1.GetHashCode())
-                + (_pKey2 == null ? 0 : _pKey2.GetHashCode());
+            int hash = _pKey1 == null ? 0 : _pKey1.GetHashCode();
+            return (hash << 5) - hash + (_pKey2 == null ? 0 : _pKey2.GetHashCode());
         }
     }
 


### PR DESCRIPTION
Avoid potential for false key matching.

Fixes #25201

* Remove `ErrorType.typeArgs`

Consistently empty for named errors, null for unnamed, so have no real effect.

Allows removal of remaining use of `GetNameFromPtrs()`

* Add multiply into KeyPair.GetHashCode()

Mix the bits a bit more.