### PR TITLE
Revert "Implement cancellation token for SslStream new AuthenticateAs*Async methods"

### DIFF
--- a/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
+++ b/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
@@ -53,7 +53,7 @@ namespace System.Net
                 int remainingCount = request.Count, offset = request.Offset;
                 do
                 {
-                    int bytes = await transport.ReadAsync(request.Buffer, offset, remainingCount, request.CancellationToken).ConfigureAwait(false);
+                    int bytes = await transport.ReadAsync(request.Buffer, offset, remainingCount, CancellationToken.None).ConfigureAwait(false);
                     if (bytes == 0)
                     {
                         if (remainingCount != request.Count)

--- a/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
+++ b/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
@@ -21,7 +21,7 @@ namespace System.Net
     internal class AsyncProtocolRequest
     {
 #if DEBUG
-        internal object _debugAsyncChain;         // Optionally used to track chains of async calls.
+        internal object _DebugAsyncChain;         // Optionally used to track chains of async calls.
 #endif
 
         private AsyncProtocolCallback _callback;
@@ -34,15 +34,12 @@ namespace System.Net
         public LazyAsyncResult UserAsyncResult;
         public int Result;
         public object AsyncState;
-        public readonly CancellationToken CancellationToken;
 
         public byte[] Buffer; // Temporary buffer reused by a protocol.
         public int Offset;
         public int Count;
 
-        public AsyncProtocolRequest(LazyAsyncResult userAsyncResult) : this(userAsyncResult, CancellationToken.None) { }
-
-        public AsyncProtocolRequest(LazyAsyncResult userAsyncResult, CancellationToken cancellationToken)
+        public AsyncProtocolRequest(LazyAsyncResult userAsyncResult)
         {
             if (userAsyncResult == null)
             {
@@ -52,9 +49,7 @@ namespace System.Net
             {
                 NetEventSource.Fail(this, "userAsyncResult is already completed.");
             }
-
             UserAsyncResult = userAsyncResult;
-            CancellationToken = cancellationToken;
         }
 
         public void Reset(LazyAsyncResult userAsyncResult)
@@ -77,7 +72,7 @@ namespace System.Net
             Offset = 0;
             Count = 0;
 #if DEBUG
-            _debugAsyncChain = 0;
+            _DebugAsyncChain = 0;
 #endif
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -185,7 +185,7 @@ namespace System.Net.Security
             _sslState.ValidateCreateContext(sslClientAuthenticationOptions);
 
             LazyAsyncResult result = new LazyAsyncResult(_sslState, asyncState, asyncCallback);
-            _sslState.ProcessAuthentication(result, cancellationToken);
+            _sslState.ProcessAuthentication(result);
             return result;
         }
 
@@ -239,7 +239,7 @@ namespace System.Net.Security
             _sslState.ValidateCreateContext(sslServerAuthenticationOptions);
 
             LazyAsyncResult result = new LazyAsyncResult(_sslState, asyncState, asyncCallback);
-            _sslState.ProcessAuthentication(result, cancellationToken);
+            _sslState.ProcessAuthentication(result);
             return result;
         }
 
@@ -307,7 +307,7 @@ namespace System.Net.Security
             sslClientAuthenticationOptions._certSelectionDelegate = _certSelectionDelegate;
 
             _sslState.ValidateCreateContext(sslClientAuthenticationOptions);
-            _sslState.ProcessAuthentication(null, CancellationToken.None);
+            _sslState.ProcessAuthentication(null);
         }
 
         public virtual void AuthenticateAsServer(X509Certificate serverCertificate)
@@ -343,7 +343,7 @@ namespace System.Net.Security
             sslServerAuthenticationOptions._certValidationDelegate = _certValidationDelegate;
 
             _sslState.ValidateCreateContext(sslServerAuthenticationOptions);
-            _sslState.ProcessAuthentication(null, CancellationToken.None);
+            _sslState.ProcessAuthentication(null);
         }
         #endregion
 

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -61,60 +61,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        public void SslStream_StreamToStream_ClientCancellation_Throws()
-        {
-            VirtualNetwork network = new VirtualNetwork();
-            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
-            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
-            using (var client = new SslStream(clientStream))
-            using (var server = new SslStream(serverStream))
-            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
-            {
-                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions();
-                clientOptions.RemoteCertificateValidationCallback = AllowAnyServerCertificate;
-                clientOptions.TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false);
-
-                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions();
-                serverOptions.ServerCertificate = certificate;
-
-                CancellationTokenSource cts = new CancellationTokenSource();
-                cts.Cancel();
-
-                Task clientTask = Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.AuthenticateAsClientAsync(clientOptions, cts.Token));
-                Task serverTask = Assert.ThrowsAsync<TimeoutException>(() => server.AuthenticateAsServerAsync(serverOptions, CancellationToken.None));
-
-                Assert.True(Task.WaitAll(new[] { clientTask, serverTask }, TestConfiguration.PassingTestTimeoutMilliseconds));
-            }
-        }
-
-        [Fact]
-        public void SslStream_StreamToStream_ServerCancellation_Throws()
-        {
-            VirtualNetwork network = new VirtualNetwork();
-            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
-            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
-            using (var client = new SslStream(clientStream))
-            using (var server = new SslStream(serverStream))
-            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
-            {
-                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions();
-                clientOptions.RemoteCertificateValidationCallback = AllowAnyServerCertificate;
-                clientOptions.TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false);
-
-                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions();
-                serverOptions.ServerCertificate = certificate;
-
-                CancellationTokenSource cts = new CancellationTokenSource();
-                cts.Cancel();
-
-                Task clientTask = Assert.ThrowsAsync<TimeoutException>(() => client.AuthenticateAsClientAsync(clientOptions, CancellationToken.None));
-                Task serverTask = Assert.ThrowsAnyAsync<OperationCanceledException>(() => server.AuthenticateAsServerAsync(serverOptions, cts.Token));
-
-                Assert.True(Task.WaitAll(new[] { clientTask, serverTask }, TestConfiguration.PassingTestTimeoutMilliseconds));
-            }
-        }
-
-        [Fact]
         public void SslStream_StreamToStream_DuplicateOptions_Throws()
         {
             RemoteCertificateValidationCallback rCallback = (sender, certificate, chain, errors) => { return true; };
@@ -193,8 +139,8 @@ namespace System.Net.Security.Tests
                     ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 },
                     ServerCertificate = certificate,
                 };
-
-                Task t1 = Assert.ThrowsAsync<TimeoutException>(() => client.AuthenticateAsClientAsync(clientOptions, CancellationToken.None));
+                
+                Task t1 = Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(clientOptions, CancellationToken.None));
                 Task t2 = Assert.ThrowsAsync<AuthenticationException>(() => server.AuthenticateAsServerAsync(serverOptions, CancellationToken.None));
 
                 Assert.True(Task.WaitAll(new[] { t1, t2 }, TestConfiguration.PassingTestTimeoutMilliseconds));

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
@@ -183,7 +183,7 @@ namespace System.Net.Security
         // This method assumes that a SSPI context is already in a good shape.
         // For example it is either a fresh context or already authenticated context that needs renegotiation.
         //
-        internal void ProcessAuthentication(LazyAsyncResult lazyResult, CancellationToken cancellationToken)
+        internal void ProcessAuthentication(LazyAsyncResult lazyResult)
         {
         }
 


### PR DESCRIPTION
Reverts dotnet/corefx#24857

Per investigation in https://github.com/dotnet/corefx/pull/25199, https://github.com/dotnet/corefx/pull/25198
cc: @Priya91 