### PR TITLE
Replace instead of push to stack in S.L.Expressions interpreter.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
@@ -21,13 +21,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((sbyte)((sbyte)left & (sbyte)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((sbyte)((sbyte)left & (sbyte)right));
+                    }
+                }
+
                 return 1;
             }
         }
@@ -37,45 +43,63 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((short)((short)left & (short)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((short)((short)left & (short)right));
+                    }
+                }
+
                 return 1;
             }
-        }
+    }
 
         private sealed class AndInt32 : AndInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((int)left & (int)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((int)left & (int)right);
+                    }
+                }
+
                 return 1;
             }
-        }
+    }
 
         private sealed class AndInt64 : AndInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((long)left & (long)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((long)left & (long)right);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -85,13 +109,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((byte)((byte)left & (byte)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((byte)((byte)left & (byte)right));
+                    }
+                }
+
                 return 1;
             }
         }
@@ -101,13 +131,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((ushort)((ushort)left & (ushort)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((ushort)((ushort)left & (ushort)right));
+                    }
+                }
+
                 return 1;
             }
         }
@@ -117,13 +153,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((uint)left & (uint)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((uint)left & (uint)right);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -133,13 +175,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((ulong)left & (ulong)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((ulong)left & (ulong)right);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -149,25 +197,12 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
+                object left = frame.Peek();
+                if (left != null ? (bool)left : right != null && !(bool)right)
                 {
-                    if (right == null)
-                    {
-                        frame.Push(null);
-                    }
-                    else
-                    {
-                        frame.Push((bool)right ? null : Utils.BoxedFalse);
-                    }
-                    return 1;
+                    frame.Replace(right);
                 }
-                else if (right == null)
-                {
-                    frame.Push((bool)left ? null : Utils.BoxedFalse);
-                    return 1;
-                }
-                frame.Push((bool)left & (bool)right);
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
@@ -46,11 +46,11 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            int length = ConvertHelper.ToInt32NoNull(frame.Pop());
+            int length = ConvertHelper.ToInt32NoNull(frame.Peek());
             // To make behavior aligned with array creation emitted by C# compiler if length is less than
             // zero we try to use it to create an array, which will throw an OverflowException with the
             // correct localized error message.
-            frame.Push(length < 0 ? new int[length] : Array.CreateInstance(_elementType, length));
+            frame.Replace(length < 0 ? new int[length] : Array.CreateInstance(_elementType, length));
             return 1;
         }
     }
@@ -104,8 +104,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int Run(InterpretedFrame frame)
         {
             int index = ConvertHelper.ToInt32NoNull(frame.Pop());
-            Array array = (Array)frame.Pop();
-            frame.Push(array.GetValue(index));
+            frame.Replace(((Array)frame.Peek()).GetValue(index));
             return 1;
         }
     }
@@ -141,8 +140,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            object obj = frame.Pop();
-            frame.Push(((Array)obj).Length);
+            frame.Replace(((Array)frame.Peek()).Length);
             return 1;
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
@@ -21,15 +21,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked((short)((short)obj - 1)));
                 }
-                else
-                {
-                    frame.Push(unchecked((short)((short)obj - 1)));
-                }
+
                 return 1;
             }
         }
@@ -38,15 +35,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked((int)obj - 1));
                 }
-                else
-                {
-                    frame.Push(unchecked((int)obj - 1));
-                }
+
                 return 1;
             }
         }
@@ -55,15 +49,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked((long)obj - 1));
                 }
-                else
-                {
-                    frame.Push(unchecked((long)obj - 1));
-                }
+
                 return 1;
             }
         }
@@ -72,15 +63,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked((ushort)((ushort)obj - 1)));
                 }
-                else
-                {
-                    frame.Push(unchecked((ushort)((ushort)obj - 1)));
-                }
+
                 return 1;
             }
         }
@@ -89,15 +77,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked((uint)obj - 1));
                 }
-                else
-                {
-                    frame.Push(unchecked((uint)obj - 1));
-                }
+
                 return 1;
             }
         }
@@ -106,15 +91,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked((ulong)obj - 1));
                 }
