### PR TITLE
Eliminate dirent memcpy when using readdir.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -63,12 +63,7 @@ internal static partial class Interop
                 // - If the platform does not support reading into a buffer, the information returned in
                 // InternalDirectoryEntry points to native memory owned by the SafeDirectoryHandle.
                 // We extend the reference until we have copied all data from that native memory to ensure
-                // it does not become invalid by a CloseDir; or by a concurrent ReadDir call.
-                int readerCount = Interlocked.Increment(ref dir.ReadDirCounter);
-                if (readerCount != 1)
-                {
-                    ThrowConcurrentReadNotSupported();
-                }
+                // it does not become invalid by a CloseDir.
                 dir.DangerousAddRef(ref addedRef);
 
                 unsafe
@@ -90,7 +85,6 @@ internal static partial class Interop
                 {
                     dir.DangerousRelease();
                 }
-                Interlocked.Decrement(ref dir.ReadDirCounter);
             }
         }
 
@@ -100,11 +94,6 @@ internal static partial class Interop
                 return Marshal.PtrToStringAnsi(dirEnt.Name);
             else
                 return Marshal.PtrToStringAnsi(dirEnt.Name, dirEnt.NameLength);
-        }
-
-        private static void ThrowConcurrentReadNotSupported()
-        {
-            throw new NotSupportedException("Concurrent directory enumeration is not supported.");
         }
     }
 }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeDirectoryHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeDirectoryHandle.Unix.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeDirectoryHandle : SafeHandle
     {
+        internal int ReadDirCounter;
+
         private SafeDirectoryHandle() : base(IntPtr.Zero, true)
         {
         }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeDirectoryHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeDirectoryHandle.Unix.cs
@@ -9,8 +9,6 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeDirectoryHandle : SafeHandle
     {
-        internal int ReadDirCounter;
-
         private SafeDirectoryHandle() : base(IntPtr.Zero, true)
         {
         }

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -324,41 +324,38 @@ static void ConvertDirent(const struct dirent* entry, struct DirectoryEntry* out
 #endif
 }
 
-int32_t SystemNative_GetDirentSize(void)
+int32_t SystemNative_GetReadDirRBufferSize(void)
 {
+#if HAVE_READDIR_R
     // dirent should be under 2k in size
     assert(sizeof(struct dirent) < 2048);
     return sizeof(struct dirent);
+#else
+    return 0;
+#endif
 }
 
-// To reduce the number of string copies, this function calling pattern works as follows:
-// 1) The managed code calls GetDirentSize() to get the platform-specific
-//    size of the dirent struct.
-// 2) The managed code creates a byte[] buffer of the size of the native dirent
-//    and passes a pointer to this buffer to this function.
-// 3) This function passes input byte[] buffer to the OS to fill with dirent
-//    data which makes the 1st strcpy.
-// 4) The ConvertDirent function will fill DirectoryEntry outputEntry with
-//    pointers from byte[] buffer.
-// 5) The managed code uses DirectoryEntry outputEntry to find start of d_name
-//    and the value of d_namelen, if avalable, to copy the name from
-//    byte[] buffer into a managed string that the caller can use; this makes
-//    the 2nd and final strcpy.
+// To reduce the number of string copies, the caller of this function is responsible to ensure the memory
+// referenced by outputEntry remains valid until it is read.
+// If the platform supports readdir_r, the caller provides a buffer into which the data is read.
+// If the platform uses readdir, the caller must ensure no calls are made to readdir/closedir since those will invalidate
+// the current dirent.
 int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, struct DirectoryEntry* outputEntry)
 {
-    assert(buffer != NULL);
     assert(dir != NULL);
     assert(outputEntry != NULL);
 
+#if HAVE_READDIR_R
+    assert(buffer != NULL);
+
     if (bufferSize < (int32_t)sizeof(struct dirent))
     {
-        assert(false && "Buffer size too small; use GetDirentSize to get required buffer size");
+        assert(false && "Buffer size too small; use GetReadDirRBufferSize to get required buffer size");
         return ERANGE;
     }
 
     struct dirent* result = NULL;
     struct dirent* entry = (struct dirent*)buffer;
-#if HAVE_READDIR_R
     int error = readdir_r(dir, entry, &result);
 
     // positive error number returned -> failure
@@ -379,11 +376,13 @@ int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, struct
     // 0 returned with non-null result (guaranteed to be set to entry arg) -> success
     assert(result == entry);
 #else
+    (void)buffer;     // unused
+    (void)bufferSize; // unused
     errno = 0;
-    result = readdir(dir);
+    struct dirent* entry = readdir(dir);
 
     // 0 returned with null result -> end-of-stream
-    if (result == NULL)
+    if (entry == NULL)
     {
         memset(outputEntry, 0, sizeof(*outputEntry)); // managed out param must be initialized
 
@@ -395,9 +394,6 @@ int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, struct
         }
         return -1;
     }
-
-    assert(result->d_reclen <= bufferSize);
-    memcpy_s(entry, sizeof(struct dirent), result, (size_t)result->d_reclen);
 #endif
     ConvertDirent(entry, outputEntry);
     return 0;

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -339,7 +339,7 @@ int32_t SystemNative_GetReadDirRBufferSize(void)
 // referenced by outputEntry remains valid until it is read.
 // If the platform supports readdir_r, the caller provides a buffer into which the data is read.
 // If the platform uses readdir, the caller must ensure no calls are made to readdir/closedir since those will invalidate
-// the current dirent.
+// the current dirent. We assume the platform supports concurrent readdir calls to different DIRs.
 int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, struct DirectoryEntry* outputEntry)
 {
     assert(dir != NULL);

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -356,7 +356,7 @@ int32_t SystemNative_ShmUnlink(const char* name);
 /**
  * Returns the size of the dirent struct on the current architecture
  */
-int32_t SystemNative_GetDirentSize(void);
+int32_t SystemNative_GetReadDirRBufferSize(void);
 
 /**
  * Re-entrant readdir that will retrieve the next dirent from the directory stream pointed to by dir.


### PR DESCRIPTION
@stephentoub this eliminates the memcpy for the readdir case as suggested in https://github.com/dotnet/corefx/issues/25375.

I have included a check to throw on concurrent readdir. I can remove that if it is not desired.