### PR TITLE
Support Syndication Support Rss Optional Elements

### DIFF
--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.netcoreapp.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.netcoreapp.cs
@@ -10,10 +10,22 @@ namespace System.ServiceModel.Syndication
     public partial class SyndicationFeed
     {
         public SyndicationLink Documentation { get{ throw null; } set{ } }
+        public System.Collections.Generic.ICollection<string> SkipDays { get { throw null; } }
+        public System.Collections.Generic.ICollection<int> SkipHours { get { throw null; } }
+        public System.ServiceModel.Syndication.SyndicationTextInput TextInput { get { throw null; } set { } }
+        public int TimeToLive { get { throw null; } set { } }
     }
     public abstract partial class SyndicationFeedFormatter
     {
         public System.Func<string, string, string, System.DateTimeOffset> DateTimeParser { get { throw null; } set { } }
         public System.Func<string, System.UriKind, string, string, System.Uri> UriParser { get { throw null; } set { } }
+    }
+    public partial class SyndicationTextInput
+    {
+        public string Description;
+        public System.ServiceModel.Syndication.SyndicationLink Link;
+        public string Name;
+        public string Title;
+        public SyndicationTextInput() { }
     }
 }

--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.netcoreapp.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.netcoreapp.cs
@@ -10,8 +10,8 @@ namespace System.ServiceModel.Syndication
     public partial class SyndicationFeed
     {
         public SyndicationLink Documentation { get{ throw null; } set{ } }
-        public System.Collections.Generic.ICollection<string> SkipDays { get { throw null; } }
-        public System.Collections.Generic.ICollection<int> SkipHours { get { throw null; } }
+        public System.Collections.Generic.ICollection<string> SkipDays { get { throw null; } set { } }
+        public System.Collections.Generic.ICollection<int> SkipHours { get { throw null; } set { } }
         public System.ServiceModel.Syndication.SyndicationTextInput TextInput { get { throw null; } set { } }
         public int TimeToLive { get { throw null; } set { } }
     }

--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.netcoreapp.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.netcoreapp.cs
@@ -13,7 +13,7 @@ namespace System.ServiceModel.Syndication
         public System.Collections.ObjectModel.Collection<string> SkipDays { get { throw null; } }
         public System.Collections.ObjectModel.Collection<int> SkipHours { get { throw null; } }
         public System.ServiceModel.Syndication.SyndicationTextInput TextInput { get { throw null; } set { } }
-        public int TimeToLive { get { throw null; } set { } }
+        public int? TimeToLive { get { throw null; } set { } }
     }
     public abstract partial class SyndicationFeedFormatter
     {

--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.netcoreapp.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.netcoreapp.cs
@@ -7,6 +7,10 @@
 
 namespace System.ServiceModel.Syndication
 {
+    public partial class SyndicationFeed
+    {
+        public SyndicationLink Documentation { get{ throw null; } set{ } }
+    }
     public abstract partial class SyndicationFeedFormatter
     {
         public System.Func<string, string, string, System.DateTimeOffset> DateTimeParser { get { throw null; } set { } }

--- a/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.netcoreapp.cs
+++ b/src/System.ServiceModel.Syndication/ref/System.ServiceModel.Syndication.netcoreapp.cs
@@ -10,8 +10,8 @@ namespace System.ServiceModel.Syndication
     public partial class SyndicationFeed
     {
         public SyndicationLink Documentation { get{ throw null; } set{ } }
-        public System.Collections.Generic.ICollection<string> SkipDays { get { throw null; } set { } }
-        public System.Collections.Generic.ICollection<int> SkipHours { get { throw null; } set { } }
+        public System.Collections.ObjectModel.Collection<string> SkipDays { get { throw null; } }
+        public System.Collections.ObjectModel.Collection<int> SkipHours { get { throw null; } }
         public System.ServiceModel.Syndication.SyndicationTextInput TextInput { get { throw null; } set { } }
         public int TimeToLive { get { throw null; } set { } }
     }

--- a/src/System.ServiceModel.Syndication/src/Resources/Strings.resx
+++ b/src/System.ServiceModel.Syndication/src/Resources/Strings.resx
@@ -255,4 +255,7 @@
   <data name="XmlStartElementExpected" xml:space="preserve">
     <value>Start element expected. Found {0}.</value>
   </data>
+  <data name="InvalidSkipHourValue" xml:space="preserve">
+    <value>Cannot parse string `{0}` as skip hour. The value for skip hours must be an integer betwen 0 and 23.</value>
+  </data>
 </root>

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ExtensibleSyndicationObject.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/ExtensibleSyndicationObject.cs
@@ -117,7 +117,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        internal void WriteElementExtensions(XmlWriter writer)
+        internal void WriteElementExtensions(XmlWriter writer, Func<string, string, bool> shouldSkipElement = null)
         {
             if (writer == null)
             {
@@ -125,7 +125,7 @@ namespace System.ServiceModel.Syndication
             }
             if (_elementExtensions != null)
             {
-                _elementExtensions.WriteTo(writer);
+                _elementExtensions.WriteTo(writer, shouldSkipElement);
             }
         }
 

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20Constants.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20Constants.cs
@@ -34,5 +34,13 @@ namespace System.ServiceModel.Syndication
         public const string UrlTag = "url";
         public const string Version = "2.0";
         public const string VersionTag = "version";
+        public const string DocumentationTag = "docs";
+        public const string TimeToLiveTag = "ttl";
+        public const string TextInputTag = "textInput";
+        public const string SkipHoursTag = "skipHours";
+        public const string SkipDaysTag = "skipDays";
+        public const string HourTag = "hour";
+        public const string DayTag = "day";
+        public const string NameTag = "name";
     }
 }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -1026,10 +1026,50 @@ namespace System.ServiceModel.Syndication
             }
 
             // Optional spec items
