### PR TITLE
Improve Syndication DateTime Parsing

### DIFF
--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
@@ -391,7 +391,10 @@ namespace System.ServiceModel.Syndication
     {
         protected SyndicationFeedFormatter() { }
         protected SyndicationFeedFormatter(System.ServiceModel.Syndication.SyndicationFeed feedToWrite) { }
+        public System.Func<string, string, string, System.DateTimeOffset> DateTimeParser { get { throw null; } set { } }
         public System.ServiceModel.Syndication.SyndicationFeed Feed { get { throw null; } }
+        public System.Func<string, string, string, string> StringParser { get { throw null; } set { } }
+        public System.Func<string, System.UriKind, string, string, System.Uri> UriParser { get { throw null; } set { } }
         public abstract string Version { get; }
         public abstract bool CanRead(System.Xml.XmlReader reader);
         protected internal static System.ServiceModel.Syndication.SyndicationCategory CreateCategory(System.ServiceModel.Syndication.SyndicationFeed feed) { throw null; }

--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.cs
@@ -393,7 +393,6 @@ namespace System.ServiceModel.Syndication
         protected SyndicationFeedFormatter(System.ServiceModel.Syndication.SyndicationFeed feedToWrite) { }
         public System.Func<string, string, string, System.DateTimeOffset> DateTimeParser { get { throw null; } set { } }
         public System.ServiceModel.Syndication.SyndicationFeed Feed { get { throw null; } }
-        public System.Func<string, string, string, string> StringParser { get { throw null; } set { } }
         public System.Func<string, System.UriKind, string, string, System.Uri> UriParser { get { throw null; } set { } }
         public abstract string Version { get; }
         public abstract bool CanRead(System.Xml.XmlReader reader);

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -249,7 +249,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        internal TextSyndicationContent ReadTextContentFrom(XmlReader reader, string context, bool preserveAttributeExtensions)
+        internal static TextSyndicationContent ReadTextContentFrom(XmlReader reader, string context, bool preserveAttributeExtensions)
         {
             string type = reader.GetAttribute(Atom10Constants.TypeTag);
             return ReadTextContentFromHelper(reader, type, context, preserveAttributeExtensions);
@@ -297,11 +297,11 @@ namespace System.ServiceModel.Syndication
             }
             else if (reader.IsStartElement(Atom10Constants.GeneratorTag, Atom10Constants.Atom10Namespace))
             {
-                result.Generator = StringParser(reader.ReadElementString(), Atom10Constants.GeneratorTag, Atom10Constants.Atom10Namespace);
+                result.Generator = reader.ReadElementString();
             }
             else if (reader.IsStartElement(Atom10Constants.IdTag, Atom10Constants.Atom10Namespace))
             {
-                result.Id = StringParser(reader.ReadElementString(), Atom10Constants.IdTag, Atom10Constants.Atom10Namespace);
+                result.Id = reader.ReadElementString();
             }
             else if (reader.IsStartElement(Atom10Constants.LinkTag, Atom10Constants.Atom10Namespace))
             {
@@ -365,7 +365,7 @@ namespace System.ServiceModel.Syndication
             }
             else if (reader.IsStartElement(Atom10Constants.IdTag, Atom10Constants.Atom10Namespace))
             {
-                result.Id = StringParser(reader.ReadElementString(), Atom10Constants.IdTag, Atom10Constants.Atom10Namespace);
+                result.Id = reader.ReadElementString();
             }
             else if (reader.IsStartElement(Atom10Constants.LinkTag, Atom10Constants.Atom10Namespace))
             {
@@ -602,7 +602,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        private TextSyndicationContent ReadTextContentFromHelper(XmlReader reader, string type, string context, bool preserveAttributeExtensions)
+        private static TextSyndicationContent ReadTextContentFromHelper(XmlReader reader, string type, string context, bool preserveAttributeExtensions)
         {
             if (string.IsNullOrEmpty(type))
             {
@@ -658,7 +658,7 @@ namespace System.ServiceModel.Syndication
             reader.MoveToElement();
             string localName = reader.LocalName;
             string nameSpace = reader.NamespaceURI;
-            string val = (kind == TextSyndicationContentKind.XHtml) ? reader.ReadInnerXml() : StringParser(reader.ReadElementString(), localName, nameSpace); // cant custom parse because its static
+            string val = (kind == TextSyndicationContentKind.XHtml) ? reader.ReadInnerXml() : reader.ReadElementString();
             TextSyndicationContent result = new TextSyndicationContent(val, kind);
             if (attrs != null)
             {
@@ -1152,15 +1152,15 @@ namespace System.ServiceModel.Syndication
                     {
                         if (reader.IsStartElement(Atom10Constants.NameTag, Atom10Constants.Atom10Namespace))
                         {
-                            result.Name = StringParser(reader.ReadElementString(), Atom10Constants.NameTag, reader.NamespaceURI);
+                            result.Name = reader.ReadElementString();
                         }
                         else if (reader.IsStartElement(Atom10Constants.UriTag, Atom10Constants.Atom10Namespace))
                         {
-                            result.Uri = StringParser(reader.ReadElementString(), Atom10Constants.UriTag, reader.NamespaceURI);
+                            result.Uri = reader.ReadElementString();
                         }
                         else if (reader.IsStartElement(Atom10Constants.EmailTag, Atom10Constants.Atom10Namespace))
                         {
-                            result.Email = StringParser(reader.ReadElementString(), Atom10Constants.EmailTag, reader.NamespaceURI);
+                            result.Email = reader.ReadElementString();
                         }
                         else
                         {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -333,7 +333,7 @@ namespace System.ServiceModel.Syndication
                 }
                 catch (XmlException e)
                 {
-                    result.LastUpdatedTimeError = e;
+                    result.LastUpdatedTimeException = e;
                 }
 
                 reader.ReadEndElement();
@@ -381,7 +381,7 @@ namespace System.ServiceModel.Syndication
                 }
                 catch (XmlException e)
                 {
-                    result.PublishDateError = e;
+                    result.PublishDateException = e;
                 }
 
                 reader.ReadEndElement();
@@ -414,7 +414,7 @@ namespace System.ServiceModel.Syndication
                 }
                 catch (XmlException e)
                 {
-                    result.LastUpdatedTimeError = e;
+                    result.LastUpdatedTimeException = e;
                 }
 
                 reader.ReadEndElement();
@@ -995,7 +995,6 @@ namespace System.ServiceModel.Syndication
             string title = null;
             string lengthStr = null;
             string val = null;
-            string ns = null;
             link.BaseUri = baseUri;
             if (reader.HasAttributes)
             {
@@ -1024,7 +1023,6 @@ namespace System.ServiceModel.Syndication
                     else if (reader.LocalName == Atom10Constants.HrefTag && reader.NamespaceURI == string.Empty)
                     {
                         val = reader.Value;
-                        ns = reader.NamespaceURI;
                     }
                     else if (!FeedUtils.IsXmlns(reader.LocalName, reader.NamespaceURI))
                     {
@@ -1083,7 +1081,7 @@ namespace System.ServiceModel.Syndication
             link.MediaType = mediaType;
             link.RelationshipType = relationship;
             link.Title = title;
-            link.Uri = (val != null) ? UriParser(val, UriKind.RelativeOrAbsolute, Atom10Constants.LinkTag, ns) : null;
+            link.Uri = (val != null) ? UriParser(val, UriKind.RelativeOrAbsolute, Atom10Constants.LinkTag, string.Empty) : null;
         }
 
         private SyndicationLink ReadLinkFrom(XmlReader reader, SyndicationFeed feed)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -321,7 +321,16 @@ namespace System.ServiceModel.Syndication
             else if (reader.IsStartElement(Atom10Constants.UpdatedTag, Atom10Constants.Atom10Namespace))
             {
                 reader.ReadStartElement();
-                result.LastUpdatedTime = DateFromString(reader.ReadString(), reader);
+                string dtoString = reader.ReadString();
+                try
+                {
+                    result.LastUpdatedTime = DateFromString(dtoString, reader);
+                }
+                catch (XmlException e)
+                {
+                    result.LastUpdatedTimeError = e;
+                }
+
                 reader.ReadEndElement();
             }
             else
@@ -360,7 +369,16 @@ namespace System.ServiceModel.Syndication
             else if (reader.IsStartElement(Atom10Constants.PublishedTag, Atom10Constants.Atom10Namespace))
             {
                 reader.ReadStartElement();
-                result.PublishDate = DateFromString(reader.ReadString(), reader);
+                string dtoString = reader.ReadString();
+                try
+                {
+                    result.PublishDate = DateFromString(dtoString, reader);
+                }
+                catch (XmlException e)
+                {
+                    result.PublishDateError = e;
+                }
+
                 reader.ReadEndElement();
             }
             else if (reader.IsStartElement(Atom10Constants.RightsTag, Atom10Constants.Atom10Namespace))
@@ -384,7 +402,16 @@ namespace System.ServiceModel.Syndication
             else if (reader.IsStartElement(Atom10Constants.UpdatedTag, Atom10Constants.Atom10Namespace))
             {
                 reader.ReadStartElement();
-                result.LastUpdatedTime = DateFromString(reader.ReadString(), reader);
+                string dtoString = reader.ReadString();
+                try
+                {
+                    result.LastUpdatedTime = DateFromString(dtoString, reader);
+                }
+                catch (XmlException e)
+                {
+                    result.LastUpdatedTimeError = e;
+                }
+
                 reader.ReadEndElement();
             }
             else

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -728,7 +728,7 @@ namespace System.ServiceModel.Syndication
 
             if (!string.IsNullOrEmpty(src))
             {
-                result = new UrlSyndicationContent(new Uri(src, UriKind.RelativeOrAbsolute), type);
+                result = new UrlSyndicationContent(UriParser(src, UriKind.RelativeOrAbsolute, Atom10Constants.ContentTag, Atom10Constants.Atom10Namespace), type);
                 bool isEmpty = reader.IsEmptyElement;
                 if (reader.HasAttributes)
                 {
@@ -1081,7 +1081,7 @@ namespace System.ServiceModel.Syndication
             link.MediaType = mediaType;
             link.RelationshipType = relationship;
             link.Title = title;
-            link.Uri = (val != null) ? UriParser(val, UriKind.RelativeOrAbsolute, Atom10Constants.LinkTag, string.Empty) : null;
+            link.Uri = (val != null) ? UriParser(val, UriKind.RelativeOrAbsolute, Atom10Constants.LinkTag, Atom10Constants.Atom10Namespace) : null;
         }
 
         private SyndicationLink ReadLinkFrom(XmlReader reader, SyndicationFeed feed)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -249,7 +249,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        internal static TextSyndicationContent ReadTextContentFrom(XmlReader reader, string context, bool preserveAttributeExtensions)
+        internal TextSyndicationContent ReadTextContentFrom(XmlReader reader, string context, bool preserveAttributeExtensions)
         {
             string type = reader.GetAttribute(Atom10Constants.TypeTag);
             return ReadTextContentFromHelper(reader, type, context, preserveAttributeExtensions);
@@ -297,11 +297,11 @@ namespace System.ServiceModel.Syndication
             }
             else if (reader.IsStartElement(Atom10Constants.GeneratorTag, Atom10Constants.Atom10Namespace))
             {
-                result.Generator = reader.ReadElementString();
+                result.Generator = StringParser(reader.ReadElementString(), Atom10Constants.GeneratorTag, Atom10Constants.Atom10Namespace);
             }
             else if (reader.IsStartElement(Atom10Constants.IdTag, Atom10Constants.Atom10Namespace))
             {
-                result.Id = reader.ReadElementString();
+                result.Id = StringParser(reader.ReadElementString(), Atom10Constants.IdTag, Atom10Constants.Atom10Namespace);
             }
             else if (reader.IsStartElement(Atom10Constants.LinkTag, Atom10Constants.Atom10Namespace))
             {
@@ -365,7 +365,7 @@ namespace System.ServiceModel.Syndication
             }
             else if (reader.IsStartElement(Atom10Constants.IdTag, Atom10Constants.Atom10Namespace))
             {
-                result.Id = reader.ReadElementString();
+                result.Id = StringParser(reader.ReadElementString(), Atom10Constants.IdTag, Atom10Constants.Atom10Namespace);
             }
             else if (reader.IsStartElement(Atom10Constants.LinkTag, Atom10Constants.Atom10Namespace))
             {
@@ -602,7 +602,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        private static TextSyndicationContent ReadTextContentFromHelper(XmlReader reader, string type, string context, bool preserveAttributeExtensions)
+        private TextSyndicationContent ReadTextContentFromHelper(XmlReader reader, string type, string context, bool preserveAttributeExtensions)
         {
             if (string.IsNullOrEmpty(type))
             {
@@ -656,7 +656,7 @@ namespace System.ServiceModel.Syndication
                 }
             }
             reader.MoveToElement();
-            string val = (kind == TextSyndicationContentKind.XHtml) ? reader.ReadInnerXml() : reader.ReadElementString();
+            string val = (kind == TextSyndicationContentKind.XHtml) ? reader.ReadInnerXml() : StringParser(reader.ReadElementString(), reader.LocalName, reader.NamespaceURI); // cant custom parse because its static
             TextSyndicationContent result = new TextSyndicationContent(val, kind);
             if (attrs != null)
             {
@@ -1148,15 +1148,15 @@ namespace System.ServiceModel.Syndication
                     {
                         if (reader.IsStartElement(Atom10Constants.NameTag, Atom10Constants.Atom10Namespace))
                         {
-                            result.Name = reader.ReadElementString();
+                            result.Name = StringParser(reader.ReadElementString(), Atom10Constants.NameTag, reader.NamespaceURI);
                         }
                         else if (reader.IsStartElement(Atom10Constants.UriTag, Atom10Constants.Atom10Namespace))
                         {
-                            result.Uri = reader.ReadElementString();
+                            result.Uri = StringParser(reader.ReadElementString(), Atom10Constants.UriTag, reader.NamespaceURI);
                         }
                         else if (reader.IsStartElement(Atom10Constants.EmailTag, Atom10Constants.Atom10Namespace))
                         {
-                            result.Email = reader.ReadElementString();
+                            result.Email = StringParser(reader.ReadElementString(), Atom10Constants.EmailTag, reader.NamespaceURI);
                         }
                         else
                         {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -309,7 +309,7 @@ namespace System.ServiceModel.Syndication
             }
             else if (reader.IsStartElement(Atom10Constants.LogoTag, Atom10Constants.Atom10Namespace))
             {
-                result.ImageUrl = new Uri(reader.ReadElementString(), UriKind.RelativeOrAbsolute);
+                result.ImageUrl = UriParser(reader.ReadElementString(), UriKind.RelativeOrAbsolute, Atom10Constants.LogoTag, Atom10Constants.Atom10Namespace);
             }
             else if (reader.IsStartElement(Atom10Constants.RightsTag, Atom10Constants.Atom10Namespace))
             {
@@ -656,7 +656,9 @@ namespace System.ServiceModel.Syndication
                 }
             }
             reader.MoveToElement();
-            string val = (kind == TextSyndicationContentKind.XHtml) ? reader.ReadInnerXml() : StringParser(reader.ReadElementString(), reader.LocalName, reader.NamespaceURI); // cant custom parse because its static
+            string localName = reader.LocalName;
+            string nameSpace = reader.NamespaceURI;
+            string val = (kind == TextSyndicationContentKind.XHtml) ? reader.ReadInnerXml() : StringParser(reader.ReadElementString(), localName, nameSpace); // cant custom parse because its static
             TextSyndicationContent result = new TextSyndicationContent(val, kind);
             if (attrs != null)
             {
@@ -993,6 +995,7 @@ namespace System.ServiceModel.Syndication
             string title = null;
             string lengthStr = null;
             string val = null;
+            string ns = null;
             link.BaseUri = baseUri;
             if (reader.HasAttributes)
             {
@@ -1021,6 +1024,7 @@ namespace System.ServiceModel.Syndication
                     else if (reader.LocalName == Atom10Constants.HrefTag && reader.NamespaceURI == string.Empty)
                     {
                         val = reader.Value;
+                        ns = reader.NamespaceURI;
                     }
                     else if (!FeedUtils.IsXmlns(reader.LocalName, reader.NamespaceURI))
                     {
@@ -1079,7 +1083,7 @@ namespace System.ServiceModel.Syndication
             link.MediaType = mediaType;
             link.RelationshipType = relationship;
             link.Title = title;
-            link.Uri = (val != null) ? new Uri(val, UriKind.RelativeOrAbsolute) : null;
+            link.Uri = (val != null) ? UriParser(val, UriKind.RelativeOrAbsolute, Atom10Constants.LinkTag, ns) : null;
         }
 
         private SyndicationLink ReadLinkFrom(XmlReader reader, SyndicationFeed feed)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
@@ -475,7 +475,7 @@ namespace System.ServiceModel.Syndication
                 {
                     if (reader.IsStartElement(Atom10Constants.TitleTag, Atom10Constants.Atom10Namespace))
                     {
-                        result.Title = new Atom10FeedFormatter().ReadTextContentFrom(reader, "//app:service/app:workspace/app:collection/atom:title[@type]", _preserveAttributeExtensions);
+                        result.Title = Atom10FeedFormatter.ReadTextContentFrom(reader, "//app:service/app:workspace/app:collection/atom:title[@type]", _preserveAttributeExtensions);
                     }
                     else if (reader.IsStartElement(App10Constants.Categories, App10Constants.Namespace))
                     {
@@ -663,7 +663,7 @@ namespace System.ServiceModel.Syndication
                 {
                     if (reader.IsStartElement(Atom10Constants.TitleTag, Atom10Constants.Atom10Namespace))
                     {
-                        result.Title = new Atom10FeedFormatter().ReadTextContentFrom(reader, "//app:service/app:workspace/atom:title[@type]", _preserveAttributeExtensions);
+                        result.Title = Atom10FeedFormatter.ReadTextContentFrom(reader, "//app:service/app:workspace/atom:title[@type]", _preserveAttributeExtensions);
                     }
                     else if (reader.IsStartElement(App10Constants.Collection, App10Constants.Namespace))
                     {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatter.cs
@@ -475,7 +475,7 @@ namespace System.ServiceModel.Syndication
                 {
                     if (reader.IsStartElement(Atom10Constants.TitleTag, Atom10Constants.Atom10Namespace))
                     {
-                        result.Title = Atom10FeedFormatter.ReadTextContentFrom(reader, "//app:service/app:workspace/app:collection/atom:title[@type]", _preserveAttributeExtensions);
+                        result.Title = new Atom10FeedFormatter().ReadTextContentFrom(reader, "//app:service/app:workspace/app:collection/atom:title[@type]", _preserveAttributeExtensions);
                     }
                     else if (reader.IsStartElement(App10Constants.Categories, App10Constants.Namespace))
                     {
@@ -663,7 +663,7 @@ namespace System.ServiceModel.Syndication
                 {
                     if (reader.IsStartElement(Atom10Constants.TitleTag, Atom10Constants.Atom10Namespace))
                     {
-                        result.Title = Atom10FeedFormatter.ReadTextContentFrom(reader, "//app:service/app:workspace/atom:title[@type]", _preserveAttributeExtensions);
+                        result.Title = new Atom10FeedFormatter().ReadTextContentFrom(reader, "//app:service/app:workspace/atom:title[@type]", _preserveAttributeExtensions);
                     }
                     else if (reader.IsStartElement(App10Constants.Collection, App10Constants.Namespace))
                     {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
@@ -1,0 +1,217 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text;
+
+namespace System.ServiceModel.Syndication
+{
+    internal static class DateTimeHelper
+    {
+        private const string Rfc3339DateTimeFormat = "yyyy-MM-ddTHH:mm:ssK";
+
+        public static DateTimeOffset DefaultRss20DateTimeParser(string dateTimeString, string localName, string ns)
+        {
+            DateTimeOffset dto;
+
+            // First check if DateTimeOffset default parsing can parse the date
+            if (DateTimeOffset.TryParse(dateTimeString, out dto))
+            {
+                return dto;
+            }
+
+            // RSS specifies RFC822
+            if (Rfc822DateTimeParser(dateTimeString, out dto))
+            {
+                return dto;
+            }
+
+            // Event though RCS3339 is for Atom, someone might be using this for RSS
+            if (Rfc3339DateTimeParser(dateTimeString, out dto))
+            {
+                return dto;
+            }
+
+            // Unable to parse - using a default date;
+            throw new FormatException(SR.ErrorParsingDateTime);
+        }
+
+        public static DateTimeOffset DefaultAtom10DateTimeParser(string dateTimeString, string localName, string ns)
+        {
+            if (Rfc3339DateTimeParser(dateTimeString, out DateTimeOffset dto))
+            {
+                return dto;
+            }
+
+            throw new FormatException(SR.ErrorParsingDateTime);
+        }
+
+        private static bool Rfc3339DateTimeParser(string dateTimeString, out DateTimeOffset dto)
+        {
+            dateTimeString = dateTimeString.Trim();
+            if (dateTimeString.Length < 20)
+            {
+                return false;
+            }
+
+            if (dateTimeString[19] == '.')
+            {
+                // remove any fractional seconds, we choose to ignore them
+                int i = 20;
+                while (dateTimeString.Length > i && char.IsDigit(dateTimeString[i]))
+                {
+                    ++i;
+                }
+
+                dateTimeString = dateTimeString.Substring(0, 19) + dateTimeString.Substring(i);
+            }
+
+            return DateTimeOffset.TryParseExact(dateTimeString, Rfc3339DateTimeFormat, CultureInfo.InvariantCulture.DateTimeFormat, DateTimeStyles.None, out dto);
+        }
+
+        private static bool Rfc822DateTimeParser(string dateTimeString, out DateTimeOffset dto)
+        {
+            StringBuilder dateTimeStringBuilder = new StringBuilder(dateTimeString.Trim());
+            if (dateTimeStringBuilder.Length < 18)
+            {
+                return false;
+            }
+
+            int timeZoneStartIndex;
+            for (timeZoneStartIndex = dateTimeStringBuilder.Length - 1; dateTimeStringBuilder[timeZoneStartIndex] != ' '; timeZoneStartIndex--)
+                ;
+            timeZoneStartIndex++;
+
+            int timeZoneLength = dateTimeStringBuilder.Length - timeZoneStartIndex;
+            string timeZoneSuffix = dateTimeStringBuilder.ToString(timeZoneStartIndex, timeZoneLength);
+            dateTimeStringBuilder.Remove(timeZoneStartIndex, timeZoneLength);
+            bool isUtc;
+            dateTimeStringBuilder.Append(NormalizeTimeZone(timeZoneSuffix, out isUtc));
+            string wellFormattedString = dateTimeStringBuilder.ToString();
+
+            DateTimeOffset theTime;
+            string[] parseFormat =
+            {
+                "ddd, dd MMMM yyyy HH:mm:ss zzz",
+                "dd MMMM yyyy HH:mm:ss zzz",
+                "ddd, dd MMM yyyy HH:mm:ss zzz",
+                "dd MMM yyyy HH:mm:ss zzz",
+
+                "ddd, dd MMMM yyyy HH:mm zzz",
+                "dd MMMM yyyy HH:mm zzz",
+                "ddd, dd MMM yyyy HH:mm zzz",
+                "dd MMM yyyy HH:mm zzz",
+
+                // The original RFC822 spec listed 2 digit years. RFC1123 updated the format to include 4 digit years and states that you should use 4 digits.
+                // Technically RSS2.0 specifies RFC822 but it's presumed that RFC1123 will be used as we're now past Y2K and everyone knows better. The 4 digit
+                // formats are listed first for performance reasons as it's presumed they will be more likely to match first.
+                "ddd, dd MMMM yy HH:mm:ss zzz",
+                "dd MMMM yyyy HH:mm:ss zzz",
+                "ddd, dd MMM yy HH:mm:ss zzz",
+                "dd MMM yyyy HH:mm:ss zzz",
+
+                "ddd, dd MMMM yy HH:mm zzz",
+                "dd MMMM yyyy HH:mm zzz",
+                "ddd, dd MMM yy HH:mm zzz",
+                "dd MMM yyyy HH:mm zzz"
+            };
+
+            if (DateTimeOffset.TryParseExact(wellFormattedString, parseFormat,
+                CultureInfo.InvariantCulture.DateTimeFormat,
+                (isUtc ? DateTimeStyles.AdjustToUniversal : DateTimeStyles.None), out theTime))
+            {
+                dto = theTime;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static string NormalizeTimeZone(string rfc822TimeZone, out bool isUtc)
+        {
+            isUtc = false;
+            // return a string in "-08:00" format
+            if (rfc822TimeZone[0] == '+' || rfc822TimeZone[0] == '-')
+            {
+                // the time zone is supposed to be 4 digits but some feeds omit the initial 0
+                StringBuilder result = new StringBuilder(rfc822TimeZone);
+                if (result.Length == 4)
+                {
+                    // the timezone is +/-HMM. Convert to +/-HHMM
+                    result.Insert(1, '0');
+                }
+                result.Insert(3, ':');
+                return result.ToString();
+            }
+            switch (rfc822TimeZone)
+            {
+                case "UT":
+                case "Z":
+                    isUtc = true;
+                    return "-00:00";
+                case "GMT":
+                    return "-00:00";
+                case "A":
+                    return "-01:00";
+                case "B":
+                    return "-02:00";
+                case "C":
+                    return "-03:00";
+                case "D":
+                case "EDT":
+                    return "-04:00";
+                case "E":
+                case "EST":
+                case "CDT":
+                    return "-05:00";
+                case "F":
+                case "CST":
+                case "MDT":
+                    return "-06:00";
+                case "G":
+                case "MST":
+                case "PDT":
+                    return "-07:00";
+                case "H":
+                case "PST":
+                    return "-08:00";
+                case "I":
+                    return "-09:00";
+                case "K":
+                    return "-10:00";
+                case "L":
+                    return "-11:00";
+                case "M":
+                    return "-12:00";
+                case "N":
+                    return "+01:00";
+                case "O":
+                    return "+02:00";
+                case "P":
+                    return "+03:00";
+                case "Q":
+                    return "+04:00";
+                case "R":
+                    return "+05:00";
+                case "S":
+                    return "+06:00";
+                case "T":
+                    return "+07:00";
+                case "U":
+                    return "+08:00";
+                case "V":
+                    return "+09:00";
+                case "W":
+                    return "+10:00";
+                case "X":
+                    return "+11:00";
+                case "Y":
+                    return "+12:00";
+                default:
+                    return "";
+            }
+        }
+
+    }
+}

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -470,7 +470,7 @@ namespace System.ServiceModel.Syndication
                                         }
                                         catch (XmlException e)
                                         {
-                                            result.PublishDateError = e;
+                                            result.PublishDateException = e;
                                         }
                                     }
                                     reader.ReadEndElement();
@@ -776,7 +776,7 @@ namespace System.ServiceModel.Syndication
                                     }
                                     catch (XmlException e)
                                     {
-                                        result.LastUpdatedTimeError = e;
+                                        result.LastUpdatedTimeException = e;
                                     }
                                 }
                                 reader.ReadEndElement();

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -78,6 +78,11 @@ namespace System.ServiceModel.Syndication
             _feedType = feedToWrite.GetType();
         }
 
+        internal override Func<string, string, string, DateTimeOffset> GetDefaultDateTimeParser()
+        {
+            return DateTimeHelper.DefaultRss20DateTimeParser;
+        }
+
         public bool PreserveAttributeExtensions
         {
             get { return _preserveAttributeExtensions; }
@@ -254,211 +259,10 @@ namespace System.ServiceModel.Syndication
                 this.WriteItem(writer, item, feedBaseUri);
             }
         }
-
-        private static DateTimeOffset DateFromString(string dateTimeString, XmlReader reader)
-        {
-            StringBuilder dateTimeStringBuilder = new StringBuilder(dateTimeString.Trim());
-            if (dateTimeStringBuilder.Length < 18)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                    new XmlException(FeedUtils.AddLineInfo(reader,
-                    SR.ErrorParsingDateTime)));
-            }
-            if (dateTimeStringBuilder[3] == ',')
-            {
-                // There is a leading (e.g.) "Tue, ", strip it off
-                dateTimeStringBuilder.Remove(0, 4);
-                // There's supposed to be a space here but some implementations dont have one
-                RemoveExtraWhiteSpaceAtStart(dateTimeStringBuilder);
-            }
-            ReplaceMultipleWhiteSpaceWithSingleWhiteSpace(dateTimeStringBuilder);
-            if (char.IsDigit(dateTimeStringBuilder[1]))
-            {
-                // two-digit day, we are good
-            }
-            else
-            {
-                dateTimeStringBuilder.Insert(0, '0');
-            }
-            if (dateTimeStringBuilder.Length < 19)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                    new XmlException(FeedUtils.AddLineInfo(reader,
-                    SR.ErrorParsingDateTime)));
-            }
-            bool thereAreSeconds = (dateTimeStringBuilder[17] == ':');
-            int timeZoneStartIndex;
-            if (thereAreSeconds)
-            {
-                timeZoneStartIndex = 21;
-            }
-            else
-            {
-                timeZoneStartIndex = 18;
-            }
-            string timeZoneSuffix = dateTimeStringBuilder.ToString().Substring(timeZoneStartIndex);
-            dateTimeStringBuilder.Remove(timeZoneStartIndex, dateTimeStringBuilder.Length - timeZoneStartIndex);
-            bool isUtc;
-            dateTimeStringBuilder.Append(NormalizeTimeZone(timeZoneSuffix, out isUtc));
-            string wellFormattedString = dateTimeStringBuilder.ToString();
-
-            DateTimeOffset theTime;
-            string parseFormat;
-            if (thereAreSeconds)
-            {
-                parseFormat = "dd MMM yyyy HH:mm:ss zzz";
-            }
-            else
-            {
-                parseFormat = "dd MMM yyyy HH:mm zzz";
-            }
-            if (DateTimeOffset.TryParseExact(wellFormattedString, parseFormat,
-                CultureInfo.InvariantCulture.DateTimeFormat,
-                (isUtc ? DateTimeStyles.AdjustToUniversal : DateTimeStyles.None), out theTime))
-            {
-                return theTime;
-            }
-            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                new XmlException(FeedUtils.AddLineInfo(reader,
-                SR.ErrorParsingDateTime)));
-        }
-
-        private static string NormalizeTimeZone(string rfc822TimeZone, out bool isUtc)
-        {
-            isUtc = false;
-            // return a string in "-08:00" format
-            if (rfc822TimeZone[0] == '+' || rfc822TimeZone[0] == '-')
-            {
-                // the time zone is supposed to be 4 digits but some feeds omit the initial 0
-                StringBuilder result = new StringBuilder(rfc822TimeZone);
-                if (result.Length == 4)
-                {
-                    // the timezone is +/-HMM. Convert to +/-HHMM
-                    result.Insert(1, '0');
-                }
-                result.Insert(3, ':');
-                return result.ToString();
-            }
-            switch (rfc822TimeZone)
-            {
-                case "UT":
-                case "Z":
-                    isUtc = true;
-                    return "-00:00";
-                case "GMT":
-                    return "-00:00";
-                case "A":
-                    return "-01:00";
-                case "B":
-                    return "-02:00";
-                case "C":
-                    return "-03:00";
-                case "D":
-                case "EDT":
-                    return "-04:00";
-                case "E":
-                case "EST":
-                case "CDT":
-                    return "-05:00";
-                case "F":
-                case "CST":
-                case "MDT":
-                    return "-06:00";
-                case "G":
-                case "MST":
-                case "PDT":
-                    return "-07:00";
-                case "H":
-                case "PST":
-                    return "-08:00";
-                case "I":
-                    return "-09:00";
-                case "K":
-                    return "-10:00";
-                case "L":
-                    return "-11:00";
-                case "M":
-                    return "-12:00";
-                case "N":
-                    return "+01:00";
-                case "O":
-                    return "+02:00";
-                case "P":
-                    return "+03:00";
-                case "Q":
-                    return "+04:00";
-                case "R":
-                    return "+05:00";
-                case "S":
-                    return "+06:00";
-                case "T":
-                    return "+07:00";
-                case "U":
-                    return "+08:00";
-                case "V":
-                    return "+09:00";
-                case "W":
-                    return "+10:00";
-                case "X":
-                    return "+11:00";
-                case "Y":
-                    return "+12:00";
-                default:
-                    return "";
-            }
-        }
-
-        private static void RemoveExtraWhiteSpaceAtStart(StringBuilder stringBuilder)
-        {
-            int i = 0;
-            while (i < stringBuilder.Length)
-            {
-                if (!char.IsWhiteSpace(stringBuilder[i]))
-                {
-                    break;
-                }
-                ++i;
-            }
-            if (i > 0)
-            {
-                stringBuilder.Remove(0, i);
-            }
-        }
-
-        private static void ReplaceMultipleWhiteSpaceWithSingleWhiteSpace(StringBuilder builder)
-        {
-            int index = 0;
-            int whiteSpaceStart = -1;
-            while (index < builder.Length)
-            {
-                if (char.IsWhiteSpace(builder[index]))
-                {
-                    if (whiteSpaceStart < 0)
-                    {
-                        whiteSpaceStart = index;
-                        // normalize all white spaces to be ' ' so that the date time parsing works
-                        builder[index] = ' ';
-                    }
-                }
-                else if (whiteSpaceStart >= 0)
-                {
-                    if (index > whiteSpaceStart + 1)
-                    {
-                        // there are at least 2 spaces... replace by 1
-                        builder.Remove(whiteSpaceStart, index - whiteSpaceStart - 1);
-                        index = whiteSpaceStart + 1;
-                    }
-                    whiteSpaceStart = -1;
-                }
-                ++index;
-            }
-            // we have already trimmed the start and end so there cannot be a trail of white spaces in the end
-            Debug.Assert(builder.Length == 0 || builder[builder.Length - 1] != ' ', "The string builder doesnt end in a white space");
-        }
-
+        
         private string AsString(DateTimeOffset dateTime)
         {
-            if (dateTime.Offset == Atom10FeedFormatter.zeroOffset)
+            if (dateTime.Offset == Atom10FeedFormatter.ZeroOffset)
             {
                 return dateTime.ToUniversalTime().ToString(Rfc822OutputUtcDateTimeFormat, CultureInfo.InvariantCulture);
             }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -357,7 +357,7 @@ namespace System.ServiceModel.Syndication
             reader.ReadStartElement(Rss20Constants.CategoryTag, Rss20Constants.Rss20Namespace);
             if (!isEmpty)
             {
-                category.Name = StringParser(reader.ReadString(), reader.LocalName, Rss20Constants.Rss20Namespace);
+                category.Name = reader.ReadString();
                 reader.ReadEndElement();
             }
         }
@@ -417,7 +417,7 @@ namespace System.ServiceModel.Syndication
                         {
                             if (reader.IsStartElement(Rss20Constants.TitleTag, Rss20Constants.Rss20Namespace))
                             {
-                                result.Title = new TextSyndicationContent(StringParser(reader.ReadElementString(), Rss20Constants.TitleTag, Rss20Constants.Rss20Namespace));
+                                result.Title = new TextSyndicationContent(reader.ReadElementString());
                             }
                             else if (reader.IsStartElement(Rss20Constants.LinkTag, Rss20Constants.Rss20Namespace))
                             {
@@ -426,7 +426,7 @@ namespace System.ServiceModel.Syndication
                             }
                             else if (reader.IsStartElement(Rss20Constants.DescriptionTag, Rss20Constants.Rss20Namespace))
                             {
-                                result.Summary = new TextSyndicationContent(StringParser(reader.ReadElementString(), Rss20Constants.DescriptionTag, Rss20Constants.Rss20Namespace));
+                                result.Summary = new TextSyndicationContent(reader.ReadElementString());
                             }
                             else if (reader.IsStartElement(Rss20Constants.AuthorTag, Rss20Constants.Rss20Namespace))
                             {
@@ -449,7 +449,7 @@ namespace System.ServiceModel.Syndication
                                     isPermalink = false;
                                 }
 
-                                result.Id = StringParser(reader.ReadElementString(), Rss20Constants.GuidTag, Rss20Constants.Rss20Namespace);
+                                result.Id = reader.ReadElementString();
                                 if (isPermalink)
                                 {
                                     fallbackAlternateLink = result.Id;
@@ -508,7 +508,7 @@ namespace System.ServiceModel.Syndication
                                     }
                                 }
 
-                                string feedTitle = StringParser(reader.ReadElementString(), Rss20Constants.SourceTag, Rss20Constants.Rss20Namespace);
+                                string feedTitle = reader.ReadElementString();
                                 feed.Title = new TextSyndicationContent(feedTitle);
                                 result.SourceFeed = feed;
                             }
@@ -666,7 +666,7 @@ namespace System.ServiceModel.Syndication
             reader.ReadStartElement();
             if (!isEmpty)
             {
-                string email = StringParser(reader.ReadString(), reader.LocalName, reader.NamespaceURI);
+                string email = reader.ReadString();
                 reader.ReadEndElement();
                 person.Email = email;
             }
@@ -739,7 +739,7 @@ namespace System.ServiceModel.Syndication
                     {
                         if (reader.IsStartElement(Rss20Constants.TitleTag, Rss20Constants.Rss20Namespace))
                         {
-                            result.Title = new TextSyndicationContent(StringParser(reader.ReadElementString(), Rss20Constants.TitleTag, Rss20Constants.Rss20Namespace));
+                            result.Title = new TextSyndicationContent(reader.ReadElementString());
                         }
                         else if (reader.IsStartElement(Rss20Constants.LinkTag, Rss20Constants.Rss20Namespace))
                         {
@@ -747,15 +747,15 @@ namespace System.ServiceModel.Syndication
                         }
                         else if (reader.IsStartElement(Rss20Constants.DescriptionTag, Rss20Constants.Rss20Namespace))
                         {
-                            result.Description = new TextSyndicationContent(StringParser(reader.ReadElementString(), Rss20Constants.DescriptionTag, Rss20Constants.Rss20Namespace));
+                            result.Description = new TextSyndicationContent(reader.ReadElementString());
                         }
                         else if (reader.IsStartElement(Rss20Constants.LanguageTag, Rss20Constants.Rss20Namespace))
                         {
-                            result.Language = StringParser(reader.ReadElementString(), Rss20Constants.LanguageTag, Rss20Constants.Rss20Namespace);
+                            result.Language = reader.ReadElementString();
                         }
                         else if (reader.IsStartElement(Rss20Constants.CopyrightTag, Rss20Constants.Rss20Namespace))
                         {
-                            result.Copyright = new TextSyndicationContent(StringParser(reader.ReadElementString(), Rss20Constants.CopyrightTag, Rss20Constants.Rss20Namespace));
+                            result.Copyright = new TextSyndicationContent(reader.ReadElementString());
                         }
                         else if (reader.IsStartElement(Rss20Constants.ManagingEditorTag, Rss20Constants.Rss20Namespace))
                         {
@@ -788,7 +788,7 @@ namespace System.ServiceModel.Syndication
                         }
                         else if (reader.IsStartElement(Rss20Constants.GeneratorTag, Rss20Constants.Rss20Namespace))
                         {
-                            result.Generator = StringParser(reader.ReadElementString(), Rss20Constants.GeneratorTag, Rss20Constants.Rss20Namespace);
+                            result.Generator = reader.ReadElementString();
                         }
                         else if (reader.IsStartElement(Rss20Constants.ImageTag, Rss20Constants.Rss20Namespace))
                         {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -354,7 +354,7 @@ namespace System.ServiceModel.Syndication
             reader.ReadStartElement(Rss20Constants.CategoryTag, Rss20Constants.Rss20Namespace);
             if (!isEmpty)
             {
-                category.Name = reader.ReadString();
+                category.Name = StringParser(reader.ReadString(), reader.LocalName, Rss20Constants.Rss20Namespace);
                 reader.ReadEndElement();
             }
         }
@@ -414,7 +414,7 @@ namespace System.ServiceModel.Syndication
                         {
                             if (reader.IsStartElement(Rss20Constants.TitleTag, Rss20Constants.Rss20Namespace))
                             {
-                                result.Title = new TextSyndicationContent(reader.ReadElementString());
+                                result.Title = new TextSyndicationContent(StringParser(reader.ReadElementString(), Rss20Constants.TitleTag, Rss20Constants.Rss20Namespace));
                             }
                             else if (reader.IsStartElement(Rss20Constants.LinkTag, Rss20Constants.Rss20Namespace))
                             {
@@ -423,7 +423,7 @@ namespace System.ServiceModel.Syndication
                             }
                             else if (reader.IsStartElement(Rss20Constants.DescriptionTag, Rss20Constants.Rss20Namespace))
                             {
-                                result.Summary = new TextSyndicationContent(reader.ReadElementString());
+                                result.Summary = new TextSyndicationContent(StringParser(reader.ReadElementString(), Rss20Constants.DescriptionTag, Rss20Constants.Rss20Namespace));
                             }
                             else if (reader.IsStartElement(Rss20Constants.AuthorTag, Rss20Constants.Rss20Namespace))
                             {
@@ -445,7 +445,8 @@ namespace System.ServiceModel.Syndication
                                 {
                                     isPermalink = false;
                                 }
-                                result.Id = reader.ReadElementString();
+
+                                result.Id = StringParser(reader.ReadElementString(), Rss20Constants.GuidTag, Rss20Constants.Rss20Namespace);
                                 if (isPermalink)
                                 {
                                     fallbackAlternateLink = result.Id;
@@ -503,7 +504,8 @@ namespace System.ServiceModel.Syndication
                                         }
                                     }
                                 }
-                                string feedTitle = reader.ReadElementString();
+
+                                string feedTitle = StringParser(reader.ReadElementString(), Rss20Constants.SourceTag, Rss20Constants.Rss20Namespace);
                                 feed.Title = new TextSyndicationContent(feedTitle);
                                 result.SourceFeed = feed;
                             }
@@ -661,7 +663,7 @@ namespace System.ServiceModel.Syndication
             reader.ReadStartElement();
             if (!isEmpty)
             {
-                string email = reader.ReadString();
+                string email = StringParser(reader.ReadString(), reader.LocalName, reader.NamespaceURI);
                 reader.ReadEndElement();
                 person.Email = email;
             }
@@ -734,7 +736,7 @@ namespace System.ServiceModel.Syndication
                     {
                         if (reader.IsStartElement(Rss20Constants.TitleTag, Rss20Constants.Rss20Namespace))
                         {
-                            result.Title = new TextSyndicationContent(reader.ReadElementString());
+                            result.Title = new TextSyndicationContent(StringParser(reader.ReadElementString(), Rss20Constants.TitleTag, Rss20Constants.Rss20Namespace));
                         }
                         else if (reader.IsStartElement(Rss20Constants.LinkTag, Rss20Constants.Rss20Namespace))
                         {
@@ -742,15 +744,15 @@ namespace System.ServiceModel.Syndication
                         }
                         else if (reader.IsStartElement(Rss20Constants.DescriptionTag, Rss20Constants.Rss20Namespace))
                         {
-                            result.Description = new TextSyndicationContent(reader.ReadElementString());
+                            result.Description = new TextSyndicationContent(StringParser(reader.ReadElementString(), Rss20Constants.DescriptionTag, Rss20Constants.Rss20Namespace));
                         }
                         else if (reader.IsStartElement(Rss20Constants.LanguageTag, Rss20Constants.Rss20Namespace))
                         {
-                            result.Language = reader.ReadElementString();
+                            result.Language = StringParser(reader.ReadElementString(), Rss20Constants.LanguageTag, Rss20Constants.Rss20Namespace);
                         }
                         else if (reader.IsStartElement(Rss20Constants.CopyrightTag, Rss20Constants.Rss20Namespace))
                         {
-                            result.Copyright = new TextSyndicationContent(reader.ReadElementString());
+                            result.Copyright = new TextSyndicationContent(StringParser(reader.ReadElementString(), Rss20Constants.CopyrightTag, Rss20Constants.Rss20Namespace));
                         }
                         else if (reader.IsStartElement(Rss20Constants.ManagingEditorTag, Rss20Constants.Rss20Namespace))
                         {
@@ -783,7 +785,7 @@ namespace System.ServiceModel.Syndication
                         }
                         else if (reader.IsStartElement(Rss20Constants.GeneratorTag, Rss20Constants.Rss20Namespace))
                         {
-                            result.Generator = reader.ReadElementString();
+                            result.Generator = StringParser(reader.ReadElementString(), Rss20Constants.GeneratorTag, Rss20Constants.Rss20Namespace);
                         }
                         else if (reader.IsStartElement(Rss20Constants.ImageTag, Rss20Constants.Rss20Namespace))
                         {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -301,8 +301,11 @@ namespace System.ServiceModel.Syndication
                     }
                 }
             }
+
+            string localName = reader.LocalName;
+            string namespaceUri = reader.NamespaceURI;
             string uri = reader.ReadElementString();
-            link.Uri = new Uri(uri, UriKind.RelativeOrAbsolute);
+            link.Uri = UriParser(uri, UriKind.RelativeOrAbsolute, localName, namespaceUri);
             return link;
         }
 
@@ -489,7 +492,7 @@ namespace System.ServiceModel.Syndication
                                         string val = reader.Value;
                                         if (name == Rss20Constants.UrlTag && ns == Rss20Constants.Rss20Namespace)
                                         {
-                                            feed.Links.Add(SyndicationLink.CreateSelfLink(new Uri(val, UriKind.RelativeOrAbsolute)));
+                                            feed.Links.Add(SyndicationLink.CreateSelfLink(UriParser(val, UriKind.RelativeOrAbsolute, Rss20Constants.UrlTag, Rss20Constants.Rss20Namespace)));
                                         }
                                         else if (!FeedUtils.IsXmlns(name, ns))
                                         {
@@ -588,7 +591,7 @@ namespace System.ServiceModel.Syndication
                     string val = reader.Value;
                     if (name == Rss20Constants.UrlTag && ns == Rss20Constants.Rss20Namespace)
                     {
-                        link.Uri = new Uri(val, UriKind.RelativeOrAbsolute);
+                        link.Uri = UriParser(val, UriKind.RelativeOrAbsolute, Rss20Constants.UrlTag, Rss20Constants.Rss20Namespace);
                     }
                     else if (name == Rss20Constants.TypeTag && ns == Rss20Constants.Rss20Namespace)
                     {
@@ -794,7 +797,7 @@ namespace System.ServiceModel.Syndication
                             {
                                 if (reader.IsStartElement(Rss20Constants.UrlTag, Rss20Constants.Rss20Namespace))
                                 {
-                                    result.ImageUrl = new Uri(reader.ReadElementString(), UriKind.RelativeOrAbsolute);
+                                    result.ImageUrl = UriParser(reader.ReadElementString(), UriKind.RelativeOrAbsolute, Rss20Constants.UrlTag, Rss20Constants.Rss20Namespace);
                                 }
                                 else
                                 {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -656,7 +656,14 @@ namespace System.ServiceModel.Syndication
                                     string str = reader.ReadString();
                                     if (!string.IsNullOrEmpty(str))
                                     {
-                                        result.PublishDate = DateFromString(str, reader);
+                                        try
+                                        {
+                                            result.PublishDate = DateFromString(str, reader);
+                                        }
+                                        catch (XmlException e)
+                                        {
+                                            result.PublishDateError = e;
+                                        }
                                     }
                                     reader.ReadEndElement();
                                 }
@@ -954,7 +961,14 @@ namespace System.ServiceModel.Syndication
                                 string str = reader.ReadString();
                                 if (!string.IsNullOrEmpty(str))
                                 {
-                                    result.LastUpdatedTime = DateFromString(str, reader);
+                                    try
+                                    {
+                                        result.LastUpdatedTime = DateFromString(str, reader);
+                                    }
+                                    catch (XmlException e)
+                                    {
+                                        result.LastUpdatedTimeError = e;
+                                    }
                                 }
                                 reader.ReadEndElement();
                             }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
@@ -227,10 +227,24 @@ namespace System.ServiceModel.Syndication
             set { _language = value; }
         }
 
+        internal Exception LastUpdatedTimeError { get; set; }
+
         public DateTimeOffset LastUpdatedTime
         {
-            get { return _lastUpdatedTime; }
-            set { _lastUpdatedTime = value; }
+            get
+            {
+                if (LastUpdatedTimeError != null)
+                {
+                    throw LastUpdatedTimeError;
+                }
+
+                return _lastUpdatedTime;
+            }
+            set
+            {
+                LastUpdatedTimeError = null;
+                _lastUpdatedTime = value;
+            }
         }
 
         public Collection<SyndicationLink> Links

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
@@ -227,22 +227,22 @@ namespace System.ServiceModel.Syndication
             set { _language = value; }
         }
 
-        internal Exception LastUpdatedTimeError { get; set; }
+        internal Exception LastUpdatedTimeException { get; set; }
 
         public DateTimeOffset LastUpdatedTime
         {
             get
             {
-                if (LastUpdatedTimeError != null)
+                if (LastUpdatedTimeException != null)
                 {
-                    throw LastUpdatedTimeError;
+                    throw LastUpdatedTimeException;
                 }
 
                 return _lastUpdatedTime;
             }
             set
             {
-                LastUpdatedTimeError = null;
+                LastUpdatedTimeException = null;
                 _lastUpdatedTime = value;
             }
         }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
@@ -7,11 +7,9 @@ namespace System.ServiceModel.Syndication
     using System;
     using System.Diagnostics;
     using System.Globalization;
-    using System.Runtime;
     using System.Runtime.Serialization;
     using System.Xml;
     using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
-    using System.Runtime.CompilerServices;
 
     [DataContract]
     public abstract class SyndicationFeedFormatter
@@ -21,6 +19,7 @@ namespace System.ServiceModel.Syndication
         protected SyndicationFeedFormatter()
         {
             _feed = null;
+            DateTimeParser = GetDefaultDateTimeParser();
         }
 
         protected SyndicationFeedFormatter(SyndicationFeed feedToWrite)
@@ -30,6 +29,7 @@ namespace System.ServiceModel.Syndication
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("feedToWrite");
             }
             _feed = feedToWrite;
+            DateTimeParser = GetDefaultDateTimeParser();
         }
 
         public SyndicationFeed Feed
@@ -39,6 +39,15 @@ namespace System.ServiceModel.Syndication
                 return _feed;
             }
         }
+
+        public Func<string, string, string, string> StringParser { get; set; } = DefaultStringParser;
+
+        public Func<string, UriKind, string, string, Uri> UriParser { get; set; } = DefaultUriParser;
+
+        // Different DateTimeParsers are needed for Atom and Rss so can't set inline
+        public Func<string, string, string, DateTimeOffset> DateTimeParser { get; set; }
+
+        internal abstract Func<string, string, string, DateTimeOffset> GetDefaultDateTimeParser();
 
         public abstract string Version
         { get; }
@@ -374,6 +383,29 @@ namespace System.ServiceModel.Syndication
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("feed");
             }
             _feed = feed;
+        }
+
+        internal DateTimeOffset DateFromString(string dateTimeString, XmlReader reader)
+        {
+            try
+            {
+                return DateTimeParser(dateTimeString, reader.LocalName, reader.NamespaceURI);
+            }
+            catch (FormatException e)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                    new XmlException(FeedUtils.AddLineInfo(reader, SR.ErrorParsingDateTime), e));
+            }
+        }
+
+        private static string DefaultStringParser(string value, string localName, string ns)
+        {
+            return value;
+        }
+
+        private static Uri DefaultUriParser(string value, UriKind kind, string localName, string ns)
+        {
+            return new Uri(value, kind);
         }
 
         internal static void CloseBuffer(XmlBuffer buffer, XmlDictionaryWriter extWriter)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
