### PR TITLE
Change destination path for compat package script

### DIFF
--- a/pkg/Microsoft.Windows.Compatibility/tests/publishcompatibilityassets.ps1
+++ b/pkg/Microsoft.Windows.Compatibility/tests/publishcompatibilityassets.ps1
@@ -50,7 +50,7 @@ function _restoreAndPublish($targetFramework, $rid, $runtimeFramework, $refDirNa
 
 	Write-Output (-join("Published succedded for: ", $targetFramework))
 	
-	$refPath = -join($repoRoot, "\bin\ref\ApiPort\", $refDirName)
+	$refPath = -join($repoRoot, "\bin\ref\", $refDirName)
 
 	if (Test-Path $refPath)
 	{


### PR DESCRIPTION
I edited the build definition to include this script's execution and realize that the way it copies the artifacts it included the "ApiPort" directory in the final drop and we don't want that to be consistent. So I'm deleting that from the local corefx drop so that when we bin place it in the ApiPort share drop it is consistent to the current structure. 