### PR TITLE
Several improvements to Sockets

### DIFF
--- a/src/Common/tests/System/Buffers/NativeOwnedMemory.cs
+++ b/src/Common/tests/System/Buffers/NativeOwnedMemory.cs
@@ -6,7 +6,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
-namespace System.IO.Tests
+namespace System.Buffers
 {
     internal sealed class NativeOwnedMemory : OwnedMemory<byte>
     {

--- a/src/System.Net.Http/tests/FunctionalTests/ReadOnlyMemoryContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ReadOnlyMemoryContentTest.cs
@@ -5,7 +5,6 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Tests;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.netcoreapp.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.netcoreapp.cs
@@ -26,7 +26,7 @@ namespace System.Net.Sockets
 
     public partial class SocketAsyncEventArgs : System.EventArgs, System.IDisposable
     {
-        public System.Memory<byte> GetBuffer() { throw null; }
+        public System.Memory<byte> MemoryBuffer { get { throw null; } }
         public void SetBuffer(System.Memory<byte> buffer) { throw null; }
     }
 

--- a/src/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/System.Net.Sockets/src/Resources/Strings.resx
@@ -235,4 +235,7 @@
   <data name="PlatformNotSupported_IPProtectionLevel" xml:space="preserve">
     <value>IP protection level cannot be controlled on this platform.</value>
   </data>
+  <data name="InvalidOperation_BufferNotExplicitArray" xml:space="preserve">
+    <value>This operation may only be performed when the buffer was set using the SetBuffer overload that accepts an array.</value>
+  </data>
 </root>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
@@ -127,7 +127,7 @@ namespace System.Net.Sockets
 
                     _internalArgs = new SocketAsyncEventArgs();
                     _internalArgs.Completed += InternalConnectCallback;
-                    _internalArgs.SetBuffer(_userArgs.Buffer, _userArgs.Offset, _userArgs.Count);
+                    _internalArgs.CopyBufferFrom(_userArgs);
 
                     exception = AttemptConnection();
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -521,7 +521,7 @@ namespace System.Net.Sockets
             // so as to minimize overhead if the same buffers are used for subsequent operations (which is likely).
             // But SAEA doesn't support having both a buffer and a buffer list configured, so clear out a buffer
             // if there is one before we set the desired buffer list.
-            if (saea.Buffer != null) saea.SetBuffer(null, 0, 0);
+            if (!saea.MemoryBuffer.Equals(default)) saea.SetBuffer(default);
             saea.BufferList = buffers;
             saea.SocketFlags = socketFlags;
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3994,7 +3994,7 @@ namespace System.Net.Sockets
             SocketError socketError;
             try
             {
-                socketError = e.DoOperationReceive(_handle, out _);
+                socketError = e.DoOperationReceive(_handle);
             }
             catch
             {
@@ -4047,7 +4047,7 @@ namespace System.Net.Sockets
             SocketError socketError;
             try
             {
-                socketError = e.DoOperationReceiveFrom(_handle, out _);
+                socketError = e.DoOperationReceiveFrom(_handle);
             }
             catch
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3757,14 +3757,10 @@ namespace System.Net.Sockets
             SafeCloseSocket acceptHandle;
             e.AcceptSocket = GetOrCreateAcceptSocket(e.AcceptSocket, true, "AcceptSocket", out acceptHandle);
 
-            // Prepare for the native call.
-            e.StartOperationCommon(this);
+            // Prepare for and make the native call.
+            e.StartOperationCommon(this, SocketAsyncOperation.Accept);
             e.StartOperationAccept();
-
-            // Local variables for sync completion.
             SocketError socketError = SocketError.Success;
-
-            // Make the native call.
             try
             {
                 socketError = e.DoOperationAccept(this, _handle, acceptHandle);
@@ -3825,8 +3821,8 @@ namespace System.Net.Sockets
 
                 MultipleConnectAsync multipleConnectAsync = new SingleSocketMultipleConnectAsync(this, true);
 
-                e.StartOperationCommon(this);
-                e.StartOperationWrapperConnect(multipleConnectAsync);
+                e.StartOperationCommon(this, SocketAsyncOperation.Connect);
+                e.StartOperationConnect(multipleConnectAsync);
 
                 pending = multipleConnectAsync.StartConnectAsync(e, dnsEP);
             }
@@ -3863,7 +3859,7 @@ namespace System.Net.Sockets
                 }
 
                 // Prepare for the native call.
-                e.StartOperationCommon(this);
+                e.StartOperationCommon(this, SocketAsyncOperation.Connect);
                 e.StartOperationConnect();
 
                 // Make the native call.
@@ -3926,8 +3922,8 @@ namespace System.Net.Sockets
                     multipleConnectAsync = new SingleSocketMultipleConnectAsync(attemptSocket, false);
                 }
 
-                e.StartOperationCommon(attemptSocket);
-                e.StartOperationWrapperConnect(multipleConnectAsync);
+                e.StartOperationCommon(attemptSocket, SocketAsyncOperation.Connect);
+                e.StartOperationConnect(multipleConnectAsync);
 
                 pending = multipleConnectAsync.StartConnectAsync(e, dnsEP);
             }
@@ -3960,10 +3956,8 @@ namespace System.Net.Sockets
                 throw new ObjectDisposedException(GetType().FullName);
             }
 
-            // Prepare for the native call.
-            e.StartOperationCommon(this);
-            e.StartOperationDisconnect();
-
+            // Prepare for and make the native call.
+            e.StartOperationCommon(this, SocketAsyncOperation.Disconnect);
             SocketError socketError = SocketError.Success;
             try
             {
@@ -3995,14 +3989,9 @@ namespace System.Net.Sockets
                 throw new ArgumentNullException(nameof(e));
             }
 