@@ -45,7 +45,15 @@ namespace System.ServiceModel.Syndication
         // Different DateTimeParsers are needed for Atom and Rss so can't set inline
         public Func<string, string, string, DateTimeOffset> DateTimeParser { get; set; }
 
-        internal abstract Func<string, string, string, DateTimeOffset> GetDefaultDateTimeParser();
+        internal virtual Func<string, string, string, DateTimeOffset> GetDefaultDateTimeParser()
+        {
+            return NotImplementedDateTimeParser;
+        }
+
+        private DateTimeOffset NotImplementedDateTimeParser(string dtoString, string localName, string ns)
+        {
+            throw new NotImplementedException();
+        }
 
         public abstract string Version
         { get; }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
@@ -40,8 +40,6 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        public Func<string, string, string, string> StringParser { get; set; } = DefaultStringParser;
-
         public Func<string, UriKind, string, string, Uri> UriParser { get; set; } = DefaultUriParser;
 
         // Different DateTimeParsers are needed for Atom and Rss so can't set inline
@@ -396,11 +394,6 @@ namespace System.ServiceModel.Syndication
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
                     new XmlException(FeedUtils.AddLineInfo(reader, SR.ErrorParsingDateTime), e));
             }
-        }
-
-        private static string DefaultStringParser(string value, string localName, string ns)
-        {
-            return value;
         }
 
         private static Uri DefaultUriParser(string value, UriKind kind, string localName, string ns)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItem.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItem.cs