-                else
-                {
-                    frame.Push(unchecked((ulong)obj - 1));
-                }
+
                 return 1;
             }
         }
@@ -123,15 +105,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace((float)obj - 1);
                 }
-                else
-                {
-                    frame.Push(unchecked((float)obj - 1));
-                }
+
                 return 1;
             }
         }
@@ -140,15 +119,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace((double)obj - 1);
                 }
-                else
-                {
-                    frame.Push(unchecked((double)obj - 1));
-                }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -24,19 +24,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((bool)left == (bool)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (bool)left == (bool)right);
                 return 1;
             }
         }
@@ -46,19 +35,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((sbyte)left == (sbyte)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (sbyte)left == (sbyte)right);
                 return 1;
             }
         }
@@ -68,19 +46,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((short)left == (short)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (short)left == (short)right);
                 return 1;
             }
         }
@@ -90,19 +57,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((char)left == (char)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (char)left == (char)right);
                 return 1;
             }
         }
@@ -112,19 +68,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((int)left == (int)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (int)left == (int)right);
                 return 1;
             }
         }
@@ -134,19 +79,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((long)left == (long)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (long)left == (long)right);
                 return 1;
             }
         }
@@ -156,19 +90,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((byte)left == (byte)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (byte)left == (byte)right);
                 return 1;
             }
         }
@@ -178,19 +101,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((ushort)left == (ushort)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (ushort)left == (ushort)right);
                 return 1;
             }
         }
@@ -200,19 +112,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((uint)left == (uint)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (uint)left == (uint)right);
                 return 1;
             }
         }
@@ -222,19 +123,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((ulong)left == (ulong)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (ulong)left == (ulong)right);
                 return 1;
             }
         }
@@ -244,19 +134,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((float)left == (float)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (float)left == (float)right);
                 return 1;
             }
         }
@@ -266,19 +145,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right == null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(false);
-                }
-                else
-                {
-                    frame.Push((double)left == (double)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left == right : (double)left == (double)right);
                 return 1;
             }
         }
@@ -287,7 +155,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                frame.Push(frame.Pop() == frame.Pop());
+                object right = frame.Pop();
+                frame.Replace(frame.Peek() == right);
                 return 1;
             }
         }
@@ -297,15 +166,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
-                else
+                else if (!(bool)right)
                 {
-                    frame.Push((bool)left == (bool)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace(!(bool)left);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -315,15 +188,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((sbyte)left == (sbyte)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((sbyte)left == (sbyte)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -333,15 +210,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((short)left == (short)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((short)left == (short)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -351,15 +232,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((char)left == (char)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((char)left == (char)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -369,15 +254,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((int)left == (int)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((int)left == (int)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -387,15 +276,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((long)left == (long)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((long)left == (long)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -405,15 +298,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((byte)left == (byte)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((byte)left == (byte)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -423,15 +320,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((ushort)left == (ushort)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((ushort)left == (ushort)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -441,15 +342,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((uint)left == (uint)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((uint)left == (uint)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -459,15 +364,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((ulong)left == (ulong)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((ulong)left == (ulong)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -477,15 +386,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((float)left == (float)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((float)left == (float)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -495,15 +408,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((double)left == (double)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((double)left == (double)right);
+                    }
                 }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
@@ -21,13 +21,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((sbyte)((sbyte)left ^ (sbyte)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((sbyte)((sbyte)left ^ (sbyte)right));
+                    }
+                }
+
                 return 1;
             }
         }
@@ -37,13 +43,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((short)((short)left ^ (short)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((short)((short)left ^ (short)right));
+                    }
+                }
+
                 return 1;
             }
         }
@@ -53,13 +65,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((int)left ^ (int)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((int)left ^ (int)right);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -69,13 +87,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((long)left ^ (long)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((long)left ^ (long)right);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -85,13 +109,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((byte)((byte)left ^ (byte)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((byte)((byte)left ^ (byte)right));
+                    }
+                }
+
                 return 1;
             }
         }
@@ -101,13 +131,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((ushort)((ushort)left ^ (ushort)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((ushort)((ushort)left ^ (ushort)right));
+                    }
+                }
+
                 return 1;
             }
         }
@@ -117,13 +153,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((uint)left ^ (uint)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((uint)left ^ (uint)right);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -133,13 +175,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((ulong)left ^ (ulong)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((ulong)left ^ (ulong)right);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -149,13 +197,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((bool)left ^ (bool)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((bool)left ^ (bool)right);
+                    }
+                }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
@@ -51,10 +51,10 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            object self = frame.Pop();
+            object self = frame.Peek();
 
             NullCheck(self);
-            frame.Push(_field.GetValue(self));
+            frame.Replace(_field.GetValue(self));
             return 1;
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -32,15 +32,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((sbyte)left > (sbyte)right);
+                    frame.Replace((sbyte)left > (sbyte)right);
                 }
+
                 return 1;
             }
         }
@@ -55,15 +56,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((short)left > (short)right);
+                    frame.Replace((short)left > (short)right);
                 }
+
                 return 1;
             }
         }
@@ -78,15 +80,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((char)left > (char)right);
+                    frame.Replace((char)left > (char)right);
                 }
+
                 return 1;
             }
         }
@@ -101,15 +104,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((int)left > (int)right);
+                    frame.Replace((int)left > (int)right);
                 }
+
                 return 1;
             }
         }
@@ -124,15 +128,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((long)left > (long)right);
+                    frame.Replace((long)left > (long)right);
                 }
+
                 return 1;
             }
         }
@@ -147,15 +152,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((byte)left > (byte)right);
+                    frame.Replace((byte)left > (byte)right);
                 }
