### PR TITLE
readdir_r: align read buffer at dirent

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -11,7 +11,8 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        private static readonly int s_readBufferSize = GetReadDirRBufferSize();
+        // We'll allocate the read buffer in 'long's to have 8-byte alignment.
+        private static readonly int s_readBufferLongSize = (GetReadDirRBufferSize() + sizeof(long) - 1) / sizeof(long);
 
         internal enum NodeType : int
         {
@@ -70,10 +71,11 @@ internal static partial class Interop
 
                 unsafe
                 {
-                    // s_readBufferSize is zero when the native implementation does not support reading into a buffer.
-                    byte* buffer = stackalloc byte[s_readBufferSize];
+                    // s_readBufferLongSize is zero when the native implementation does not support reading into a buffer.
+                    // Align the buffer at 8 bytes by allocating as 'long'.
+                    long* buffer = stackalloc long[s_readBufferLongSize];
                     InternalDirectoryEntry temp;
-                    int ret = ReadDirR(dir.DangerousGetHandle(), buffer, s_readBufferSize, out temp);
+                    int ret = ReadDirR(dir.DangerousGetHandle(), (byte*)buffer, s_readBufferLongSize * sizeof(long), out temp);
                     // We copy data into DirectoryEntry to ensure there are no dangling references.
                     outputEntry = ret == 0 ?
                                 new DirectoryEntry() { InodeName = GetDirectoryEntryName(temp), InodeType = temp.InodeType } : 

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -11,8 +11,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        // We'll allocate the read buffer in 'long's to have 8-byte alignment.
-        private static readonly int s_readBufferLongSize = (GetReadDirRBufferSize() + sizeof(long) - 1) / sizeof(long);
+        private static readonly int s_readBufferSize = GetReadDirRBufferSize();
 
         internal enum NodeType : int
         {
@@ -71,11 +70,10 @@ internal static partial class Interop
 
                 unsafe
                 {
-                    // s_readBufferLongSize is zero when the native implementation does not support reading into a buffer.
-                    // Align the buffer at 8 bytes by allocating as 'long'.
-                    long* buffer = stackalloc long[s_readBufferLongSize];
+                    // s_readBufferSize is zero when the native implementation does not support reading into a buffer.
+                    byte* buffer = stackalloc byte[s_readBufferSize];
                     InternalDirectoryEntry temp;
-                    int ret = ReadDirR(dir.DangerousGetHandle(), (byte*)buffer, s_readBufferLongSize * sizeof(long), out temp);
+                    int ret = ReadDirR(dir.DangerousGetHandle(), buffer, s_readBufferSize, out temp);
                     // We copy data into DirectoryEntry to ensure there are no dangling references.
                     outputEntry = ret == 0 ?
                                 new DirectoryEntry() { InodeName = GetDirectoryEntryName(temp), InodeType = temp.InodeType } : 

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -351,10 +351,10 @@ int32_t SystemNative_ReadDirR(DIR* dir, uint8_t* buffer, int32_t bufferSize, str
     assert(buffer != NULL);
 
     // align to dirent
-    struct dirent* entry = (struct dirent*)((buffer + alignof(struct dirent) - 1) & ~(alignof(struct dirent) - 1));
+    struct dirent* entry = (struct dirent*)((size_t)(buffer + alignof(struct dirent) - 1) & ~(alignof(struct dirent) - 1));
 
     // check there is dirent size available at entry
-    if ((buffer + bufferSize) < (entry + 1))
+    if ((buffer + bufferSize) < (uint8_t*)(entry + 1))
     {
         assert(false && "Buffer size too small; use GetReadDirRBufferSize to get required buffer size");
         return ERANGE;

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -342,7 +342,7 @@ int32_t SystemNative_GetReadDirRBufferSize(void)
 // If the platform supports readdir_r, the caller provides a buffer into which the data is read.
 // If the platform uses readdir, the caller must ensure no calls are made to readdir/closedir since those will invalidate
 // the current dirent. We assume the platform supports concurrent readdir calls to different DIRs.
-int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, struct DirectoryEntry* outputEntry)
+int32_t SystemNative_ReadDirR(DIR* dir, uint8_t* buffer, int32_t bufferSize, struct DirectoryEntry* outputEntry)
 {
     assert(dir != NULL);
     assert(outputEntry != NULL);

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include <fnmatch.h>
 #include <poll.h>
+#include <stdalign.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/mman.h>

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -358,7 +358,7 @@ int32_t SystemNative_ReadDirR(DIR* dir, uint8_t* buffer, int32_t bufferSize, str
     struct dirent* entry = (struct dirent*)((size_t)(buffer + dirent_alignment - 1) & ~(dirent_alignment - 1));
 
     // check there is dirent size available at entry
-    if ((buffer + bufferSize) < (uint8_t*)(entry + 1))
+    if ((buffer + bufferSize) < ((uint8_t*)entry + sizeof(struct dirent)))
     {
         assert(false && "Buffer size too small; use GetReadDirRBufferSize to get required buffer size");
         return ERANGE;

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -363,7 +363,7 @@ int32_t SystemNative_GetReadDirRBufferSize(void);
  *
  * Returns 0 when data is retrieved; returns -1 when end-of-stream is reached; returns an error code on failure
  */
-int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, struct DirectoryEntry* outputEntry);
+int32_t SystemNative_ReadDirR(DIR* dir, uint8_t* buffer, int32_t bufferSize, struct DirectoryEntry* outputEntry);
 
 /**
  * Returns a DIR struct containing info about the current path or NULL on failure; sets errno on fail.


### PR DESCRIPTION
This avoids unaligned access when readdir_r is filling the dirent.

CC @stephentoub 