-            // docs
             if (Feed.InternalDocumentation?.Uri != null)
             {
                 writer.WriteElementString(Rss20Constants.DocumentationTag, Feed.InternalDocumentation.Uri.ToString());
+            }
+
+            if (Feed.InternalTimeToLive != null)
+            {
+                writer.WriteElementString(Rss20Constants.TimeToLiveTag, Feed.InternalTimeToLive.ToString());
+            }
+
+            if (Feed.InternalSkipHours?.Count > 0)
+            {
+                writer.WriteStartElement(Rss20Constants.SkipHoursTag);
+
+                foreach (int hour in Feed.InternalSkipHours)
+                {
+                    writer.WriteElementString(Rss20Constants.HourTag, hour.ToString());
+                }
+
+                writer.WriteEndElement();
+            }
+
+            if (Feed.InternalSkipDays?.Count > 0)
+            {
+                writer.WriteStartElement(Rss20Constants.SkipDaysTag);
+
+                foreach (string day in Feed.InternalSkipDays)
+                {
+                    writer.WriteElementString(Rss20Constants.DayTag, day);
+                }
+
+                writer.WriteEndElement();
+            }
+
+            if (Feed.InternalTextInput != null)
+            {
+                writer.WriteStartElement(Rss20Constants.TextInputTag);
+
+                writer.WriteElementString(Rss20Constants.DescriptionTag, Feed.InternalTextInput.Description);
+                writer.WriteElementString(Rss20Constants.TitleTag, Feed.InternalTextInput.Title);
+                writer.WriteElementString(Rss20Constants.LinkTag, Feed.InternalTextInput.Link.GetAbsoluteUri().ToString());
+                writer.WriteElementString(Rss20Constants.NameTag, Feed.InternalTextInput.Name);
+
+                writer.WriteEndElement();
             }
 
             if (_serializeExtensionsAsAtom)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -275,7 +275,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        internal SyndicationLink ReadAlternateLink(XmlReader reader, Uri baseUri)
+        internal static SyndicationLink ReadAlternateLink(XmlReader reader, Uri baseUri, Func<string, UriKind, string, string, Uri> uriParser, bool preserveAttributeExtensions)
         {
             SyndicationLink link = new SyndicationLink();
             link.BaseUri = baseUri;
@@ -290,7 +290,7 @@ namespace System.ServiceModel.Syndication
                     }
                     else if (!FeedUtils.IsXmlns(reader.LocalName, reader.NamespaceURI))
                     {
-                        if (this.PreserveAttributeExtensions)
+                        if (preserveAttributeExtensions)
                         {
                             link.AttributeExtensions.Add(new XmlQualifiedName(reader.LocalName, reader.NamespaceURI), reader.Value);
                         }
@@ -303,7 +303,7 @@ namespace System.ServiceModel.Syndication
             }
 
             string uri = reader.ReadElementString();
-            link.Uri = UriParser(uri, UriKind.RelativeOrAbsolute, Rss20Constants.LinkTag, Rss20Constants.Rss20Namespace);
+            link.Uri = uriParser(uri, UriKind.RelativeOrAbsolute, Rss20Constants.LinkTag, Rss20Constants.Rss20Namespace);
             return link;
         }
 
@@ -421,7 +421,7 @@ namespace System.ServiceModel.Syndication
                             }
                             else if (reader.IsStartElement(Rss20Constants.LinkTag, Rss20Constants.Rss20Namespace))
                             {
-                                result.Links.Add(ReadAlternateLink(reader, result.BaseUri));
+                                result.Links.Add(ReadAlternateLink(reader, result.BaseUri, UriParser, PreserveAttributeExtensions));
                                 readAlternateLink = true;
                             }
                             else if (reader.IsStartElement(Rss20Constants.DescriptionTag, Rss20Constants.Rss20Namespace))
@@ -757,7 +757,7 @@ namespace System.ServiceModel.Syndication
                         }
                         else if (reader.IsStartElement(Rss20Constants.LinkTag, Rss20Constants.Rss20Namespace))
                         {
-                            result.Links.Add(ReadAlternateLink(reader, result.BaseUri));
+                            result.Links.Add(ReadAlternateLink(reader, result.BaseUri, UriParser, PreserveAttributeExtensions));
                         }
                         else if (reader.IsStartElement(Rss20Constants.DescriptionTag, Rss20Constants.Rss20Namespace))
                         {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -1027,9 +1027,9 @@ namespace System.ServiceModel.Syndication
 
             // Optional spec items
             // docs
-            if (Feed.GetDocumentation() != null)
+            if (Feed.InternalDocumentation?.Uri != null)
             {
-                writer.WriteElementString(Rss20Constants.DocumentationTag, Feed.GetDocumentation().Uri.ToString());
+                writer.WriteElementString(Rss20Constants.DocumentationTag, Feed.InternalDocumentation.Uri.ToString());
             }
 
             if (_serializeExtensionsAsAtom)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Rss20FeedFormatter.cs
@@ -275,7 +275,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        private SyndicationLink ReadAlternateLink(XmlReader reader, Uri baseUri)
+        internal SyndicationLink ReadAlternateLink(XmlReader reader, Uri baseUri)
         {
             SyndicationLink link = new SyndicationLink();
             link.BaseUri = baseUri;
@@ -1023,6 +1023,13 @@ namespace System.ServiceModel.Syndication
                 string imgAlternateLink = (alternateLink != null) ? FeedUtils.GetUriString(alternateLink.Uri) : string.Empty;
                 writer.WriteElementString(Rss20Constants.LinkTag, Rss20Constants.Rss20Namespace, imgAlternateLink);
                 writer.WriteEndElement(); // image
+            }
+
+            // Optional spec items
+            // docs
+            if (Feed.GetDocumentation() != null)
+            {
+                writer.WriteElementString(Rss20Constants.DocumentationTag, Feed.GetDocumentation().Uri.ToString());
             }
 
             if (_serializeExtensionsAsAtom)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationElementExtensionCollection.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationElementExtensionCollection.cs
@@ -133,7 +133,7 @@ namespace System.ServiceModel.Syndication
             return ReadExtensions<TExtension>(extensionName, extensionNamespace, null, serializer);
         }
 