+
                 return 1;
             }
         }
@@ -170,15 +176,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((ushort)left > (ushort)right);
+                    frame.Replace((ushort)left > (ushort)right);
                 }
+
                 return 1;
             }
         }
@@ -193,15 +200,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((uint)left > (uint)right);
+                    frame.Replace((uint)left > (uint)right);
                 }
+
                 return 1;
             }
         }
@@ -216,15 +224,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((ulong)left > (ulong)right);
+                    frame.Replace((ulong)left > (ulong)right);
                 }
+
                 return 1;
             }
         }
@@ -239,15 +248,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((float)left > (float)right);
+                    frame.Replace((float)left > (float)right);
                 }
+
                 return 1;
             }
         }
@@ -262,15 +272,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((double)left > (double)right);
+                    frame.Replace((double)left > (double)right);
                 }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
@@ -32,15 +32,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((sbyte)left >= (sbyte)right);
+                    frame.Replace((sbyte)left >= (sbyte)right);
                 }
+
                 return 1;
             }
         }
@@ -55,15 +56,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((short)left >= (short)right);
+                    frame.Replace((short)left >= (short)right);
                 }
+
                 return 1;
             }
         }
@@ -78,15 +80,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((char)left >= (char)right);
+                    frame.Replace((char)left >= (char)right);
                 }
+
                 return 1;
             }
         }
@@ -101,15 +104,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((int)left >= (int)right);
+                    frame.Replace((int)left >= (int)right);
                 }
+
                 return 1;
             }
         }
@@ -124,15 +128,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((long)left >= (long)right);
+                    frame.Replace((long)left >= (long)right);
                 }
+
                 return 1;
             }
         }
@@ -147,15 +152,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((byte)left >= (byte)right);
+                    frame.Replace((byte)left >= (byte)right);
                 }
+
                 return 1;
             }
         }
@@ -170,15 +176,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((ushort)left >= (ushort)right);
+                    frame.Replace((ushort)left >= (ushort)right);
                 }
+
                 return 1;
             }
         }
@@ -193,15 +200,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((uint)left >= (uint)right);
+                    frame.Replace((uint)left >= (uint)right);
                 }
+
                 return 1;
             }
         }
@@ -216,15 +224,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((ulong)left >= (ulong)right);
+                    frame.Replace((ulong)left >= (ulong)right);
                 }
+
                 return 1;
             }
         }
@@ -239,15 +248,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((float)left >= (float)right);
+                    frame.Replace((float)left >= (float)right);
                 }
