### PR TITLE
Have System.Linq.Expressions consider its own types safe for caching

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -755,14 +755,19 @@ namespace System.Dynamic.Utils
         }
 
         private static Assembly s_mscorlib;
+        private static Assembly s_thisAssembly;
 
         private static Assembly MsCorLib => s_mscorlib ?? (s_mscorlib = typeof(object).Assembly);
+
+        private static Assembly ThisAssembly => s_thisAssembly ?? (s_thisAssembly = typeof(TypeUtils).Assembly);
 
         /// <summary>
         /// We can cache references to types, as long as they aren't in
         /// collectible assemblies. Unfortunately, we can't really distinguish
         /// between different flavors of assemblies. But, we can at least
         /// create a cache for types in mscorlib (so we get the primitives, etc).
+        /// We can also cache types from this assembly, as if this assembly is
+        /// loaded in a collectible way, then the cache can be collected too.
         /// </summary>
         public static bool CanCache(this Type t)
         {
@@ -774,7 +779,7 @@ namespace System.Dynamic.Utils
             // assemblies.
 
             Assembly asm = t.Assembly;
-            if (asm != MsCorLib)
+            if (asm != MsCorLib & asm != ThisAssembly)
             {
                 // Not in mscorlib or our assembly
                 return false;

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -778,25 +778,34 @@ namespace System.Dynamic.Utils
             // that allows mscorlib types to be specialized by types in other
             // assemblies.
 
-            Assembly asm = t.Assembly;
-            if (asm != MsCorLib & asm != ThisAssembly)
+            for (;;)
             {
-                // Not in mscorlib or our assembly
-                return false;
-            }
-
-            if (t.IsGenericType)
-            {
-                foreach (Type g in t.GetGenericArguments())
+                Assembly asm = t.Assembly;
+                if (asm != MsCorLib & asm != ThisAssembly)
                 {
-                    if (!g.CanCache())
+                    // Not in mscorlib or our assembly
+                    return false;
+                }
+
+                if (t.IsGenericType)
+                {
+                    Type[] arguments = t.GetGenericArguments();
+                    for (int i = 1; i < arguments.Length; i++)
                     {
-                        return false;
+                        if (!arguments[i].CanCache())
+                        {
+                            return false;
+                        }
                     }
+
+                    // Iterate rather than recurse on the first argument (often the only argument).
+                    t = arguments[0];
+                }
+                else
+                {
+                    return true;
                 }
             }
-
-            return true;
         }
 
         public static MethodInfo GetInvokeMethod(this Type delegateType)


### PR DESCRIPTION
Since the cache is in that assembly, it's as collectible or not as the types are, so they're safe to cache.

Increases `CanCache` true returns from  0.05% to 54.40% during the Microsoft.CSharp tests and 0.27% to 41.87% during the System.Dynamic.Runtime tests (a more moderate 49.59% to 54.34% for S.L.Expressions itself).