### PR TITLE
Add test for mutating nullable value

### DIFF
--- a/src/System.Runtime/tests/System/NullableTests.cs
+++ b/src/System.Runtime/tests/System/NullableTests.cs
@@ -113,6 +113,47 @@ namespace System.Tests
             Assert.Equal(expected, Nullable.Compare(n1, n2));
         }
 
+        [Fact]
+        public static void MutatingMethods_MutationsAffectOriginal()
+        {
+            MutatingStruct? ms = new MutatingStruct() { Value = 1 };
+
+            for (int i = 1; i <= 2; i++)
+            {
+                Assert.Equal(i.ToString(), ms.Value.ToString());
+                Assert.Equal(i, ms.Value.Value);
+
+                Assert.Equal(i.ToString(), ms.ToString());
+                Assert.Equal(i + 1, ms.Value.Value);
+            }
+
+            for (int i = 3; i <= 4; i++)
+            {
+                Assert.Equal(i, ms.Value.GetHashCode());
+                Assert.Equal(i, ms.Value.Value);
+
+                Assert.Equal(i, ms.GetHashCode());
+                Assert.Equal(i + 1, ms.Value.Value);
+            }
+
+            for (int i = 5; i <= 6; i++)
+            {
+                ms.Value.Equals(new object());
+                Assert.Equal(i, ms.Value.Value);
+
+                ms.Equals(new object());
+                Assert.Equal(i + 1, ms.Value.Value);
+            }
+        }
+
+        private struct MutatingStruct
+        {
+            public int Value;
+            public override string ToString() => Value++.ToString();
+            public override bool Equals(object obj) => Value++.Equals(null);
+            public override int GetHashCode() => Value++.GetHashCode();
+        }
+
         private class G<T> { }
     }
 }


### PR DESCRIPTION
Depends on https://github.com/dotnet/coreclr/pull/15198

(I apparently neglected to add readonly to the ref for nullable, so I don't need to remove it here.)