### PR TITLE
Fix NetworkStream.Write() when UNIX signal interrupts the system call

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -381,9 +381,16 @@ namespace System.Net.Sockets
 
                 try
                 {
-                    // Since the socket is in blocking mode this will always complete
+                    // Since the socket is in blocking mode this should complete
                     // after ALL the requested number of bytes was transferred.
-                    _streamSocket.Send(buffer, offset, size, SocketFlags.None);
+                    // On UNIX systems we can be interrupted by a signal, so we
+                    // have to make sure it really was.
+                    while (size > 0)
+                    {
+                        int result = _streamSocket.Send(buffer, offset, size, SocketFlags.None);
+                        size -= result;
+                        offset += result;
+                    }
                 }
                 catch (Exception exception) when (!(exception is OutOfMemoryException))
                 {


### PR DESCRIPTION
Comment in the code has stated, that since the socket is in the blocking mode send() operation will always complete after all requested bytes were transferred. On UNIX systems send() system call can be interrupted by a signal. This change makes sure that all bytes were transferred, even in case when the system call was interrupted.