### PR TITLE
Issue #23141 Fix ManagedHandler cancellation Tests

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -308,7 +308,7 @@ namespace System.Net.Http
                 }
 
                 // Parse the response status line.
-                var response = new HttpResponseMessage() { RequestMessage = request, Content = new HttpConnectionContent(CancellationToken.None) };
+                var response = new HttpResponseMessage() { RequestMessage = request, Content = new HttpConnectionContent(cancellationToken) };
                 ParseStatusLine(await ReadNextLineAsync(cancellationToken).ConfigureAwait(false), response);
                 
                 // If we sent an Expect: 100-continue header, handle the response accordingly.

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionContent.cs
@@ -47,8 +47,14 @@ namespace System.Net.Http
 
                 using (HttpContentStream contentStream = ConsumeStream())
                 {
-                    const int BufferSize = 8192;
-                    await contentStream.CopyToAsync(stream, BufferSize, _cancellationToken).ConfigureAwait(false);
+                    using (_cancellationToken.Register(() =>
+                    {
+                        contentStream.Dispose();
+                    }))
+                    {
+                        const int BufferSize = 8192;
+                        await contentStream.CopyToAsync(stream, BufferSize, _cancellationToken).ConfigureAwait(false);
+                    }
                 }
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
@@ -29,7 +29,6 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(true, false)]
         [InlineData(true, true)]
         [ActiveIssue("dotnet/corefx #20010", TargetFrameworkMonikers.Uap)]
-        [ActiveIssue("dotnet/corefx #19038", TargetFrameworkMonikers.NetFramework)]
         public async Task GetAsync_ResponseContentRead_CancelUsingTimeoutOrToken_TaskCanceledQuickly(
             bool useTimeout, bool startResponseBody)
         {

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -104,16 +104,11 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseManagedHandler => true;
     }
 
-    // TODO #23141: Socket's don't support canceling individual operations, so ReadStream on NetworkStream
-    // isn't cancelable once the operation has started.  We either need to wrap the operation with one that's
-    // "cancelable", meaning that the underlying operation will still be running even though we've returned "canceled",
-    // or we need to just recognize that cancellation in such situations can be left up to the caller to do the
-    // same thing if it's really important.
-    //public sealed class ManagedHandler_CancellationTest : CancellationTest
-    //{
-    //    public ManagedHandler_CancellationTest(ITestOutputHelper output) : base(output) { }
-    //    protected override bool UseManagedHandler => true;
-    //}
+    public sealed class ManagedHandler_CancellationTest : CancellationTest
+    {
+        public ManagedHandler_CancellationTest(ITestOutputHelper output) : base(output) { }
+        protected override bool UseManagedHandler => true;
+    }
 
     // TODO #23142: The managed handler doesn't currently track how much data was written for the response headers.
     //public sealed class ManagedHandler_HttpClientHandler_MaxResponseHeadersLength_Test : HttpClientHandler_MaxResponseHeadersLength_Test


### PR DESCRIPTION
An attempt to solve #23141. There are two parts to the PR.
1. Improving the cancellation support in ManagedHandler: this employs handling the cancellation via the CancellationToken while allowing the operation to still run in background (as discussed in [this](https://github.com/dotnet/corefx/issues/23141#issuecomment-346678600) comment). The idea is based on the blog article [here](https://blogs.msdn.microsoft.com/pfxteam/2012/10/05/how-do-i-cancel-non-cancelable-async-operations/) :-)

2. Even with the above 'by-pass' fix, the test 'ReadAsStreamAsync_ReadAsync_Cancel_TaskCanceledQuickly' still hanged while doing `ReadAsync` from the stream. In case of `ManagedHandler` the response stream is of type `ContentLengthReadStream` which needed fix on the lines of cancelable functionality in `WinHttpResponseStream` ([here](https://github.com/dotnet/corefx/blob/035b1e367c18db600c9d7158102fd2ab4e7a7ed2/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs#L216))

I am still trying to find out how to close / dispose the HttpConnection or the stream instead of allowing the operations to run in the background, consequences of which I am not very sure of.

@stephentoub, I have created this PR as we discussed [here](https://github.com/dotnet/corefx/issues/23141#issuecomment-340493361). Appreciate your inputs.

Thanks,
Mandar