+
                 return 1;
             }
         }
@@ -262,15 +272,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((double)left >= (double)right);
+                    frame.Replace((double)left >= (double)right);
                 }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
@@ -21,15 +21,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked((short)(1 + (short)obj)));
                 }
-                else
-                {
-                    frame.Push(unchecked((short)(1 + (short)obj)));
-                }
+
                 return 1;
             }
         }
@@ -38,15 +35,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked(1 + (int)obj));
                 }
-                else
-                {
-                    frame.Push(unchecked(1 + (int)obj));
-                }
+
                 return 1;
             }
         }
@@ -55,15 +49,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked(1 + (long)obj));
                 }
-                else
-                {
-                    frame.Push(unchecked(1 + (long)obj));
-                }
+
                 return 1;
             }
         }
@@ -72,15 +63,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked((ushort)(1 + (ushort)obj)));
                 }
-                else
-                {
-                    frame.Push(unchecked((ushort)(1 + (ushort)obj)));
-                }
+
                 return 1;
             }
         }
@@ -89,15 +77,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked(1 + (uint)obj));
                 }
-                else
-                {
-                    frame.Push(unchecked(1 + (uint)obj));
-                }
+
                 return 1;
             }
         }
@@ -106,15 +91,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked(1 + (ulong)obj));
                 }
-                else
-                {
-                    frame.Push(unchecked(1 + (ulong)obj));
-                }
+
                 return 1;
             }
         }
@@ -123,15 +105,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(1 + (float)obj);
                 }
-                else
-                {
-                    frame.Push(unchecked(1 + (float)obj));
-                }
+
                 return 1;
             }
         }
@@ -140,15 +119,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(1 + (double)obj);
                 }
-                else
-                {
-                    frame.Push(unchecked(1 + (double)obj));
-                }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -71,34 +71,44 @@ namespace System.Linq.Expressions.Interpreter
             Data[StackIndex++] = value;
         }
 
-        public void Push(bool value)
-        {
-            Data[StackIndex++] = value ? Utils.BoxedTrue : Utils.BoxedFalse;
-        }
-
         public void Push(int value)
         {
             Data[StackIndex++] = ScriptingRuntimeHelpers.Int32ToObject(value);
         }
 
-        public void Push(byte value)
+        public void Replace(object value)
         {
-            Data[StackIndex++] = value;
+            Data[StackIndex - 1] = value;
         }
 
-        public void Push(sbyte value)
+        public void Replace(bool value)
         {
-            Data[StackIndex++] = value;
+            Data[StackIndex - 1] = value ? Utils.BoxedTrue : Utils.BoxedFalse;
         }
 
-        public void Push(short value)
+        public void Replace(int value)
         {
-            Data[StackIndex++] = value;
+            Data[StackIndex - 1] = ScriptingRuntimeHelpers.Int32ToObject(value);
         }
 
-        public void Push(ushort value)
+        public void Replace(byte value)
         {
-            Data[StackIndex++] = value;
+            Data[StackIndex - 1] = value;
+        }
+
+        public void Replace(sbyte value)
+        {
+            Data[StackIndex - 1] = value;
+        }
+
+        public void Replace(short value)
+        {
+            Data[StackIndex - 1] = value;
+        }
+
+        public void Replace(ushort value)
+        {
+            Data[StackIndex - 1] = value;
         }
 
         public object Pop()

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
@@ -21,15 +21,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push(unchecked((sbyte)((sbyte)value << (int)shift)));
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace(unchecked((sbyte)((sbyte)value << (int)shift)));
+                    }
                 }
+
                 return 1;
             }
         }
@@ -39,15 +43,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push(unchecked((short)((short)value << (int)shift)));
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace(unchecked((short)((short)value << (int)shift)));
+                    }
                 }
+
                 return 1;
             }
         }
@@ -57,15 +65,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((int)value << (int)shift);
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((int)value << (int)shift);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -75,15 +87,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((long)value << (int)shift);
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((long)value << (int)shift);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -93,15 +109,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push(unchecked((byte)((byte)value << (int)shift)));
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace(unchecked((byte)((byte)value << (int)shift)));
+                    }
                 }
