### PR TITLE
Remove some pointer-related dead code from Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpArgInfo.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpArgInfo.cs
@@ -59,26 +59,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return (mask & BinOpMask.Enum) != 0;
             }
-
-            public bool ValidForPointer()
-            {
-                return (mask & BinOpMask.Ptr) != 0;
-            }
-
-            public bool ValidForVoidPointer()
-            {
-                return (mask & BinOpMask.VoidPtr) != 0;
-            }
-
-            public bool ValidForPointerAndNumber()
-            {
-                return (mask & BinOpMask.PtrNum) != 0;
-            }
-
-            public bool ValidForNumberAndPointer()
-            {
-                return (mask & BinOpMask.NumPtr) != 0;
-            }
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpKind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpKind.cs
@@ -42,9 +42,5 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         Enum = Sub | Equal | Compare | Bitwise | BitXor,
         EnumUnder = Add | Sub,
         UnderEnum = Add,
-        Ptr = Sub,
-        PtrNum = Add | Sub,
-        NumPtr = Add,
-        VoidPtr = Equal | Compare,
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -561,14 +561,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             checkUnsafe(pFieldType); // added to the binder so we don't bind to pointer ops
 
-            bool isLValue = pOptionalObject?.Type is PointerType || objectIsLvalue(pOptionalObject);
-
-            // Exception: a readonly field is not an lvalue unless we're in the constructor/static constructor appropriate
-            // for the field.
-            if (fwt.Field().isReadOnly)
-            {
-                isLValue = false;
-            }
+            // lvalue if the object is an lvalue (or it's static) and the field is not readonly.
+            bool isLValue = objectIsLvalue(pOptionalObject) && !fwt.Field().isReadOnly;
 
             AggregateType fieldType = null;
             // If this field is the backing field of a WindowsRuntime event then we need to bind to its

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -495,7 +495,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             bool fConstrained;
             Expr pObject = pMemGroup.OptionalObject;
             CType callingObjectType = pObject?.Type;
-            PostBindMethod(ref mwi);
+            PostBindMethod(mwi);
             pObject = AdjustMemberObject(mwi, pObject, out fConstrained);
             pMemGroup.OptionalObject = pObject;
 
@@ -1124,24 +1124,17 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return true;
         }
 
