### PR TITLE
Remove dead code from MS.CSharp's BadOperatorTypesError and related methods

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -961,33 +961,21 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             pOperand1 = UnwrapExpression(pOperand1);
 
-            if (pOperand1 != null)
+            Debug.Assert(pOperand1 != null);
+            Debug.Assert(pOperand1.Type != null);
+            Debug.Assert(!(pOperand1.Type is ErrorType));
+
+            if (pOperand2 != null)
             {
-                if (pOperand2 != null)
-                {
-                    pOperand2 = UnwrapExpression(pOperand2);
-                    if (pOperand1.Type != null &&
-                            !(pOperand1.Type is ErrorType) &&
-                            pOperand2.Type != null &&
-                            !(pOperand2.Type is ErrorType))
-                    {
-                        throw ErrorContext.Error(ErrorCode.ERR_BadBinaryOps, strOp, pOperand1.Type, pOperand2.Type);
-                    }
-                }
-                else if (pOperand1.Type != null && !(pOperand1.Type is ErrorType))
-                {
-                    throw ErrorContext.Error(ErrorCode.ERR_BadUnaryOp, strOp, pOperand1.Type);
-                }
+                pOperand2 = UnwrapExpression(pOperand2);
+
+                Debug.Assert(pOperand2.Type != null);
+                Debug.Assert(!(pOperand2.Type is ErrorType));
+
+                throw ErrorContext.Error(ErrorCode.ERR_BadBinaryOps, strOp, pOperand1.Type, pOperand2.Type);
             }
 
-            if (pTypeErr == null)
-            {
-                pTypeErr = GetPredefindType(PredefinedType.PT_OBJECT);
-            }
-
-            ExprOperator rval = GetExprFactory().CreateOperator(ek, pTypeErr, pOperand1, pOperand2);
-            rval.SetError();
-            return rval;
+            throw ErrorContext.Error(ErrorCode.ERR_BadUnaryOp, strOp, pOperand1.Type);
         }
 
         private Expr UnwrapExpression(Expr pExpression)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -948,12 +948,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         ////////////////////////////////////////////////////////////////////////////////
         // Report a bad operator types error to the user.
-        private ExprOperator BadOperatorTypesError(ExpressionKind ek, Expr pOperand1, Expr pOperand2)
-        {
-            return BadOperatorTypesError(ek, pOperand1, pOperand2, null);
-        }
-
-        private ExprOperator BadOperatorTypesError(ExpressionKind ek, Expr pOperand1, Expr pOperand2, CType pTypeErr)
+        private ExprOperator BadOperatorTypesError(Expr pOperand1, Expr pOperand2)
         {
             // This is a hack, but we need to store the operation somewhere... the first argument's as 
             // good a place as any.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -948,9 +948,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         ////////////////////////////////////////////////////////////////////////////////
         // Report a bad operator types error to the user.
-        private ExprOperator BadOperatorTypesError(Expr pOperand1, Expr pOperand2)
+        private RuntimeBinderException BadOperatorTypesError(Expr pOperand1, Expr pOperand2)
         {
-            // This is a hack, but we need to store the operation somewhere... the first argument's as 
+            // This is a hack, but we need to store the operation somewhere... the first argument's as
             // good a place as any.
             string strOp = pOperand1.ErrorString;
 
@@ -967,10 +967,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(pOperand2.Type != null);
                 Debug.Assert(!(pOperand2.Type is ErrorType));
 
-                throw ErrorContext.Error(ErrorCode.ERR_BadBinaryOps, strOp, pOperand1.Type, pOperand2.Type);
+                return ErrorContext.Error(ErrorCode.ERR_BadBinaryOps, strOp, pOperand1.Type, pOperand2.Type);
             }
 
-            throw ErrorContext.Error(ErrorCode.ERR_BadUnaryOp, strOp, pOperand1.Type);
+            return ErrorContext.Error(ErrorCode.ERR_BadUnaryOp, strOp, pOperand1.Type);
         }
 
         private Expr UnwrapExpression(Expr pExpression)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -954,16 +954,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // good a place as any.
             string strOp = pOperand1.ErrorString;
 
