### PR TITLE
Added explicit conversion APIs for Span to ROSpan and Memory to ROMemory

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -109,7 +109,9 @@ namespace System
         public static Span<T> AsSpan<T>(this T[] array) { throw null; }
         public static Span<T> AsSpan<T>(this ArraySegment<T> arraySegment) { throw null; }
         public static ReadOnlySpan<T> AsReadOnlySpan<T>(this T[] array) { throw null; }
+        public static ReadOnlySpan<T> AsReadOnlySpan<T>(this Span<T> span) { throw null; }
         public static ReadOnlySpan<T> AsReadOnlySpan<T>(this ArraySegment<T> arraySegment) { throw null; }
+        public static ReadOnlyMemory<T> AsReadOnlyMemory<T>(this Memory<T> memory) { throw null; }
 
         public static void CopyTo<T>(this T[] array, Span<T> destination) { throw null; }
         public static void CopyTo<T>(this T[] array, Memory<T> destination) { throw null; }

--- a/src/System.Memory/src/System/MemoryExtensions.cs
+++ b/src/System.Memory/src/System/MemoryExtensions.cs
@@ -250,6 +250,12 @@ namespace System
         }
 
         /// <summary>
+        /// Creates a new readonly span over the entire target span.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<T> AsReadOnlySpan<T>(this Span<T> span) => span;
+
+        /// <summary>
         /// Creates a new readonly span over the target array segment.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -257,6 +263,12 @@ namespace System
         {
             return new ReadOnlySpan<T>(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
         }
+
+        /// <summary>
+        /// Creates a new readonly memory over the entire target memory.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlyMemory<T> AsReadOnlyMemory<T>(this Memory<T> memory) => memory;
 
         /// <summary>
         /// Copies the contents of the array into the span. If the source

--- a/src/System.Memory/src/System/MemoryExtensions.cs
+++ b/src/System.Memory/src/System/MemoryExtensions.cs
@@ -252,7 +252,6 @@ namespace System
         /// <summary>
         /// Creates a new readonly span over the entire target span.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<T> AsReadOnlySpan<T>(this Span<T> span) => span;
 
         /// <summary>
@@ -267,7 +266,6 @@ namespace System
         /// <summary>
         /// Creates a new readonly memory over the entire target memory.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlyMemory<T> AsReadOnlyMemory<T>(this Memory<T> memory) => memory;
 
         /// <summary>

--- a/src/System.Memory/tests/Memory/AsReadOnlyMemory.cs
+++ b/src/System.Memory/tests/Memory/AsReadOnlyMemory.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.MemoryTests
+{
+    public static partial class AsReadOnlyMemory
+    {
+        [Fact]
+        public static void EmptyMemoryAsReadOnlyMemory()
+        {
+            Memory<int> memory = default;
+            Assert.True(memory.AsReadOnlyMemory().IsEmpty);
+        }
+
+        [Fact]
+        public static void MemoryAsReadOnlyMemory()
+        {
+            int[] a = { 19, -17 };
+            Memory<int> memory = new Memory<int>(a);
+            ReadOnlyMemory<int> readOnlyMemory = memory.AsReadOnlyMemory();
+
+            readOnlyMemory.Validate(a);
+        }
+    }
+}

--- a/src/System.Memory/tests/Memory/AsReadOnlyMemory.cs
+++ b/src/System.Memory/tests/Memory/AsReadOnlyMemory.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.MemoryTests
 {
-    public static partial class AsReadOnlyMemory
+    public static class AsReadOnlyMemory
     {
         [Fact]
         public static void EmptyMemoryAsReadOnlyMemory()

--- a/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
@@ -119,5 +119,22 @@ namespace System.SpanTests
             string s = null;
             Assert.Throws<ArgumentNullException>(() => s.AsReadOnlySpan().DontBox());
         }
+
+        [Fact]
+        public static void EmptySpanAsReadOnlySpan()
+        {
+            Span<int> span = default;
+            Assert.True(span.AsReadOnlySpan().IsEmpty);
+        }
+
+        [Fact]
+        public static void SpanAsReadOnlySpan()
+        {
+            int[] a = { 19, -17 };
+            Span<int> span = new Span<int>(a);
+            ReadOnlySpan<int> readOnlySpan = span.AsReadOnlySpan();
+
+            readOnlySpan.Validate(a);
+        }
     }
 }

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -9,7 +9,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AllocationHelper.cs" />
-    <Compile Include="Memory\AsReadOnlyMemory.cs" />
     <Compile Include="TInt.cs" />
     <Compile Include="TestException.cs" />
     <Compile Include="TestHelpers.cs" />
@@ -78,6 +77,7 @@
     <Compile Include="ReadOnlySpan\ToArray.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Memory\AsReadOnlyMemory.cs" />
     <Compile Include="Memory\CopyTo.cs" />
     <Compile Include="Memory\CtorArray.cs" />
     <Compile Include="Memory\CtorArrayIntInt.cs" />

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AllocationHelper.cs" />
+    <Compile Include="Memory\AsReadOnlyMemory.cs" />
     <Compile Include="TInt.cs" />
     <Compile Include="TestException.cs" />
     <Compile Include="TestHelpers.cs" />


### PR DESCRIPTION
Added explicit conversion APIs to ```Span<T>``` and ```Memory<T>```:
```csharp
public static ReadOnlyMemory<T> AsReadOnlyMemory(this Memory<T> memory);
public static ReadOnlySpan<T> AsReadOnlySpan(this Span<T> span);
```
Resolves #24564
I'm not sure if tests required.