+
                 return 1;
             }
         }
@@ -111,15 +131,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push(unchecked((ushort)((ushort)value << (int)shift)));
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace(unchecked((ushort)((ushort)value << (int)shift)));
+                    }
                 }
+
                 return 1;
             }
         }
@@ -129,15 +153,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((uint)value << (int)shift);
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((uint)value << (int)shift);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -147,15 +175,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((ulong)value << (int)shift);
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((ulong)value << (int)shift);
+                    }
                 }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -32,15 +32,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((sbyte)left < (sbyte)right);
+                    frame.Replace((sbyte)left < (sbyte)right);
                 }
+
                 return 1;
             }
         }
@@ -55,15 +56,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((short)left < (short)right);
+                    frame.Replace((short)left < (short)right);
                 }
+
                 return 1;
             }
         }
@@ -78,15 +80,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((char)left < (char)right);
+                    frame.Replace((char)left < (char)right);
                 }
+
                 return 1;
             }
         }
@@ -101,15 +104,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((int)left < (int)right);
+                    frame.Replace((int)left < (int)right);
                 }
+
                 return 1;
             }
         }
@@ -124,15 +128,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((long)left < (long)right);
+                    frame.Replace((long)left < (long)right);
                 }
+
                 return 1;
             }
         }
@@ -147,15 +152,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((byte)left < (byte)right);
+                    frame.Replace((byte)left < (byte)right);
                 }
+
                 return 1;
             }
         }
@@ -170,15 +176,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((ushort)left < (ushort)right);
+                    frame.Replace((ushort)left < (ushort)right);
                 }
+
                 return 1;
             }
         }
@@ -193,15 +200,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((uint)left < (uint)right);
+                    frame.Replace((uint)left < (uint)right);
                 }
+
                 return 1;
             }
         }
@@ -216,15 +224,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((ulong)left < (ulong)right);
+                    frame.Replace((ulong)left < (ulong)right);
                 }
+
                 return 1;
             }
         }
@@ -239,15 +248,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((float)left < (float)right);
+                    frame.Replace((float)left < (float)right);
                 }
+
                 return 1;
             }
         }
@@ -262,15 +272,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((double)left < (double)right);
+                    frame.Replace((double)left < (double)right);
                 }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanOrEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanOrEqualInstruction.cs
@@ -32,15 +32,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((sbyte)left <= (sbyte)right);
+                    frame.Replace((sbyte)left <= (sbyte)right);
                 }
+
                 return 1;
             }
         }
@@ -55,15 +56,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((short)left <= (short)right);
+                    frame.Replace((short)left <= (short)right);
                 }
+
                 return 1;
             }
         }
@@ -78,15 +80,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((char)left <= (char)right);
+                    frame.Replace((char)left <= (char)right);
                 }
+
                 return 1;
             }
         }
@@ -101,15 +104,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((int)left <= (int)right);
+                    frame.Replace((int)left <= (int)right);
                 }
+
                 return 1;
             }
         }
@@ -124,15 +128,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((long)left <= (long)right);
+                    frame.Replace((long)left <= (long)right);
                 }
+
                 return 1;
             }
         }
@@ -147,15 +152,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((byte)left <= (byte)right);
+                    frame.Replace((byte)left <= (byte)right);
                 }
+
                 return 1;
             }
         }
@@ -170,15 +176,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((ushort)left <= (ushort)right);
+                    frame.Replace((ushort)left <= (ushort)right);
                 }
+
                 return 1;
             }
         }
@@ -193,15 +200,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((uint)left <= (uint)right);
+                    frame.Replace((uint)left <= (uint)right);
                 }
+
                 return 1;
             }
         }
@@ -216,15 +224,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((ulong)left <= (ulong)right);
+                    frame.Replace((ulong)left <= (ulong)right);
                 }
+
                 return 1;
             }
         }
@@ -239,15 +248,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((float)left <= (float)right);
+                    frame.Replace((float)left <= (float)right);
                 }
+
                 return 1;
             }
         }