-            pOperand1 = UnwrapExpression(pOperand1);
-
             Debug.Assert(pOperand1 != null);
             Debug.Assert(pOperand1.Type != null);
             Debug.Assert(!(pOperand1.Type is ErrorType));
 
             if (pOperand2 != null)
             {
-                pOperand2 = UnwrapExpression(pOperand2);
-
                 Debug.Assert(pOperand2.Type != null);
                 Debug.Assert(!(pOperand2.Type is ErrorType));
 
@@ -971,22 +967,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             return ErrorContext.Error(ErrorCode.ERR_BadUnaryOp, strOp, pOperand1.Type);
-        }
-
-        private Expr UnwrapExpression(Expr pExpression)
-        {
-            while (pExpression is ExprWrap wrap)
-            {
-                Expr wrapped = wrap.OptionalExpression;
-                if (wrapped == null)
-                {
-                    break;
-                }
-
-                pExpression = wrapped;
-            }
-
-            return pExpression;
         }
 
         private static ErrorCode GetStandardLvalueError(CheckLvalueKind kind)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -427,9 +427,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return exprRes;
                 }
             }
-            Expr pExpr = BadOperatorTypesError(info.arg1, info.arg2);
-            pExpr.AssertIsBin();
-            return (ExprBinOp)pExpr;
+
+            throw BadOperatorTypesError(info.arg1, info.arg2);
         }
 
         /*
@@ -446,7 +445,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 // If we don't get the BinopKind and the flags, then we must have had some bad operator types.
 
-                return BadOperatorTypesError(arg1, arg2);
+                throw BadOperatorTypesError(arg1, arg2);
             }
 
             info.mask = (BinOpMask)(1 << (int)info.binopKind);
@@ -516,7 +515,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             if (bofs.pfn == null)
             {
-                return BadOperatorTypesError(info.arg1, info.arg2);
+                throw BadOperatorTypesError(info.arg1, info.arg2);
             }
 
             if (!bofs.isLifted() || !bofs.AutoLift())
@@ -1169,7 +1168,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                            out unaryOpKind/*out*/,
                            out flags/*out*/))
             {
-                return BadOperatorTypesError(pArgument, null);
+                throw BadOperatorTypesError(pArgument, null);
             }
 
             UnaOpMask unaryOpMask = (UnaOpMask)(1 << (int)unaryOpKind);
@@ -1197,7 +1196,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     if (pSignatures.Count == 0)
                     {
-                        return BadOperatorTypesError(pArgument, null);
+                        throw BadOperatorTypesError(pArgument, null);
                     }
 
                     nBestSignature = 0;
@@ -1261,7 +1260,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return BindIncOp(ek, flags, pArgument, uofs);
                 }
 
-                return BadOperatorTypesError(pArgument, null);
+                throw BadOperatorTypesError(pArgument, null);
             }
 
             if (uofs.isLifted())
@@ -1508,7 +1507,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(arg?.Type != null);
             if (arg.Type is NullType)
             {
-                return BadOperatorTypesError(arg, null);
+                throw BadOperatorTypesError(arg, null);
             }
 
             LiftArgument(arg, uofs.GetType(), uofs.Convert(), out Expr pArgument, out Expr nonLiftedArg);
@@ -2273,7 +2272,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (ptOp == PredefinedType.PT_ULONG)
             {
-                return BadOperatorTypesError(op, null);
+                throw BadOperatorTypesError(op, null);
             }
 
             if (ptOp == PredefinedType.PT_UINT && op.Type.fundType() == FUNDTYPE.FT_U4)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -427,7 +427,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return exprRes;
                 }
             }
-            Expr pExpr = BadOperatorTypesError(ek, info.arg1, info.arg2, GetTypes().GetErrorSym());
+            Expr pExpr = BadOperatorTypesError(info.arg1, info.arg2);
             pExpr.AssertIsBin();
             return (ExprBinOp)pExpr;
         }
@@ -446,7 +446,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 // If we don't get the BinopKind and the flags, then we must have had some bad operator types.
 
