### PR TITLE
Explore making state part of the find data

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.Windows.cs
@@ -8,11 +8,12 @@ namespace System.IO
 {
     partial class DirectoryInfo
     {
-        internal unsafe DirectoryInfo(string fullPath, string fileName, ref RawFindData findData)
-            : this(fullPath, fileName: fileName, isNormalized: true)
+        internal static unsafe DirectoryInfo Create<TState>(string fullPath, string fileName, ref RawFindData<TState> findData)
         {
             Debug.Assert(fileName.Equals(Path.GetFileName(fullPath)));
-            Init(findData._info);
+            DirectoryInfo info = new DirectoryInfo(fullPath, fileName: fileName, isNormalized: true);
+            info.Init(findData._info);
+            return info;
         }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/FileInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileInfo.Windows.cs
@@ -8,11 +8,12 @@ namespace System.IO
 {
     partial class FileInfo
     {
-        internal unsafe FileInfo(string fullPath, string fileName, ref RawFindData findData)
-            : this(fullPath, fileName: fileName, isNormalized: true)
+        internal static unsafe FileInfo Create<TState>(string fullPath, string fileName, ref RawFindData<TState> findData)
         {
             Debug.Assert(fileName.Equals(Path.GetFileName(fullPath)));
-            Init(findData._info);
+            FileInfo info = new FileInfo(fullPath, fileName: fileName, isNormalized: true);
+            info.Init(findData._info);
+            return info;
         }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/FindEnumerable.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FindEnumerable.Windows.cs
@@ -17,7 +17,7 @@ namespace System.IO
         private readonly string _originalFullPath;
         private readonly string _originalUserPath;
         private readonly bool _recursive;
-        private readonly FindTransform<TResult> _transform;
+        private readonly FindTransform<TResult, TState> _transform;
         private readonly FindPredicate<TState> _predicate;
         private readonly TState _state;
 
@@ -40,7 +40,7 @@ namespace System.IO
         /// <param name="directory">The directory to search in.</param>
         public FindEnumerable(
             string directory,
-            FindTransform<TResult> transform,
+            FindTransform<TResult, TState> transform,
             FindPredicate<TState> predicate,
             TState state = default,
             bool recursive = false)
@@ -57,7 +57,7 @@ namespace System.IO
         private FindEnumerable(
             string originalUserPath,
             string originalFullPath,
-            FindTransform<TResult> transform,
+            FindTransform<TResult, TState> transform,
             FindPredicate<TState> predicate,
             TState state,
             bool recursive)
@@ -134,7 +134,7 @@ namespace System.IO
                 if (_lastEntryFound)
                     return false;
 
-                RawFindData findData = default;
+                RawFindData<TState> findData = default;
                 do
                 {
                     FindNextFile();
@@ -158,9 +158,9 @@ namespace System.IO
                             }
                         }
 
-                        findData = new RawFindData(_info, _currentPath, _originalFullPath, _originalUserPath);
+                        findData = new RawFindData<TState>(_info, _currentPath, _originalFullPath, _originalUserPath, _state);
                     }
-                } while (!_lastEntryFound && !_predicate(ref findData, _state));
+                } while (!_lastEntryFound && !_predicate(ref findData));
 
                 if (!_lastEntryFound)
                     _current = _transform(ref findData);

