### PR TITLE
Optimize Utf-8 Integer Formatter for the default case

### DIFF
--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -57,9 +57,11 @@
     <Compile Include="System\Buffers\Text\Utf8Formatter\Utf8Formatter.Integer.cs" />
     <Compile Include="System\Buffers\Text\Utf8Formatter\Utf8Formatter.Integer.Signed.cs" />
     <Compile Include="System\Buffers\Text\Utf8Formatter\Utf8Formatter.Integer.Signed.D.cs" />
+    <Compile Include="System\Buffers\Text\Utf8Formatter\Utf8Formatter.Integer.Signed.Default.cs" />
     <Compile Include="System\Buffers\Text\Utf8Formatter\Utf8Formatter.Integer.Signed.N.cs" />
     <Compile Include="System\Buffers\Text\Utf8Formatter\Utf8Formatter.Integer.Unsigned.cs" />
     <Compile Include="System\Buffers\Text\Utf8Formatter\Utf8Formatter.Integer.Unsigned.D.cs" />
+    <Compile Include="System\Buffers\Text\Utf8Formatter\Utf8Formatter.Integer.Unsigned.Default.cs" />
     <Compile Include="System\Buffers\Text\Utf8Formatter\Utf8Formatter.Integer.Unsigned.N.cs" />
     <Compile Include="System\Buffers\Text\Utf8Formatter\Utf8Formatter.Integer.Unsigned.X.cs" />
     <Compile Include="System\Buffers\Text\Utf8Formatter\Utf8Formatter.TimeSpan.cs" />

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
@@ -39,34 +39,19 @@ namespace System.Buffers.Text
             WriteDigits(value, digitCount, ref buffer, index);
         }
 
