### PR TITLE
MS.CSharp some error improvements

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -970,10 +970,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Debug.Assert(n <= 0);
                     if (n >= 0)
                     {
-                        if (!needExprDest)
-                            return true;
-                        iuciBestDst = iuci;
-                        pexprDst = HandleAmbiguity(exprSrc, typeSrc, typeDst, prguci, iuciBestSrc, iuciBestDst);
+                        if (needExprDest)
+                        {
+                            throw HandleAmbiguity(typeSrc, typeDst, prguci, iuciBestSrc, iuci);
+                        }
+
                         return true;
                     }
                 }
@@ -983,10 +984,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Debug.Assert(n <= 0);
                     if (n >= 0)
                     {
-                        if (!needExprDest)
-                            return true;
-                        iuciBestDst = iuci;
-                        pexprDst = HandleAmbiguity(exprSrc, typeSrc, typeDst, prguci, iuciBestSrc, iuciBestDst);
+                        if (needExprDest)
+                        {
+                            throw HandleAmbiguity(typeSrc, typeDst, prguci, iuciBestSrc, iuci);
+                        }
+
                         return true;
                     }
                 }
@@ -997,15 +999,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (iuciBest < 0)
             {
-                pexprDst = HandleAmbiguity(exprSrc, typeSrc, typeDst, prguci, iuciBestSrc, iuciBestDst);
-                return true;
+                throw HandleAmbiguity(typeSrc, typeDst, prguci, iuciBestSrc, iuciBestDst);
             }
             if (iuciAmbig >= 0)
             {
-                iuciBestSrc = iuciBest;
-                iuciBestDst = iuciAmbig;
-                pexprDst = HandleAmbiguity(exprSrc, typeSrc, typeDst, prguci, iuciBestSrc, iuciBestDst);
-                return true;
+                throw HandleAmbiguity(typeSrc, typeDst, prguci, iuciBest, iuciAmbig);
             }
 
             MethWithInst mwiBest = new MethWithInst(prguci[iuciBest].mwt.Meth(), prguci[iuciBest].mwt.GetType(), null);
@@ -1083,11 +1081,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return true;
         }
 
-        private Expr HandleAmbiguity(Expr exprSrc, CType typeSrc, CType typeDst, List<UdConvInfo> prguci, int iuciBestSrc, int iuciBestDst)
+        private RuntimeBinderException HandleAmbiguity(CType typeSrc, CType typeDst, List<UdConvInfo> prguci, int iuciBestSrc, int iuciBestDst)
         {
             Debug.Assert(0 <= iuciBestSrc && iuciBestSrc < prguci.Count);
             Debug.Assert(0 <= iuciBestDst && iuciBestDst < prguci.Count);
-            throw ErrorContext.Error(ErrorCode.ERR_AmbigUDConv, prguci[iuciBestSrc].mwt, prguci[iuciBestDst].mwt, typeSrc, typeDst);
+            return ErrorContext.Error(ErrorCode.ERR_AmbigUDConv, prguci[iuciBestSrc].mwt, prguci[iuciBestDst].mwt, typeSrc, typeDst);
         }
 
         private void MarkAsIntermediateConversion(Expr pExpr)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -880,9 +880,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         ////////////////////////////////////////////////////////////////////////////////
         // Given a method group or indexer group, bind it to the arguments for an 
-        // invocation. This method can change the arguments to bind with Extension 
-        // Methods
-        private bool BindMethodGroupToArgumentsCore(out GroupToArgsBinderResult pResults, BindingFlag bindFlags, ExprMemberGroup grp, ref Expr args, int carg, bool bHasNamedArgumentSpecifiers)
+        // invocation.
+        private GroupToArgsBinderResult BindMethodGroupToArgumentsCore(BindingFlag bindFlags, ExprMemberGroup grp, ref Expr args, int carg, bool bHasNamedArgumentSpecifiers)
         {
             ArgInfos pargInfo = new ArgInfos {carg = carg};
             FillInArgInfoFromArgList(pargInfo, args);
@@ -891,10 +890,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             FillInArgInfoFromArgList(pOriginalArgInfo, args);
 
             GroupToArgsBinder binder = new GroupToArgsBinder(this, bindFlags, grp, pargInfo, pOriginalArgInfo, bHasNamedArgumentSpecifiers);
-            bool retval = binder.Bind();
+            binder.Bind();
 
-            pResults = binder.GetResultsOfBind();
-            return retval;
+            return binder.GetResultsOfBind();
         }
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -921,14 +919,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // fixed arguments.
             bool seenNamed = VerifyNamedArgumentsAfterFixed(args);
 
