### PR TITLE
Fix handling of unary operations on nullable enums in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
@@ -25,18 +25,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             return _pErrorContext;
         }
+
         private static bool IsNullableConstructor(Expr expr, out ExprCall call)
         {
             Debug.Assert(expr != null);
 
-            if (expr is ExprCall pCall && pCall.MemberGroup.OptionalObject == null)
+            if (expr is ExprCall pCall && pCall.MemberGroup.OptionalObject == null
+                && (pCall.MethWithInst?.Meth().IsNullableConstructor() ?? false))
             {
-                MethodSymbol meth = pCall.MethWithInst.Meth();
-                if (meth != null && meth.IsNullableConstructor())
-                {
-                    call = pCall;
-                    return true;
-                }
+                call = pCall;
+                return true;
             }
 
             call = null;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1396,26 +1396,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // Enum types are special in that they carry a set of "predefined" operators (~ and inc/dec).
                 if (pRawType.isEnumType())
                 {
+                    // Nullable enums are dealt with already.
+                    Debug.Assert(pRawType == pArgumentType);
+                    Debug.Assert(pArgumentType is AggregateType);
                     if ((unaryOpMask & (UnaOpMask.Tilde | UnaOpMask.IncDec)) != 0)
                     {
                         // We have an exact match.
-                        LiftFlags liftFlags = LiftFlags.None;
-                        CType typeSig = pArgumentType;
-
-                        if (typeSig is NullableType nubTypeSig)
-                        {
-                            if (nubTypeSig.GetUnderlyingType() != pRawType)
-                            {
-                                typeSig = GetSymbolLoader().GetTypeManager().GetNullable(pRawType);
-                            }
-                            liftFlags = LiftFlags.Lift1;
-                        }
                         if (unaryOpKind == UnaOpKind.Tilde)
                         {
                             pSignatures.Add(new UnaOpFullSig(
-                                    typeSig.getAggregate().GetUnderlyingType(),
+                                    pArgumentType.getAggregate().GetUnderlyingType(),
                                     BindEnumUnaOp,
-                                    liftFlags,
+                                    LiftFlags.None,
                                     UnaOpFuncKind.EnumUnaOp));
                         }
                         else
@@ -1423,11 +1415,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             // For enums, we want to add the signature as the underlying type so that we'll
                             // perform the conversions to and from the enum type.
                             pSignatures.Add(new UnaOpFullSig(
-                                    typeSig.getAggregate().GetUnderlyingType(),
+                                    pArgumentType.getAggregate().GetUnderlyingType(),
                                     null,
-                                    liftFlags,
+                                    LiftFlags.None,
                                     UnaOpFuncKind.None));
                         }
+
                         return UnaryOperatorSignatureFindResult.Match;
                     }
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -499,28 +499,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             Expr origOp = expr.Child;
 
-            return GenerateBuiltInUnaryOperator(pdm, origOp, expr);
-        }
-
-        private Expr GenerateBuiltInUnaryOperator(PREDEFMETH pdm, Expr pOriginalOperator, Expr pOperator)
-        {
-            Expr op = Visit(pOriginalOperator);
-            bool isNullableEnum = pOriginalOperator.Type is NullableType nub && nub.underlyingType().isEnumType();
-            if (isNullableEnum)
-            {
-                Debug.Assert(pOperator.Kind == ExpressionKind.BitwiseNot); // The only built-in unary operator defined on nullable enum.
-                CType underlyingType = pOriginalOperator.Type.StripNubs().underlyingEnumType();
-                CType nullableType = GetSymbolLoader().GetTypeManager().GetNullable(underlyingType);
-                op = GenerateCall(PREDEFMETH.PM_EXPRESSION_CONVERT, op, CreateTypeOf(nullableType));
-            }
-
-            Expr call = GenerateCall(pdm, op);
-            if (isNullableEnum)
-            {
-                call = GenerateCall(PREDEFMETH.PM_EXPRESSION_CONVERT, call, CreateTypeOf(pOperator.Type));
-            }
-
-            return call;
+            // Such operations are always already casts on operations on casts.
+            Debug.Assert(!(origOp.Type is NullableType nub) || !nub.UnderlyingType.isEnumType());
+            return GenerateCall(pdm, Visit(origOp));
         }
 
         private Expr GenerateUserDefinedBinaryOperator(ExprBinOp expr)

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -17,6 +17,7 @@
     <Compile Include="IntegerBinaryOperationTests.cs" />
     <Compile Include="IntegerUnaryOperationTests.cs" />
     <Compile Include="IsEventTests.cs" />
+    <Compile Include="NullableEnumUnaryOperationTest.cs" />
     <Compile Include="RuntimeBinderExceptionTests.cs" />
     <Compile Include="RuntimeBinderInternalCompilerExceptionTests.cs" />
     <Compile Include="RuntimeBinderTests.cs" />

