### PR TITLE
Fix Alpine CURL concurrency issue

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/OSX/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/OSX/CurlHandler.SslProvider.cs
@@ -12,19 +12,6 @@ namespace System.Net.Http
 {
     internal partial class CurlHandler : HttpMessageHandler
     {
-        static partial void UseSingletonMultiAgent(ref bool result)
-        {
-            // Some backends other than OpenSSL need locks initialized in order to use them in a
-            // multithreaded context, which would happen with multiple HttpClients and thus multiple
-            // MultiAgents. Since we don't currently have the ability to do so initialization, instead we
-            // restrict all HttpClients to use the same MultiAgent instance in this case.  We know LibreSSL
-            // is in this camp, so we currently special-case it.
-            string curlSslVersion = Interop.Http.GetSslVersionDescription();
-            result =
-                !string.IsNullOrEmpty(curlSslVersion) &&
-                curlSslVersion.StartsWith(Interop.Http.LibreSslDescription, StringComparison.OrdinalIgnoreCase);
-        }
-
         private static class SslProvider
         {
             internal static void SetSslOptions(EasyRequest easy, ClientCertificateOption clientCertOption)

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -174,9 +174,7 @@ namespace System.Net.Http
             // By default every CurlHandler gets its own MultiAgent.  But for some backends,
             // we need to restrict the number of threads involved in processing libcurl work,
             // so we create a single MultiAgent that's used by all handlers.
-            bool useSingleton = false;
-            UseSingletonMultiAgent(ref useSingleton);
-            if (useSingleton)
+            if (UseSingletonMultiAgent)
             {
                 s_singletonSharedAgent = new MultiAgent(null);
             }
@@ -189,24 +187,26 @@ namespace System.Net.Http
             _agent = s_singletonSharedAgent ?? new MultiAgent(this);
         }
 
-        /// <summary>Set <see cref="result"/> to true if a single MultiAgent should be used.</summary>
-        static void UseSingletonMultiAgent(ref bool result)
-        {
-            // Some backends other than OpenSSL need locks initialized in order to use them in a
-            // multithreaded context, which would happen with multiple HttpClients and thus multiple
-            // MultiAgents. Since we don't currently have the ability to do so initialization, instead we
-            // restrict all HttpClients to use the same MultiAgent instance in this case.  We know LibreSSL
-            // is in this camp, so we currently special-case it.
-            string curlSslVersion = Interop.Http.GetSslVersionDescription();
-            result =
-                !string.IsNullOrEmpty(curlSslVersion) &&
-                curlSslVersion.StartsWith(Interop.Http.LibreSslDescription, StringComparison.OrdinalIgnoreCase);
-        }
-
         #region Properties
 
         private static string CurlVersionDescription => s_curlVersionDescription ?? (s_curlVersionDescription = Interop.Http.GetVersionDescription() ?? string.Empty);
         private static string CurlSslVersionDescription => s_curlSslVersionDescription ?? (s_curlSslVersionDescription = Interop.Http.GetSslVersionDescription() ?? string.Empty);
+
+        private static bool UseSingletonMultiAgent
+        {
+            get
+            {
+                // Some backends other than OpenSSL need locks initialized in order to use them in a
+                // multithreaded context, which would happen with multiple HttpClients and thus multiple
+                // MultiAgents. Since we don't currently have the ability to do so initialization, instead we
+                // restrict all HttpClients to use the same MultiAgent instance in this case.  We know LibreSSL
+                // is in this camp, so we currently special-case it.
+                string curlSslVersion = Interop.Http.GetSslVersionDescription();
+                return
+                    !string.IsNullOrEmpty(curlSslVersion) &&
+                    curlSslVersion.StartsWith(Interop.Http.LibreSslDescription, StringComparison.OrdinalIgnoreCase);
+            }
+        }
 
         internal bool AllowAutoRedirect
         {


### PR DESCRIPTION
On Alpine Linux, CURL uses LibreSSL for its HTTPS needs. That creates
the same concurrency issue that we had with LibreSSL on OSX. It was
fixed for OSX only in the past by detecting which SSL library CURL uses
and using shared MultiAgent for all CurlHandler instances.
This change extends it to all Unixes, since if CURL uses LibreSSL on a
Linux distro, we need the same workaround.