### PR TITLE
Simplify some casting and conversion related code in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
@@ -322,7 +322,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 ExprList list = (ExprList)pExpr.OptionalArguments;
                 ExprList list2 = (ExprList)list.OptionalNextListNode;
                 e = GetExpression(list.OptionalElement);
-                t = ((ExprTypeOf)list2.OptionalElement).SourceType.Type.AssociatedSystemType;
+                t = ((ExprTypeOf)list2.OptionalElement).SourceType.AssociatedSystemType;
 
                 if (e.Type.MakeByRefType() == t)
                 {
@@ -350,7 +350,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 ExprList list = (ExprList)pExpr.OptionalArguments;
 
                 e = GetExpression(list.OptionalElement);
-                t = ((ExprTypeOf)list.OptionalNextListNode).SourceType.Type.AssociatedSystemType;
+                t = ((ExprTypeOf)list.OptionalNextListNode).SourceType.AssociatedSystemType;
 
                 if (e.Type.MakeByRefType() == t)
                 {
@@ -466,7 +466,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             return Expression.Constant(
                 GetObject(list.OptionalElement),
-                ((ExprTypeOf)list.OptionalNextListNode).SourceType.Type.AssociatedSystemType);
+                ((ExprTypeOf)list.OptionalNextListNode).SourceType.AssociatedSystemType);
         }
 
         /////////////////////////////////////////////////////////////////////////////////
@@ -780,7 +780,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                         ExprList list = (ExprList)call.OptionalArguments;
                         return
                             Expression.NewArrayInit(
-                                ((ExprTypeOf)list.OptionalElement).SourceType.Type.AssociatedSystemType,
+                                ((ExprTypeOf)list.OptionalElement).SourceType.AssociatedSystemType,
                                 GetArgumentsFromArrayInit((ExprArrayInit)list.OptionalNextListNode));
                     }
 
@@ -881,7 +881,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 }
                 else if (pExpr is ExprTypeOf typeOf)
                 {
-                    return typeOf.SourceType.Type.AssociatedSystemType;
+                    return typeOf.SourceType.AssociatedSystemType;
                 }
                 else if (pExpr is ExprMethodInfo methodInfo)
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private delegate bool ConversionFunc(
             Expr pSourceExpr,
             CType pSourceType,
-            ExprClass pDestinationTypeExpr,
+            CType pDestinationType,
             bool needsExprDest,
             out Expr ppDestinationExpr,
             CONVERTTYPE flags);
@@ -330,43 +330,25 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         // returns true if an implicit conversion exists from source type to dest type. flags is an optional parameter.
-        private bool canConvert(CType src, CType dest, CONVERTTYPE flags)
-        {
-            ExprClass exprDest = ExprFactory.CreateClass(dest);
-            return BindImplicitConversion(null, src, exprDest, flags);
-        }
+        private bool canConvert(CType src, CType dest, CONVERTTYPE flags) => BindImplicitConversion(null, src, dest, flags);
 
-        public bool canConvert(CType src, CType dest)
-        {
-            return canConvert(src, dest, 0);
-        }
+        public bool canConvert(CType src, CType dest) => canConvert(src, dest, 0);
 
         // returns true if a implicit conversion exists from source expr to dest type. flags is an optional parameter.
-        private bool canConvert(Expr expr, CType dest)
-        {
-            return canConvert(expr, dest, 0);
-        }
+        private bool canConvert(Expr expr, CType dest) => canConvert(expr, dest, 0);
 
-        private bool canConvert(Expr expr, CType dest, CONVERTTYPE flags)
-        {
-            ExprClass exprDest = ExprFactory.CreateClass(dest);
-            return BindImplicitConversion(expr, expr.Type, exprDest, flags);
-        }
+        private bool canConvert(Expr expr, CType dest, CONVERTTYPE flags) =>
+            BindImplicitConversion(expr, expr.Type, dest, flags);
 
         // performs an implicit conversion if it's possible. otherwise displays an error. flags is an optional parameter.
 
-        private Expr mustConvertCore(Expr expr, ExprClass destExpr)
-        {
-            return mustConvertCore(expr, destExpr, 0);
-        }
+        private Expr mustConvertCore(Expr expr, CType destExpr) => mustConvertCore(expr, destExpr, 0);
 
-        private Expr mustConvertCore(Expr expr, ExprClass destExpr, CONVERTTYPE flags)
+        private Expr mustConvertCore(Expr expr, CType dest, CONVERTTYPE flags)
         {
             Debug.Assert(!(expr is ExprMemberGroup));
-            Expr exprResult;
-            CType dest = destExpr.Type;
 
-            if (BindImplicitConversion(expr, expr.Type, destExpr, out exprResult, flags))
+            if (BindImplicitConversion(expr, expr.Type, dest, out Expr exprResult, flags))
             {
                 // Conversion works.
                 checkUnsafe(expr.Type); // added to the binder so we don't bind to pointer ops
@@ -405,7 +387,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 throw ErrorContext.Error(canCast(expr.Type, dest, flags) ? ErrorCode.ERR_NoImplicitConvCast : ErrorCode.ERR_NoImplicitConv, new ErrArg(expr.Type, ErrArgFlags.Unique), new ErrArg(dest, ErrArgFlags.Unique));
             }
 
-            exprResult = ExprFactory.CreateCast(0, destExpr, expr);
+            exprResult = ExprFactory.CreateCast(0, dest, expr);
             exprResult.SetError();
             return exprResult;
         }
