### PR TITLE
Add logic to skip alpn tests where unsupported.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class OpenSsl
+    {
+        private static Version s_opensslVersion;
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SSLEayVersion")]
+        private static extern string OpenSslVersionDescription();
+
+        internal static Version OpenSslVersion
+        {
+            get
+            {
+                if (s_opensslVersion == null)
+                {
+                    const string OpenSSL = "OpenSSL ";
+
+                    // Skip OpenSSL part, and get the version string of format x.y.z
+                    if (!Version.TryParse(OpenSslVersionDescription().AsReadOnlySpan().Slice(OpenSSL.Length, 5), out s_opensslVersion))
+                    {
+                        s_opensslVersion = new Version(0, 0, 0);
+                    }
+                }
+
+                return s_opensslVersion;
+            }
+        }
+    }
+}

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -77,6 +77,7 @@ namespace System
         public static bool IsNotRedHatFamily6 { get { throw null; } }
         public static bool IsUap { get { throw null; } }
         public static Version ICUVersion { get { return null; } }
+        public static Version OpenSslVersion { get { return null; } }
         public static bool IsUbuntu { get { throw null; } }
         public static bool IsUbuntu1404 { get { throw null; } }
         public static bool IsUbuntu1604 { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -42,6 +42,7 @@
     <Compile Include="System\TheoryExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Memory" />
     <Reference Include="Microsoft.Win32.Registry" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.IO.FileSystem" />
@@ -93,6 +94,9 @@
     <Compile Include="System\AdminHelpers.Windows.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs</Link>
+    </Compile>
     <Compile Include="System\AdminHelpers.Unix.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEUid.cs">
       <Link>Common\Interop\Unix\Interop.GetEUid.cs</Link>

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -52,6 +52,8 @@ namespace System
 
         public static Version OSXVersion { get; } = ToVersion(Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.OperatingSystemVersion);
 
+        public static Version OpenSslVersion => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? Interop.OpenSsl.OpenSslVersion : throw new PlatformNotSupportedException();
+
         public static string GetDistroVersionString()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -15,6 +15,7 @@ namespace System
     public static partial class PlatformDetection
     {
         public static Version OSXVersion => throw new PlatformNotSupportedException();
+        public static Version OpenSslVersion => throw new PlatformNotSupportedException();
         public static bool IsSuperUser => throw new PlatformNotSupportedException();
         public static bool IsCentos6 => false;
         public static bool IsOpenSUSE => false;

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp
@@ -1389,3 +1389,18 @@ done:
     pthread_mutex_unlock(&g_initLock);
     return ret;
 }
+
+/*
+Function:
+SSLEayVersion
+
+Gets the version of openssl library.
+
+Return values:
+Textual description of the version on success.
+"not available" string on failure.
+*/
+extern "C" char* CryptoNative_SSLEayVersion()
+{
+    return strdup(SSLeay_version(SSLEAY_VERSION));
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -14,6 +14,7 @@
 #include <openssl/asn1.h>
 #include <openssl/bio.h>
 #include <openssl/bn.h>
+#include <openssl/crypto.h>
 #include <openssl/dsa.h>
 #include <openssl/ecdsa.h>
 #include <openssl/ec.h>
@@ -297,6 +298,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(SSL_set_connect_state, true) \
     PER_FUNCTION_BLOCK(SSL_shutdown, true) \
     PER_FUNCTION_BLOCK(SSL_state, true) \
+    PER_FUNCTION_BLOCK(SSLeay_version, true) \
     PER_FUNCTION_BLOCK(SSLv23_method, true) \
     PER_FUNCTION_BLOCK(SSL_write, true) \
     PER_FUNCTION_BLOCK(TLSv1_1_method, true) \
@@ -590,6 +592,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_set_connect_state SSL_set_connect_state_ptr
 #define SSL_shutdown SSL_shutdown_ptr
 #define SSL_state SSL_state_ptr
+#define SSLeay_version SSLeay_version_ptr
 #define SSLv23_method SSLv23_method_ptr
 #define SSL_write SSL_write_ptr
 #define TLSv1_1_method TLSv1_1_method_ptr

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -7,9 +7,6 @@
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetsLinux)' == 'true'">
-    <DefineConstants>TargetsLinux</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Windows_NT-Debug|AnyCPU'" />

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -7,6 +7,9 @@
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetsLinux)' == 'true'">
+    <DefineConstants>TargetsLinux</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Windows_NT-Debug|AnyCPU'" />


### PR DESCRIPTION
fixes #25033 

Adding logic to detect openssl version is greater than 1.0.2 before running the alpn tests. This has been causing test failures in several runs redhat6.9 distro was not added in the distro skip list. This method is more reliable.

cc @stephentoub @wfurt @karelz 