### PR TITLE
SslStream - Linux Solving it all in 4 lines (and deleting 2)

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -94,6 +94,10 @@ extern "C" SSL* CryptoNative_SslCreate(SSL_CTX* ctx)
 
 extern "C" int32_t CryptoNative_SslGetError(SSL* ssl, int32_t ret)
 {
+    while(ERR_peek_error() != ERR_peek_last_error())
+    {
+        ERR_get_error();
+    }
     return SSL_get_error(ssl, ret);
 }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -94,7 +94,16 @@ extern "C" SSL* CryptoNative_SslCreate(SSL_CTX* ctx)
 
 extern "C" int32_t CryptoNative_SslGetError(SSL* ssl, int32_t ret)
 {
-    return SSL_get_error(ssl, ret);
+    // This pops off "old" errors left by other operations
+    // until the first and last error are the same
+    // this should be looked at again when OpenSsl 1.1 is migrated to
+    while(ERR_peek_error() != ERR_peek_last_error())
+    {
+        ERR_get_error();
+    }
+    int32_t errorCode = SSL_get_error(ssl, ret);
+    ERR_clear_error();
+    return errorCode;
 }
 
 extern "C" void CryptoNative_SslDestroy(SSL* ssl)
@@ -384,19 +393,11 @@ err:
 
 extern "C" int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num)
 {
-    if(ERR_peek_error() != 0)
-    {
-        ERR_clear_error();
-    }
     return SSL_write(ssl, buf, num);
 }
 
 extern "C" int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num)
 {
-    if(ERR_peek_error() != 0)
-    {
-        ERR_clear_error();
-    }
     return SSL_read(ssl, buf, num);
 }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -97,7 +97,7 @@ extern "C" int32_t CryptoNative_SslGetError(SSL* ssl, int32_t ret)
     // This pops off "old" errors left by other operations
     // until the first and last error are the same
     // this should be looked at again when OpenSsl 1.1 is migrated to
-    while(ERR_peek_error() != ERR_peek_last_error())
+    while (ERR_peek_error() != ERR_peek_last_error())
     {
         ERR_get_error();
     }
@@ -228,7 +228,10 @@ static ExchangeAlgorithmType MapExchangeAlgorithmType(const char* keyExchange, s
     return ExchangeAlgorithmType::None;
 }
 
-static void GetHashAlgorithmTypeAndSize(const char* mac, size_t macLength, HashAlgorithmType& dataHashAlg, DataHashSize& hashKeySize)
+static void GetHashAlgorithmTypeAndSize(const char* mac,
+                                        size_t macLength,
+                                        HashAlgorithmType& dataHashAlg,
+                                        DataHashSize& hashKeySize)
 {
     if (StringSpanEquals(mac, "MD5", macLength))
     {
@@ -283,7 +286,8 @@ Given a keyName string like "Enc=XXX", parses the description string and returns
 
 Returns a value indicating whether the pattern starting with keyName was found in description.
 */
-static bool GetDescriptionValue(const char* description, const char* keyName, size_t keyNameLength, const char** value, size_t& valueLength)
+static bool GetDescriptionValue(
+    const char* description, const char* keyName, size_t keyNameLength, const char** value, size_t& valueLength)
 {
     // search for keyName in description
     const char* keyNameStart = strstr(description, keyName);
@@ -588,4 +592,3 @@ extern "C" int32_t CryptoNative_SslSetTlsExtHostName(SSL* ssl, const uint8_t* na
 {
     return static_cast<int32_t>(SSL_set_tlsext_host_name(ssl, name));
 }
-

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -94,6 +94,9 @@ extern "C" SSL* CryptoNative_SslCreate(SSL_CTX* ctx)
 
 extern "C" int32_t CryptoNative_SslGetError(SSL* ssl, int32_t ret)
 {
+    // This pops off "old" errors left by other operations
+    // until the first and last error are the same
+    // this should be looked at again when OpenSsl 1.1 is migrated to
     while(ERR_peek_error() != ERR_peek_last_error())
     {
         ERR_get_error();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -94,13 +94,6 @@ extern "C" SSL* CryptoNative_SslCreate(SSL_CTX* ctx)
 
 extern "C" int32_t CryptoNative_SslGetError(SSL* ssl, int32_t ret)
 {
-    // This pops off "old" errors left by other operations
-    // until the first and last error are the same
-    // this should be looked at again when OpenSsl 1.1 is migrated to
-    while(ERR_peek_error() != ERR_peek_last_error())
-    {
-        ERR_get_error();
-    }
     return SSL_get_error(ssl, ret);
 }
 
@@ -391,11 +384,19 @@ err:
 
 extern "C" int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num)
 {
+    if(ERR_peek_error() != 0)
+    {
+        ERR_clear_error();
+    }
     return SSL_write(ssl, buf, num);
 }
 
 extern "C" int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num)
 {
+    if(ERR_peek_error() != 0)
+    {
+        ERR_clear_error();
+    }
     return SSL_read(ssl, buf, num);
 }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -388,13 +388,11 @@ err:
 
 extern "C" int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num)
 {
-    ERR_clear_error();
     return SSL_write(ssl, buf, num);
 }
 
 extern "C" int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num)
 {
-    ERR_clear_error();
     return SSL_read(ssl, buf, num);
 }
 


### PR DESCRIPTION
Well, I sat, I thought, ... I read some c.. and I think I figured it out..

Basically the problem is if another bit of code that used this thread didn't clean up after itself (bad manners if you ask me but you can't control everyone).

The errors are just a queue and we can "peek_last_error" but the problem is that we are calling Ssl_Get_Error.

Ssl_Get_Error is a about 100 lines of code that does a bunch of other things than just check the error queue (checks internal bio states for async needs read/write etc).

So we can't change that, and we can't change that it needs the error code of the latest error.  And we can't change that it looks at the "first" item in the queue.

The current solution is to clear the error queue before each encrypt/decrypt but that hits the evil global lock and causes all the grief. And removing the clear of course causes potentially the wrong item at the top of the error queue.

However the clear is on the hot path, and what isn't on the hot path is the "Ssl_Get_Error" mostly because SslStream ensures sending of complete frames to OpenSSL so we don't rely on the "Needs Read/Write" in hot situations. We will get these for an actual error, but then that is now a slow path anyway.

To get to it, my solution is not to do the clear, but when we are in the error state, just makesure the queues first and last error number are the same with a Peek of the first and last (the only operations I have other than get). If they aren't the same then do a get to pop one off the queue and repeat until they equal.


Master ~200k rps
Throttle ~400k rps
Throttle with ProcCount/2 ~580k rps
With my error change 

 713021.51

This is my preferred solution over #25187 