@@ -262,15 +272,16 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                object left = frame.Peek();
+                if (left == null | right == null)
                 {
-                    frame.Push(_nullValue);
+                    frame.Replace(_nullValue);
                 }
                 else
                 {
-                    frame.Push((double)left <= (double)right);
+                    frame.Replace((double)left <= (double)right);
                 }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -225,8 +225,8 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            object o = frame.Pop();
-            frame.Push(o == null ? o : RuntimeHelpers.GetObjectValue(o));
+            object o = frame.Peek();
+            frame.Replace(RuntimeHelpers.GetObjectValue(o));
             return 1;
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
@@ -21,15 +21,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked((short)-(short)obj));
                 }
-                else
-                {
-                    frame.Push(unchecked((short)(-(short)obj)));
-                }
+
                 return 1;
             }
         }
@@ -38,15 +35,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked(-(int)obj));
                 }
-                else
-                {
-                    frame.Push(unchecked(-(int)obj));
-                }
+
                 return 1;
             }
         }
@@ -55,15 +49,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked(-(long)obj));
                 }
-                else
-                {
-                    frame.Push(unchecked(-(long)obj));
-                }
+
                 return 1;
             }
         }
@@ -72,15 +63,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(-(float)obj);
                 }
-                else
-                {
-                    frame.Push(-(float)obj);
-                }
+
                 return 1;
             }
         }
@@ -89,15 +77,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(-(double)obj);
                 }
-                else
-                {
-                    frame.Push(-(double)obj);
-                }
+
                 return 1;
             }
         }
@@ -132,15 +117,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(checked(-(int)obj));
                 }
-                else
-                {
-                    frame.Push(checked(-(int)obj));
-                }
+
                 return 1;
             }
         }
@@ -149,15 +131,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(checked((short)-(short)obj));
                 }
-                else
-                {
-                    frame.Push(checked((short)(-(short)obj)));
-                }
+
                 return 1;
             }
         }
@@ -166,15 +145,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object obj = frame.Pop();
-                if (obj == null)
+                object obj = frame.Peek();
+                if (obj != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(checked(-(long)obj));
                 }
-                else
-                {
-                    frame.Push(checked(-(long)obj));
-                }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -24,19 +24,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((bool)left != (bool)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (bool)left != (bool)right);
                 return 1;
             }
         }
@@ -46,19 +35,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((sbyte)left != (sbyte)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (sbyte)left != (sbyte)right);
                 return 1;
             }
         }
@@ -68,19 +46,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((short)left != (short)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (short)left != (short)right);
                 return 1;
             }
         }
@@ -90,19 +57,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((char)left != (char)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (char)left != (char)right);
                 return 1;
             }
         }
@@ -112,19 +68,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((int)left != (int)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (int)left != (int)right);
                 return 1;
             }
         }
@@ -134,19 +79,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((long)left != (long)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (long)left != (long)right);
                 return 1;
             }
         }
@@ -156,19 +90,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((byte)left != (byte)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (byte)left != (byte)right);
                 return 1;
             }
         }
@@ -178,19 +101,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((ushort)left != (ushort)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (ushort)left != (ushort)right);
                 return 1;
             }
         }
@@ -200,19 +112,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((uint)left != (uint)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (uint)left != (uint)right);
                 return 1;
             }
         }
@@ -222,19 +123,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((ulong)left != (ulong)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (ulong)left != (ulong)right);
                 return 1;
             }
         }
@@ -244,19 +134,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((float)left != (float)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (float)left != (float)right);
                 return 1;
             }
         }
@@ -266,19 +145,8 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
-                {
-                    frame.Push(right != null);
-                }
-                else if (right == null)
-                {
-                    frame.Push(true);
-                }
-                else
-                {
-                    frame.Push((double)left != (double)right);
-                }
+                object left = frame.Peek();
+                frame.Replace(left == null | right == null ? left != right : (double)left != (double)right);
                 return 1;
             }
         }
@@ -287,7 +155,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                frame.Push(frame.Pop() != frame.Pop());
+                object right = frame.Pop();
+                frame.Replace(frame.Peek() != right);
                 return 1;
             }
         }
