### PR TITLE
Microsoft.CSharp: Remove check for ExprMemberGroup being used as a lvalue

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -63,7 +63,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_ReturnNotLValue = 1612,
         ERR_AssgReadonly2 = 1648,
         ERR_AssgReadonlyStatic2 = 1650,
-        ERR_AssgReadonlyLocalCause = 1656,
         ERR_BadCtorArgCount = 1729,
         ERR_NonInvocableMemberCalled = 1955,
         ERR_NamedArgumentSpecificationBeforeFixedArgument = 5002,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -185,9 +185,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case ErrorCode.ERR_AssgReadonlyStatic2:
                     codeStr = SR.AssgReadonlyStatic2;
                     break;
-                case ErrorCode.ERR_AssgReadonlyLocalCause:
-                    codeStr = SR.AssgReadonlyLocalCause;
-                    break;
                 case ErrorCode.ERR_BadCtorArgCount:
                     codeStr = SR.BadCtorArgCount;
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFmt.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFmt.cs
@@ -17,20 +17,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
     internal enum ErrArgKind
     {
         Int,
-        Hresult,
-        Ids,
         SymKind,
         Sym,
         Type,
         Name,
         Str,
-        PredefName,
-        LocNode,
-        Ptr,
         SymWithType,
         MethWithInst,
-        Expr,
-        Lim
     }
 
     [Flags]
@@ -59,7 +52,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
     {
         public ErrArgKind eak;
         public ErrArgFlags eaf;
-        internal MessageID ids;
         internal int n;
         internal SYMKIND sk;
         internal Name name;
@@ -181,16 +173,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             this.eak = ErrArgKind.Type;
             this.eaf = ErrArgFlags.None;
             this.pType = pType;
-        }
-    }
-
-    internal sealed class ErrArgIds : ErrArg
-    {
-        public ErrArgIds(MessageID ids)
-        {
-            this.eak = ErrArgKind.Ids;
-            this.eaf = ErrArgFlags.None;
-            this.ids = ids;
         }
     }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -614,9 +614,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
             switch (parg.eak)
             {
-                case ErrArgKind.Ids:
-                    ErrId(out psz, parg.ids);
-                    break;
                 case ErrArgKind.SymKind:
                     ErrSK(out psz, parg.sk);
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1126,6 +1126,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             Debug.Assert(!(expr is ExprLocal));
+            Debug.Assert(!(expr is ExprMemberGroup));
 
             switch (expr.Kind)
             {
@@ -1163,10 +1164,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case ExpressionKind.BoundLambda:
                 case ExpressionKind.Constant:
                     throw ErrorContext.Error(GetStandardLvalueError(kind));
-
-                case ExpressionKind.MemberGroup:
-                    ErrorCode err = ErrorCode.ERR_AssgReadonlyLocalCause;
-                    throw ErrorContext.Error(err, ((ExprMemberGroup)expr).Name, new ErrArgIds(MessageID.MethodGroup));
             }
 
             TryReportLvalueFailure(expr, kind);

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -268,9 +268,6 @@
   <data name="AssgReadonlyStatic2" xml:space="preserve">
     <value>Fields of static readonly field '{0}' cannot be assigned to (except in a static constructor or a variable initializer)</value>
   </data>
-  <data name="AssgReadonlyLocalCause" xml:space="preserve">
-    <value>Cannot assign to '{0}' because it is a '{1}'</value>
-  </data>
   <data name="BadCtorArgCount" xml:space="preserve">
     <value>'{0}' does not contain a constructor that takes '{1}' arguments</value>
   </data>


### PR DESCRIPTION
`ExprMemberGroup`s only exist within `ExprCall` and `ExprProperty` objects and can never be passed as operands, so this is unreachable. (Unlike in static compilation where it would be the result of someone trying e.g. `obj.ToString = 3`).

Results in removal of ERR_AssgReadonlyLocalCause, contributes to #22470.

* Remove `ErrArgIds` class

Only place it was instantiated has now been removed.

Clean-up all unused `ErrArgKind` as well as `Ids` that this makes unused.