### PR TITLE
Ensure Microsoft.CSharp's binders only enumerate arguments once.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
@@ -384,7 +384,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        internal static CallInfo CreateCallInfo(IEnumerable<CSharpArgumentInfo> argInfos, int discard)
+        internal static CallInfo CreateCallInfo(ref IEnumerable<CSharpArgumentInfo> argInfos, int discard)
         {
             // This function converts the C# Binder's notion of argument information to the
             // DLR's notion. The DLR counts arguments differently than C#. Here are some
@@ -402,8 +402,9 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             int argCount = 0;
             List<string> argNames = new List<string>();
-
-            foreach (CSharpArgumentInfo info in argInfos)
+            CSharpArgumentInfo[] infoArray = ToArray(argInfos);
+            argInfos = infoArray; // Write back the array to allow single enumeration.
+            foreach (CSharpArgumentInfo info in infoArray)
             {
                 if (info.NamedArgument)
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetIndexBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetIndexBinder.cs
@@ -48,10 +48,10 @@ namespace Microsoft.CSharp.RuntimeBinder
         public CSharpGetIndexBinder(
             Type callingContext,
             IEnumerable<CSharpArgumentInfo> argumentInfo) :
-            base(BinderHelper.CreateCallInfo(argumentInfo, 1)) // discard 1 argument: the target object
+            base(BinderHelper.CreateCallInfo(ref argumentInfo, 1)) // discard 1 argument: the target object
         {
             CallingContext = callingContext;
-            _argumentInfo = BinderHelper.ToArray(argumentInfo);
+            _argumentInfo = argumentInfo as CSharpArgumentInfo[];
             _binder = RuntimeBinder.GetInstance();
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
@@ -57,11 +57,11 @@ namespace Microsoft.CSharp.RuntimeBinder
                 CSharpCallFlags flags,
                 Type callingContext,
                 IEnumerable<CSharpArgumentInfo> argumentInfo) :
-            base(BinderHelper.CreateCallInfo(argumentInfo, 1)) // discard 1 argument: the target object (even if static, arg is type)
+            base(BinderHelper.CreateCallInfo(ref argumentInfo, 1)) // discard 1 argument: the target object (even if static, arg is type)
         {
             _flags = flags;
             CallingContext = callingContext;
-            _argumentInfo = BinderHelper.ToArray(argumentInfo);
+            _argumentInfo = argumentInfo as CSharpArgumentInfo[];
             _binder = RuntimeBinder.GetInstance();
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeMemberBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeMemberBinder.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 Type callingContext,
                 IEnumerable<Type> typeArguments,
                 IEnumerable<CSharpArgumentInfo> argumentInfo) :
-            base(name, false, BinderHelper.CreateCallInfo(argumentInfo, 1)) // discard 1 argument: the target object (even if static, arg is type)
+            base(name, false, BinderHelper.CreateCallInfo(ref argumentInfo, 1)) // discard 1 argument: the target object (even if static, arg is type)
         {
             Flags = flags;
             CallingContext = callingContext;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetIndexBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetIndexBinder.cs
@@ -53,12 +53,12 @@ namespace Microsoft.CSharp.RuntimeBinder
             bool isChecked,
             Type callingContext,
             IEnumerable<CSharpArgumentInfo> argumentInfo) :
-            base(BinderHelper.CreateCallInfo(argumentInfo, 2)) // discard 2 arguments: the target object and the value
+            base(BinderHelper.CreateCallInfo(ref argumentInfo, 2)) // discard 2 arguments: the target object and the value
         {
             IsCompoundAssignment = isCompoundAssignment;
             IsChecked = isChecked;
             CallingContext = callingContext;
-            _argumentInfo = BinderHelper.ToArray(argumentInfo);
+            _argumentInfo = argumentInfo as CSharpArgumentInfo[];
             _binder = RuntimeBinder.GetInstance();
         }
 


### PR DESCRIPTION
Fixes #25225