### PR TITLE
Make Process.Start wait for child process to exec on OSX

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -156,7 +156,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Theory, InlineData("/usr/bin/open"), InlineData("/usr/bin/nano")]
+        [Theory, InlineData("open"), InlineData("nano")]
         [PlatformSpecific(TestPlatforms.OSX)]
         [OuterLoop("Opens program")]
         public void ProcessStart_OpenFileOnOsx_UsesSpecifiedProgram(string programToOpenWith)
@@ -165,8 +165,7 @@ namespace System.Diagnostics.Tests
             File.WriteAllText(fileToOpen, $"{nameof(ProcessStart_OpenFileOnOsx_UsesSpecifiedProgram)}");
             using (var px = Process.Start(programToOpenWith, fileToOpen))
             {
-                // Assert.Equal(programToOpenWith, px.ProcessName); // on OSX, process name is dotnet for some reason. Refer to #23972
-                Console.WriteLine($"in OSX, {nameof(programToOpenWith)} is {programToOpenWith}, while {nameof(px.ProcessName)} is {px.ProcessName}.");
+                Assert.Equal(programToOpenWith, px.ProcessName);
                 px.Kill();
                 px.WaitForExit();
                 Assert.True(px.HasExited);


### PR DESCRIPTION
OSX doesn't have pipe2. SystemNative_Pipe() is used instead.
https://github.com/dotnet/corefx/pull/5421 this workaround seems only working on Linux. SystemNative_Pipe() can be used to allow OSX which doesn't have `pipe2()` to create `waitForChildToExecPipe` pipe with `FD_CLOEXEC` flag set during child process creation.
Please review. Thanks.

Fixes: https://github.com/dotnet/corefx/issues/23972
Refs: https://github.com/dotnet/corefx/pull/5421