### PR TITLE
Add CLSCompliant(false) to APIs in System.Memory

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -12,6 +12,7 @@ namespace System
         public static ReadOnlySpan<T> Empty { get { throw null; } }
         public ReadOnlySpan(T[] array) { throw null; }
         public ReadOnlySpan(T[] array, int start, int length) { throw null; }
+        [CLSCompliant(false)]
         public unsafe ReadOnlySpan(void* pointer, int length) { throw null; }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; }}
@@ -50,6 +51,7 @@ namespace System
         public static Span<T> Empty { get { throw null; } }
         public Span(T[] array) { throw null; }
         public Span(T[] array, int start, int length) { throw null; }
+        [CLSCompliant(false)]
         public unsafe Span(void* pointer, int length) { throw null; }
         public bool IsEmpty { get { throw null; } }
         public ref T this[int index] { get { throw null; } }
@@ -187,7 +189,9 @@ namespace System.Buffers
 {
     public unsafe struct MemoryHandle : IDisposable 
     {
+        [CLSCompliant(false)]
         public MemoryHandle(IRetainable owner, void* pointer = null,  System.Runtime.InteropServices.GCHandle handle = default(System.Runtime.InteropServices.GCHandle))  { throw null; }
+        [CLSCompliant(false)]
         public void* Pointer { get { throw null; } }
         public bool HasPointer { get { throw null; } }
         public void Dispose() { throw null; }
@@ -227,13 +231,17 @@ namespace System.Buffers.Binary
 {
     public static class BinaryPrimitives
     {
+        [CLSCompliant(false)]
         public static sbyte ReverseEndianness(sbyte value) { throw null; }
         public static byte ReverseEndianness(byte value) { throw null; }
         public static short ReverseEndianness(short value) { throw null; }
+        [CLSCompliant(false)]
         public static ushort ReverseEndianness(ushort value) { throw null; }
         public static int ReverseEndianness(int value) { throw null; }
+        [CLSCompliant(false)]
         public static uint ReverseEndianness(uint value) { throw null; }
         public static long ReverseEndianness(long value) { throw null; }
+        [CLSCompliant(false)]
         public static ulong ReverseEndianness(ulong value) { throw null; }
 
         public static T ReadMachineEndian<T>(ReadOnlySpan<byte> buffer) where T : struct { throw null; }
@@ -242,29 +250,41 @@ namespace System.Buffers.Binary
         public static short ReadInt16LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
         public static int ReadInt32LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
         public static long ReadInt64LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
+        [CLSCompliant(false)]
         public static ushort ReadUInt16LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
+        [CLSCompliant(false)]
         public static uint ReadUInt32LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
+        [CLSCompliant(false)]
         public static ulong ReadUInt64LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
 
         public static bool TryReadInt16LittleEndian(ReadOnlySpan<byte> buffer, out short value) { throw null; }
         public static bool TryReadInt32LittleEndian(ReadOnlySpan<byte> buffer, out int value) { throw null; }
         public static bool TryReadInt64LittleEndian(ReadOnlySpan<byte> buffer, out long value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryReadUInt16LittleEndian(ReadOnlySpan<byte> buffer, out ushort value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryReadUInt32LittleEndian(ReadOnlySpan<byte> buffer, out uint value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryReadUInt64LittleEndian(ReadOnlySpan<byte> buffer, out ulong value) { throw null; }
 
         public static short ReadInt16BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
         public static int ReadInt32BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
         public static long ReadInt64BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
+        [CLSCompliant(false)]
         public static ushort ReadUInt16BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
+        [CLSCompliant(false)]
         public static uint ReadUInt32BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
+        [CLSCompliant(false)]
         public static ulong ReadUInt64BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
 
         public static bool TryReadInt16BigEndian(ReadOnlySpan<byte> buffer, out short value) { throw null; }
         public static bool TryReadInt32BigEndian(ReadOnlySpan<byte> buffer, out int value) { throw null; }
         public static bool TryReadInt64BigEndian(ReadOnlySpan<byte> buffer, out long value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryReadUInt16BigEndian(ReadOnlySpan<byte> buffer, out ushort value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryReadUInt32BigEndian(ReadOnlySpan<byte> buffer, out uint value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryReadUInt64BigEndian(ReadOnlySpan<byte> buffer, out ulong value) { throw null; }
 
         public static void WriteMachineEndian<T>(Span<byte> buffer, ref T value) where T : struct { throw null; }
@@ -273,29 +293,41 @@ namespace System.Buffers.Binary
         public static void WriteInt16LittleEndian(Span<byte> buffer, short value) { throw null; }
         public static void WriteInt32LittleEndian(Span<byte> buffer, int value) { throw null; }
         public static void WriteInt64LittleEndian(Span<byte> buffer, long value) { throw null; }
+        [CLSCompliant(false)]
         public static void WriteUInt16LittleEndian(Span<byte> buffer, ushort value) { throw null; }
+        [CLSCompliant(false)]
         public static void WriteUInt32LittleEndian(Span<byte> buffer, uint value) { throw null; }
+        [CLSCompliant(false)]
         public static void WriteUInt64LittleEndian(Span<byte> buffer, ulong value) { throw null; }
 
         public static bool TryWriteInt16LittleEndian(Span<byte> buffer, short value) { throw null; }
         public static bool TryWriteInt32LittleEndian(Span<byte> buffer, int value) { throw null; }
         public static bool TryWriteInt64LittleEndian(Span<byte> buffer, long value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryWriteUInt16LittleEndian(Span<byte> buffer, ushort value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryWriteUInt32LittleEndian(Span<byte> buffer, uint value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryWriteUInt64LittleEndian(Span<byte> buffer, ulong value) { throw null; }
 
         public static void WriteInt16BigEndian(Span<byte> buffer, short value) { throw null; }
         public static void WriteInt32BigEndian(Span<byte> buffer, int value) { throw null; }
         public static void WriteInt64BigEndian(Span<byte> buffer, long value) { throw null; }
+        [CLSCompliant(false)]
         public static void WriteUInt16BigEndian(Span<byte> buffer, ushort value) { throw null; }
+        [CLSCompliant(false)]
         public static void WriteUInt32BigEndian(Span<byte> buffer, uint value) { throw null; }
+        [CLSCompliant(false)]
         public static void WriteUInt64BigEndian(Span<byte> buffer, ulong value) { throw null; }
 
         public static bool TryWriteInt16BigEndian(Span<byte> buffer, short value) { throw null; }
         public static bool TryWriteInt32BigEndian(Span<byte> buffer, int value) { throw null; }
         public static bool TryWriteInt64BigEndian(Span<byte> buffer, long value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryWriteUInt16BigEndian(Span<byte> buffer, ushort value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryWriteUInt32BigEndian(Span<byte> buffer, uint value) { throw null; }
+        [CLSCompliant(false)]
         public static bool TryWriteUInt64BigEndian(Span<byte> buffer, ulong value) { throw null; }
     }
 }
@@ -346,11 +378,15 @@ namespace System.Buffers.Text
         public static bool TryFormat(short value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
         public static bool TryFormat(int value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
         public static bool TryFormat(long value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
+        [CLSCompliant(false)]
         public static bool TryFormat(sbyte value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
         public static bool TryFormat(float value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
         public static bool TryFormat(TimeSpan value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
+        [CLSCompliant(false)]
         public static bool TryFormat(ushort value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
+        [CLSCompliant(false)]
         public static bool TryFormat(uint value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
+        [CLSCompliant(false)]
         public static bool TryFormat(ulong value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
     }
     public static class Utf8Parser
@@ -365,11 +401,15 @@ namespace System.Buffers.Text
         public static bool TryParse(ReadOnlySpan<byte> text, out short value, out int bytesConsumed, char standardFormat = default) => throw null;
         public static bool TryParse(ReadOnlySpan<byte> text, out int value, out int bytesConsumed, char standardFormat = default) => throw null;
         public static bool TryParse(ReadOnlySpan<byte> text, out long value, out int bytesConsumed, char standardFormat = default) => throw null;
+        [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> text, out sbyte value, out int bytesConsumed, char standardFormat = default) => throw null;
         public static bool TryParse(ReadOnlySpan<byte> text, out float value, out int bytesConsumed, char standardFormat = default) => throw null;
         public static bool TryParse(ReadOnlySpan<byte> text, out TimeSpan value, out int bytesConsumed, char standardFormat = default) => throw null;
+        [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> text, out ushort value, out int bytesConsumed, char standardFormat = default) => throw null;
+        [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed, char standardFormat = default) => throw null;
+        [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> text, out ulong value, out int bytesConsumed, char standardFormat = default) => throw null;
     }
 }

--- a/src/System.Memory/ref/System.Memory.csproj
+++ b/src/System.Memory/ref/System.Memory.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLSCompliant>false</CLSCompliant>
     <ProjectGuid>{E883935B-D8FD-4FC9-A189-9D9E7F7EF550}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' Or '$(TargetGroup)' == 'uap'">true</IsPartialFacadeAssembly>
   </PropertyGroup>

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{4BBC8F69-D03E-4432-AA8A-D458FA5B235A}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLSCompliant>false</CLSCompliant>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">true</IsPartialFacadeAssembly>
     <DefineConstants Condition="'$(IsPartialFacadeAssembly)' != 'true'">$(DefineConstants);netstandard</DefineConstants>

--- a/src/System.Memory/src/System/Buffers/Binary/Reader.cs
+++ b/src/System.Memory/src/System/Buffers/Binary/Reader.cs
@@ -21,6 +21,7 @@ namespace System.Buffers.Binary
         /// This allows the caller to read a struct of numeric primitives and reverse each field
         /// rather than having to skip sbyte fields.
         /// </summary> 
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static sbyte ReverseEndianness(sbyte value)
         {
@@ -62,6 +63,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reverses a primitive value - performs an endianness swap
         /// </summary> 
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ReverseEndianness(ushort value)
         {
@@ -71,6 +73,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reverses a primitive value - performs an endianness swap
         /// </summary> 
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ReverseEndianness(uint value)
         {
@@ -82,6 +85,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reverses a primitive value - performs an endianness swap
         /// </summary> 
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ReverseEndianness(ulong value)
         {

--- a/src/System.Memory/src/System/Buffers/Binary/ReaderBigEndian.cs
+++ b/src/System.Memory/src/System/Buffers/Binary/ReaderBigEndian.cs
@@ -53,6 +53,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a UInt16 out of a read-only span of bytes as big endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ReadUInt16BigEndian(ReadOnlySpan<byte> buffer)
         {
@@ -67,6 +68,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a UInt32 out of a read-only span of bytes as big endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ReadUInt32BigEndian(ReadOnlySpan<byte> buffer)
         {
@@ -81,6 +83,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a UInt64 out of a read-only span of bytes as big endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ReadUInt64BigEndian(ReadOnlySpan<byte> buffer)
         {
@@ -141,6 +144,7 @@ namespace System.Buffers.Binary
         /// Reads a UInt16 out of a read-only span of bytes as big endian.
         /// <returns>If the span is too small to contain a UInt16, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt16BigEndian(ReadOnlySpan<byte> buffer, out ushort value)
         {
@@ -156,6 +160,7 @@ namespace System.Buffers.Binary
         /// Reads a UInt32 out of a read-only span of bytes as big endian.
         /// <returns>If the span is too small to contain a UInt32, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt32BigEndian(ReadOnlySpan<byte> buffer, out uint value)
         {
@@ -171,6 +176,7 @@ namespace System.Buffers.Binary
         /// Reads a UInt64 out of a read-only span of bytes as big endian.
         /// <returns>If the span is too small to contain a UInt64, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt64BigEndian(ReadOnlySpan<byte> buffer, out ulong value)
         {

--- a/src/System.Memory/src/System/Buffers/Binary/ReaderLittleEndian.cs
+++ b/src/System.Memory/src/System/Buffers/Binary/ReaderLittleEndian.cs
@@ -53,6 +53,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a UInt16 out of a read-only span of bytes as little endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ReadUInt16LittleEndian(ReadOnlySpan<byte> buffer)
         {
@@ -67,6 +68,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a UInt32 out of a read-only span of bytes as little endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ReadUInt32LittleEndian(ReadOnlySpan<byte> buffer)
         {
@@ -81,6 +83,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a UInt64 out of a read-only span of bytes as little endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ReadUInt64LittleEndian(ReadOnlySpan<byte> buffer)
         {
@@ -141,6 +144,7 @@ namespace System.Buffers.Binary
         /// Reads a UInt16 out of a read-only span of bytes as little endian.
         /// <returns>If the span is too small to contain a UInt16, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt16LittleEndian(ReadOnlySpan<byte> buffer, out ushort value)
         {
@@ -156,6 +160,7 @@ namespace System.Buffers.Binary
         /// Reads a UInt32 out of a read-only span of bytes as little endian.
         /// <returns>If the span is too small to contain a UInt32, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt32LittleEndian(ReadOnlySpan<byte> buffer, out uint value)
         {
@@ -171,6 +176,7 @@ namespace System.Buffers.Binary
         /// Reads a UInt64 out of a read-only span of bytes as little endian.
         /// <returns>If the span is too small to contain a UInt64, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt64LittleEndian(ReadOnlySpan<byte> buffer, out ulong value)
         {

--- a/src/System.Memory/src/System/Buffers/Binary/WriterBigEndian.cs
+++ b/src/System.Memory/src/System/Buffers/Binary/WriterBigEndian.cs
@@ -50,6 +50,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a UInt16 into a span of bytes as big endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt16BigEndian(Span<byte> buffer, ushort value)
         {
@@ -63,6 +64,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a UInt32 into a span of bytes as big endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt32BigEndian(Span<byte> buffer, uint value)
         {
@@ -76,6 +78,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a UInt64 into a span of bytes as big endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt64BigEndian(Span<byte> buffer, ulong value)
         {
@@ -132,6 +135,7 @@ namespace System.Buffers.Binary
         /// Write a UInt16 into a span of bytes as big endian.
         /// <returns>If the span is too small to contain the value, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt16BigEndian(Span<byte> buffer, ushort value)
         {
@@ -146,6 +150,7 @@ namespace System.Buffers.Binary
         /// Write a UInt32 into a span of bytes as big endian.
         /// <returns>If the span is too small to contain the value, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt32BigEndian(Span<byte> buffer, uint value)
         {
@@ -160,6 +165,7 @@ namespace System.Buffers.Binary
         /// Write a UInt64 into a span of bytes as big endian.
         /// <returns>If the span is too small to contain the value, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt64BigEndian(Span<byte> buffer, ulong value)
         {

--- a/src/System.Memory/src/System/Buffers/Binary/WriterLittleEndian.cs
+++ b/src/System.Memory/src/System/Buffers/Binary/WriterLittleEndian.cs
@@ -50,6 +50,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a UInt16 into a span of bytes as little endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt16LittleEndian(Span<byte> buffer, ushort value)
         {
@@ -63,6 +64,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a UInt32 into a span of bytes as little endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt32LittleEndian(Span<byte> buffer, uint value)
         {
@@ -76,6 +78,7 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a UInt64 into a span of bytes as little endian.
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt64LittleEndian(Span<byte> buffer, ulong value)
         {
@@ -132,6 +135,7 @@ namespace System.Buffers.Binary
         /// Write a UInt16 into a span of bytes as little endian.
         /// <returns>If the span is too small to contain the value, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt16LittleEndian(Span<byte> buffer, ushort value)
         {
@@ -146,6 +150,7 @@ namespace System.Buffers.Binary
         /// Write a UInt32 into a span of bytes as little endian.
         /// <returns>If the span is too small to contain the value, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt32LittleEndian(Span<byte> buffer, uint value)
         {
@@ -160,6 +165,7 @@ namespace System.Buffers.Binary
         /// Write a UInt64 into a span of bytes as little endian.
         /// <returns>If the span is too small to contain the value, return false.</returns>
         /// </summary>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt64LittleEndian(Span<byte> buffer, ulong value)
         {

--- a/src/System.Memory/src/System/Buffers/MemoryHandle.cs
+++ b/src/System.Memory/src/System/Buffers/MemoryHandle.cs
@@ -22,6 +22,7 @@ namespace System.Buffers
         /// <param name="retainable">reference to manually managed object</param>
         /// <param name="pointer">pointer to memory, or null if a pointer was not provided when the handle was created</param>
         /// <param name="handle">handle used to pin array buffers</param>
+        [CLSCompliant(false)]
         public MemoryHandle(IRetainable retainable, void* pointer = null, GCHandle handle = default(GCHandle))
         {
             _retainable = retainable;
@@ -32,6 +33,7 @@ namespace System.Buffers
         /// <summary>
         /// Returns the pointer to memory, or null if a pointer was not provided when the handle was created.
         /// </summary>
+        [CLSCompliant(false)]
         public void* Pointer => _pointer;
 
         /// <summary>

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.cs
@@ -57,6 +57,7 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
+        [CLSCompliant(false)]
         public static bool TryFormat(sbyte value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default)
             => TryFormatInt64(value, 0xff, buffer, out bytesWritten, format);
 
@@ -81,6 +82,7 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
+        [CLSCompliant(false)]
         public static bool TryFormat(ushort value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default)
             => TryFormatUInt64(value, buffer, out bytesWritten, format);
 
@@ -129,6 +131,7 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
+        [CLSCompliant(false)]
         public static bool TryFormat(uint value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default)
             => TryFormatUInt64(value, buffer, out bytesWritten, format);
 
@@ -177,6 +180,7 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
+        [CLSCompliant(false)]
         public static bool TryFormat(ulong value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default)
             => TryFormatUInt64(value, buffer, out bytesWritten, format);
 

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.cs
@@ -32,6 +32,7 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
+        [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> text, out sbyte value, out int bytesConsumed, char standardFormat = default)
         {
             switch (standardFormat)

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
@@ -72,6 +72,7 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
+        [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> text, out ushort value, out int bytesConsumed, char standardFormat = default)
         {
             switch (standardFormat)
@@ -117,6 +118,7 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
+        [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed, char standardFormat = default)
         {
             switch (standardFormat)
@@ -162,6 +164,7 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
+        [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> text, out ulong value, out int bytesConsumed, char standardFormat = default)
         {
             switch (standardFormat)

--- a/src/System.Memory/src/System/ReadOnlySpan.cs
+++ b/src/System.Memory/src/System/ReadOnlySpan.cs
@@ -77,6 +77,7 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="length"/> is negative.
         /// </exception>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe ReadOnlySpan(void* pointer, int length)
         {

--- a/src/System.Memory/src/System/Span.cs
+++ b/src/System.Memory/src/System/Span.cs
@@ -81,6 +81,7 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="length"/> is negative.
         /// </exception>
+        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe Span(void* pointer, int length)
         {


### PR DESCRIPTION
It's there in the coreclr version but not in the corefx version:
- https://github.com/dotnet/coreclr/blob/3c0149df881a3846af3405013db530551308cfbe/src/mscorlib/shared/System/ReadOnlySpan.cs#L85
- https://github.com/dotnet/coreclr/blob/3c0149df881a3846af3405013db530551308cfbe/src/mscorlib/shared/System/Span.cs#L97

Otherwise we'd get `error CS3001: Argument type 'void*' is not CLS-compliant` when using the file in Mono.