### PR TITLE
Stop Microsoft.CSharp getting confused by varargs overloads to callable members

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
          * Does NOT include ()
          */
 
-        private void ErrAppendParamList(TypeArray @params, bool isVarargs, bool isParamArray)
+        private void ErrAppendParamList(TypeArray @params, bool isParamArray)
         {
             if (null == @params)
                 return;
@@ -100,16 +100,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
                 // parameter type name
                 ErrAppendType(@params[i], null);
-            }
-
-            if (isVarargs)
-            {
-                if (@params.Count != 0)
-                {
-                    ErrAppendString(", ");
-                }
-
-                ErrAppendString("...");
             }
         }
 
@@ -291,7 +281,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 // append argument types
                 ErrAppendChar('(');
 
-                ErrAppendParamList(GetTypeManager().SubstTypeArray(meth.Params, pctx), meth.isVarargs, meth.isParamArray);
+                ErrAppendParamList(GetTypeManager().SubstTypeArray(meth.Params, pctx), meth.isParamArray);
 
                 ErrAppendChar(')');
             }
@@ -300,7 +290,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         private void ErrAppendIndexer(IndexerSymbol indexer, SubstContext pctx)
         {
             ErrAppendString("this[");
-            ErrAppendParamList(GetTypeManager().SubstTypeArray(indexer.Params, pctx), false, indexer.isParamArray);
+            ErrAppendParamList(GetTypeManager().SubstTypeArray(indexer.Params, pctx), indexer.isParamArray);
             ErrAppendChar(']');
         }
         private void ErrAppendProperty(PropertySymbol prop, SubstContext pctx)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
@@ -23,9 +23,9 @@ namespace Microsoft.CSharp.RuntimeBinder
         // or not members have been added to an AggSym or not.
         public static bool IsEquivalentTo(this MemberInfo mi1, MemberInfo mi2)
         {
-            if (mi1 == null || mi2 == null)
+            if (mi1 == null | mi2 == null)
             {
-                return mi1 == null && mi2 == null;
+                return mi1 == null & mi2 == null;
             }
 
 #if UNSUPPORTEDAPI
@@ -37,10 +37,8 @@ namespace Microsoft.CSharp.RuntimeBinder
                 return true;
             }
 
-            if (mi1 is MethodInfo && mi2 is MethodInfo)
+            if (mi1 is MethodInfo method1 && mi2 is MethodInfo method2)
             {
-                MethodInfo method1 = mi1 as MethodInfo;
-                MethodInfo method2 = mi2 as MethodInfo;
                 ParameterInfo[] pis1;
                 ParameterInfo[] pis2;
 
@@ -69,10 +67,8 @@ namespace Microsoft.CSharp.RuntimeBinder
                     && Enumerable.All(Enumerable.Zip(pis1, pis2, (pi1, pi2) => pi1.IsEquivalentTo(pi2, method1, method2)), x => x);
             }
 
-            if (mi1 is ConstructorInfo && mi2 is ConstructorInfo)
+            if (mi1 is ConstructorInfo ctor1 && mi2 is ConstructorInfo ctor2)
             {
-                ConstructorInfo ctor1 = mi1 as ConstructorInfo;
-                ConstructorInfo ctor2 = mi2 as ConstructorInfo;
                 ParameterInfo[] pis1;
                 ParameterInfo[] pis2;
 
@@ -83,11 +79,8 @@ namespace Microsoft.CSharp.RuntimeBinder
                     && Enumerable.All(Enumerable.Zip(pis1, pis2, (pi1, pi2) => pi1.IsEquivalentTo(pi2, ctor1, ctor2)), x => x);
             }
 
