### PR TITLE
Force Microsoft.XmlSerializer.Generator to use the same PrereleaseLabel as the other packages

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/dir.props
+++ b/src/Microsoft.XmlSerializer.Generator/dir.props
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <PreReleaseLabel>preview1</PreReleaseLabel>
     <PackageVersion>1.0.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>


### PR DESCRIPTION
This is to resolve conflict during publish due to packages having the same name.

@weshaggard @dagood @MichalStrehovsky @shmao 