### PR TITLE
Make Process.Start throw Win32Exception when child process doesn't exec.

### DIFF
--- a/src/Native/Unix/System.Native/pal_process.cpp
+++ b/src/Native/Unix/System.Native/pal_process.cpp
@@ -92,6 +92,16 @@ static int Dup2WithInterruptedRetry(int oldfd, int newfd)
     return result;
 }
 
+__attribute__((noreturn))
+static void ExitChild(int pipeToParent, int error)
+{
+    if (pipeToParent != -1)
+    {
+        while (CheckInterrupted(write(pipeToParent, &error, sizeof(error))));
+    }
+    _exit(error != 0 ? error : EXIT_FAILURE);
+}
+
 extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
                                       char* const argv[],
                                       char* const envp[],
@@ -153,6 +163,7 @@ extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
     // child process is actually transitioned to the target program.  This avoids problems
     // where the parent process uses members of Process, like ProcessName, when the Process
     // is still the clone of this one. This is a best-effort attempt, so ignore any errors.
+    // If the child fails to exec we use the pipe to pass the errno to the parent process.
 #if HAVE_PIPE2
     pipe2(waitForChildToExecPipe, O_CLOEXEC);
 #endif
@@ -172,7 +183,7 @@ extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
             (redirectStdout && Dup2WithInterruptedRetry(stdoutFds[WRITE_END_OF_PIPE], STDOUT_FILENO) == -1) ||
             (redirectStderr && Dup2WithInterruptedRetry(stderrFds[WRITE_END_OF_PIPE], STDERR_FILENO) == -1))
         {
-            _exit(errno != 0 ? errno : EXIT_FAILURE);
+            ExitChild(waitForChildToExecPipe[WRITE_END_OF_PIPE], errno);
         }
 
         // Change to the designated working directory, if one was specified
@@ -182,13 +193,13 @@ extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
             while (CheckInterrupted(result = chdir(cwd)));
             if (result == -1)
             {
-                _exit(errno != 0 ? errno : EXIT_FAILURE);
+                ExitChild(waitForChildToExecPipe[WRITE_END_OF_PIPE], errno);
             }
         }
 
         // Finally, execute the new process.  execve will not return if it's successful.
         execve(filename, argv, envp);
-        _exit(errno != 0 ? errno : EXIT_FAILURE); // execve failed
+        ExitChild(waitForChildToExecPipe[WRITE_END_OF_PIPE], errno); // execve failed
     }
 
     // This is the parent process. processId == pid of the child
@@ -212,10 +223,16 @@ done:
     CloseIfOpen(waitForChildToExecPipe[WRITE_END_OF_PIPE]);
     if (waitForChildToExecPipe[READ_END_OF_PIPE] != -1)
     {
-        int ignored;
+        int childError;
         if (success)
         {
-            while (CheckInterrupted(read(waitForChildToExecPipe[READ_END_OF_PIPE], &ignored, 1)));
+            ssize_t result;
+            while (CheckInterrupted(result = read(waitForChildToExecPipe[READ_END_OF_PIPE], &childError, sizeof(childError))));
+            if (result == sizeof(childError))
+            {
+                success = false;
+                priorErrno = childError;
+            }
         }
         CloseIfOpen(waitForChildToExecPipe[READ_END_OF_PIPE]);
     }

--- a/src/System.Diagnostics.Process/tests/Performance/System.Diagnostics.Process.Performance.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/Performance/System.Diagnostics.Process.Performance.Tests.csproj
@@ -17,6 +17,9 @@
     <Compile Include="$(CommonPath)\System\PasteArguments.cs">
       <Link>Common\System\PasteArguments.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StringParser.cs">
+      <Link>Common\System\IO\StringParser.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>

--- a/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Threading;
 using Xunit;
@@ -68,6 +69,32 @@ namespace System.Diagnostics.Tests
             Thread.Sleep(200);
             p.Kill();
             Assert.True(p.WaitForExit(WaitInMS));
