### PR TITLE
Improve performance of BigInteger.ToString("x")

### DIFF
--- a/src/Common/src/System/Text/ValueStringBuilder.cs
+++ b/src/Common/src/System/Text/ValueStringBuilder.cs
@@ -1,0 +1,174 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Text
+{
+    internal ref struct ValueStringBuilder
+    {
+        private char[] _arrayToReturnToPool;
+        private Span<char> _chars;
+        private int _pos;
+
+        public ValueStringBuilder(Span<char> initialBuffer)
+        {
+            _arrayToReturnToPool = null;
+            _chars = initialBuffer;
+            _pos = 0;
+        }
+
+        public string GetString()
+        {
+            var s = new string(_chars.Slice(0, _pos));
+
+            char[] toReturn = _arrayToReturnToPool;
+            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+
+            return s;
+        }
+
+        public bool TryCopyTo(Span<char> destination, out int charsWritten)
+        {
+            if (_pos > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            bool copied = _chars.Slice(0, _pos).TryCopyTo(destination);
+            Debug.Assert(copied);
+            charsWritten = _pos;
+
+            char[] toReturn = _arrayToReturnToPool;
+            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char c)
+        {
+            int pos = _pos;
+            if (pos < _chars.Length)
+            {
+                _chars[pos] = c;
+                _pos = pos + 1;
+            }
+            else
+            {
+                GrowAndAppend(c);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string s)
+        {
+            int pos = _pos;
+            if (s.Length == 1 && pos < _chars.Length) // very common case, e.g. appending strings from NumberFormatInfo like separators, percent symbols, etc.
+            {
+                _chars[pos] = s[0];
+                _pos = pos + 1;
+            }
+            else
+            {
+                AppendSlow(s);
+            }
+        }
+
+        private void AppendSlow(string s)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - s.Length)
+            {
+                Grow(s.Length);
+            }
+
+            bool copied = s.AsReadOnlySpan().TryCopyTo(_chars.Slice(pos));
+            Debug.Assert(copied, "Grow should have made enough room to successfully copy");
+            _pos += s.Length;
+        }
+
+        public void Append(char c, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            Span<char> dst = _chars.Slice(_pos, count);
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] = c;
+            }
+            _pos += count;
+        }
+
+        public unsafe void Append(char* value, int length)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - length)
+            {
+                Grow(length);
+            }
+
+            Span<char> dst = _chars.Slice(_pos, length);
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] = *value++;
+            }
+            _pos += length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<char> AppendSpan(int length)
+        {
+            int origPos = _pos;
+            if (origPos > _chars.Length - length)
+            {
+                Grow(length);
+            }
+
+            _pos = origPos + length;
+            return _chars.Slice(origPos, length);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GrowAndAppend(char c)
+        {
+            Grow(1);
+            Append(c);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Grow(int requiredAdditionalCapacity)
+        {
+            Debug.Assert(requiredAdditionalCapacity > _chars.Length - _pos);
+
+            char[] poolArray = ArrayPool<char>.Shared.Rent(_pos + requiredAdditionalCapacity);
+
+            bool success = _chars.TryCopyTo(poolArray);
+            Debug.Assert(success);
+
+            char[] toReturn = _arrayToReturnToPool;
+            _chars = _arrayToReturnToPool = poolArray;
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Text/ValueStringBuilder.cs
+++ b/src/Common/src/System/Text/ValueStringBuilder.cs
@@ -21,44 +21,28 @@ namespace System.Text
             _pos = 0;
         }
 
-        public string GetString()
+        public int Length => _pos;
+
+        public override string ToString()
         {
             var s = new string(_chars.Slice(0, _pos));
-
-            char[] toReturn = _arrayToReturnToPool;
-            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
-
-            if (toReturn != null)
-            {
-                ArrayPool<char>.Shared.Return(toReturn);
-            }
-
+            Clear();
             return s;
         }
 
-        public int Length => _pos;
-
         public bool TryCopyTo(Span<char> destination, out int charsWritten)
         {
-            if (_pos > destination.Length)
+            if (_chars.Slice(0, _pos).TryCopyTo(destination))
+            {
+                charsWritten = _pos;
+                Clear();
+                return true;
+            }
+            else
             {
                 charsWritten = 0;
                 return false;
             }
-
-            bool copied = _chars.Slice(0, _pos).TryCopyTo(destination);
-            Debug.Assert(copied);
-            charsWritten = _pos;
-
-            char[] toReturn = _arrayToReturnToPool;
-            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
-
-            if (toReturn != null)
-            {
-                ArrayPool<char>.Shared.Return(toReturn);
-            }
-
-            return true;
         }
 
         public void Insert(int index, char value, int count)
@@ -173,13 +157,24 @@ namespace System.Text
         {
             Debug.Assert(requiredAdditionalCapacity > _chars.Length - _pos);
 
-            char[] poolArray = ArrayPool<char>.Shared.Rent(_pos + requiredAdditionalCapacity);
+            char[] poolArray = ArrayPool<char>.Shared.Rent(Math.Max(_pos + requiredAdditionalCapacity, _chars.Length * 2));
 
             bool success = _chars.TryCopyTo(poolArray);
             Debug.Assert(success);
 
             char[] toReturn = _arrayToReturnToPool;
             _chars = _arrayToReturnToPool = poolArray;
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Clear()
+        {
+            char[] toReturn = _arrayToReturnToPool;
+            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
             if (toReturn != null)
             {
                 ArrayPool<char>.Shared.Return(toReturn);

--- a/src/Common/src/System/Text/ValueStringBuilder.cs
+++ b/src/Common/src/System/Text/ValueStringBuilder.cs
@@ -36,6 +36,8 @@ namespace System.Text
             return s;
         }
 
+        public int Length => _pos;
+
         public bool TryCopyTo(Span<char> destination, out int charsWritten)
         {
             if (_pos > destination.Length)
@@ -57,6 +59,19 @@ namespace System.Text
             }
 
             return true;
+        }
+
+        public void Insert(int index, char value, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            _chars.Slice(index, count).Fill(value);
+            _pos += count;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -62,6 +62,9 @@
     <Compile Include="$(CommonPath)\System\Text\ReusableTextReader.cs">
       <Link>Common\System\Text\ReusableTextReader.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Text\ValueStringBuilder.cs">
+      <Link>Common\System\Text\ValueStringBuilder.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Security\IdentityHelper.cs">
       <Link>Common\System\Security\IdentityHelper.cs</Link>
     </Compile>
@@ -71,6 +74,7 @@
     <Compile Include="Tests\System\IO\StringParserTests.cs" />
     <Compile Include="Tests\System\MarvinTests.cs" />
     <Compile Include="Tests\System\Security\IdentityHelperTests.cs" />
+    <Compile Include="Tests\System\Text\ValueStringBuilderTests.cs" />
     <Compile Include="Tests\System\StringExtensions.Tests.cs" />
     <Compile Include="Tests\System\Collections\Generic\ArrayBuilderTests.cs" />
     <Compile Include="Tests\System\Collections\Generic\LargeArrayBuilderTests.cs" />

--- a/src/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
+++ b/src/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
@@ -1,0 +1,220 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Text.Tests
+{
+    public class ValueStringBuilderTests
+    {
+        [Fact]
+        public void Ctor_Default_CanAppend()
+        {
+            var vsb = default(ValueStringBuilder);
+            Assert.Equal(0, vsb.Length);
+
+            vsb.Append('a');
+            Assert.Equal(1, vsb.Length);
+            Assert.Equal("a", vsb.ToString());
+        }
+
+        [Fact]
+        public void Ctor_Span_CanAppend()
+        {
+            var vsb = new ValueStringBuilder(new char[1]);
+            Assert.Equal(0, vsb.Length);
+
+            vsb.Append('a');
+            Assert.Equal(1, vsb.Length);
+            Assert.Equal("a", vsb.ToString());
+        }
+
+        [Fact]
+        public void Append_Char_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                sb.Append((char)i);
+                vsb.Append((char)i);
+            }
+
+            Assert.Equal(sb.Length, vsb.Length);
+            Assert.Equal(sb.ToString(), vsb.ToString());
+        }
+
+        [Fact]
+        public void Append_String_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                string s = i.ToString();
+                sb.Append(s);
+                vsb.Append(s);
+            }
+
+            Assert.Equal(sb.Length, vsb.Length);
+            Assert.Equal(sb.ToString(), vsb.ToString());
+        }
+
+        [Theory]
+        [InlineData(0, 4*1024*1024)]
+        [InlineData(1025, 4*1024*1024)]
+        [InlineData(3*1024*1024, 6*1024*1024)]
+        public void Append_String_Large_MatchesStringBuilder(int initialLength, int stringLength)
+        {
+            var sb = new StringBuilder(initialLength);
+            var vsb = new ValueStringBuilder(new char[initialLength]);
+
+            string s = new string('a', stringLength);
+            sb.Append(s);
+            vsb.Append(s);
+
+            Assert.Equal(sb.Length, vsb.Length);
+            Assert.Equal(sb.ToString(), vsb.ToString());
+        }
+
+        [Fact]
+        public void Append_CharInt_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                sb.Append((char)i, i);
+                vsb.Append((char)i, i);
+            }
+
+            Assert.Equal(sb.Length, vsb.Length);
+            Assert.Equal(sb.ToString(), vsb.ToString());
+        }
+
+        [Fact]
+        public unsafe void Append_PtrInt_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                string s = i.ToString();
+                fixed (char* p = s)
+                {
+                    sb.Append(p, s.Length);
+                    vsb.Append(p, s.Length);
+                }
+            }
+
+            Assert.Equal(sb.Length, vsb.Length);
+            Assert.Equal(sb.ToString(), vsb.ToString());
+        }
+
+        [Fact]
+        public void AppendSpan_DataAppendedCorrectly()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+
+            for (int i = 1; i <= 1000; i++)
+            {
+                string s = i.ToString();
+
+                sb.Append(s);
+
+                Span<char> span = vsb.AppendSpan(s.Length);
+                Assert.Equal(sb.Length, vsb.Length);
+
+                s.AsReadOnlySpan().CopyTo(span);
+            }
+
+            Assert.Equal(sb.Length, vsb.Length);
+            Assert.Equal(sb.ToString(), vsb.ToString());
+        }
+
+        [Fact]
+        public void Insert_IntCharInt_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            var rand = new Random(42);
+
+            for (int i = 1; i <= 100; i++)
+            {
+                int index = rand.Next(sb.Length);
+                sb.Insert(index, new string((char)i, 1), i);
+                vsb.Insert(index, (char)i, i);
+            }
+
+            Assert.Equal(sb.Length, vsb.Length);
+            Assert.Equal(sb.ToString(), vsb.ToString());
+        }
+
+        [Fact]
+        public void ToString_ClearsBuilder_ThenReusable()
+        {
+            const string Text1 = "test";
+            var vsb = new ValueStringBuilder();
+
+            vsb.Append(Text1);
+            Assert.Equal(Text1.Length, vsb.Length);
+
+            string s = vsb.ToString();
+            Assert.Equal(Text1, s);
+
+            Assert.Equal(0, vsb.Length);
+            Assert.Equal(string.Empty, vsb.ToString());
+            Assert.True(vsb.TryCopyTo(Span<char>.Empty, out _));
+
+            const string Text2 = "another test";
+            vsb.Append(Text2);
+            Assert.Equal(Text2.Length, vsb.Length);
+            Assert.Equal(Text2, vsb.ToString());
+        }
+
+        [Fact]
+        public void TryCopyTo_FailsWhenDestinationIsTooSmall_SucceedsWhenItsLargeEnough()
+        {
+            var vsb = new ValueStringBuilder();
+
+            const string Text = "expected text";
+            vsb.Append(Text);
+            Assert.Equal(Text.Length, vsb.Length);
+
+            Span<char> dst = new char[Text.Length - 1];
+            Assert.False(vsb.TryCopyTo(dst, out int charsWritten));
+            Assert.Equal(0, charsWritten);
+
+            dst = new char[Text.Length];
+            Assert.True(vsb.TryCopyTo(dst, out charsWritten));
+            Assert.Equal(Text.Length, charsWritten);
+            Assert.Equal(0, vsb.Length);
+        }
+
+        [Fact]
+        public void TryCopyTo_ClearsBuilder_ThenReusable()
+        {
+            const string Text1 = "test";
+            var vsb = new ValueStringBuilder();
+
+            vsb.Append(Text1);
+            Assert.Equal(Text1.Length, vsb.Length);
+
+            Span<char> dst = new char[Text1.Length];
+            Assert.True(vsb.TryCopyTo(dst, out int charsWritten));
+            Assert.Equal(Text1.Length, charsWritten);
+            Assert.Equal(Text1, new string(dst));
+
+            Assert.Equal(0, vsb.Length);
+            Assert.Equal(string.Empty, vsb.ToString());
+            Assert.True(vsb.TryCopyTo(Span<char>.Empty, out _));
+
+            const string Text2 = "another test";
+            vsb.Append(Text2);
+            Assert.Equal(Text2.Length, vsb.Length);
+            Assert.Equal(Text2, vsb.ToString());
+        }
+    }
+}

