### PR TITLE
Swap partial and static keywords since this causes compile errors with latest compiler.

### DIFF
--- a/src/System.Net.Sockets/ref/System.Net.Sockets.netcoreapp.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.netcoreapp.cs
@@ -18,7 +18,7 @@ namespace System.Net.Sockets
         public int Send(ReadOnlySpan<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { throw null; }
     }
 
-    public partial static class SocketTaskExtensions
+    public static partial class SocketTaskExtensions
     {
         public static System.Threading.Tasks.ValueTask<int> ReceiveAsync(this System.Net.Sockets.Socket socket, System.Memory<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.ValueTask<int> SendAsync(this System.Net.Sockets.Socket socket, System.ReadOnlyMemory<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }


### PR DESCRIPTION
Fixing a simple mistake that was flagged when compiling with the latest Roslyn compiler.  I'm not sure how our current version of Roslyn doesn't catch this, but it got through.

I'll need this change in order to [update to the latest Roslyn compiler](https://github.com/dotnet/buildtools/pull/1808) which is coming soon.

See https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0267 for details on the compile error.