### PR TITLE
Add a test to verify the XmlQualifiedName "duration" of TimeSpan type.

### DIFF
--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -2924,9 +2924,8 @@ public static partial class XmlSerializerTests
     }
 
     [ConditionalFact(nameof(IsTimeSpanSerializationAvailable))]
-    public static void TimeSpanXmlQualifiedNameTest()
+    public static void VerifyRestrictionElementForTimeSpanTest()
     {
-        string baseline = "<?xml version=\"1.0\"?>\r\n<xs:schema xmlns:tns=\"http://microsoft.com/wsdl/types/\" elementFormDefault=\"qualified\" targetNamespace=\"http://microsoft.com/wsdl/types/\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n  <xs:simpleType name=\"TimeSpan\">\r\n    <xs:restriction base=\"xs:duration\" />\r\n  </xs:simpleType>\r\n</xs:schema>";
         var schemas = new XmlSchemas();
         var exporter = new XmlSchemaExporter(schemas);
         XmlTypeMapping mapping = new XmlReflectionImporter().ImportTypeMapping(typeof(TimeSpan));
@@ -2943,8 +2942,8 @@ public static partial class XmlSerializerTests
             element = element.Elements().First();
         }
 
-        string expected = element.LastAttribute.Value;
-        Assert.True(expected == "xs:duration", string.Format("{0}Test failed for wrong output from schema: {0}Expected: {1}{0}Actual: {2}",
-                Environment.NewLine, baseline, actualOutput));
+        string expectedAttribute = "xs:duration";
+        Assert.True(element.LastAttribute.Value == expectedAttribute, string.Format("{0}Test failed for wrong output from schema: {0}Expected Output: {1}{0}Actual Output: {2}",
+                Environment.NewLine, "<?xml version=\"1.0\"?>\r\n<xs:schema xmlns:tns=\"http://microsoft.com/wsdl/types/\" elementFormDefault=\"qualified\" targetNamespace=\"http://microsoft.com/wsdl/types/\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n  <xs:simpleType name=\"TimeSpan\">\r\n    <xs:restriction base=\"xs:duration\" />\r\n  </xs:simpleType>\r\n</xs:schema>", actualOutput));
     }
 }

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -2937,7 +2937,7 @@ public static partial class XmlSerializerTests
         schema.Write(ms);
         ms.Position = 0;
         string actualOutput = new StreamReader(ms).ReadToEnd();
-        Utils.CompareResult result = Utils.Compare(baseline, actualOutput);
+        Utils.CompareResult result = Utils.Compare(baseline, actualOutput, false);
         Assert.True(result.Equal, string.Format("{1}{0}Test failed for wrong output from schema: {0}Expected: {2}{0}Actual: {3}",
                 Environment.NewLine, result.ErrorMessage, baseline, actualOutput));
     }

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -2923,7 +2923,7 @@ public static partial class XmlSerializerTests
         Assert.StrictEqual(value, actual);
     }
 
-    [Fact]
+    [ConditionalFact(nameof(IsTimeSpanSerializationAvailable))]
     public static void TimeSpanXmlQualifiedNameTest()
     {
         string baseline = "<?xml version=\"1.0\"?>\r\n<xs:schema xmlns:tns=\"http://microsoft.com/wsdl/types/\" elementFormDefault=\"qualified\" targetNamespace=\"http://microsoft.com/wsdl/types/\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n  <xs:simpleType name=\"TimeSpan\">\r\n    <xs:restriction base=\"xs:duration\" />\r\n  </xs:simpleType>\r\n</xs:schema>";
@@ -2931,11 +2931,10 @@ public static partial class XmlSerializerTests
         var exporter = new XmlSchemaExporter(schemas);
         XmlTypeMapping mapping = new XmlReflectionImporter().ImportTypeMapping(typeof(TimeSpan));
         exporter.ExportTypeMapping(mapping);
-        var schemaEnumerator = new XmlSchemaEnumerator(schemas);
+        XmlSchema schema = schemas.Where(s => s.TargetNamespace == "http://microsoft.com/wsdl/types/").FirstOrDefault();
+        Assert.NotNull(schema);
         var ms = new MemoryStream();
-        schemaEnumerator.MoveNext();
-        schemaEnumerator.MoveNext();
-        schemaEnumerator.Current.Write(ms);
+        schema.Write(ms);
         ms.Position = 0;
         string actualOutput = new StreamReader(ms).ReadToEnd();
         Utils.CompareResult result = Utils.Compare(baseline, actualOutput);

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -2943,7 +2943,8 @@ public static partial class XmlSerializerTests
         }
 
         string expectedAttribute = "xs:duration";