-            GroupToArgsBinderResult result;
-            if (!BindMethodGroupToArgumentsCore(out result, bindFlags, grp, ref args, carg, seenNamed))
-            {
-                Debug.Assert(false, "Why didn't BindMethodGroupToArgumentsCore throw an error?");
-                return null;
-            }
-
-            MethPropWithInst mpwiBest = result.GetBestResult();
+            MethPropWithInst mpwiBest = BindMethodGroupToArgumentsCore(bindFlags, grp, ref args, carg, seenNamed)
+                .GetBestResult();
             if (grp.SymKind == SYMKIND.SK_PropertySymbol)
             {
                 Debug.Assert((grp.Flags & EXPRFLAG.EXF_INDEXER) != 0);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -891,7 +891,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             FillInArgInfoFromArgList(pOriginalArgInfo, args);
 
             GroupToArgsBinder binder = new GroupToArgsBinder(this, bindFlags, grp, pargInfo, pOriginalArgInfo, bHasNamedArgumentSpecifiers);
-            bool retval = binder.Bind(bReportErrors: true);
+            bool retval = binder.Bind();
 
             pResults = binder.GetResultsOfBind();
             return retval;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // This method does the actual binding.
             // ----------------------------------------------------------------------------
 
-            public bool Bind(bool bReportErrors)
+            public bool Bind()
             {
                 Debug.Assert(_pGroup.SymKind == SYMKIND.SK_MethodSymbol || _pGroup.SymKind == SYMKIND.SK_PropertySymbol && 0 != (_pGroup.Flags & EXPRFLAG.EXF_INDEXER));
 
@@ -96,14 +96,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(_pArguments.fHasExprs);
 
                 LookForCandidates();
-                if (!GetResultOfBind(bReportErrors))
+                if (!GetResultOfBind())
                 {
-                    if (bReportErrors)
-                    {
-                        throw ReportErrorsOnFailure();
-                    }
-
-                    return false;
+                    throw ReportErrorsOnFailure();
                 }
 
                 return true;
@@ -328,7 +323,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
             }
 
-            private bool GetResultOfBind(bool bReportErrors)
+            private bool GetResultOfBind()
             {
                 // We looked at all the evidence, and we come to render the verdict:
 
@@ -348,27 +343,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                         if (null == pmethBest)
                         {
-                            // Arbitrarily use the first one, but make sure to report errors or give the ambiguous one
-                            // back to the caller.
-                            pmethBest = pAmbig1;
                             _results.AmbiguousResult = pAmbig2.mpwi;
-
-                            if (bReportErrors)
+                            if (pAmbig1.@params != pAmbig2.@params ||
+                                pAmbig1.mpwi.MethProp().Params.Count != pAmbig2.mpwi.MethProp().Params.Count ||
+                                pAmbig1.mpwi.TypeArgs != pAmbig2.mpwi.TypeArgs ||
+                                pAmbig1.mpwi.GetType() != pAmbig2.mpwi.GetType() ||
+                                pAmbig1.mpwi.MethProp().Params == pAmbig2.mpwi.MethProp().Params)
                             {
-                                if (pAmbig1.@params != pAmbig2.@params ||
-                                    pAmbig1.mpwi.MethProp().Params.Count != pAmbig2.mpwi.MethProp().Params.Count ||
-                                    pAmbig1.mpwi.TypeArgs != pAmbig2.mpwi.TypeArgs ||
-                                    pAmbig1.mpwi.GetType() != pAmbig2.mpwi.GetType() ||
-                                    pAmbig1.mpwi.MethProp().Params == pAmbig2.mpwi.MethProp().Params)
-                                {
-                                    throw GetErrorContext().Error(ErrorCode.ERR_AmbigCall, pAmbig1.mpwi, pAmbig2.mpwi);
-                                }
-                                else
-                                {
-                                    // The two signatures are identical so don't use the type args in the error message.
-                                    throw GetErrorContext().Error(ErrorCode.ERR_AmbigCall, pAmbig1.mpwi.MethProp(), pAmbig2.mpwi.MethProp());
-                                }
+                                throw GetErrorContext().Error(ErrorCode.ERR_AmbigCall, pAmbig1.mpwi, pAmbig2.mpwi);
                             }
+
+                            // The two signatures are identical so don't use the type args in the error message.
+                            throw GetErrorContext().Error(ErrorCode.ERR_AmbigCall, pAmbig1.mpwi.MethProp(), pAmbig2.mpwi.MethProp());
                         }
                     }
 
@@ -378,10 +364,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                     // Record our best match in the memgroup as well. This is temporary.
 
-                    if (bReportErrors)
+                    if (true)
                     {
                         ReportErrorsOnSuccess();
                     }
+
                     return true;
                 }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // This method does the actual binding.
             // ----------------------------------------------------------------------------
 
-            public bool Bind()
+            public void Bind()
             {
                 Debug.Assert(_pGroup.SymKind == SYMKIND.SK_MethodSymbol || _pGroup.SymKind == SYMKIND.SK_PropertySymbol && 0 != (_pGroup.Flags & EXPRFLAG.EXF_INDEXER));
 
@@ -100,8 +100,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     throw ReportErrorsOnFailure();
                 }
-
-                return true;
             }
 
             public GroupToArgsBinderResult GetResultsOfBind()


### PR DESCRIPTION
* Have `HandleAmbiguity` return `RuntimeBinderException` to throw at callsite

Should have been done in #22748 but was missed. Also remove unused argument.

* Remove unused boolean parameter passed through `GroupToArgsBinder.Bind()`

* Replace always true result from `GroupToArgsBinder.Bind()` with void.

Replace always true result from `BindMethodGroupToArgumentsCore` with `GroupToArgsBinderResult` that was `out` parameter.

Remove unreachable debug-time error catch.

Also remove incorrect comment about extension methods.
