### PR TITLE
disable ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed on windows

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -80,7 +80,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-	[ActiveIssue(25640, TestPlatforms.Windows)] // TODO It should be enabled for managed Handler on all platforms
+        [ActiveIssue(25640, TestPlatforms.Windows)] // TODO It should be enabled for managed Handler on all platforms
         public void ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed(bool useProxy)
         {
             int port = 0;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -82,8 +82,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(true)]
         public void ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed(bool useProxy)
         {
-            //bool envVarsSupported = UseManagedHandler || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-	    // TODO: Issue #25640
+            // TODO: Issue #25640 It should be enabled for managed Handler on all platforms
             bool envVarsSupported = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             if (!envVarsSupported)
             {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -80,15 +80,9 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+	[ActiveIssue(25640, TestPlatforms.Windows)] // TODO It should be enabled for managed Handler on all platforms
         public void ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed(bool useProxy)
         {
-            // TODO: Issue #25640 It should be enabled for managed Handler on all platforms
-            bool envVarsSupported = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            if (!envVarsSupported)
-            {
-                return;
-            }
-
             int port = 0;
             Task<LoopbackGetRequestHttpProxy.ProxyResult> proxyTask = null;
             if (useProxy)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -82,7 +82,9 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(true)]
         public void ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed(bool useProxy)
         {
-            bool envVarsSupported = UseManagedHandler || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            //bool envVarsSupported = UseManagedHandler || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+	    // TODO: Issue #25640
+            bool envVarsSupported = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             if (!envVarsSupported)
             {
                 return;


### PR DESCRIPTION
disabling for now per agreement with @karelz 

failed 12 times in November on various windows  version. 

#25640 filed to track it.