### PR TITLE
Microsoft.CSharp: Remove unused SymWithType fields from MemberLookup

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -64,7 +64,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private readonly SymWithType _swtBad;       // If we're looking for a constructor or indexer, this matched on name, but isn't the right thing.
         private readonly SymWithType _swtBogus;     // A bogus member - such as an indexed property.
         private readonly SymWithType _swtBadArity;  // An symbol with the wrong arity.
-        private SymWithType _swtAmbigWarn; // An ambiguous symbol, but only warn.
 
         // We have an override symbol, which we've errored on in SymbolPrepare. If we have nothing better, use this.
         // This is because if we have:
@@ -313,7 +312,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         // Give method groups priority.
                         if (!(symCur is MethodSymbol))
                             goto LAmbig;
-                        _swtAmbigWarn = _swtFirst;
                         // Erase previous results so we'll record this method as the first.
                         _prgtype = new List<AggregateType>();
                         _csym = 0;
@@ -327,8 +325,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             // Give method groups priority.
                             if (!(_swtFirst.Sym is MethodSymbol))
                                 goto LAmbig;
-                            if (!_swtAmbigWarn)
-                                _swtAmbigWarn.Set(symCur, typeCur);
                         }
                         // This one is hidden by another. This one also hides any more in base types.
                         pfHideByName = true;
@@ -549,7 +545,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _swtBad = new SymWithType();
             _swtBogus = new SymWithType();
             _swtBadArity = new SymWithType();
-            _swtAmbigWarn = new SymWithType();
             _swtOverride = new SymWithType();
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -64,24 +64,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private readonly SymWithType _swtBad;       // If we're looking for a constructor or indexer, this matched on name, but isn't the right thing.
         private readonly SymWithType _swtBogus;     // A bogus member - such as an indexed property.
         private readonly SymWithType _swtBadArity;  // An symbol with the wrong arity.
-
-        // We have an override symbol, which we've errored on in SymbolPrepare. If we have nothing better, use this.
-        // This is because if we have:
-        //
-        // class C : D
-        // {
-        //     public override int M() { }
-        //     static void Main()
-        //     {
-        //         C c = new C();
-        //         c.M(); <-- 
-        //
-        // We try to look up M, and find the M on C, but throw it out since its an override, and 
-        // we want the virtual that it overrides. However, in this case, we'll never find that
-        // virtual, since it doesn't exist. We therefore want to use the override anyway, and
-        // continue on to give results with that.
-
-        private readonly SymWithType _swtOverride;
         private bool _fMulti;              // Whether symFirst is of a kind for which we collect multiples (methods and indexers).
 
         /***************************************************************************************************
@@ -175,10 +157,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // Check for user callability.
                 if (symCur.IsOverride() && !symCur.IsHideByName())
                 {
-                    if (!_swtOverride)
-                    {
-                        _swtOverride.Set(symCur, typeCur);
-                    }
                     continue;
                 }
 
@@ -545,7 +523,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _swtBad = new SymWithType();
             _swtBogus = new SymWithType();
             _swtBadArity = new SymWithType();
-            _swtOverride = new SymWithType();
         }
 
         /***************************************************************************************************


### PR DESCRIPTION
* Remove `_swtAmbigWarn`

Not sure if setting it can be reached, but it's never used if it is, because we can only error or not, with no mechanism to warn.

* Remove `_swtOverride`

Set, but never used (since we can't have a bogus override against an already-compiled type, which it is stored to potentially error against in static compilation).
