### PR TITLE
System.Net.Sockets Remove some Task blocks to make tests async

### DIFF
--- a/src/Common/tests/System/Net/Sockets/TestSettings.cs
+++ b/src/Common/tests/System/Net/Sockets/TestSettings.cs
@@ -20,9 +20,6 @@ namespace System.Net.Sockets.Tests
         // This occurs on *nix but not Windows because *nix uses random values (1024-65535) while Windows increments.
         public const int UDPRedundancy = 1;
 
-        public static Task<bool> WhenAllWithTimeout(params Task[] tasks)
-        {
-            return tasks.WhenAllWithTimeout(PassingTestTimeout);
-        }
+        public static Task WhenAllOrAnyFailedWithTimeout(params Task[] tasks) => tasks.WhenAllOrAnyFailed(PassingTestTimeout);
     }
 }

--- a/src/Common/tests/System/Net/Sockets/TestSettings.cs
+++ b/src/Common/tests/System/Net/Sockets/TestSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
+
 namespace System.Net.Sockets.Tests
 {
     public static class TestSettings
@@ -17,5 +19,10 @@ namespace System.Net.Sockets.Tests
         // have the same port #.
         // This occurs on *nix but not Windows because *nix uses random values (1024-65535) while Windows increments.
         public const int UDPRedundancy = 1;
+
+        public static Task<bool> WhenAllWithTimeout(params Task[] tasks)
+        {
+            return tasks.WhenAllWithTimeout(PassingTestTimeout);
+        }
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -12,7 +12,7 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(Loopbacks))]
-        public void Connect_Success(IPAddress listenAt)
+        public async Task Connect_Success(IPAddress listenAt)
         {
             int port;
             using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, listenAt, out port))
@@ -20,7 +20,7 @@ namespace System.Net.Sockets.Tests
                 using (Socket client = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
                 {
                     Task connectTask = ConnectAsync(client, new IPEndPoint(listenAt, port));
-                    Assert.True(connectTask.Wait(TestSettings.PassingTestTimeout), "IPv4: Timed out while waiting for connection");
+                    Assert.True(await TestSettings.WhenAllWithTimeout(connectTask), "IPv4: Timed out while waiting for connection");
                     Assert.True(client.Connected);
                 }
             }
@@ -29,7 +29,7 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(Loopbacks))]
-        public void Connect_MultipleIPAddresses_Success(IPAddress listenAt)
+        public async Task Connect_MultipleIPAddresses_Success(IPAddress listenAt)
         {
             if (!SupportsMultiConnect)
                 return;
@@ -39,7 +39,7 @@ namespace System.Net.Sockets.Tests
             using (Socket client = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
             {
                 Task connectTask = MultiConnectAsync(client, new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback }, port);
-                Assert.True(connectTask.Wait(TestSettings.PassingTestTimeout), "Timed out while waiting for connection");
+                Assert.True(await TestSettings.WhenAllWithTimeout(connectTask), "Timed out while waiting for connection");
                 Assert.True(client.Connected);
             }
         }

--- a/src/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -20,7 +20,7 @@ namespace System.Net.Sockets.Tests
                 using (Socket client = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
                 {
                     Task connectTask = ConnectAsync(client, new IPEndPoint(listenAt, port));
-                    Assert.True(await TestSettings.WhenAllWithTimeout(connectTask), "IPv4: Timed out while waiting for connection");
+                    await TestSettings.WhenAllOrAnyFailedWithTimeout(connectTask);
                     Assert.True(client.Connected);
                 }
             }
@@ -39,7 +39,7 @@ namespace System.Net.Sockets.Tests
             using (Socket client = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
             {
                 Task connectTask = MultiConnectAsync(client, new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback }, port);
-                Assert.True(await TestSettings.WhenAllWithTimeout(connectTask), "Timed out while waiting for connection");
+                await TestSettings.WhenAllOrAnyFailedWithTimeout(connectTask);
                 Assert.True(client.Connected);
             }
         }

