### PR TITLE
Create new property for OfficialBuildLeg and set it for offline build

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.builds
+++ b/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.builds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <ItemGroup Condition="'$(OfficialBuildId)' == '' Or '$(BuildAllConfigurations)' == 'true'">
+  <ItemGroup Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' Or '$(BuildAllConfigurations)' == 'true'">
     <Project Include="Microsoft.NETCore.Platforms.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.builds
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.builds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <ItemGroup Condition="'$(OfficialBuildId)' == '' Or '$(BuildAllConfigurations)' == 'true'">
+  <ItemGroup Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' Or '$(BuildAllConfigurations)' == 'true'">
     <Project Include="Microsoft.NETCore.Targets.pkgproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.builds
+++ b/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.builds
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <!-- for official builds, only build during the AllConfigurations leg -->
-  <ItemGroup Condition="'$(OfficialBuildId)' == '' Or '$(BuildAllConfigurations)' == 'true'">
+  <ItemGroup Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' Or '$(BuildAllConfigurations)' == 'true'">
     <Project Include="$(MSBuildProjectName).pkgproj" />
   </ItemGroup>
 

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -3,6 +3,9 @@
   <Import Project="..\dir.props" />
 
   <PropertyGroup>
+    <!-- Used to determine if we should build some packages only once across multiple official build legs. 
+         For offline builds we still set OfficialBuildId but we need to build all the packages for a single 
+         leg only, so we also take DotNetBuildOffline into account. -->
     <BuildingAnOfficialBuildLeg Condition="'$(BuildingAnOfficialBuildLeg)' == '' AND '$(OfficialBuildId)' != '' AND '$(DotNetBuildOffline)' != 'true'">true</BuildingAnOfficialBuildLeg>
   </PropertyGroup>
   

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -3,6 +3,10 @@
   <Import Project="..\dir.props" />
 
   <PropertyGroup>
+    <BuildingAnOfficialBuildLeg Condition="'$(OfficialBuildId)' != '' AND '$(DotNetBuildOffline)' != 'true'">true</BuildingAnOfficialBuildLeg>
+  </PropertyGroup>
+  
+  <PropertyGroup>
     <_runtimeOSVersionIndex>$(RuntimeOS.IndexOfAny(".-0123456789"))</_runtimeOSVersionIndex>
     <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' != '-1'">$(RuntimeOS.SubString(0, $(_runtimeOSVersionIndex)))</_runtimeOSFamily>
   </PropertyGroup>

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -3,7 +3,7 @@
   <Import Project="..\dir.props" />
 
   <PropertyGroup>
-    <BuildingAnOfficialBuildLeg Condition="'$(OfficialBuildId)' != '' AND '$(DotNetBuildOffline)' != 'true'">true</BuildingAnOfficialBuildLeg>
+    <BuildingAnOfficialBuildLeg Condition="'$(BuildingAnOfficialBuildLeg)' == '' AND '$(OfficialBuildId)' != '' AND '$(DotNetBuildOffline)' != 'true'">true</BuildingAnOfficialBuildLeg>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/pkg/dir.traversal.targets
+++ b/pkg/dir.traversal.targets
@@ -3,10 +3,6 @@
 
   <Import Project="..\dir.traversal.targets" />
 
-  <PropertyGroup>
-    <BuildingAnOfficialBuildLeg Condition="'$(OfficialBuildId)' != '' AND '$(DotNetBuildOffline)' != 'true'">true</BuildingAnOfficialBuildLeg>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(BuildingAnOfficialBuildLeg)' != ''">   
     <!-- During an official build, only build identity packages in the AllConfigurations build -->
     <SkipBuildIdentityPackage Condition="'$(BuildAllConfigurations)' != 'true'">true</SkipBuildIdentityPackage>

--- a/pkg/dir.traversal.targets
+++ b/pkg/dir.traversal.targets
@@ -3,7 +3,7 @@
 
   <Import Project="..\dir.traversal.targets" />
 
-  <PropertyGroup Condition="'$(BuildingAnOfficialBuildLeg)' != ''">   
+  <PropertyGroup Condition="'$(BuildingAnOfficialBuildLeg)' == 'true'">   
     <!-- During an official build, only build identity packages in the AllConfigurations build -->
     <SkipBuildIdentityPackage Condition="'$(BuildAllConfigurations)' != 'true'">true</SkipBuildIdentityPackage>
 

--- a/pkg/dir.traversal.targets
+++ b/pkg/dir.traversal.targets
@@ -2,8 +2,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="..\dir.traversal.targets" />
-  
-  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
+
+  <PropertyGroup>
+    <BuildingAnOfficialBuildLeg Condition="'$(OfficialBuildId)' != '' AND '$(DotNetBuildOffline)' != 'true'">true</BuildingAnOfficialBuildLeg>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(BuildingAnOfficialBuildLeg)' != ''">   
     <!-- During an official build, only build identity packages in the AllConfigurations build -->
     <SkipBuildIdentityPackage Condition="'$(BuildAllConfigurations)' != 'true'">true</SkipBuildIdentityPackage>
 


### PR DESCRIPTION
When doing an offline build, we need the identity package and runtime package to be built.  Adding an "OfficialBuildLeg" property and setting it based on OfficialBuildId being set or an OfflineBuild being in progress.