-            if (mi1 is PropertyInfo && mi2 is PropertyInfo)
+            if (mi1 is PropertyInfo prop1 && mi2 is PropertyInfo prop2)
             {
-                PropertyInfo prop1 = mi1 as PropertyInfo;
-                PropertyInfo prop2 = mi2 as PropertyInfo;
-
                 return prop1 != prop2
                     && prop1.Name == prop2.Name
                     && prop1.DeclaringType.IsGenericallyEqual(prop2.DeclaringType)
@@ -101,9 +94,9 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private static bool IsEquivalentTo(this ParameterInfo pi1, ParameterInfo pi2, MethodBase method1, MethodBase method2)
         {
-            if (pi1 == null || pi2 == null)
+            if (pi1 == null | pi2 == null)
             {
-                return pi1 == null && pi2 == null;
+                return pi1 == null & pi2 == null;
             }
 
             if (pi1.Equals(pi2))
@@ -116,9 +109,9 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private static bool IsGenericallyEqual(this Type t1, Type t2)
         {
-            if (t1 == null || t2 == null)
+            if (t1 == null | t2 == null)
             {
-                return t1 == null && t2 == null;
+                return t1 == null & t2 == null;
             }
 
             if (t1.Equals(t2))

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
@@ -37,9 +37,9 @@ namespace Microsoft.CSharp.RuntimeBinder
                 return true;
             }
 
-            if (mi1 is MethodInfo method1 && mi2 is MethodInfo method2)
+            if (mi1 is MethodInfo method1)
             {
-                if (method1.IsGenericMethod != method2.IsGenericMethod)
+                if (!(mi2 is MethodInfo method2) || method1.IsGenericMethod != method2.IsGenericMethod)
                 {
                     return false;
                 }
@@ -63,25 +63,22 @@ namespace Microsoft.CSharp.RuntimeBinder
                     && method1.AreParametersEquivalent(method2);
             }
 
-            if (mi1 is ConstructorInfo ctor1 && mi2 is ConstructorInfo ctor2)
+            if (mi1 is ConstructorInfo ctor1)
             {
-                return ctor1 != ctor2
+                return mi2 is ConstructorInfo ctor2
+                    && ctor1 != ctor2
                     && ctor1.CallingConvention == ctor2.CallingConvention
                     && ctor1.DeclaringType.IsGenericallyEqual(ctor2.DeclaringType)
                     && ctor1.AreParametersEquivalent(ctor2);
             }
 
-            if (mi1 is PropertyInfo prop1 && mi2 is PropertyInfo prop2)
-            {
-                return prop1 != prop2
-                    && prop1.Name == prop2.Name
-                    && prop1.DeclaringType.IsGenericallyEqual(prop2.DeclaringType)
-                    && prop1.PropertyType.IsGenericallyEquivalentTo(prop2.PropertyType, prop1, prop2)
-                    && prop1.GetGetMethod(true).IsEquivalentTo(prop2.GetGetMethod(true))
-                    && prop1.GetSetMethod(true).IsEquivalentTo(prop2.GetSetMethod(true));
-            }
-
-            return false;
+            return mi1 is PropertyInfo prop1 && mi2 is PropertyInfo prop2
+                && prop1 != prop2
+                && prop1.Name == prop2.Name
+                && prop1.DeclaringType.IsGenericallyEqual(prop2.DeclaringType)
+                && prop1.PropertyType.IsGenericallyEquivalentTo(prop2.PropertyType, prop1, prop2)
+                && prop1.GetGetMethod(true).IsEquivalentTo(prop2.GetGetMethod(true))
+                && prop1.GetSetMethod(true).IsEquivalentTo(prop2.GetSetMethod(true));
         }
 
         private static bool AreParametersEquivalent(this MethodBase method1, MethodBase method2)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
@@ -23,9 +23,9 @@ namespace Microsoft.CSharp.RuntimeBinder
         // or not members have been added to an AggSym or not.
         public static bool IsEquivalentTo(this MemberInfo mi1, MemberInfo mi2)
         {
-            if (mi1 == null | mi2 == null)
+            if (mi1 == null || mi2 == null)
             {
-                return mi1 == null & mi2 == null;
+                return mi1 == null && mi2 == null;
             }
 
 #if UNSUPPORTEDAPI
@@ -103,9 +103,9 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private static bool IsEquivalentTo(this ParameterInfo pi1, ParameterInfo pi2, MethodBase method1, MethodBase method2)
         {
-            if (pi1 == null | pi2 == null)
+            if (pi1 == null || pi2 == null)
             {
-                return pi1 == null & pi2 == null;
+                return pi1 == null && pi2 == null;
             }
 
             if (pi1.Equals(pi2))
@@ -118,9 +118,9 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private static bool IsGenericallyEqual(this Type t1, Type t2)
         {
-            if (t1 == null | t2 == null)
+            if (t1 == null || t2 == null)
             {
-                return t1 == null & t2 == null;
+                return t1 == null && t2 == null;
             }
 
             if (t1.Equals(t2))

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
@@ -61,6 +61,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 }
 
                 return method1 != method2
+                    && method1.CallingConvention == method2.CallingConvention
                     && method1.Name == method2.Name
                     && method1.DeclaringType.IsGenericallyEqual(method2.DeclaringType)
                     && method1.ReturnType.IsGenericallyEquivalentTo(method2.ReturnType, method1, method2)
@@ -76,6 +77,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 ParameterInfo[] pis2;
 
                 return ctor1 != ctor2
+                    && ctor1.CallingConvention == ctor2.CallingConvention
                     && ctor1.DeclaringType.IsGenericallyEqual(ctor2.DeclaringType)
                     && (pis1 = ctor1.GetParameters()).Length == (pis2 = ctor2.GetParameters()).Length
                     && Enumerable.All(Enumerable.Zip(pis1, pis2, (pi1, pi2) => pi1.IsEquivalentTo(pi2, ctor1, ctor2)), x => x);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CSharp.RuntimeBinder.Errors;
 using Microsoft.CSharp.RuntimeBinder.Syntax;
 
@@ -1349,7 +1350,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             MethodSymbol m = mp as MethodSymbol;
             int argCount = ExpressionIterator.Count(argsPtr);
 
-            Debug.Assert(m == null || !m.isVarargs); // We should never have picked a varargs method to bind to.
+            Debug.Assert(!@params.Items.Any(p => p is ArgumentListType)); // We should never have picked a varargs method to bind to.
 
             bool bDontFixParamArray = false;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1349,10 +1349,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             MethodSymbol m = mp as MethodSymbol;
             int argCount = ExpressionIterator.Count(argsPtr);
 
-            if (m != null && m.isVarargs)
-            {
-                paramCount--; // we don't care about the vararg sentinel
-            }
+            Debug.Assert(m == null || !m.isVarargs); // We should never have picked a varargs method to bind to.
 
             bool bDontFixParamArray = false;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
@@ -24,8 +24,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private EventSymbol _evt;     // For event accessors, this is the EventSymbol.
 
         public bool isVirtual;              // Virtual member?
-        public bool isAbstract;             // Abstract method?
-        public bool isVarargs;              // has varargs
         public MemberInfo AssociatedMemberInfo;
 
         public TypeArray typeVars;          // All the type variables for a generic method, as declarations.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1829,10 +1829,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 types.Add(GetTypeOfParameter(p, associatedInfo));
             }
 
-
-            if (associatedInfo is MethodInfo mi
-                ? (mi.CallingConvention & CallingConventions.VarArgs) != 0
-                : associatedInfo is ConstructorInfo ci && (ci.CallingConvention & CallingConventions.VarArgs) != 0)
+            if (associatedInfo is MethodBase mb && (mb.CallingConvention & CallingConventions.VarArgs) != 0)
             {
                 types.Add(_typeManager.GetArgListType());
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1589,7 +1589,6 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             methodSymbol.SetAccess(access);
             methodSymbol.isVirtual = member.IsVirtual;
-            methodSymbol.isAbstract = member.IsAbstract;
             methodSymbol.isStatic = member.IsStatic;
 
             if (method != null)
@@ -1598,7 +1597,6 @@ namespace Microsoft.CSharp.RuntimeBinder
                 methodSymbol.isOverride = method.IsVirtual && method.IsHideBySig && method.GetRuntimeBaseDefinition() != method;
                 methodSymbol.isOperator = IsOperator(method);
                 methodSymbol.swtSlot = GetSlotForOverride(method);
-                methodSymbol.isVarargs = (method.CallingConvention & CallingConventions.VarArgs) == CallingConventions.VarArgs;
                 methodSymbol.RetType = GetCTypeFromType(method.ReturnType);
             }
             else
@@ -1607,7 +1605,6 @@ namespace Microsoft.CSharp.RuntimeBinder
                 methodSymbol.isOverride = false;
                 methodSymbol.isOperator = false;
                 methodSymbol.swtSlot = null;
-                methodSymbol.isVarargs = (((ConstructorInfo)member).CallingConvention & CallingConventions.VarArgs) != 0;
                 methodSymbol.RetType = _typeManager.GetVoid();
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1607,7 +1607,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 methodSymbol.isOverride = false;
                 methodSymbol.isOperator = false;
                 methodSymbol.swtSlot = null;
-                methodSymbol.isVarargs = false;
+                methodSymbol.isVarargs = (((ConstructorInfo)member).CallingConvention & CallingConventions.VarArgs) != 0;
                 methodSymbol.RetType = _typeManager.GetVoid();
             }
 
@@ -1832,9 +1832,10 @@ namespace Microsoft.CSharp.RuntimeBinder
                 types.Add(GetTypeOfParameter(p, associatedInfo));
             }
 