@@ -158,10 +158,24 @@ namespace System.ServiceModel.Syndication
             set { _id = value; }
         }
 
+        internal Exception LastUpdatedTimeError { get; set; }
+
         public DateTimeOffset LastUpdatedTime
         {
-            get { return _lastUpdatedTime; }
-            set { _lastUpdatedTime = value; }
+            get
+            {
+                if (LastUpdatedTimeError != null)
+                {
+                    throw LastUpdatedTimeError;
+                }
+
+                return _lastUpdatedTime;
+            }
+            set
+            {
+                LastUpdatedTimeError = null;
+                _lastUpdatedTime = value;
+            }
         }
 
         public Collection<SyndicationLink> Links
@@ -176,10 +190,24 @@ namespace System.ServiceModel.Syndication
             }
         }
 
+        internal Exception PublishDateError { get; set; }
+
         public DateTimeOffset PublishDate
         {
-            get { return _publishDate; }
-            set { _publishDate = value; }
+            get
+            {
+                if (PublishDateError != null)
+                {
+                    throw PublishDateError;
+                }
+
+                return _publishDate;
+            }
+            set
+            {
+                PublishDateError = null;
+                _publishDate = value;
+            }
         }
 
         public SyndicationFeed SourceFeed

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItem.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationItem.cs
@@ -158,22 +158,22 @@ namespace System.ServiceModel.Syndication
             set { _id = value; }
         }
 