-        internal void WriteTo(XmlWriter writer)
+        internal void WriteTo(XmlWriter writer, Func<string, string, bool> shouldSkipElement)
         {
             if (_buffer != null)
             {
@@ -142,6 +142,12 @@ namespace System.ServiceModel.Syndication
                     reader.ReadStartElement();
                     while (reader.IsStartElement())
                     {
+                        if (shouldSkipElement != null && shouldSkipElement(reader.LocalName, reader.NamespaceURI))
+                        {
+                            reader.Skip();
+                            continue;
+                        }
+
                         writer.WriteNode(reader, false);
                     }
                 }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
@@ -40,10 +40,9 @@ namespace System.ServiceModel.Syndication
         // optional RSS tags
         private SyndicationLink _documentation;
         private int? _timeToLive;
-        private Collection<int> _skipHours;
-        private Collection<string> _skipDays;
+        private ICollection<int> _skipHours;
+        private ICollection<string> _skipDays;
         private SyndicationTextInput _textInput;
-        private Uri _iconImage;
 
         public SyndicationFeed()
             : this((IEnumerable<SyndicationItem>)null)
@@ -345,6 +344,10 @@ namespace System.ServiceModel.Syndication
 
                 return _skipHours;
             }
+            set
+            {
+                _skipHours = value;
+            }
         }
 
         internal ICollection<string> InternalSkipDays
@@ -365,6 +368,10 @@ namespace System.ServiceModel.Syndication
                 }
 
                 return _skipDays;
+            }
+            set
+            {
+                _skipDays = value;
             }
         }
 
@@ -389,25 +396,7 @@ namespace System.ServiceModel.Syndication
             }
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
                 _textInput = value;
-            }
-        }
-
-        public Uri IconImage
-        {
-            get
-            {
-                return _iconImage;
-            }
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                _iconImage = value;
             }
         }
 

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
@@ -269,9 +269,12 @@ namespace System.ServiceModel.Syndication
             set { _title = value; }
         }
 
-        internal SyndicationLink GetDocumentation()
+        internal SyndicationLink InternalDocumentation
         {
-            return _documentation;
+            get
+            {
+                return _documentation;
+            }
         }
 
         public SyndicationLink Documentation
@@ -409,7 +412,7 @@ namespace System.ServiceModel.Syndication
             switch (localName)
             {
                 case Rss20Constants.DocumentationTag:
-                    if (ns == Rss20Constants.Rss20Namespace && GetDocumentation() != null)
+                    if (ns == Rss20Constants.Rss20Namespace && InternalDocumentation != null)
                     {
                         return true;
                     }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
@@ -40,8 +40,8 @@ namespace System.ServiceModel.Syndication
         // optional RSS tags
         private SyndicationLink _documentation;
         private int? _timeToLive;
-        private ICollection<int> _skipHours;
-        private ICollection<string> _skipDays;
+        private Collection<int> _skipHours;
+        private Collection<string> _skipDays;
         private SyndicationTextInput _textInput;
 
         public SyndicationFeed()
@@ -325,7 +325,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        internal ICollection<int> InternalSkipHours
+        internal Collection<int> InternalSkipHours
         {
             get
             {
@@ -333,24 +333,22 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        public ICollection<int> SkipHours
+        public Collection<int> SkipHours
         {
             get
             {
                 if (_skipHours == null)
                 {
-                    _skipHours = TryReadSkipHoursFromExtension(ElementExtensions);
+                    var skipHours = new Collection<int>();
+                    TryReadSkipHoursFromExtension(ElementExtensions, skipHours);
+                    _skipHours = skipHours;
                 }
 
                 return _skipHours;
             }
-            set
-            {
-                _skipHours = value;
-            }
         }
 
-        internal ICollection<string> InternalSkipDays
+        internal Collection<string> InternalSkipDays
         {
             get
             {
@@ -358,20 +356,18 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        public ICollection<string> SkipDays
+        public Collection<string> SkipDays
         {
             get
             {
                 if (_skipDays == null)
                 {
-                    _skipDays = TryReadSkipDaysFromExtension(ElementExtensions);
+                    var skipDays = new Collection<string>();
+                    TryReadSkipDaysFromExtension(ElementExtensions, skipDays);
+                    _skipDays = skipDays;
                 }
 
                 return _skipDays;
-            }
-            set
-            {
-                _skipDays = value;
             }
         }
 
@@ -433,16 +429,15 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        private Collection<int> TryReadSkipHoursFromExtension(SyndicationElementExtensionCollection elementExtensions)
+        private void TryReadSkipHoursFromExtension(SyndicationElementExtensionCollection elementExtensions, Collection<int> skipHours)
         {
             SyndicationElementExtension skipHoursElement = elementExtensions
                                       .Where((e) => e.OuterName == Rss20Constants.SkipHoursTag && e.OuterNamespace == Rss20Constants.Rss20Namespace)
                                       .FirstOrDefault();
 
             if (skipHoursElement == null)
-                return null;
+                return;
 
-            var skipHours = new Collection<int>();
             using (XmlReader reader = skipHoursElement.GetReader())
             {
                 reader.ReadStartElement();
@@ -474,20 +469,17 @@ namespace System.ServiceModel.Syndication
                     }
                 }
             }
-
-            return skipHours;
         }
 
-        private Collection<string> TryReadSkipDaysFromExtension(SyndicationElementExtensionCollection elementExtensions)
+        private void TryReadSkipDaysFromExtension(SyndicationElementExtensionCollection elementExtensions, Collection<string> skipDays)
         {
             SyndicationElementExtension skipDaysElement = elementExtensions
                                       .Where((e) => e.OuterName == Rss20Constants.SkipDaysTag && e.OuterNamespace == Rss20Constants.Rss20Namespace)
                                       .FirstOrDefault();
 
             if (skipDaysElement == null)
-                return null;
+                return;
 
-            var skipDays = new Collection<string>();
             using (XmlReader reader = skipDaysElement.GetReader())
             {
                 reader.ReadStartElement();
@@ -512,8 +504,6 @@ namespace System.ServiceModel.Syndication
 
                 reader.ReadEndElement();
             }
-
-            return skipDays;
         }
 
         private bool checkDay(string day)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeed.cs
@@ -302,7 +302,7 @@ namespace System.ServiceModel.Syndication
 
             using (XmlReader reader = documentationElement.GetReader())
             {
-                SyndicationLink documentation = new Rss20FeedFormatter().ReadAlternateLink(reader, BaseUri);
+                SyndicationLink documentation = Rss20FeedFormatter.ReadAlternateLink(reader, BaseUri, SyndicationFeedFormatter.DefaultUriParser, preserveAttributeExtensions: true);
                 return documentation;
             }
         }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
@@ -404,7 +404,7 @@ namespace System.ServiceModel.Syndication
             }
         }
 