--- a/src/System.Net.Sockets/tests/FunctionalTests/SelectTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SelectTest.cs
@@ -241,7 +241,7 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop]
         [Fact]
-        public static void Select_AcceptNonBlocking_Success()
+        public static async Task Select_AcceptNonBlocking_Success()
         {
             using (Socket listenSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
@@ -264,8 +264,7 @@ namespace System.Net.Sockets.Tests
                 }
 
                 // Give the task 5 seconds to complete; if not, assume it's hung.
-                bool completed = t.Wait(5000);
-                Assert.True(completed);
+                await t.TimeoutAfter(5000);
             }
         }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -183,7 +183,7 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(SendFile_MemberData))]
-        public void SendFile_APM(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend)
+        public async Task SendFile_APM(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend)
         {
             const int ListenBacklog = 1, TestTimeout = 30000;
 
@@ -228,10 +228,7 @@ namespace System.Net.Sockets.Tests
                 });
 
                 // Wait for the tasks to complete
-                Task<Task> firstCompleted = Task.WhenAny(serverTask, clientTask);
-                Assert.True(firstCompleted.Wait(TestTimeout), "Neither client nor server task completed within allowed time");
-                firstCompleted.Result.GetAwaiter().GetResult();
-                Assert.True(Task.WaitAll(new[] { serverTask, clientTask }, TestTimeout), $"Tasks didn't complete within allowed time. Server:{serverTask.Status} Client:{clientTask.Status}");
+                Assert.True(await (new[] { serverTask, clientTask }).WhenAllWithTimeout(TestTimeout), $"Tasks didn't complete within allowed time. Server:{serverTask.Status} Client:{clientTask.Status}");
 
                 // Validate the results
                 Assert.Equal(bytesToSend, bytesReceived);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -141,7 +141,7 @@ namespace System.Net.Sockets.Tests
                     using (remote)
                     {
                         var recvBuffer = new byte[256];
-                        for (;;)
+                        for (; ; )
                         {
                             int received = remote.Receive(recvBuffer, 0, recvBuffer.Length, SocketFlags.None);
                             if (received == 0)
@@ -228,7 +228,7 @@ namespace System.Net.Sockets.Tests
                 });
 
                 // Wait for the tasks to complete
-                Assert.True(await (new[] { serverTask, clientTask }).WhenAllWithTimeout(TestTimeout), $"Tasks didn't complete within allowed time. Server:{serverTask.Status} Client:{clientTask.Status}");
+                await (new[] { serverTask, clientTask }).WhenAllOrAnyFailed(TestTimeout);
 
                 // Validate the results
                 Assert.Equal(bytesToSend, bytesReceived);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -553,7 +553,7 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(LoopbacksAndBuffers))]
-        public void SendRecvPollSync_TcpListener_Socket(IPAddress listenAt, bool pollBeforeOperation)
+        public async Task SendRecvPollSync_TcpListener_Socket(IPAddress listenAt, bool pollBeforeOperation)
         {
             const int BytesToSend = 123456;
             const int ListenBacklog = 1;
@@ -622,7 +622,7 @@ namespace System.Net.Sockets.Tests
                     }
                 });
 
-                Assert.True(Task.WaitAll(new[] { serverTask, clientTask }, TestTimeout), "Wait timed out");
+                Assert.True(await (new[] { serverTask, clientTask }).WhenAllWithTimeout(TestTimeout), "Wait timed out");
 
                 Assert.Equal(bytesSent, bytesReceived);
                 Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
@@ -1041,7 +1041,7 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(Loopbacks))]
-        public void SendToRecvFromAsync_Datagram_UDP_UdpClient(IPAddress loopbackAddress)
+        public async Task SendToRecvFromAsync_Datagram_UDP_UdpClient(IPAddress loopbackAddress)
         {
             IPAddress leftAddress = loopbackAddress, rightAddress = loopbackAddress;
 
@@ -1107,7 +1107,7 @@ namespace System.Net.Sockets.Tests
                     }
                 });
 