+        }
+
+        /// <summary>
+        /// Checks if the program is installed
+        /// </summary>
+        /// <param name="program"></param>
+        /// <returns></returns>
+        protected static bool IsProgramInstalled(string program)
+        {
+            string path;
+            string pathEnvVar = Environment.GetEnvironmentVariable("PATH");
+            char separator = PlatformDetection.IsWindows ? ';' : ':';
+            if (pathEnvVar != null)
+            {
+                var pathParser = new StringParser(pathEnvVar, separator, skipEmpty: true);
+                while (pathParser.MoveNext())
+                {
+                    string subPath = pathParser.ExtractCurrent();
+                    path = Path.Combine(subPath, program);
+                    if (File.Exists(path))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -274,11 +274,23 @@ namespace System.Diagnostics.Tests
 
             Assert.Equal(0, chmod(path, mode)); // execute permissions
 
-            using (Process p = Process.Start(path))
+            Assert.Throws<Win32Exception>(() => Process.Start(path).Dispose());
+        }
+
+        [Fact]
+        public void TestStartOnUnixWithBadWorkingDirectory()
+        {
+            string program = "uname";
+            Assert.True(IsProgramInstalled(program));
+
+            var psi = new ProcessStartInfo
             {
-                p.WaitForExit();
-                Assert.NotEqual(0, p.ExitCode);
-            }
+                FileName = program,
+                UseShellExecute = false,
+                WorkingDirectory = "/does-not-exist"
+            };
+
+            Assert.Throws<Win32Exception>(() => Process.Start(psi).Dispose());
         }
 
         [DllImport("libc")]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -140,6 +140,11 @@ namespace System.Diagnostics.Tests
         [PlatformSpecific(~TestPlatforms.OSX)] // OSX doesn't support throwing on Process.Start
         public void TestStartWithBadWorkingDirectory()
         {
+            if (PlatformDetection.IsUap) // UWP overrides WorkingDirectory (https://github.com/dotnet/corefx/pull/25266#issuecomment-347719832).
+            {
+                return;
+            }
+
             string program;
             string workingDirectory;
             if (PlatformDetection.IsWindows)

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -138,13 +138,9 @@ namespace System.Diagnostics.Tests
 
         [Fact]
         [PlatformSpecific(~TestPlatforms.OSX)] // OSX doesn't support throwing on Process.Start
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // UWP overrides WorkingDirectory (https://github.com/dotnet/corefx/pull/25266#issuecomment-347719832).
         public void TestStartWithBadWorkingDirectory()
         {
-            if (PlatformDetection.IsUap) // UWP overrides WorkingDirectory (https://github.com/dotnet/corefx/pull/25266#issuecomment-347719832).
-            {
-                return;
-            }
-
             string program;
             string workingDirectory;
             if (PlatformDetection.IsWindows)

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -135,6 +135,36 @@ namespace System.Diagnostics.Tests
         {
             Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = Path.GetTempPath() }));
         }
+
+        [Fact]
+        [PlatformSpecific(~TestPlatforms.OSX)] // OSX doesn't support throwing on Process.Start
+        public void TestStartOnUnixWithBadWorkingDirectory()
+        {
+            string program;
+            string workingDirectory;
+            if (PlatformDetection.IsWindows)
+            {
+                program = "type";
+                workingDirectory = @"C:\does-not-exist";
+            }
+            else
+            {
+                program = "uname";
+                workingDirectory = "/does-not-exist";
+            }
+
+            Assert.True(IsProgramInstalled(program));
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = program,
+                UseShellExecute = false,
+                WorkingDirectory = workingDirectory
+            };
+
+            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(psi));
+            Assert.NotEqual(0, e.NativeErrorCode);
+        }
         
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasWindowsShell))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "not supported on UAP")]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -144,7 +144,7 @@ namespace System.Diagnostics.Tests
             string workingDirectory;
             if (PlatformDetection.IsWindows)
             {
-                program = "type";
+                program = "powershell.exe";
                 workingDirectory = @"C:\does-not-exist";
             }
             else

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -138,7 +138,7 @@ namespace System.Diagnostics.Tests
 
         [Fact]
         [PlatformSpecific(~TestPlatforms.OSX)] // OSX doesn't support throwing on Process.Start
-        public void TestStartOnUnixWithBadWorkingDirectory()
+        public void TestStartWithBadWorkingDirectory()
         {
             string program;
             string workingDirectory;

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -153,19 +153,24 @@ namespace System.Diagnostics.Tests
                 workingDirectory = "/does-not-exist";
             }
 
-            Assert.True(IsProgramInstalled(program));
-
-            var psi = new ProcessStartInfo
+            if (IsProgramInstalled(program))
             {
-                FileName = program,
-                UseShellExecute = false,
-                WorkingDirectory = workingDirectory
-            };
+                var psi = new ProcessStartInfo
+                {
+                    FileName = program,
+                    UseShellExecute = false,
+                    WorkingDirectory = workingDirectory
+                };
 
-            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(psi));
-            Assert.NotEqual(0, e.NativeErrorCode);
+                Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(psi));
+                Assert.NotEqual(0, e.NativeErrorCode);
+            }
+            else
+            {
+                Console.WriteLine($"Program {program} is not installed on this machine.");
+            }
         }
-        
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasWindowsShell))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "not supported on UAP")]
         [OuterLoop("Launches File Explorer")]


### PR DESCRIPTION
This improves the behavior when a child process can't be successfully started.

CC @stephentoub 