-                return BadOperatorTypesError(ek, arg1, arg2);
+                return BadOperatorTypesError(arg1, arg2);
             }
 
             info.mask = (BinOpMask)(1 << (int)info.binopKind);
@@ -516,7 +516,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             if (bofs.pfn == null)
             {
-                return BadOperatorTypesError(ek, info.arg1, info.arg2);
+                return BadOperatorTypesError(info.arg1, info.arg2);
             }
 
             if (!bofs.isLifted() || !bofs.AutoLift())
@@ -1169,7 +1169,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                            out unaryOpKind/*out*/,
                            out flags/*out*/))
             {
-                return BadOperatorTypesError(ExpressionKind.UnaryOp, pArgument, null);
+                return BadOperatorTypesError(pArgument, null);
             }
 
             UnaOpMask unaryOpMask = (UnaOpMask)(1 << (int)unaryOpKind);
@@ -1197,7 +1197,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     if (pSignatures.Count == 0)
                     {
-                        return BadOperatorTypesError(ek, pArgument, null);
+                        return BadOperatorTypesError(pArgument, null);
                     }
 
                     nBestSignature = 0;
@@ -1260,7 +1260,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     return BindIncOp(ek, flags, pArgument, uofs);
                 }
-                return BadOperatorTypesError(ek, pArgument, null);
+
+                return BadOperatorTypesError(pArgument, null);
             }
 
             if (uofs.isLifted())
@@ -1507,7 +1508,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(arg?.Type != null);
             if (arg.Type is NullType)
             {
-                return BadOperatorTypesError(ek, arg, null, type);
+                return BadOperatorTypesError(arg, null);
             }
 
             LiftArgument(arg, uofs.GetType(), uofs.Convert(), out Expr pArgument, out Expr nonLiftedArg);
@@ -2272,7 +2273,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (ptOp == PredefinedType.PT_ULONG)
             {
-                return BadOperatorTypesError(ExpressionKind.Negate, op, null);
+                return BadOperatorTypesError(op, null);
             }
 
             if (ptOp == PredefinedType.PT_UINT && op.Type.fundType() == FUNDTYPE.FT_U4)


### PR DESCRIPTION
* Remove dead paths in `BadOperatorTypesError`

`pOperand1` is never null, and neither operand can ever have a null or `ErrorType` type, so remove path for those possibilities.

It's worth noting the possible call paths here, and what types they can possibly give to the operands

```
BadOperatorTypesError
    BindLiftedStandardUnop
        BindStandardUnaryOperator
            Recurse (predef)
            RB.BindUnaryOperation (creates the operands, never with ErrorType)
    bindNullEqualityComparison
        BindStandardBinop
            BindBinaryOperation (creates the operands, never with ErrorType)
    BadOperatorTypesError (overload)
        BindIntegerNeg
            BindIntOp
                BindEnumUnaOp (predef)
                BindEnumBinOp (predef)
                BindIntUnaOp (predef-always binding)
                BindIntBinOp (predef-always binding)
        BindStandardUnaryOperator (see above)
        BindStandardBinop (see above)
        BindStandardBinopCore
            BindStandardBinop (see above)
```

* Remove unused parameters from `BadOperatorTypesError`

`ek` and `pTypeErr` are never used, so remove them. Merges the overloads.

* Change `BadOperatorTypesError` to return rather than throwing exceptions

Since it throws in every path, have the error thrown at the call site, making it more clearly an error path.

* Remove `UnwrapExpression`

The only place `ExprWraps` are produced outside of the `ExpressionTreeRewriter` is in `BindUserBoolOp` which passes them to `bindUDUnop`. There's no path that can bring them to `BadOperatorTypesError` which calls `UnwrapExpression`.

* Have `CalculateExprAndUnaryOpKinds` return a value tuple and throw ICE on failure.

Rather than have an impossible condition checked for outside of it.
(ICE is more appropriate, too).

* Have GetBinopKindAndFlags return value tuple and throw ICE on failure.

Rather than have an impossible condition checked for outside of it.