-        private void PostBindMethod(ref MethWithInst pMWI)
+        private void PostBindMethod(MethWithInst pMWI)
         {
-            if (pMWI.Meth().RetType != null)
+            MethodSymbol meth = pMWI.Meth();
+            if (meth.RetType != null)
             {
-                checkUnsafe(pMWI.Meth().RetType);
+                checkUnsafe(meth.RetType);
 
                 // We need to check unsafe on the parameters as well, since we cannot check in conversion.
-                TypeArray pParams = pMWI.Meth().Params;
-
-                for (int i = 0; i < pParams.Count; i++)
+                foreach (CType type in meth.Params.Items)
                 {
-                    // This is an optimization: don't call this in the vast majority of cases
-                    CType type = pParams[i];
-
-                    if (type.isUnsafe())
-                    {
-                        checkUnsafe(type);
-                    }
+                    checkUnsafe(type);
                 }
             }
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -117,8 +117,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         DelBinOp,
         EnumBinOp,
         IntBinOp,
-        PtrBinOp,
-        PtrCmpOp,
         RealBinOp,
         RefCmpOp,
         ShiftOp,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1303,16 +1303,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 else if (unaryOpKind == UnaOpKind.IncDec)
                 {
-                    // Check for pointers
-                    if (pArgumentType is PointerType)
-                    {
-                        pSignatures.Add(new UnaOpFullSig(
-                                pArgumentType,
-                                null,
-                                LiftFlags.None,
-                                UnaOpFuncKind.None));
-                        return UnaryOperatorSignatureFindResult.Match;
-                    }
+                    Debug.Assert(!(pArgumentType is PointerType));
 
                     // Check for user defined inc/dec
                     ExprMultiGet exprGet = GetExprFactory().CreateMultiGet(0, pArgumentType, null);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -44,15 +44,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 (enum,      under)      :       + -
                 (under,     enum)       :       +
          
-                (ptr,       ptr)        :         -
-                (ptr,       int)        :       + -
-                (ptr,       uint)       :       + -
-                (ptr,       long)       :       + -
-                (ptr,       ulong)      :       + -
-                (int,       ptr)        :       +
-                (uint,      ptr)        :       +
-                (long,      ptr)        :       +
-                (ulong,     ptr)        :       +
+                (ptr,       ptr)        :         -     Not callable through dynamic
+                (ptr,       int)        :       + -     Not callable through dynamic
+                (ptr,       uint)       :       + -     Not callable through dynamic
+                (ptr,       long)       :       + -     Not callable through dynamic
+                (ptr,       ulong)      :       + -     Not callable through dynamic
+                (int,       ptr)        :       +       Not callable through dynamic
+                (uint,      ptr)        :       +       Not callable through dynamic
+                (long,      ptr)        :       +       Not callable through dynamic
+                (ulong,     ptr)        :       +       Not callable through dynamic
          
                 (void,     void)      :                   == != < > <= >=
          
@@ -73,7 +73,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 enum    :       ~
                 ptr     :          
          
-            Note that pointer operators cannot be lifted over nullable.
+            Note that pointer operators cannot be lifted over nullable and are not callable through dynamic
         */
 
         // BinOpBindMethod and UnaOpBindMethod are method pointer arrays to dispatch the appropriate operator binder.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1618,6 +1618,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 type = GetPredefindType(PredefinedType.PT_INT);
             }
 
+            Debug.Assert(type.fundType() != FUNDTYPE.FT_PTR); // Can't have a pointer.
             switch (type.fundType())
             {
                 default:
@@ -1635,9 +1636,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
 
                     return CreateUnaryOpForPredefMethodCall(ek, predefMeth, type, exprVal);
-
-                case FUNDTYPE.FT_PTR:
-                    return BindPtrBinOp(ek, flags, exprVal, GetExprFactory().CreateConstant(GetPredefindType(PredefinedType.PT_INT), ConstVal.Get(1)));
 
                 case FUNDTYPE.FT_I1:
                 case FUNDTYPE.FT_I2:
@@ -2117,15 +2115,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             return mustCastInUncheckedContext(exprRes, typeEnum, CONVERTTYPE.NOUDC);
-        }
-
-
-        /*
-            Handles pointer binary operators (+ and -).
-        */
-        private Expr BindPtrBinOp(ExpressionKind ek, EXPRFLAG flags, Expr arg1, Expr arg2)
-        {
-            return null;
         }
 
         /*


### PR DESCRIPTION
* Remove `GetPtrBinOpSigs` and code used by it.

Is only called by `GetSpecialBinopSignatures`, which is only called by `BindStandardBinop`, which is only called by `BindBinaryOperation`, which creates its arguments from `ArgumentObject` objects which cannot contain pointers, so there is no way to reach this with a `PointerType`.

* Remove `BindPtrBinOp`

Now only called by `BindIncOpCore`, only called by `BindLiftedIncOp` & `BindNonliftedIncOp`, both only called by `BindIncOp`, only called by `BindStandardUnaryOperator` which is only called by `BindUnaryOperation`, which creates its argument from an `ArgumentObject` object which cannot contain a pointer, so there is no way to reach this with a `PointerType`.

* Update comments on possible binary operations excluding pointers.

* Remove `PointerType` branch from `PopulateSignatureList`

Only called from `BindStandardUnaryOperator`, so can't have pointers as per above.

* Remove pointer condition on `BindToField`.

Only called by `CreateField`, called by `BindProperty` which creates the relevant expression from an `ArgumentObject`.