### PR TITLE
Microsoft.CSharp: Remove code for checking possible membergroup → delegate conversion

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_ObjectRequired = 120,
         ERR_AmbigCall = 121,
         ERR_BadAccess = 122,
-        ERR_MethDelegateMismatch = 123,
         ERR_AssgLvalueExpected = 131,
         ERR_NoConstructors = 143,
         ERR_PropertyLacksGet = 154,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -59,9 +59,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case ErrorCode.ERR_BadAccess:
                     codeStr = SR.BadAccess;
                     break;
-                case ErrorCode.ERR_MethDelegateMismatch:
-                    codeStr = SR.MethDelegateMismatch;
-                    break;
                 case ErrorCode.ERR_AssgLvalueExpected:
                     codeStr = SR.AssgLvalueExpected;
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -916,7 +916,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             ArgInfos pOriginalArgInfo = new ArgInfos {carg = carg};
             FillInArgInfoFromArgList(pOriginalArgInfo, args);
 
-            GroupToArgsBinder binder = new GroupToArgsBinder(this, bindFlags, grp, pargInfo, pOriginalArgInfo, bHasNamedArgumentSpecifiers, null/*atsDelegate*/);
+            GroupToArgsBinder binder = new GroupToArgsBinder(this, bindFlags, grp, pargInfo, pOriginalArgInfo, bHasNamedArgumentSpecifiers);
             bool retval = binder.Bind(bReportErrors: true);
 
             pResults = binder.GetResultsOfBind();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -33,7 +33,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private readonly ArgInfos _pArguments;
             private readonly ArgInfos _pOriginalArguments;
             private readonly bool _bHasNamedArguments;
-            private readonly AggregateType _pDelegate;
             private AggregateType _pCurrentType;
             private MethodOrPropertySymbol _pCurrentSym;
             private TypeArray _pCurrentTypeArgs;
@@ -57,7 +56,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private readonly List<CType> _HiddenTypes;
             private bool _bArgumentsChangedForNamedOrOptionalArguments;
 
-            public GroupToArgsBinder(ExpressionBinder exprBinder, BindingFlag bindFlags, ExprMemberGroup grp, ArgInfos args, ArgInfos originalArgs, bool bHasNamedArguments, AggregateType atsDelegate)
+            public GroupToArgsBinder(ExpressionBinder exprBinder, BindingFlag bindFlags, ExprMemberGroup grp, ArgInfos args, ArgInfos originalArgs, bool bHasNamedArguments)
             {
                 Debug.Assert(grp != null);
                 Debug.Assert(exprBinder != null);
@@ -70,7 +69,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 _pArguments = args;
                 _pOriginalArguments = originalArgs;
                 _bHasNamedArguments = bHasNamedArguments;
-                _pDelegate = atsDelegate;
                 _pCurrentType = null;
                 _pCurrentSym = null;
                 _pCurrentTypeArgs = null;
@@ -95,7 +93,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(_pGroup.SymKind == SYMKIND.SK_MethodSymbol || _pGroup.SymKind == SYMKIND.SK_PropertySymbol && 0 != (_pGroup.Flags & EXPRFLAG.EXF_INDEXER));
 
                 // We need the Exprs for error reporting for non-delegates
-                Debug.Assert(_pDelegate != null || _pArguments.fHasExprs);
+                Debug.Assert(_pArguments.fHasExprs);
 
                 LookForCandidates();
                 if (!GetResultOfBind(bReportErrors))
@@ -1193,7 +1191,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
             }
 
-            private Exception ReportErrorsOnFailure()
+            private RuntimeBinderException ReportErrorsOnFailure()
             {
                 // First and foremost, report if the user specified a name more than once.
                 if (_pDuplicateSpecifiedName != null)
@@ -1234,7 +1232,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 if (_results.GetBestResult())
                 {
                     // If we had some invalid arguments for best matching.
-                    return ReportErrorsForBestMatching(bUseDelegateErrors, nameErr);
+                    return ReportErrorsForBestMatching(bUseDelegateErrors);
                 }
 
                 if (_results.GetUninferableResult() || _mpwiCantInferInstArg)
@@ -1281,11 +1279,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return GetErrorContext().Error(ErrorCode.ERR_NamedArgumentUsedInPositional, _pNameUsedInPositionalArgument);
                 }
 
-                if (_pDelegate != null)
-                {
-                    return GetErrorContext().Error(ErrorCode.ERR_MethDelegateMismatch, nameErr, _pDelegate);
-                }
-
                 // The number of arguments must be wrong.
 
                 if (_fCandidatesUnsupported)
@@ -1308,15 +1301,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return GetErrorContext().Error(ErrorCode.ERR_BadArgCount, nameErr, _pArguments.carg);
             }
 
