### PR TITLE
Add BigInteger.TryFormat

### DIFF
--- a/src/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -668,11 +668,9 @@ namespace System.Globalization
                 return 'G';
             }
 
-            internal static unsafe string NumberToString(NumberBuffer number, char format, int nMaxDigits, NumberFormatInfo info, bool isDecimal)
+            internal static unsafe void NumberToString(StringBuilder sb, NumberBuffer number, char format, int nMaxDigits, NumberFormatInfo info, bool isDecimal)
             {
                 int nMinDigits = -1;
-
-                StringBuilder sb = new StringBuilder(MIN_SB_BUFFER_SIZE);
 
                 switch (format)
                 {
@@ -802,8 +800,6 @@ namespace System.Globalization
                     default:
                         throw new FormatException(SR.Argument_BadFormatSpecifier);
                 }
-
-                return sb.ToString();
             }
 
             private static void FormatCurrency(StringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info)
@@ -1153,7 +1149,7 @@ namespace System.Globalization
                 }
             }
 
-            internal static unsafe string NumberToStringFormat(NumberBuffer number, string format, NumberFormatInfo info)
+            internal static unsafe void NumberToStringFormat(StringBuilder sb, NumberBuffer number, string format, NumberFormatInfo info)
             {
                 int digitCount;
                 int decimalPos;
@@ -1346,8 +1342,6 @@ namespace System.Globalization
                     }
                 }
 
-                StringBuilder sb = new StringBuilder(MIN_SB_BUFFER_SIZE);
-
                 if (number.sign && section == 0)
                     sb.Append(info.NegativeSign);
 
@@ -1503,8 +1497,6 @@ namespace System.Globalization
                         }
                     }
                 }
-
-                return sb.ToString();
             }
         }
     }

--- a/src/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -668,7 +668,7 @@ namespace System.Globalization
                 return 'G';
             }
 
-            internal static unsafe void NumberToString(StringBuilder sb, NumberBuffer number, char format, int nMaxDigits, NumberFormatInfo info, bool isDecimal)
+            internal static unsafe void NumberToString(ref ValueStringBuilder sb, NumberBuffer number, char format, int nMaxDigits, NumberFormatInfo info, bool isDecimal)
             {
                 int nMinDigits = -1;
 
@@ -683,7 +683,7 @@ namespace System.Globalization
 
                             RoundNumber(ref number, number.scale + nMaxDigits); // Don't change this line to use digPos since digCount could have its sign changed.
 
-                            FormatCurrency(sb, number, nMinDigits, nMaxDigits, info);
+                            FormatCurrency(ref sb, number, nMinDigits, nMaxDigits, info);
 
                             break;
                         }
@@ -701,7 +701,7 @@ namespace System.Globalization
                             if (number.sign)
                                 sb.Append(info.NegativeSign);
 
-                            FormatFixed(sb, number, nMinDigits, nMaxDigits, info, null, info.NumberDecimalSeparator, null);
+                            FormatFixed(ref sb, number, nMinDigits, nMaxDigits, info, null, info.NumberDecimalSeparator, null);
 
                             break;
                         }
@@ -716,7 +716,7 @@ namespace System.Globalization
 
                             RoundNumber(ref number, number.scale + nMaxDigits);
 
-                            FormatNumber(sb, number, nMinDigits, nMaxDigits, info);
+                            FormatNumber(ref sb, number, nMinDigits, nMaxDigits, info);
 
                             break;
                         }
@@ -735,7 +735,7 @@ namespace System.Globalization
                             if (number.sign)
                                 sb.Append(info.NegativeSign);
 
-                            FormatScientific(sb, number, nMinDigits, nMaxDigits, info, format);
+                            FormatScientific(ref sb, number, nMinDigits, nMaxDigits, info, format);
 
                             break;
                         }
@@ -776,7 +776,7 @@ namespace System.Globalization
                             if (number.sign)
                                 sb.Append(info.NegativeSign);
 
-                            FormatGeneral(sb, number, nMinDigits, nMaxDigits, info, (char)(format - ('G' - 'E')), !enableRounding);
+                            FormatGeneral(ref sb, number, nMinDigits, nMaxDigits, info, (char)(format - ('G' - 'E')), !enableRounding);
 
                             break;
                         }
