### PR TITLE
UnsafeTests: force explicit layout, so tests work on 32bit and 64bit platforms

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
@@ -792,9 +792,12 @@ namespace System.Runtime.CompilerServices
         public fixed byte Bytes[512];
     }
 
+    [StructLayout(LayoutKind.Explicit, Size=16)]
     public unsafe struct Int32Double
     {
+        [FieldOffset(0)]
         public int Int32;
+        [FieldOffset(8)]
         public double Double;
 
         public static unsafe byte[] Unaligned(int i, double d)


### PR DESCRIPTION
On Mono, we have issues around those tests that assume `Int32Double` is 16 byte, e.g.:
```csharp
        public static unsafe void WriteUnaligned_ByRef_Double()
        {
            byte[] unaligned = new byte[sizeof(Int32Double) + 1];

            Unsafe.WriteUnaligned(ref unaligned[9], 3.42);

            double actual = Int32Double.Aligned(unaligned).Double;
            Assert.Equal(3.42, actual);
        }
```
Runtimes don't have to necessarily put the field `double` at offset 8, which is the case on 32-bit platforms with Mono.

related: https://github.com/mono/mono/pull/6129