### PR TITLE
Speed up Windows ProcessManager.OpenProcess

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -195,7 +195,8 @@ namespace System.Diagnostics
             }
 
             // If the handle is invalid because the process has exited, only throw an exception if throwIfExited is true.            
-            if (!IsProcessRunning(processId))
+            // Assume the process is still running if the error was ERROR_ACCESS_DENIED for better performance
+            if (result != Interop.Errors.ERROR_ACCESS_DENIED && !IsProcessRunning(processId))
             {
                 if (throwIfExited)
                 {


### PR DESCRIPTION
If a process is running as a normal user (not elevated), many calls to
`kernel32.OpenProcess` fail.

In `ProcessManager.OpenProcess`, when the first call to `kernel32.OpenProcess`
fails, another call is made indirectly in `ProcessManager.IsProcessRunning`
which will also fail.

When `ProcessManager.IsProcessRunning` can't get a handle to the process, it
falls back on a much more expensive check - enumerating all processes.

The fix is to assume the process is running if the error code is
ERROR_ACCESS_DENIED.

This performance issue adds roughly 1 second of overhead when running
`Get-Process` in an interactive non-elevated PowerShell session where
the CPU property is displayed.