@@ -792,7 +792,7 @@ namespace System.Globalization
 
                             RoundNumber(ref number, number.scale + nMaxDigits);
 
-                            FormatPercent(sb, number, nMinDigits, nMaxDigits, info);
+                            FormatPercent(ref sb, number, nMinDigits, nMaxDigits, info);
 
                             break;
                         }
@@ -802,7 +802,7 @@ namespace System.Globalization
                 }
             }
 
-            private static void FormatCurrency(StringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info)
+            private static void FormatCurrency(ref ValueStringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info)
             {
                 string fmt = number.sign ?
                     s_negCurrencyFormats[info.CurrencyNegativePattern] :
@@ -813,7 +813,7 @@ namespace System.Globalization
                     switch (ch)
                     {
                         case '#':
-                            FormatFixed(sb, number, nMinDigits, nMaxDigits, info, info.CurrencyGroupSizes, info.CurrencyDecimalSeparator, info.CurrencyGroupSeparator);
+                            FormatFixed(ref sb, number, nMinDigits, nMaxDigits, info, info.CurrencyGroupSizes, info.CurrencyDecimalSeparator, info.CurrencyGroupSeparator);
                             break;
                         case '-':
                             sb.Append(info.NegativeSign);
@@ -836,7 +836,7 @@ namespace System.Globalization
                 return result;
             }
 
-            private static unsafe void FormatFixed(StringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info, int[] groupDigits, string sDecimal, string sGroup)
+            private static unsafe void FormatFixed(ref ValueStringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info, int[] groupDigits, string sDecimal, string sGroup)
             {
                 int digPos = number.scale;
                 char* dig = number.digits;
@@ -940,7 +940,7 @@ namespace System.Globalization
                 }
             }
 
-            private static void FormatNumber(StringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info)
+            private static void FormatNumber(ref ValueStringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info)
             {
                 string fmt = number.sign ?
                     s_negNumberFormats[info.NumberNegativePattern] :
@@ -951,7 +951,7 @@ namespace System.Globalization
                     switch (ch)
                     {
                         case '#':
-                            FormatFixed(sb, number, nMinDigits, nMaxDigits, info, info.NumberGroupSizes, info.NumberDecimalSeparator, info.NumberGroupSeparator);
+                            FormatFixed(ref sb, number, nMinDigits, nMaxDigits, info, info.NumberGroupSizes, info.NumberDecimalSeparator, info.NumberGroupSeparator);
                             break;
                         case '-':
                             sb.Append(info.NegativeSign);
@@ -963,7 +963,7 @@ namespace System.Globalization
                 }
             }
 
-            private static unsafe void FormatScientific(StringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info, char expChar)
+            private static unsafe void FormatScientific(ref ValueStringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info, char expChar)
             {
                 char* dig = number.digits;
 
@@ -976,10 +976,10 @@ namespace System.Globalization
                     sb.Append((*dig != 0) ? *dig++ : '0');
 
                 int e = number.digits[0] == 0 ? 0 : number.scale - 1;
-                FormatExponent(sb, info, e, expChar, 3, true);
+                FormatExponent(ref sb, info, e, expChar, 3, true);
             }
 
-            private static unsafe void FormatExponent(StringBuilder sb, NumberFormatInfo info, int value, char expChar, int minDigits, bool positiveSign)
+            private static unsafe void FormatExponent(ref ValueStringBuilder sb, NumberFormatInfo info, int value, char expChar, int minDigits, bool positiveSign)
             {
                 sb.Append(expChar);
 
@@ -1002,7 +1002,7 @@ namespace System.Globalization
                     sb.Append(digits[index++]);
             }
 
-            private static unsafe void FormatGeneral(StringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info, char expChar, bool bSuppressScientific)
+            private static unsafe void FormatGeneral(ref ValueStringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info, char expChar, bool bSuppressScientific)
             {
                 int digPos = number.scale;
                 bool scientific = false;
@@ -1046,10 +1046,10 @@ namespace System.Globalization
                 }
 
                 if (scientific)