-            MethodInfo mi = associatedInfo as MethodInfo;
 
-            if (mi != null && (mi.CallingConvention & CallingConventions.VarArgs) == CallingConventions.VarArgs)
+            if (associatedInfo is MethodInfo mi
+                ? (mi.CallingConvention & CallingConventions.VarArgs) != 0
+                : associatedInfo is ConstructorInfo ci && (ci.CallingConvention & CallingConventions.VarArgs) != 0)
             {
                 types.Add(_typeManager.GetArgListType());
             }

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -19,6 +19,7 @@
     <Compile Include="RuntimeBinderInternalCompilerExceptionTests.cs" />
     <Compile Include="RuntimeBinderTests.cs" />
     <Compile Include="UserDefinedShortCircuitOperators.cs" />
+    <Compile Include="VarArgsTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Microsoft.CSharp/tests/VarArgsTests.cs
+++ b/src/Microsoft.CSharp/tests/VarArgsTests.cs
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public class VarArgsTests
+    {
+        // The inability to cast __arglist to object means it can't be used with dynamic bounding
+        // but we still need to be sure that the binder doesn't choke when it encounters a varargs
+        // method, or attempt to bind to it.
+
+        public class HasVarargs
+        {
+            public void OnlyVarargs(__arglist)
+            {
+            }
+
+            // Overloads where the varargs form could perhaps be confused with another
+            public int Nullary(__arglist) => 0;
+
+            public int Nullary() => 1;
+
+            public int Unary0(int i, __arglist) => 0;
+
+            public int Unary0(int i) => i;
+
+            public int Unary1(int i, __arglist) => 0;
+
+            public int Unary1() => 1;
+
+            public int Unary1(long l) => (int)l;
+
+            public int Unary1(long l, string s) => 2;
+
+            public int Binary(int i, __arglist) => 0;
+
+            public int Binary(int i, int j, __arglist) => 0;
+
+            public int Binary(int i, int j) => i + j;
+        }
+
+        public class VarArgCtorOption
+        {
+            public int Value { get; }
+            public VarArgCtorOption(__arglist)
+            {
+            }
+
+            public VarArgCtorOption(int i, __arglist)
+            {
+            }
+
+            public VarArgCtorOption(int i) => Value = i;
+        }
+
+        [Fact]
+        public void FailBindOnlyVarargsAvailable()
+        {
+            dynamic d = new HasVarargs();
+            Assert.Throws<RuntimeBinderException>(() => d.OnlyVarargs());
+            Assert.Throws<RuntimeBinderException>(() => d.OnlyVarargs(1));
+        }
+
+        [Fact]
+        public void CorrectNullaryOverload()
+        {
+            dynamic d = new HasVarargs();
+            Assert.Equal(1, d.Nullary());
+        }
+
+        [Fact]
+        public void CorrectUnaryOverload()
+        {
+            dynamic d = new HasVarargs();
+            Assert.Equal(32, d.Unary0(32));
+        }
+
+        [Fact]
+        public void CorrectUnaryOverloadNeedingImplicitConversion()
+        {
+            dynamic d = new HasVarargs();
+            Assert.Equal(9392, d.Unary1(9392));
+        }
+
+        [Fact]
+        public void CorrectBinaryOverload()
+        {
+            dynamic d = new HasVarargs();
+            Assert.Equal(7, d.Binary(3, 4));
+            Assert.Equal(8, d.Binary((byte)2, (byte)6));
+        }
+
+        [Fact]
+        public void CorrectCtor()
+        {
+            dynamic d = 19;
+            VarArgCtorOption vars = new VarArgCtorOption(d);
+            Assert.Equal(19, vars.Value);
+        }
+    }
+}

