### PR TITLE
Fixed failing test System.Data.Tests.AppDomainsAndFormatInfo.Bug55978

### DIFF
--- a/src/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -4041,7 +4041,7 @@ Assert.False(true);
 
             DataView dv = dt.DefaultView;
             dv.RowFilter = string.Format(CultureInfo.InvariantCulture,
-                                "StartDate >= '{0}' and StartDate <= '{1}'",
+                                "StartDate >= #{0}# and StartDate <= #{1}#",
                                 DateTime.Now.AddDays(2),
                                 DateTime.Now.AddDays(4));
             Assert.Equal(10, dt.Rows.Count);


### PR DESCRIPTION
Fixes #25409
Changed ' to # in RowFilter to fix broken test due to en-GB locale.