-                    FormatExponent(sb, info, number.scale - 1, expChar, 2, true);
+                    FormatExponent(ref sb, info, number.scale - 1, expChar, 2, true);
             }
 
-            private static void FormatPercent(StringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info)
+            private static void FormatPercent(ref ValueStringBuilder sb, NumberBuffer number, int nMinDigits, int nMaxDigits, NumberFormatInfo info)
             {
                 string fmt = number.sign ?
                     s_negPercentFormats[info.PercentNegativePattern] :
@@ -1060,7 +1060,7 @@ namespace System.Globalization
                     switch (ch)
                     {
                         case '#':
-                            FormatFixed(sb, number, nMinDigits, nMaxDigits, info, info.PercentGroupSizes, info.PercentDecimalSeparator, info.PercentGroupSeparator);
+                            FormatFixed(ref sb, number, nMinDigits, nMaxDigits, info, info.PercentGroupSizes, info.PercentDecimalSeparator, info.PercentGroupSeparator);
                             break;
                         case '-':
                             sb.Append(info.NegativeSign);
@@ -1149,7 +1149,7 @@ namespace System.Globalization
                 }
             }
 
-            internal static unsafe void NumberToStringFormat(StringBuilder sb, NumberBuffer number, string format, NumberFormatInfo info)
+            internal static unsafe void NumberToStringFormat(ref ValueStringBuilder sb, NumberBuffer number, string format, NumberFormatInfo info)
             {
                 int digitCount;
                 int decimalPos;
@@ -1478,7 +1478,7 @@ namespace System.Globalization
                                             i = 10;
 
                                         int exp = dig[0] == 0 ? 0 : number.scale - decimalPos;
-                                        FormatExponent(sb, info, exp, ch, i, positiveSign);
+                                        FormatExponent(ref sb, info, exp, ch, i, positiveSign);
                                         scientific = false;
                                     }
                                     else

--- a/src/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
+++ b/src/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
@@ -158,6 +158,7 @@ namespace System.Numerics
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
+        public bool TryFormat(Span<char> destination, out int charsWritten, string format = default, IFormatProvider provider = null) { throw null; }
         public static bool TryParse(string value, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Numerics.BigInteger result) { throw null; }
         public static bool TryParse(string value, out System.Numerics.BigInteger result) { throw null; }
         public static bool TryParse(ReadOnlySpan<char> value, out System.Numerics.BigInteger result) { throw null; }

