### PR TITLE
Remove some unreachable errors from Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
@@ -13,11 +13,6 @@ namespace Microsoft.CSharp.RuntimeBinder
             return new RuntimeBinderInternalCompilerException(SR.InternalCompilerError);
         }
 
-        internal static Exception BindRequireArguments()
-        {
-            return new ArgumentException(SR.BindRequireArguments);
-        }
-
         internal static Exception BindCallFailedOverloadResolution()
         {
             return new RuntimeBinderException(SR.BindCallFailedOverloadResolution);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
@@ -23,11 +23,6 @@ namespace Microsoft.CSharp.RuntimeBinder
             return new RuntimeBinderException(SR.BindCallFailedOverloadResolution);
         }
 
-        internal static Exception BindUnaryOperatorRequireOneArgument()
-        {
-            return new ArgumentException(SR.BindUnaryOperatorRequireOneArgument);
-        }
-
         internal static Exception BindBinaryAssignmentRequireTwoArguments()
         {
             return new ArgumentException(SR.BindBinaryAssignmentRequireTwoArguments);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
@@ -23,11 +23,6 @@ namespace Microsoft.CSharp.RuntimeBinder
             return new RuntimeBinderException(SR.BindCallFailedOverloadResolution);
         }
 
-        internal static Exception BindBinaryOperatorRequireTwoArguments()
-        {
-            return new ArgumentException(SR.BindBinaryOperatorRequireTwoArguments);
-        }
-
         internal static Exception BindUnaryOperatorRequireOneArgument()
         {
             return new ArgumentException(SR.BindUnaryOperatorRequireOneArgument);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
@@ -23,11 +23,6 @@ namespace Microsoft.CSharp.RuntimeBinder
             return new RuntimeBinderException(SR.BindCallFailedOverloadResolution);
         }
 
