### PR TITLE
Temporarily removing use of ReadOnlySpan indexer in Runtime.Extensions

### DIFF
--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -258,6 +258,7 @@
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
     <ProjectReference Include="..\..\System.Security.Principal\src\System.Security.Principal.csproj" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uapaot' or '$(TargetGroup)' == 'uap'">
     <Reference Include="mscorlib" />

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -258,7 +258,6 @@
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
     <ProjectReference Include="..\..\System.Security.Principal\src\System.Security.Principal.csproj" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uapaot' or '$(TargetGroup)' == 'uap'">
     <Reference Include="mscorlib" />
@@ -266,6 +265,9 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <ReferenceFromRuntime Include="System.Private.Interop" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'uapaot'">
+    <ProjectReference Include="..\..\System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
   </ItemGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -266,9 +266,6 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <ReferenceFromRuntime Include="System.Private.Interop" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'uapaot'">
-    <ProjectReference Include="..\..\System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
-  </ItemGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />
   </ItemGroup>

--- a/src/System.Runtime.Extensions/src/System/IO/StreamReader.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StreamReader.cs
@@ -560,31 +560,29 @@ namespace System.IO
         // there is no match. If there is no match, every byte read previously will be available 
         // for further consumption. If there is a match, we will compress the buffer for the 
         // leading preamble bytes
-        private bool IsPreamble()
+        private unsafe bool IsPreamble()
         {
             if (!_checkPreamble)
             {
                 return _checkPreamble;
             }
 
-            ReadOnlySpan<byte> readonlyPreamble = _encoding.Preamble;
-            Span<byte> preamble;
-            
-            unsafe
-            {
-                preamble = new Span<byte>(Unsafe.AsPointer<byte>(ref readonlyPreamble.DangerousGetPinnableReference()), readonlyPreamble.Length);
-            }
+            ReadOnlySpan<byte> preamble = _encoding.Preamble;
 
             Debug.Assert(_bytePos <= preamble.Length, "_compressPreamble was called with the current bytePos greater than the preamble buffer length.  Are two threads using this StreamReader at the same time?");
             int len = (_byteLen >= (preamble.Length)) ? (preamble.Length - _bytePos) : (_byteLen - _bytePos);
 
-            for (int i = 0; i < len; i++, _bytePos++)
+            fixed (byte* preamblePtr = &preamble.DangerousGetPinnableReference())
             {
-                if (_byteBuffer[_bytePos] != preamble[_bytePos])
+                var preambleSpan = new Span<byte>(preamblePtr, preamble.Length);
+                for (int i = 0; i < len; i++, _bytePos++)
                 {
-                    _bytePos = 0;
-                    _checkPreamble = false;
-                    break;
+                    if (_byteBuffer[_bytePos] != preambleSpan[_bytePos])
+                    {
+                        _bytePos = 0;
+                        _checkPreamble = false;
+                        break;
+                    }
                 }
             }
 
@@ -601,7 +599,6 @@ namespace System.IO
                     _detectEncoding = false;
                 }
             }
-
             return _checkPreamble;
         }
 

--- a/src/System.Runtime.Extensions/src/System/IO/StreamReader.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StreamReader.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -566,7 +567,13 @@ namespace System.IO
                 return _checkPreamble;
             }
 
-            byte[] preamble = _encoding.Preamble.ToArray();;
+            ReadOnlySpan<byte> readonlyPreamble = _encoding.Preamble;
+            Span<byte> preamble;
+            
+            unsafe
+            {
+                preamble = new Span<byte>(Unsafe.AsPointer<byte>(ref readonlyPreamble.DangerousGetPinnableReference()), readonlyPreamble.Length);
+            }
 
             Debug.Assert(_bytePos <= preamble.Length, "_compressPreamble was called with the current bytePos greater than the preamble buffer length.  Are two threads using this StreamReader at the same time?");
             int len = (_byteLen >= (preamble.Length)) ? (preamble.Length - _bytePos) : (_byteLen - _bytePos);

--- a/src/System.Runtime.Extensions/src/System/IO/StreamReader.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StreamReader.cs
@@ -566,7 +566,7 @@ namespace System.IO
                 return _checkPreamble;
             }
 
-            ReadOnlySpan<byte> preamble = _encoding.Preamble;
+            byte[] preamble = _encoding.Preamble.ToArray();;
 
             Debug.Assert(_bytePos <= preamble.Length, "_compressPreamble was called with the current bytePos greater than the preamble buffer length.  Are two threads using this StreamReader at the same time?");
             int len = (_byteLen >= (preamble.Length)) ? (preamble.Length - _bytePos) : (_byteLen - _bytePos);

--- a/src/System.Runtime.Extensions/src/System/IO/StreamReader.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StreamReader.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -599,6 +598,7 @@ namespace System.IO
                     _detectEncoding = false;
                 }
             }
+
             return _checkPreamble;
         }
 

--- a/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
@@ -370,14 +370,15 @@ namespace System.IO
         {
             CheckAsyncTaskInProgress();
 
-            if (buffer.Length <= 4 && // Threshold of 4 chosen based on perf experimentation
-                buffer.Length <= _charLen - _charPos)
+            char[] bufferArray = buffer.ToArray();
+            if (bufferArray.Length <= 4 && // Threshold of 4 chosen based on perf experimentation
+                bufferArray.Length <= _charLen - _charPos)
             {
                 // For very short buffers and when we don't need to worry about running out of space
                 // in the char buffer, just copy the chars individually.
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < bufferArray.Length; i++)
                 {
-                    _charBuffer[_charPos++] = buffer[i];
+                    _charBuffer[_charPos++] = bufferArray[i];
                 }
             }
             else
@@ -394,11 +395,12 @@ namespace System.IO
                     throw new ObjectDisposedException(null, SR.ObjectDisposed_WriterClosed);
                 }
 
-                fixed (char* bufferPtr = &buffer.DangerousGetPinnableReference())
+                if (bufferArray.Length == 0) return;
+                fixed (char* bufferPtr = &bufferArray[0])
                 fixed (char* dstPtr = &charBuffer[0])
                 {
                     char* srcPtr = bufferPtr;
-                    int count = buffer.Length;
+                    int count = bufferArray.Length;
                     int dstPos = _charPos; // use a local copy of _charPos for safety
                     while (count > 0)
                     {

--- a/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;


### PR DESCRIPTION
Removing the use of the ReadOnlySpan indexer to help the implementation change go through with the least disabling of tests.

This is a temporary workaround that is required to reduce the number of failing tests that would need to be disabled due to the change to ReadOnlySpan indexer to return ref readonly, here: https://github.com/dotnet/coreclr/pull/14727

cc @weshaggard, @stephentoub, @KrzysztofCwalina, @jkotas 

**This change should be reverted once the change propogates (and the tests enabled): https://github.com/dotnet/coreclr/issues/15089**