-        private static Uri DefaultUriParser(string value, UriKind kind, string localName, string ns)
+        internal static Uri DefaultUriParser(string value, UriKind kind, string localName, string ns)
         {
             return new Uri(value, kind);
         }

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationTextInput.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationTextInput.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ServiceModel.Syndication
+{
+    public class SyndicationTextInput
+    {
+        public string Description;
+        public string Title;
+        public SyndicationLink Link;
+        public string Name;
+    }
+}

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -51,16 +51,20 @@ namespace System.ServiceModel.Syndication.Tests
             try
             {
                 // *** SETUP *** \\\
-                XmlReader xmlr = XmlReader.Create(@"SimpleRssFeed.xml");
-                SyndicationFeed sf = SyndicationFeed.Load(xmlr);
-                Assert.True(sf != null);
+                SyndicationFeed sf;
+                using (XmlReader xmlr = XmlReader.Create(@"SimpleRssFeed.xml"))
+                {
+                    sf = SyndicationFeed.Load(xmlr);
+                    Assert.True(sf != null);
+                }
 
                 // *** EXECUTE *** \\
                 //Write the same feed that was read.
-                XmlWriter xmlw = XmlWriter.Create(path);
-                Rss20FeedFormatter atomFeed = new Rss20FeedFormatter(sf);
-                atomFeed.WriteTo(xmlw);
-                xmlw.Close();
+                using (XmlWriter xmlw = XmlWriter.Create(path))
+                {
+                    Rss20FeedFormatter atomFeed = new Rss20FeedFormatter(sf);
+                    atomFeed.WriteTo(xmlw);
+                }
 
                 // *** VALIDATE *** \\
                 Assert.True(File.Exists(path));
@@ -80,19 +84,21 @@ namespace System.ServiceModel.Syndication.Tests
             try
             {
                 // *** SETUP *** \\\
-                XmlReaderSettings settingsReader = new XmlReaderSettings();
-                XmlReader xmlr = XmlReader.Create(@"rssSpecExample.xml", settingsReader);
-                SyndicationFeed sf = SyndicationFeed.Load(xmlr);
-                Assert.True(sf != null);
+                SyndicationFeed sf;
+                using (XmlReader xmlr = XmlReader.Create(@"rssSpecExample.xml"))
+                {
+                    sf = SyndicationFeed.Load(xmlr);
+                    Assert.True(sf != null);
+                }
 
                 // *** EXECUTE *** \\
                 //Write the same feed that was read.
                 XmlWriterSettings settingsWriter = new XmlWriterSettings();
-                XmlWriter xmlw = XmlWriter.Create(path, settingsWriter);
-                Rss20FeedFormatter atomFeed = new Rss20FeedFormatter(sf);
-                atomFeed.WriteTo(xmlw);
-
-                xmlw.Close();
+                using (XmlWriter xmlw = XmlWriter.Create(path, settingsWriter))
+                {
+                    Rss20FeedFormatter atomFeed = new Rss20FeedFormatter(sf);
+                    atomFeed.WriteTo(xmlw);
+                }
 
                 // *** VALIDATE *** \\
                 Assert.True(File.Exists(path));
@@ -112,17 +118,20 @@ namespace System.ServiceModel.Syndication.Tests
             try
             {
                 // *** SETUP *** \\\
-                XmlReaderSettings setting = new XmlReaderSettings();
-                XmlReader xmlr = XmlReader.Create(@"SimpleAtomFeed.xml", setting);
-                SyndicationFeed sf = SyndicationFeed.Load(xmlr);
-                Assert.True(sf != null);
+                SyndicationFeed sf;
+                using (XmlReader xmlr = XmlReader.Create(@"SimpleAtomFeed.xml"))
+                {
+                    sf = SyndicationFeed.Load(xmlr);
+                    Assert.True(sf != null);
+                }
 
                 // *** EXECUTE *** \\
                 //Write the same feed that was read.
-                XmlWriter xmlw = XmlWriter.Create(path);
-                Atom10FeedFormatter atomFeed = new Atom10FeedFormatter(sf);
-                atomFeed.WriteTo(xmlw);
-                xmlw.Close();
+                using (XmlWriter xmlw = XmlWriter.Create(path))
+                {
+                    Atom10FeedFormatter atomFeed = new Atom10FeedFormatter(sf);
+                    atomFeed.WriteTo(xmlw);
+                }
 
                 // *** VALIDATE *** \\
                 Assert.True(File.Exists(path));
@@ -142,19 +151,20 @@ namespace System.ServiceModel.Syndication.Tests
             try
             {
                 // *** SETUP *** \\\
-                XmlReaderSettings readerSettings = new XmlReaderSettings();
-                XmlReader xmlr = XmlReader.Create(@"atom_spec_example.xml", readerSettings);
-                SyndicationFeed sf = SyndicationFeed.Load(xmlr);
-                Assert.True(sf != null);
+                SyndicationFeed sf;
+                using (XmlReader xmlr = XmlReader.Create(@"atom_spec_example.xml"))
+                {
+                    sf = SyndicationFeed.Load(xmlr);
+                    Assert.True(sf != null);
+                }
 
                 // *** EXECUTE *** \\
                 //Write the same feed that was read.
-                XmlWriterSettings writerSettings = new XmlWriterSettings();
-
-                XmlWriter xmlw = XmlWriter.Create(path, writerSettings);
-                Atom10FeedFormatter atomFeed = new Atom10FeedFormatter(sf);
-                atomFeed.WriteTo(xmlw);
-                xmlw.Close();
+                using (XmlWriter xmlw = XmlWriter.Create(path))
+                {
+                    Atom10FeedFormatter atomFeed = new Atom10FeedFormatter(sf);
+                    atomFeed.WriteTo(xmlw);
+                }
 
                 // *** VALIDATE *** \\
                 Assert.True(File.Exists(path));
@@ -195,22 +205,19 @@ namespace System.ServiceModel.Syndication.Tests
                 feed.BaseUri = new Uri("http://mypage.com");
 
                 // Write to XML > rss
-                XmlWriterSettings settings = new XmlWriterSettings();
-                XmlWriter xmlwRss = XmlWriter.Create(RssPath, settings);
-                Rss20FeedFormatter rssff = new Rss20FeedFormatter(feed);
+                using (XmlWriter xmlwRss = XmlWriter.Create(RssPath))
+                {
+                    Rss20FeedFormatter rssff = new Rss20FeedFormatter(feed);
+                    rssff.WriteTo(xmlwRss);
+                }
 
                 // Write to XML > atom
 
-                XmlWriter xmlwAtom = XmlWriter.Create(AtomPath);
-                Atom10FeedFormatter atomf = new Atom10FeedFormatter(feed);
-
-
-                // *** EXECUTE *** \\
-                rssff.WriteTo(xmlwRss);
-                xmlwRss.Close();
-
-                atomf.WriteTo(xmlwAtom); ;
-                xmlwAtom.Close();
+                using (XmlWriter xmlwAtom = XmlWriter.Create(AtomPath))
+                {
+                    Atom10FeedFormatter atomf = new Atom10FeedFormatter(feed);
+                    atomf.WriteTo(xmlwAtom);
+                }
 
                 // *** ASSERT *** \\
                 Assert.True(File.Exists(RssPath));
@@ -302,7 +309,7 @@ namespace System.ServiceModel.Syndication.Tests
             SyndicationItem[] items = res.Items.ToArray();
             DateTimeOffset dateTimeOffset;
             Assert.Throws<XmlException>(() => dateTimeOffset = items[2].PublishDate);
-        }
+        }    
 
         [Fact]
         public static void AtomEntryPositiveTest()
@@ -487,7 +494,7 @@ namespace System.ServiceModel.Syndication.Tests
             }
         }
 
