### PR TITLE
Fix IndexOutOfRangeException in Socket.Begin/EndConnect

### DIFF
--- a/src/Common/src/System/Net/ContextAwareResult.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.cs
@@ -393,5 +393,7 @@ namespace System.Net
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Context set, calling callback.");
             base.Complete(IntPtr.Zero);
         }
+
+        internal virtual EndPoint RemoteEndPoint => null;
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ConnectOverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ConnectOverlappedAsyncResult.cs
@@ -15,7 +15,7 @@ namespace System.Net.Sockets
             _endPoint = endPoint;
         }
 
-        internal EndPoint RemoteEndPoint
+        internal override EndPoint RemoteEndPoint
         {
             get { return _endPoint; }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2357,36 +2357,10 @@ namespace System.Net.Sockets
                 throw new ArgumentNullException(nameof(asyncResult));
             }
 
-            LazyAsyncResult castedAsyncResult = null;
-            EndPoint remoteEndPoint = null;
-            ConnectOverlappedAsyncResult coar;
-            MultipleAddressConnectAsyncResult macar;
-            ConnectAsyncResult car;
-
-            coar = asyncResult as ConnectOverlappedAsyncResult;
-            if (coar == null)
-            {
-                macar = asyncResult as MultipleAddressConnectAsyncResult;
-                if (macar == null)
-                {
-                    car = asyncResult as ConnectAsyncResult;
-                    if (car != null)
-                    {
-                        remoteEndPoint = car.RemoteEndPoint;
-                        castedAsyncResult = car;
-                    }
-                }
-                else
-                {
-                    remoteEndPoint = macar.RemoteEndPoint;
-                    castedAsyncResult = macar;
-                }
-            }
-            else
-            {
-                remoteEndPoint = coar.RemoteEndPoint;
-                castedAsyncResult = coar;
-            }
+            ContextAwareResult castedAsyncResult =
+                asyncResult as ConnectOverlappedAsyncResult ??
+                asyncResult as MultipleAddressConnectAsyncResult ??
+                (ContextAwareResult)(asyncResult as ConnectAsyncResult);
 
             if (castedAsyncResult == null || castedAsyncResult.AsyncObject != this)
             {
@@ -2408,7 +2382,7 @@ namespace System.Net.Sockets
                 if (ex == null)
                 {
                     // Update the internal state of this socket according to the error before throwing.
-                    SocketException se = SocketExceptionFactory.CreateSocketException(castedAsyncResult.ErrorCode, remoteEndPoint);
+                    SocketException se = SocketExceptionFactory.CreateSocketException(castedAsyncResult.ErrorCode, castedAsyncResult.RemoteEndPoint);
                     UpdateStatusAfterSocketError(se);
                     ex = se;
                 }
@@ -4951,7 +4925,7 @@ namespace System.Net.Sockets
                 _endPoint = endPoint;
             }
 
-            internal EndPoint RemoteEndPoint
+            internal override EndPoint RemoteEndPoint
             {
                 get { return _endPoint; }
             }
@@ -4973,7 +4947,7 @@ namespace System.Net.Sockets
             internal int _port;
             internal Exception _lastException;
 
-            internal EndPoint RemoteEndPoint
+            internal override EndPoint RemoteEndPoint
             {
                 get
                 {


### PR DESCRIPTION
There is a race condition in Socket.EndConnect, where it attempts to access the RemoteEndPoint of the async result before waiting for the async result to complete.  Thus if EndConnect is used immediately after BeginConnect (e.g. without a callback and just invoking it synchronosuly), we might access the remote end point before it's been initialized.

Fixes https://github.com/dotnet/corefx/issues/24869
cc: @davidsh