-        internal Exception LastUpdatedTimeError { get; set; }
+        internal Exception LastUpdatedTimeException { get; set; }
 
         public DateTimeOffset LastUpdatedTime
         {
             get
             {
-                if (LastUpdatedTimeError != null)
+                if (LastUpdatedTimeException != null)
                 {
-                    throw LastUpdatedTimeError;
+                    throw LastUpdatedTimeException;
                 }
 
                 return _lastUpdatedTime;
             }
             set
             {
-                LastUpdatedTimeError = null;
+                LastUpdatedTimeException = null;
                 _lastUpdatedTime = value;
             }
         }
@@ -190,22 +190,22 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        internal Exception PublishDateError { get; set; }
+        internal Exception PublishDateException { get; set; }
 
         public DateTimeOffset PublishDate
         {
             get
             {
-                if (PublishDateError != null)
+                if (PublishDateException != null)
                 {
-                    throw PublishDateError;
+                    throw PublishDateException;
                 }
 
                 return _publishDate;
             }
             set
             {
-                PublishDateError = null;
+                PublishDateException = null;
                 _publishDate = value;
             }
         }

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -289,8 +289,6 @@ namespace System.ServiceModel.Syndication.Tests
         public static void SyndicationFeed_Rss_WrongDateFormat()
         {
             // *** SETUP *** \\
-            Rss20FeedFormatter rssformatter = new Rss20FeedFormatter();
-
             XmlReader reader = XmlReader.Create(@"rssSpecExampleWrongDateFormat.xml");
 
             // *** EXECUTE *** \\
@@ -304,6 +302,116 @@ namespace System.ServiceModel.Syndication.Tests
             SyndicationItem[] items = res.Items.ToArray();
             DateTimeOffset dateTimeOffset;
             Assert.Throws<XmlException>(() => dateTimeOffset = items[2].PublishDate);
+        }
+
+        [Fact]
+        public static void SyndicationFeed_Rss_DateTimeParser()
+        {
+            // *** SETUP *** \\
+            // *** EXECUTE *** \\
+            SyndicationFeed feed;
+            DateTimeOffset dto = new DateTimeOffset(2017, 1, 2, 3, 4, 5, new TimeSpan(0));
+            using (XmlReader reader = XmlReader.Create(@"RssSpecCustomParser.xml"))
+            {
+                var formatter = new Rss20FeedFormatter();
+                formatter.DateTimeParser = (value, localName, ns) => dto;
+                formatter.ReadFrom(reader);
+                feed = formatter.Feed;
+            }
+
+            // *** ASSERT *** \\
+            Assert.True(feed != null, "res was null.");
+            Assert.Equal(dto, feed.LastUpdatedTime);
+        }
+
+        [Fact]
+        public static void SyndicationFeed_Rss_StringParser()
+        {
+            // *** SETUP *** \\
+            // *** EXECUTE *** \\
+            SyndicationFeed feed;
+            using (XmlReader reader = XmlReader.Create(@"RssSpecCustomParser.xml"))
+            {
+                var formatter = new Rss20FeedFormatter();
+                formatter.StringParser = (value, localName, ns) => $"value:{value}-localName:{localName}-ns:{ns}";
+                formatter.ReadFrom(reader);
+                feed = formatter.Feed;
+            }
+
+            // *** ASSERT *** \\
+            Assert.True(feed != null, "res was null.");
+            Assert.Equal("value:FeedGenerator-localName:generator-ns:", feed.Generator);
+            Assert.Equal("value:FeedTitle-localName:title-ns:", feed.Title.Text);
+            Assert.Equal("value:FeedDescription-localName:description-ns:", feed.Description.Text);
+            Assert.Equal("value:FeedCopyright-localName:copyright-ns:", feed.Copyright.Text);
+            Assert.Equal("value:FeedLanguage-localName:language-ns:", feed.Language);
+            Assert.NotNull(feed.Authors);
+            Assert.Equal(1, feed.Authors.Count);
+            Assert.Equal("value:FeedEditorEmail-localName:managingEditor-ns:", feed.Authors.First().Email);
+            Assert.NotNull(feed.Categories);
+            Assert.Equal(1, feed.Categories.Count);
+            Assert.Equal("value:FeedCategory-localName:category-ns:", feed.Categories.First().Name);
+            
+            Assert.True(feed.Items != null, "res.Items was null.");
+            Assert.Equal(1, feed.Items.Count());
+            Assert.Equal("value:ItemTitle-localName:title-ns:", feed.Items.First().Title.Text);
+            Assert.Equal("value:ItemGuid-localName:guid-ns:", feed.Items.First().Id);
+            Assert.Equal("value:ItemDescription-localName:description-ns:", feed.Items.First().Summary.Text);
+        }
+
+        [Fact]
+        public static void SyndicationFeed_Atom_DateTimeParser()
+        {
+            // *** SETUP *** \\
+            // *** EXECUTE *** \\
+            SyndicationFeed feed;
+            DateTimeOffset dto = new DateTimeOffset(2017, 1, 2, 3, 4, 5, new TimeSpan(0));
+            using (XmlReader reader = XmlReader.Create(@"SimpleAtomFeedCustomParser.xml"))
+            {
+                var formatter = new Atom10FeedFormatter();
+                formatter.DateTimeParser = (value, localName, ns) => dto;
+                formatter.ReadFrom(reader);
+                feed = formatter.Feed;
+            }
+
+
+            // *** ASSERT *** \\
+            Assert.True(feed != null, "res was null.");
+            Assert.Equal(dto, feed.LastUpdatedTime);
+
+            Assert.True(feed.Items != null, "res.Items was null.");
+            Assert.Equal(1, feed.Items.Count());
+            Assert.Equal(dto, feed.Items.First().LastUpdatedTime);
+        }
+
+        [Fact]
+        public static void SyndicationFeed_Atom_StringParser()
+        {
+            // *** SETUP *** \\
+            // *** EXECUTE *** \\
+            SyndicationFeed feed;
+            using (XmlReader reader = XmlReader.Create(@"SimpleAtomFeedCustomParser.xml"))
+            {
+                var formatter = new Atom10FeedFormatter();
+                formatter.StringParser = (value, localName, ns) => $"value:{value}-localName:{localName}-ns:{ns}";
+                formatter.ReadFrom(reader);
+                feed = formatter.Feed;
+            }
+
+            
+            // *** ASSERT *** \\
+            Assert.True(feed != null, "res was null.");
+            Assert.Equal("value:FeedGenerator-localName:generator-ns:http://www.w3.org/2005/Atom", feed.Generator);
+            Assert.Equal("value:FeedID-localName:id-ns:http://www.w3.org/2005/Atom", feed.Id);
+            Assert.NotNull(feed.Authors);
+            Assert.Equal(1, feed.Authors.Count);
+            Assert.Equal("value:AuthorName-localName:name-ns:", feed.Authors.First().Name);
+            Assert.Equal("value:author@Contoso.com-localName:email-ns:", feed.Authors.First().Email);
+            Assert.Equal("value:AuthorUri-localName:uri-ns:", feed.Authors.First().Uri);
+
+            Assert.True(feed.Items != null, "res.Items was null.");
+            Assert.Equal(1, feed.Items.Count());
+            Assert.Equal("value:EntryId-localName:id-ns:http://www.w3.org/2005/Atom", feed.Items.First().Id);
         }
 
         [Fact]

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -332,8 +332,10 @@ namespace System.ServiceModel.Syndication.Tests
             SyndicationFeed feed;
             using (XmlReader reader = XmlReader.Create(@"RssSpecCustomParser.xml"))
             {
-                var formatter = new Rss20FeedFormatter();
-                formatter.StringParser = (value, localName, ns) => $"value:{value}-localName:{localName}-ns:{ns}";
+                var formatter = new Rss20FeedFormatter
+                {
+                    StringParser = (value, localName, ns) => $"value:{value}-localName:{localName}-ns:{ns}"
+                };
                 formatter.ReadFrom(reader);
                 feed = formatter.Feed;
             }
