### PR TITLE
Change Suse to OpenSuse

### DIFF
--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -52,7 +52,7 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
                                      'Debian.87.Amd64.Open',
                                      'Ubuntu.1404.Amd64.Open',
                                      'Ubuntu.1604.Amd64.Open',
-                                     'suse.422.amd64.Open',
+                                     'opensuse.422.amd64.open',
                                      'fedora.25.amd64.Open',]
             if (params.TestOuter) {
                 targetHelixQueues += ['Debian.90.Amd64.Open',


### PR DESCRIPTION
Queue has been renamed, old queue worked but is actually just forwarding.  This helps the repro tool.

@maririos FYI