@@ -297,15 +166,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((sbyte)left != (sbyte)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((sbyte)left != (sbyte)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -315,15 +188,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((short)left != (short)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((short)left != (short)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -333,15 +210,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((char)left != (char)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((char)left != (char)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -351,15 +232,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((int)left != (int)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((int)left != (int)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -369,15 +254,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((long)left != (long)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((long)left != (long)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -387,15 +276,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((byte)left != (byte)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((byte)left != (byte)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -405,15 +298,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((ushort)left != (ushort)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((ushort)left != (ushort)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -423,15 +320,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((uint)left != (uint)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((uint)left != (uint)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -441,15 +342,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((ulong)left != (ulong)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((ulong)left != (ulong)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -459,15 +364,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((float)left != (float)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((float)left != (float)right);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -477,15 +386,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
+                if (right == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((double)left != (double)right);
+                    object left = frame.Peek();
+                    if (left != null)
+                    {
+                        frame.Replace((double)left != (double)right);
+                    }
                 }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
@@ -20,15 +20,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object value = frame.Peek();
+                if (value != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(!(bool)value);
                 }
-                else
-                {
-                    frame.Push(!(bool)value);
-                }
+
                 return 1;
             }
         }
@@ -37,15 +34,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object value = frame.Peek();
+                if (value != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(~(long)value);
                 }
-                else
-                {
-                    frame.Push(~(long)value);
-                }
+
                 return 1;
             }
         }
@@ -54,15 +48,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object value = frame.Peek();
+                if (value != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(~(int)value);
                 }
-                else
-                {
-                    frame.Push(~(int)value);
-                }
+
                 return 1;
             }
         }
@@ -71,15 +62,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object value = frame.Peek();
+                if (value != null)
                 {
-                    frame.Push(null);
+                    frame.Replace((short)~(short)value);
                 }
-                else
-                {
-                    frame.Push((short)(~(short)value));
-                }
+
                 return 1;
             }
         }
@@ -88,15 +76,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object value = frame.Peek();
+                if (value != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(~(ulong)value);
                 }
-                else
-                {
-                    frame.Push(~(ulong)value);
-                }
+
                 return 1;
             }
         }
@@ -105,15 +90,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object value = frame.Peek();
+                if (value != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(~(uint)value);
                 }
-                else
-                {
-                    frame.Push(~(uint)value);
-                }
+
                 return 1;
             }
         }
@@ -122,15 +104,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object value = frame.Peek();
+                if (value != null)
                 {
-                    frame.Push(null);
+                    frame.Replace((ushort)~(ushort)value);
                 }
-                else
-                {
-                    frame.Push(unchecked((ushort)(~(ushort)value)));
-                }
+
                 return 1;
             }
         }
@@ -139,15 +118,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object value = frame.Peek();
+                if (value != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked((byte)~(byte)value));
                 }
-                else
-                {
-                    frame.Push(unchecked((byte)(~(byte)value)));
-                }
+
                 return 1;
             }
         }
@@ -156,15 +132,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                object value = frame.Pop();
-                if (value == null)
+                object value = frame.Peek();
+                if (value != null)
                 {
-                    frame.Push(null);
+                    frame.Replace(unchecked((sbyte)~(sbyte)value));
                 }
-                else
-                {
-                    frame.Push((sbyte)(~(sbyte)value));
-                }
+
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
@@ -20,15 +20,10 @@ namespace System.Linq.Expressions.Interpreter
 
         public sealed override int Run(InterpretedFrame frame)
         {
-            object obj = frame.Pop();
-            object converted;
+            object obj = frame.Peek();
             if (obj == null)
             {
-                if (_isLiftedToNull)
-                {
-                    converted = null;
-                }
-                else
+                if (!_isLiftedToNull)
                 {
                     // We cannot have null in a non-lifted numeric context. Throw the exception
                     // about not Nullable object requiring a value.
@@ -37,10 +32,9 @@ namespace System.Linq.Expressions.Interpreter
             }
             else
             {
-                converted = Convert(obj);
+                frame.Replace(Convert(obj));
             }
 
-            frame.Push(converted);
             return 1;
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
@@ -21,13 +21,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((sbyte)((sbyte)left | (sbyte)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((sbyte)((sbyte)left | (sbyte)right));
+                    }
+                }
+
                 return 1;
             }
         }
@@ -37,13 +43,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((short)((short)left | (short)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((short)((short)left | (short)right));
+                    }
+                }
+
                 return 1;
             }
         }
