### PR TITLE
SslApplicationProtocol: Use the copied byte array

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
@@ -33,8 +33,8 @@ namespace System.Net.Security
             if (copy)
             {
                 byte[] temp = new byte[protocol.Length];
-                Array.Copy(protocol, temp, protocol.Length);
-                _readOnlyProtocol = new ReadOnlyMemory<byte>(protocol);
+                Array.Copy(protocol, 0, temp, 0, protocol.Length);
+                _readOnlyProtocol = new ReadOnlyMemory<byte>(temp);
             }
             else
             {

--- a/src/System.Net.Security/tests/UnitTests/SslApplicationProtocolTests.cs
+++ b/src/System.Net.Security/tests/UnitTests/SslApplicationProtocolTests.cs
@@ -38,6 +38,18 @@ namespace System.Net.Security.Tests
             Assert.Throws<EncoderFallbackException>(() => { new SslApplicationProtocol("\uDC00"); });
         }
 
+        [Fact]
+        public void Constructor_ByteArray_Copies()
+        {
+            byte[] expected = Encoding.UTF8.GetBytes("hello");
+            SslApplicationProtocol byteProtocol = new SslApplicationProtocol(expected);
+
+            ArraySegment<byte> arraySegment;
+            Assert.True(byteProtocol.Protocol.DangerousTryGetArray(out arraySegment));
+            Assert.Equal(expected, arraySegment.Array);
+            Assert.NotSame(expected, arraySegment.Array);
+        }
+
         [Theory]
         [MemberData(nameof(Protocol_Equality_TestData))]
         public void Equality_Tests_Succeeds(SslApplicationProtocol left, SslApplicationProtocol right)


### PR DESCRIPTION
When `copy` is true, the `protocol` byte array is copied to a new array, but then the new array is never used. Instead, use the new array.