### PR TITLE
Disable parallelization for EventLog

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -69,7 +69,6 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ActiveIssue(24874)]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void CheckingEntryEqualityAndIndex()
         {
@@ -100,7 +99,6 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ActiveIssue(24874)]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void CheckingEntryInEquality()
         {

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -6,6 +6,9 @@ using System.ComponentModel;
 using System.Threading;
 using Xunit;
 
+// Implementation is not robust with respect to concurrently writing and reading log
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
 namespace System.Diagnostics.Tests
 {
     internal class Helpers


### PR DESCRIPTION
Fixes #25069, #24874 
Running test time increased from around 0.5-0.6 Seconds to 0.7-0.8 seconds
