### PR TITLE
UnixDomainSocketEndPoint: support Linux abstract socket address.

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.netcoreapp.cs
@@ -422,13 +422,13 @@ namespace System.Net.Sockets.Tests
             // Bind
             using (Socket socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
             {
-                Assert.Throws<SocketException>(() => socket.Bind(new UnixDomainSocketEndPoint(address)));
+                Assert.ThrowsAny<SocketException>(() => socket.Bind(new UnixDomainSocketEndPoint(address)));
             }
 
             // Connect
             using (Socket socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
             {
-                Assert.Throws<SocketException>(() => socket.Connect(new UnixDomainSocketEndPoint(address)));
+                Assert.ThrowsAny<SocketException>(() => socket.Connect(new UnixDomainSocketEndPoint(address)));
             }
         }
 


### PR DESCRIPTION
This adds support for Linux abstract socket addresses.

The added test round-trips the address _managed -> native -> managed_ to ensure we have connected to the correct address.
To succeed for pathname addresses, the terminating null needed to be stripped.

CC @stephentoub @eerhardt 