### PR TITLE
Send notification about HTTP response without content (netfx)

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
@@ -38,6 +38,7 @@ namespace System.Diagnostics.Tests
         /// A simple test to make sure the Http Diagnostic Source is initialized properly after we subscribed to it, using
         /// the subscribe overload with just the observer argument.
         /// </summary>
+        [OuterLoop]
         [Fact]
         public void TestReflectInitializationViaSubscription1()
         {
@@ -59,6 +60,7 @@ namespace System.Diagnostics.Tests
         /// A simple test to make sure the Http Diagnostic Source is initialized properly after we subscribed to it, using
         /// the subscribe overload with just the observer argument and the more complicating enable filter function.
         /// </summary>
+        [OuterLoop]
         [Fact]
         public void TestReflectInitializationViaSubscription2()
         {
@@ -80,6 +82,7 @@ namespace System.Diagnostics.Tests
         /// A simple test to make sure the Http Diagnostic Source is initialized properly after we subscribed to it, using
         /// the subscribe overload with the observer argument and the simple predicate argument.
         /// </summary>
+        [OuterLoop]
         [Fact]
         public void TestReflectInitializationViaSubscription3()
         {
@@ -100,6 +103,7 @@ namespace System.Diagnostics.Tests
         /// <summary>
         /// Test to make sure we get both request and response events.
         /// </summary>
+        [OuterLoop]
         [Fact]
         public async Task TestBasicReceiveAndResponseEvents()
         {
@@ -137,6 +141,7 @@ namespace System.Diagnostics.Tests
         /// <summary>
         /// Test to make sure we get both request and response events.
         /// </summary>
+        [OuterLoop]
         [Fact]
         public async Task TestResponseWithoutContentEvents()
         {
@@ -173,9 +178,11 @@ namespace System.Diagnostics.Tests
                 Assert.NotNull(headers);
             }
         }
+
         /// <summary>
         /// Test that if request is redirected, it gets only one Start and one Stop event
         /// </summary>
+        [OuterLoop]
         [Fact]
         public async Task TestRedirectedRequest()
         {
@@ -197,6 +204,7 @@ namespace System.Diagnostics.Tests
         /// <summary>
         /// Test exception in request processing: exception should have expected type/status and now be swallowed by reflection hook
         /// </summary>
+        [OuterLoop]
         [Fact]
         public async Task TestRequestWithException()
         {
@@ -220,6 +228,7 @@ namespace System.Diagnostics.Tests
         /// <summary>
         /// Test request cancellation: reflection hook does not throw
         /// </summary>
+        [OuterLoop]
         [Fact]
         public async Task TestCanceledRequest()
         {
@@ -241,6 +250,7 @@ namespace System.Diagnostics.Tests
         /// <summary>
         /// Test Request-Id and Correlation-Context headers injection
         /// </summary>
+        [OuterLoop]
         [Fact]
         public async Task TestActivityIsCreated()
         {
@@ -271,6 +281,7 @@ namespace System.Diagnostics.Tests
         /// <summary>
         /// Tests IsEnabled order and parameters
         /// </summary>
+        [OuterLoop]
         [Fact]
         public async Task TestIsEnabled()
         {
@@ -301,10 +312,11 @@ namespace System.Diagnostics.Tests
                 Assert.Equal(2, eventNumber);
             }
         }
-        
+
         /// <summary>
         /// Tests that nothing happens if IsEnabled returns false
         /// </summary>
+        [OuterLoop]
         [Fact]
         public async Task TestIsEnabledAllOff()
         {
@@ -322,6 +334,7 @@ namespace System.Diagnostics.Tests
         /// <summary>
         /// Tests that if IsEnabled for request  is false, request is not instrumented
         /// </summary>
+        [OuterLoop]
         [Fact]
         public async Task TestIsEnabledRequestOff()
         {
@@ -350,6 +363,7 @@ namespace System.Diagnostics.Tests
         /// <summary>
         /// Test to make sure every event record has the right dynamic properties.
         /// </summary>
+        [OuterLoop]
         [Fact]
         public void TestMultipleConcurrentRequests()
         {


### PR DESCRIPTION
On netfx, HttpClient (WebRequests) is not instrumented with DiagnosticSource events.
Instead, DiagnosticSource implements the reflection-based hook that injects instrumentation at runtime if the user enabled it.

The hook does not properly notify about async responses that have 0-length content.
This case is treated specially here: http://referencesource.microsoft.com/#System/net/System/Net/HttpWebResponse.cs,525

It happens because at the hook is called moment, HttpWebRequest does not yet have `_HttpResponse` property assigned (that is used by the hook).

However, it has `_CoreResponse` data holding status code and response headers (that is what we expect listeners to be interested in).

This changes fires a 'Stop' event (with a new name) and new payload (status and headers).

The fix is needed for ApplicationInsights (https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/739) as it cannot track 0-length responses done with HttpClient on .net fx.

Request to document internal API is submitted - TFS 533155.

@brahmnes @vancem @zakimaksyutov