+        string baseline = "<?xml version=\"1.0\"?>\r\n<xs:schema xmlns:tns=\"http://microsoft.com/wsdl/types/\" elementFormDefault=\"qualified\" targetNamespace=\"http://microsoft.com/wsdl/types/\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n  <xs:simpleType name=\"TimeSpan\">\r\n    <xs:restriction base=\"xs:duration\" />\r\n  </xs:simpleType>\r\n</xs:schema>";
         Assert.True(element.LastAttribute.Value == expectedAttribute, string.Format("{0}Test failed for wrong output from schema: {0}Expected Output: {1}{0}Actual Output: {2}",
-                Environment.NewLine, "<?xml version=\"1.0\"?>\r\n<xs:schema xmlns:tns=\"http://microsoft.com/wsdl/types/\" elementFormDefault=\"qualified\" targetNamespace=\"http://microsoft.com/wsdl/types/\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n  <xs:simpleType name=\"TimeSpan\">\r\n    <xs:restriction base=\"xs:duration\" />\r\n  </xs:simpleType>\r\n</xs:schema>", actualOutput));
+                Environment.NewLine, baseline, actualOutput));
     }
 }

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -2922,4 +2922,24 @@ public static partial class XmlSerializerTests
 
         Assert.StrictEqual(value, actual);
     }
+
+    [Fact]
+    public static void TimeSpanXmlQualifiedNameTest()
+    {
+        string baseline = "<?xml version=\"1.0\"?>\r\n<xs:schema xmlns:tns=\"http://microsoft.com/wsdl/types/\" elementFormDefault=\"qualified\" targetNamespace=\"http://microsoft.com/wsdl/types/\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n  <xs:simpleType name=\"TimeSpan\">\r\n    <xs:restriction base=\"xs:duration\" />\r\n  </xs:simpleType>\r\n</xs:schema>";
+        var schemas = new XmlSchemas();
+        var exporter = new XmlSchemaExporter(schemas);
+        XmlTypeMapping mapping = new XmlReflectionImporter().ImportTypeMapping(typeof(TimeSpan));
+        exporter.ExportTypeMapping(mapping);
+        var schemaEnumerator = new XmlSchemaEnumerator(schemas);
+        var ms = new MemoryStream();
+        schemaEnumerator.MoveNext();
+        schemaEnumerator.MoveNext();
+        schemaEnumerator.Current.Write(ms);
+        ms.Position = 0;
+        string actualOutput = new StreamReader(ms).ReadToEnd();
+        Utils.CompareResult result = Utils.Compare(baseline, actualOutput);
+        Assert.True(result.Equal, string.Format("{1}{0}Test failed for wrong output from schema: {0}Expected: {2}{0}Actual: {3}",
+                Environment.NewLine, result.ErrorMessage, baseline, actualOutput));
+    }
 }

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -2937,8 +2937,14 @@ public static partial class XmlSerializerTests
         schema.Write(ms);
         ms.Position = 0;
         string actualOutput = new StreamReader(ms).ReadToEnd();
-        Utils.CompareResult result = Utils.Compare(baseline, actualOutput, false);
-        Assert.True(result.Equal, string.Format("{1}{0}Test failed for wrong output from schema: {0}Expected: {2}{0}Actual: {3}",
-                Environment.NewLine, result.ErrorMessage, baseline, actualOutput));
+        XElement element = XElement.Parse(actualOutput);
+        while (element.Elements().Count() != 0)
+        {
+            element = element.Elements().First();
+        }
+
+        string expected = element.LastAttribute.Value;
+        Assert.True(expected == "xs:duration", string.Format("{0}Test failed for wrong output from schema: {0}Expected: {1}{0}Actual: {2}",
+                Environment.NewLine, baseline, actualOutput));
     }
 }


### PR DESCRIPTION
Add a test to verify "duration" in the following line.

`AddNonXsdPrimitive(typeof(TimeSpan), "TimeSpan", UrtTypes.Namespace, "TimeSpan", new XmlQualifiedName("duration", XmlSchema.Namespace), new XmlSchemaFacet[0], TypeFlags.CanBeAttributeValue | TypeFlags.CanBeElementValue | TypeFlags.XmlEncodingNotRequired);`

Fix #18854 

@shmao @zhenlan @mconnew 