### PR TITLE
Set handshake failure for alpn failure on Linux.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -27,7 +27,6 @@ internal static partial class Interop
         private static readonly IdnMapping s_idnMapping = new IdnMapping();
 
         #region internal methods
-
         internal static SafeChannelBindingHandle QueryChannelBinding(SafeSslHandle context, ChannelBindingKind bindingType)
         {
             Debug.Assert(
@@ -391,6 +390,10 @@ internal static partial class Interop
             {
                 return Ssl.SSL_TLSEXT_ERR_NOACK;
             }
+
+            // No common application protocol was negotiated, free the alpnHandle.
+            // It is ok to clear the handle value here, this results in handshake failure, so the SslStream object is disposed.
+            protocolHandle.Target = null;
 
             return Ssl.SSL_TLSEXT_ERR_NOACK;
         }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -388,10 +388,14 @@ internal static partial class Interop
             }
             catch
             {
+                // No common application protocol was negotiated, set the target on the alpnHandle to null.
+                // It is ok to clear the handle value here, this results in handshake failure, so the SslStream object is disposed.
+                protocolHandle.Target = null;
+
                 return Ssl.SSL_TLSEXT_ERR_NOACK;
             }
 
-            // No common application protocol was negotiated, free the alpnHandle.
+            // No common application protocol was negotiated, set the target on the alpnHandle to null.
             // It is ok to clear the handle value here, this results in handshake failure, so the SslStream object is disposed.
             protocolHandle.Target = null;
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Win32.SafeHandles
         private bool _isServer;
         private bool _handshakeCompleted = false;
 