--- a/src/System.IO.FileSystem/src/System/IO/FindEnumerableFactory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FindEnumerableFactory.cs
@@ -38,12 +38,12 @@ namespace System.IO
         {
             return new FindEnumerable<string, string>(
                 directory,
-                (ref RawFindData findData) => FindTransforms.AsUserFullPath(ref findData),
-                (ref RawFindData findData, string expr) =>
+                (ref RawFindData<string> findData) => FindTransforms.AsUserFullPath<string>(ref findData),
+                (ref RawFindData<string> findData) =>
                 {
                     return FindPredicates.NotDotOrDotDot(ref findData)
                         && !FindPredicates.IsDirectory(ref findData)
-                        && DosMatcher.MatchPattern(expr, findData.FileName, ignoreCase: true);
+                        && DosMatcher.MatchPattern(findData.State, findData.FileName, ignoreCase: true);
                 },
                 DosMatcher.TranslateExpression(expression),
                 recursive);
@@ -55,12 +55,12 @@ namespace System.IO
         {
             return new FindEnumerable<string, string>(
                 directory,
-                (ref RawFindData findData) => FindTransforms.AsUserFullPath(ref findData),
-                (ref RawFindData findData, string expr) =>
+                (ref RawFindData<string> findData) => FindTransforms.AsUserFullPath(ref findData),
+                (ref RawFindData<string> findData) =>
                 {
                     return FindPredicates.NotDotOrDotDot(ref findData)
                         && FindPredicates.IsDirectory(ref findData)
-                        && DosMatcher.MatchPattern(expr, findData.FileName, ignoreCase: true);
+                        && DosMatcher.MatchPattern(findData.State, findData.FileName, ignoreCase: true);
                 },
                 DosMatcher.TranslateExpression(expression),
                 recursive);
@@ -72,11 +72,11 @@ namespace System.IO
         {
             return new FindEnumerable<string, string>(
                 directory,
-                (ref RawFindData findData) => FindTransforms.AsUserFullPath(ref findData),
-                (ref RawFindData findData, string expr) =>
+                (ref RawFindData<string> findData) => FindTransforms.AsUserFullPath(ref findData),
+                (ref RawFindData<string> findData) =>
                 {
                     return FindPredicates.NotDotOrDotDot(ref findData)
-                        && DosMatcher.MatchPattern(expr, findData.FileName, ignoreCase: true);
+                        && DosMatcher.MatchPattern(findData.State, findData.FileName, ignoreCase: true);
                 },
                 DosMatcher.TranslateExpression(expression),
                 recursive);
@@ -89,12 +89,12 @@ namespace System.IO
         {
              return new FindEnumerable<FileInfo, string>(
                 directory,
-                (ref RawFindData findData) => FindTransforms.AsFileInfo(ref findData),
-                (ref RawFindData findData, string expr) =>
+                (ref RawFindData<string> findData) => FindTransforms.AsFileInfo(ref findData),
+                (ref RawFindData<string> findData) =>
                 {
                     return FindPredicates.NotDotOrDotDot(ref findData)
                         && !FindPredicates.IsDirectory(ref findData)
-                        && DosMatcher.MatchPattern(expr, findData.FileName, ignoreCase: true);
+                        && DosMatcher.MatchPattern(findData.State, findData.FileName, ignoreCase: true);
                 },
                 DosMatcher.TranslateExpression(expression),
                 recursive);
@@ -107,12 +107,12 @@ namespace System.IO
         {
             return new FindEnumerable<DirectoryInfo, string>(
                directory,
-               (ref RawFindData findData) => FindTransforms.AsDirectoryInfo(ref findData),
-               (ref RawFindData findData, string expr) =>
+               (ref RawFindData<string> findData) => FindTransforms.AsDirectoryInfo(ref findData),
+               (ref RawFindData<string> findData) =>
                {
                    return FindPredicates.NotDotOrDotDot(ref findData)
                        && FindPredicates.IsDirectory(ref findData)
-                       && DosMatcher.MatchPattern(expr, findData.FileName, ignoreCase: true);
+                       && DosMatcher.MatchPattern(findData.State, findData.FileName, ignoreCase: true);
                },
                DosMatcher.TranslateExpression(expression),
                recursive);
@@ -125,11 +125,11 @@ namespace System.IO
         {
             return new FindEnumerable<FileSystemInfo, string>(
                directory,
-               (ref RawFindData findData) => FindTransforms.AsFileSystemInfo(ref findData),
-               (ref RawFindData findData, string expr) =>
+               (ref RawFindData<string> findData) => FindTransforms.AsFileSystemInfo(ref findData),
+               (ref RawFindData<string> findData) =>
                {
                    return FindPredicates.NotDotOrDotDot(ref findData)
-                       && DosMatcher.MatchPattern(expr, findData.FileName, ignoreCase: true);
+                       && DosMatcher.MatchPattern(findData.State, findData.FileName, ignoreCase: true);
                },
                DosMatcher.TranslateExpression(expression),
                recursive);

--- a/src/System.IO.FileSystem/src/System/IO/FindPredicate.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FindPredicate.cs
@@ -7,5 +7,5 @@ namespace System.IO
     /// <summary>
     /// Interface for filtering out find results.
     /// </summary>
-    internal delegate bool FindPredicate<TState>(ref RawFindData findData, TState state);
+    internal delegate bool FindPredicate<TState>(ref RawFindData<TState> findData);
 }

--- a/src/System.IO.FileSystem/src/System/IO/FindPredicates.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FindPredicates.cs
@@ -6,9 +6,9 @@ namespace System.IO
 {
     internal static partial class FindPredicates
     {
-        internal static bool NotDotOrDotDot(ref RawFindData findData) => !PathHelpers.IsDotOrDotDot(findData.FileName);
+        internal static bool NotDotOrDotDot<TState>(ref RawFindData<TState> findData) => !PathHelpers.IsDotOrDotDot(findData.FileName);
 
-        internal static bool IsDirectory(ref RawFindData findData)
+        internal static bool IsDirectory<TState>(ref RawFindData<TState> findData)
         {
             FileAttributes attributes = findData.Attributes;
             return attributes != (FileAttributes)(-1)

--- a/src/System.IO.FileSystem/src/System/IO/FindTransform.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FindTransform.cs
@@ -7,5 +7,5 @@ namespace System.IO
     /// <summary>
     /// Delegate for transforming raw find data into a result.
     /// </summary>
-    internal delegate T FindTransform<T>(ref RawFindData findData);
+    internal delegate TResult FindTransform<TResult, TState>(ref RawFindData<TState> findData);
 }

--- a/src/System.IO.FileSystem/src/System/IO/FindTransforms.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FindTransforms.cs
@@ -6,32 +6,32 @@ namespace System.IO
 {
     internal static partial class FindTransforms
     {
-        internal static DirectoryInfo AsDirectoryInfo(ref RawFindData findData)
+        internal static DirectoryInfo AsDirectoryInfo<TState>(ref RawFindData<TState> findData)
         {
             string fileName = new string(findData.FileName);
-            return new DirectoryInfo(PathHelpers.CombineNoChecks(findData.Directory, fileName), fileName, ref findData);
+            return DirectoryInfo.Create(PathHelpers.CombineNoChecks(findData.Directory, fileName), fileName, ref findData);
         }
 
-        internal static FileInfo AsFileInfo(ref RawFindData findData)
+        internal static FileInfo AsFileInfo<TState>(ref RawFindData<TState> findData)
         {
             string fileName = new string(findData.FileName);
-            return new FileInfo(PathHelpers.CombineNoChecks(findData.Directory, fileName), fileName, ref findData);
+            return FileInfo.Create(PathHelpers.CombineNoChecks(findData.Directory, fileName), fileName, ref findData);
         }
 
-        internal static FileSystemInfo AsFileSystemInfo(ref RawFindData findData)
+        internal static FileSystemInfo AsFileSystemInfo<TState>(ref RawFindData<TState> findData)
         {
             string fileName = new string(findData.FileName);
             string fullPath = PathHelpers.CombineNoChecks(findData.Directory, fileName);
 
             return (findData.Attributes & FileAttributes.Directory) != 0
-                ? (FileSystemInfo)new DirectoryInfo(fullPath, fileName, ref findData)
-                : (FileSystemInfo)new FileInfo(fullPath, fileName, ref findData);
+                ? (FileSystemInfo)DirectoryInfo.Create(fullPath, fileName, ref findData)
+                : (FileSystemInfo)FileInfo.Create(fullPath, fileName, ref findData);
         }
 
         /// <summary>
         /// Returns the full path for find results, based off of the initially provided path.
         /// </summary>
-        internal static string AsUserFullPath(ref RawFindData findData)
+        internal static string AsUserFullPath<TState>(ref RawFindData<TState> findData)
         {
             ReadOnlySpan<char> subdirectory = findData.Directory.AsReadOnlySpan().Slice(findData.OriginalDirectory.Length);
             return PathHelpers.CombineNoChecks(findData.OriginalUserDirectory, subdirectory, findData.FileName);

--- a/src/System.IO.FileSystem/src/System/IO/RawFindData.cs
+++ b/src/System.IO.FileSystem/src/System/IO/RawFindData.cs
@@ -7,20 +7,22 @@ namespace System.IO
     /// <summary>
     /// Used for processing and filtering find results.
     /// </summary>
-    internal unsafe ref struct RawFindData
+    internal unsafe ref struct RawFindData<TState>
     {
-        internal RawFindData(Interop.NtDll.FILE_FULL_DIR_INFORMATION* info, string directory, string originalDirectory, string originalUserDirectory)
+        internal RawFindData(Interop.NtDll.FILE_FULL_DIR_INFORMATION* info, string directory, string originalDirectory, string originalUserDirectory, TState state)
         {
             _info = info;
             Directory = directory;
             OriginalDirectory = originalDirectory;
             OriginalUserDirectory = originalUserDirectory;
+            State = state;
         }
 
         internal unsafe Interop.NtDll.FILE_FULL_DIR_INFORMATION* _info;
         public string Directory { get; private set; }
         public string OriginalDirectory { get; private set; }
         public string OriginalUserDirectory { get; private set; }
+        public TState State { get; private set; }
 
         public ReadOnlySpan<char> FileName => _info->FileName;
         public FileAttributes Attributes => _info->FileAttributes;


### PR DESCRIPTION
Making the change to put state in RawFindData as suggested by @svick on https://github.com/dotnet/designs/pull/24#issuecomment-348785224. I think this way is better- note that I haven't added state to the transform delegate before, but it is intended to have it per the spec.

@svick, @danmosemsft, @terrajobst  