### PR TITLE
Proposal: Add ToList(capacity) to LINQ, can improve the performance for large lists.

### DIFF
--- a/src/System.Linq/ref/System.Linq.cs
+++ b/src/System.Linq/ref/System.Linq.cs
@@ -182,6 +182,7 @@ namespace System.Linq
         public static System.Collections.Generic.HashSet<TSource> ToHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
         public static System.Collections.Generic.HashSet<TSource> ToHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IEqualityComparer<TSource> comparer) { throw null; }
         public static System.Collections.Generic.List<TSource> ToList<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
+        public static System.Collections.Generic.List<TSource> ToList<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, int capacity) { throw null; }
         public static System.Linq.ILookup<TKey, TSource> ToLookup<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
         public static System.Linq.ILookup<TKey, TSource> ToLookup<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
         public static System.Linq.ILookup<TKey, TElement> ToLookup<TSource, TKey, TElement>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TElement> elementSelector) { throw null; }

--- a/src/System.Linq/src/System/Linq/ToCollection.cs
+++ b/src/System.Linq/src/System/Linq/ToCollection.cs
@@ -30,6 +30,22 @@ namespace System.Linq
             return source is IIListProvider<TSource> listProvider ? listProvider.ToList() : new List<TSource>(source);
         }
 
+        public static List<TSource> ToList<TSource>(this IEnumerable<TSource> source, int capacity)
+        {
+            if (source == null)
+            {
+                throw Error.ArgumentNull(nameof(source));
+            }
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity), "Non-negative number required.");
+            }
+
+            var list = new List<TSource>(capacity);
+            list.AddRange(source);
+            return list;
+        }
+
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
             ToDictionary(source, keySelector, null);
 

--- a/src/System.Linq/tests/ToListTests.cs
+++ b/src/System.Linq/tests/ToListTests.cs
@@ -25,6 +25,16 @@ namespace System.Linq.Tests
         }
 
 
+        [Fact]
+        public void ToList_Capacity()
+        {
+            List<int> sourceList = new List<int>() { 1, 2, 3, 4, 5 };
+            List<int> resultList = sourceList.ToList(20);
+
+            Assert.Equal(20, resultList.Capacity);
+            Assert.Equal(sourceList, resultList);
+        }
+
         private void RunToListOnAllCollectionTypes<T>(T[] items, Action<List<T>> validation)
         {
             validation(Enumerable.ToList(items));
@@ -63,7 +73,9 @@ namespace System.Linq.Tests
                 {
                     Assert.Equal(sourceStringArray.Length, resultStringList.Count);
                     for (int i = 0; i < sourceStringArray.Length; i++)
+                    {
                         Assert.Same(sourceStringArray[i], resultStringList[i]);
+                    }
                 });
         }
 


### PR DESCRIPTION
The ToList(capacity) returns a List<T> with the given capacity. This can improve the performance by eliminating unnecessary resizing. 