### PR TITLE
Remove some dead code from Microsoft.CSharp's PredefinedMembers

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -283,7 +283,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         .GetArray(LoadTypeFromSignature(signature, ref indexIntoSignatures, classTyVars), 1, true);
 
                 case MethodSignatureEnum.SIG_METH_TYVAR:
-
                     return GetTypeManager().GetStdMethTypeVar(signature[indexIntoSignatures++]);
 
                 case MethodSignatureEnum.SIG_CLASS_TYVAR:
@@ -301,14 +300,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         typeArgs[iTypeArg] = LoadTypeFromSignature(signature, ref indexIntoSignatures, classTyVars);
                     }
 
-                    AggregateType type = GetTypeManager()
-                        .GetAggregate(agg, getBSymmgr().AllocParams(agg.GetTypeVars().Count, typeArgs));
-                    if (type.isPredefType(PredefinedType.PT_G_OPTIONAL))
-                    {
-                        return GetTypeManager().GetNubFromNullable(type);
-                    }
-
-                    return type;
+                    return GetTypeManager().GetAggregate(agg, getBSymmgr().AllocParams(typeArgs));
             }
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -279,40 +279,26 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             switch (current)
             {
                 case MethodSignatureEnum.SIG_SZ_ARRAY:
-                    {
-                        CType elementType = LoadTypeFromSignature(signature, ref indexIntoSignatures, classTyVars);
-                        if (elementType == null)
-                        {
-                            return null;
-                        }
-                        return GetTypeManager().GetArray(elementType, 1, true);
-                    }
+                    return GetTypeManager()
+                        .GetArray(LoadTypeFromSignature(signature, ref indexIntoSignatures, classTyVars), 1, true);
+
                 case MethodSignatureEnum.SIG_METH_TYVAR:
-                    {
-                        int index = signature[indexIntoSignatures];
-                        indexIntoSignatures++;
-                        return GetTypeManager().GetStdMethTypeVar(index);
-                    }
+
+                    return GetTypeManager().GetStdMethTypeVar(signature[indexIntoSignatures++]);
+
                 case MethodSignatureEnum.SIG_CLASS_TYVAR:
-                    {
-                        int index = signature[indexIntoSignatures];
-                        indexIntoSignatures++;
-                        return classTyVars[index];
-                    }
+                    return classTyVars[signature[indexIntoSignatures++]];
+
                 case (MethodSignatureEnum)PredefinedType.PT_VOID:
                     return GetTypeManager().GetVoid();
+
                 default:
-                {
                     Debug.Assert(current >= 0 && (int)current < (int)PredefinedType.PT_COUNT);
                     AggregateSymbol agg = GetPredefAgg((PredefinedType)current);
                     CType[] typeArgs = new CType[agg.GetTypeVars().Count];
-                    for (int iTypeArg = 0; iTypeArg < agg.GetTypeVars().Count; iTypeArg++)
+                    for (int iTypeArg = 0; iTypeArg < typeArgs.Length; iTypeArg++)
                     {
                         typeArgs[iTypeArg] = LoadTypeFromSignature(signature, ref indexIntoSignatures, classTyVars);
-                        if (typeArgs[iTypeArg] == null)
-                        {
-                            return null;
-                        }
                     }
 
                     AggregateType type = GetTypeManager()
@@ -323,9 +309,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
 
                     return type;
-                }
             }
         }
+
         private TypeArray LoadTypeArrayFromSignature(int[] signature, ref int indexIntoSignatures, TypeArray classTyVars)
         {
             Debug.Assert(signature != null);
@@ -336,14 +322,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(count >= 0);
 
             CType[] ptypes = new CType[count];
-            for (int i = 0; i < count; i++)
+            for (int i = 0; i < ptypes.Length; i++)
             {
                 ptypes[i] = LoadTypeFromSignature(signature, ref indexIntoSignatures, classTyVars);
-                if (ptypes[i] == null)
-                {
-                    return null;
-                }
             }
+
             return getBSymmgr().AllocParams(count, ptypes);
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -294,7 +294,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 default:
                     Debug.Assert(current >= 0 && (int)current < (int)PredefinedType.PT_COUNT);
                     AggregateSymbol agg = GetPredefAgg((PredefinedType)current);
-                    CType[] typeArgs = new CType[agg.GetTypeVars().Count];
+                    int typeCount = agg.GetTypeVars().Count;
+                    if (typeCount == 0)
+                    {
+                        return GetTypeManager().GetAggregate(agg, BSYMMGR.EmptyTypeArray());
+                    }
+
+                    CType[] typeArgs = new CType[typeCount];
                     for (int iTypeArg = 0; iTypeArg < typeArgs.Length; iTypeArg++)
                     {
                         typeArgs[iTypeArg] = LoadTypeFromSignature(signature, ref indexIntoSignatures, classTyVars);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -150,9 +150,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // start next value at PredefinedType.PT_VOID + 1,
         SIG_CLASS_TYVAR = (int)PredefinedType.PT_VOID + 1,          // next element in signature is index of class tyvar
         SIG_METH_TYVAR,                         // next element in signature is index of method tyvar
-        SIG_SZ_ARRAY,                           // must be followed by signature type of array elements
-        SIG_REF,                                // must be followed by signature of ref type
-        SIG_OUT,                                // must be followed by signature of out type
+        SIG_SZ_ARRAY                            // must be followed by signature type of array elements
     }
 
     // A description of a method the compiler uses while compiling.
@@ -280,24 +278,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             switch (current)
             {
-                case MethodSignatureEnum.SIG_REF:
-                    {
-                        CType refType = LoadTypeFromSignature(signature, ref indexIntoSignatures, classTyVars);
-                        if (refType == null)
-                        {
-                            return null;
-                        }
-                        return GetTypeManager().GetParameterModifier(refType, false);
-                    }
-                case MethodSignatureEnum.SIG_OUT:
-                    {
-                        CType outType = LoadTypeFromSignature(signature, ref indexIntoSignatures, classTyVars);
-                        if (outType == null)
-                        {
-                            return null;
-                        }
-                        return GetTypeManager().GetParameterModifier(outType, true);
-                    }
                 case MethodSignatureEnum.SIG_SZ_ARRAY:
                     {
                         CType elementType = LoadTypeFromSignature(signature, ref indexIntoSignatures, classTyVars);


### PR DESCRIPTION
* Remove `MethodSignatureEnum.SIG_REF` and `.SIG_OUT`

No predefined methods used these.

* Remove checks that `GetOptPredefAgg` may have returned null.

It can't, as we won't start up without types we expect are there.
Rename to `GetPredefAgg`, since it's not "Opt".

* Remove branches for `LoadTypeFromSignature` returning null.

Since we can now see that this can never happen

* Remove `PredefinedType.PT_G_OPTIONAL` branch in `LoadTypeArrayFromSignature`

No parameter list contains it.

* Skip getting type arguments for predefined members when there are none.

Avoids creating and throwing away an array.