--- a/src/System.Runtime.Numerics/src/System/Globalization/FormatProvider.BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Globalization/FormatProvider.BigInteger.cs
@@ -9,7 +9,7 @@ namespace System.Globalization
 {
     internal partial class FormatProvider
     {
-        internal static void FormatBigInteger(StringBuilder sb, int precision, int scale, bool sign, string format, NumberFormatInfo numberFormatInfo, char[] digits, int startIndex)
+        internal static void FormatBigInteger(ref ValueStringBuilder sb, int precision, int scale, bool sign, string format, NumberFormatInfo numberFormatInfo, char[] digits, int startIndex)
         {
             unsafe
             {
@@ -24,11 +24,11 @@ namespace System.Globalization
                     char fmt = Number.ParseFormatSpecifier(format, out int maxDigits);
                     if (fmt != 0)
                     {
-                        Number.NumberToString(sb, numberBuffer, fmt, maxDigits, numberFormatInfo, isDecimal: false);
+                        Number.NumberToString(ref sb, numberBuffer, fmt, maxDigits, numberFormatInfo, isDecimal: false);
                     }
                     else
                     {
-                        Number.NumberToStringFormat(sb, numberBuffer, format, numberFormatInfo);
+                        Number.NumberToStringFormat(ref sb, numberBuffer, format, numberFormatInfo);
                     }
                 }
             }

--- a/src/System.Runtime.Numerics/src/System/Globalization/FormatProvider.BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Globalization/FormatProvider.BigInteger.cs
@@ -9,23 +9,27 @@ namespace System.Globalization
 {
     internal partial class FormatProvider
     {
-        internal static string FormatBigInteger(int precision, int scale, bool sign, string format, NumberFormatInfo numberFormatInfo, char[] digits, int startIndex)
+        internal static void FormatBigInteger(StringBuilder sb, int precision, int scale, bool sign, string format, NumberFormatInfo numberFormatInfo, char[] digits, int startIndex)
         {
             unsafe
             {
-                int maxDigits;
-                char fmt = Number.ParseFormatSpecifier(format, out maxDigits);
-
                 fixed (char* overrideDigits = digits)
                 {
-                    FormatProvider.Number.NumberBuffer numberBuffer = new FormatProvider.Number.NumberBuffer();
+                    var numberBuffer = new Number.NumberBuffer();
                     numberBuffer.overrideDigits = overrideDigits + startIndex;
                     numberBuffer.precision = precision;
                     numberBuffer.scale = scale;
                     numberBuffer.sign = sign;
+
+                    char fmt = Number.ParseFormatSpecifier(format, out int maxDigits);
                     if (fmt != 0)
-                        return Number.NumberToString(numberBuffer, fmt, maxDigits, numberFormatInfo, isDecimal: false);
-                    return Number.NumberToStringFormat(numberBuffer, format, numberFormatInfo);
+                    {
+                        Number.NumberToString(sb, numberBuffer, fmt, maxDigits, numberFormatInfo, isDecimal: false);
+                    }
+                    else
+                    {
+                        Number.NumberToStringFormat(sb, numberBuffer, format, numberFormatInfo);
+                    }
                 }
             }
         }

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1462,6 +1462,11 @@ namespace System.Numerics
             return BigNumber.FormatBigInteger(this, format, NumberFormatInfo.GetInstance(provider));
         }
 
+        public bool TryFormat(Span<char> destination, out int charsWritten, string format = default, IFormatProvider provider = null) // TODO: change format to ReadOnlySpan<char>
+        {
+            return BigNumber.TryFormatBigInteger(this, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+        }
+
         private static BigInteger Add(uint[] leftBits, int leftSign, uint[] rightBits, int rightSign)
         {
             bool trivialLeft = leftBits == null;

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1176,6 +1176,17 @@ namespace System.Numerics
         public bool TryWriteBytes(Span<byte> destination, out int bytesWritten, bool isUnsigned=false, bool isBigEndian=false)
         {
             bytesWritten = 0;
+            if (TryGetBytes(GetBytesMode.Span, destination, isUnsigned, isBigEndian, ref bytesWritten) == null)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+            return true;
+        }
+
+        internal bool TryWriteOrCountBytes(Span<byte> destination, out int bytesWritten, bool isUnsigned = false, bool isBigEndian = false)
+        {
+            bytesWritten = 0;
             return TryGetBytes(GetBytesMode.Span, destination, isUnsigned, isBigEndian, ref bytesWritten) != null;
         }
 
@@ -1204,7 +1215,7 @@ namespace System.Numerics
         /// <param name="bytesWritten">
         /// If <paramref name="mode"/>==<see cref="GetBytesMode.AllocateArray"/>, ignored.
         /// If <paramref name="mode"/>==<see cref="GetBytesMode.Count"/>, the number of bytes that would be written.
-        /// If <paramref name="mode"/>==<see cref="GetBytesMode.Span"/>, the number of bytes written to the span.
+        /// If <paramref name="mode"/>==<see cref="GetBytesMode.Span"/>, the number of bytes written to the span or that would be written if it were long enough.
         /// </param>
         /// <returns>
         /// If <paramref name="mode"/>==<see cref="GetBytesMode.AllocateArray"/>, the result array.
@@ -1228,10 +1239,10 @@ namespace System.Numerics
                         bytesWritten = 1;
                         return null;
                     default: // case GetBytesMode.Span:
+                        bytesWritten = 1;
                         if (destination.Length != 0)
                         {
                             destination[0] = 0;
-                            bytesWritten = 1;
                             return s_success;
                         }
                         return null;
@@ -1325,11 +1336,11 @@ namespace System.Numerics
                     bytesWritten = length;
                     return null;
                 default: // case GetBytesMode.Span:
+                    bytesWritten = length;
                     if (destination.Length < length)
                     {
                         return null;
                     }
-                    bytesWritten = length;
                     array = s_success;
                     break;
             }

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -504,8 +504,6 @@ namespace System.Numerics
 
         private static string FormatBigIntegerToHex(BigInteger value, char format, int digits, NumberFormatInfo info)
         {
-            Debug.Assert(format == 'x' || format == 'X');
-
             // Get the bytes that make up the BigInteger.
             Span<byte> bits = stackalloc byte[64]; // arbitrary limit to switch from stack to heap
             bits = value.TryWriteBytes(bits, out int bytesWritten) ?
@@ -514,8 +512,33 @@ namespace System.Numerics
 
             Span<char> stackSpace = stackalloc char[128]; // each byte is typically two chars
             var sb = new ValueStringBuilder(stackSpace);
-            int cur = bits.Length - 1;
 
+            FormatBigIntegerToHex(bits, ref sb, value, format, digits, info);
+
+            return sb.ToString();
+        }
+
+        private static bool TryFormatBigIntegerToHex(BigInteger value, char format, int digits, NumberFormatInfo info, Span<char> destination, out int charsWritten)
+        {
+            // Get the bytes that make up the BigInteger.
+            Span<byte> bits = stackalloc byte[64]; // arbitrary limit to switch from stack to heap
+            bits = value.TryWriteBytes(bits, out int bytesWritten) ?
+                bits.Slice(0, bytesWritten) :
+                value.ToByteArray();
+
+            Span<char> stackSpace = stackalloc char[128]; // each byte is typically two chars
+            var sb = new ValueStringBuilder(stackSpace);
+
+            FormatBigIntegerToHex(bits, ref sb, value, format, digits, info);
+
+            return sb.TryCopyTo(destination, out charsWritten);
+        }
+
+        private static void FormatBigIntegerToHex(Span<byte> bits, ref ValueStringBuilder sb, BigInteger value, char format, int digits, NumberFormatInfo info)
+        {
+            Debug.Assert(format == 'x' || format == 'X');
+
+            int cur = bits.Length - 1;
             if (cur > -1)
             {
                 // [FF..F8] drop the high F as the two's complement negative number remains clear
@@ -562,31 +585,58 @@ namespace System.Numerics
                     value._sign >= 0 ? '0' : (format == 'x') ? 'f' : 'F',
                     digits - sb.Length);
             }
-
-            return sb.ToString();
         }
 
         internal static string FormatBigInteger(BigInteger value, string format, NumberFormatInfo info)
         {
+            return FormatBigInteger(targetSpan: false, value, format, info, default, out _, out _);
+        }
+
+        internal static bool TryFormatBigInteger(BigInteger value, string format, NumberFormatInfo info, Span<char> destination, out int charsWritten)
+        {
+            FormatBigInteger(targetSpan: true, value, format, info, destination, out charsWritten, out bool spanSuccess);
+            return spanSuccess;
+        }
+
+        private static string FormatBigInteger(bool targetSpan, BigInteger value, string format, NumberFormatInfo info, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        {
             int digits = 0;
             char fmt = ParseFormatSpecifier(format, out digits);
             if (fmt == 'x' || fmt == 'X')
-                return FormatBigIntegerToHex(value, fmt, digits, info);
+            {
+                if (targetSpan)
+                {
+                    spanSuccess = TryFormatBigIntegerToHex(value, fmt, digits, info, destination, out charsWritten);
+                    return null;
+                }
+                else
+                {
+                    charsWritten = 0;
+                    spanSuccess = false;
+                    return FormatBigIntegerToHex(value, fmt, digits, info);
+                }
+            }
 
-            bool decimalFmt = (fmt == 'g' || fmt == 'G' || fmt == 'd' || fmt == 'D' || fmt == 'r' || fmt == 'R');
 
             if (value._bits == null)
             {
                 if (fmt == 'g' || fmt == 'G' || fmt == 'r' || fmt == 'R')
                 {
-                    if (digits > 0)
-                        format = string.Format(CultureInfo.InvariantCulture, "D{0}", digits.ToString(CultureInfo.InvariantCulture));
-                    else
-                        format = "D";
+                    format = digits > 0 ? string.Format("D{0}", digits) : "D";
                 }
-                return value._sign.ToString(format, info);
-            }
 
+                if (targetSpan)
+                {
+                    spanSuccess = value._sign.TryFormat(destination, out charsWritten, format, info);
+                    return null;
+                }
+                else
+                {
+                    charsWritten = 0;
+                    spanSuccess = false;
+                    return value._sign.ToString(format, info);
+                }
+            }
 
             // First convert to base 10^9.
             const uint kuBase = 1000000000; // 10^9
@@ -629,6 +679,7 @@ namespace System.Numerics
             }
             catch (OverflowException e) { throw new FormatException(SR.Format_TooLarge, e); }
 
+            bool decimalFmt = (fmt == 'g' || fmt == 'G' || fmt == 'd' || fmt == 'D' || fmt == 'r' || fmt == 'R');
             if (decimalFmt)
             {
                 if (digits > 0 && digits > cchMax)
@@ -682,7 +733,28 @@ namespace System.Numerics
                 int precision = 29;
                 int scale = cchMax - ichDst;
 
-                return FormatProvider.FormatBigInteger(precision, scale, sign, format, info, rgch, ichDst);
+                var sb = new StringBuilder();
+                FormatProvider.FormatBigInteger(sb, precision, scale, sign, format, info, rgch, ichDst);
+
+                if (!targetSpan)
+                {
+                    charsWritten = 0;
+                    spanSuccess = false;
+                    return sb.ToString();
+                }
+                else if (sb.Length <= destination.Length)
+                {
+                    sb.CopyTo(0, destination, sb.Length);
+                    charsWritten = sb.Length;
+                    spanSuccess = true;
+                    return null;
+                }
+                else
+                {
+                    charsWritten = 0;
+                    spanSuccess = false;
+                    return null;
+                }
             }
 
             // Format Round-trip decimal
@@ -704,7 +776,26 @@ namespace System.Numerics
                 for (int i = info.NegativeSign.Length - 1; i > -1; i--)
                     rgch[--ichDst] = info.NegativeSign[i];
             }
-            return new string(rgch, ichDst, cchMax - ichDst);
+
+            int resultLength = cchMax - ichDst;
+            if (!targetSpan)
+            {
+                charsWritten = 0;
+                spanSuccess = false;
+                return new string(rgch, ichDst, cchMax - ichDst);
+            }
+            else if (new ReadOnlySpan<char>(rgch, ichDst, cchMax - ichDst).TryCopyTo(destination))
+            {
+                charsWritten = resultLength;
+                spanSuccess = true;
+                return null;
+            }
+            else
+            {
+                charsWritten = 0;
+                spanSuccess = false;
+                return null;
+            }
         }
     }
 }

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -733,27 +733,20 @@ namespace System.Numerics
                 int precision = 29;
                 int scale = cchMax - ichDst;
 
