### PR TITLE
Don't cache TypeParameterType in table.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -821,18 +821,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return _stvcClass.GetTypeVarSym(iv, this, false);
         }
 
+        // These are singletons for each.
         public TypeParameterType GetTypeParameter(TypeParameterSymbol pSymbol)
         {
-            // These guys should be singletons for each.
-
-            TypeParameterType pTypeParameter = _typeTable.LookupTypeParameter(pSymbol);
-            if (pTypeParameter == null)
-            {
-                pTypeParameter = _typeFactory.CreateTypeParameter(pSymbol);
-                _typeTable.InsertTypeParameter(pSymbol, pTypeParameter);
-            }
-
-            return pTypeParameter;
+            Debug.Assert(pSymbol.GetTypeParameterType() == null); // Should have been checked first before creating
+            return _typeFactory.CreateTypeParameter(pSymbol);
         }
 
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
@@ -55,7 +55,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private readonly Dictionary<Name, ErrorType> _pErrorWithNamespaceParentTable;
         private readonly Dictionary<CType, PointerType> _pPointerTable;
         private readonly Dictionary<CType, NullableType> _pNullableTable;
-        private readonly Dictionary<TypeParameterSymbol, TypeParameterType> _pTypeParameterTable;
 
         public TypeTable()
         {
@@ -65,7 +64,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _pParameterModifierTable = new Dictionary<KeyPair<CType, Name>, ParameterModifierType>();
             _pPointerTable = new Dictionary<CType, PointerType>();
             _pNullableTable = new Dictionary<CType, NullableType>();
-            _pTypeParameterTable = new Dictionary<TypeParameterSymbol, TypeParameterType>();
         }
 
         private static KeyPair<TKey1, TKey2> MakeKey<TKey1, TKey2>(TKey1 key1, TKey2 key2) =>
@@ -158,23 +156,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public void InsertNullable(CType pUnderlyingType, NullableType pNullable)
         {
             _pNullableTable.Add(pUnderlyingType, pNullable);
-        }
-
-        public TypeParameterType LookupTypeParameter(TypeParameterSymbol pTypeParameterSymbol)
-        {
-            TypeParameterType result;
-            if (_pTypeParameterTable.TryGetValue(pTypeParameterSymbol, out result))
-            {
-                return result;
-            }
-            return null;
-        }
-
-        public void InsertTypeParameter(
-                TypeParameterSymbol pTypeParameterSymbol,
-                TypeParameterType pTypeParameter)
-        {
-            _pTypeParameterTable.Add(pTypeParameterSymbol, pTypeParameter);
         }
     }
 }


### PR DESCRIPTION
There's only one per symbol, and its stored in the symbol and looked-for there first, so never found in the lookup table.

Remove the table.