@@ -53,13 +65,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((int)left | (int)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((int)left | (int)right);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -69,13 +87,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((long)left | (long)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((long)left | (long)right);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -85,13 +109,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((byte)((byte)left | (byte)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((byte)((byte)left | (byte)right));
+                    }
+                }
+
                 return 1;
             }
         }
@@ -101,13 +131,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((ushort)((ushort)left | (ushort)right));
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((ushort)((ushort)left | (ushort)right));
+                    }
+                }
+
                 return 1;
             }
         }
@@ -117,13 +153,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((uint)left | (uint)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((uint)left | (uint)right);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -133,13 +175,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object left = frame.Pop();
-                object right = frame.Pop();
-                if (left == null || right == null)
+                if (left == null)
                 {
-                    frame.Push(null);
-                    return 1;
+                    frame.Replace(null);
                 }
-                frame.Push((ulong)left | (ulong)right);
+                else
+                {
+                    object right = frame.Peek();
+                    if (right != null)
+                    {
+                        frame.Replace((ulong)left | (ulong)right);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -149,27 +197,12 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null)
+                object left = frame.Peek();
+                if (left != null ? !(bool)left : right == null || (bool)right)
                 {
-                    if (right == null)
-                    {
-                        frame.Push(null);
-                    }
-                    else
-                    {
-                        frame.Push((bool)right ? Utils.BoxedTrue : null);
-                    }
-                    return 1;
+                    frame.Replace(right);
                 }
 
-                if (right == null)
-                {
-                    frame.Push((bool)left ? Utils.BoxedTrue : null);
-                    return 1;
-                }
-
-                frame.Push((bool)left | (bool)right);
                 return 1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
@@ -21,15 +21,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((sbyte)((sbyte)value >> (int)shift));
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((sbyte)((sbyte)value >> (int)shift));
+                    }
                 }
+
                 return 1;
             }
         }
@@ -39,15 +43,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((short)((short)value >> (int)shift));
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((short)((short)value >> (int)shift));
+                    }
                 }
+
                 return 1;
             }
         }
@@ -57,15 +65,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((int)value >> (int)shift);
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((int)value >> (int)shift);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -75,15 +87,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((long)value >> (int)shift);
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((long)value >> (int)shift);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -93,15 +109,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((byte)((byte)value >> (int)shift));
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((byte)((byte)value >> (int)shift));
+                    }
                 }
+
                 return 1;
             }
         }
@@ -111,15 +131,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((ushort)((ushort)value >> (int)shift));
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((ushort)((ushort)value >> (int)shift));
+                    }
                 }
+
                 return 1;
             }
         }
@@ -129,15 +153,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((uint)value >> (int)shift);
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((uint)value >> (int)shift);
+                    }
                 }
+
                 return 1;
             }
         }
@@ -147,15 +175,19 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object shift = frame.Pop();
-                object value = frame.Pop();
-                if (value == null || shift == null)
+                if (shift == null)
                 {
-                    frame.Push(null);
+                    frame.Replace(null);
                 }
                 else
                 {
-                    frame.Push((ulong)value >> (int)shift);
+                    object value = frame.Peek();
+                    if (value != null)
+                    {
+                        frame.Replace((ulong)value >> (int)shift);
+                    }
                 }
+
                 return 1;
             }
         }


### PR DESCRIPTION
The interpreter does a lot of stack pushes and pops, but very often pushing right after a pop, and often pushing the value just popped.

Offering a `Replace()` method means that not only can a `Peek`/`Replace` avoid changing the stack pointer, but often it can leave the stack alone, or short-circuit a lifted operation after examining only one operand.

Do so.