-                var sb = new StringBuilder();
-                FormatProvider.FormatBigInteger(sb, precision, scale, sign, format, info, rgch, ichDst);
+                Span<char> stackSpace = stackalloc char[128]; // arbitrary stack cut-off
+                var sb = new ValueStringBuilder(stackSpace);
+                FormatProvider.FormatBigInteger(ref sb, precision, scale, sign, format, info, rgch, ichDst);
 
-                if (!targetSpan)
+                if (targetSpan)
                 {
-                    charsWritten = 0;
-                    spanSuccess = false;
-                    return sb.ToString();
-                }
-                else if (sb.Length <= destination.Length)
-                {
-                    sb.CopyTo(0, destination, sb.Length);
-                    charsWritten = sb.Length;
-                    spanSuccess = true;
+                    spanSuccess = sb.TryCopyTo(destination, out charsWritten);
                     return null;
                 }
                 else
                 {
                     charsWritten = 0;
                     spanSuccess = false;
-                    return null;
+                    return sb.ToString();
                 }
             }
 

--- a/src/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -1418,37 +1418,38 @@ namespace System.Numerics.Tests
 
                 Assert.False(expectError, "Expected exception not encountered.");
 
-                if (expectedResult != result)
-                {
-                    Assert.Equal(expectedResult.Length, result.Length);
-
-                    int index = expectedResult.LastIndexOf("E", StringComparison.OrdinalIgnoreCase);
-                    Assert.False(index == 0, "'E' found at beginning of expectedResult");
-
-                    bool equal = false;
-                    if (index > 0)
-                    {
-                        var dig1 = (byte)expectedResult[index - 1];
-                        var dig2 = (byte)result[index - 1];
-
-                        equal |= (dig2 == dig1 - 1 || dig2 == dig1 + 1);
-                        equal |= (dig1 == '9' && dig2 == '0' || dig2 == '9' && dig1 == '0');
-                        equal |= (index == 1 && (dig1 == '9' && dig2 == '1' || dig2 == '9' && dig1 == '1'));
-                    }
-
-                    Assert.True(equal);
-                }
-                else
-                {
-                    Assert.Equal(expectedResult, result);
-                }
+                VerifyExpectedStringResult(expectedResult, result);
             }
