### PR TITLE
readlink: handle truncated return

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadLink.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadLink.cs
@@ -38,11 +38,10 @@ internal static partial class Interop
                 byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
                 try
                 {
-                    int resultLength = Interop.Sys.ReadLink(path, buffer, buffer.Length - 1); // -1 for null termination
+                    int resultLength = Interop.Sys.ReadLink(path, buffer, buffer.Length);
                     if (resultLength > 0)
                     {
-                        // success, null terminate
-                        buffer[resultLength] = (byte)'\0';
+                        // success
                         return Encoding.UTF8.GetString(buffer, 0, resultLength);
                     }
                     else if (resultLength < 0)

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadLink.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadLink.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
         /// <param name="buffer">The buffer to hold the output path</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <returns>
-        /// Returns the number of bytes placed into the buffer on success; otherwise, -1 is returned
+        /// Returns the number of bytes placed into the buffer on success; 0 if the buffer is too small; and -1 on error.
         /// </returns>
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadLink", SetLastError = true)]
         internal static extern unsafe int ReadLink(string path, byte[] buffer, int bufferSize);

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -995,7 +995,7 @@ int32_t SystemNative_ReadLink(const char* path, char* buffer, int32_t bufferSize
     assert(buffer != NULL || bufferSize == 0);
     assert(bufferSize >= 0);
 
-    if (bufferSize < 0)
+    if (bufferSize <= 0)
     {
         errno = EINVAL;
         return -1;
@@ -1003,6 +1003,13 @@ int32_t SystemNative_ReadLink(const char* path, char* buffer, int32_t bufferSize
 
     ssize_t count = readlink(path, buffer, (size_t)bufferSize);
     assert(count >= -1 && count <= bufferSize);
+
+    // Check if buffer may be truncated.
+    if (count == bufferSize)
+    {
+        return 0;
+    }
+
     return (int32_t)count;
 }
 

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -423,7 +423,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />
     <Reference Condition="'$(TargetGroup)' != 'uap'" Include="Microsoft.Win32.Registry" />
-    <Reference Condition="'$(TargetGroup)' == 'uap'" Include="System.Buffers" />
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.NonGeneric" />

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -251,7 +251,7 @@ namespace System.Diagnostics
 
                 // If the buffer was too small, loop around again and try with a larger buffer.
                 // Otherwise, bail.
-                if (resultLength == 0 || Interop.Sys.GetLastError() != Interop.Error.ENAMETOOLONG)
+                if (resultLength < 0)
                 {
                     break;
                 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -232,33 +232,7 @@ namespace System.Diagnostics
                 Interop.procfs.SelfExeFilePath :
                 Interop.procfs.GetExeFilePathForProcess(processId);
 
-            // Determine the maximum size of a path
-            int maxPath = Interop.Sys.MaxPath;
-
-            // Start small with a buffer allocation, and grow only up to the max path
-            for (int pathLen = 256; pathLen < maxPath; pathLen *= 2)
-            {
-                // Read from procfs the symbolic link to this process' executable
-                byte[] buffer = new byte[pathLen + 1]; // +1 for null termination
-                int resultLength = Interop.Sys.ReadLink(exeFilePath, buffer, pathLen);
-
-                // If we got one, null terminate it (readlink doesn't do this) and return the string
-                if (resultLength > 0)
-                {
-                    buffer[resultLength] = (byte)'\0';
-                    return Encoding.UTF8.GetString(buffer, 0, resultLength);
-                }
-
-                // If the buffer was too small, loop around again and try with a larger buffer.
-                // Otherwise, bail.
-                if (resultLength < 0)
-                {
-                    break;
-                }
-            }
-
-            // Could not get a path
-            return null;
+            return Interop.Sys.ReadLink(exeFilePath);
         }
 
         // ----------------------------------


### PR DESCRIPTION
Makes Readlink return 0 when truncated.

Remove ENAMETOOLONG case. This is not indicating truncated paths, but a problem with the path argument.