@@ -423,31 +405,20 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private Expr tryConvert(Expr expr, CType dest, CONVERTTYPE flags)
         {
-            Expr exprResult;
-            ExprClass exprDest = ExprFactory.CreateClass(dest);
-            if (BindImplicitConversion(expr, expr.Type, exprDest, out exprResult, flags))
+            if (BindImplicitConversion(expr, expr.Type, dest, out Expr exprResult, flags))
             {
                 checkUnsafe(expr.Type); // added to the binder so we don't bind to pointer ops
                 checkUnsafe(dest); // added to the binder so we don't bind to pointer ops
                 // Conversion works.
                 return exprResult;
             }
+
             return null;
         }
-        public Expr mustConvert(Expr expr, CType dest)
-        {
-            return mustConvert(expr, dest, (CONVERTTYPE)0);
-        }
 
-        private Expr mustConvert(Expr expr, CType dest, CONVERTTYPE flags)
-        {
-            ExprClass exprClass = ExprFactory.CreateClass(dest);
-            return mustConvert(expr, exprClass, flags);
-        }
-        private Expr mustConvert(Expr expr, ExprClass dest, CONVERTTYPE flags)
-        {
-            return mustConvertCore(expr, dest, flags);
-        }
+        public Expr mustConvert(Expr expr, CType dest) => mustConvert(expr, dest, (CONVERTTYPE)0);
+
+        private Expr mustConvert(Expr expr, CType dest, CONVERTTYPE flags) => mustConvertCore(expr, dest, flags);
 
         //        public bool canCast(Expr expr, CType dest)
         //        {
@@ -456,17 +427,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         //        }
 
         // performs an explicit conversion if its possible. otherwise displays an error.