@@ -360,6 +362,34 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        public static void SyndicationFeed_Rss_UriParser()
+        {
+            // *** SETUP *** \\
+            // *** EXECUTE *** \\
+            SyndicationFeed feed;
+            using (XmlReader reader = XmlReader.Create(@"RssSpecCustomParser.xml"))
+            {
+                var formatter = new Rss20FeedFormatter
+                {
+                    UriParser = (value, kind, localName, ns) => new Uri($"http://value-{value}-kind-{kind}-localName-{localName}-ns-{ns}-end")
+                };
+                formatter.ReadFrom(reader);
+                feed = formatter.Feed;
+            }
+
+            // *** ASSERT *** \\
+            Assert.True(feed != null, "res was null.");
+            Assert.NotNull(feed.Links);
+            Assert.Equal(1, feed.Links.Count);
+            Assert.Equal(new Uri("http://value-FeedLink-kind-relativeorabsolute-localName-link-ns--end"), feed.Links.First().Uri);
+
+            Assert.True(feed.Items != null, "res.Items was null.");
+            Assert.Equal(1, feed.Items.Count());
+            Assert.Equal(1, feed.Items.First().Links.Count);
+            Assert.Equal(new Uri("http://value-itemlink-kind-relativeorabsolute-localName-link-ns--end"), feed.Items.First().Links.First().Uri);
+        }
+
+        [Fact]
         public static void SyndicationFeed_Atom_DateTimeParser()
         {
             // *** SETUP *** \\
@@ -368,12 +398,13 @@ namespace System.ServiceModel.Syndication.Tests
             DateTimeOffset dto = new DateTimeOffset(2017, 1, 2, 3, 4, 5, new TimeSpan(0));
             using (XmlReader reader = XmlReader.Create(@"SimpleAtomFeedCustomParser.xml"))
             {
-                var formatter = new Atom10FeedFormatter();
-                formatter.DateTimeParser = (value, localName, ns) => dto;
+                var formatter = new Atom10FeedFormatter
+                {
+                    DateTimeParser = (value, localName, ns) => dto
+                };
                 formatter.ReadFrom(reader);
                 feed = formatter.Feed;
             }
-
 
             // *** ASSERT *** \\
             Assert.True(feed != null, "res was null.");
@@ -392,12 +423,13 @@ namespace System.ServiceModel.Syndication.Tests
             SyndicationFeed feed;
             using (XmlReader reader = XmlReader.Create(@"SimpleAtomFeedCustomParser.xml"))
             {
-                var formatter = new Atom10FeedFormatter();
-                formatter.StringParser = (value, localName, ns) => $"value:{value}-localName:{localName}-ns:{ns}";
+                var formatter = new Atom10FeedFormatter
+                {
+                    StringParser = (value, localName, ns) => $"value:{value}-localName:{localName}-ns:{ns}"
+                };
                 formatter.ReadFrom(reader);
                 feed = formatter.Feed;
             }
-
             
             // *** ASSERT *** \\
             Assert.True(feed != null, "res was null.");
@@ -412,6 +444,33 @@ namespace System.ServiceModel.Syndication.Tests
             Assert.True(feed.Items != null, "res.Items was null.");
             Assert.Equal(1, feed.Items.Count());
             Assert.Equal("value:EntryId-localName:id-ns:http://www.w3.org/2005/Atom", feed.Items.First().Id);
+        }
+
+        [Fact]
+        public static void SyndicationFeed_Atom_UriParser()
+        {
+            // *** SETUP *** \\
+            // *** EXECUTE *** \\
+            SyndicationFeed feed;
+            using (XmlReader reader = XmlReader.Create(@"SimpleAtomFeedCustomParser.xml"))
+            {
+                var formatter = new Atom10FeedFormatter
+                {
+                    UriParser = (value, kind, localName, ns) => new Uri($"http://value-{value}-kind-{kind}-localName-{localName}-ns-{ns}-end")
+                };
+                formatter.ReadFrom(reader);
+                feed = formatter.Feed;
+            }
+
+            // *** ASSERT *** \\
+            Assert.True(feed != null, "res was null.");
+            Assert.Equal(new Uri("http://value-FeedLogo-kind-relativeorabsolute-localName-logo-ns-http//www.w3.org/2005/Atom-end"), feed.ImageUrl);
+
+            Assert.True(feed.Items != null, "res.Items was null.");
+            Assert.Equal(1, feed.Items.Count());
+            Assert.NotNull(feed.Items.First().Links);
+            Assert.Equal(1, feed.Items.First().Links.Count);
+            Assert.Equal(new Uri("http://value-EntryLinkHref-kind-relativeorabsolute-localName-link-ns--end"), feed.Items.First().Links.First().Uri);
         }
 
         [Fact]

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -298,14 +298,12 @@ namespace System.ServiceModel.Syndication.Tests
 
             // *** ASSERT *** \\
             Assert.True(res != null, "res was null.");
