### PR TITLE
Remove code in Microsoft.CSharp related to casting method groups or unbound lambdas

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
@@ -129,11 +129,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private TypeArray RearrangeNamedArguments(TypeArray pta, MethPropWithInst mpwi,
             CType pTypeThrough, ArgInfos args)
         {
-            if (!args.fHasExprs)
-            {
-                return pta;
-            }
-
 #if DEBUG
             // We never have a named argument that is in a position in the argument
             // list past the end of what would be the formal parameter list.
@@ -238,7 +233,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             int carg = args.carg;
             for (int i = 0; i < carg; i++)
             {
-                Expr arg = args.fHasExprs ? args.prgexpr[i] : null;
+                Expr arg = args.prgexpr[i];
                 CType p1 = pta1[i];
                 CType p2 = pta2[i];
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     {
         public int carg;
         public TypeArray types;
-        public bool fHasExprs;
         public List<Expr> prgexpr;
     }
 
@@ -1597,7 +1596,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         internal void FillInArgInfoFromArgList(ArgInfos argInfo, Expr args)
         {
             CType[] prgtype = new CType[argInfo.carg];
-            argInfo.fHasExprs = true;
             argInfo.prgexpr = new List<Expr>();
 
             int iarg = 0;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -938,15 +938,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                     // Try to infer. If we have an errorsym in the type arguments, we know we cant infer,
                     // but we want to attempt it anyway. We'll mark this as "cant infer" so that we can
-                    // report the appropriate error, but we'll continue inferring, since we want 
+                    // report the appropriate error, but we'll continue inferring, since we want
                     // error sym to go to any type.
 
-                    bool inferenceSucceeded;
-
-                    inferenceSucceeded = MethodTypeInferrer.Infer(
-                                _pExprBinder, GetSymbolLoader(),
-                                methSym, _pCurrentType.GetTypeArgsAll(), _pCurrentParameters,
-                                _pArguments, out _pCurrentTypeArgs);
+                    bool inferenceSucceeded = MethodTypeInferrer.Infer(
+                        _pExprBinder, GetSymbolLoader(), methSym, _pCurrentParameters, _pArguments,
+                        out _pCurrentTypeArgs);
 
                     if (!inferenceSucceeded)
                     {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -30,7 +30,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private readonly SymbolLoader _symbolLoader;
         private readonly ExpressionBinder _binder;
         private readonly TypeArray _pMethodTypeParameters;
-        private readonly TypeArray _pClassTypeArguments;
         private readonly TypeArray _pMethodFormalParameterTypes;
         private readonly ArgInfos _pMethodArguments;
         private readonly List<CType>[] _pExactBounds;
@@ -84,7 +83,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             ExpressionBinder binder,
             SymbolLoader symbolLoader,
             MethodSymbol pMethod,
-            TypeArray pClassTypeArguments,
             TypeArray pMethodFormalParameterTypes,
             ArgInfos pMethodArguments,
             out TypeArray ppInferredTypeArguments)
@@ -103,7 +101,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             var inferrer = new MethodTypeInferrer(binder, symbolLoader,
                 pMethodFormalParameterTypes, pMethodArguments,
-                pMethod.typeVars, pClassTypeArguments);
+                pMethod.typeVars);
             bool success;
             if (pMethodArguments.fHasExprs)
             {
@@ -130,14 +128,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private MethodTypeInferrer(
             ExpressionBinder exprBinder, SymbolLoader symLoader,
             TypeArray pMethodFormalParameterTypes, ArgInfos pMethodArguments,
-            TypeArray pMethodTypeParameters, TypeArray pClassTypeArguments)
+            TypeArray pMethodTypeParameters)
         {
             _binder = exprBinder;
             _symbolLoader = symLoader;
             _pMethodFormalParameterTypes = pMethodFormalParameterTypes;
             _pMethodArguments = pMethodArguments;
             _pMethodTypeParameters = pMethodTypeParameters;
-            _pClassTypeArguments = pClassTypeArguments;
             _pFixedResults = new CType[pMethodTypeParameters.Count];
             _pLowerBounds = new List<CType>[pMethodTypeParameters.Count];
             _pUpperBounds = new List<CType>[pMethodTypeParameters.Count];

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
@@ -198,30 +198,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             return _winrtifacesAll;
         }
-
-        public TypeArray GetDelegateParameters(SymbolLoader pSymbolLoader)
-        {
-            Debug.Assert(isDelegateType());
-            MethodSymbol invoke = pSymbolLoader.LookupInvokeMeth(getAggregate());
-            if (invoke == null || !invoke.isInvoke())
-            {
-                // This can happen if the delegate is internal to another assembly. 
-                return null;
-            }
-            return getAggregate().GetTypeManager().SubstTypeArray(invoke.Params, this);
-        }
-
-        public CType GetDelegateReturnType(SymbolLoader pSymbolLoader)
-        {
-            Debug.Assert(isDelegateType());
-            MethodSymbol invoke = pSymbolLoader.LookupInvokeMeth(getAggregate());
-            if (invoke == null || !invoke.isInvoke())
-            {
-                // This can happen if the delegate is internal to another assembly. 
-                return null;
-            }
-            return getAggregate().GetTypeManager().SubstType(invoke.RetType, this);
-        }
     }
 }
 


### PR DESCRIPTION
* Remove branches for inferring method group arguments to methods.

We can never have a method-group or bound lambda expression as an argument, so these branches can never find a result.

* Remove `MethodTypeInferrer._pClassTypeArguments`

Set, but never used.

* Remove `ArgInfos.fHasExprs` and paths for it being false.

Always set to true in `FillInArgInfoFromArgList` immediately after creation.

Removing the dead code this orphans removes `InferForMethodGroupConversion`, which dealt with passing generic method groups as arguments, and hence irrelevant to dynamic binding.