-                Assert.True(Task.WaitAll(new[] { receiverTask, senderTask }, TestTimeout));
+                Assert.True(await (new[] { receiverTask, senderTask }).WhenAllWithTimeout(TestTimeout));
                 for (int i = 0; i < DatagramsToSend; i++)
                 {
                     Assert.NotNull(receivedChecksums[i]);
@@ -1122,7 +1122,7 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(Loopbacks))]
-        public void SendRecvAsync_TcpListener_TcpClient(IPAddress listenAt)
+        public async Task SendRecvAsync_TcpListener_TcpClient(IPAddress listenAt)
         {
             const int BytesToSend = 123456;
             const int ListenBacklog = 1;
@@ -1184,7 +1184,7 @@ namespace System.Net.Sockets.Tests
                 }
             });
 
-            Assert.True(Task.WaitAll(new[] { serverTask, clientTask }, TestTimeout),
+            Assert.True(await (new[] { serverTask, clientTask }).WhenAllWithTimeout(TestTimeout),
                 $"Time out waiting for serverTask ({serverTask.Status}) and clientTask ({clientTask.Status})");
 
             Assert.Equal(bytesSent, bytesReceived);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -137,7 +137,7 @@ namespace System.Net.Sockets.Tests
                         if (!useMultipleBuffers)
                         {
                             var recvBuffer = new byte[256];
-                            for (;;)
+                            for (; ; )
                             {
                                 int received = await ReceiveAsync(remote, new ArraySegment<byte>(recvBuffer));
                                 if (received == 0)
@@ -156,7 +156,7 @@ namespace System.Net.Sockets.Tests
                                 new ArraySegment<byte>(new byte[256], 2, 100),
                                 new ArraySegment<byte>(new byte[1], 0, 0),
                                 new ArraySegment<byte>(new byte[64], 9, 33)};
-                            for (;;)
+                            for (; ; )
                             {
                                 int received = await ReceiveAsync(remote, recvBuffers);
                                 if (received == 0)
@@ -622,7 +622,7 @@ namespace System.Net.Sockets.Tests
                     }
                 });
 
-                Assert.True(await (new[] { serverTask, clientTask }).WhenAllWithTimeout(TestTimeout), "Wait timed out");
+                await (new[] { serverTask, clientTask }).WhenAllOrAnyFailed(TestTimeout);
 
                 Assert.Equal(bytesSent, bytesReceived);
                 Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
@@ -1107,7 +1107,7 @@ namespace System.Net.Sockets.Tests
                     }
                 });
 
-                Assert.True(await (new[] { receiverTask, senderTask }).WhenAllWithTimeout(TestTimeout));
+                await (new[] { receiverTask, senderTask }).WhenAllOrAnyFailed(TestTimeout);
                 for (int i = 0; i < DatagramsToSend; i++)
                 {
                     Assert.NotNull(receivedChecksums[i]);
@@ -1140,7 +1140,7 @@ namespace System.Net.Sockets.Tests
                 using (NetworkStream stream = remote.GetStream())
                 {
                     var recvBuffer = new byte[256];
-                    for (;;)
+                    for (; ; )
                     {
                         int received = await stream.ReadAsync(recvBuffer, 0, recvBuffer.Length);
                         if (received == 0)
@@ -1184,8 +1184,7 @@ namespace System.Net.Sockets.Tests
                 }
             });
 
-            Assert.True(await (new[] { serverTask, clientTask }).WhenAllWithTimeout(TestTimeout),
-                $"Time out waiting for serverTask ({serverTask.Status}) and clientTask ({clientTask.Status})");
+            await (new[] { serverTask, clientTask }).WhenAllOrAnyFailed(TestTimeout);
 
             Assert.Equal(bytesSent, bytesReceived);
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -95,6 +95,9 @@
     <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
       <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+      <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
@@ -301,8 +301,7 @@ namespace System.Net.Sockets.Tests
                     writes[i] = Task.Factory.StartNew(s => client.Send(sendData, (int)s, 1, SocketFlags.None), i,
                         CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
                 }
