### PR TITLE
Remove FEATURE_INTERPRET from System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -2,16 +2,11 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <!-- Enabling the interpreter for RC1 in all builds, see https://github.com/dotnet/corefx/issues/4033 -->
-    <FeatureInterpret>true</FeatureInterpret>
-  </PropertyGroup>
-  <PropertyGroup>
     <ProjectGuid>{AEF718E9-D4FC-418F-A7AE-ED6B2C7B3787}</ProjectGuid>
     <AssemblyName>System.Linq.Expressions</AssemblyName>
     <RootNamespace>System.Linq.Expressions</RootNamespace>
     <IsInterpreting Condition="'$(TargetGroup)' == 'uapaot'">true</IsInterpreting>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
-    <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
@@ -50,6 +45,7 @@
     </Compile>
     <Compile Include="System\Dynamic\Utils\CacheDict.cs" />
     <Compile Include="System\Dynamic\Utils\ContractUtils.cs" />
+    <Compile Include="System\Dynamic\Utils\DelegateHelpers.cs" />
     <Compile Include="System\Dynamic\Utils\ExpressionUtils.cs" />
     <Compile Include="System\Dynamic\Utils\ExpressionVisitorUtils.cs" />
     <Compile Include="System\Dynamic\Utils\ListArgumentProvider.cs" />
@@ -78,6 +74,51 @@
     <Compile Include="System\Linq\Expressions\IArgumentProvider.cs" />
     <Compile Include="System\Linq\Expressions\IDynamicExpression.cs" />
     <Compile Include="System\Linq\Expressions\IndexExpression.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\AddInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\AndInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\ArrayOperations.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\BranchLabel.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\CallInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\CallInstruction.Generated.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\ControlFlowInstructions.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\DecrementInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\DefaultValueInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\DivInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\EqualInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\ExclusiveOrInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\FieldOperations.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\GreaterThanInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\GreaterThanOrEqualInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\IncrementInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\Instruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\InstructionList.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\InterpretedFrame.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\Interpreter.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LabelInfo.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LeftShiftInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LessThanInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LessThanOrEqualInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LightCompiler.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LightDelegateCreator.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LightLambda.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LightLambda.Generated.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LocalAccess.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\LocalVariables.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\ModuloInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\MulInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\NegateInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\NewInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\NotEqualInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\NotInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\NumericConvertInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\NullCheckInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\OrInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\RightShiftInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\RuntimeVariables.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\StackOperations.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\SubInstruction.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\TypeOperations.cs" />
+    <Compile Include="System\Linq\Expressions\Interpreter\Utilities.cs" />
     <Compile Include="System\Linq\Expressions\InvocationExpression.cs" />
     <Compile Include="System\Linq\Expressions\IParameterProvider.cs" />
     <Compile Include="System\Linq\Expressions\LabelExpression.cs" />
@@ -110,8 +151,6 @@
     <Compile Include="System\Runtime\CompilerServices\RuntimeOps.RuntimeVariables.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeOps.MergedRuntimeVariables.cs" />
     <Compile Include="System\Runtime\CompilerServices\ReadOnlyCollectionBuilder.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="System\Linq\Expressions\DynamicExpressionVisitor.cs" />
     <Compile Include="System\Linq\Expressions\DynamicExpression.cs" />
     <Compile Include="System\Linq\Expressions\Compiler\TypeInfoExtensions.cs" />
@@ -193,54 +232,6 @@
     <Compile Include="System\Runtime\CompilerServices\Closure.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeOps.ExpressionQuoter.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeOps.RuntimeVariableList.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(IsInterpreting)' == 'true' Or '$(FeatureInterpret)' == 'true'">
-    <Compile Include="System\Dynamic\Utils\DelegateHelpers.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\AddInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\AndInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\ArrayOperations.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\BranchLabel.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\CallInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\CallInstruction.Generated.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\ControlFlowInstructions.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\DecrementInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\DefaultValueInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\DivInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\EqualInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\ExclusiveOrInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\FieldOperations.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\GreaterThanInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\GreaterThanOrEqualInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\IncrementInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\Instruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\InstructionList.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\InterpretedFrame.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\Interpreter.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\LabelInfo.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\LeftShiftInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\LessThanInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\LessThanOrEqualInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\LightCompiler.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\LightDelegateCreator.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\LightLambda.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\LightLambda.Generated.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\LocalAccess.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\LocalVariables.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\ModuloInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\MulInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\NegateInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\NewInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\NotEqualInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\NotInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\NumericConvertInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\NullCheckInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\OrInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\RightShiftInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\RuntimeVariables.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\StackOperations.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\SubInstruction.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\TypeOperations.cs" />
-    <Compile Include="System\Linq\Expressions\Interpreter\Utilities.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -107,10 +107,7 @@ namespace System.Linq.Expressions
         /// Produces a delegate that represents the lambda expression.
         /// </summary>
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
-        public Delegate Compile()
-        {
-            return Compile(preferInterpretation: false);
-        }
+        public Delegate Compile() => Compile(preferInterpretation: false);
 
         /// <summary>
         /// Produces a delegate that represents the lambda expression.