-        public GCHandle AlpnHandle { get; set; }
+        public GCHandle AlpnHandle;
 
         public bool IsServer
         {

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -198,9 +198,8 @@ namespace Microsoft.Win32.SafeHandles
         private SafeBioHandle _writeBio;
         private bool _isServer;
         private bool _handshakeCompleted = false;
-        private GCHandle _alpnHandle;
 
-        public GCHandle AlpnHandle { set => _alpnHandle = value; }
+        public GCHandle AlpnHandle { get; set; }
 
         public bool IsServer
         {
@@ -283,9 +282,9 @@ namespace Microsoft.Win32.SafeHandles
                 _writeBio?.Dispose();
             }
 
-            if (_alpnHandle.IsAllocated)
+            if (AlpnHandle.IsAllocated)
             {
-                _alpnHandle.Free();
+                AlpnHandle.Free();
             }
 
             base.Dispose(disposing);

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -41,6 +41,7 @@ namespace System
         public static System.PlatformDetection.Range[] FrameworkRanges { get { throw null; } }
         public static bool HasWindowsShell { get { throw null; } }
         public static bool IsArmProcess { get { throw null; } }
+        public static bool IsCentos6 { get { throw null; } }
         public static bool IsDebian { get { throw null; } }
         public static bool IsDebian8 { get { throw null; } }
         public static bool IsDrawingSupported { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -27,6 +27,7 @@ namespace System
         public static bool IsInAppContainer => false;
         public static int WindowsVersion => -1;
 
+        public static bool IsCentos6 => IsDistroAndVersion("centos", 6);
         public static bool IsOpenSUSE => IsDistroAndVersion("opensuse");
         public static bool IsUbuntu => IsDistroAndVersion("ubuntu");
         public static bool IsDebian => IsDistroAndVersion("debian");

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -16,6 +16,7 @@ namespace System
     {
         public static Version OSXVersion => throw new PlatformNotSupportedException();
         public static bool IsSuperUser => throw new PlatformNotSupportedException();
+        public static bool IsCentos6 => false;
         public static bool IsOpenSUSE => false;
         public static bool IsUbuntu => false;
         public static bool IsDebian => false;

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -417,6 +417,9 @@
   <data name="net_alpn_config_failed" xml:space="preserve">
     <value>ALPN configuration failed on this platform.</value>
   </data>
+  <data name="net_alpn_failed" xml:space="preserve">
+    <value>No common application protocol exists between the client and the server. Application negotiation failed.</value>
+  </data>
   <data name="net_ssl_app_protocols_invalid" xml:space="preserve">
     <value>The application protocol list is invalid.</value>
   </data>

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -167,7 +167,7 @@ namespace System.Net.Security
                 SafeSslHandle sslContext = ((SafeDeleteSslContext)context).SslContext;
                 if (done && sslAuthenticationOptions.IsServer && sslAuthenticationOptions.ApplicationProtocols != null && sslContext.AlpnHandle.IsAllocated && sslContext.AlpnHandle.Target == null)
                 {
-                    throw Interop.OpenSsl.CreateSslException(SR.net_alpn_failed);
+                    return new SecurityStatusPal(SecurityStatusPalErrorCode.InternalError, Interop.OpenSsl.CreateSslException(SR.net_alpn_failed));
                 }
 
                 outputBuffer.size = outputSize;

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -83,7 +83,7 @@ namespace System.Net.Security
 
         public static SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, ReadOnlyMemory<byte> input, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
         {
-            return EncryptDecryptHelper(securityContext, input, offset:0, size: 0, encrypt: true, output: ref output, resultSize: out resultSize);
+            return EncryptDecryptHelper(securityContext, input, offset: 0, size: 0, encrypt: true, output: ref output, resultSize: out resultSize);
         }
 
         public static SecurityStatusPal DecryptMessage(SafeDeleteContext securityContext, byte[] buffer, ref int offset, ref int count)
@@ -158,6 +158,17 @@ namespace System.Net.Security
                 else
                 {
                     done = Interop.OpenSsl.DoSslHandshake(((SafeDeleteSslContext)context).SslContext, inputBuffer.token, inputBuffer.offset, inputBuffer.size, out output, out outputSize);
+                }
+
+                // When the handshake is done, and the context is server, check if the alpnHandle was freed during ALPN.
+                // If it was freed, then that indiciates ALPN failed, send failure.
+                // We have this workaround, as openssl supports terminating handshake only from version 1.1.0,
+                // whereas ALPN is supported from version 1.0.2.
+                if (done && sslAuthenticationOptions.IsServer &&
+                    sslAuthenticationOptions.ApplicationProtocols != null && ((SafeDeleteSslContext)context).SslContext.AlpnHandle.IsAllocated &&
+                    ((SafeDeleteSslContext)context).SslContext.AlpnHandle.Target == null)
+                {
+                    throw Interop.OpenSsl.CreateSslException(SR.net_alpn_failed);
                 }
 
                 outputBuffer.size = outputSize;

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -160,13 +160,12 @@ namespace System.Net.Security
                     done = Interop.OpenSsl.DoSslHandshake(((SafeDeleteSslContext)context).SslContext, inputBuffer.token, inputBuffer.offset, inputBuffer.size, out output, out outputSize);
                 }
 
-                // When the handshake is done, and the context is server, check if the alpnHandle was freed during ALPN.
-                // If it was freed, then that indiciates ALPN failed, send failure.
+                // When the handshake is done, and the context is server, check if the alpnHandle target was set to null during ALPN.
+                // If it was, then that indiciates ALPN failed, send failure.
                 // We have this workaround, as openssl supports terminating handshake only from version 1.1.0,
                 // whereas ALPN is supported from version 1.0.2.
-                if (done && sslAuthenticationOptions.IsServer &&
-                    sslAuthenticationOptions.ApplicationProtocols != null && ((SafeDeleteSslContext)context).SslContext.AlpnHandle.IsAllocated &&
-                    ((SafeDeleteSslContext)context).SslContext.AlpnHandle.Target == null)
+                SafeSslHandle sslContext = ((SafeDeleteSslContext)context).SslContext;
+                if (done && sslAuthenticationOptions.IsServer && sslAuthenticationOptions.ApplicationProtocols != null && sslContext.AlpnHandle.IsAllocated && sslContext.AlpnHandle.Target == null)
                 {
                     throw Interop.OpenSsl.CreateSslException(SR.net_alpn_failed);
                 }

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -151,12 +151,14 @@ namespace System.Net.Security.Tests
                             (PlatformDetection.IsWindows && !PlatformDetection.IsWindows7))
                         {
                             Task t1 = Assert.ThrowsAsync<IOException>(() => clientStream.AuthenticateAsClientAsync(clientOptions, CancellationToken.None));
-                            Task t2 = Assert.ThrowsAsync<AuthenticationException>(() => serverStream.AuthenticateAsServerAsync(serverOptions, CancellationToken.None)).ContinueWith(t =>
+                            try
                             {
-                                server.Dispose();
-                            }, TaskScheduler.Default);
+                                await serverStream.AuthenticateAsServerAsync(serverOptions, CancellationToken.None);
+                                Assert.True(false, "AuthenticationException was not thrown.");
+                            }
+                            catch (AuthenticationException) { server.Dispose(); }
 
-                            await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2);
+                            await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1);
                         }
                         else
                         {

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
@@ -116,34 +118,62 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [ActiveIssue(24853)]
-        [PlatformSpecific(~TestPlatforms.OSX)]
         public async Task SslStream_StreamToStream_Alpn_NonMatchingProtocols_Fail()
         {
-            VirtualNetwork network = new VirtualNetwork();
-            using (var clientStream = new VirtualNetworkStream(network, false))
-            using (var serverStream = new VirtualNetworkStream(network, true))
-            using (var client = new SslStream(clientStream, false))
-            using (var server = new SslStream(serverStream, false))
-            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            try
             {
-                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
+                listener.Start();
+                using (TcpClient client = new TcpClient())
                 {
-                    ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http11 },
-                    RemoteCertificateValidationCallback = AllowAnyServerCertificate,
-                    TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false),
-                };
+                    Task<TcpClient> serverTask = listener.AcceptTcpClientAsync();
+                    await client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndpoint).Port);
 