--- a/src/Microsoft.CSharp/tests/VarArgsTests.cs
+++ b/src/Microsoft.CSharp/tests/VarArgsTests.cs
@@ -61,8 +61,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         public void FailBindOnlyVarargsAvailable()
         {
             dynamic d = new HasVarargs();
-            Assert.Throws<RuntimeBinderException>(() => d.OnlyVarargs());
-            Assert.Throws<RuntimeBinderException>(() => d.OnlyVarargs(1));
+            string errorMessage = Assert.Throws<RuntimeBinderException>(() => d.OnlyVarargs()).Message;
+            // No overload for method 'OnlyVarargs' takes '0' arguments
+            // Localized forms should contain the name and count.
+            Assert.Contains("OnlyVarargs", errorMessage);
+            Assert.Contains("0", errorMessage);
+            errorMessage = Assert.Throws<RuntimeBinderException>(() => d.OnlyVarargs(1)).Message;
+            // "The best overloaded method match for 'Microsoft.CSharp.RuntimeBinder.Tests.VarArgsTests.HasVarargs.OnlyVarargs(__arglist)' has some invalid arguments"
+            // Localized form should contain the name,
+            Assert.Contains("Microsoft.CSharp.RuntimeBinder.Tests.VarArgsTests.HasVarargs.OnlyVarargs(__arglist)", errorMessage);
         }
 
         [Fact]


### PR DESCRIPTION
* Include calling convention in `MemberInfo` equality checks

Prevents the binder from thinking a callable method is a varargs (and hence uncallable) method it has already seen, and not recording it.

Fixes #25503

* Record whether a constructor is varargs.

Constructors were assumed to not be varargs, so a varargs constructor could be erroneously called.

* Remove vararg handling from `AdjustCallArgumentsForParams`

We will never get this far with a vararg method.

* Don't include ellipses in error messages about varargs members.

Since we're including `__arglist`, the ellipsis representing the argument list is redundant.

Fixes #25506

* Remove `isVarargs` and `isAbstract` from `MethodSymbol`

`isVarargs` had only been used in error messages (no longer the case) and an assertion added when vararg handling was removed from `AdjustCallArgumentsForParams` above (can be replaced with a check for an `ArgumentListType` parameter), with varargs members correctly failing overload resolution due to the `ArgumentListType` parameter not matching rather than the `isVarargs` flag.

`isAbstract` was set but never used.