-            private RuntimeBinderException ReportErrorsForBestMatching(bool bUseDelegateErrors, Name nameErr)
+            private RuntimeBinderException ReportErrorsForBestMatching(bool bUseDelegateErrors)
             {
-                // Best matching overloaded method 'name' had some invalid arguments.
-                if (_pDelegate != null)
-                {
-                    return GetErrorContext().Error(
-                        ErrorCode.ERR_MethDelegateMismatch, nameErr, _pDelegate, _results.GetBestResult());
-                }
-
                 if (bUseDelegateErrors)
                 {
                     // Point to the Delegate, not the Invoke method

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -283,33 +283,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         ////////////////////////////////////////////////////////////////////////////////
-
-        private TypeArray GetFixedDelegateParameters(AggregateType pDelegateType)
-        {
-            Debug.Assert(pDelegateType.isDelegateType());
-
-            // We have a delegate where the input types use no unfixed parameters.  Create
-            // a substitution context; we can substitute unfixed parameters for themselves
-            // since they don't actually occur in the inputs.  (They may occur in the outputs,
-            // or there may be input parameters fixed to _unfixed_ method CType variables.
-            // Both of those scenarios are legal.)
-
-            CType[] ppMethodParameters = new CType[_pMethodTypeParameters.Count];
-            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; iParam++)
-            {
-                TypeParameterType pParam = (TypeParameterType)_pMethodTypeParameters[iParam];
-                ppMethodParameters[iParam] = IsUnfixed(iParam) ? pParam : _pFixedResults[iParam];
-            }
-            SubstContext subsctx = new SubstContext(_pClassTypeArguments.Items, _pClassTypeArguments.Count,
-                ppMethodParameters, _pMethodTypeParameters.Count);
-            AggregateType pFixedDelegateType =
-                GetTypeManager().SubstType(pDelegateType, subsctx) as AggregateType;
-            TypeArray pFixedDelegateParams =
-                pFixedDelegateType.GetDelegateParameters(GetSymbolLoader());
-            return pFixedDelegateParams;
-        }
-
-        ////////////////////////////////////////////////////////////////////////////////
         //
         // Phases
         //
@@ -565,7 +538,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     {
                         pSource = modSource.GetParameterType();
                     }
-                    OutputTypeInference(pExpr, pSource, pDest);
+
+                    Debug.Assert(!(pExpr is ExprMemberGroup));
+                    OutputTypeInference(pSource, pDest);
                 }
             }
         }
@@ -1019,8 +994,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         ////////////////////////////////////////////////////////////////////////////////
 
-        private void OutputTypeInference(Expr pExpr, CType pSource, CType pDest)
+        private void OutputTypeInference(CType pSource, CType pDest)
         {
+            // Skipped part of spec: We can never have a method group expression here, so this
+            // never applies.
             // SPEC: An output CType inference is made from an expression E to a CType T
             // SPEC: in the following way:
 
@@ -1033,10 +1010,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // SPEC:   CType Tb and overload resolution of E with the types T1...Tk
             // SPEC:   yields a single method with return CType U then a lower-bound
             // SPEC:   inference is made from U to Tb.
-            if (MethodGroupReturnTypeInference(pExpr, pDest))
-            {
-                return;
-            }
+            // End of skipped part.
+
             // SPEC:  Otherwise, if E is an expression with CType U then a lower-bound
             // SPEC:   inference is made from U to T.
             if (IsReallyAType(pSource))
@@ -1044,66 +1019,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 LowerBoundInference(pSource, pDest);
             }
             // SPEC:  Otherwise, no inferences are made.
-        }
-
-        ////////////////////////////////////////////////////////////////////////////////
-
-        private bool MethodGroupReturnTypeInference(Expr pSource, CType pType)
-        {
-            // SPEC:  Otherwise, if E is a method group and T is a delegate CType or
-            // SPEC:   expression tree CType with parameter types T1...Tk and return
-            // SPEC:   CType Tb and overload resolution of E with the types T1...Tk
-            // SPEC:   yields a single method with return CType U then a lower-bound
-            // SPEC:   inference is made from U to Tb.
-
-            if (!(pSource is ExprMemberGroup memGrp))
-            {
-                return false;
-            }
-            pType = pType.GetDelegateTypeOfPossibleExpression();
-            if (!pType.isDelegateType())
-            {
-                return false;
-            }
-            AggregateType pDelegateType = pType as AggregateType;
-            CType pDelegateReturnType = pDelegateType.GetDelegateReturnType(GetSymbolLoader());
-            if (pDelegateReturnType == null)
-            {
-                return false;
-            }
-            if (pDelegateReturnType is VoidType)
-            {
-                return false;
-            }
-
-            // At this point we are in the second phase; we know that all the input types are fixed.
-
-            TypeArray pDelegateParameters = GetFixedDelegateParameters(pDelegateType);
-            if (pDelegateParameters == null)
-            {
-                return false;
-            }
-
-            ArgInfos argInfo = new ArgInfos() { carg = pDelegateParameters.Count, types = pDelegateParameters, fHasExprs = false, prgexpr = null };
-
-            var argsBinder = new ExpressionBinder.GroupToArgsBinder(_binder, 0/* flags */, memGrp, argInfo, null, false, pDelegateType);
-
-            bool success = argsBinder.Bind(false);
-            if (!success)
-            {
-                return false;
-            }
-
-            MethPropWithInst mwi = argsBinder.GetResultsOfBind().GetBestResult();
-            CType pMethodReturnType = GetTypeManager().SubstType(mwi.Meth().RetType,
-                mwi.GetType(), mwi.TypeArgs);
-            if (pMethodReturnType is VoidType)
-            {
-                return false;
-            }
-
-            LowerBoundInference(pMethodReturnType, pDelegateReturnType);
-            return true;
         }
 
         ////////////////////////////////////////////////////////////////////////////////

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -142,9 +142,6 @@
   <data name="BadAccess" xml:space="preserve">
     <value>'{0}' is inaccessible due to its protection level</value>
   </data>
-  <data name="MethDelegateMismatch" xml:space="preserve">
-    <value>No overload for '{0}' matches delegate '{1}'</value>
-  </data>
   <data name="AssgLvalueExpected" xml:space="preserve">
     <value>The left-hand side of an assignment must be a variable, property or indexer</value>
   </data>


### PR DESCRIPTION
* Remove `MethodGroupReturnTypeInference()` method.

Initial `if (!(pSource is ExprMemberGroup memGrp))` will always be hit, since we can't have a member group expression as an argument within dynamic code, so it will always return false.

* Remove `GroupToArgsBinder._pDelegate`

The only remaining call to the constructor always passes null to this.
Remove it, and paths for it being non-null.

Results in removal of `ERR_MethDelegateMismatch`. Contributes to #22470