### PR TITLE
Convert managed implementation of Marvin hashing to ReadOnlySpan

### DIFF
--- a/src/Common/src/System/Marvin.cs
+++ b/src/Common/src/System/Marvin.cs
@@ -14,74 +14,52 @@ namespace System
         /// Convenience method to compute a Marvin hash and collapse it into a 32-bit hash.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ComputeHash32(ref byte data, int count, ulong seed)
+        public static int ComputeHash32(ReadOnlySpan<byte> data, ulong seed)
         {
-            long hash64 = ComputeHash(ref data, count, seed);
+            long hash64 = ComputeHash(data, seed);
             return ((int)(hash64 >> 32)) ^ (int)hash64;
         }
 
         /// <summary>
         /// Computes a 64-hash using the Marvin algorithm.
         /// </summary>
-        public static long ComputeHash(ref byte data, int count, ulong seed)
+        public static long ComputeHash(ReadOnlySpan<byte> data, ulong seed)
         {
-            uint ucount = (uint)count;
             uint p0 = (uint)seed;
             uint p1 = (uint)(seed >> 32);
 
-            int byteOffset = 0;  // declared as signed int so we don't have to cast everywhere (it's passed to Unsafe.Add() and used for nothing else.)
-
-            while (ucount >= 8)
+            if (data.Length >= sizeof(uint))
             {
-                p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset));
-                Block(ref p0, ref p1);
+                ReadOnlySpan<uint> uData = data.NonPortableCast<byte, uint>();
 
-                p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset + 4));
-                Block(ref p0, ref p1);
+                for (int i = 0; i < uData.Length; i++)
+                {
+                    p0 += uData[i];
+                    Block(ref p0, ref p1);
+                }
 
-                byteOffset += 8;
-                ucount -= 8;
+                // byteOffset = data.Length - data.Length % 4
+                // is equivalent to clearing last 2 bits of length
+                int byteOffset = data.Length & (~3);
+                data = data.Slice(byteOffset);
             }
 
-            switch (ucount)
+            switch (data.Length)
             {
-                case 4:
-                    p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset));
-                    Block(ref p0, ref p1);
-                    goto case 0;
-
                 case 0:
                     p0 += 0x80u;
                     break;
 
-                case 5:
-                    p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset));
-                    byteOffset += 4;
-                    Block(ref p0, ref p1);
-                    goto case 1;
-
                 case 1:
-                    p0 += 0x8000u | Unsafe.Add(ref data, byteOffset);
+                    p0 += 0x8000u | data[0];
                     break;
-
-                case 6:
-                    p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset));
-                    byteOffset += 4;
-                    Block(ref p0, ref p1);
-                    goto case 2;
 
                 case 2:
-                    p0 += 0x800000u | Unsafe.As<byte, ushort>(ref Unsafe.Add(ref data, byteOffset));
+                    p0 += 0x800000u | data.NonPortableCast<byte, ushort>()[0];
                     break;
 
-                case 7:
-                    p0 += Unsafe.As<byte, uint>(ref Unsafe.Add(ref data, byteOffset));
-                    byteOffset += 4;
-                    Block(ref p0, ref p1);
-                    goto case 3;
-
                 case 3:
-                    p0 += 0x80000000u | (((uint)(Unsafe.Add(ref data, byteOffset + 2))) << 16)| (uint)(Unsafe.As<byte, ushort>(ref Unsafe.Add(ref data, byteOffset)));
+                    p0 += 0x80000000u | (((uint)data[2]) << 16) | (uint)(data.NonPortableCast<byte, ushort>()[0]);
                     break;
 
                 default:

--- a/src/Common/src/System/Marvin.cs
+++ b/src/Common/src/System/Marvin.cs
@@ -40,6 +40,7 @@ namespace System
 
                 // byteOffset = data.Length - data.Length % 4
                 // is equivalent to clearing last 2 bits of length
+                // Using it directly gives a perf hit for short strings making it at least 5% or more slower.
                 int byteOffset = data.Length & (~3);
                 data = data.Slice(byteOffset);
             }

