### PR TITLE
Performance issue fix for manged sni

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -374,8 +374,6 @@ namespace System.Data.SqlClient.SNI
         public override void SetBufferSize(int bufferSize)
         {
             _bufferSize = bufferSize;
-            _socket.SendBufferSize = bufferSize;
-            _socket.ReceiveBufferSize = bufferSize;
         }
 
         /// <summary>


### PR DESCRIPTION
Setting buffer size of socket manually causes the performance issue. This is a fix for the issue: https://github.com/dotnet/corefx/issues/24480