### PR TITLE
Benchmarking .NET Core 2.0/2.1 applications with BenchmarkDotNet

### DIFF
--- a/Documentation/project-docs/benchmarking.md
+++ b/Documentation/project-docs/benchmarking.md
@@ -1,5 +1,4 @@
-# Using BenchmarkDotNet
-In this example we are using BenchmarkDotNet (https://github.com/dotnet/BenchmarkDotNet) for our testing. Make sure to use the latest version which allows to specify a custom SKD path.
+In this example we are using **BenchmarkDotNet** (https://github.com/dotnet/BenchmarkDotNet) for our testing. Make sure to use the latest version which allows to specify a custom SKD path.
 
 ```
 <ItemGroup>
@@ -18,12 +17,12 @@ In this tutorial we won't modify the `PATH` variable and instead always explicit
 Check which version of the shared framework is bundled with the downloaded SDK and remember it for later. At the time writing this documentation it was `2.1.0-preview1-25919-02`.
 > C:\Program Files\dotnet-nightly\shared\Microsoft.NETCore.App\2.1.0-preview1-25919-02
 
+## Shared framework
 You can either decide to use your local self-compiled shared framework package or use the one from the .NET Core 2.1 SDK.
 
-## Using the shared framework from the .NET Core 2.1 SDK
+### Using the shared framework from the .NET Core 2.1 SDK
 Follow the instructions described here https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/dogfooding.md#advanced-scenario---using-a-nightly-build-of-microsoftnetcoreapp and skip the last part which calls the `dotnet.exe`.
 
-### Configuring BenchmarkDotNet to use the .NET Core 2.1 SDK
 Now we are going to create a BenchmarkDotNet configuration file to set the path to the .NET Core 2.1 SDK
 
 ```
@@ -54,24 +53,12 @@ public class MainConfig : ManualConfig
 }
 ```
 
-Pass the configuration to the BenchmarkRunner.
 
-### Executing
 
-As mentioned before, instead of calling the dotnet in the `PATH` we call the `dotnet.exe` explicitely from the downloaded SDK folder:
-
-```
-> cd "path/to/your/benchmark/project"
-> "C:\Program Files\dotnet-nightly\dotnet.exe" restore
-> "C:\Program Files\dotnet-nightly\dotnet.exe" build -c Release
-> "C:\Program Files\dotnet-nightly\dotnet.exe" run -c Release
-```
-
-## Using your self-compiled shared framework
+### Using your self-compiled shared framework
 Follow the instructions described here https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/dogfooding.md#more-advanced-scenario---using-your-local-corefx-build and skip the last part which calls the `dotnet.exe`.
 Make sure to build your local corefx repository in RELEASE mode `.\build -release`! You currently need to have a self-contained application to inject your local shared framework package.
 
-### Configuring BenchmarkDotNet to use the .NET Core 2.1 SDK
 Now we are going to create a BenchmarkDotNet configuration file. Currently there is no easy way to run your BenchmarkDotNet application in a dedicated process, therefore we are using the InProcess switch:
 
 ```
@@ -97,9 +84,13 @@ public class MainConfig : ManualConfig
 }
 ```
 
-### Executing
+## Running the benchmark
 
-As mentioned before, instead of calling the dotnet in the `PATH` we call the `dotnet.exe` explicitely from the downloaded SDK folder:
+In your application entry point pass the configuration to the BenchmarkRunner:
+`BenchmarkRunner.Run<T>(new MainConfig()); // <-- Configuration class`
+
+As mentioned before, instead of calling the dotnet in the `PATH` we call the `dotnet.exe` explicitely from the downloaded SDK folder.
+To get valid results make sure to compile and run your project with RELEASE configuration:
 
 ```
 > cd "path/to/your/benchmark/project"

--- a/Documentation/project-docs/benchmarking.md
+++ b/Documentation/project-docs/benchmarking.md
@@ -1,6 +1,6 @@
 # Benchmarking .NET Core 2.0 / 2.1 applications
 
-In this example we are using **BenchmarkDotNet** (https://github.com/dotnet/BenchmarkDotNet) for our testing. Make sure to use the latest version which allows to specify a custom SKD path.
+We recommend using [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) as with the latest version it allows specifying custom SDK paths and measuring performance not just in-proc but also out-of-proc as a dedicated executable.
 
 ```
 <ItemGroup>