-        private Expr mustCastCore(Expr expr, ExprClass destExpr, CONVERTTYPE flags)
+        private Expr mustCastCore(Expr expr, CType dest, CONVERTTYPE flags)
         {
             Debug.Assert(!(expr is ExprMemberGroup));
             Expr exprResult;
-
-            CType dest = destExpr.Type;
-
             SemanticChecker.CheckForStaticClass(null, dest, ErrorCode.ERR_ConvertToStaticClass);
             if (expr.IsOK)
             {
-                if (BindExplicitConversion(expr, expr.Type, destExpr, out exprResult, flags))
+                if (BindExplicitConversion(expr, expr.Type, dest, out exprResult, flags))
                 {
                     // Conversion works.
                     checkUnsafe(expr.Type); // added to the binder so we don't bind to pointer ops
@@ -493,7 +461,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if (simpleConstToSimpleDestination && Context.Checked)
                     {
                         // check if we failed because we are in checked mode...
-                        bool okNow = canExplicitConversionBeBoundInUncheckedContext(expr, expr.Type, destExpr, flags | CONVERTTYPE.NOUDC);
+                        bool okNow = canExplicitConversionBeBoundInUncheckedContext(expr, expr.Type, dest, flags | CONVERTTYPE.NOUDC);
 
                         if (!okNow)
                         {
@@ -532,7 +500,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
             }
         CANTCONVERT:
-            exprResult = ExprFactory.CreateCast(0, destExpr, expr);
+            exprResult = ExprFactory.CreateCast(0, dest, expr);
             exprResult.SetError();
             return exprResult;
         }
@@ -546,15 +514,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 throw ErrorContext.Error(ErrorCode.ERR_NoExplicitConv, new ErrArg(expr.Type, ErrArgFlags.Unique), new ErrArg(dest, ErrArgFlags.Unique));
             }
         }
-        public Expr mustCast(Expr expr, CType dest)
-        {
-            return mustCast(expr, dest, 0);
-        }
-        public Expr mustCast(Expr expr, CType dest, CONVERTTYPE flags)
-        {
-            ExprClass exprDest = ExprFactory.CreateClass(dest);
-            return mustCastCore(expr, exprDest, flags);
-        }
+
+        public Expr mustCast(Expr expr, CType dest) => mustCast(expr, dest, 0);
+
+        public Expr mustCast(Expr expr, CType dest, CONVERTTYPE flags) => mustCastCore(expr, dest, flags);
+
         private Expr mustCastInUncheckedContext(Expr expr, CType dest, CONVERTTYPE flags)
         {
             BindingContext ctx = new BindingContext(Context);
@@ -562,52 +526,48 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         // returns true if an explicit conversion exists from source type to dest type. flags is an optional parameter.
-        private bool canCast(CType src, CType dest, CONVERTTYPE flags)
-        {
-            ExprClass destExpr = ExprFactory.CreateClass(dest);
-            return BindExplicitConversion(null, src, destExpr, flags);
-        }
+        private bool canCast(CType src, CType dest, CONVERTTYPE flags) => BindExplicitConversion(null, src, dest, flags);
 
-        private bool BindImplicitConversion(Expr pSourceExpr, CType pSourceType, ExprClass pDestinationTypeExpr, CONVERTTYPE flags)
+        private bool BindImplicitConversion(Expr pSourceExpr, CType pSourceType, CType destinationType, CONVERTTYPE flags)
         {
-            ImplicitConversion binder = new ImplicitConversion(this, pSourceExpr, pSourceType, pDestinationTypeExpr, false, flags);
+            ImplicitConversion binder = new ImplicitConversion(this, pSourceExpr, pSourceType, destinationType, false, flags);
             return binder.Bind();
         }
-        private bool BindImplicitConversion(Expr pSourceExpr, CType pSourceType, ExprClass pDestinationTypeExpr, out Expr ppDestinationExpr, CONVERTTYPE flags)
+        private bool BindImplicitConversion(Expr pSourceExpr, CType pSourceType, CType destinationType, out Expr ppDestinationExpr, CONVERTTYPE flags)
         {
-            ImplicitConversion binder = new ImplicitConversion(this, pSourceExpr, pSourceType, pDestinationTypeExpr, true, flags);
+            ImplicitConversion binder = new ImplicitConversion(this, pSourceExpr, pSourceType, destinationType, true, flags);
             bool result = binder.Bind();
             ppDestinationExpr = binder.ExprDest;
             return result;
         }
 
-        private bool BindImplicitConversion(Expr pSourceExpr, CType pSourceType, ExprClass pDestinationTypeExpr, bool needsExprDest, out Expr ppDestinationExpr, CONVERTTYPE flags)
+        private bool BindImplicitConversion(Expr pSourceExpr, CType pSourceType, CType destinationType, bool needsExprDest, out Expr ppDestinationExpr, CONVERTTYPE flags)
         {
-            ImplicitConversion binder = new ImplicitConversion(this, pSourceExpr, pSourceType, pDestinationTypeExpr, needsExprDest, flags);
+            ImplicitConversion binder = new ImplicitConversion(this, pSourceExpr, pSourceType, destinationType, needsExprDest, flags);
             bool result = binder.Bind();
             ppDestinationExpr = needsExprDest ? binder.ExprDest : null;
             return result;
         }
 
-        private bool BindExplicitConversion(Expr pSourceExpr, CType pSourceType, ExprClass pDestinationTypeExpr, bool needsExprDest, out Expr ppDestinationExpr, CONVERTTYPE flags)
+        private bool BindExplicitConversion(Expr pSourceExpr, CType pSourceType, CType destinationType, bool needsExprDest, out Expr ppDestinationExpr, CONVERTTYPE flags)
         {
-            ExplicitConversion binder = new ExplicitConversion(this, pSourceExpr, pSourceType, pDestinationTypeExpr, needsExprDest, flags);
+            ExplicitConversion binder = new ExplicitConversion(this, pSourceExpr, pSourceType, destinationType, needsExprDest, flags);
             bool result = binder.Bind();
             ppDestinationExpr = needsExprDest ? binder.ExprDest : null;
             return result;
         }
 
-        private bool BindExplicitConversion(Expr pSourceExpr, CType pSourceType, ExprClass pDestinationTypeExpr, out Expr ppDestinationExpr, CONVERTTYPE flags)
+        private bool BindExplicitConversion(Expr pSourceExpr, CType pSourceType, CType destinationType, out Expr ppDestinationExpr, CONVERTTYPE flags)
         {
-            ExplicitConversion binder = new ExplicitConversion(this, pSourceExpr, pSourceType, pDestinationTypeExpr, true, flags);
+            ExplicitConversion binder = new ExplicitConversion(this, pSourceExpr, pSourceType, destinationType, true, flags);
             bool result = binder.Bind();
             ppDestinationExpr = binder.ExprDest;
             return result;
         }
 
-        private bool BindExplicitConversion(Expr pSourceExpr, CType pSourceType, ExprClass pDestinationTypeExpr, CONVERTTYPE flags)
+        private bool BindExplicitConversion(Expr pSourceExpr, CType pSourceType, CType destinationType, CONVERTTYPE flags)
         {
-            ExplicitConversion binder = new ExplicitConversion(this, pSourceExpr, pSourceType, pDestinationTypeExpr, false, flags);
+            ExplicitConversion binder = new ExplicitConversion(this, pSourceExpr, pSourceType, destinationType, false, flags);
             return binder.Bind();
         }
 
@@ -1127,13 +1087,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private Expr BindUDConversionCore(Expr pFrom, CType pTypeFrom, CType pTypeTo, CType pTypeDestination, MethWithInst mwiBest, out Expr ppTransformedArgument)
         {
-            ExprClass pClassFrom = ExprFactory.CreateClass(pTypeFrom);
-            Expr pTransformedArgument = mustCastCore(pFrom, pClassFrom, CONVERTTYPE.NOUDC);
+            Expr pTransformedArgument = mustCastCore(pFrom, pTypeFrom, CONVERTTYPE.NOUDC);
             Debug.Assert(pTransformedArgument != null);
             ExprMemberGroup pMemGroup = ExprFactory.CreateMemGroup(null, mwiBest);
             ExprCall pCall = ExprFactory.CreateCall(0, pTypeTo, pTransformedArgument, pMemGroup, mwiBest);
-            ExprClass pDestination = ExprFactory.CreateClass(pTypeDestination);
-            Expr pCast = mustCastCore(pCall, pDestination, CONVERTTYPE.NOUDC);
+            Expr pCast = mustCastCore(pCall, pTypeDestination, CONVERTTYPE.NOUDC);
             Debug.Assert(pCast != null);
             ppTransformedArgument = pTransformedArgument;
             return pCast;
@@ -1142,12 +1100,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         /*
          * Fold a constant cast. Returns true if the constant could be folded.
          */
-        private ConstCastResult bindConstantCast(Expr exprSrc, ExprClass exprTypeDest, bool needExprDest, out Expr pexprDest, bool explicitConversion)
+        private ConstCastResult bindConstantCast(Expr exprSrc, CType typeDest, bool needExprDest, out Expr pexprDest, bool explicitConversion)
         {
             pexprDest = null;
             long valueInt = 0;
             double valueFlt = 0;
-            CType typeDest = exprTypeDest.Type;
             FUNDTYPE ftSrc = exprSrc.Type.fundType();
             FUNDTYPE ftDest = typeDest.fundType();
             bool srcIntegral = (ftSrc <= FUNDTYPE.FT_LASTINTEGRAL);
@@ -1158,7 +1115,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (ftSrc == FUNDTYPE.FT_STRUCT || ftDest == FUNDTYPE.FT_STRUCT)
             {
                 // Do constant folding involving decimal constants.
-                Expr expr = bindDecimalConstCast(exprTypeDest, exprSrc.Type, constSrc);
+                Expr expr = bindDecimalConstCast(typeDest, exprSrc.Type, constSrc);
 
                 if (expr == null)
                 {
@@ -1400,9 +1357,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         /*
          * Bind a constant cast to or from decimal. Return null if cast can't be done.
          */
-        private Expr bindDecimalConstCast(ExprClass exprDestType, CType srcType, ExprConstant src)
+        private Expr bindDecimalConstCast(CType destType, CType srcType, ExprConstant src)
         {
-            CType destType = exprDestType.Type;
             CType typeDecimal = SymbolLoader.GetPredefindType(PredefinedType.PT_DECIMAL);
             ConstVal cv;
 
@@ -1509,11 +1465,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return null;
         }
 
-        private bool canExplicitConversionBeBoundInUncheckedContext(Expr exprSrc, CType typeSrc, ExprClass typeDest, CONVERTTYPE flags)
+        private bool canExplicitConversionBeBoundInUncheckedContext(Expr exprSrc, CType typeSrc, CType typeDest, CONVERTTYPE flags)
         {
             BindingContext ctx = new BindingContext(Context);
             Debug.Assert(typeDest != null);
-            Debug.Assert(typeDest.Type != null);
             return (new ExpressionBinder(ctx)).BindExplicitConversion(exprSrc, typeSrc, typeDest, flags);
         }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -36,7 +36,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // to report the error on, so that when the lambda conversion fails, it reports
             // errors on the correct type.
 
-            private readonly CType _pDestinationTypeForLambdaErrorReporting;
             private Expr _exprDest;
             private readonly bool _needsExprDest;
             private readonly CONVERTTYPE _flags;
@@ -45,13 +44,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // BindExplicitConversion
             // ----------------------------------------------------------------------------
 
-            public ExplicitConversion(ExpressionBinder binder, Expr exprSrc, CType typeSrc, ExprClass typeDest, CType pDestinationTypeForLambdaErrorReporting, bool needsExprDest, CONVERTTYPE flags)
+            public ExplicitConversion(ExpressionBinder binder, Expr exprSrc, CType typeSrc, ExprClass typeDest, bool needsExprDest, CONVERTTYPE flags)
             {
                 _binder = binder;
                 _exprSrc = exprSrc;
                 _typeSrc = typeSrc;
                 _typeDest = typeDest.Type;
-                _pDestinationTypeForLambdaErrorReporting = pDestinationTypeForLambdaErrorReporting;
                 _exprTypeDest = typeDest;
                 _needsExprDest = needsExprDest;
                 _flags = flags;
@@ -100,7 +98,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // The set of explicit conversions includes all implicit conversions.
 
                 // Don't try user-defined conversions now because we'll try them again later.
-                if (_binder.BindImplicitConversion(_exprSrc, _typeSrc, _exprTypeDest, _pDestinationTypeForLambdaErrorReporting, _needsExprDest, out _exprDest, _flags | CONVERTTYPE.ISEXPLICIT))
+                if (_binder.BindImplicitConversion(_exprSrc, _typeSrc, _exprTypeDest, _needsExprDest, out _exprDest, _flags | CONVERTTYPE.ISEXPLICIT))
                 {
                     return true;
                 }
@@ -194,7 +192,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 // If S and T are value types and there is a builtin conversion from S => T then there is an
                 // explicit conversion from S? => T that throws on null.
-                if (_typeDest.IsValType() && _binder.BindExplicitConversion(null, _typeSrc.StripNubs(), _exprTypeDest, _pDestinationTypeForLambdaErrorReporting, _flags | CONVERTTYPE.NOUDC))
+                if (_typeDest.IsValType() && _binder.BindExplicitConversion(null, _typeSrc.StripNubs(), _exprTypeDest, _flags | CONVERTTYPE.NOUDC))
                 {
                     if (_needsExprDest)
                     {
@@ -205,7 +203,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
 
                         Debug.Assert(valueSrc.Type == _typeSrc.StripNubs());
-                        if (!_binder.BindExplicitConversion(valueSrc, valueSrc.Type, _exprTypeDest, _pDestinationTypeForLambdaErrorReporting, _needsExprDest, out _exprDest, _flags | CONVERTTYPE.NOUDC))
+                        if (!_binder.BindExplicitConversion(valueSrc, valueSrc.Type, _exprTypeDest, _needsExprDest, out _exprDest, _flags | CONVERTTYPE.NOUDC))
                         {
                             Debug.Fail("BindExplicitConversion failed unexpectedly");
                             return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
@@ -51,9 +51,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public ExprUserDefinedConversion CreateUserDefinedConversion(Expr arg, Expr call, MethWithInst method) => 
             new ExprUserDefinedConversion(arg, call, method);
 
-        public ExprCast CreateCast(CType type, Expr argument) => CreateCast(0, CreateClass(type), argument);
+        public ExprCast CreateCast(CType type, Expr argument) => CreateCast(0, type, argument);
 
-        public ExprCast CreateCast(EXPRFLAG flags, ExprClass type, Expr argument) => new ExprCast(flags, type, argument);
+        public ExprCast CreateCast(EXPRFLAG flags, CType type, Expr argument) => new ExprCast(flags, type, argument);
 
         public ExprReturn CreateReturn(Expr optionalObject) => new ExprReturn(optionalObject);
 
@@ -81,10 +81,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public ExprFieldInfo CreateFieldInfo(FieldSymbol field, AggregateType fieldType) => 
             new ExprFieldInfo(field, fieldType, Types.GetPredefAgg(PredefinedType.PT_FIELDINFO).getThisType());
 
-        private ExprTypeOf CreateTypeOf(ExprClass sourceType) => 
+        public ExprTypeOf CreateTypeOf(CType sourceType) => 
             new ExprTypeOf(Types.GetPredefAgg(PredefinedType.PT_TYPE).getThisType(), sourceType);
 
-        public ExprTypeOf CreateTypeOf(CType sourceType) => CreateTypeOf(CreateClass(sourceType));
 
         public ExprUserLogicalOp CreateUserLogOp(CType type, Expr trueFalseCall, ExprCall operatorCall) => 
             new ExprUserLogicalOp(type, trueFalseCall, operatorCall);
@@ -126,7 +125,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case FUNDTYPE.FT_PTR:
                     {
                         // Just allocate a new node and fill it in.
-                        return CreateCast(0, CreateClass(type), CreateNull());
+                        return CreateCast(0, type, CreateNull());
                     }
 
                 case FUNDTYPE.FT_STRUCT:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -348,7 +348,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Expr exprTmp = _exprSrc;
 
                     // If there is an implicit/explicit S => T then there is an implicit/explicit S => T?
-                    if (_typeSrc == typeDstBase || pfn(_exprSrc, _typeSrc, exprTypeDstBase, nubDst, _needsExprDest, out exprTmp, _flags | CONVERTTYPE.NOUDC))
+                    if (_typeSrc == typeDstBase || pfn(_exprSrc, _typeSrc, exprTypeDstBase, _needsExprDest, out exprTmp, _flags | CONVERTTYPE.NOUDC))
                     {
                         if (_needsExprDest)
                         {
@@ -383,7 +383,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 // Both are Nullable so there is only a conversion if there is a conversion between the base types.
                 // That is, if there is an implicit/explicit S => T then there is an implicit/explicit S?+ => T?+.
-                if (typeSrcBase != typeDstBase && !pfn(null, typeSrcBase, exprTypeDstBase, nubDst, false, out _exprDest, _flags | CONVERTTYPE.NOUDC))
+                if (typeSrcBase != typeDstBase && !pfn(null, typeSrcBase, exprTypeDstBase, false, out _exprDest, _flags | CONVERTTYPE.NOUDC))
                 {
                     // No builtin conversion. Maybe there is a user defined conversion....
                     return 0 == (_flags & CONVERTTYPE.NOUDC) && _binder.bindUserDefinedConversion(_exprSrc, _typeSrc, nubDst, _needsExprDest, out _exprDest, 0 == (_flags & CONVERTTYPE.ISEXPLICIT));
@@ -402,9 +402,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                     bool convertible = (_flags & CONVERTTYPE.ISEXPLICIT) != 0
                         ? _binder.BindExplicitConversion(
-                            arg1, arg1.Type, arg2, typeDstBase, out arg1, _flags | CONVERTTYPE.NOUDC)
+                            arg1, arg1.Type, arg2, out arg1, _flags | CONVERTTYPE.NOUDC)
                         : _binder.BindImplicitConversion(
-                            arg1, arg1.Type, arg2, typeDstBase, out arg1, _flags | CONVERTTYPE.NOUDC);
+                            arg1, arg1.Type, arg2, out arg1, _flags | CONVERTTYPE.NOUDC);
 
                     if (!convertible)
                     {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -15,13 +15,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private sealed class ImplicitConversion
         {
-            public ImplicitConversion(ExpressionBinder binder, Expr exprSrc, CType typeSrc, ExprClass typeDest, bool needsExprDest, CONVERTTYPE flags)
+            public ImplicitConversion(ExpressionBinder binder, Expr exprSrc, CType typeSrc, CType typeDest, bool needsExprDest, CONVERTTYPE flags)
             {
                 _binder = binder;
                 _exprSrc = exprSrc;
                 _typeSrc = typeSrc;
-                _typeDest = typeDest.Type;
-                _exprTypeDest = typeDest;
+                _typeDest = typeDest;
                 _needsExprDest = needsExprDest;
                 _flags = flags;
                 _exprDest = null;
@@ -32,7 +31,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private readonly Expr _exprSrc;
             private readonly CType _typeSrc;
             private readonly CType _typeDest;
-            private readonly ExprClass _exprTypeDest;
             private readonly bool _needsExprDest;
             private CONVERTTYPE _flags;
 
@@ -218,7 +216,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     if (_needsExprDest)
                     {
-                        _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest, _exprSrc.Flags & EXPRFLAG.EXF_CANTBENULL);
+                        _binder.bindSimpleCast(_exprSrc, _typeDest, out _exprDest, _exprSrc.Flags & EXPRFLAG.EXF_CANTBENULL);
                     }
                     return true;
                 }
@@ -307,7 +305,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                     if (_needsExprDest)
                     {
-                        _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest, EXPRFLAG.EXF_UNBOX);
+                        _binder.bindSimpleCast(_exprSrc, _typeDest, out _exprDest, EXPRFLAG.EXF_UNBOX);
                     }
                     return true;
                 }
@@ -315,7 +313,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 bool dstWasNullable;
                 bool srcWasNullable;
                 CType typeDstBase = nubDst.StripNubs(out dstWasNullable);
-                ExprClass exprTypeDstBase = GetExprFactory().CreateClass(typeDstBase);
                 CType typeSrcBase = _typeSrc.StripNubs(out srcWasNullable);
                 ConversionFunc pfn = (_flags & CONVERTTYPE.ISEXPLICIT) != 0 ?
                     (ConversionFunc)_binder.BindExplicitConversion :
@@ -348,7 +345,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Expr exprTmp = _exprSrc;
 
                     // If there is an implicit/explicit S => T then there is an implicit/explicit S => T?
-                    if (_typeSrc == typeDstBase || pfn(_exprSrc, _typeSrc, exprTypeDstBase, _needsExprDest, out exprTmp, _flags | CONVERTTYPE.NOUDC))
+                    if (_typeSrc == typeDstBase || pfn(_exprSrc, _typeSrc, typeDstBase, _needsExprDest, out exprTmp, _flags | CONVERTTYPE.NOUDC))
                     {
                         if (_needsExprDest)
                         {
@@ -383,7 +380,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 // Both are Nullable so there is only a conversion if there is a conversion between the base types.
                 // That is, if there is an implicit/explicit S => T then there is an implicit/explicit S?+ => T?+.
-                if (typeSrcBase != typeDstBase && !pfn(null, typeSrcBase, exprTypeDstBase, false, out _exprDest, _flags | CONVERTTYPE.NOUDC))
+                if (typeSrcBase != typeDstBase && !pfn(null, typeSrcBase, typeDstBase, false, out _exprDest, _flags | CONVERTTYPE.NOUDC))
                 {
                     // No builtin conversion. Maybe there is a user defined conversion....
                     return 0 == (_flags & CONVERTTYPE.NOUDC) && _binder.bindUserDefinedConversion(_exprSrc, _typeSrc, nubDst, _needsExprDest, out _exprDest, 0 == (_flags & CONVERTTYPE.ISEXPLICIT));
@@ -398,13 +395,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     // Here we want to first check whether or not the conversions work on the base types.
 
                     Expr arg1 = _binder.mustCast(_exprSrc, typeSrcBase);
-                    ExprClass arg2 = GetExprFactory().CreateClass(typeDstBase);
-
                     bool convertible = (_flags & CONVERTTYPE.ISEXPLICIT) != 0
                         ? _binder.BindExplicitConversion(
-                            arg1, arg1.Type, arg2, out arg1, _flags | CONVERTTYPE.NOUDC)
+                            arg1, arg1.Type, typeDstBase, out arg1, _flags | CONVERTTYPE.NOUDC)
                         : _binder.BindImplicitConversion(
-                            arg1, arg1.Type, arg2, out arg1, _flags | CONVERTTYPE.NOUDC);
+                            arg1, arg1.Type, typeDstBase, out arg1, _flags | CONVERTTYPE.NOUDC);
 
                     if (!convertible)
                     {
@@ -480,13 +475,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     if (_needsExprDest)
                     {
-                        _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest, EXPRFLAG.EXF_BOX);
+                        _binder.bindSimpleCast(_exprSrc, _typeDest, out _exprDest, EXPRFLAG.EXF_BOX);
                         if (!_typeDest.isPredefType(PredefinedType.PT_OBJECT))
                         {
                             // The base type of a nullable is always a non-nullable value type, 
                             // therefore so is typeDest unless typeDest is PT_OBJECT. In this case the conversion 
                             // needs to be unboxed. We only need this if we actually will use the result. 
-                            _binder.bindSimpleCast(_exprDest, _exprTypeDest, out _exprDest, EXPRFLAG.EXF_FORCE_UNBOX);
+                            _binder.bindSimpleCast(_exprDest, _typeDest, out _exprDest, EXPRFLAG.EXF_FORCE_UNBOX);
                         }
                     }
                     return true;
@@ -535,7 +530,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 if (_needsExprDest)
                 {
-                    _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest, grfex);
+                    _binder.bindSimpleCast(_exprSrc, _typeDest, out _exprDest, grfex);
                 }
                 return true;
             }
@@ -552,7 +547,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 if (_typeDest is PointerType ptDest && ptDest.GetReferentType() == _binder.getVoidType())
                 {
                     if (_needsExprDest)
-                        _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest);
+                        _binder.bindSimpleCast(_exprSrc, _typeDest, out _exprDest);
                     return true;
                 }
                 return false;
@@ -617,7 +612,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     flags = _exprSrc.Flags & EXPRFLAG.EXF_CANTBENULL;
                 }
                 if (_needsExprDest)
-                    _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest, flags);
+                    _binder.bindSimpleCast(_exprSrc, _typeDest, out _exprDest, flags);
                 return true;
             }
 
@@ -636,7 +631,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 if (_typeDest is AggregateType aggDest && GetSymbolLoader().HasBaseConversion(aggTypeSrc, aggDest))
                 {
                     if (_needsExprDest)
-                        _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest, EXPRFLAG.EXF_BOX | EXPRFLAG.EXF_CANTBENULL);
+                        _binder.bindSimpleCast(_exprSrc, _typeDest, out _exprDest, EXPRFLAG.EXF_BOX | EXPRFLAG.EXF_CANTBENULL);
                     return true;
                 }
                 return false;
@@ -742,7 +737,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 if (_exprSrc.GetConst() != null)
                 {
                     // Fold the constant cast if possible.
-                    ConstCastResult result = _binder.bindConstantCast(_exprSrc, _exprTypeDest, _needsExprDest, out _exprDest, false);
+                    ConstCastResult result = _binder.bindConstantCast(_exprSrc, _typeDest, _needsExprDest, out _exprDest, false);
                     if (result == ConstCastResult.Success)
                     {
                         return true;  // else, don't fold and use a regular cast, below.
@@ -761,7 +756,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return _binder.bindUserDefinedConversion(_exprSrc, aggTypeSrc, _typeDest, _needsExprDest, out _exprDest, true);
                 }
                 if (_needsExprDest)
-                    _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest);
+                    _binder.bindSimpleCast(_exprSrc, _typeDest, out _exprDest);
                 return true;
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -2380,8 +2380,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (ptOp == PredefinedType.PT_UINT && op.Type.fundType() == FUNDTYPE.FT_U4)
             {
-                ExprClass exprObj = GetExprFactory().CreateClass(GetPredefindType(PredefinedType.PT_LONG));
-                op = mustConvertCore(op, exprObj, CONVERTTYPE.NOUDC);
+                op = mustConvertCore(op, GetPredefindType(PredefinedType.PT_LONG), CONVERTTYPE.NOUDC);
             }
 
             ExprOperator exprRes = GetExprFactory().CreateNeg(flags, op);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Cast.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Cast.cs
@@ -6,28 +6,18 @@ using System.Diagnostics;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal sealed class ExprCast : Expr
+    internal sealed class ExprCast : ExprWithType
     {
-        private ExprClass _destinationType;
-
-        public ExprCast(EXPRFLAG flags, ExprClass destinationType, Expr argument)
-            : base(ExpressionKind.Cast)
+        public ExprCast(EXPRFLAG flags, CType type, Expr argument)
+            : base(ExpressionKind.Cast, type)
         {
             Debug.Assert(argument != null);
-            Debug.Assert(destinationType != null);
             Debug.Assert((flags & ~(EXPRFLAG.EXF_CAST_ALL | EXPRFLAG.EXF_MASK_ANY)) == 0);
             Argument = argument;
             Flags = flags;
-            DestinationType = destinationType;
         }
 
         public Expr Argument { get; set; }
-
-        public ExprClass DestinationType
-        {
-            get => _destinationType;
-            set => Type = (_destinationType = value).Type;
-        }
 
         public bool IsBoxingCast => (Flags & (EXPRFLAG.EXF_BOX | EXPRFLAG.EXF_FORCE_BOX)) != 0;
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/TypeOf.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/TypeOf.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             SourceType = sourceType;
         }
 
-        public CType SourceType { get; set; }
+        public CType SourceType { get; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/TypeOf.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/TypeOf.cs
@@ -6,13 +6,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal sealed class ExprTypeOf : ExprWithType
     {
-        public ExprTypeOf(CType type, ExprClass pSourceType)
+        public ExprTypeOf(CType type, CType sourceType)
             : base(ExpressionKind.TypeOf, type)
         {
             Flags = EXPRFLAG.EXF_CANTBENULL;
-            SourceType = pSourceType;
+            SourceType = sourceType;
         }
 
-        public ExprClass SourceType { get; set; }
+        public CType SourceType { get; set; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
@@ -329,16 +329,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
 
                 case ExpressionKind.TypeOf:
-                    exprRet = Visit((pExpr as ExprTypeOf).SourceType);
-                    (pExpr as ExprTypeOf).SourceType = exprRet as ExprClass;
                     break;
 
                 case ExpressionKind.Cast:
                     exprRet = Visit((pExpr as ExprCast).Argument);
                     Debug.Assert(exprRet != null);
                     (pExpr as ExprCast).Argument = exprRet;
-                    exprRet = Visit((pExpr as ExprCast).DestinationType);
-                    (pExpr as ExprCast).DestinationType = exprRet as ExprClass;
                     break;
 
                 case ExpressionKind.UserDefinedConversion:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case ExpressionKind.Constant:
                     return VisitCONSTANT(pExpr as ExprConstant);
                 case ExpressionKind.Class:
-                    return VisitCLASS(pExpr as ExprClass);
+                    return pExpr;
                 case ExpressionKind.Property:
                     return VisitPROP(pExpr as ExprProperty);
                 case ExpressionKind.Multi:
@@ -481,10 +481,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         protected virtual Expr VisitRETURN(ExprReturn pExpr)
         {
             return VisitSTMT(pExpr);
-        }
-        protected virtual Expr VisitCLASS(ExprClass pExpr)
-        {
-            return VisitEXPR(pExpr);
         }
         protected virtual Expr VisitSTMT(ExprStatement pExpr)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -958,8 +958,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Expr newIndex = it.Current();
                 if (newIndex.Type != intType)
                 {
-                    ExprClass exprType = expressionFactory.CreateClass(intType);
-                    newIndex = expressionFactory.CreateCast(EXPRFLAG.EXF_INDEXEXPR, exprType, newIndex);
+                    newIndex = expressionFactory.CreateCast(EXPRFLAG.EXF_INDEXEXPR, intType, newIndex);
                     newIndex.Flags |= EXPRFLAG.EXF_CHECKOVERFLOW;
                 }
                 Expr rewrittenIndex = Visit(newIndex);
@@ -986,8 +985,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 flags = EXPRFLAG.EXF_BOX;
             }
 
-            ExprClass objectType = GetExprFactory().CreateClass(pObject);
-            ExprCast cast = GetExprFactory().CreateCast(flags, objectType, expr);
+            ExprCast cast = GetExprFactory().CreateCast(flags, pObject, expr);
             ExprTypeOf pTypeOf2 = CreateTypeOf(expr.Type);
 
             return GenerateCall(PREDEFMETH.PM_EXPRESSION_CONSTANT_OBJECT_TYPE, cast, pTypeOf2);


### PR DESCRIPTION
* Remove `pDestinationTypeForLambdaErrorReporting` from conversions.

Stored in a field and passed around, but never used for anything beside.

* Don't use `ExprClass` in casts and `ExprTypeOf`

Acts as a wrapper around the type, but provides nothing beyond that wrapper, so it is just unwrapped again. (Visiting an `ExprClass` is always a nop, so that's not a reason to wrap it).

Use the `CType` directly instead.

(`ExprClass` remains in use as the target of static calls).

* Make visiting `ExprClass` explicitly just return it directly.

This is what happens anyway, but since the previous change depends on this, making this clear makes that being correct clearer, as well as a minor efficiency gain.