--- a/src/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
+++ b/src/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
@@ -34,6 +34,7 @@
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />

--- a/src/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
+++ b/src/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
@@ -29,8 +29,12 @@
     <Compile Include="$(CommonPath)\System\Globalization\FormatProvider.Number.cs">
       <Link>System\Globalization\FormatProvider.Number.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Text\ValueStringBuilder.cs">
+      <Link>System\Text\ValueStringBuilder.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />


### PR DESCRIPTION
Benchmark:
```C#
using System;
using System.Numerics;
using BenchmarkDotNet.Attributes.Jobs;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

[MemoryDiagnoser]
[InProcess]
public class Program
{
    public static void Main() => BenchmarkRunner.Run<Program>();

    private static BigInteger s_smallBigInt = new BigInteger(100);
    private static BigInteger s_largeBigInt = BigInteger.Parse(new string('9', 2000));

    [Benchmark]
    public void BigIntegerToString_Small()
    {
        BigInteger small = s_smallBigInt;
        for (int i = 0; i < 100_000; i++) small.ToString("x");
    }

    [Benchmark]
    public void BigIntegerToString_Large()
    {
        BigInteger large = s_largeBigInt;
        for (int i = 0; i < 1_000; i++) large.ToString("x");
    }
}
```

Before:
```
 |                   Method |     Mean |     Error |    StdDev |     Gen 0 | Allocated |
 |------------------------- |---------:|----------:|----------:|----------:|----------:|
 | BigIntegerToString_Small | 20.01 ms | 0.4187 ms | 0.6519 ms | 6843.7500 |  27.47 MB |
 | BigIntegerToString_Large | 29.62 ms | 0.3435 ms | 0.3045 ms | 8468.7500 |  33.91 MB |
```

After:
```
 |                   Method |     Mean |     Error |    StdDev |     Gen 0 | Allocated |
 |------------------------- |---------:|----------:|----------:|----------:|----------:|
 | BigIntegerToString_Small | 9.445 ms | 0.1153 ms | 0.0834 ms |  750.0000 |   3.05 MB |
 | BigIntegerToString_Large | 3.946 ms | 0.0603 ms | 0.0534 ms | 1000.0000 |   4.01 MB |
```

So for this small value, an ~2x throughput improvement, and for this large value, an ~8x throughput improvement, and for both, an ~9x reduction in allocation.

cc: @bartonjs 