-            // Prepare for the native call.
-            e.StartOperationCommon(this);
-            e.StartOperationReceive();
-
-            // Local vars for sync completion of native call.
+            // Prepare for and make the native call.
+            e.StartOperationCommon(this, SocketAsyncOperation.Receive);
             SocketError socketError;
-
-            // Wrap native methods with try/catch so event args object can be cleaned up.
             try
             {
                 socketError = e.DoOperationReceive(_handle, out _);
@@ -4053,13 +4042,9 @@ namespace System.Net.Sockets
             // e.m_SocketAddres for Create to work later.
             e.RemoteEndPoint = endPointSnapshot;
 
-            // Prepare for the native call.
-            e.StartOperationCommon(this);
-            e.StartOperationReceiveFrom();
-
-            // Make the native call.
+            // Prepare for and make the native call.
+            e.StartOperationCommon(this, SocketAsyncOperation.ReceiveFrom);
             SocketError socketError;
-
             try
             {
                 socketError = e.DoOperationReceiveFrom(_handle, out _);
@@ -4112,13 +4097,9 @@ namespace System.Net.Sockets
 
             SetReceivingPacketInformation();
 
-            // Prepare for the native call.
-            e.StartOperationCommon(this);
-            e.StartOperationReceiveMessageFrom();
-
-            // Make the native call.
+            // Prepare for and make the native call.
+            e.StartOperationCommon(this, SocketAsyncOperation.ReceiveMessageFrom);
             SocketError socketError;
-
             try
             {
                 socketError = e.DoOperationReceiveMessageFrom(this, _handle);
@@ -4149,14 +4130,9 @@ namespace System.Net.Sockets
                 throw new ArgumentNullException(nameof(e));
             }
 
-            // Prepare for the native call.
-            e.StartOperationCommon(this);
-            e.StartOperationSend();
-
-            // Local vars for sync completion of native call.
+            // Prepare for and make the native call.
+            e.StartOperationCommon(this, SocketAsyncOperation.Send);
             SocketError socketError;
-
-            // Wrap native methods with try/catch so event args object can be cleaned up.
             try
             {
                 socketError = e.DoOperationSend(_handle);
@@ -4196,33 +4172,18 @@ namespace System.Net.Sockets
                 throw new NotSupportedException(SR.net_notconnected);
             }
 
-            // Prepare for the native call.
-            e.StartOperationCommon(this);
-            e.StartOperationSendPackets();
-
-            // Make the native call.
+            // Prepare for and make the native call.
+            e.StartOperationCommon(this, SocketAsyncOperation.SendPackets);
             SocketError socketError;
-
-            Debug.Assert(e.SendPacketsDescriptorCount != null);
-
-            if (e.SendPacketsDescriptorCount > 0)
+            try
             {
-                try
-                {
-                    socketError = e.DoOperationSendPackets(this, _handle);
-                }
-                catch (Exception)
-                {
-                    // Clear in-use flag on event args object.
-                    e.Complete();
-                    throw;
-                }
+                socketError = e.DoOperationSendPackets(this, _handle);
             }
-            else
+            catch (Exception)
             {
-                // No buffers or files to send.
-                e.FinishOperationSyncSuccess(0, SocketFlags.None);
-                socketError = SocketError.Success;
+                // Clear in-use flag on event args object.
+                e.Complete();
+                throw;
             }
 
             bool pending = (socketError == SocketError.IOPending);
@@ -4252,14 +4213,9 @@ namespace System.Net.Sockets
             EndPoint endPointSnapshot = e.RemoteEndPoint;
             e._socketAddress = SnapshotAndSerialize(ref endPointSnapshot);
 
-            // Prepare for the native call.
-            e.StartOperationCommon(this);
-            e.StartOperationSendTo();
-
-            // Make the native call.
+            // Prepare for and make the native call.
+            e.StartOperationCommon(this, SocketAsyncOperation.SendTo);
             SocketError socketError;
-
-            // Wrap native methods with try/catch so event args object can be cleaned up.
             try
             {
                 socketError = e.DoOperationSendTo(_handle);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -4000,13 +4000,12 @@ namespace System.Net.Sockets
             e.StartOperationReceive();
 
             // Local vars for sync completion of native call.
-            SocketFlags flags;
             SocketError socketError;
 
             // Wrap native methods with try/catch so event args object can be cleaned up.
             try
             {
-                socketError = e.DoOperationReceive(_handle, out flags);
+                socketError = e.DoOperationReceive(_handle, out _);
             }
             catch
             {
@@ -4059,12 +4058,11 @@ namespace System.Net.Sockets
             e.StartOperationReceiveFrom();
 
             // Make the native call.
-            SocketFlags flags;
             SocketError socketError;
 
             try
             {
-                socketError = e.DoOperationReceiveFrom(_handle, out flags);
+                socketError = e.DoOperationReceiveFrom(_handle, out _);
             }
             catch
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1282,11 +1282,9 @@ namespace System.Net.Sockets
             return operation.ErrorCode;
         }
 
-        public SocketError ReceiveMessageFromAsync(Memory<byte> buffer, IList<ArraySegment<byte>> buffers, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, Action<int, byte[], int, SocketFlags, IPPacketInformation, SocketError> callback)
+        public SocketError ReceiveMessageFromAsync(Memory<byte> buffer, IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, Action<int, byte[], int, SocketFlags, IPPacketInformation, SocketError> callback)
         {
             SetNonBlocking();
-
-            buffer = buffer.Slice(offset, count);
 
             SocketError errorCode;
             int observedSequenceNumber;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -31,80 +31,85 @@ namespace System.Net.Sockets
 
     internal sealed class SocketAsyncContext
     {
+        // TODO: https://github.com/dotnet/corefx/issues/25439
+        // Caching has been commented out, due to it causing null reference exceptions.
+        // We need to figure out why and re-enable it by uncommenting out / fixing
+        // the code below.
+
         // Cached operation instances for operations commonly repeated on the same socket instance,
-        // e.g. accepts and async sends/receives with single and multiple buffers.  More can be
+        // e.g. async accepts, sends/receives with single and multiple buffers.  More can be
         // added in the future if necessary, at the expense of extra fields here.  With a larger
         // refactoring, these could also potentially be moved to SocketAsyncEventArgs, which
         // would be more invasive but which would allow them to be reused across socket instances
         // and also eliminate the interlocked necessary to rent the instances.
-        private AcceptOperation _cachedAcceptOperation;
-        private BufferMemoryReceiveOperation _cachedBufferMemoryReceiveOperation;
-        private BufferListReceiveOperation _cachedBufferListReceiveOperation;
-        private BufferMemorySendOperation _cachedBufferMemorySendOperation;
-        private BufferListSendOperation _cachedBufferListSendOperation;
+        //private AcceptOperation _cachedAcceptOperation;
+        //private BufferMemoryReceiveOperation _cachedBufferMemoryReceiveOperation;
+        //private BufferListReceiveOperation _cachedBufferListReceiveOperation;
+        //private BufferMemorySendOperation _cachedBufferMemorySendOperation;
+        //private BufferListSendOperation _cachedBufferListSendOperation;
 
         private void ReturnOperation(AcceptOperation operation)
         {
-            operation.Reset();
-            operation.Callback = null;
-            operation.SocketAddress = null;
-            Volatile.Write(ref _cachedAcceptOperation, operation); // benign race condition
+            //operation.Reset();
+            //operation.Callback = null;
+            //operation.SocketAddress = null;
+            //Volatile.Write(ref _cachedAcceptOperation, operation); // benign race condition
         }
 
         private void ReturnOperation(BufferMemoryReceiveOperation operation)
         {
-            operation.Reset();
-            operation.Buffer = default;
-            operation.Callback = null;
-            operation.SocketAddress = null;
-            Volatile.Write(ref _cachedBufferMemoryReceiveOperation, operation); // benign race condition
+            //operation.Reset();
+            //operation.Buffer = default;
+            //operation.Callback = null;
+            //operation.SocketAddress = null;
+            //Volatile.Write(ref _cachedBufferMemoryReceiveOperation, operation); // benign race condition
         }
 
         private void ReturnOperation(BufferListReceiveOperation operation)
         {
-            operation.Reset();
-            operation.Buffers = null;
-            operation.Callback = null;
-            operation.SocketAddress = null;
-            Volatile.Write(ref _cachedBufferListReceiveOperation, operation); // benign race condition
+            //operation.Reset();
+            //operation.Buffers = null;
+            //operation.Callback = null;
+            //operation.SocketAddress = null;
+            //Volatile.Write(ref _cachedBufferListReceiveOperation, operation); // benign race condition
         }
 
         private void ReturnOperation(BufferMemorySendOperation operation)
         {
-            operation.Reset();
-            operation.Buffer = default;
-            operation.Callback = null;
-            operation.SocketAddress = null;
-            Volatile.Write(ref _cachedBufferMemorySendOperation, operation); // benign race condition
+            //operation.Reset();
+            //operation.Buffer = default;
+            //operation.Callback = null;
+            //operation.SocketAddress = null;
+            //Volatile.Write(ref _cachedBufferMemorySendOperation, operation); // benign race condition
         }
 
         private void ReturnOperation(BufferListSendOperation operation)
         {
-            operation.Reset();
-            operation.Buffers = null;
-            operation.Callback = null;
-            operation.SocketAddress = null;
-            Volatile.Write(ref _cachedBufferListSendOperation, operation); // benign race condition
+            //operation.Reset();
+            //operation.Buffers = null;
+            //operation.Callback = null;
+            //operation.SocketAddress = null;
+            //Volatile.Write(ref _cachedBufferListSendOperation, operation); // benign race condition
         }
 
         private AcceptOperation RentAcceptOperation() =>
-            Interlocked.Exchange(ref _cachedAcceptOperation, null) ??
+            //Interlocked.Exchange(ref _cachedAcceptOperation, null) ??
             new AcceptOperation(this);
 
         private BufferMemoryReceiveOperation RentBufferMemoryReceiveOperation() =>
-            Interlocked.Exchange(ref _cachedBufferMemoryReceiveOperation, null) ??
+            //Interlocked.Exchange(ref _cachedBufferMemoryReceiveOperation, null) ??
             new BufferMemoryReceiveOperation(this);
 
         private BufferListReceiveOperation RentBufferListReceiveOperation() =>
-            Interlocked.Exchange(ref _cachedBufferListReceiveOperation, null) ??
+            //Interlocked.Exchange(ref _cachedBufferListReceiveOperation, null) ??
             new BufferListReceiveOperation(this);
 
         private BufferMemorySendOperation RentBufferMemorySendOperation() =>
-            Interlocked.Exchange(ref _cachedBufferMemorySendOperation, null) ??
+            //Interlocked.Exchange(ref _cachedBufferMemorySendOperation, null) ??
             new BufferMemorySendOperation(this);
 
         private BufferListSendOperation RentBufferListSendOperation() =>
-            Interlocked.Exchange(ref _cachedBufferListSendOperation, null) ??
+            //Interlocked.Exchange(ref _cachedBufferListSendOperation, null) ??
             new BufferListSendOperation(this);
 
         private abstract class AsyncOperation

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -128,11 +128,12 @@ namespace System.Net.Sockets
             _receivedFlags = receivedFlags;
         }
 
-        internal unsafe SocketError DoOperationReceive(SafeCloseSocket handle, out SocketFlags flags)
+        internal unsafe SocketError DoOperationReceive(SafeCloseSocket handle)
         {
             _receivedFlags = System.Net.Sockets.SocketFlags.None;
             _socketAddressSize = 0;
 
+            SocketFlags flags;
             int bytesReceived;
             SocketError errorCode;
             if (_bufferList == null)
@@ -153,11 +154,12 @@ namespace System.Net.Sockets
             return errorCode;
         }
 
-        internal unsafe SocketError DoOperationReceiveFrom(SafeCloseSocket handle, out SocketFlags flags)
+        internal unsafe SocketError DoOperationReceiveFrom(SafeCloseSocket handle)
         {
             _receivedFlags = System.Net.Sockets.SocketFlags.None;
             _socketAddressSize = 0;
 
+            SocketFlags flags;
             SocketError errorCode;
             int bytesReceived = 0;
             int socketAddressLen = _socketAddress.Size;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -211,7 +211,7 @@ namespace System.Net.Sockets
             int bytesReceived;
             SocketFlags receivedFlags;
             IPPacketInformation ipPacketInformation;
-            SocketError socketError = handle.AsyncContext.ReceiveMessageFromAsync(_buffer, _bufferListInternal, _offset, _count, _socketFlags, _socketAddress.Buffer, ref socketAddressSize, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, ReceiveMessageFromCompletionCallback);
+            SocketError socketError = handle.AsyncContext.ReceiveMessageFromAsync(_buffer.Slice(_offset, _count), _bufferListInternal, _socketFlags, _socketAddress.Buffer, ref socketAddressSize, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, ReceiveMessageFromCompletionCallback);
             if (socketError != SocketError.IOPending)
             {
                 CompleteReceiveMessageFromOperation(bytesReceived, _socketAddress.Buffer, socketAddressSize, receivedFlags, ipPacketInformation, socketError);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -249,13 +249,12 @@ namespace System.Net.Sockets
             }
         }
 
-        internal SocketError DoOperationReceive(SafeCloseSocket handle, out SocketFlags flags) => _bufferList == null ? 
-            DoOperationReceiveSingleBuffer(handle, out flags) :
-            DoOperationReceiveMultiBuffer(handle, out flags);
+        internal SocketError DoOperationReceive(SafeCloseSocket handle) => _bufferList == null ? 
+            DoOperationReceiveSingleBuffer(handle) :
+            DoOperationReceiveMultiBuffer(handle);
 
-        internal unsafe SocketError DoOperationReceiveSingleBuffer(SafeCloseSocket handle, out SocketFlags flags)
+        internal unsafe SocketError DoOperationReceiveSingleBuffer(SafeCloseSocket handle)
         {
-            flags = _socketFlags;
             SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
@@ -265,6 +264,7 @@ namespace System.Net.Sockets
                     Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None, $"Expected None, got {_singleBufferHandleState}");
                     _singleBufferHandleState = SingleBufferHandleState.InProcess;
                     var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
+                    SocketFlags flags = _socketFlags;
 
                     socketError = Interop.Winsock.WSARecv(
                         handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
@@ -291,13 +291,13 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationReceiveMultiBuffer(SafeCloseSocket handle, out SocketFlags flags)
+        internal unsafe SocketError DoOperationReceiveMultiBuffer(SafeCloseSocket handle)
         {
-            flags = _socketFlags;
             SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
             {
+                SocketFlags flags = _socketFlags;
                 socketError = Interop.Winsock.WSARecv(
                     handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     _wsaBufferArray,
@@ -317,7 +317,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationReceiveFrom(SafeCloseSocket handle, out SocketFlags flags)
+        internal unsafe SocketError DoOperationReceiveFrom(SafeCloseSocket handle)
         {
             // WSARecvFrom uses a WSABuffer array describing buffers in which to 
             // receive data and from which to send data respectively. Single and multiple buffers
@@ -327,13 +327,12 @@ namespace System.Net.Sockets
             PinSocketAddressBuffer();
 
             return _bufferList == null ?
-                DoOperationReceiveFromSingleBuffer(handle, out flags) :
-                DoOperationReceiveFromMultiBuffer(handle, out flags);
+                DoOperationReceiveFromSingleBuffer(handle) :
+                DoOperationReceiveFromMultiBuffer(handle);
         }
 
-        internal unsafe SocketError DoOperationReceiveFromSingleBuffer(SafeCloseSocket handle, out SocketFlags flags)
+        internal unsafe SocketError DoOperationReceiveFromSingleBuffer(SafeCloseSocket handle)
         {
-            flags = _socketFlags;
 
             SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
@@ -344,6 +343,7 @@ namespace System.Net.Sockets
                     Debug.Assert(_singleBufferHandleState == SingleBufferHandleState.None);
                     _singleBufferHandleState = SingleBufferHandleState.InProcess;
                     var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
+                    SocketFlags flags = _socketFlags;
 
                     socketError = Interop.Winsock.WSARecvFrom(
                         handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
@@ -372,14 +372,14 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationReceiveFromMultiBuffer(SafeCloseSocket handle, out SocketFlags flags)
+        internal unsafe SocketError DoOperationReceiveFromMultiBuffer(SafeCloseSocket handle)
         {
-            flags = _socketFlags;
 
             SocketError socketError = SocketError.Success;
             NativeOverlapped* overlapped = AllocateNativeOverlapped();
             try
             {
+                SocketFlags flags = _socketFlags;
                 socketError = Interop.Winsock.WSARecvFrom(
                     handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     _wsaBufferArray,

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -98,6 +98,9 @@ namespace System.Net.Sockets
                     FinishOperationSyncSuccess(bytesTransferred, SocketFlags.None);
                     return SocketError.Success;
                 }
+                
+                // Completed synchronously, but the handle wasn't marked as skip completion port on success,
+                // so we still need to fall through and behave as if the IO was pending.
             }
             else
             {
@@ -105,9 +108,12 @@ namespace System.Net.Sockets
                 SocketError socketError = SocketPal.GetLastSocketError();
                 if (socketError != SocketError.IOPending)
                 {
+                    // Completed synchronously with a failure.
                     FinishOperationSyncFailure(socketError, bytesTransferred, SocketFlags.None);
                     return socketError;
                 }
+
+                // Fall through to IOPending handling for asynchronous completion.
             }
 
             // Socket handle is going to post a completion to the completion port (may have done so already).
@@ -128,6 +134,9 @@ namespace System.Net.Sockets
                     FinishOperationSyncSuccess(bytesTransferred, SocketFlags.None);
                     return SocketError.Success;
                 }
+
+                // Completed synchronously, but the handle wasn't marked as skip completion port on success,
+                // so we still need to fall through and behave as if the IO was pending.
             }
             else
             {
@@ -135,10 +144,13 @@ namespace System.Net.Sockets
                 socketError = SocketPal.GetLastSocketError();
                 if (socketError != SocketError.IOPending)
                 {
+                    // Completed synchronously with a failure.
                     _singleBufferHandleState = SingleBufferHandleState.None;
                     FinishOperationSyncFailure(socketError, bytesTransferred, SocketFlags.None);
                     return socketError;
                 }
+
+                // Fall through to IOPending handling for asynchronous completion.
             }
 
             // Socket handle is going to post a completion to the completion port (may have done so already).

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -11,7 +11,7 @@ namespace System.Net.Sockets
     public partial class SocketAsyncEventArgs : EventArgs, IDisposable
     {
         // AcceptSocket property variables.
-        internal Socket _acceptSocket;
+        private Socket _acceptSocket;
         private Socket _connectSocket;
 
         // Single buffer.
@@ -44,27 +44,27 @@ namespace System.Net.Sockets
         private EndPoint _remoteEndPoint;
 
         // SendPacketsSendSize property variable.
-        internal int _sendPacketsSendSize;
+        private int _sendPacketsSendSize;
 
         // SendPacketsElements property variables.
-        internal SendPacketsElement[] _sendPacketsElements;
+        private SendPacketsElement[] _sendPacketsElements;
 
         // SendPacketsFlags property variable.
-        internal TransmitFileOptions _sendPacketsFlags;
+        private TransmitFileOptions _sendPacketsFlags;
 
         // SocketError property variables.
         private SocketError _socketError;
         private Exception _connectByNameError;
 
         // SocketFlags property variables.
-        internal SocketFlags _socketFlags;
+        private SocketFlags _socketFlags;
 
         // UserToken property variables.
         private object _userToken;
 
         // Internal buffer for AcceptEx when Buffer not supplied.
-        internal byte[] _acceptBuffer;
-        internal int _acceptAddressBufferCount;
+        private byte[] _acceptBuffer;
+        private int _acceptAddressBufferCount;
 
         // Internal SocketAddress buffer.
         internal Internals.SocketAddress _socketAddress;
@@ -238,7 +238,6 @@ namespace System.Net.Sockets
                 try
                 {
                     _sendPacketsElements = value;
-                    SetupSendPacketsElements();
                 }
                 finally
                 {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -342,7 +342,7 @@ namespace System.Net.Sockets
             return checked((int)received);
         }
 
-        private static unsafe int ReceiveMessageFrom(SafeCloseSocket socket, SocketFlags flags, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
+        private static unsafe int ReceiveMessageFrom(SafeCloseSocket socket, SocketFlags flags, Span<byte> buffer, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
         {
             Debug.Assert(socketAddress != null, "Expected non-null socketAddress");
 
@@ -355,17 +355,15 @@ namespace System.Net.Sockets
 
             long received;
             fixed (byte* rawSocketAddress = socketAddress)
-            fixed (byte* b = buffer)
+            fixed (byte* b = &buffer.DangerousGetPinnableReference())
             {
-                var sockAddr = (byte*)rawSocketAddress;
-
                 var iov = new Interop.Sys.IOVector {
-                    Base = &b[offset],
-                    Count = (UIntPtr)count
+                    Base = b,
+                    Count = (UIntPtr)buffer.Length
                 };
 
                 messageHeader = new Interop.Sys.MessageHeader {
-                    SocketAddress = sockAddr,
+                    SocketAddress = rawSocketAddress,
                     SocketAddressLen = sockAddrLen,
                     IOVectors = &iov,
                     IOVectorCount = 1,
@@ -582,9 +580,6 @@ namespace System.Net.Sockets
             return true;
         }
 
-        public static bool TryCompleteReceiveFrom(SafeCloseSocket socket, byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode) =>
-            TryCompleteReceiveFrom(socket, new Span<byte>(buffer, offset, count), null, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
-
         public static bool TryCompleteReceiveFrom(SafeCloseSocket socket, Span<byte> buffer, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode) =>
             TryCompleteReceiveFrom(socket, buffer, null, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
 
@@ -651,18 +646,14 @@ namespace System.Net.Sockets
             }
         }
 
-        public static unsafe bool TryCompleteReceiveMessageFrom(SafeCloseSocket socket, byte[] buffer, IList<ArraySegment<byte>> buffers, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
+        public static unsafe bool TryCompleteReceiveMessageFrom(SafeCloseSocket socket, Span<byte> buffer, IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
         {
-            Debug.Assert(
-                (buffer == null) ^ (buffers == null),
-                "One and only one of buffer and buffers must be null");
-
             try
             {
                 Interop.Error errno;
 
-                int received = buffer != null ?
-                    ReceiveMessageFrom(socket, flags, buffer, offset, count, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno) :
+                int received = buffers == null ?
+                    ReceiveMessageFrom(socket, flags, buffer, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno) :
                     ReceiveMessageFrom(socket, flags, buffers, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno);
 
                 if (received != -1)
@@ -694,7 +685,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public static bool TryCompleteSendTo(SafeCloseSocket socket, byte[] buffer, ref int offset, ref int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        public static bool TryCompleteSendTo(SafeCloseSocket socket, Span<byte> buffer, ref int offset, ref int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
         {
             int bufferIndex = 0;
             return TryCompleteSendTo(socket, buffer, null, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
@@ -977,12 +968,12 @@ namespace System.Net.Sockets
         {
             if (!handle.IsNonBlocking)
             {
-                return handle.AsyncContext.Receive(buffer, offset, count, ref socketFlags, handle.ReceiveTimeout, out bytesTransferred);
+                return handle.AsyncContext.Receive(new Memory<byte>(buffer, offset, count), ref socketFlags, handle.ReceiveTimeout, out bytesTransferred);
             }
 
             int socketAddressLen = 0;
             SocketError errorCode;
-            bool completed = TryCompleteReceiveFrom(handle, buffer, offset, count, socketFlags, null, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
+            bool completed = TryCompleteReceiveFrom(handle, new Span<byte>(buffer, offset, count), socketFlags, null, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -1010,11 +1001,11 @@ namespace System.Net.Sockets
             SocketError errorCode;
             if (!handle.IsNonBlocking)
             {
-                errorCode = handle.AsyncContext.ReceiveMessageFrom(buffer, null, offset, count, ref socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, handle.ReceiveTimeout, out ipPacketInformation, out bytesTransferred);
+                errorCode = handle.AsyncContext.ReceiveMessageFrom(new Memory<byte>(buffer, offset, count), null, ref socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, handle.ReceiveTimeout, out ipPacketInformation, out bytesTransferred);
             }
             else
             {
-                if (!TryCompleteReceiveMessageFrom(handle, buffer, null, offset, count, socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
+                if (!TryCompleteReceiveMessageFrom(handle, new Span<byte>(buffer, offset, count), null, socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
                 {
                     errorCode = SocketError.WouldBlock;
                 }
@@ -1029,11 +1020,11 @@ namespace System.Net.Sockets
         {
             if (!handle.IsNonBlocking)
             {
-                return handle.AsyncContext.ReceiveFrom(buffer, offset, count, ref socketFlags, socketAddress, ref socketAddressLen, handle.ReceiveTimeout, out bytesTransferred);
+                return handle.AsyncContext.ReceiveFrom(new Memory<byte>(buffer, offset, count), ref socketFlags, socketAddress, ref socketAddressLen, handle.ReceiveTimeout, out bytesTransferred);
             }
 
             SocketError errorCode;
-            bool completed = TryCompleteReceiveFrom(handle, buffer, offset, count, socketFlags, socketAddress, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
+            bool completed = TryCompleteReceiveFrom(handle, new Span<byte>(buffer, offset, count), socketFlags, socketAddress, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -1639,7 +1630,7 @@ namespace System.Net.Sockets
         {
             int bytesReceived;
             SocketFlags receivedFlags;
-            SocketError socketError = handle.AsyncContext.ReceiveAsync(buffer, offset, count, socketFlags, out bytesReceived, out receivedFlags, asyncResult.CompletionCallback);
+            SocketError socketError = handle.AsyncContext.ReceiveAsync(new Memory<byte>(buffer, offset, count), socketFlags, out bytesReceived, out receivedFlags, asyncResult.CompletionCallback);
             if (socketError == SocketError.Success)
             {
                 asyncResult.CompletionCallback(bytesReceived, null, 0, receivedFlags, SocketError.Success);
@@ -1666,7 +1657,7 @@ namespace System.Net.Sockets
             int socketAddressSize = socketAddress.InternalSize;
             int bytesReceived;
             SocketFlags receivedFlags;
-            SocketError socketError = handle.AsyncContext.ReceiveFromAsync(buffer, offset, count, socketFlags, socketAddress.Buffer, ref socketAddressSize, out bytesReceived, out receivedFlags, asyncResult.CompletionCallback);
+            SocketError socketError = handle.AsyncContext.ReceiveFromAsync(new Memory<byte>(buffer, offset, count), socketFlags, socketAddress.Buffer, ref socketAddressSize, out bytesReceived, out receivedFlags, asyncResult.CompletionCallback);
             if (socketError == SocketError.Success)
             {
                 asyncResult.CompletionCallback(bytesReceived, socketAddress.Buffer, socketAddressSize, receivedFlags, SocketError.Success);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1676,7 +1676,7 @@ namespace System.Net.Sockets
             int bytesReceived;
             SocketFlags receivedFlags;
             IPPacketInformation ipPacketInformation;
-            SocketError socketError = handle.AsyncContext.ReceiveMessageFromAsync(buffer, null, offset, count, socketFlags, socketAddress.Buffer, ref socketAddressSize, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, asyncResult.CompletionCallback);
+            SocketError socketError = handle.AsyncContext.ReceiveMessageFromAsync(new Memory<byte>(buffer, offset, count), null, socketFlags, socketAddress.Buffer, ref socketAddressSize, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, asyncResult.CompletionCallback);
             if (socketError == SocketError.Success)
             {
                 asyncResult.CompletionCallback(bytesReceived, socketAddress.Buffer, socketAddressSize, receivedFlags, ipPacketInformation, SocketError.Success);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -34,12 +34,7 @@ namespace System.Net.Sockets
         public static SocketError GetLastSocketError()
         {
             int win32Error = Marshal.GetLastWin32Error();
-
-            if (win32Error == 0)
-            {
-                NetEventSource.Fail(null, "GetLastWin32Error() returned zero.");
-            }
-
+            Debug.Assert(win32Error != 0, "Expected non-0 error");
             return (SocketError)win32Error;
         }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -19,7 +19,7 @@ namespace System.Net.Sockets.Tests
         [InlineData(1, 1, 2)] // count high
         public async Task InvalidArguments_Throws(int? length, int offset, int count)
         {
-            if (length == null && !ValidatesArrayArguments) return;
+            if (!ValidatesArrayArguments) return;
 
             using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
@@ -697,6 +697,7 @@ namespace System.Net.Sockets.Tests
                     Assert.False(receive.IsCompleted, $"Task should not have been completed, was {receive.Status}");
 
                     // Disconnect the client
+                    server.Shutdown(SocketShutdown.Both);
                     server.Close();
 
                     // The client should now wake up

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.netcoreapp.cs
@@ -7,4 +7,5 @@ namespace System.Net.Sockets.Tests
     public sealed class SendReceiveSpanSync : SendReceive<SocketHelperSpanSync> { }
     public sealed class SendReceiveSpanSyncForceNonBlocking : SendReceive<SocketHelperSpanSyncForceNonBlocking> { }
     public sealed class SendReceiveMemoryArrayTask : SendReceive<SocketHelperMemoryArrayTask> { }
+    public sealed class SendReceiveMemoryNativeTask : SendReceive<SocketHelperMemoryNativeTask> { }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace System.Net.Sockets.Tests
 {
-    public class SocketAsyncEventArgsTest
+    public partial class SocketAsyncEventArgsTest
     {
         [Fact]
         public void Usertoken_Roundtrips()
@@ -154,6 +154,12 @@ namespace System.Net.Sockets.Tests
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => saea.SetBuffer(new byte[1], 0, -1));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => saea.SetBuffer(new byte[1], 0, 2));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => saea.SetBuffer(new byte[1], 1, 2));
+
+                saea.SetBuffer(new byte[2], 0, 2);
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => saea.SetBuffer(-1, 2));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => saea.SetBuffer(3, 2));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => saea.SetBuffer(0, -1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => saea.SetBuffer(0, 3));
             }
         }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.netcoreapp.cs
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    public partial class SocketAsyncEventArgsTest
+    {
+        [Fact]
+        public void SetBuffer_MemoryBuffer_Roundtrips()
+        {
+            using (var saea = new SocketAsyncEventArgs())
+            {
+                Memory<byte> memory = new byte[42];
+                saea.SetBuffer(memory);
+                Assert.True(memory.Equals(saea.MemoryBuffer));
+                Assert.Equal(0, saea.Offset);
+                Assert.Equal(memory.Length, saea.Count);
+                Assert.Null(saea.Buffer);
+            }
+        }
+
+        [Fact]
+        public void SetBufferMemory_ThenSetBufferIntInt_Throws()
+        {
+            using (var saea = new SocketAsyncEventArgs())
+            {
+                Memory<byte> memory = new byte[42];
+                saea.SetBuffer(memory);
+                Assert.Throws<InvalidOperationException>(() => saea.SetBuffer(0, 42));
+                Assert.Throws<InvalidOperationException>(() => saea.SetBuffer(0, 0));
+                Assert.Throws<InvalidOperationException>(() => saea.SetBuffer(1, 2));
+                Assert.True(memory.Equals(saea.MemoryBuffer));
+                Assert.Equal(0, saea.Offset);
+                Assert.Equal(memory.Length, saea.Count);
+            }
+        }
+
+        [Fact]
+        public void SetBufferArrayIntInt_AvailableFromMemoryBuffer()
+        {
+            using (var saea = new SocketAsyncEventArgs())
+            {
+                byte[] array = new byte[42];
+
+                saea.SetBuffer(array, 0, array.Length);
+                Assert.True(saea.MemoryBuffer.TryGetArray(out ArraySegment<byte> result));
+                Assert.Same(array, result.Array);
+                Assert.Same(saea.Buffer, array);
+                Assert.Equal(0, result.Offset);
+                Assert.Equal(array.Length, result.Count);
+
+                saea.SetBuffer(1, 2);
+                Assert.Same(saea.Buffer, array);
+                Assert.Equal(1, saea.Offset);
+                Assert.Equal(2, saea.Count);
+
+                Assert.True(saea.MemoryBuffer.TryGetArray(out result));
+                Assert.Same(array, result.Array);
+                Assert.Equal(0, result.Offset);
+                Assert.Equal(array.Length, result.Count);
+            }
+        }
+
+        [Fact]
+        public void SetBufferMemory_Default_ResetsCountOffset()
+        {
+            using (var saea = new SocketAsyncEventArgs())
+            {
+                saea.SetBuffer(42, 84);
+                Assert.Equal(0, saea.Offset);
+                Assert.Equal(0, saea.Count);
+
+                saea.SetBuffer(new byte[3], 1, 2);
+                Assert.Equal(1, saea.Offset);
+                Assert.Equal(2, saea.Count);
+
+                saea.SetBuffer(Memory<byte>.Empty);
+                Assert.Null(saea.Buffer);
+                Assert.Equal(0, saea.Offset);
+                Assert.Equal(0, saea.Count);
+            }
+        }
+
+        [Fact]
+        public void SetBufferListWhenMemoryBufferSet_Throws()
+        {
+            using (var saea = new SocketAsyncEventArgs())
+            {
+                var bufferList = new List<ArraySegment<byte>> { new ArraySegment<byte>(new byte[1]) };
+                Memory<byte> buffer = new byte[1];
+
+                saea.SetBuffer(buffer);
+                AssertExtensions.Throws<ArgumentException>(null, () => saea.BufferList = bufferList);
+                Assert.True(buffer.Equals(saea.MemoryBuffer));
+                Assert.Equal(0, saea.Offset);
+                Assert.Equal(buffer.Length, saea.Count);
+                Assert.Null(saea.BufferList);
+
+                saea.SetBuffer(Memory<byte>.Empty);
+                saea.BufferList = bufferList; // works fine when Buffer has been set back to null
+            }
+        }
+
+        [Fact]
+        public void SetBufferMemoryWhenBufferListSet_Throws()
+        {
+            using (var saea = new SocketAsyncEventArgs())
+            {
+                var bufferList = new List<ArraySegment<byte>> { new ArraySegment<byte>(new byte[1]) };
+                saea.BufferList = bufferList;
+
+                saea.SetBuffer(Memory<byte>.Empty); // nop
+
+                Memory<byte> buffer = new byte[2];
+                AssertExtensions.Throws<ArgumentException>(null, () => saea.SetBuffer(buffer));
+                Assert.Same(bufferList, saea.BufferList);
+                Assert.Null(saea.Buffer);
+                Assert.True(saea.MemoryBuffer.Equals(default));
+
+                saea.BufferList = null;
+                saea.SetBuffer(buffer); // works fine when BufferList has been set back to null
+            }
+        }
+
+        [Fact]
+        public void SetBufferMemoryWhenBufferMemorySet_Succeeds()
+        {
+            using (var saea = new SocketAsyncEventArgs())
+            {
+                Memory<byte> buffer1 = new byte[1];
+                Memory<byte> buffer2 = new byte[2];
+
+                for (int i = 0; i < 2; i++)
+                {
+                    saea.SetBuffer(buffer1);
+                    Assert.Null(saea.Buffer);
+                    Assert.True(saea.MemoryBuffer.Equals(buffer1));
+                    Assert.Equal(0, saea.Offset);
+                    Assert.Equal(buffer1.Length, saea.Count);
+                }
+
+                saea.SetBuffer(buffer2);
+                Assert.Null(saea.Buffer);
+                Assert.True(saea.MemoryBuffer.Equals(buffer2));
+                Assert.Equal(0, saea.Offset);
+                Assert.Equal(buffer2.Length, saea.Count);
+            }
+        }
+
+        [Fact]
+        public void SetBufferMemoryWhenBufferSet_Succeeds()
+        {
+            using (var saea = new SocketAsyncEventArgs())
+            {
+                byte[] buffer1 = new byte[3];
+                Memory<byte> buffer2 = new byte[4];
+
+                saea.SetBuffer(buffer1, 0, buffer1.Length);
+                Assert.Same(buffer1, saea.Buffer);
+                Assert.Equal(0, saea.Offset);
+                Assert.Equal(buffer1.Length, saea.Count);
+
+                saea.SetBuffer(1, 2);
+                Assert.Same(buffer1, saea.Buffer);
+                Assert.Equal(1, saea.Offset);
+                Assert.Equal(2, saea.Count);
+
+                saea.SetBuffer(buffer2);
+                Assert.Null(saea.Buffer);
+                Assert.True(saea.MemoryBuffer.Equals(buffer2));
+                Assert.Equal(0, saea.Offset);
+                Assert.Equal(buffer2.Length, saea.Count);
+            }
+        }
+
+        [Fact]
+        public void SetBufferMemory_NonArray_BufferReturnsNull()
+        {
+            using (var m = new NativeOwnedMemory(42))
+            using (var saea = new SocketAsyncEventArgs())
+            {
+                saea.SetBuffer(m.Memory);
+                Assert.True(saea.MemoryBuffer.Equals(m.Memory));
+                Assert.Equal(0, saea.Offset);
+                Assert.Equal(m.Length, saea.Count);
+                Assert.Null(saea.Buffer);
+            }
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -44,6 +44,7 @@
     <Compile Include="TcpClientTest.cs" />
     <Compile Include="Shutdown.cs" />
     <Compile Include="SocketAsyncEventArgsTest.cs" />
+    <Compile Include="SocketAsyncEventArgsTest.netcoreapp.cs" Condition="'$(TargetGroup)' != 'netstandard'" />
     <Compile Include="SocketOptionNameTest.cs" />
     <Compile Include="MulticastOptionTest.cs" />
     <Compile Include="UdpClientTest.cs" />
@@ -92,6 +93,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Buffers\NativeOwnedMemory.cs">
+      <Link>Common\System\Buffers\NativeOwnedMemory.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
       <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>


### PR DESCRIPTION
Two main changes:
- Fully enable `Memory<byte>` with SocketAsyncEventArgs.  When adding the `Memory<byte>`-based APIs, we only did so at a cursory level; the implementation was still array-based, and we'd just fish out the array from the `Memory<byte>`, which meant it wouldn't work if the `Memory<byte>` wrapped a native pointer.  This fixes that.  SocketAsyncEventArgs now relies on `Memory<byte>` internally, as well as on Windows relying on its `Retain` method instead of using `GCHandle` directly, which means `OwnedMemory<T>` implementations can do pre-pinning and then make Retain a nop to avoid some overheads.  The change also makes it so we don't pin buffers handed to us for longer than a given operation, but we also avoid calling Retain for common operations until we know we're going async.
- Cache AsyncOperation instances on Unix on the SocketAsyncContext.  Currently when an operation completes asynchronously on Unix, we allocate an AsyncOperation-derived instance to store the state for that operation.  For several of the most common operations, this change caches a AsyncOperation instance for each common type, and reuses that instance if it's available, avoiding most of the allocation associated with async completion on Unix (there's still currently the cost of the queued work item for callback handling).

Some additional cleanup is included as well, in particular eliminating the "InnerStart" pattern that was introduced when the PAL was added in.  This pattern made it more difficult to find where state was being created and stored, and was largely unnecessary.  By unraveling it, it also made it possible to remove more fields from SocketAsyncEventArgs.  This PR shrinks the size of SAEA by 10% on Windows.

Fixes https://github.com/dotnet/corefx/issues/24429
cc: @geoffkizer 