### PR TITLE
Correctly handle coalesce linq expressions that widen the rhs operand

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2583,7 +2583,7 @@ namespace System.Linq.Expressions.Interpreter
                 Type typeToCompare = node.Left.Type;
                 if (!node.Type.IsNullableType())
                 {
-                    typeToCompare = node.Left.Type.GetNonNullableType();
+                    typeToCompare = typeToCompare.GetNonNullableType();
                 }
 
                 if (!TypeUtils.AreEquivalent(node.Type, typeToCompare))

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2580,8 +2580,13 @@ namespace System.Linq.Expressions.Interpreter
                 // nullable value types with implicit (numeric) conversions which are allowed by Coalesce
                 // factory methods
 
-                Type nnLeftType = node.Left.Type.GetNonNullableType();
-                if (!TypeUtils.AreEquivalent(node.Type, nnLeftType))
+                Type typeToCompare = node.Left.Type;
+                if (!node.Type.IsNullableType())
+                {
+                    typeToCompare = node.Left.Type.GetNonNullableType();
+                }
+
+                if (!TypeUtils.AreEquivalent(node.Type, typeToCompare))
                 {
                     hasImplicitConversion = true;
                     hasConversion = true;
@@ -2601,6 +2606,12 @@ namespace System.Linq.Expressions.Interpreter
                 // skip over conversion on RHS
                 end = _instructions.MakeLabel();
                 _instructions.EmitBranch(end);
+            }
+            else if (node.Right.Type.IsValueType && !TypeUtils.AreEquivalent(node.Type, node.Right.Type))
+            {
+                // The right hand side may need to be widened to either the left hand side's type
+                // if the right hand side is nullable, or the left hand side's underlying type otherwise
+                CompileConvertToType(node.Right.Type, node.Type, isChecked: true, isLiftedToNull: node.Type.IsNullableType());
             }
 
             _instructions.MarkLabel(leftNotNull);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -525,5 +525,48 @@ namespace System.Linq.Expressions.Tests
         }
 #endif
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CoalesceWideningLeft(bool useInterpreter)
+        {
+            ParameterExpression x = Expression.Parameter(typeof(int?));
+            ParameterExpression y = Expression.Parameter(typeof(long));
+            Func<int?, long, long> func = Expression.Lambda<Func<int?, long, long>>(Expression.Coalesce(x, y), x, y).Compile(useInterpreter);
+            Assert.Equal(2, func(null, 2));
+            Assert.Equal(2, func(2, 1));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CoalesceWideningLeftNullableRight(bool useInterpreter)
+        {
+            ParameterExpression x = Expression.Parameter(typeof(int?));
+            ParameterExpression y = Expression.Parameter(typeof(long?));
+            Func<int?, long?, long?> func = Expression.Lambda<Func<int?, long?, long?>>(Expression.Coalesce(x, y), x, y).Compile(useInterpreter);
+            Assert.Equal(2, func(null, 2));
+            Assert.Equal(2, func(2, 1));
+            Assert.Equal(2, func(2, null));
+            Assert.Null(func(null, null));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CoalesceWideningRight(bool useInterpreter)
+        {
+            ParameterExpression x = Expression.Parameter(typeof(long?));
+            ParameterExpression y = Expression.Parameter(typeof(int));
+            Func<long?, int, long> func = Expression.Lambda<Func<long?, int, long>>(Expression.Coalesce(x, y), x, y).Compile(useInterpreter);
+            Assert.Equal(2, func(null, 2));
+            Assert.Equal(2, func(2, 1));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CoalesceWideningRightNullable(bool useInterpreter)
+        {
+            ParameterExpression x = Expression.Parameter(typeof(long?));
+            ParameterExpression y = Expression.Parameter(typeof(int?));
+            Func<long?, int?, long?> func = Expression.Lambda<Func<long?, int?, long?>>(Expression.Coalesce(x, y), x, y).Compile(useInterpreter);
+            Assert.Equal(2, func(null, 2));
+            Assert.Equal(2, func(2, 1));
+            Assert.Equal(2, func(2, null));
+            Assert.Null(func(null, null));
+        }
     }
 }


### PR DESCRIPTION
Fixes #25500