-            catch (Exception e)
+            catch (FormatException)
             {
-                Assert.True(expectError && e.GetType() == typeof(FormatException), "Unexpected Exception:" + e);
+                Assert.True(expectError);
             }
 
             VerifyTryFormat(test, format, provider, expectError, expectedResult);
+        }
+
+        private static void VerifyExpectedStringResult(string expectedResult, string result)
+        {
+            if (expectedResult != result)
+            {
+                Assert.Equal(expectedResult.Length, result.Length);
+
+                int index = expectedResult.LastIndexOf("E", StringComparison.OrdinalIgnoreCase);
+                Assert.False(index == 0, "'E' found at beginning of expectedResult");
+
+                bool equal = false;
+                if (index > 0)
+                {
+                    var dig1 = (byte)expectedResult[index - 1];
+                    var dig2 = (byte)result[index - 1];
+
+                    equal |= (dig2 == dig1 - 1 || dig2 == dig1 + 1);
+                    equal |= (dig1 == '9' && dig2 == '0' || dig2 == '9' && dig1 == '0');
+                    equal |= (index == 1 && (dig1 == '9' && dig2 == '1' || dig2 == '9' && dig1 == '1'));
+                }
+
+                Assert.True(equal);
+            }
         }
 
         static partial void VerifyTryFormat(string test, string format, IFormatProvider provider, bool expectError, string expectedResult);