-        private static void ReadWriteSyndicationFeed(string file, Func<SyndicationFeed, SyndicationFeedFormatter> feedFormatter, List<AllowableDifference> allowableDifferences = null)
+        private static void ReadWriteSyndicationFeed(string file, Func<SyndicationFeed, SyndicationFeedFormatter> feedFormatter, List<AllowableDifference> allowableDifferences = null, Action<SyndicationFeed> verifySyndicationFeedRead = null)
         {
             string serializeFilePath = Path.GetTempFileName();
             bool toDeletedFile = true;
@@ -500,6 +507,7 @@ namespace System.ServiceModel.Syndication.Tests
                     using (XmlReader reader = XmlDictionaryReader.CreateTextReader(fileStream, XmlDictionaryReaderQuotas.Max))
                     {
                         feedObjct = SyndicationFeed.Load(reader);
+                        verifySyndicationFeedRead?.Invoke(feedObjct);
                     }
                 }
 

--- a/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -23,15 +23,16 @@ namespace System.ServiceModel.Syndication.Tests
             try
             {
                 // *** SETUP *** \\
-                SyndicationFeed sf = new SyndicationFeed("First feed on .net core ever!!", "This is the first feed on .net core ever!", new Uri("https://github.com/dotnet/wcf"));
+                var sf = new SyndicationFeed("First feed on .net core ever!!", "This is the first feed on .net core ever!", new Uri("https://github.com/dotnet/wcf"));
                 Assert.True(sf != null);
 
-                XmlWriter xmlw = XmlWriter.Create(filePath);
-                Rss20FeedFormatter rssf = new Rss20FeedFormatter(sf);
+                using (XmlWriter xmlw = XmlWriter.Create(filePath))
+                {
+                    var rssf = new Rss20FeedFormatter(sf);
 
-                // *** EXECUTE *** \\
-                rssf.WriteTo(xmlw);
-                xmlw.Close();
+                    // *** EXECUTE *** \\
+                    rssf.WriteTo(xmlw);
+                }
 
                 // *** VALIDATE *** \\
                 Assert.True(File.Exists(filePath));
@@ -62,8 +63,8 @@ namespace System.ServiceModel.Syndication.Tests
                 //Write the same feed that was read.
                 using (XmlWriter xmlw = XmlWriter.Create(path))
                 {
-                    Rss20FeedFormatter atomFeed = new Rss20FeedFormatter(sf);
-                    atomFeed.WriteTo(xmlw);
+                    var rss20FeedFormatter = new Rss20FeedFormatter(sf);
+                    rss20FeedFormatter.WriteTo(xmlw);
                 }
 
                 // *** VALIDATE *** \\
@@ -96,8 +97,8 @@ namespace System.ServiceModel.Syndication.Tests
                 XmlWriterSettings settingsWriter = new XmlWriterSettings();
                 using (XmlWriter xmlw = XmlWriter.Create(path, settingsWriter))
                 {
-                    Rss20FeedFormatter atomFeed = new Rss20FeedFormatter(sf);
-                    atomFeed.WriteTo(xmlw);
+                    var rss20FeedFormatter = new Rss20FeedFormatter(sf);
+                    rss20FeedFormatter.WriteTo(xmlw);
                 }
 
                 // *** VALIDATE *** \\
@@ -129,8 +130,8 @@ namespace System.ServiceModel.Syndication.Tests
                 //Write the same feed that was read.
                 using (XmlWriter xmlw = XmlWriter.Create(path))
                 {
-                    Atom10FeedFormatter atomFeed = new Atom10FeedFormatter(sf);
-                    atomFeed.WriteTo(xmlw);
+                    var atom10FeedFormatter = new Atom10FeedFormatter(sf);
+                    atom10FeedFormatter.WriteTo(xmlw);
                 }
 
                 // *** VALIDATE *** \\
@@ -162,8 +163,8 @@ namespace System.ServiceModel.Syndication.Tests
                 //Write the same feed that was read.
                 using (XmlWriter xmlw = XmlWriter.Create(path))
                 {
-                    Atom10FeedFormatter atomFeed = new Atom10FeedFormatter(sf);
-                    atomFeed.WriteTo(xmlw);
+                    var atom10FeedFormatter = new Atom10FeedFormatter(sf);
+                    atom10FeedFormatter.WriteTo(xmlw);
                 }
 
                 // *** VALIDATE *** \\

--- a/src/System.ServiceModel.Syndication/tests/TestFeeds/rssOptionalElements.xml
+++ b/src/System.ServiceModel.Syndication/tests/TestFeeds/rssOptionalElements.xml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0"?>
+<rss version="2.0">
+  <channel customAttribute="customAtt">
+    <title>Liftoff News</title>
+    <link>http://contoso.com/</link>
+    <description>Liftoff to Space Exploration.</description>
+    <language>en-us</language>
+    <lastBuildDate>Tue, 10 Jun 2003 09:41:01 Z</lastBuildDate>
+    <docs>http://contoso.com/rss</docs>
+    <generator>Weblog Editor 2.0</generator>
+    <managingEditor>editor@example.com</managingEditor>
+    <category>TestingFeeds</category>
+    <copyright>Contoso Rights.</copyright>
+    <ttl>60</ttl>
+    <skipHours>
+      <hour>1</hour>
+      <hour>2</hour>
+      <hour>3</hour>
+    </skipHours>
+    <skipDays>
+      <day>Saturday</day>
+      <day>Sunday</day>
+    </skipDays>
+    <textInput>
+      <description>Search Online</description>
+      <title>Search</title>
+      <asdasdasd>asdasdasdasdasd</asdasdasd>
+      <link>http://www.contoso.no/search?</link>
+      <name>input Name</name>
+    </textInput>
+    <!--
+    <image>
+      <url>http://2.bp.blogspot.com/-NA5Jb-64eUg/URx8CSdcj_I/AAAAAAAAAUo/eCx0irI0rq0/s1600/bg_Contoso_logo3-20120824073001907469-620x349.jpg</url>
+      <title>The title is not the same to the original one</title>
+      <link>http://www.contoso.com/notnews</link>
+    </image>
+    -->
+  </channel>
+</rss>

--- a/src/System.ServiceModel.Syndication/tests/TestFeeds/rssOptionalElements.xml
+++ b/src/System.ServiceModel.Syndication/tests/TestFeeds/rssOptionalElements.xml
@@ -24,16 +24,8 @@
     <textInput>
       <description>Search Online</description>
       <title>Search</title>
-      <asdasdasd>asdasdasdasdasd</asdasdasd>
       <link>http://www.contoso.no/search?</link>
       <name>input Name</name>
     </textInput>
-    <!--
-    <image>
-      <url>http://2.bp.blogspot.com/-NA5Jb-64eUg/URx8CSdcj_I/AAAAAAAAAUo/eCx0irI0rq0/s1600/bg_Contoso_logo3-20120824073001907469-620x349.jpg</url>
-      <title>The title is not the same to the original one</title>
-      <link>http://www.contoso.com/notnews</link>
-    </image>
-    -->
   </channel>
 </rss>

--- a/src/System.ServiceModel.Syndication/tests/TestFeeds/rssSpecExample.xml
+++ b/src/System.ServiceModel.Syndication/tests/TestFeeds/rssSpecExample.xml
@@ -2,11 +2,11 @@
 <rss version="2.0">
   <channel customAttribute="customAtt">
     <title>Liftoff News</title>
-    <link>http://liftoff.msfc.nasa.gov/</link>
+    <link>http://contoso.com/</link>
     <description>Liftoff to Space Exploration.</description>
     <language>en-us</language>
     <lastBuildDate>Tue, 10 Jun 2003 09:41:01 GMT</lastBuildDate>
-    <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+    <docs>http://contoso.com/rss</docs>
     <generator>Weblog Editor 2.0</generator>
     <managingEditor>editor@example.com</managingEditor>
     <category>TestingFeeds</category>
@@ -37,33 +37,33 @@
     </image>
     <item>
       <title>Star City</title>
-      <link>http://liftoff.msfc.nasa.gov/news/2003/news-starcity.asp</link>
+      <link>http://contoso.com/news/2003/news-starcity.asp</link>
       <description>
         How do Americans get ready to work with Russians aboard the International Space Station? They take a crash course in culture, language and protocol at Russia's Star City.
       </description>
       <pubDate>Tue, 03 Jun 2003 09:39:21 GMT</pubDate>
-      <guid>http://liftoff.msfc.nasa.gov/2003/06/03.html#item573</guid>
+      <guid>http://contoso.com/2003/06/03.html#item573</guid>
     </item>
     <item>
       <description>
         Sky watchers in Europe, Asia, and parts of Alaska and Canada will experience a partial eclipse of the Sun on Saturday, May 31st.
       </description>
       <pubDate>Fri, 30 May 2003 11:06:42 GMT</pubDate>
-      <guid>http://liftoff.msfc.nasa.gov/2003/05/30.html#item572</guid>
+      <guid>http://contoso.com/2003/05/30.html#item572</guid>
     </item>
     <item>
       <title>The Engine That Does More</title>
-      <link>http://liftoff.msfc.nasa.gov/news/2003/news-VASIMR.asp</link>
+      <link>http://contoso.com/news/2003/news-VASIMR.asp</link>
       <description>Before man travels to Mars, NASA hopes to design new engines that will let us fly through the Solar System more quickly. The proposed VASIMR engine would do that.</description>
       <pubDate>Tue, 27 May 2003 08:37:32 GMT</pubDate>
-      <guid>http://liftoff.msfc.nasa.gov/2003/05/27.html#item571</guid>
+      <guid>http://contoso.com/2003/05/27.html#item571</guid>
     </item>
     <item>
       <title>Astronauts' Dirty Laundry</title>
-      <link>http://liftoff.msfc.nasa.gov/news/2003/news-laundry.asp</link>
+      <link>http://contoso.com/news/2003/news-laundry.asp</link>
       <description>Compared to earlier spacecraft, the International Space Station has many luxuries, but laundry facilities are not one of them. Instead, astronauts have other options.</description>
       <pubDate>Tue, 20 May 2003 08:56:02 GMT</pubDate>
-      <guid>http://liftoff.msfc.nasa.gov/2003/05/20.html#item570</guid>
+      <guid>http://contoso.com/2003/05/20.html#item570</guid>
     </item>
   </channel>
 </rss>

--- a/src/System.ServiceModel.Syndication/tests/TestFeeds/rssSpecExample.xml
+++ b/src/System.ServiceModel.Syndication/tests/TestFeeds/rssSpecExample.xml
@@ -18,6 +18,11 @@
       <hour>3</hour>
     </skipHours>
     <skipDays>
+      <day>Monday</day>
+      <day>TUESDAY</day>
+      <day>Wednesday</day>
+      <day>Thursday</day>
+      <day>FridaY</day>
       <day>Saturday</day>
       <day>Sunday</day>
     </skipDays>

--- a/src/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
+++ b/src/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
@@ -121,7 +121,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
         
         [Fact]
-        public static void SyndicationFeed_RSS_Optional_Documentation()
+        public static void SyndicationFeed_RSS_Optional_Elements()
         {
             using (XmlReader reader = XmlReader.Create(@"rssSpecExample.xml"))
             {
@@ -147,7 +147,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
-        public static void SyndicationFeed_Load_Write_RSS_Documentation()
+        public static void SyndicationFeed_Load_Write_RSS_With_Optional_Elements()
         {
             List<AllowableDifference> allowableDifferences = GetRssFeedPositiveTestAllowableDifferences();
             ReadWriteSyndicationFeed(
@@ -158,7 +158,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
-        public static void SyndicationFeed_Load_Write_RSS_Documentation_Using_Optional_Element_Properties()
+        public static void SyndicationFeed_Load_Write_RSS_Use_Optional_Element_Properties()
         {
             List<AllowableDifference> allowableDifferences = GetRssFeedPositiveTestAllowableDifferences();
             ReadWriteSyndicationFeed(

--- a/src/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
+++ b/src/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
@@ -125,14 +125,40 @@ namespace System.ServiceModel.Syndication.Tests
         {
             using (XmlReader reader = XmlReader.Create(@"rssSpecExample.xml"))
             {
-                SyndicationFeed rss = SyndicationFeed.Load(reader);
-                Assert.NotNull(rss.Documentation);
-                Assert.True(rss.Documentation.GetAbsoluteUri().ToString() == "http://contoso.com/rss");
+                SyndicationFeed feed = SyndicationFeed.Load(reader);
+
+                Assert.NotNull(feed.Documentation);
+                Assert.Equal("http://contoso.com/rss", feed.Documentation.GetAbsoluteUri().ToString());
+
+                Assert.Equal(60, feed.TimeToLive);
+
+                Assert.NotNull(feed.SkipHours);
+                Assert.Equal(3, feed.SkipHours.Count);
+
+                Assert.NotNull(feed.SkipDays);
+                Assert.Equal(2, feed.SkipDays.Count);
+
+                Assert.NotNull(feed.TextInput);
+                Assert.Equal("Search Online", feed.TextInput.Description);
+                Assert.Equal("Search", feed.TextInput.Title);
+                Assert.Equal("input Name", feed.TextInput.Name);
+                Assert.Equal("http://www.contoso.no/search?", feed.TextInput.Link.Uri.ToString());
             }
         }
 
         [Fact]
         public static void SyndicationFeed_Load_Write_RSS_Documentation()
+        {
+            List<AllowableDifference> allowableDifferences = GetRssFeedPositiveTestAllowableDifferences();
+            ReadWriteSyndicationFeed(
+                file: "rssOptionalElements.xml",
+                feedFormatter: (feedObject) => new Rss20FeedFormatter(feedObject),
+                allowableDifferences: allowableDifferences
+                );
+        }
+
+        [Fact]
+        public static void SyndicationFeed_Load_Write_RSS_Documentation_Using_Optional_Element_Properties()
         {
             List<AllowableDifference> allowableDifferences = GetRssFeedPositiveTestAllowableDifferences();
             ReadWriteSyndicationFeed(
@@ -144,6 +170,20 @@ namespace System.ServiceModel.Syndication.Tests
                     Assert.NotNull(feed);
                     Assert.NotNull(feed.Documentation);
                     Assert.True(feed.Documentation.GetAbsoluteUri().ToString() == "http://contoso.com/rss");
+
+                    Assert.Equal(60, feed.TimeToLive);
+
+                    Assert.NotNull(feed.SkipHours);
+                    Assert.Equal(3, feed.SkipHours.Count);
+
+                    Assert.NotNull(feed.SkipDays);
+                    Assert.Equal(2, feed.SkipDays.Count);
+
+                    Assert.NotNull(feed.TextInput);
+                    Assert.Equal("Search Online", feed.TextInput.Description);
+                    Assert.Equal("Search", feed.TextInput.Title);
+                    Assert.Equal("input Name", feed.TextInput.Name);
+                    Assert.Equal("http://www.contoso.no/search?", feed.TextInput.Link.Uri.ToString());
                 });
         }
     }

--- a/src/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
+++ b/src/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
@@ -119,5 +119,32 @@ namespace System.ServiceModel.Syndication.Tests
             Assert.Equal(new Uri("http://value-EntryLinkHref-kind-relativeorabsolute-localName-link-ns-http//www.w3.org/2005/Atom-end"), feed.Items.First().Links.First().Uri);
             Assert.Equal(new Uri("http://value-EntryContentSrc-kind-relativeorabsolute-localName-content-ns-http://www.w3.org/2005/Atom-end"), ((UrlSyndicationContent)feed.Items.First().Content).Url);
         }
+        
+        [Fact]
+        public static void SyndicationFeed_RSS_Optional_Documentation()
+        {
+            using (XmlReader reader = XmlReader.Create(@"rssSpecExample.xml"))
+            {
+                SyndicationFeed rss = SyndicationFeed.Load(reader);
+                Assert.NotNull(rss.Documentation);
+                Assert.True(rss.Documentation.GetAbsoluteUri().ToString() == "http://contoso.com/rss");
+            }
+        }
+
+        [Fact]
+        public static void SyndicationFeed_Load_Write_RSS_Documentation()
+        {
+            List<AllowableDifference> allowableDifferences = GetRssFeedPositiveTestAllowableDifferences();
+            ReadWriteSyndicationFeed(
+                file: "rssOptionalElements.xml",
+                feedFormatter: (feedObject) => new Rss20FeedFormatter(feedObject),
+                allowableDifferences: allowableDifferences,
+                verifySyndicationFeedRead: (feed) =>
+                {
+                    Assert.NotNull(feed);
+                    Assert.NotNull(feed.Documentation);
+                    Assert.True(feed.Documentation.GetAbsoluteUri().ToString() == "http://contoso.com/rss");
+                });
+        }
     }
 }

--- a/src/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
+++ b/src/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
@@ -130,13 +130,14 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.NotNull(feed.Documentation);
                 Assert.Equal("http://contoso.com/rss", feed.Documentation.GetAbsoluteUri().ToString());
 
+                Assert.NotNull(feed.TimeToLive);
                 Assert.Equal(60, feed.TimeToLive);
 
                 Assert.NotNull(feed.SkipHours);
                 Assert.Equal(3, feed.SkipHours.Count);
 
                 Assert.NotNull(feed.SkipDays);
-                Assert.Equal(2, feed.SkipDays.Count);
+                Assert.Equal(7, feed.SkipDays.Count);
 
                 Assert.NotNull(feed.TextInput);
                 Assert.Equal("Search Online", feed.TextInput.Description);
@@ -171,6 +172,7 @@ namespace System.ServiceModel.Syndication.Tests
                     Assert.NotNull(feed.Documentation);
                     Assert.True(feed.Documentation.GetAbsoluteUri().ToString() == "http://contoso.com/rss");
 
+                    Assert.NotNull(feed.TimeToLive);
                     Assert.Equal(60, feed.TimeToLive);
 
                     Assert.NotNull(feed.SkipHours);


### PR DESCRIPTION
I'm prototyping supporting RSS optional elements using the `<docs>`element. Please let me know if you have any concerns or suggestions. I'll apply this to other optional elements after this PR.

The change enable users to read/wring `<docs>` via `SyndicationFeed.Documentation `. Here's a couple of things worth to note:

1. Any existing applications that read/write `<docs>` via `SyndicationFeed.ElementExtensions` would still work after the change.
2. If `SyndicationFeed.Documentation` is ever used and becomes not null, `SyndicationFeedFormatter.WriteTo` would write `<docs>` with the value of `SyndicationFeed.Documentation ` and ignore the corresponding ElementExtension.

Ref #25608.