@@ -14,18 +14,18 @@ For benchmarking .NET Core 2.0 applications you only need the .NET Core 2.0 SDK 
 # Benchmarking .NET Core 2.1 applications
 Make sure to download the .NET Core 2.1 SDK zip archive (https://github.com/dotnet/core-setup#daily-builds) and extract it somewhere locally, e.g.: `C:\Program Files\dotnet-nightly\`.
 
-In this tutorial we won't modify the `PATH` variable and instead always explicitely call the `dotnet.exe` from the downloaded SDK folder.
+In this tutorial we won't modify the `PATH` variable and instead always explicitly call the `dotnet.exe` from the downloaded SDK folder.
 
 Check which version of the shared framework is bundled with the downloaded SDK and remember it for later. At the time writing this documentation it was `2.1.0-preview1-25919-02`.
 > C:\Program Files\dotnet-nightly\shared\Microsoft.NETCore.App\2.1.0-preview1-25919-02
 
 ## Shared framework
-You can either decide to use your local self-compiled shared framework package or use the one from the .NET Core 2.1 SDK.
+The shared framework is a set of assemblies that are packed into a `netcoreapp` Nuget package which is used when you set your `TargetFramework` to `netcoreappX.X`. You can either decide to use your local self-compiled shared framework package or use the one from the .NET Core 2.1 SDK.
 
-### Using the shared framework from the .NET Core 2.1 SDK
+### Alternative 1 - Using the shared framework from the .NET Core 2.1 SDK
 Follow the instructions described here https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/dogfooding.md#advanced-scenario---using-a-nightly-build-of-microsoftnetcoreapp and skip the last part which calls the `dotnet.exe`.
 
-Now we are going to create a BenchmarkDotNet configuration file to set the path to the .NET Core 2.1 SDK
+Now we are going to create a BenchmarkDotNet configuration file (let's call it `MainConfig.cs`) and add it to the project. The manual configuration allows us to set the path to our SDK via the `customDotNetCliPath` property: 
 
 ```
 public class MainConfig : ManualConfig
@@ -55,13 +55,11 @@ public class MainConfig : ManualConfig
 }
 ```
 
-
-
-### Using your self-compiled shared framework
+### Alternative 2 - Using your self-compiled shared framework
 Follow the instructions described here https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/dogfooding.md#more-advanced-scenario---using-your-local-corefx-build and skip the last part which calls the `dotnet.exe`.
 Make sure to build your local corefx repository in RELEASE mode `.\build -release`! You currently need to have a self-contained application to inject your local shared framework package.
 
-Now we are going to create a BenchmarkDotNet configuration file. Currently there is no easy way to run your BenchmarkDotNet application in a dedicated process, therefore we are using the InProcess switch:
+Now we are going to create a BenchmarkDotNet configuration file (let's call it `MainConfig.cs`) and add it to the project. Currently there is no easy way to run your BenchmarkDotNet application in a dedicated process, therefore we are using the InProcess switch `InProcessTollchain.Instance`:
 
 ```
 public class MainConfig : ManualConfig
@@ -86,6 +84,10 @@ public class MainConfig : ManualConfig
 }
 ```
 
+## Defining your benchmark
+
+See [BenchmarkDotNet](http://benchmarkdotnet.org/Guides/GettingStarted.htm) documentation -- minimally you need to adorn a public method with the `[Benchmark]` attribute but there are many other ways to customize what is done such as using parameter sets or setup/cleanup methods. Of course, you'll want to bracket just the relevant code in your benchmark, ensure there are sufficient iterations that you minimise noise, as well as leaving the machine otherwise idle while you measure.
+
 ## Running the benchmark
 
 In your application entry point pass the configuration to the BenchmarkRunner:
@@ -100,3 +102,12 @@ To get valid results make sure to compile and run your project with RELEASE conf
 > "C:\Program Files\dotnet-nightly\dotnet.exe" build -c Release
 > "C:\Program Files\dotnet-nightly\dotnet.exe" run -c Release
 ```
+
+## Reporting results
+
+Often in a Github Pull Request or issue you will want to share performance results to justify a change. If you add the `MarkdownExporter` job in the configuration (as you can see in the example), BenchmarkDotNet will have created a Markdown (*.md) file in the `BenchmarkDotNet.Artifacts` folder which you can paste in, along with the code you benchmarked.
+
+# References
+[BenchmarkDotNet](http://benchmarkdotnet.org/)
+[BenchmarkDotNet Github](https://github.com/dotnet/BenchmarkDotNet)
+[.NET Core SDK](https://github.com/dotnet/core-setup)

--- a/Documentation/project-docs/benchmarking.md
+++ b/Documentation/project-docs/benchmarking.md
@@ -8,6 +8,10 @@ We recommend using [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) 
 </ItemGroup>
 ```
 
+## Defining your benchmark
+
+See [BenchmarkDotNet](http://benchmarkdotnet.org/Guides/GettingStarted.htm) documentation -- minimally you need to adorn a public method with the `[Benchmark]` attribute but there are many other ways to customize what is done such as using parameter sets or setup/cleanup methods. Of course, you'll want to bracket just the relevant code in your benchmark, ensure there are sufficient iterations that you minimise noise, as well as leaving the machine otherwise idle while you measure.
+
 # Benchmarking .NET Core 2.0 applications
 For benchmarking .NET Core 2.0 applications you only need the .NET Core 2.0 SDK installed: https://dotnetcli.blob.core.windows.net/dotnet/Runtime/release/2.0.0/dotnet-runtime-latest-win-x64.exe. Make sure that your `TargetFramework` property in your csproj is set to `netcoreapp2.0` and follow the official BenchmarkDotNet instructions: https://github.com/dotnet/BenchmarkDotNet/blob/master/docs/guide/Configs/Toolchains.md
 
@@ -84,10 +88,6 @@ public class MainConfig : ManualConfig
 }
 ```
 
-## Defining your benchmark
-
-See [BenchmarkDotNet](http://benchmarkdotnet.org/Guides/GettingStarted.htm) documentation -- minimally you need to adorn a public method with the `[Benchmark]` attribute but there are many other ways to customize what is done such as using parameter sets or setup/cleanup methods. Of course, you'll want to bracket just the relevant code in your benchmark, ensure there are sufficient iterations that you minimise noise, as well as leaving the machine otherwise idle while you measure.
-
 ## Running the benchmark
 
 In your application entry point pass the configuration to the BenchmarkRunner:
@@ -103,11 +103,11 @@ To get valid results make sure to compile and run your project with RELEASE conf
 > "C:\Program Files\dotnet-nightly\dotnet.exe" run -c Release
 ```
 
-## Reporting results
+# Reporting results
 
 Often in a Github Pull Request or issue you will want to share performance results to justify a change. If you add the `MarkdownExporter` job in the configuration (as you can see in the example), BenchmarkDotNet will have created a Markdown (*.md) file in the `BenchmarkDotNet.Artifacts` folder which you can paste in, along with the code you benchmarked.
 
 # References
-[BenchmarkDotNet](http://benchmarkdotnet.org/)
-[BenchmarkDotNet Github](https://github.com/dotnet/BenchmarkDotNet)
-[.NET Core SDK](https://github.com/dotnet/core-setup)
+- [BenchmarkDotNet](http://benchmarkdotnet.org/)
+- [BenchmarkDotNet Github](https://github.com/dotnet/BenchmarkDotNet)
+- [.NET Core SDK](https://github.com/dotnet/core-setup)

--- a/Documentation/project-docs/benchmarking.md
+++ b/Documentation/project-docs/benchmarking.md
@@ -1,0 +1,109 @@
+# Using BenchmarkDotNet
+In this example we are using BenchmarkDotNet (https://github.com/dotnet/BenchmarkDotNet) for our testing. Make sure to use the latest version which allows to specify a custom SKD path.
+
+```
+<ItemGroup>
+   <PackageReference Include="BenchmarkDotNet" Version="0.10.10" />
+</ItemGroup>
+```
+
+# Benchmarking .NET Core 2.0 applications
+For benchmarking .NET Core 2.0 applications you only need the .NET Core 2.0 SDK installed: https://dotnetcli.blob.core.windows.net/dotnet/Runtime/release/2.0.0/dotnet-runtime-latest-win-x64.exe. Make sure that your `TargetFramework` property in your csproj is set to `netcoreapp2.0` and follow the official BenchmarkDotNet instructions: https://github.com/dotnet/BenchmarkDotNet/blob/master/docs/guide/Configs/Toolchains.md
+
+# Benchmarking .NET Core 2.1 applications
+Make sure to download the .NET Core 2.1 SDK zip archive (https://github.com/dotnet/core-setup#daily-builds) and extract it somewhere locally, e.g.: `C:\Program Files\dotnet-nightly\`.
+
+In this tutorial we won't modify the `PATH` variable and instead always explicitely call the `dotnet.exe` from the downloaded SDK folder.
+
+Check which version of the shared framework is bundled with the downloaded SDK and remember it for later. At the time writing this documentation it was `2.1.0-preview1-25919-02`.
+> C:\Program Files\dotnet-nightly\shared\Microsoft.NETCore.App\2.1.0-preview1-25919-02
+
+You can either decide to use your local self-compiled shared framework package or use the one from the .NET Core 2.1 SDK.
+
+## Using the shared framework from the .NET Core 2.1 SDK
+Follow the instructions described here https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/dogfooding.md#advanced-scenario---using-a-nightly-build-of-microsoftnetcoreapp and skip the last part which calls the `dotnet.exe`.
+
+### Configuring BenchmarkDotNet to use the .NET Core 2.1 SDK
+Now we are going to create a BenchmarkDotNet configuration file to set the path to the .NET Core 2.1 SDK
+
+```
+public class MainConfig : ManualConfig
+{
+    public MainConfig()
+    {
+        Add(Job.Default
+            .With(Runtime.Core)
+            .With(CsProjCoreToolchain.From(new NetCoreAppSettings(
+                targetFrameworkMoniker: "netcoreapp2.1",
+                runtimeFrameworkVersion: "2.1.0-preview1-25919-02", // <-- Adjust version here
+                customDotNetCliPath: @"C:\Program Files\dotnet-nightly\dotnet.exe", // <-- Adjust path here
+                name: "Core 2.1.0-preview")))
+            .WithLaunchCount(1)
+            .WithWarmupCount(1)
+            .WithInvocationCount(10)
+            .WithUnrollFactor(1)
+            .WithTargetCount(3));
+
+        // Add whatever jobs you need
+        Add(DefaultColumnProviders.Instance);
+        Add(MarkdownExporter.GitHub);
+        Add(new ConsoleLogger());
+        Add(new HtmlExporter());
+        Add(MemoryDiagnoser.Default);
+    }
+}
+```
+
+Pass the configuration to the BenchmarkRunner.
+
+### Executing
+
+As mentioned before, instead of calling the dotnet in the `PATH` we call the `dotnet.exe` explicitely from the downloaded SDK folder:
+
+```
+> cd "path/to/your/benchmark/project"
+> "C:\Program Files\dotnet-nightly\dotnet.exe" restore
+> "C:\Program Files\dotnet-nightly\dotnet.exe" build -c Release
+> "C:\Program Files\dotnet-nightly\dotnet.exe" run -c Release
+```
+
+## Using your self-compiled shared framework
+Follow the instructions described here https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/dogfooding.md#more-advanced-scenario---using-your-local-corefx-build and skip the last part which calls the `dotnet.exe`.
+Make sure to build your local corefx repository in RELEASE mode `.\build -release`! You currently need to have a self-contained application to inject your local shared framework package.
+
+### Configuring BenchmarkDotNet to use the .NET Core 2.1 SDK
+Now we are going to create a BenchmarkDotNet configuration file. Currently there is no easy way to run your BenchmarkDotNet application in a dedicated process, therefore we are using the InProcess switch:
+
+```
+public class MainConfig : ManualConfig
+{
+    public MainConfig()
+    {
+        Add(Job.Default
+            .With(InProcessToolchain.Instance) <-- To run against your local built shared framework (in corefx folder)
+            .WithLaunchCount(1)
+            .WithWarmupCount(1)
+            .WithInvocationCount(1)
+            .WithUnrollFactor(1)
+            .WithTargetCount(3));
+
+        // Add whatever jobs you need
+        Add(DefaultColumnProviders.Instance);
+        Add(MarkdownExporter.GitHub);
+        Add(new ConsoleLogger());
+        Add(new HtmlExporter());
+        Add(MemoryDiagnoser.Default);
+    }
+}
+```
+
+### Executing
+
+As mentioned before, instead of calling the dotnet in the `PATH` we call the `dotnet.exe` explicitely from the downloaded SDK folder:
+
+```
+> cd "path/to/your/benchmark/project"
+> "C:\Program Files\dotnet-nightly\dotnet.exe" restore
+> "C:\Program Files\dotnet-nightly\dotnet.exe" build -c Release
+> "C:\Program Files\dotnet-nightly\dotnet.exe" run -c Release
+```

--- a/Documentation/project-docs/benchmarking.md
+++ b/Documentation/project-docs/benchmarking.md
@@ -1,3 +1,5 @@
+# Benchmarking .NET Core 2.0 / 2.1 applications
+
 In this example we are using **BenchmarkDotNet** (https://github.com/dotnet/BenchmarkDotNet) for our testing. Make sure to use the latest version which allows to specify a custom SKD path.
 
 ```


### PR DESCRIPTION
Instructions for using BenchmarkDotNet with .NET Core 2.0/2.1 (shared framework from either the nightly SDK or from your local built corefx package)