--- a/src/Common/tests/Performance/Common.Performance.Tests.csproj
+++ b/src/Common/tests/Performance/Common.Performance.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
+    <ProjectGuid>{B96198F5-9BF7-42DE-83E8-3EE39DA25F43}</ProjectGuid>
+    <DisableTests Condition="'$(TargetGroup)' == 'uap' AND ('$(ArchGroup)' == 'arm' OR '$(ArchGroup)' == 'arm64')">true</DisableTests>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
+  <ItemGroup Condition="'$(DisableTests)' != 'true'">
+    <Compile Include="$(CommonPath)\System\Marvin.cs">
+      <Link>Common\System\Marvin.cs</Link>
+    </Compile>
+    <Compile Include="Perf.Marvin.cs" />
+    <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
+      <Link>Common\System\PerfUtils.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(DisableTests)' != 'true'">
+    <ProjectReference Include="$(CommonPath)\..\perf\PerfRunner\PerfRunner.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>PerfRunner</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Common/tests/Performance/Configurations.props
+++ b/src/Common/tests/Performance/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netcoreapp;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/Common/tests/Performance/Perf.Marvin.cs
+++ b/src/Common/tests/Performance/Perf.Marvin.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xunit.Performance;
+using Xunit;
+
+namespace System
+{
+    public class Perf_Marvin
+    {
+        private static IEnumerable<object[]> EnumerateRandomByteArrayTestCases()
+        {
+            var r = new Random(123);
+            foreach (int size in
+                Enumerable.Range(0, 25)
+                .Union(new int[] { 50, 100, 200, 2000, 20000, 200000, 2000000 }))
+            {
+                byte[] array = new byte[size];
+                r.NextBytes(array);
+
+                int iterations = 2000000 / Math.Max(1, size);
+                yield return new object[] { iterations, array };
+            }
+        }
+
+        [Benchmark]
+        [MemberData(nameof(EnumerateRandomByteArrayTestCases))]
+        public void Add(int iterations, byte[] data)
+        {
+            Span<byte> otherData = new byte[] { 1, 2, 3 };
+            var bytes = new Span<byte>(data);
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        Marvin.ComputeHash(ref bytes[0], bytes.Length, 123123123123UL);
+                        Marvin.ComputeHash(ref otherData[0], otherData.Length, 555888555888UL);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Common/tests/Performance/Perf.Marvin.cs
+++ b/src/Common/tests/Performance/Perf.Marvin.cs
@@ -38,8 +38,8 @@ namespace System
                 {
                     for (int i = 0; i < iterations; i++)
                     {
-                        Marvin.ComputeHash(ref bytes[0], bytes.Length, 123123123123UL);
-                        Marvin.ComputeHash(ref otherData[0], otherData.Length, 555888555888UL);
+                        Marvin.ComputeHash(bytes, 123123123123UL);
+                        Marvin.ComputeHash(otherData, 555888555888UL);
                     }
                 }
             }

--- a/src/Common/tests/Tests/System/MarvinTests.cs
+++ b/src/Common/tests/Tests/System/MarvinTests.cs
@@ -29,7 +29,7 @@ namespace Tests.System
         public void ComputeHash_Success(ulong seed, string testDataString, ulong expectedHash)
         {
             var testDataSpan = new Span<byte>(testDataString.HexToByteArray());
-            long hash = Marvin.ComputeHash(ref testDataSpan.DangerousGetPinnableReference(), testDataSpan.Length, seed);
+            long hash = Marvin.ComputeHash(testDataSpan, seed);
             Assert.Equal((long)expectedHash, hash);
         }
 

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -634,16 +634,17 @@ namespace System.Net
                 Debug.Assert(scopeWritten);
 
                 hashCode = Marvin.ComputeHash32(
-                    ref addressAndScopeIdSpan[0],
-                    addressAndScopeIdLength,
+                    addressAndScopeIdSpan,
                     Marvin.DefaultSeed);
             }
             else
             {
+                Span<uint> addressOrScopeIdSpan = stackalloc uint[1];
+                addressOrScopeIdSpan[0] = _addressOrScopeId;
+ 
                 // For IPv4 addresses, we use Marvin on the integer representation of the Address.
                 hashCode = Marvin.ComputeHash32(
-                    ref Unsafe.As<uint, byte>(ref _addressOrScopeId),
-                    sizeof(uint),
+                    addressOrScopeIdSpan.AsBytes(),
                     Marvin.DefaultSeed);
             }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/25734

Converts Marvin to use ReadOnlySpan.

Straightforward port of the implementation was causing regression of 0.5% up to 70%. I optimized it a little:  current implementation is anything from 7% faster to 30% slower where slowest cases are around 8-15 bytes of data - really short and really long chunks of data are being hashed similarly - I tried unrolling the loop for certain lengths, writing it differently but seems like the most straight forward loop is the fastest - any ideas how to improve this are welcome.