### PR TITLE
Use Mono workaround to parse internal Uri relationships in packages

### DIFF
--- a/src/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
@@ -27,6 +27,12 @@ namespace System.IO.Packaging
     /// </summary>
     internal class InternalRelationshipCollection : IEnumerable<PackageRelationship>
     {
+        // Mono will parse a URI starting with '/' as an absolute URI, while .NET Core and
+        // .NET Framework will parse this as relative. This will break internal relationships
+        // in packaging. For more information, see
+        // http://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/
+        private static readonly UriKind DotNetRelativeOrAbsolute = Type.GetType ("Mono.Runtime") == null ? UriKind.RelativeOrAbsolute : (UriKind)300;
+
         #region IEnumerable
         /// <summary>
         /// Returns an enumerator over all the relationships for a Package or a PackagePart
@@ -354,7 +360,7 @@ namespace System.IO.Packaging
             if (string.IsNullOrEmpty(targetAttributeValue))
                 throw new XmlException(SR.Format(SR.RequiredRelationshipAttributeMissing, s_targetAttributeName), null, reader.LineNumber, reader.LinePosition);
 
-            Uri targetUri = new Uri(targetAttributeValue, UriKind.RelativeOrAbsolute);
+            Uri targetUri = new Uri(targetAttributeValue, DotNetRelativeOrAbsolute);
 
             // Attribute : Type
             string typeAttributeValue = reader.GetAttribute(s_typeAttributeName);

--- a/src/System.IO.Packaging/tests/Tests.cs
+++ b/src/System.IO.Packaging/tests/Tests.cs
@@ -1279,6 +1279,31 @@ namespace System.IO.Packaging.Tests
             packagePath1.Delete();
         }
 
+        [Fact]
+        public void OpenInternalTargetRelationships()
+        {
+            // This is to test different behavior on Mono vs .NET Core
+            using (var ms = new MemoryStream())
+            {
+                using (var package = Package.Open(ms, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+                {
+                    package.CreateRelationship(new Uri("/target", UriKind.Relative), TargetMode.Internal, "type");
+                }
+
+                ms.Position = 0;
+
+                using (var package = Package.Open(ms, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+                {
+                    var relationships = package.GetRelationships();
+
+                    var relationship = Assert.Single(relationships);
+
+                    Assert.Equal(new Uri("/", UriKind.Relative), relationship.SourceUri);
+                    Assert.Equal(new Uri("/target", UriKind.Relative), relationship.TargetUri);
+                    Assert.Equal(TargetMode.Internal, relationship.TargetMode);
+                }
+            }
+        }
 
         [Fact]
         public void T035_ModifyAllPackageProperties()


### PR DESCRIPTION
Uri parsing on Mono has a quirk when parsing a Uri that if you pass UriKind.RelativeOrAbsolute, a forward slash / is treated as absolute while in .NET Framework this would be parsed as relative. This causes `System.IO.Packaging.Package` to not be able to load relative URIs that are used as part of internal relationships.

Fixes #24822 