### PR TITLE
Avoid filling the TRUSTED_ISSUERS entry in SSL handshake on Linux

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -399,40 +399,6 @@ internal static partial class Interop
             return Ssl.SSL_TLSEXT_ERR_NOACK;
         }
 
-        private static void AddX509Names(SafeX509NameStackHandle nameStack, StoreLocation storeLocation, HashSet<string> issuerNameHashSet)
-        {
-            using (var store = new X509Store(StoreName.Root, storeLocation))
-            {
-                store.Open(OpenFlags.ReadOnly);
-
-                foreach (var certificate in store.Certificates)
-                {
-                    //Check if issuer name is already present
-                    //Avoiding duplicate names
-                    if (!issuerNameHashSet.Add(certificate.Issuer))
-                    {
-                        continue;
-                    }
-
-                    using (SafeX509Handle certHandle = Crypto.X509UpRef(certificate.Handle))
-                    {
-                        using (SafeX509NameHandle nameHandle = Crypto.DuplicateX509Name(Crypto.X509GetIssuerName(certHandle)))
-                        {
-                            if (Crypto.PushX509NameStackField(nameStack, nameHandle))
-                            {
-                                // The handle ownership has been transferred into the STACK_OF(X509_NAME).
-                                nameHandle.SetHandleAsInvalid();
-                            }
-                            else
-                            {
-                                throw new CryptographicException(SR.net_ssl_x509Name_push_failed_error);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
         private static int BioRead(SafeBioHandle bio, byte[] buffer, int count)
         {
             Debug.Assert(buffer != null);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
@@ -32,8 +32,5 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetEncryptionPolicy")]
         internal static extern bool SetEncryptionPolicy(SafeSslContextHandle ctx, EncryptionPolicy policy);
-
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetClientCAList")]
-        internal static extern void SslCtxSetClientCAList(SafeSslContextHandle ctx, SafeX509NameStackHandle x509NameStackPtr);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
@@ -25,9 +25,6 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_NewX509NameStack")]
         internal static extern SafeX509NameStackHandle NewX509NameStack();
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DuplicateX509Name")]
-        internal static extern SafeX509NameHandle DuplicateX509Name(IntPtr x509Name);
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NameStackField")]
         private static extern SafeSharedX509NameHandle GetX509NameStackField_private(SafeSharedX509NameStackHandle sk,
             int loc);

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -269,7 +269,6 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(SSL_CTX_set_alpn_select_cb, false) \
     PER_FUNCTION_BLOCK(SSL_CTX_set_cert_verify_callback, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_set_cipher_list, true) \
-    PER_FUNCTION_BLOCK(SSL_CTX_set_client_CA_list, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_set_client_cert_cb, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_set_quiet_shutdown, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_set_verify, true) \
@@ -562,7 +561,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_CTX_set_alpn_select_cb SSL_CTX_set_alpn_select_cb_ptr
 #define SSL_CTX_set_cert_verify_callback SSL_CTX_set_cert_verify_callback_ptr
 #define SSL_CTX_set_cipher_list SSL_CTX_set_cipher_list_ptr
-#define SSL_CTX_set_client_CA_list SSL_CTX_set_client_CA_list_ptr
 #define SSL_CTX_set_client_cert_cb SSL_CTX_set_client_cert_cb_ptr
 #define SSL_CTX_set_quiet_shutdown SSL_CTX_set_quiet_shutdown_ptr
 #define SSL_CTX_set_verify SSL_CTX_set_verify_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -323,7 +323,6 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     PER_FUNCTION_BLOCK(X509_get_serialNumber, true) \
     PER_FUNCTION_BLOCK(X509_get_subject_name, true) \
     PER_FUNCTION_BLOCK(X509_issuer_name_hash, true) \
-    PER_FUNCTION_BLOCK(X509_NAME_dup, true) \
     PER_FUNCTION_BLOCK(X509_NAME_entry_count, true) \
     PER_FUNCTION_BLOCK(X509_NAME_ENTRY_get_data, true) \
     PER_FUNCTION_BLOCK(X509_NAME_ENTRY_get_object, true) \
@@ -615,7 +614,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_get_serialNumber X509_get_serialNumber_ptr
 #define X509_get_subject_name X509_get_subject_name_ptr
 #define X509_issuer_name_hash X509_issuer_name_hash_ptr
-#define X509_NAME_dup X509_NAME_dup_ptr
 #define X509_NAME_entry_count X509_NAME_entry_count_ptr
 #define X509_NAME_ENTRY_get_data X509_NAME_ENTRY_get_data_ptr
 #define X509_NAME_ENTRY_get_object X509_NAME_ENTRY_get_object_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -502,10 +502,6 @@ extern "C" int32_t CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPoli
     return SSL_CTX_set_cipher_list(ctx, cipherString);
 }
 
-extern "C" void CryptoNative_SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list)
-{
-    SSL_CTX_set_client_CA_list(ctx, list);
-}
 
 extern "C" void CryptoNative_SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClientCertCallback callback)
 {

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
@@ -341,11 +341,6 @@ Returns 1 if any cipher could be selected, and 0 if none were available.
 extern "C" int32_t CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy);
 
 /*
-Shims the SSL_CTX_set_client_CA_list method.
-*/
-extern "C" void CryptoNative_SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list);
-
-/*
 Shims the SSL_CTX_set_client_cert_cb method
 */
 extern "C" void CryptoNative_SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClientCertCallback callback);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509_name.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509_name.cpp
@@ -52,11 +52,6 @@ extern "C" void CryptoNative_RecursiveFreeX509NameStack(STACK_OF(X509_NAME) * st
     sk_X509_NAME_pop_free(stack, X509_NAME_free);
 }
 
-extern "C" X509_NAME* CryptoNative_DuplicateX509Name(X509_NAME* x509Name)
-{
-    return X509_NAME_dup(x509Name);
-}
-
 extern "C" int32_t CryptoNative_GetX509NameEntryCount(X509_NAME* x509Name)
 {
     return X509_NAME_entry_count(x509Name);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509_name.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509_name.h
@@ -62,14 +62,6 @@ Direct shim to sk_X509_NAME_pop_free
 extern "C" void CryptoNative_RecursiveFreeX509NameStack(STACK_OF(X509_NAME) * stack);
 
 /*
-Function:
-DuplicateX509Name
-
-Direct shim to X509_NAME_dup
-*/
-extern "C" X509_NAME* CryptoNative_DuplicateX509Name(X509_NAME* x509Name);
-
-/*
 Direct shim to X509_NAME_entry_count
 */
 extern "C" int32_t CryptoNative_GetX509NameEntryCount(X509_NAME* x509Name);


### PR DESCRIPTION
Discussion is here: https://github.com/dotnet/corefx/issues/23938

This PR avoid filling in the TRUSTED_ISSUERS field in the SSL handshake on Linux to maintain comparability with the behavior of SslStream on Windows.

As for Windows 8 / Windows Server 2012 SChannel is no longer sending the trusted issuers by default (see: https://technet.microsoft.com/en-us/library/dn786429(v=ws.11).aspx)

This can reduce the number of bytes in an SSL handshake from `21,939`  to `1,486`  and help comparability and ease of use when using client certificates with SslStream.