-                await Task.WhenAll(writes);
-                await Task.WhenAll(reads);
+                await TestSettings.WhenAllOrAnyFailedWithTimeout(writes.Concat(reads).ToArray());
 
                 Assert.Equal(sendData.OrderBy(i => i), receiveData.OrderBy(i => i));
             }
@@ -341,8 +340,8 @@ namespace System.Net.Sockets.Tests
                 {
                     reads[i] = accepted.ReceiveAsync(new ArraySegment<byte>(receiveData, i, 1), SocketFlags.None);
                 }
-                await Task.WhenAll(writes);
-                await Task.WhenAll(reads);
+
+                await TestSettings.WhenAllOrAnyFailedWithTimeout(writes.Concat(reads).ToArray());
 
                 Assert.Equal(sendData, receiveData);
             }

--- a/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
@@ -266,7 +266,7 @@ namespace System.Net.Sockets.Tests
         [InlineData(false)]
         [InlineData(true)]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Tests ConcurrentSendReceive success for UnixDomainSocketEndPoint on Unix
-        public void ConcurrentSendReceive(bool forceNonBlocking)
+        public async Task ConcurrentSendReceive(bool forceNonBlocking)
         {
             using (Socket server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
             using (Socket client = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
@@ -283,7 +283,7 @@ namespace System.Net.Sockets.Tests
 
                 Task<Socket> acceptTask = server.AcceptAsync();
                 client.Connect(new UnixDomainSocketEndPoint(path));
-                acceptTask.Wait();
+                await acceptTask;
                 Socket accepted = acceptTask.Result;
 
                 client.ForceNonBlocking(forceNonBlocking);
@@ -301,8 +301,8 @@ namespace System.Net.Sockets.Tests
                     writes[i] = Task.Factory.StartNew(s => client.Send(sendData, (int)s, 1, SocketFlags.None), i,
                         CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
                 }
-                Task.WaitAll(writes);
-                Task.WaitAll(reads);
+                await Task.WhenAll(writes);
+                await Task.WhenAll(reads);
 
                 Assert.Equal(sendData.OrderBy(i => i), receiveData.OrderBy(i => i));
             }
@@ -311,7 +311,7 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Tests ConcurrentSendReceive success for UnixDomainSocketEndPoint on Unix
-        public void ConcurrentSendReceiveAsync()
+        public async Task ConcurrentSendReceiveAsync()
         {
             using (Socket server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
             using (Socket client = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
@@ -328,7 +328,7 @@ namespace System.Net.Sockets.Tests
 
                 Task<Socket> acceptTask = server.AcceptAsync();
                 client.Connect(new UnixDomainSocketEndPoint(path));
-                acceptTask.Wait();
+                await acceptTask;
                 Socket accepted = acceptTask.Result;
 
                 Task[] writes = new Task[Iters];
@@ -341,8 +341,8 @@ namespace System.Net.Sockets.Tests
                 {
                     reads[i] = accepted.ReceiveAsync(new ArraySegment<byte>(receiveData, i, 1), SocketFlags.None);
                 }
-                Task.WaitAll(writes);
-                Task.WaitAll(reads);
+                await Task.WhenAll(writes);
+                await Task.WhenAll(reads);
 
                 Assert.Equal(sendData, receiveData);
             }

--- a/src/System.Net.Sockets/tests/ManualPerformanceTests/System.Net.Sockets.Async.Performance.Tests.csproj
+++ b/src/System.Net.Sockets/tests/ManualPerformanceTests/System.Net.Sockets.Async.Performance.Tests.csproj
@@ -47,6 +47,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Capability.Sockets.cs">
       <Link>Common\System\Net\Capability.Sockets.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+      <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="$(CommonTestPath)\System\Net\Sockets\Performance\SocketTestMemcmp.Windows.cs">


### PR DESCRIPTION
I have removed the "easy" blocking points in the tests in here. There is more work to be done, but they require a lot more refactoring so much closer code reviewing. These the "low hanging" fruit and I will look at further PR's to sort this out.

ref #25346
