### PR TITLE
"Don't directly throw Exception" System.Data.SqlClient

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/Sql/SqlNorm.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Sql/SqlNorm.cs
@@ -101,7 +101,7 @@ namespace Microsoft.SqlServer.Server
                     {
                         FieldInfo fi = t.GetField("Null", BindingFlags.Public | BindingFlags.Static);
                         if (fi == null || fi.FieldType != t)
-                            throw new Exception("could not find Null field/property in nullable type " + t);
+                            throw new InvalidOperationException("could not find Null field/property in nullable type " + t);
                         else
                             NullInstance = fi.GetValue(null);
                     }
@@ -243,7 +243,7 @@ namespace Microsoft.SqlServer.Server
                 n = new BinaryOrderedUdtNormalizer(t, false);
             }
             if (n == null)
-                throw new Exception(SR.GetString(SR.SQL_CannotCreateNormalizer, t.FullName));
+                throw new InvalidOperationException(SR.GetString(SR.SQL_CannotCreateNormalizer, t.FullName));
             n._skipNormalize = false;
             return n;
         }

--- a/src/System.Data.SqlClient/src/System/Data/Sql/SqlNorm.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Sql/SqlNorm.cs
@@ -101,7 +101,7 @@ namespace Microsoft.SqlServer.Server
                     {
                         FieldInfo fi = t.GetField("Null", BindingFlags.Public | BindingFlags.Static);
                         if (fi == null || fi.FieldType != t)
-                            throw new InvalidOperationException("could not find Null field/property in nullable type " + t);
+                            throw new ArgumentException("could not find Null field/property in nullable type " + t);
                         else
                             NullInstance = fi.GetValue(null);
                     }
@@ -243,7 +243,7 @@ namespace Microsoft.SqlServer.Server
                 n = new BinaryOrderedUdtNormalizer(t, false);
             }
             if (n == null)
-                throw new InvalidOperationException(SR.GetString(SR.SQL_CannotCreateNormalizer, t.FullName));
+                throw new ArgumentException(SR.GetString(SR.SQL_CannotCreateNormalizer, t.FullName));
             n._skipNormalize = false;
             return n;
         }

--- a/src/System.Data.SqlClient/src/System/Data/Sql/SqlSer.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Sql/SqlSer.cs
@@ -196,7 +196,7 @@ namespace Microsoft.SqlServer.Server
 
         private void DontDoIt()
         {
-            throw new Exception(SR.GetString(SR.Sql_InternalError));
+            throw new InvalidOperationException(SR.GetString(SR.Sql_InternalError));
         }
 
         public override bool CanRead => false;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
@@ -34,7 +34,7 @@ namespace System.Data.SqlClient.SNI
             }
             catch (SocketException se)
             {
-                throw new Exception(SQLMessage.SqlServerBrowserNotAccessible(), se);
+                throw new InvalidOperationException(SQLMessage.SqlServerBrowserNotAccessible(), se);
             }
 
             const byte SvrResp = 0x05;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
@@ -34,7 +34,7 @@ namespace System.Data.SqlClient.SNI
             }
             catch (SocketException se)
             {
-                throw new InvalidOperationException(SQLMessage.SqlServerBrowserNotAccessible(), se);
+                throw new System.InvalidOperationException(SQLMessage.SqlServerBrowserNotAccessible(), se);
             }
 
             const byte SvrResp = 0x05;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
@@ -34,7 +34,7 @@ namespace System.Data.SqlClient.SNI
             }
             catch (SocketException se)
             {
-                throw new System.InvalidOperationException(SQLMessage.SqlServerBrowserNotAccessible(), se);
+                throw new InvalidOperationException(SQLMessage.SqlServerBrowserNotAccessible(), se);
             }
 
             const byte SvrResp = 0x05;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -194,7 +194,7 @@ namespace System.Data.SqlClient
         }
         internal static Exception SynchronousCallMayNotPend()
         {
-            return new Exception(SR.GetString(SR.Sql_InternalError));
+            return new InvalidOperationException(SR.GetString(SR.Sql_InternalError));
         }
         internal static Exception ConnectionLockedForBcpEvent()
         {


### PR DESCRIPTION
@saurabh500 i've found other place where there are "throw new Exception()" what do you think?Instead of ArgumentException i found also a more specialized exception InvalidUdtException(but i'm not sure if make sense). 
contributes to #23748