### PR TITLE
fix ODBC build break on FreeBSD

### DIFF
--- a/src/System.Data.Odbc/src/Configurations.props
+++ b/src/System.Data.Odbc/src/Configurations.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
+      netcoreapp2.0-FreeBSD;
       netcoreapp2.0-Linux;
       netcoreapp2.0-OSX;
       netcoreapp2.0-Windows_NT;

--- a/src/System.Data.Odbc/src/System.Data.Odbc.csproj
+++ b/src/System.Data.Odbc/src/System.Data.Odbc.csproj
@@ -113,7 +113,7 @@
       <Link>Common\Interop\Interop.Odbc.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
+  <ItemGroup Condition="'$(TargetsLinux)' == 'true' OR '$(TargetsFreeBSD)' == 'true'">
     <Compile Include="$(CommonPath)\Interop\Linux\Interop.Libraries.cs">
       <Link>Common\Interop\Linux\Interop.Libraries.cs</Link>
     </Compile>


### PR DESCRIPTION
Unlike some other assemblies where there is stub of UnknownUnix ODBC failed on FreeBSD.

This fixes #25517 and it is part of #1626 
Odbc on FreeBSD is same as Linux and comes from unixODBC package. 

With this "./build.sh  -OS=FreeBSD  -SkipManagedPackageBuild" works again on FreeBSD 11. 