### PR TITLE
readlink: don't special case too small buffer in native code

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadLink.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadLink.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
         /// <param name="buffer">The buffer to hold the output path</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <returns>
-        /// Returns the number of bytes placed into the buffer on success; 0 if the buffer is too small; and -1 on error.
+        /// Returns the number of bytes placed into the buffer on success; bufferSize if the buffer is too small; and -1 on error.
         /// </returns>
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadLink", SetLastError = true)]
         private static extern unsafe int ReadLink(string path, byte[] buffer, int bufferSize);
@@ -39,15 +39,15 @@ internal static partial class Interop
                 try
                 {
                     int resultLength = Interop.Sys.ReadLink(path, buffer, buffer.Length);
-                    if (resultLength > 0)
-                    {
-                        // success
-                        return Encoding.UTF8.GetString(buffer, 0, resultLength);
-                    }
-                    else if (resultLength < 0)
+                    if (resultLength < 0)
                     {
                         // error
                         return null;
+                    }
+                    else if (resultLength < buffer.Length)
+                    {
+                        // success
+                        return Encoding.UTF8.GetString(buffer, 0, resultLength);
                     }
                 }
                 finally

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -1013,12 +1013,6 @@ int32_t SystemNative_ReadLink(const char* path, char* buffer, int32_t bufferSize
     ssize_t count = readlink(path, buffer, (size_t)bufferSize);
     assert(count >= -1 && count <= bufferSize);
 
-    // Check if buffer may be truncated.
-    if (count == bufferSize)
-    {
-        return 0;
-    }
-
     return (int32_t)count;
 }
 


### PR DESCRIPTION
@eerhardt this implements the change you suggested https://github.com/dotnet/corefx/pull/25543#discussion_r153558034