-                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions
-                {
-                    ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 },
-                    ServerCertificate = certificate,
-                };
+                    using (TcpClient server = await serverTask)
+                    using (SslStream serverStream = new SslStream(server.GetStream(), leaveInnerStreamOpen: false))
+                    using (SslStream clientStream = new SslStream(client.GetStream(), leaveInnerStreamOpen: false))
+                    using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+                    {
+                        SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions
+                        {
+                            ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 },
+                            ServerCertificate = certificate,
+                        };
+                        SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
+                        {
+                            ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http11 },
+                            RemoteCertificateValidationCallback = AllowAnyServerCertificate,
+                            TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false),
+                        };
 
-                Task t1 = Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(clientOptions, CancellationToken.None));
-                Task t2 = Assert.ThrowsAsync<AuthenticationException>(() => server.AuthenticateAsServerAsync(serverOptions, CancellationToken.None));
+                        // Test alpn failure only on platforms that supports ALPN.
+                        if ((RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !(PlatformDetection.IsUbuntu1404 || PlatformDetection.IsDebian8 || PlatformDetection.IsCentos6)) ||
+                            (PlatformDetection.IsWindows && !PlatformDetection.IsWindows7))
+                        {
+                            Task t1 = Assert.ThrowsAsync<IOException>(() => clientStream.AuthenticateAsClientAsync(clientOptions, CancellationToken.None));
+                            Task t2 = Assert.ThrowsAsync<AuthenticationException>(() => serverStream.AuthenticateAsServerAsync(serverOptions, CancellationToken.None)).ContinueWith(t =>
+                            {
+                                server.Dispose();
+                            }, TaskScheduler.Default);
 
-                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2);
+                            await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2);
+                        }
+                        else
+                        {
+                            Task t1 = clientStream.AuthenticateAsClientAsync(clientOptions, CancellationToken.None);
+                            Task t2 = serverStream.AuthenticateAsServerAsync(serverOptions, CancellationToken.None);
+
+                            await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2);
+
+                            Assert.Equal(default(SslApplicationProtocol), clientStream.NegotiatedApplicationProtocol);
+                            Assert.Equal(default(SslApplicationProtocol), serverStream.NegotiatedApplicationProtocol);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                listener.Stop();
             }
         }
 
@@ -163,7 +193,7 @@ namespace System.Net.Security.Tests
             {
                 // Works on linux distros with openssl 1.0.2, CI machines Ubuntu14.04 and Debian 87 don't have openssl 1.0.2
                 // Works on Windows OSes > 7.0
-                bool featureWorks = (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !(PlatformDetection.IsUbuntu1404 || PlatformDetection.IsDebian8)) ||
+                bool featureWorks = (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !(PlatformDetection.IsUbuntu1404 || PlatformDetection.IsDebian8 || PlatformDetection.IsCentos6)) ||
                                     (PlatformDetection.IsWindows && !PlatformDetection.IsWindows7);
 
                 yield return new object[] { new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 }, new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 }, featureWorks ? SslApplicationProtocol.Http2 : default };


### PR DESCRIPTION
cc @stephentoub @Drawaes 

fixes #24853 

The client throws a TimeoutException, because the server is not sending fatal handshake failed alert before terminating the connection, so the client times out waiting for reply from handshake.

@davidsh When i was debugging this on windows, the ```ProtocolToken.Status``` was ```ApplicationProtocolMismatch``` error, but the ```ProtocolToken.Payload``` was null, which means there are no outgoing buffers from Schannel. Does SChannel not send alert for ALPN failure?