### PR TITLE
MS.CSharp Remove some dead paths for impossible errors in FillInArgInfoFromArgList & BindMethodGroupToArguments

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1020,7 +1020,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             ArgInfos argInfo = new ArgInfos
             {
-                carg = ExpressionBinder.CountArguments(arguments, out _)
+                carg = ExpressionBinder.CountArguments(arguments)
             };
             _binder.FillInArgInfoFromArgList(argInfo, arguments);
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -882,15 +882,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // Count the args.
             int carg = CountArguments(args);
 
-            // If we weren't given a pName, then we couldn't bind the method pName, so we should
-            // just bail out of here.
-
-            if (grp.Name == null)
-            {
-                ExprCall rval = GetExprFactory().CreateCall(0, GetTypes().GetErrorSym(), args, grp, null);
-                rval.SetError();
-                return rval;
-            }
+            Debug.Assert(grp.Name != null);
 
             // If we have named arguments specified, make sure we have them all appearing after
             // fixed arguments.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -858,7 +858,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         ////////////////////////////////////////////////////////////////////////////////
         // Given a method group or indexer group, bind it to the arguments for an 
         // invocation.
-        private GroupToArgsBinderResult BindMethodGroupToArgumentsCore(BindingFlag bindFlags, ExprMemberGroup grp, ref Expr args, int carg, bool bHasNamedArgumentSpecifiers)
+        private GroupToArgsBinderResult BindMethodGroupToArgumentsCore(BindingFlag bindFlags, ExprMemberGroup grp, Expr args, int carg, bool bHasNamedArgumentSpecifiers)
         {
             ArgInfos pargInfo = new ArgInfos {carg = carg};
             FillInArgInfoFromArgList(pargInfo, args);
@@ -892,11 +892,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return rval;
             }
 
-            // If we have named arguments specified, make sure we have them all appearing after 
+            // If we have named arguments specified, make sure we have them all appearing after
             // fixed arguments.
             bool seenNamed = VerifyNamedArgumentsAfterFixed(args);
 
-            MethPropWithInst mpwiBest = BindMethodGroupToArgumentsCore(bindFlags, grp, ref args, carg, seenNamed)
+            MethPropWithInst mpwiBest = BindMethodGroupToArgumentsCore(bindFlags, grp, args, carg, seenNamed)
                 .GetBestResult();
             if (grp.SymKind == SYMKIND.SK_PropertySymbol)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -880,7 +880,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(grp.SymKind == SYMKIND.SK_MethodSymbol || grp.SymKind == SYMKIND.SK_PropertySymbol && ((grp.Flags & EXPRFLAG.EXF_INDEXER) != 0));
 
             // Count the args.
-            int carg = CountArguments(args, out bool _);
+            int carg = CountArguments(args);
 
             // If we weren't given a pName, then we couldn't bind the method pName, so we should
             // just bail out of here.
@@ -1891,10 +1891,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return GetExprFactory().CreateAssignment(op1, op2);
         }
 
-        internal static int CountArguments(Expr args, out bool typeErrors)
+        internal static int CountArguments(Expr args)
         {
             int carg = 0;
-            typeErrors = false;
             for (Expr list = args; list != null; carg++)
             {
                 Expr arg;
@@ -1911,12 +1910,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 Debug.Assert(arg != null);
-
-                if (arg.Type == null || arg.Type is ErrorType)
-                {
-                    typeErrors = true;
-                }
             }
+
             return carg;
         }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1585,15 +1585,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 Debug.Assert(arg != null);
+                Debug.Assert(arg.Type != null);
 
-                if (arg.Type != null)
-                {
-                    prgtype[iarg] = arg.Type;
-                }
-                else
-                {
-                    prgtype[iarg] = GetTypes().GetErrorSym();
-                }
+                prgtype[iarg] = arg.Type;
                 argInfo.prgexpr.Add(arg);
             }
 


### PR DESCRIPTION
Like #25711 this has more path following and verification than changes, but like it it knocks out an impossible use of `ErrorType` that could allow for a bigger pay-off in simplification when they're all gone.

* Remove `typeErrors` `out` parameter from `CountArguments`

Never used.

* Remove `ref` qualifier from `BindMethodGroupToArgumentsCore` argument.

Never written back.

* Remove unreachable error case from `FillInArgInfoFromArgList`

`arg.Type` can never be null, so remove branch for that happening.

The tributaries of `FillInArgInfoFromArgList`, so to speak are as follows, noting which argument goes on to provide the `arg` local within `FillInArgInfoFromArgList`.

```
FillInArgInfoFromArgList
    ReorderArgumentsForNamedAndOptional (result.OptionalArguments)
        BindCall (Creates arguments from ArgumentObjects, which always have type)
        CreateIndexer
            BindProperty (from ArgumentObject)
    BindUDBinop (arg1, arg2)
        BindUserDefinedBinOp (info)
            BindStandardBinop (arg1, arg2)
                BindBinaryOperation (from ArgumentObject)
        BindUserDefinedBinOp (info)
            BindStandardBinop (above)
    BindMethodGroupToArgumentsCore (args)
        BindMethodGroupToArguments (args)
            BindWinRTEventAccessor (one from ArgumentObject, one or two with MethodGroupType type)
            BindCall (above)
            CreateIndexer (above)
    bindUDUnop (arg)
        BindUnaryOperation (from ArgumentObject)
        BindUserBoolOp (pCall.OptionalArguments.OptionalElement)
            BindUserDefinedBinOp (above)
        PopulateSignatureList (pArgument)
            BindStandardUnaryOperator (pArgument)
                BindUnaryOperation (above)
                BindUnaryOperation (predef type)
                    BindStandardUnaryOperator (cast to predef type)
        PopulateSignatureList (above)
```

* Remove dead path for impossible error from BindMethodGroupToArguments

`grp.Name` could never be null.

Tracking calls to `BindMethodGroupToArguments` and where `grp.Name` comes from:
```
BindMethodGroupToArguments
    BindWinRTEventAccessor (always predefined named)
    BindCall (from payload name)
        CreateMemberGroupEXPR (string overload, guarantees always non-null name)
    CreateIndexer
        CreateMemberGroupEXPR (as above).
```