-        // Passing the span and using the indexer is 5-10% slower than using Unsafe APIs on ref byte.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteDigits(long value, int digitCount, Span<byte> buffer, int index)
-        {
-            long left = value;
-
-            for (int i = digitCount - 1; i >= 0; i--)
-            {
-                left = DivMod(left, 10, out long num);
-                buffer[index + i] = (byte)('0' + num);
-            }
-            
-            Debug.Assert(left == 0);
-        }
-
-        // Passing the span and using the indexer is 5-10% slower than using Unsafe APIs on ref byte.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteDigits(ulong value, int digitCount, Span<byte> buffer, int index)
+        public static void WriteDigits(ulong value, Span<byte> buffer)
         {
             ulong left = value;
 
-            for (int i = digitCount - 1; i >= 0; i--)
+            for (int i = buffer.Length - 1; i >= 1; i--)
             {
                 left = DivMod(left, 10, out ulong num);
-                buffer[index + i] = (byte)('0' + num);
+                buffer[i] = (byte)('0' + num);
             }
 
-            Debug.Assert(left == 0);
+            Debug.Assert(left < 10);
+            buffer[0] = (byte)('0' + left);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -148,6 +133,7 @@ namespace System.Buffers.Text
             return digits;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountDigits(ulong value)
         {
             int digits = 1;

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
@@ -31,16 +31,46 @@ namespace System.Buffers.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int WriteFractionDigits(long value, int digitCount, ref byte buffer, int index)
+        public static void WriteFractionDigits(long value, int digitCount, ref byte buffer, int index)
         {
             for (int i = FractionDigits; i > digitCount; i--)
                 value /= 10;
 
-            return WriteDigits(value, digitCount, ref buffer, index);
+            WriteDigits(value, digitCount, ref buffer, index);
+        }
+
+        // Passing the span and using the indexer is 5-10% slower than using Unsafe APIs on ref byte.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteDigits(long value, int digitCount, Span<byte> buffer, int index)
+        {
+            long left = value;
+
+            for (int i = digitCount - 1; i >= 0; i--)
+            {
+                left = DivMod(left, 10, out long num);
+                buffer[index + i] = (byte)('0' + num);
+            }
+            
+            Debug.Assert(left == 0);
+        }
+
+        // Passing the span and using the indexer is 5-10% slower than using Unsafe APIs on ref byte.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteDigits(ulong value, int digitCount, Span<byte> buffer, int index)
+        {
+            ulong left = value;
+
+            for (int i = digitCount - 1; i >= 0; i--)
+            {
+                left = DivMod(left, 10, out ulong num);
+                buffer[index + i] = (byte)('0' + num);
+            }
+
+            Debug.Assert(left == 0);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int WriteDigits(long value, int digitCount, ref byte buffer, int index)
+        public static void WriteDigits(long value, int digitCount, ref byte buffer, int index)
         {
             long left = value;
 
@@ -50,7 +80,7 @@ namespace System.Buffers.Text
                 Unsafe.Add(ref buffer, index + i) = (byte)('0' + num);
             }
 
-            return digitCount;
+            Debug.Assert(left == 0);
         }
 
         /// <summary>
@@ -59,7 +89,7 @@ namespace System.Buffers.Text
         /// you definitely need to deal with numbers larger than long.MaxValue.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int WriteDigits(ulong value, int digitCount, ref byte buffer, int index)
+        public static void WriteDigits(ulong value, int digitCount, ref byte buffer, int index)
         {
             ulong left = value;
 
@@ -68,8 +98,8 @@ namespace System.Buffers.Text
                 left = DivMod(left, 10, out ulong num);
                 Unsafe.Add(ref buffer, index + i) = (byte)('0' + num);
             }
-
-            return digitCount;
+            
+            Debug.Assert(left == 0);
         }
 
         #endregion UTF-8 Helper methods
@@ -113,6 +143,61 @@ namespace System.Buffers.Text
             {
                 n /= 10;
                 digits++;
+            }
+
+            return digits;
+        }
+
+        public static int CountDigits(ulong value)
+        {
+            int digits = 1;
+            uint part;
+            if (value >= 10000000)
+            {
+                if (value >= 100000000000000)
+                {
+                    part = (uint)(value / 100000000000000);
+                    digits += 14;
+                }
+                else
+                {
+                    part = (uint)(value / 10000000);
+                    digits += 7;
+                }
+            }
+            else
+            {
+                part = (uint)value;
+            }
+
+            if (part < 10) 
+            { 
+                // no-op
+            }
+            else if (part < 100) 
+            {
+                digits += 1;
+            }
+            else if (part < 1000)
+            {
+                digits += 2;
+            }
+            else if (part < 10000) 
+            {
+                digits += 3;
+            }
+            else if (part < 100000) 
+            {
+                digits += 4;
+            }
+            else if (part < 1000000) 
+            {
+                digits += 5;
+            }
+            else 
+            { 
+                Debug.Assert(part < 10000000);
+                digits += 6;
             }
 
             return digits;

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.D.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.D.cs
@@ -45,9 +45,9 @@ namespace System.Buffers.Text
                     }
 
                     Unsafe.Add(ref utf8Bytes, idx++) = (byte)'9';
-                    idx += FormattingHelpers.WriteDigits(223372036854775808L, 18, ref utf8Bytes, idx);
+                    FormattingHelpers.WriteDigits(223372036854775808L, 18, ref utf8Bytes, idx);
 
-                    bytesWritten = idx;
+                    bytesWritten = idx + 18;
                     return true;
                 }
 
@@ -61,9 +61,9 @@ namespace System.Buffers.Text
                     Unsafe.Add(ref utf8Bytes, idx++) = (byte)'0';
             }
 
-            idx += FormattingHelpers.WriteDigits(value, digitCount, ref utf8Bytes, idx);
+            FormattingHelpers.WriteDigits(value, digitCount, ref utf8Bytes, idx);
 