--- a/src/Microsoft.CSharp/tests/NullableEnumUnaryOperationTest.cs
+++ b/src/Microsoft.CSharp/tests/NullableEnumUnaryOperationTest.cs
@@ -1,0 +1,186 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public class NullableEnumUnaryOperationTest
+    {
+        public enum Int8Enum
+        {
+            A,
+            B,
+            C,
+            D,
+            E
+        }
+
+        public enum Int32Enum
+        {
+            A,
+            B,
+            C,
+            D,
+            E
+        }
+
+        public enum UInt32Enum
+        {
+            A,
+            B,
+            C,
+            D,
+            E
+        }
+
+        public enum Int64Enum : long
+        {
+            A,
+            B,
+            C,
+            D,
+            E
+        }
+
+        public static IEnumerable<object[]> Int8Enums() => Enum.GetValues(typeof(Int8Enum))
+            .Cast<Int8Enum>()
+            .Select(x => new object[] { x });
+
+        public static IEnumerable<object[]> Int8NullableEnums() => Int8Enums().Append(new object[] { null });
+
+        public static IEnumerable<object[]> Int32Enums() => Enum.GetValues(typeof(Int32Enum))
+            .Cast<Int32Enum>()
+            .Select(x => new object[] { x });
+
+        public static IEnumerable<object[]> Int32NullableEnums() => Int32Enums().Append(new object[] { null });
+
+        public static IEnumerable<object[]> UInt32Enums() => Enum.GetValues(typeof(UInt32Enum))
+            .Cast<UInt32Enum>()
+            .Select(x => new object[] { x });
+
+        public static IEnumerable<object[]> UInt32NullableEnums() => UInt32Enums().Append(new object[] { null });
+
+        public static IEnumerable<object[]> Int64Enums() => Enum.GetValues(typeof(Int64Enum))
+            .Cast<Int64Enum>()
+            .Select(x => new object[] { x });
+
+        public static IEnumerable<object[]> Int64NullableEnums() => Int64Enums().Append(new object[] { null });
+
+        [Theory, MemberData(nameof(Int8NullableEnums)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "25067 is not fixed in NetFX")]
+        public void ComplementInt8NullableEnum(Int8Enum? value)
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.OnesComplement,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, Int8Enum?, object>> site = CallSite<Func<CallSite, Int8Enum?, object>>.Create(binder);
+            Func<CallSite, Int8Enum?, object> targ = site.Target;
+            object result = targ(site, value);
+            Assert.Equal(~value, result);
+        }
+
+        [Theory, MemberData(nameof(Int32NullableEnums)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "25067 is not fixed in NetFX")]
+        public void ComplementInt32NullableEnum(Int32Enum? value)
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.OnesComplement,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, Int32Enum?, object>> site = CallSite<Func<CallSite, Int32Enum?, object>>.Create(binder);
+            Func<CallSite, Int32Enum?, object> targ = site.Target;
+            object result = targ(site, value);
+            Assert.Equal(~value, result);
+        }
+
+        [Theory, MemberData(nameof(UInt32NullableEnums)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "25067 is not fixed in NetFX")]
+        public void ComplementUInt32NullableEnum(UInt32Enum? value)
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.OnesComplement,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, UInt32Enum?, object>> site = CallSite<Func<CallSite, UInt32Enum?, object>>.Create(binder);
+            Func<CallSite, UInt32Enum?, object> targ = site.Target;
+            object result = targ(site, value);
+            Assert.Equal(~value, result);
+        }
+
+        [Theory, MemberData(nameof(Int64NullableEnums)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "25067 is not fixed in NetFX")]
+        public void ComplementInt64NullableEnum(Int64Enum? value)
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.OnesComplement,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, Int64Enum?, object>> site = CallSite<Func<CallSite, Int64Enum?, object>>.Create(binder);
+            Func<CallSite, Int64Enum?, object> targ = site.Target;
+            object result = targ(site, value);
+            Assert.Equal(~value, result);
+        }
+
+        [Theory, MemberData(nameof(Int32Enums))]
+        public void IncrementInt32NullableEnum(Int32Enum? value)
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.Increment,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, Int32Enum?, object>> site = CallSite<Func<CallSite, Int32Enum?, object>>.Create(binder);
+            Func<CallSite, Int32Enum?, object> targ = site.Target;
+            object result = targ(site, value);
+            Assert.Equal(++value, result); // Note that there is no write-back to value.
+        }
+
+        [Theory, MemberData(nameof(Int32Enums))]
+        public void DecrementInt32NullableEnum(Int32Enum? value)
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.Decrement,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, Int32Enum?, object>> site = CallSite<Func<CallSite, Int32Enum?, object>>.Create(binder);
+            Func<CallSite, Int32Enum?, object> targ = site.Target;
+            object result = targ(site, value);
+            Assert.Equal(--value, result); // Note that there is no write-back to value.
+        }
+
+        [Fact]
+        public void CannotIncrementNullNullableEnum()
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.Increment,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, Int32Enum?, object>> site = CallSite<Func<CallSite, Int32Enum?, object>>.Create(binder);
+            Func<CallSite, Int32Enum?, object> targ = site.Target;
+            Assert.Throws<RuntimeBinderException>(() => targ(site, default));
+        }
+
+        [Fact]
+        public void CannotDecrementNullNullableEnum()
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+            CallSiteBinder binder =
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.Decrement,
+                    GetType(), new[] { x });
+            CallSite<Func<CallSite, Int32Enum?, object>> site = CallSite<Func<CallSite, Int32Enum?, object>>.Create(binder);
+            Func<CallSite, Int32Enum?, object> targ = site.Target;
+            Assert.Throws<RuntimeBinderException>(() => targ(site, default));
+        }
+    }
+}


### PR DESCRIPTION
The code that covered this case would put a `NullableType` where an `AggregateType` would then be expected, and throw `NullReferenceException` after an `as AggregateType` it would hit. There was also no code to handle the necessary cast, then lifted operation, then cast back.

Catch the case of nullable enums early, and turn it into a cast on the operation on a cast to the underlying type (or `int` if smaller than `int`)

Fixes #25067

* Remove now-dead buggy code for unary operators and nullable enums.

* Remove dead code in `ExpressionTreeRewriter`

Would carry out the cast-of-operation-of-cast rewrite already done in the initial bind, but this having been already done makes it unreachable.