### PR TITLE
Add static library definitions to CMakeLists for CoreRT

### DIFF
--- a/src/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
@@ -12,8 +12,19 @@ add_library(System.IO.Compression.Native
     ${VERSION_FILE_PATH}
 )
 
+add_library(System.IO.Compression.Native-Static
+    STATIC
+    ${NATIVECOMPRESSION_SOURCES}
+    ${VERSION_FILE_PATH}
+)
+
+# Disable the "lib" prefix and override default name
+set_target_properties(System.IO.Compression.Native-Static PROPERTIES PREFIX "")
+set_target_properties(System.IO.Compression.Native-Static PROPERTIES OUTPUT_NAME System.IO.Compression.Native  CLEAN_DIRECT_OUTPUT 1)
+
 target_link_libraries(System.IO.Compression.Native
     ${ZLIB_LIBRARIES}
 )
 
 install_library_and_symbols (System.IO.Compression.Native)
+install (TARGETS System.IO.Compression.Native-Static DESTINATION .)

--- a/src/Native/Unix/System.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Native/CMakeLists.txt
@@ -42,8 +42,10 @@ add_library(System.Native-Static
     ${NATIVE_SOURCES}
     ${VERSION_FILE_PATH}
 )
-SET_TARGET_PROPERTIES(System.Native-Static PROPERTIES PREFIX "")
-SET_TARGET_PROPERTIES(System.Native-Static PROPERTIES OUTPUT_NAME System.Native CLEAN_DIRECT_OUTPUT 1)
+
+# Disable the "lib" prefix and override default name
+set_target_properties(System.Native-Static PROPERTIES PREFIX "")
+set_target_properties(System.Native-Static PROPERTIES OUTPUT_NAME System.Native CLEAN_DIRECT_OUTPUT 1)
 
 if (CMAKE_SYSTEM_NAME STREQUAL Linux AND NOT CLR_CMAKE_PLATFORM_ANDROID)
     target_link_libraries(System.Native rt)

--- a/src/Native/Unix/System.Net.Http.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Net.Http.Native/CMakeLists.txt
@@ -31,8 +31,19 @@ add_library(System.Net.Http.Native
     ${VERSION_FILE_PATH}
 )
 
+add_library(System.Net.Http.Native-Static
+    STATIC
+    ${NATIVEHTTP_SOURCES}
+    ${VERSION_FILE_PATH}
+)
+
+# Disable the "lib" prefix and override default name
+set_target_properties(System.Net.Http.Native-Static PROPERTIES PREFIX "")
+set_target_properties(System.Net.Http.Native-Static PROPERTIES OUTPUT_NAME System.Net.Http.Native CLEAN_DIRECT_OUTPUT 1)
+
 target_link_libraries(System.Net.Http.Native
   ${CURL_LIBRARIES}
 )
 
 install_library_and_symbols (System.Net.Http.Native)
+install (TARGETS System.Net.Http.Native-Static DESTINATION .)

--- a/src/Native/Unix/System.Net.Security.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Net.Security.Native/CMakeLists.txt
@@ -33,8 +33,19 @@ add_library(System.Net.Security.Native
     ${VERSION_FILE_PATH}
 )
 
+add_library(System.Net.Security.Native-Static
+    STATIC
+    ${NATIVEGSS_SOURCES}
+    ${VERSION_FILE_PATH}
+)
+
+# Disable the "lib" prefix and override default name
+set_target_properties(System.Net.Security.Native-Static PROPERTIES PREFIX "")
+set_target_properties(System.Net.Security.Native-Static PROPERTIES OUTPUT_NAME System.Net.Security.Native CLEAN_DIRECT_OUTPUT 1)
+
 target_link_libraries(System.Net.Security.Native
     ${LIBGSS}
 )
 
 install_library_and_symbols (System.Net.Security.Native)
+install (TARGETS System.Net.Security.Native-Static DESTINATION .)

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -31,8 +31,18 @@ add_library(System.Security.Cryptography.Native.Apple
     ${VERSION_FILE_PATH}
 )
 
+add_library(System.Security.Cryptography.Native.Apple-Static
+    STATIC
+    ${NATIVECRYPTO_SOURCES}
+    ${VERSION_FILE_PATH}
+)
+
 # Disable the "lib" prefix.
 set_target_properties(System.Security.Cryptography.Native.Apple PROPERTIES PREFIX "")
+
+# Disable the "lib" prefix and override default name
+set_target_properties(System.Security.Cryptography.Native.Apple-Static PROPERTIES PREFIX "")
+set_target_properties(System.Security.Cryptography.Native.Apple-Static PROPERTIES OUTPUT_NAME System.Security.Cryptography.Native.Apple CLEAN_DIRECT_OUTPUT 1)
 
 target_link_libraries(System.Security.Cryptography.Native.Apple
     ${COREFOUNDATION_LIBRARY}

--- a/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -61,8 +61,17 @@ add_library(System.Security.Cryptography.Native.OpenSsl
     $<TARGET_OBJECTS:objlib>
 )
 
+add_library(System.Security.Cryptography.Native.OpenSsl-Static
+    STATIC
+    $<TARGET_OBJECTS:objlib>
+)
+
 # Disable the "lib" prefix.
 set_target_properties(System.Security.Cryptography.Native.OpenSsl PROPERTIES PREFIX "")
+
+# Disable the "lib" prefix and override default name
+set_target_properties(System.Security.Cryptography.Native.OpenSsl-Static PROPERTIES PREFIX "")
+set_target_properties(System.Security.Cryptography.Native.OpenSsl-Static PROPERTIES OUTPUT_NAME System.Security.Cryptography.Native.OpenSsl CLEAN_DIRECT_OUTPUT 1)
 
 if (FEATURE_DISTRO_AGNOSTIC_SSL)
     add_custom_command(TARGET System.Security.Cryptography.Native.OpenSsl POST_BUILD
@@ -103,3 +112,4 @@ endif()
 include(configure.cmake)
 
 install_library_and_symbols (System.Security.Cryptography.Native.OpenSsl)
+install (TARGETS System.Security.Cryptography.Native.OpenSsl-Static DESTINATION .)


### PR DESCRIPTION
Add static library definitions to be consumed by CoreRT, similar to the current build of System.Native. 