-            DateTimeOffset lastUpdatedTime;
-            Assert.Throws<XmlException>(() => lastUpdatedTime = res.LastUpdatedTime);
+            Assert.Equal(new DateTimeOffset(2016, 8, 23, 16, 8, 0, new TimeSpan(-4, 0, 0)), res.LastUpdatedTime);
             Assert.True(res.Items != null, "res.Items was null.");
             Assert.True(res.Items.Count() == 4, $"res.Items.Count() was not as expected. Expected: 4; Actual: {res.Items.Count()}");
             SyndicationItem[] items = res.Items.ToArray();
-            DateTimeOffset pubDate;
-            Assert.Throws<XmlException>(() => pubDate = items[1].PublishDate);
-            Assert.Throws<XmlException>(() => pubDate = items[2].PublishDate);
+            DateTimeOffset dateTimeOffset;
+            Assert.Throws<XmlException>(() => dateTimeOffset = items[2].PublishDate);
         }
 
         [Fact]

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -325,43 +325,6 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
-        public static void SyndicationFeed_Rss_StringParser()
-        {
-            // *** SETUP *** \\
-            // *** EXECUTE *** \\
-            SyndicationFeed feed;
-            using (XmlReader reader = XmlReader.Create(@"RssSpecCustomParser.xml"))
-            {
-                var formatter = new Rss20FeedFormatter
-                {
-                    StringParser = (value, localName, ns) => $"value:{value}-localName:{localName}-ns:{ns}"
-                };
-                formatter.ReadFrom(reader);
-                feed = formatter.Feed;
-            }
-
-            // *** ASSERT *** \\
-            Assert.True(feed != null, "res was null.");
-            Assert.Equal("value:FeedGenerator-localName:generator-ns:", feed.Generator);
-            Assert.Equal("value:FeedTitle-localName:title-ns:", feed.Title.Text);
-            Assert.Equal("value:FeedDescription-localName:description-ns:", feed.Description.Text);
-            Assert.Equal("value:FeedCopyright-localName:copyright-ns:", feed.Copyright.Text);
-            Assert.Equal("value:FeedLanguage-localName:language-ns:", feed.Language);
-            Assert.NotNull(feed.Authors);
-            Assert.Equal(1, feed.Authors.Count);
-            Assert.Equal("value:FeedEditorEmail-localName:managingEditor-ns:", feed.Authors.First().Email);
-            Assert.NotNull(feed.Categories);
-            Assert.Equal(1, feed.Categories.Count);
-            Assert.Equal("value:FeedCategory-localName:category-ns:", feed.Categories.First().Name);
-            
-            Assert.True(feed.Items != null, "res.Items was null.");
-            Assert.Equal(1, feed.Items.Count());
-            Assert.Equal("value:ItemTitle-localName:title-ns:", feed.Items.First().Title.Text);
-            Assert.Equal("value:ItemGuid-localName:guid-ns:", feed.Items.First().Id);
-            Assert.Equal("value:ItemDescription-localName:description-ns:", feed.Items.First().Summary.Text);
-        }
-
-        [Fact]
         public static void SyndicationFeed_Rss_UriParser()
         {
             // *** SETUP *** \\
@@ -413,37 +376,6 @@ namespace System.ServiceModel.Syndication.Tests
             Assert.True(feed.Items != null, "res.Items was null.");
             Assert.Equal(1, feed.Items.Count());
             Assert.Equal(dto, feed.Items.First().LastUpdatedTime);
-        }
-
-        [Fact]
-        public static void SyndicationFeed_Atom_StringParser()
-        {
-            // *** SETUP *** \\
-            // *** EXECUTE *** \\
-            SyndicationFeed feed;
-            using (XmlReader reader = XmlReader.Create(@"SimpleAtomFeedCustomParser.xml"))
-            {
-                var formatter = new Atom10FeedFormatter
-                {
-                    StringParser = (value, localName, ns) => $"value:{value}-localName:{localName}-ns:{ns}"
-                };
-                formatter.ReadFrom(reader);
-                feed = formatter.Feed;
-            }
-            
-            // *** ASSERT *** \\
-            Assert.True(feed != null, "res was null.");
-            Assert.Equal("value:FeedGenerator-localName:generator-ns:http://www.w3.org/2005/Atom", feed.Generator);
-            Assert.Equal("value:FeedID-localName:id-ns:http://www.w3.org/2005/Atom", feed.Id);
-            Assert.NotNull(feed.Authors);
-            Assert.Equal(1, feed.Authors.Count);
-            Assert.Equal("value:AuthorName-localName:name-ns:", feed.Authors.First().Name);
-            Assert.Equal("value:author@Contoso.com-localName:email-ns:", feed.Authors.First().Email);
-            Assert.Equal("value:AuthorUri-localName:uri-ns:", feed.Authors.First().Uri);
-
-            Assert.True(feed.Items != null, "res.Items was null.");
-            Assert.Equal(1, feed.Items.Count());
-            Assert.Equal("value:EntryId-localName:id-ns:http://www.w3.org/2005/Atom", feed.Items.First().Id);
         }
 
         [Fact]

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -9,6 +9,7 @@ using System.ServiceModel.Syndication;
 using System.Xml;
 using System.IO;
 using Xunit;