-        internal static Exception BindBinaryAssignmentRequireTwoArguments()
-        {
-            return new ArgumentException(SR.BindBinaryAssignmentRequireTwoArguments);
-        }
-
         internal static Exception BindPropertyFailedMethodGroup(object p0)
         {
             return new RuntimeBinderException(SR.Format(SR.BindPropertyFailedMethodGroup, p0));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -146,10 +146,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             DynamicMetaObject[] args,
             out DynamicMetaObject deferredBinding)
         {
-            if (args.Length < 1)
-            {
-                throw Error.BindRequireArguments();
-            }
+            Debug.Assert(args.Length >= 1);
 
             InitializeCallingContext(payload);
             ArgumentObject[] arguments = CreateArgumentArray(payload, parameters, args);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1463,10 +1463,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             ArgumentObject[] arguments,
             LocalVariableSymbol[] locals)
         {
-            if (arguments.Length < 2)
-            {
-                throw Error.BindBinaryAssignmentRequireTwoArguments();
-            }
+            Debug.Assert(arguments.Length >= 2);
 
             string name = payload.Name;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1157,10 +1157,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             ArgumentObject[] arguments,
             LocalVariableSymbol[] locals)
         {
-            if (arguments.Length != 1)
-            {
-                throw Error.BindUnaryOperatorRequireOneArgument();
-            }
+            Debug.Assert(arguments.Length == 1);
 
             OperatorKind op = GetOperatorKind(payload.Operation);
             Expr arg1 = CreateArgumentEXPR(arguments[0], locals[0]);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1204,10 +1204,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 ArgumentObject[] arguments,
                 LocalVariableSymbol[] locals)
         {
-            if (arguments.Length != 2)
-            {
-                throw Error.BindBinaryOperatorRequireTwoArguments();
-            }
+            Debug.Assert(arguments.Length == 2);
 
             ExpressionKind ek = Operators.GetExpressionKind(GetOperatorKind(payload.Operation, payload.IsLogicalOperation));
             Expr arg1 = CreateArgumentEXPR(arguments[0], locals[0]);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -99,12 +99,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             // than 1/1000 sec for the whole 4000 of them.
 
             ICSharpBinder binder = payload as ICSharpBinder;
-            if (binder == null)
-            {
-                Debug.Assert(false, "Unknown payload kind");
-                throw Error.InternalCompilerError();
-            }
-
+            Debug.Assert(binder != null);
 
             lock (_bindLock)
             {

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -61,9 +61,6 @@
   <data name="InternalCompilerError" xml:space="preserve">
     <value>An unexpected exception occurred while binding a dynamic operation</value>
   </data>
-  <data name="BindRequireArguments" xml:space="preserve">
-    <value>Cannot bind call with no calling object</value>
-  </data>
   <data name="BindCallFailedOverloadResolution" xml:space="preserve">
     <value>Overload resolution failed</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -67,9 +67,6 @@
   <data name="BindCallFailedOverloadResolution" xml:space="preserve">
     <value>Overload resolution failed</value>
   </data>
-  <data name="BindBinaryOperatorRequireTwoArguments" xml:space="preserve">
-    <value>Binary operators must be invoked with two arguments</value>
-  </data>
   <data name="BindUnaryOperatorRequireOneArgument" xml:space="preserve">
     <value>Unary operators must be invoked with one argument</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -76,9 +76,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>Cannot invoke a non-delegate type</value>
   </data>
-  <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
-    <value>Binary operators cannot be invoked with one argument</value>
-  </data>
   <data name="BindBinaryAssignmentFailedNullReference" xml:space="preserve">
     <value>Cannot perform member assignment on a null reference</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -67,9 +67,6 @@
   <data name="BindCallFailedOverloadResolution" xml:space="preserve">
     <value>Overload resolution failed</value>
   </data>
-  <data name="BindUnaryOperatorRequireOneArgument" xml:space="preserve">
-    <value>Unary operators must be invoked with one argument</value>
-  </data>
   <data name="BindPropertyFailedMethodGroup" xml:space="preserve">
     <value>The name '{0}' is bound to a method and cannot be used like a property</value>
   </data>


### PR DESCRIPTION
* Remove `Error.BindBinaryOperatorRequireTwoArguments()`

`BindBinaryOperation` is only called by `DispatchPayload`, which is only called by `RuntimeBinder.BindCore`, which is only called by `RuntimeBinder.Bind`, which is only called with a `CSharpBinaryOperationBinder` as the first argument from `CSharpBinaryOperationBinder.FallbackBinaryOperation` which passes a fixed 2-element array. Anything but 2-elements is hence impossible.

Include tests that try to pass an different number, which throw in the `DynamicMetaObjectBinder` base.

* Remove `Error.BindUnaryOperatorRequireOneArgument()`

`BindUnaryOperation` is only called by `DispatchPayload`, which is only called by `RuntimeBinder.BindCore`, which is only called by `RuntimeBinder.Bind`, which is only called with a `CSharpUnaryOperationBinder` as the first argument from `CSharpUnaryOperationBinder.FallbackBinaryOperation` which passes a fixed 1-element array. Anything but 1 element is hence impossible.

* Remove `Error.BindBinaryAssignmentRequireTwoArguments()`

`BindUnaryOperation` is only called by `CSharpSetIndexBinder.DispatchPayload` or `CSharpSetMemberBinder.DispatchPayload`.

`CSharpSetMemberBinder.DispatchPayload` will only be calling with a fixed 2-element array. `CSharpSetIndexBinder.DispatchPayload` will only be called with an array with at least 3 elements.

Anything but with fewer than 2 elements is hence impossible.

* Remove `Error.BindRequireArguments()`

All calls include the target in the arguments, some include more, so there's never fewer than one `arg`.

* Remove check that payload to `RuntimeBinder.Bind` is `ICSharpBinder`

Call always traces back to an `ICSharpBinder` implementation passing this so can never not be so.