-            bytesWritten = idx;
+            bytesWritten = digitCount + idx;
             return true;
         }
     }

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.Default.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.Default.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Buffers.Text
+{
+    /// <summary>
+    /// Methods to format common data types as Utf8 strings.
+    /// </summary>
+    public static partial class Utf8Formatter
+    {
+        private static bool TryFormatInt64Default(long value, Span<byte> buffer, out int bytesWritten)
+        {
+            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+            int idx = 0;
+
+            if (value < 0)
+            {
+                if (buffer.Length < 2) goto FalseExit;  // Buffer of length 1 won't have space for the digits after the minus sign
+                Unsafe.Add(ref utf8Bytes, idx++) = Utf8Constants.Minus;
+
+                // Abs(long.MinValue) == long.MaxValue + 1, so we need to handle this specially.
+                if (value == long.MinValue)
+                {
+                    if (buffer.Length < 20) goto FalseExit; // WriteDigits does not do bounds checks
+                    Unsafe.Add(ref utf8Bytes, 1) = (byte)'9';
+                    FormattingHelpers.WriteDigits(223372036854775808L, 18, ref utf8Bytes, 2);
+                    bytesWritten = 20;
+                    return true;
+                }
+
+                value = -value;
+            }
+
+            long left = value;
+            for (int i = idx; i < buffer.Length; i++)
+            {
+                left = FormattingHelpers.DivMod(left, 10, out long num);
+                Unsafe.Add(ref utf8Bytes, i) = (byte)('0' + num);
+                if (left == 0)
+                {
+                    i++;
+                    // Reverse the bytes
+                    for (int j = 0; j < ((i - idx) >> 1); j++)
+                    {
+                        byte temp = Unsafe.Add(ref utf8Bytes, j + idx);
+                        Unsafe.Add(ref utf8Bytes, j + idx) = Unsafe.Add(ref utf8Bytes, i - j - 1);
+                        Unsafe.Add(ref utf8Bytes, i - j - 1) = temp;
+                    }
+                    bytesWritten = i;
+                    return true;
+                }
+            }
+
+            // Buffer too small, clean up what has been written
+            buffer.Clear();
+        FalseExit:
+            bytesWritten = 0;
+            return false;
+        }
+    }
+}

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.cs
@@ -19,8 +19,7 @@ namespace System.Buffers.Text
         {
             if (format.IsDefault)
             {
-                // Officially, the default is "G" but "G without a precision is equivalent to "D" and so that's why we're using "D" (eliminates an unnecessary HasPrecision check)
-                format = 'D';
+                return TryFormatInt64Default(value, buffer, out bytesWritten);
             }
 
             switch (format.Symbol)

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.D.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.D.cs
@@ -36,7 +36,8 @@ namespace System.Buffers.Text
             }
 
             ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-            bytesWritten += FormattingHelpers.WriteDigits(lastDigit, 1, ref utf8Bytes, bytesWritten);
+            FormattingHelpers.WriteDigits(lastDigit, 1, ref utf8Bytes, bytesWritten);
+            bytesWritten += 1;
             return true;
         }
     }

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.Default.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.Default.cs
@@ -20,9 +20,10 @@ namespace System.Buffers.Text
             }
 
             int digitCount = FormattingHelpers.CountDigits(value);
-            if (buffer.Length < digitCount) goto FalseExit;  // WriteDigits does not do bounds checks
-            FormattingHelpers.WriteDigits(value, digitCount, ref buffer.DangerousGetPinnableReference(), 0);
+            if (digitCount > buffer.Length) goto FalseExit;
             bytesWritten = digitCount;