--- a/src/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Numerics.Tests
 {
-    public class ToStringTest
+    public partial class ToStringTest
     {
         private static bool s_noZeroOut = true;
 
@@ -1447,7 +1447,11 @@ namespace System.Numerics.Tests
             {
                 Assert.True(expectError && e.GetType() == typeof(FormatException), "Unexpected Exception:" + e);
             }
+
+            VerifyTryFormat(test, format, provider, expectError, expectedResult);
         }
+
+        static partial void VerifyTryFormat(string test, string format, IFormatProvider provider, bool expectError, string expectedResult);
 
         private static String GetDigitSequence(int min, int max, Random random)
         {

--- a/src/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.netcoreapp.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.netcoreapp.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Numerics.Tests
+{
+    public partial class ToStringTest
+    {
+        static partial void VerifyTryFormat(string test, string format, IFormatProvider provider, bool expectError, string expectedResult)
+        {
+            try
+            {
+                BigInteger bi = BigInteger.Parse(test, provider);
+
+                char[] destination = expectedResult != null ? new char[expectedResult.Length] : Array.Empty<char>();
+                bool success = bi.TryFormat(destination, out int charsWritten, format, provider);
+                Assert.False(expectError);
+                Assert.True(success);
+                Assert.Equal(expectedResult.Length, charsWritten);
+
+                string result = new string(destination, 0, charsWritten);
+                if (expectedResult != result)
+                {
+                    Assert.Equal(expectedResult.Length, result.Length);
+
+                    int index = expectedResult.LastIndexOf("E", StringComparison.OrdinalIgnoreCase);
+                    Assert.False(index == 0, "'E' found at beginning of expectedResult");
+
+                    bool equal = false;
+                    if (index > 0)
+                    {
+                        var dig1 = (byte)expectedResult[index - 1];
+                        var dig2 = (byte)result[index - 1];
+
+                        equal |= (dig2 == dig1 - 1 || dig2 == dig1 + 1);
+                        equal |= (dig1 == '9' && dig2 == '0' || dig2 == '9' && dig1 == '0');
+                        equal |= (index == 1 && (dig1 == '9' && dig2 == '1' || dig2 == '9' && dig1 == '1'));
+                    }
+
+                    Assert.True(equal);
+                }
+                else
+                {
+                    Assert.Equal(expectedResult, result);
+
+                    if (expectedResult.Length > 0)
+                    {
+                        Assert.False(bi.TryFormat(new char[expectedResult.Length - 1], out charsWritten, format, provider));
+                        Assert.Equal(0, charsWritten);
+                    }
+                }
+
+            }
+            catch (Exception e)
+            {
+                Assert.True(expectError && e.GetType() == typeof(FormatException), "Unexpected Exception:" + e);
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.netcoreapp.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.netcoreapp.cs
@@ -15,47 +15,20 @@ namespace System.Numerics.Tests
                 BigInteger bi = BigInteger.Parse(test, provider);
 
                 char[] destination = expectedResult != null ? new char[expectedResult.Length] : Array.Empty<char>();
-                bool success = bi.TryFormat(destination, out int charsWritten, format, provider);
+                Assert.True(bi.TryFormat(destination, out int charsWritten, format, provider));
                 Assert.False(expectError);
-                Assert.True(success);
-                Assert.Equal(expectedResult.Length, charsWritten);
 
-                string result = new string(destination, 0, charsWritten);
-                if (expectedResult != result)
+                VerifyExpectedStringResult(expectedResult, new string(destination, 0, charsWritten));
+
+                if (expectedResult.Length > 0)
                 {
-                    Assert.Equal(expectedResult.Length, result.Length);
-
-                    int index = expectedResult.LastIndexOf("E", StringComparison.OrdinalIgnoreCase);
-                    Assert.False(index == 0, "'E' found at beginning of expectedResult");
-
-                    bool equal = false;
-                    if (index > 0)
-                    {
-                        var dig1 = (byte)expectedResult[index - 1];
-                        var dig2 = (byte)result[index - 1];
-
-                        equal |= (dig2 == dig1 - 1 || dig2 == dig1 + 1);
-                        equal |= (dig1 == '9' && dig2 == '0' || dig2 == '9' && dig1 == '0');
-                        equal |= (index == 1 && (dig1 == '9' && dig2 == '1' || dig2 == '9' && dig1 == '1'));
-                    }
-
-                    Assert.True(equal);
+                    Assert.False(bi.TryFormat(new char[expectedResult.Length - 1], out charsWritten, format, provider));
+                    Assert.Equal(0, charsWritten);
                 }
-                else
-                {
-                    Assert.Equal(expectedResult, result);
-
-                    if (expectedResult.Length > 0)
-                    {
-                        Assert.False(bi.TryFormat(new char[expectedResult.Length - 1], out charsWritten, format, provider));
-                        Assert.Equal(0, charsWritten);
-                    }
-                }
-
             }
-            catch (Exception e)
+            catch (FormatException)
             {
-                Assert.True(expectError && e.GetType() == typeof(FormatException), "Unexpected Exception:" + e);
+                Assert.True(expectError);
             }
         }
     }

--- a/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
+++ b/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="BigInteger\absolutevalue.cs" />
     <Compile Include="BigInteger\BigIntegerToStringTests.cs" />
+    <Compile Include="BigInteger\BigIntegerToStringTests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="BigInteger\BigInteger.AddTests.cs" />
     <Compile Include="BigInteger\BigInteger.SubtractTests.cs" />
     <Compile Include="BigInteger\BigIntTools.cs" />


### PR DESCRIPTION
Note that I'm waiting for https://github.com/dotnet/corefx/issues/25337 to land and will then update this with using `ReadOnlySpan<char>` instead of `string` for the `format`.  After that I'll run some perf tests to verify nothing's regressed.

Contributes to https://github.com/dotnet/corefx/issues/25336
cc: @bartonjs 