### PR TITLE
Disable SendAsync_ExpectedDiagnosticCancelledActivityLogging test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -582,6 +582,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseManagedHandler.ToString()).Dispose();
         }
 
+        [ActiveIssue(23209)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendAsync_ExpectedDiagnosticCancelledActivityLogging()


### PR DESCRIPTION
It's failing sporadically on outerloop, both Windows and Unix, both WinHttp/CurlHandler and ManagedHandler.