+            // WriteDigits does not do bounds checks
+            FormattingHelpers.WriteDigits(value, buffer.Slice(0, digitCount));
             return true;
 
         FalseExit:

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.Default.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.Default.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Buffers.Text
+{
+    /// <summary>
+    /// Methods to format common data types as Utf8 strings.
+    /// </summary>
+    public static partial class Utf8Formatter
+    {
+        private static bool TryFormatUInt64Default(ulong value, Span<byte> buffer, out int bytesWritten)
+        {
+            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+
+            ulong left = value;
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                left = FormattingHelpers.DivMod(left, 10, out ulong num);
+                Unsafe.Add(ref utf8Bytes, i) = (byte)('0' + num);
+                if (left == 0)
+                {
+                    i++;
+                    // Reverse the bytes
+                    for (int j = 0; j < (i >> 1); j++)
+                    {
+                        byte temp = Unsafe.Add(ref utf8Bytes, j);
+                        Unsafe.Add(ref utf8Bytes, j) = Unsafe.Add(ref utf8Bytes, i - j - 1);
+                        Unsafe.Add(ref utf8Bytes, i - j - 1) = temp;
+                    }
+                    bytesWritten = i;
+                    return true;
+                }
+            }
+
+            // Buffer too small, clean up what has been written
+            buffer.Clear();
+            bytesWritten = 0;
+            return false;
+        }
+    }
+}

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.N.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.N.cs
@@ -47,7 +47,8 @@ namespace System.Buffers.Text
 
             // Write the last group
             Unsafe.Add(ref utf8Bytes, idx++) = Utf8Constants.Separator;
-            idx += FormattingHelpers.WriteDigits(lastGroup, 3, ref utf8Bytes, idx);
+            FormattingHelpers.WriteDigits(lastGroup, 3, ref utf8Bytes, idx);
+            idx += 3;
 
             // Write out the trailing zeros
             if (precision > 0)

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.cs
@@ -19,8 +19,7 @@ namespace System.Buffers.Text
         {
             if (format.IsDefault)
             {
-                // Officially, the default is "G" but "G without a precision is equivalent to "D" and so that's why we're using "D" (eliminates an unnecessary HasPrecision check)
-                format = 'D';
+                return TryFormatUInt64Default(value, buffer, out bytesWritten);
             }
 
             switch (format.Symbol)

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.TimeSpan.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.TimeSpan.cs
@@ -91,22 +91,27 @@ namespace System.Buffers.Text
 
                         if (dayDigits > 0)
                         {
-                            idx += FormattingHelpers.WriteDigits(days, dayDigits, ref utf8Bytes, idx);
+                            FormattingHelpers.WriteDigits(days, dayDigits, ref utf8Bytes, idx);
+                            idx += dayDigits;
                             Unsafe.Add(ref utf8Bytes, idx++) = constant ? Utf8Constants.Period : Utf8Constants.Colon;
                         }
 
-                        idx += FormattingHelpers.WriteDigits(hours, hourDigits, ref utf8Bytes, idx);
+                        FormattingHelpers.WriteDigits(hours, hourDigits, ref utf8Bytes, idx);
+                        idx += hourDigits;
                         Unsafe.Add(ref utf8Bytes, idx++) = Utf8Constants.Colon;
 
-                        idx += FormattingHelpers.WriteDigits(minutes, 2, ref utf8Bytes, idx);
+                        FormattingHelpers.WriteDigits(minutes, 2, ref utf8Bytes, idx);
+                        idx += 2;
                         Unsafe.Add(ref utf8Bytes, idx++) = Utf8Constants.Colon;
 
-                        idx += FormattingHelpers.WriteDigits(seconds, 2, ref utf8Bytes, idx);
+                        FormattingHelpers.WriteDigits(seconds, 2, ref utf8Bytes, idx);
+                        idx += 2;
 
                         if (fractionDigits > 0)
                         {
                             Unsafe.Add(ref utf8Bytes, idx++) = Utf8Constants.Period;
-                            idx += FormattingHelpers.WriteFractionDigits(fraction, fractionDigits, ref utf8Bytes, idx);
+                            FormattingHelpers.WriteFractionDigits(fraction, fractionDigits, ref utf8Bytes, idx);
+                            idx += fractionDigits;
                         }
 
                         return true;


### PR DESCRIPTION
Using the 'D' Standard Format has too much overhead due to precision checks.

Also, instead of calculating the digit count first and then writing the digits (which results in `O(2n)` operations, where n is the length of the number), write the digits in reverse order and then reverse the digits in place (which results in `O(n + n/2)` operations).

![image](https://user-images.githubusercontent.com/6527137/33106649-f99c9a98-cee7-11e7-836e-03049e063c01.png)

cc @AtsushiKan, @KrzysztofCwalina, @jkotas