### PR TITLE
MS.CSharp: Stop string conversion being incorrectly considered "simple"

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -268,7 +268,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return BetterType.Right;
             }
-            if ((int)pt1 <= NUM_EXT_TYPES && (int)pt2 <= NUM_EXT_TYPES)
+            if ((int)pt1 < NUM_EXT_TYPES && (int)pt2 < NUM_EXT_TYPES)
             {
                 return WhichSimpleConversionIsBetter(pt1, pt2);
             }
@@ -322,7 +322,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             PredefinedType pt1 = (type1 as NullableType).UnderlyingType.getPredefType();
             PredefinedType pt2 = (type2 as NullableType).UnderlyingType.getPredefType();
 
-            if ((int)pt1 <= NUM_EXT_TYPES && (int)pt2 <= NUM_EXT_TYPES)
+            if ((int)pt1 < NUM_EXT_TYPES && (int)pt2 < NUM_EXT_TYPES)
             {
                 return WhichSimpleConversionIsBetter(pt1, pt2);
             }

--- a/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
@@ -194,5 +194,26 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         class Third<T> : Second<Third<T>>
         {
         }
+
+        public class Castable
+        {
+            public static implicit operator int(Castable _) => 2;
+
+            public static implicit operator string(Castable _) => "abc";
+        }
+
+        [Fact]
+        public void ImplicitOperatorForPlus()
+        {
+            dynamic d = new Castable();
+            dynamic result = d + 1;
+            Assert.Equal(3, result);
+            result = 5 + d;
+            Assert.Equal(7, result);
+            result = d + "def";
+            Assert.Equal("abcdef", result);
+            result = "xyz" + d;
+            Assert.Equal("xyzabc", result);
+        }
     }
 }


### PR DESCRIPTION
Correct check that the predefined type must be `<= NUM_EXT_TYPES` to the correct `< NUM_EXT_TYPES`. Stops string conversion being considered when not appropriate.

Fixes #25338