### PR TITLE
make sure crypto_Init is done before calling ssl_init

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -14,8 +14,11 @@ static_assert(PAL_SSL_ERROR_WANT_WRITE == SSL_ERROR_WANT_WRITE, "");
 static_assert(PAL_SSL_ERROR_SYSCALL == SSL_ERROR_SYSCALL, "");
 static_assert(PAL_SSL_ERROR_ZERO_RETURN == SSL_ERROR_ZERO_RETURN, "");
 
+extern "C" int32_t CryptoNative_EnsureOpenSslInitialized();
+
 extern "C" void CryptoNative_EnsureLibSslInitialized()
 {
+    CryptoNative_EnsureOpenSslInitialized();
     SSL_library_init();
     SSL_load_error_strings();
 }


### PR DESCRIPTION
fixes #25230 

The problem is that openssl initialization is not re-entrant/thread safe.
The trace shows SSL_library_init calls OBJ_NAME_add() This is exactly what crypto init would do. Further more, locking needs to be set in openssl. 

This change ensures crypto init is called before ssl_init. That should be no-op if CryptoNative_EnsureOpenSslInitialized() was already called. 

With this change  did 5000 iterations of HTTP test suite without any crash.