+using System.Linq;
 
 namespace System.ServiceModel.Syndication.Tests
 {
@@ -285,7 +286,6 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
-        [ActiveIssue(25156)]
         public static void SyndicationFeed_Rss_WrongDateFormat()
         {
             // *** SETUP *** \\
@@ -297,7 +297,15 @@ namespace System.ServiceModel.Syndication.Tests
             SyndicationFeed res = SyndicationFeed.Load(reader);
 
             // *** ASSERT *** \\
-            Assert.True(!res.LastUpdatedTime.Equals(new DateTimeOffset()));
+            Assert.True(res != null, "res was null.");
+            DateTimeOffset lastUpdatedTime;
+            Assert.Throws<XmlException>(() => lastUpdatedTime = res.LastUpdatedTime);
+            Assert.True(res.Items != null, "res.Items was null.");
+            Assert.True(res.Items.Count() == 4, $"res.Items.Count() was not as expected. Expected: 4; Actual: {res.Items.Count()}");
+            SyndicationItem[] items = res.Items.ToArray();
+            DateTimeOffset pubDate;
+            Assert.Throws<XmlException>(() => pubDate = items[1].PublishDate);
+            Assert.Throws<XmlException>(() => pubDate = items[2].PublishDate);
         }
 
         [Fact]

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -342,6 +342,8 @@ namespace System.ServiceModel.Syndication.Tests
 
             // *** ASSERT *** \\
             Assert.True(feed != null, "res was null.");
+            Assert.Equal(new Uri("http://value-ChannelBase-kind-relativeorabsolute-localName-channel-ns--end"), feed.BaseUri);
+            Assert.Equal(new Uri("http://value-ImageUrl-kind-relativeorabsolute-localName-url-ns--end"), feed.ImageUrl);
             Assert.NotNull(feed.Links);
             Assert.Equal(1, feed.Links.Count);
             Assert.Equal(new Uri("http://value-FeedLink-kind-relativeorabsolute-localName-link-ns--end"), feed.Links.First().Uri);
@@ -402,7 +404,8 @@ namespace System.ServiceModel.Syndication.Tests
             Assert.Equal(1, feed.Items.Count());
             Assert.NotNull(feed.Items.First().Links);
             Assert.Equal(1, feed.Items.First().Links.Count);
-            Assert.Equal(new Uri("http://value-EntryLinkHref-kind-relativeorabsolute-localName-link-ns--end"), feed.Items.First().Links.First().Uri);
+            Assert.Equal(new Uri("http://value-EntryLinkHref-kind-relativeorabsolute-localName-link-ns-http//www.w3.org/2005/Atom-end"), feed.Items.First().Links.First().Uri);
+            Assert.Equal(new Uri("http://value-EntryContentSrc-kind-relativeorabsolute-localName-content-ns-http://www.w3.org/2005/Atom-end"), ((UrlSyndicationContent)feed.Items.First().Content).Url);
         }
 
         [Fact]