@@ -120,16 +117,12 @@ namespace System.Linq.Expressions
         public Delegate Compile(bool preferInterpretation)
         {
 #if FEATURE_COMPILE
-#if FEATURE_INTERPRET
-            if (preferInterpretation)
+            if (!preferInterpretation)
             {
-                return new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+                return Compiler.LambdaCompiler.Compile(this);
             }
 #endif
-            return Compiler.LambdaCompiler.Compile(this);
-#else
             return new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
-#endif
         }
 
 #if FEATURE_COMPILE_TO_METHODBUILDER
@@ -187,30 +180,14 @@ namespace System.Linq.Expressions
         /// Produces a delegate that represents the lambda expression.
         /// </summary>
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
-        public new TDelegate Compile()
-        {
-            return Compile(preferInterpretation: false);
-        }
+        public new TDelegate Compile() => Compile(preferInterpretation: false);
 
         /// <summary>
         /// Produces a delegate that represents the lambda expression.
         /// </summary>
         /// <param name="preferInterpretation">A <see cref="bool"/> that indicates if the expression should be compiled to an interpreted form, if available.</param>
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
-        public new TDelegate Compile(bool preferInterpretation)
-        {
-#if FEATURE_COMPILE
-#if FEATURE_INTERPRET
-            if (preferInterpretation)
-            {
-                return (TDelegate)(object)new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
-            }
-#endif
-            return (TDelegate)(object)Compiler.LambdaCompiler.Compile(this);
-#else
-            return (TDelegate)(object)new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
-#endif
-        }
+        public new TDelegate Compile(bool preferInterpretation) => (TDelegate)(object)base.Compile(preferInterpretation);
 
         /// <summary>
         /// Creates a new expression that is like this one, but using the

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -249,7 +249,7 @@ namespace System.Linq.Expressions.Tests
     {
         private static readonly IEnumerable<object[]> Booleans = new[]
         {
-#if FEATURE_COMPILE && FEATURE_INTERPRET
+#if FEATURE_COMPILE
             new object[] {false},
 #endif
             new object[] {true},
@@ -457,11 +457,9 @@ namespace System.Linq.Expressions.Tests
         {
 #if FEATURE_COMPILE
             expression.VerifyIL(il);
-#endif
 
             // FEATURE_COMPILE is not directly required, 
             // but this functionality relies on private reflection and that would not work with AOT
-#if FEATURE_INTERPRET && FEATURE_COMPILE
             expression.VerifyInstructions(instructions);
 #endif
         }

--- a/src/System.Linq.Expressions/tests/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/InterpreterTests.cs
@@ -4,7 +4,7 @@
 
 // FEATURE_COMPILE is not directly required, 
 // but this functionality relies on private reflection and that would not work with AOT
-#if FEATURE_INTERPRET && FEATURE_COMPILE
+#if FEATURE_COMPILE
 
 using System.Linq.Expressions.Interpreter;
 using System.Reflection;

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -2,14 +2,9 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <!-- Enabling the interpreter for RC1 in all builds, see https://github.com/dotnet/corefx/issues/4033 -->
-    <FeatureInterpret>true</FeatureInterpret>
-  </PropertyGroup>
-  <PropertyGroup>
     <ProjectGuid>{4B4AA59B-89F9-4A34-B3C3-C97EF531EE00}</ProjectGuid>
     <IsInterpreting Condition="'$(TargetGroup)' == 'uapaot'">true</IsInterpreting>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
-    <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
     <IncludeDefaultReferences>false</IncludeDefaultReferences>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />

--- a/src/System.Linq.Expressions/tests/TestExtensions/InlinePerCompilationTypeAttribute.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/InlinePerCompilationTypeAttribute.cs
@@ -12,10 +12,10 @@ namespace System.Linq.Expressions.Tests
     {
         private static readonly object[] s_boxedBooleans =
         {
+#if FEATURE_COMPILE
             false,
-#if FEATURE_COMPILE && FEATURE_INTERPRET
-            true
 #endif
+            true
         };
 
         private readonly object[] _data;

--- a/src/System.Linq.Expressions/tests/TestExtensions/PerCompilationTypeAttribute.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/PerCompilationTypeAttribute.cs
@@ -37,17 +37,13 @@ namespace System.Linq.Expressions.Tests
                 object[] withFalse = new object[received.Length + 1];
 #endif
 
-#if FEATURE_INTERPRET
                 object[] withTrue = new object[received.Length + 1];
-#endif
 
 #if FEATURE_COMPILE
                 withFalse[received.Length] = s_boxedFalse;
 #endif
 
-#if FEATURE_INTERPRET
                 withTrue[received.Length] = s_boxedTrue;
-#endif
 
                 for (int i = 0; i != received.Length; ++i)
                 {
@@ -57,18 +53,14 @@ namespace System.Linq.Expressions.Tests
                     withFalse[i] = arg;
 #endif
 
-#if FEATURE_INTERPRET
                     withTrue[i] = arg;
-#endif
                 }
 
 #if FEATURE_COMPILE
                 yield return withFalse;
 #endif
 
-#if  FEATURE_INTERPRET
                 yield return withTrue;
-#endif
             }
         }
     }


### PR DESCRIPTION
Since it's been set on every build for some time, it no longer serves any purpose, and it existing implies it could perhaps not be set.