### PR TITLE
[release/2.0.0] Revert "Minor change to avoid an allocation in Uri"

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -558,10 +558,11 @@ namespace System
                         // Hence anything like x:sdsd is a relative path and be added to the baseUri Path
                         break;
                     }
-                    fixed (char* sptr = relativeStr) // relativeStr.Substring(0, i) represents the scheme
+                    string scheme = relativeStr.Substring(0, i);
+                    fixed (char* sptr = scheme)
                     {
                         UriParser syntax = null;
-                        if (CheckSchemeSyntax(sptr, (ushort)i, ref syntax) == ParsingError.None)
+                        if (CheckSchemeSyntax(sptr, (ushort)scheme.Length, ref syntax) == ParsingError.None)
                         {
                             if (baseUri.Syntax == syntax)
                             {

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -889,5 +889,12 @@ namespace System.PrivateUri.Tests
             s = uri.GetComponents(UriComponents.Host, UriFormat.UriEscaped);
             Assert.Equal(s, "www.contoso.com");
         }
+
+        [Fact]
+        public static void TestCasingWhenCombiningAbsoluteAndRelativeUris()
+        {
+            Uri u = new Uri(new Uri("http://example.com/", UriKind.Absolute), new Uri("C(B:G", UriKind.Relative));
+            Assert.Equal("http://example.com/C(B:G", u.ToString());
+        }
     }
 }


### PR DESCRIPTION
Quoting @stephentoub --
 
> While #12061 looked simple, the removal of the allocation actually broke this behavior (and worse, broke string immutability) because the CheckSchemeSyntax method that's called actually mutates the char* that's passed in. This code was bad to begin with, as this was always (even in netfx) mutating a string instance, but that PR made it worse and broke this because it ends up passing in / mutating the original string rather than a copy that's mutated and then thrown away.
> 
> The removal of the allocation can be re-done in a different way. For now, though, we need to revert.

The break is bad enough that it renders System.Uri unusable in many situations, so the fix warrants porting back to 2.0.x. 

Fixes #25548

cc: @stephentoub @karelz @davidsh 