### PR TITLE
Disable parallelism in PerfCounter tests

### DIFF
--- a/src/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
+++ b/src/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
@@ -4,6 +4,10 @@
 using System.Threading;
 using Xunit;
 
+// Implementation is not robust with respect to modifying counter categories
+// while concurrently reading counters
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
 namespace System.Diagnostics.Tests
 {
     internal class Helpers


### PR DESCRIPTION
Fixes #25400 (?)

There is at least some attempt at thread safety in the performance counters API but it seems quite that the data structures are not fully protected against eg modifying categories while concurrently enumerating them or reading counters. For example, `_customCategoryTable`, a HashTable, is modified [here](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs#L706) without protection against concurrent write at this same location (or in other places).

It is also possible that the results of multiple registry reads (eg for categories, instances, and data) are becoming mutually inconsistent because of intervening concurrent modifications to categories, etc.

Rather than attempt to analyze the possibilities (which we might not want to attempt to "fix" anyway) let's try running the tests serially.