--- a/src/System.ServiceModel.Syndication/tests/TestFeeds/RssSpecCustomParser.xml
+++ b/src/System.ServiceModel.Syndication/tests/TestFeeds/RssSpecCustomParser.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0"?>
+<rss version="2.0">
+  <channel customAttribute="customAtt">
+    <title>FeedTitle</title>
+    <link>http://liftoff.msfc.nasa.gov/</link>
+    <description>FeedDescription</description>
+    <language>FeedLanguage</language>
+    <lastBuildDate>Tue, 23 August 2016 16:08:00 EDT</lastBuildDate>
+    <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+    <generator>FeedGenerator</generator>
+    <managingEditor>FeedEditorEmail</managingEditor>
+    <category>FeedCategory</category>
+    <copyright>FeedCopyright</copyright>
+    <ttl>60</ttl>
+    <item>
+      <title>ItemTitle</title>
+      <link>http://liftoff.msfc.nasa.gov/news/2003/news-starcity.asp</link>
+      <description>ItemDescription</description>
+      <pubDate>Tue, 03 Jun 2003 09:39:21 GMT</pubDate>
+      <guid>ItemGuid</guid>
+    </item>
+  </channel>
+</rss>

--- a/src/System.ServiceModel.Syndication/tests/TestFeeds/RssSpecCustomParser.xml
+++ b/src/System.ServiceModel.Syndication/tests/TestFeeds/RssSpecCustomParser.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0"?>
 <rss version="2.0">
-  <channel customAttribute="customAtt">
+  <channel xml:base="ChannelBase" customAttribute="customAtt">
     <title>FeedTitle</title>
     <link>FeedLink</link>
     <description>FeedDescription</description>
@@ -12,6 +12,9 @@
     <category>FeedCategory</category>
     <copyright>FeedCopyright</copyright>
     <ttl>60</ttl>
+    <image>
+      <url>ImageUrl</url>
+    </image>
     <item>
       <title>ItemTitle</title>
       <link>ItemLink</link>

--- a/src/System.ServiceModel.Syndication/tests/TestFeeds/RssSpecCustomParser.xml
+++ b/src/System.ServiceModel.Syndication/tests/TestFeeds/RssSpecCustomParser.xml
@@ -2,7 +2,7 @@
 <rss version="2.0">
   <channel customAttribute="customAtt">
     <title>FeedTitle</title>
-    <link>http://liftoff.msfc.nasa.gov/</link>
+    <link>FeedLink</link>
     <description>FeedDescription</description>
     <language>FeedLanguage</language>
     <lastBuildDate>Tue, 23 August 2016 16:08:00 EDT</lastBuildDate>
@@ -14,7 +14,7 @@
     <ttl>60</ttl>
     <item>
       <title>ItemTitle</title>
-      <link>http://liftoff.msfc.nasa.gov/news/2003/news-starcity.asp</link>
+      <link>ItemLink</link>
       <description>ItemDescription</description>
       <pubDate>Tue, 03 Jun 2003 09:39:21 GMT</pubDate>
       <guid>ItemGuid</guid>

--- a/src/System.ServiceModel.Syndication/tests/TestFeeds/SimpleAtomFeedCustomParser.xml
+++ b/src/System.ServiceModel.Syndication/tests/TestFeeds/SimpleAtomFeedCustomParser.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<feed xml:base="http://mypage.com/" xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">FeedTitle</title>
+  <subtitle type="text">FeedSubtitle</subtitle>
+  <id>FeedID</id>
+  <updated>2017-06-26T14:41:43-07:00</updated>
+  <logo>http://contoso.com/123.jpg</logo>
+  <generator>FeedGenerator</generator>
+  <author>
+    <name>AuthorName</name>
+    <email>author@Contoso.com</email>
+    <uri>AuthorUri</uri>
+  </author>
+  <link rel="alternate" href="http://www.contoso.com/news" />
+  <CustomElement xmlns="">asd</CustomElement>
+  <entry>
+    <id>EntryId</id>
+    <title type="text">SyndicationFeed released for .net Core</title>
+    <updated>2017-06-26T21:41:43Z</updated>
+    <link rel="alternate" href="http://contoso.com/news/path" />
+    <content type="text">A lot of text describing the release of .net core feature</content>
+  </entry>
+</feed>

--- a/src/System.ServiceModel.Syndication/tests/TestFeeds/SimpleAtomFeedCustomParser.xml
+++ b/src/System.ServiceModel.Syndication/tests/TestFeeds/SimpleAtomFeedCustomParser.xml
@@ -4,7 +4,7 @@
   <subtitle type="text">FeedSubtitle</subtitle>
   <id>FeedID</id>
   <updated>2017-06-26T14:41:43-07:00</updated>
-  <logo>http://contoso.com/123.jpg</logo>
+  <logo>FeedLogo</logo>
   <generator>FeedGenerator</generator>
   <author>
     <name>AuthorName</name>
@@ -17,7 +17,7 @@
     <id>EntryId</id>
     <title type="text">SyndicationFeed released for .net Core</title>
     <updated>2017-06-26T21:41:43Z</updated>
-    <link rel="alternate" href="http://contoso.com/news/path" />
+    <link rel="alternate" href="EntryLinkHref" />
     <content type="text">A lot of text describing the release of .net core feature</content>
   </entry>
 </feed>

--- a/src/System.ServiceModel.Syndication/tests/TestFeeds/SimpleAtomFeedCustomParser.xml
+++ b/src/System.ServiceModel.Syndication/tests/TestFeeds/SimpleAtomFeedCustomParser.xml
@@ -18,6 +18,6 @@
     <title type="text">SyndicationFeed released for .net Core</title>
     <updated>2017-06-26T21:41:43Z</updated>
     <link rel="alternate" href="EntryLinkHref" />
-    <content type="text">A lot of text describing the release of .net core feature</content>
+    <content src="EntryContentSrc" />
   </entry>
 </feed>


### PR DESCRIPTION
The PR capture the DateTime parsing exceptions and throw them only until the property gets used. This could help those applications that encounter DateTime string error but do not actually use the value of the DateTime.

Fix #25156 