### PR TITLE
Implementing ItemRef API Proposal (C# 7.2 constructs to S.C.I)

### DIFF
--- a/src/System.Collections.Immutable/ref/Configurations.props
+++ b/src/System.Collections.Immutable/ref/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <PackageConfigurations>
       netstandard1.0;
+      netstandard1.3;
       netstandard;
     </PackageConfigurations>
     <BuildConfigurations>

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -101,6 +101,7 @@ namespace System.Collections.Immutable
         public bool IsDefaultOrEmpty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
+        public ref readonly T ItemRef(int index) { throw null; }
         public int Length { get { throw null; } }
         int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
         bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
@@ -198,6 +199,7 @@ namespace System.Collections.Immutable
             public int Capacity { get { throw null; } set { } }
             public int Count { get { throw null; } set { } }
             public T this[int index] { get { throw null; } set { } }
+            public ref readonly T ItemRef(int index) { throw null; }
             bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
             public void Add(T item) { }
             public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
@@ -868,6 +870,7 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
+        public ref readonly T ItemRef(int index) { throw null; }
         public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
         public T Max { get { throw null; } }
         public T Min { get { throw null; } }
@@ -931,6 +934,7 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public T this[int index] { get { throw null; } }
+            public ref readonly T ItemRef(int index) { throw null; }
             public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
             public T Max { get { throw null; } }
             public T Min { get { throw null; } }

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -744,6 +744,7 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public TValue this[TKey key] { get { throw null; } }
+        public ref readonly TValue ValueRef(TKey key) { throw null; }
         public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
         public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
         bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
@@ -801,6 +802,7 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public TValue this[TKey key] { get { throw null; } set { } }
+            public ref readonly TValue ValueRef(TKey key) { throw null; }
             public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
             public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
             bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -705,6 +705,7 @@ namespace System.Collections.Immutable
         public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
         public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
         public T Peek() { throw null; }
+        public ref readonly T PeekRef() { throw null; }
         System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Clear() { throw null; }
@@ -993,6 +994,7 @@ namespace System.Collections.Immutable
         public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
         public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
         public T Peek() { throw null; }
+        public ref readonly T PeekRef() { throw null; }
         public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
         public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { value = default(T); throw null; }
         public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -526,6 +526,7 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
+        public ref readonly T ItemRef(int index) { throw null; }
         bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
         T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
         bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
@@ -612,6 +613,7 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public T this[int index] { get { throw null; } set { } }
+            public ref readonly T ItemRef(int index) { throw null; }
             bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
             bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
             object System.Collections.ICollection.SyncRoot { get { throw null; } }

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -101,7 +101,9 @@ namespace System.Collections.Immutable
         public bool IsDefaultOrEmpty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
+#if ItemRefAPI
         public ref readonly T ItemRef(int index) { throw null; }
+#endif
         public int Length { get { throw null; } }
         int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
         bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
@@ -199,7 +201,9 @@ namespace System.Collections.Immutable
             public int Capacity { get { throw null; } set { } }
             public int Count { get { throw null; } set { } }
             public T this[int index] { get { throw null; } set { } }
+#if ItemRefAPI
             public ref readonly T ItemRef(int index) { throw null; }
+#endif
             bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
             public void Add(T item) { }
             public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
@@ -526,7 +530,9 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
+#if ItemRefAPI
         public ref readonly T ItemRef(int index) { throw null; }
+#endif
         bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
         T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
         bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
@@ -613,7 +619,9 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public T this[int index] { get { throw null; } set { } }
+#if ItemRefAPI
             public ref readonly T ItemRef(int index) { throw null; }
+#endif
             bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
             bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
             object System.Collections.ICollection.SyncRoot { get { throw null; } }
@@ -705,7 +713,9 @@ namespace System.Collections.Immutable
         public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
         public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
         public T Peek() { throw null; }
+#if ItemRefAPI
         public ref readonly T PeekRef() { throw null; }
+#endif
         System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Clear() { throw null; }
@@ -744,7 +754,9 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public TValue this[TKey key] { get { throw null; } }
+#if ItemRefAPI
         public ref readonly TValue ValueRef(TKey key) { throw null; }
+#endif
         public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
         public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
         bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
@@ -802,7 +814,9 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public TValue this[TKey key] { get { throw null; } set { } }
+#if ItemRefAPI
             public ref readonly TValue ValueRef(TKey key) { throw null; }
+#endif
             public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
             public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
             bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
@@ -875,7 +889,9 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
+#if ItemRefAPI
         public ref readonly T ItemRef(int index) { throw null; }
+#endif
         public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
         public T Max { get { throw null; } }
         public T Min { get { throw null; } }
@@ -939,7 +955,9 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public T this[int index] { get { throw null; } }
+#if ItemRefAPI
             public ref readonly T ItemRef(int index) { throw null; }
+#endif
             public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
             public T Max { get { throw null; } }
             public T Min { get { throw null; } }
@@ -996,7 +1014,9 @@ namespace System.Collections.Immutable
         public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
         public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
         public T Peek() { throw null; }
+#if ItemRefAPI
         public ref readonly T PeekRef() { throw null; }
+#endif
         public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
         public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { value = default(T); throw null; }
         public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -101,7 +101,7 @@ namespace System.Collections.Immutable
         public bool IsDefaultOrEmpty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         public ref readonly T ItemRef(int index) { throw null; }
 #endif
         public int Length { get { throw null; } }
@@ -201,7 +201,7 @@ namespace System.Collections.Immutable
             public int Capacity { get { throw null; } set { } }
             public int Count { get { throw null; } set { } }
             public T this[int index] { get { throw null; } set { } }
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
             public ref readonly T ItemRef(int index) { throw null; }
 #endif
             bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
@@ -530,7 +530,7 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         public ref readonly T ItemRef(int index) { throw null; }
 #endif
         bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
@@ -619,7 +619,7 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public T this[int index] { get { throw null; } set { } }
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
             public ref readonly T ItemRef(int index) { throw null; }
 #endif
             bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
@@ -713,7 +713,7 @@ namespace System.Collections.Immutable
         public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
         public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
         public T Peek() { throw null; }
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         public ref readonly T PeekRef() { throw null; }
 #endif
         System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
@@ -754,7 +754,7 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public TValue this[TKey key] { get { throw null; } }
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         public ref readonly TValue ValueRef(TKey key) { throw null; }
 #endif
         public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
@@ -814,7 +814,7 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public TValue this[TKey key] { get { throw null; } set { } }
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
             public ref readonly TValue ValueRef(TKey key) { throw null; }
 #endif
             public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
@@ -889,7 +889,7 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         public ref readonly T ItemRef(int index) { throw null; }
 #endif
         public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
@@ -955,7 +955,7 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public T this[int index] { get { throw null; } }
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
             public ref readonly T ItemRef(int index) { throw null; }
 #endif
             public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
@@ -1014,7 +1014,7 @@ namespace System.Collections.Immutable
         public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
         public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
         public T Peek() { throw null; }
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         public ref readonly T PeekRef() { throw null; }
 #endif
         public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -101,7 +101,7 @@ namespace System.Collections.Immutable
         public bool IsDefaultOrEmpty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
-#if ItemRefAPI
+#if ItemRefApi
         public ref readonly T ItemRef(int index) { throw null; }
 #endif
         public int Length { get { throw null; } }
@@ -201,7 +201,7 @@ namespace System.Collections.Immutable
             public int Capacity { get { throw null; } set { } }
             public int Count { get { throw null; } set { } }
             public T this[int index] { get { throw null; } set { } }
-#if ItemRefAPI
+#if ItemRefApi
             public ref readonly T ItemRef(int index) { throw null; }
 #endif
             bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
@@ -530,7 +530,7 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
-#if ItemRefAPI
+#if ItemRefApi
         public ref readonly T ItemRef(int index) { throw null; }
 #endif
         bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
@@ -619,7 +619,7 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public T this[int index] { get { throw null; } set { } }
-#if ItemRefAPI
+#if ItemRefApi
             public ref readonly T ItemRef(int index) { throw null; }
 #endif
             bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
@@ -713,7 +713,7 @@ namespace System.Collections.Immutable
         public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
         public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
         public T Peek() { throw null; }
-#if ItemRefAPI
+#if ItemRefApi
         public ref readonly T PeekRef() { throw null; }
 #endif
         System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
@@ -754,7 +754,7 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public TValue this[TKey key] { get { throw null; } }
-#if ItemRefAPI
+#if ItemRefApi
         public ref readonly TValue ValueRef(TKey key) { throw null; }
 #endif
         public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
@@ -814,7 +814,7 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public TValue this[TKey key] { get { throw null; } set { } }
-#if ItemRefAPI
+#if ItemRefApi
             public ref readonly TValue ValueRef(TKey key) { throw null; }
 #endif
             public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
@@ -889,7 +889,7 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
-#if ItemRefAPI
+#if ItemRefApi
         public ref readonly T ItemRef(int index) { throw null; }
 #endif
         public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
@@ -955,7 +955,7 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public T this[int index] { get { throw null; } }
-#if ItemRefAPI
+#if ItemRefApi
             public ref readonly T ItemRef(int index) { throw null; }
 #endif
             public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
@@ -1014,7 +1014,7 @@ namespace System.Collections.Immutable
         public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
         public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
         public T Peek() { throw null; }
-#if ItemRefAPI
+#if ItemRefApi
         public ref readonly T PeekRef() { throw null; }
 #endif
         public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
@@ -4,8 +4,18 @@
   <PropertyGroup>
     <ProjectGuid>{C7EFF4EE-70DC-453B-B817-4AF67921AB03}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(TargetGroup)' != 'netstandard1.0'">
-    <DefineConstants>$(DefineConstants);ItemRefApi</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ITEMREFAPI</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Collections.Immutable.cs" />
@@ -18,10 +28,8 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Collections" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
-    <Reference Include="System.Runtime" />
+  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard1.0'">
     <Reference Include="System.Runtime.InteropServices" />
-    <Reference Include="System.Collections" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{C7EFF4EE-70DC-453B-B817-4AF67921AB03}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' != 'netstandard1.0'">
-    <DefineConstants>$(DefineConstants);ItemRefAPI</DefineConstants>
+    <DefineConstants>$(DefineConstants);ItemRefApi</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Collections.Immutable.cs" />

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{C7EFF4EE-70DC-453B-B817-4AF67921AB03}</ProjectGuid>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
+  <PropertyGroup Condition="'$(TargetGroup)' != 'netstandard1.0'">
     <DefineConstants>$(DefineConstants);ItemRefAPI</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
@@ -23,12 +23,15 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' Or '$(TargetGroup)' == 'uap'">
     <ProjectReference Include="..\..\System.Collections\ref\System.Collections.csproj" />
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.InteropServices\ref\System.Runtime.InteropServices.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.0'">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Collections" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard1.0'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Collections" />
     <Reference Include="System.Runtime.InteropServices" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
@@ -4,14 +4,9 @@
   <PropertyGroup>
     <ProjectGuid>{C7EFF4EE-70DC-453B-B817-4AF67921AB03}</ProjectGuid>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
+    <DefineConstants>$(DefineConstants);ItemRefAPI</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Collections.Immutable.cs" />
   </ItemGroup>
@@ -21,6 +16,11 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.0'">
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Collections" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Collections" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Collections.Immutable/src/Configurations.props
+++ b/src/System.Collections.Immutable/src/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <PackageConfigurations>
       netstandard1.0;
+      netstandard1.3;
       netstandard;
     </PackageConfigurations>
     <BuildConfigurations>

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -10,8 +10,18 @@
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(TargetGroup)' != 'netstandard1.0'">
-    <DefineConstants>$(DefineConstants);ItemRefApi</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ITEMREFAPI</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\InternalsVisibleTo.cs" />
@@ -110,11 +120,10 @@
     <Reference Include="System.Linq" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard1.0'">
     <Reference Include="System.Runtime.InteropServices" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -10,12 +10,8 @@
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.0'">
-    <PackageTargetFramework>netstandard1.0;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
+  <PropertyGroup Condition="'$(TargetGroup)' != 'netstandard1.0'">
     <DefineConstants>$(DefineConstants);ItemRefAPI</DefineConstants>
-    <PackageTargetFramework>netstandard1.3;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\InternalsVisibleTo.cs" />

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -9,16 +9,14 @@
     <FileAlignment>512</FileAlignment>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>
-    <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.0'">netstandard1.0;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.0'">
+    <PackageTargetFramework>netstandard1.0;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
+    <DefineConstants>$(DefineConstants);ItemRefAPI</DefineConstants>
+    <PackageTargetFramework>netstandard1.3;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\InternalsVisibleTo.cs" />
     <Compile Include="GlobalSuppressions.cs" />
@@ -101,7 +99,7 @@
       <Link>Common\System\Runtime\Versioning\NonVersionableAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.0'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.0' or '$(TargetGroup)' == 'netstandard1.3'">
     <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
     </Compile>
@@ -118,6 +116,9 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
+    <Reference Include="System.Runtime.InteropServices" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -110,6 +110,7 @@
     <Reference Include="System.Linq" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
   </ItemGroup>

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -11,7 +11,7 @@
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' != 'netstandard1.0'">
-    <DefineConstants>$(DefineConstants);ItemRefAPI</DefineConstants>
+    <DefineConstants>$(DefineConstants);ItemRefApi</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\InternalsVisibleTo.cs" />

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -123,7 +123,7 @@
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard1.0'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3' or '$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap'">
     <Reference Include="System.Runtime.InteropServices" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -158,6 +158,23 @@ namespace System.Collections.Immutable
             }
 
             /// <summary>
+            /// Gets a read-only reference to the element at the specified index.
+            /// </summary>
+            /// <param name="index">The index.</param>
+            /// <returns></returns>
+            /// <exception cref="IndexOutOfRangeException">
+            /// </exception>
+            public ref readonly T ItemRef(int index)
+            {
+                if (index >= this.Count)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+
+                return ref this._elements[index];
+            }
+
+            /// <summary>
             /// Gets a value indicating whether the <see cref="ICollection{T}"/> is read-only.
             /// </summary>
             /// <returns>true if the <see cref="ICollection{T}"/> is read-only; otherwise, false.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.Contracts;
 
 namespace System.Collections.Immutable
 {
-    public readonly partial struct ImmutableArray<T>
+    public partial struct ImmutableArray<T>
     {
         /// <summary>
         /// A writable array accessor that can be converted into an <see cref="ImmutableArray{T}"/>
@@ -157,7 +157,7 @@ namespace System.Collections.Immutable
                 }
             }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
             /// <summary>
             /// Gets a read-only reference to the element at the specified index.
             /// </summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -157,6 +157,7 @@ namespace System.Collections.Immutable
                 }
             }
 
+#if ItemRefApi
             /// <summary>
             /// Gets a read-only reference to the element at the specified index.
             /// </summary>
@@ -173,6 +174,7 @@ namespace System.Collections.Immutable
 
                 return ref this._elements[index];
             }
+#endif
 
             /// <summary>
             /// Gets a value indicating whether the <see cref="ICollection{T}"/> is read-only.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.Contracts;
 
 namespace System.Collections.Immutable
 {
-    public partial struct ImmutableArray<T>
+    public readonly partial struct ImmutableArray<T>
     {
         /// <summary>
         /// A writable array accessor that can be converted into an <see cref="ImmutableArray{T}"/>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Enumerator.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Enumerator.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace System.Collections.Immutable
 {
-    public partial struct ImmutableArray<T>
+    public readonly partial struct ImmutableArray<T>
     {
         /// <summary>
         /// An array enumerator.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Enumerator.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Enumerator.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace System.Collections.Immutable
 {
-    public readonly partial struct ImmutableArray<T>
+    public partial struct ImmutableArray<T>
     {
         /// <summary>
         /// An array enumerator.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -129,6 +129,7 @@ namespace System.Collections.Immutable
             }
         }
 
+#if ItemRefApi
         /// <summary>
         /// Gets a read-only reference to the element at the specified index in the read-only list.
         /// </summary>
@@ -143,6 +144,7 @@ namespace System.Collections.Immutable
             // of removing array bounds checking to work.
             return ref this.array[index];
         }
+#endif
 
         /// <summary>
         /// Gets a value indicating whether this collection is empty.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -130,6 +130,21 @@ namespace System.Collections.Immutable
         }
 
         /// <summary>
+        /// Gets a read-only reference to the element at the specified index in the read-only list.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to get a reference to.</param>
+        /// <returns>A read-only reference to the element at the specified index in the read-only list.</returns>
+        public ref readonly T ItemRef(int index)
+        {
+            // We intentionally do not check this.array != null, and throw NullReferenceException
+            // if this is called while uninitialized.
+            // The reason for this is perf.
+            // Length and the indexer must be absolutely trivially implemented for the JIT optimization
+            // of removing array bounds checking to work.
+            return ref this.array[index];
+        }
+
+        /// <summary>
         /// Gets a value indicating whether this collection is empty.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -34,7 +34,7 @@ namespace System.Collections.Immutable
     /// </devremarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     [NonVersionable] // Applies to field layout
-    public partial struct ImmutableArray<T> : IEnumerable<T>, IEquatable<ImmutableArray<T>>, IImmutableArray
+    public readonly partial struct ImmutableArray<T> : IEnumerable<T>, IEquatable<ImmutableArray<T>>, IImmutableArray
     {
         /// <summary>
         /// An empty (initialized) instance of <see cref="ImmutableArray{T}"/>.
@@ -48,7 +48,7 @@ namespace System.Collections.Immutable
         /// This would be private, but we make it internal so that our own extension methods can access it.
         /// </remarks>
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        internal T[] array;
+        internal readonly T[] array;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableArray{T}"/> struct

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -34,7 +34,7 @@ namespace System.Collections.Immutable
     /// </devremarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     [NonVersionable] // Applies to field layout
-    public readonly partial struct ImmutableArray<T> : IEnumerable<T>, IEquatable<ImmutableArray<T>>, IImmutableArray
+    public partial struct ImmutableArray<T> : IEnumerable<T>, IEquatable<ImmutableArray<T>>, IImmutableArray
     {
         /// <summary>
         /// An empty (initialized) instance of <see cref="ImmutableArray{T}"/>.
@@ -48,7 +48,7 @@ namespace System.Collections.Immutable
         /// This would be private, but we make it internal so that our own extension methods can access it.
         /// </remarks>
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        internal readonly T[] array;
+        internal T[] array;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableArray{T}"/> struct
@@ -129,7 +129,7 @@ namespace System.Collections.Immutable
             }
         }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         /// <summary>
         /// Gets a read-only reference to the element at the specified index in the read-only list.
         /// </summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
@@ -12,7 +12,7 @@ using System.Runtime.Versioning;
 
 namespace System.Collections.Immutable
 {
-    public readonly partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
+    public partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
         /// <summary>
         /// Gets or sets the element at the specified index in the read-only list.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
@@ -12,7 +12,7 @@ using System.Runtime.Versioning;
 
 namespace System.Collections.Immutable
 {
-    public partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
+    public readonly partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
         /// <summary>
         /// Gets or sets the element at the specified index in the read-only list.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
@@ -186,7 +186,11 @@ namespace System.Collections.Immutable
                             result = OperationResult.NoChangeRequired;
                             return this;
                         case KeyCollisionBehavior.ThrowIfValueDifferent:
+#if ItemRefApi
                             ref readonly var existingEntry = ref _additionalElements.ItemRef(keyCollisionIndex);
+#else
+                            var existingEntry = _additionalElements[keyCollisionIndex];
+#endif
                             if (!valueComparer.Equals(existingEntry.Value, value))
                             {
                                 throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, SR.DuplicateKey, key));
@@ -277,7 +281,11 @@ namespace System.Collections.Immutable
                     return false;
                 }
 
+#if ItemRefApi
                 value = _additionalElements.ItemRef(index).Value;
+#else
+                value = _additionalElements[index].Value;
+#endif
                 return true;
             }
 
@@ -316,7 +324,11 @@ namespace System.Collections.Immutable
                     return false;
                 }
 
+#if ItemRefApi
                 actualKey = _additionalElements.ItemRef(index).Key;
+#else
+                actualKey = _additionalElements[index].Key;
+#endif
                 return true;
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
@@ -186,7 +186,7 @@ namespace System.Collections.Immutable
                             result = OperationResult.NoChangeRequired;
                             return this;
                         case KeyCollisionBehavior.ThrowIfValueDifferent:
-                            var existingEntry = _additionalElements[keyCollisionIndex];
+                            ref readonly var existingEntry = ref _additionalElements.ItemRef(keyCollisionIndex);
                             if (!valueComparer.Equals(existingEntry.Value, value))
                             {
                                 throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, SR.DuplicateKey, key));
@@ -277,7 +277,7 @@ namespace System.Collections.Immutable
                     return false;
                 }
 
-                value = _additionalElements[index].Value;
+                value = _additionalElements.ItemRef(index).Value;
                 return true;
             }
 
@@ -316,7 +316,7 @@ namespace System.Collections.Immutable
                     return false;
                 }
 
-                actualKey = _additionalElements[index].Key;
+                actualKey = _additionalElements.ItemRef(index).Key;
                 return true;
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
@@ -186,7 +186,7 @@ namespace System.Collections.Immutable
                             result = OperationResult.NoChangeRequired;
                             return this;
                         case KeyCollisionBehavior.ThrowIfValueDifferent:
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
                             ref readonly var existingEntry = ref _additionalElements.ItemRef(keyCollisionIndex);
 #else
                             var existingEntry = _additionalElements[keyCollisionIndex];
@@ -281,7 +281,7 @@ namespace System.Collections.Immutable
                     return false;
                 }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
                 value = _additionalElements.ItemRef(index).Value;
 #else
                 value = _additionalElements[index].Value;
@@ -324,7 +324,7 @@ namespace System.Collections.Immutable
                     return false;
                 }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
                 actualKey = _additionalElements.ItemRef(index).Key;
 #else
                 actualKey = _additionalElements[index].Key;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.HashBucket.cs
@@ -182,7 +182,7 @@ namespace System.Collections.Immutable
                     int index = _additionalElements.IndexOf(value, valueComparer);
                     if (index >= 0)
                     {
-                        existingValue = _additionalElements[index];
+                        existingValue = _additionalElements.ItemRef(index);
                         return true;
                     }
                 }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.HashBucket.cs
@@ -182,7 +182,7 @@ namespace System.Collections.Immutable
                     int index = _additionalElements.IndexOf(value, valueComparer);
                     if (index >= 0)
                     {
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
                         existingValue = _additionalElements.ItemRef(index);
 #else
                         existingValue = _additionalElements[index];

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.HashBucket.cs
@@ -182,7 +182,11 @@ namespace System.Collections.Immutable
                     int index = _additionalElements.IndexOf(value, valueComparer);
                     if (index >= 0)
                     {
+#if ItemRefApi
                         existingValue = _additionalElements.ItemRef(index);
+#else
+                        existingValue = _additionalElements[index];
+#endif
                         return true;
                     }
                 }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace System.Collections.Immutable
@@ -109,7 +110,7 @@ namespace System.Collections.Immutable
         /// <returns>The prior value at the specified <paramref name="location"/>.</returns>
         public static ImmutableArray<T> InterlockedExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value)
         {
-            return new ImmutableArray<T>(Interlocked.Exchange(ref location.array, value.array));
+            return new ImmutableArray<T>(Interlocked.Exchange(ref Unsafe.AsRef(in location.array), value.array));
         }
 
         /// <summary>
@@ -123,7 +124,7 @@ namespace System.Collections.Immutable
         /// <returns>The prior value at the specified <paramref name="location"/>.</returns>
         public static ImmutableArray<T> InterlockedCompareExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value, ImmutableArray<T> comparand)
         {
-            return new ImmutableArray<T>(Interlocked.CompareExchange(ref location.array, value.array, comparand.array));
+            return new ImmutableArray<T>(Interlocked.CompareExchange(ref Unsafe.AsRef(in location.array), value.array, comparand.array));
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace System.Collections.Immutable
@@ -110,7 +109,7 @@ namespace System.Collections.Immutable
         /// <returns>The prior value at the specified <paramref name="location"/>.</returns>
         public static ImmutableArray<T> InterlockedExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value)
         {
-            return new ImmutableArray<T>(Interlocked.Exchange(ref Unsafe.AsRef(in location.array), value.array));
+            return new ImmutableArray<T>(Interlocked.Exchange(ref location.array, value.array));
         }
 
         /// <summary>
@@ -124,7 +123,7 @@ namespace System.Collections.Immutable
         /// <returns>The prior value at the specified <paramref name="location"/>.</returns>
         public static ImmutableArray<T> InterlockedCompareExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value, ImmutableArray<T> comparand)
         {
-            return new ImmutableArray<T>(Interlocked.CompareExchange(ref Unsafe.AsRef(in location.array), value.array, comparand.array));
+            return new ImmutableArray<T>(Interlocked.CompareExchange(ref location.array, value.array, comparand.array));
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Builder.cs
@@ -135,7 +135,11 @@ namespace System.Collections.Immutable
             {
                 get
                 {
+#if ItemRefApi
                     return this.Root.ItemRef(index);
+#else
+                    return this.Root[index];
+#endif
                 }
 
                 set
@@ -155,6 +159,7 @@ namespace System.Collections.Immutable
                 }
             }
 
+#if ItemRefApi
             /// <summary>
             /// Gets a read-only reference to the value for a given index into the list.
             /// </summary>
@@ -164,6 +169,7 @@ namespace System.Collections.Immutable
             {
                 return ref this.Root.ItemRef(index);
             }
+            #endif
 
             #endregion
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Builder.cs
@@ -135,7 +135,7 @@ namespace System.Collections.Immutable
             {
                 get
                 {
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
                     return this.Root.ItemRef(index);
 #else
                     return this.Root[index];
@@ -159,7 +159,7 @@ namespace System.Collections.Immutable
                 }
             }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
             /// <summary>
             /// Gets a read-only reference to the value for a given index into the list.
             /// </summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Builder.cs
@@ -135,7 +135,7 @@ namespace System.Collections.Immutable
             {
                 get
                 {
-                    return this.Root[index];
+                    return this.Root.ItemRef(index);
                 }
 
                 set
@@ -153,6 +153,16 @@ namespace System.Collections.Immutable
                 {
                     return this[index];
                 }
+            }
+
+            /// <summary>
+            /// Gets a read-only reference to the value for a given index into the list.
+            /// </summary>
+            /// <param name="index">The index of the desired element.</param>
+            /// <returns>A read-only reference to the value at the specified index.</returns>
+            public ref readonly T ItemRef(int index)
+            {
+                return ref this.Root.ItemRef(index);
             }
 
             #endregion

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
@@ -187,7 +187,7 @@ namespace System.Collections.Immutable
                 }
             }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
             /// <summary>
             /// Gets a read-only reference to the element of the set at the given index.
             /// </summary>
@@ -524,7 +524,7 @@ namespace System.Collections.Immutable
                 int end = index + count - 1;
                 while (start < end)
                 {
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
                     T a = result.ItemRef(start);
                     T b = result.ItemRef(end);
 #else

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
@@ -163,6 +163,32 @@ namespace System.Collections.Immutable
             internal T Key => _key;
 
             /// <summary>
+            /// Gets the element of the set at the given index.
+            /// </summary>
+            /// <param name="index">The 0-based index of the element in the set to return.</param>
+            /// <returns>The element at the given position.</returns>
+            internal T this[int index]
+            {
+                get
+                {
+                    Requires.Range(index >= 0 && index < this.Count, nameof(index));
+
+                    if (index < _left._count)
+                    {
+                        return _left[index];
+                    }
+
+                    if (index > _left._count)
+                    {
+                        return _right[index - _left._count - 1];
+                    }
+
+                    return _key;
+                }
+            }
+
+#if ItemRefApi
+            /// <summary>
             /// Gets a read-only reference to the element of the set at the given index.
             /// </summary>
             /// <param name="index">The 0-based index of the element in the set to return.</param>
@@ -183,6 +209,7 @@ namespace System.Collections.Immutable
 
                 return ref _key;
             }
+#endif
 
             #region IEnumerable<T> Members
 
@@ -497,8 +524,13 @@ namespace System.Collections.Immutable
                 int end = index + count - 1;
                 while (start < end)
                 {
+#if ItemRefApi
                     T a = result.ItemRef(start);
                     T b = result.ItemRef(end);
+#else
+                    T a = result[start];
+                    T b = result[end];
+#endif
                     result = result
                         .ReplaceAt(end, a)
                         .ReplaceAt(start, b);

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
@@ -163,28 +163,25 @@ namespace System.Collections.Immutable
             internal T Key => _key;
 
             /// <summary>
-            /// Gets the element of the set at the given index.
+            /// Gets a read-only reference to the element of the set at the given index.
             /// </summary>
             /// <param name="index">The 0-based index of the element in the set to return.</param>
-            /// <returns>The element at the given position.</returns>
-            internal T this[int index]
+            /// <returns>A read-only reference to the element at the given position.</returns>
+            internal ref readonly T ItemRef(int index)
             {
-                get
+                Requires.Range(index >= 0 && index < this.Count, nameof(index));
+
+                if (index < _left._count)
                 {
-                    Requires.Range(index >= 0 && index < this.Count, nameof(index));
-
-                    if (index < _left._count)
-                    {
-                        return _left[index];
-                    }
-
-                    if (index > _left._count)
-                    {
-                        return _right[index - _left._count - 1];
-                    }
-
-                    return _key;
+                    return ref _left.ItemRef(index);
                 }
+
+                if (index > _left._count)
+                {
+                    return ref _right.ItemRef(index - _left._count - 1);
+                }
+
+                return ref _key;
             }
 
             #region IEnumerable<T> Members
@@ -500,8 +497,8 @@ namespace System.Collections.Immutable
                 int end = index + count - 1;
                 while (start < end)
                 {
-                    T a = result[start];
-                    T b = result[end];
+                    T a = result.ItemRef(start);
+                    T b = result.ItemRef(end);
                     result = result
                         .ReplaceAt(end, a)
                         .ReplaceAt(start, b);

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -169,8 +169,13 @@ namespace System.Collections.Immutable
         /// <param name="index">The 0-based index of the element in the set to return.</param>
         /// <returns>The element at the given position.</returns>
         /// <exception cref="IndexOutOfRangeException">Thrown from getter when <paramref name="index"/> is negative or not less than <see cref="Count"/>.</exception>
+#if ItemRefApi
         public T this[int index] => _root.ItemRef(index);
+#else
+        public T this[int index] => _root[index];
+#endif
 
+#if ItemRefApi
         /// <summary>
         /// Gets a read-only reference to the element of the set at the given index.
         /// </summary>
@@ -178,6 +183,7 @@ namespace System.Collections.Immutable
         /// <returns>A read-only reference to the element at the given position.</returns>
         /// <exception cref="IndexOutOfRangeException">Thrown when <paramref name="index"/> is negative or not less than <see cref="Count"/>.</exception>
         public ref readonly T ItemRef(int index) => ref _root.ItemRef(index);
+#endif
 
         #endregion
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -169,13 +169,13 @@ namespace System.Collections.Immutable
         /// <param name="index">The 0-based index of the element in the set to return.</param>
         /// <returns>The element at the given position.</returns>
         /// <exception cref="IndexOutOfRangeException">Thrown from getter when <paramref name="index"/> is negative or not less than <see cref="Count"/>.</exception>
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         public T this[int index] => _root.ItemRef(index);
 #else
         public T this[int index] => _root[index];
 #endif
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         /// <summary>
         /// Gets a read-only reference to the element of the set at the given index.
         /// </summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -169,7 +169,15 @@ namespace System.Collections.Immutable
         /// <param name="index">The 0-based index of the element in the set to return.</param>
         /// <returns>The element at the given position.</returns>
         /// <exception cref="IndexOutOfRangeException">Thrown from getter when <paramref name="index"/> is negative or not less than <see cref="Count"/>.</exception>
-        public T this[int index] => _root[index];
+        public T this[int index] => _root.ItemRef(index);
+
+        /// <summary>
+        /// Gets a read-only reference to the element of the set at the given index.
+        /// </summary>
+        /// <param name="index">The 0-based index of the element in the set to return.</param>
+        /// <returns>A read-only reference to the element at the given position.</returns>
+        /// <exception cref="IndexOutOfRangeException">Thrown when <paramref name="index"/> is negative or not less than <see cref="Count"/>.</exception>
+        public ref readonly T ItemRef(int index) => ref _root.ItemRef(index);
 
         #endregion
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
@@ -142,6 +142,21 @@ namespace System.Collections.Immutable
         }
 
         /// <summary>
+        /// Gets a read-only reference to the element at the front of the queue.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when the queue is empty.</exception>
+        [Pure]
+        public ref readonly T PeekRef()
+        {
+            if (this.IsEmpty)
+            {
+                throw new InvalidOperationException(SR.InvalidEmptyOperation);
+            }
+
+            return ref _forwards.PeekRef();
+        }
+
+        /// <summary>
         /// Adds an element to the back of the queue.
         /// </summary>
         /// <param name="value">The value.</param>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
@@ -141,7 +141,7 @@ namespace System.Collections.Immutable
             return _forwards.Peek();
         }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         /// <summary>
         /// Gets a read-only reference to the element at the front of the queue.
         /// </summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
@@ -141,6 +141,7 @@ namespace System.Collections.Immutable
             return _forwards.Peek();
         }
 
+#if ItemRefApi
         /// <summary>
         /// Gets a read-only reference to the element at the front of the queue.
         /// </summary>
@@ -155,6 +156,7 @@ namespace System.Collections.Immutable
 
             return ref _forwards.PeekRef();
         }
+#endif
 
         /// <summary>
         /// Adds an element to the back of the queue.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Builder.cs
@@ -202,6 +202,17 @@ namespace System.Collections.Immutable
                 }
             }
 
+            /// <summary>
+            /// Returns a read-only reference to the value associated with the provided key.
+            /// </summary>
+            /// <exception cref="KeyNotFoundException">If the key is not present.</exception>
+            public ref readonly TValue ValueRef(TKey key)
+            {
+                Requires.NotNullAllowStructs(key, nameof(key));
+
+                return ref _root.ValueRef(key, _keyComparer);
+            }
+
             #endregion
 
             #region IDictionary Properties

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Builder.cs
@@ -202,6 +202,7 @@ namespace System.Collections.Immutable
                 }
             }
 
+#if ItemRefApi
             /// <summary>
             /// Returns a read-only reference to the value associated with the provided key.
             /// </summary>
@@ -212,6 +213,7 @@ namespace System.Collections.Immutable
 
                 return ref _root.ValueRef(key, _keyComparer);
             }
+#endif
 
             #endregion
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Builder.cs
@@ -202,7 +202,7 @@ namespace System.Collections.Immutable
                 }
             }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
             /// <summary>
             /// Returns a read-only reference to the value associated with the provided key.
             /// </summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Node.cs
@@ -331,6 +331,25 @@ namespace System.Collections.Immutable
             }
 
             /// <summary>
+            /// Returns a read-only reference to the value associated with the provided key.
+            /// </summary>
+            /// <exception cref="KeyNotFoundException">If the key is not present.</exception>
+            [Pure]
+            internal ref readonly TValue ValueRef(TKey key, IComparer<TKey> keyComparer)
+            {
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(keyComparer, nameof(keyComparer));
+
+                var match = this.Search(key, keyComparer);
+                if (match.IsEmpty)
+                {
+                    throw new KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key.ToString()));
+                }
+
+                return ref match._value;
+            }
+
+            /// <summary>
             /// Tries to get the value.
             /// </summary>
             /// <param name="key">The key.</param>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Node.cs
@@ -330,7 +330,7 @@ namespace System.Collections.Immutable
                 return this.RemoveRecursive(key, keyComparer, out mutated);
             }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
             /// <summary>
             /// Returns a read-only reference to the value associated with the provided key.
             /// </summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Node.cs
@@ -330,6 +330,7 @@ namespace System.Collections.Immutable
                 return this.RemoveRecursive(key, keyComparer, out mutated);
             }
 
+#if ItemRefApi
             /// <summary>
             /// Returns a read-only reference to the value associated with the provided key.
             /// </summary>
@@ -348,6 +349,7 @@ namespace System.Collections.Immutable
 
                 return ref match._value;
             }
+#endif
 
             /// <summary>
             /// Tries to get the value.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
@@ -212,7 +212,7 @@ namespace System.Collections.Immutable
             }
         }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         /// <summary>
         /// Returns a read-only reference to the value associated with the provided key.
         /// </summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
@@ -212,6 +212,7 @@ namespace System.Collections.Immutable
             }
         }
 
+#if ItemRefApi
         /// <summary>
         /// Returns a read-only reference to the value associated with the provided key.
         /// </summary>
@@ -222,6 +223,7 @@ namespace System.Collections.Immutable
 
             return ref _root.ValueRef(key, _keyComparer);
         }
+#endif
 
         #endregion
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
@@ -212,6 +212,17 @@ namespace System.Collections.Immutable
             }
         }
 
+        /// <summary>
+        /// Returns a read-only reference to the value associated with the provided key.
+        /// </summary>
+        /// <exception cref="KeyNotFoundException">If the key is not present.</exception>
+        public ref readonly TValue ValueRef(TKey key)
+        {
+            Requires.NotNullAllowStructs(key, nameof(key));
+
+            return ref _root.ValueRef(key, _keyComparer);
+        }
+
         #endregion
 
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Builder.cs
@@ -105,9 +105,14 @@ namespace System.Collections.Immutable
             /// </remarks>
             public T this[int index]
             {
+#if ItemRefApi
                 get { return _root.ItemRef(index); }
+#else
+                get { return _root[index]; }
+#endif
             }
 
+#if ItemRefApi
             /// <summary>
             /// Gets a read-only reference to the element of the set at the given index.
             /// </summary>
@@ -117,6 +122,7 @@ namespace System.Collections.Immutable
             {
                 return ref _root.ItemRef(index);
             }
+#endif
 
             /// <summary>
             /// Gets the maximum value in the collection, as defined by the comparer.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Builder.cs
@@ -105,7 +105,17 @@ namespace System.Collections.Immutable
             /// </remarks>
             public T this[int index]
             {
-                get { return _root[index]; }
+                get { return _root.ItemRef(index); }
+            }
+
+            /// <summary>
+            /// Gets a read-only reference to the element of the set at the given index.
+            /// </summary>
+            /// <param name="index">The 0-based index of the element in the set to return.</param>
+            /// <returns>A read-only reference to the element at the given position.</returns>
+            public ref readonly T ItemRef(int index)
+            {
+                return ref _root.ItemRef(index);
             }
 
             /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Builder.cs
@@ -105,14 +105,14 @@ namespace System.Collections.Immutable
             /// </remarks>
             public T this[int index]
             {
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
                 get { return _root.ItemRef(index); }
 #else
                 get { return _root[index]; }
 #endif
             }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
             /// <summary>
             /// Gets a read-only reference to the element of the set at the given index.
             /// </summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
@@ -229,6 +229,32 @@ namespace System.Collections.Immutable
             }
 
             /// <summary>
+            /// Gets the element of the set at the given index.
+            /// </summary>
+            /// <param name="index">The 0-based index of the element in the set to return.</param>
+            /// <returns>The element at the given position.</returns>
+            internal T this[int index]
+            {
+                get
+                {
+                    Requires.Range(index >= 0 && index < this.Count, nameof(index));
+
+                    if (index < _left._count)
+                    {
+                        return _left[index];
+                    }
+
+                    if (index > _left._count)
+                    {
+                        return _right[index - _left._count - 1];
+                    }
+
+                    return _key;
+                }
+            }
+
+#if ItemRefApi
+            /// <summary>
             /// Gets a read-only reference to the element of the set at the given index.
             /// </summary>
             /// <param name="index">The 0-based index of the element in the set to return.</param>
@@ -249,6 +275,7 @@ namespace System.Collections.Immutable
 
                 return ref _key;
             }
+#endif
 
             #region IEnumerable<T> Members
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
@@ -253,7 +253,7 @@ namespace System.Collections.Immutable
                 }
             }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
             /// <summary>
             /// Gets a read-only reference to the element of the set at the given index.
             /// </summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
@@ -229,28 +229,25 @@ namespace System.Collections.Immutable
             }
 
             /// <summary>
-            /// Gets the element of the set at the given index.
+            /// Gets a read-only reference to the element of the set at the given index.
             /// </summary>
             /// <param name="index">The 0-based index of the element in the set to return.</param>
-            /// <returns>The element at the given position.</returns>
-            internal T this[int index]
+            /// <returns>A read-only reference to the element at the given position.</returns>
+            internal ref readonly T ItemRef(int index)
             {
-                get
+                Requires.Range(index >= 0 && index < this.Count, nameof(index));
+
+                if (index < _left._count)
                 {
-                    Requires.Range(index >= 0 && index < this.Count, nameof(index));
-
-                    if (index < _left._count)
-                    {
-                        return _left[index];
-                    }
-
-                    if (index > _left._count)
-                    {
-                        return _right[index - _left._count - 1];
-                    }
-
-                    return _key;
+                    return ref _left.ItemRef(index);
                 }
+
+                if (index > _left._count)
+                {
+                    return ref _right.ItemRef(index - _left._count - 1);
+                }
+
+                return ref _key;
             }
 
             #region IEnumerable<T> Members

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
@@ -150,10 +150,15 @@ namespace System.Collections.Immutable
         {
             get
             {
+#if ItemRefApi
                 return _root.ItemRef(index);
+#else
+                return _root[index];
+#endif
             }
         }
 
+#if ItemRefApi
         /// <summary>
         /// Gets a read-only reference of the element of the set at the given index.
         /// </summary>
@@ -163,6 +168,7 @@ namespace System.Collections.Immutable
         {
             return ref _root.ItemRef(index);
         }
+#endif
 
         #endregion
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
@@ -150,7 +150,7 @@ namespace System.Collections.Immutable
         {
             get
             {
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
                 return _root.ItemRef(index);
 #else
                 return _root[index];
@@ -158,7 +158,7 @@ namespace System.Collections.Immutable
             }
         }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         /// <summary>
         /// Gets a read-only reference of the element of the set at the given index.
         /// </summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
@@ -150,8 +150,18 @@ namespace System.Collections.Immutable
         {
             get
             {
-                return _root[index];
+                return _root.ItemRef(index);
             }
+        }
+
+        /// <summary>
+        /// Gets a read-only reference of the element of the set at the given index.
+        /// </summary>
+        /// <param name="index">The 0-based index of the element in the set to return.</param>
+        /// <returns>A read-only reference of the element at the given position.</returns>
+        public ref readonly T ItemRef(int index)
+        {
+            return ref _root.ItemRef(index);
         }
 
         #endregion

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.cs
@@ -121,6 +121,7 @@ namespace System.Collections.Immutable
             return _head;
         }
 
+#if ItemRefApi
         /// <summary>
         /// Gets a read-only reference to the element on the top of the stack.
         /// </summary>
@@ -138,6 +139,7 @@ namespace System.Collections.Immutable
 
             return ref _head;
         }
+#endif
 
         /// <summary>
         /// Pushes an element onto a stack and returns the new stack.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.cs
@@ -122,6 +122,24 @@ namespace System.Collections.Immutable
         }
 
         /// <summary>
+        /// Gets a read-only reference to the element on the top of the stack.
+        /// </summary>
+        /// <returns>
+        /// A read-only reference to the element on the top of the stack. 
+        /// </returns>
+        /// <exception cref="InvalidOperationException">Thrown when the stack is empty.</exception>
+        [Pure]
+        public ref readonly T PeekRef()
+        {
+            if (this.IsEmpty)
+            {
+                throw new InvalidOperationException(SR.InvalidEmptyOperation);
+            }
+
+            return ref _head;
+        }
+
+        /// <summary>
         /// Pushes an element onto a stack and returns the new stack.
         /// </summary>
         /// <param name="value">The element to push onto the stack.</param>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.cs
@@ -121,7 +121,7 @@ namespace System.Collections.Immutable
             return _head;
         }
 
-#if ItemRefApi
+#if FEATURE_ITEMREFAPI
         /// <summary>
         /// Gets a read-only reference to the element on the top of the stack.
         /// </summary>

--- a/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -726,6 +726,29 @@ namespace System.Collections.Immutable.Tests
             Assert.IsType<ArgumentNullException>(tie.InnerException);
         }
 
+        [Fact]
+        public void ItemRef()
+        {
+            var builder = new ImmutableArray<int>.Builder();
+            builder.Add(1);
+            builder.Add(2);
+            builder.Add(3);
+
+            ref readonly var itemRef = ref builder.ItemRef(1);
+            Assert.Equal(2, itemRef);
+        }
+
+        [Fact]
+        public void ItemRef_OutOfBounds()
+        {
+            var builder = new ImmutableArray<int>.Builder();
+            builder.Add(1);
+            builder.Add(2);
+            builder.Add(3);
+
+            Assert.Throws<IndexOutOfRangeException>(() => builder.ItemRef(5));
+        }
+
         private static ImmutableArray<T>.Builder CreateBuilderWithCount<T>(int count)
         {
             var builder = ImmutableArray.CreateBuilder<T>(count);

--- a/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests
@@ -734,8 +735,14 @@ namespace System.Collections.Immutable.Tests
             builder.Add(2);
             builder.Add(3);
 
-            ref readonly var itemRef = ref builder.ItemRef(1);
-            Assert.Equal(2, itemRef);
+            ref readonly var safeRef = ref builder.ItemRef(1);
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
+
+            Assert.Equal(2, builder.ItemRef(1));
+
+            unsafeRef = 4;
+
+            Assert.Equal(4, builder.ItemRef(1));
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -2193,8 +2193,14 @@ namespace System.Collections.Immutable.Tests
         {
             var array = new[] { 1, 2, 3 }.ToImmutableArray();
 
-            ref readonly var itemRef = ref array.ItemRef(1);
-            Assert.Equal(2, itemRef);
+            ref readonly var safeRef = ref array.ItemRef(1);
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
+
+            Assert.Equal(2, array.ItemRef(1));
+
+            unsafeRef = 4;
+
+            Assert.Equal(4, array.ItemRef(1));
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -2188,6 +2188,23 @@ namespace System.Collections.Immutable.Tests
             Assert.Equal(array, items);
         }
 
+        [Fact]
+        public void ItemRef()
+        {
+            var array = new[] { 1, 2, 3 }.ToImmutableArray();
+
+            ref readonly var itemRef = ref array.ItemRef(1);
+            Assert.Equal(2, itemRef);
+        }
+
+        [Fact]
+        public void ItemRef_OutOfBounds()
+        {
+            var array = new[] { 1, 2, 3 }.ToImmutableArray();
+
+            Assert.Throws<IndexOutOfRangeException>(() => array.ItemRef(5));
+        }
+
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)
         {
             return ImmutableArray.Create(contents);

--- a/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests
@@ -370,8 +371,14 @@ namespace System.Collections.Immutable.Tests
             var list = new[] { 1, 2, 3 }.ToImmutableList();
             var builder = new ImmutableList<int>.Builder(list);
 
-            ref readonly var itemRef = ref builder.ItemRef(1);
-            Assert.Equal(2, itemRef);
+            ref readonly var safeRef = ref builder.ItemRef(1);
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
+
+            Assert.Equal(2, builder.ItemRef(1));
+
+            unsafeRef = 4;
+
+            Assert.Equal(4, builder.ItemRef(1));
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
@@ -364,6 +364,25 @@ namespace System.Collections.Immutable.Tests
             Assert.IsType<ArgumentNullException>(tie.InnerException);
         }
 
+        [Fact]
+        public void ItemRef()
+        {
+            var list = new[] { 1, 2, 3 }.ToImmutableList();
+            var builder = new ImmutableList<int>.Builder(list);
+
+            ref readonly var itemRef = ref builder.ItemRef(1);
+            Assert.Equal(2, itemRef);
+        }
+
+        [Fact]
+        public void ItemRef_OutOfBounds()
+        {
+            var list = new[] { 1, 2, 3 }.ToImmutableList();
+            var builder = new ImmutableList<int>.Builder(list);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => builder.ItemRef(5));
+        }
+
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)
         {
             return ImmutableList<T>.Empty.AddRange(contents).ToBuilder();

--- a/src/System.Collections.Immutable/tests/ImmutableListTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTest.cs
@@ -815,6 +815,23 @@ namespace System.Collections.Immutable.Tests
         }
 #endif // netcoreapp
 
+        [Fact]
+        public void ItemRef()
+        {
+            var list = new[] { 1, 2, 3 }.ToImmutableList();
+
+            ref readonly var itemRef = ref list.ItemRef(1);
+            Assert.Equal(2, itemRef);
+        }
+
+        [Fact]
+        public void ItemRef_OutOfBounds()
+        {
+            var list = new[] { 1, 2, 3 }.ToImmutableList();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => list.ItemRef(5));
+        }
+
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)
         {
             return ImmutableList<T>.Empty.AddRange(contents);

--- a/src/System.Collections.Immutable/tests/ImmutableListTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTest.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests
@@ -820,8 +821,14 @@ namespace System.Collections.Immutable.Tests
         {
             var list = new[] { 1, 2, 3 }.ToImmutableList();
 
-            ref readonly var itemRef = ref list.ItemRef(1);
-            Assert.Equal(2, itemRef);
+            ref readonly var safeRef = ref list.ItemRef(1);
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
+
+            Assert.Equal(2, list.ItemRef(1));
+
+            unsafeRef = 4;
+
+            Assert.Equal(4, list.ItemRef(1));
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
@@ -257,6 +257,26 @@ namespace System.Collections.Immutable.Tests
             Assert.IsType<ArgumentNullException>(tie.InnerException);
         }
 
+        [Fact]
+        public void PeekRef()
+        {
+            var queue = ImmutableQueue<int>.Empty
+                .Enqueue(1)
+                .Enqueue(2)
+                .Enqueue(3);
+
+            ref readonly var peekRef = ref queue.PeekRef();
+            Assert.Equal(1, peekRef);
+        }
+
+        [Fact]
+        public void PeekRef_Empty()
+        {
+            var queue = ImmutableQueue<int>.Empty;
+
+            Assert.Throws<InvalidOperationException>(() => queue.PeekRef());
+        }
+
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)
         {
             var queue = ImmutableQueue<T>.Empty;

--- a/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests
@@ -265,8 +266,14 @@ namespace System.Collections.Immutable.Tests
                 .Enqueue(2)
                 .Enqueue(3);
 
-            ref readonly var peekRef = ref queue.PeekRef();
-            Assert.Equal(1, peekRef);
+            ref readonly var safeRef = ref queue.PeekRef();
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
+
+            Assert.Equal(1, queue.PeekRef());
+
+            unsafeRef = 4;
+
+            Assert.Equal(4, queue.PeekRef());
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryBuilderTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests
@@ -287,8 +288,14 @@ namespace System.Collections.Immutable.Tests
                 { "b", 2 }
             }.ToImmutableSortedDictionary().ToBuilder();
 
-            ref readonly var valueRef = ref builder.ValueRef("a");
-            Assert.Equal(1, valueRef);
+            ref readonly var safeRef = ref builder.ValueRef("a");
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
+
+            Assert.Equal(1, builder.ValueRef("a"));
+
+            unsafeRef = 5;
+
+            Assert.Equal(5, builder.ValueRef("a"));
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryBuilderTest.cs
@@ -278,6 +278,31 @@ namespace System.Collections.Immutable.Tests
             Assert.IsType<ArgumentNullException>(tie.InnerException);
         }
 
+        [Fact]
+        public void ValueRef()
+        {
+            var builder = new Dictionary<string, int>()
+            {
+                { "a", 1 },
+                { "b", 2 }
+            }.ToImmutableSortedDictionary().ToBuilder();
+
+            ref readonly var valueRef = ref builder.ValueRef("a");
+            Assert.Equal(1, valueRef);
+        }
+
+        [Fact]
+        public void ValueRef_NonExistentKey()
+        {
+            var builder = new Dictionary<string, int>()
+            {
+                { "a", 1 },
+                { "b", 2 }
+            }.ToImmutableSortedDictionary().ToBuilder();
+
+            Assert.Throws<KeyNotFoundException>(() => builder.ValueRef("c"));
+        }
+
         protected override IImmutableDictionary<TKey, TValue> GetEmptyImmutableDictionary<TKey, TValue>()
         {
             return ImmutableSortedDictionary.Create<TKey, TValue>();

--- a/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
@@ -479,6 +479,31 @@ namespace System.Collections.Immutable.Tests
             Debug.WriteLine("Timing_Empty:{0}{1}", Environment.NewLine, timingText);
         }
 
+        [Fact]
+        public void ValueRef()
+        {
+            var dictionary = new Dictionary<string, int>()
+            {
+                { "a", 1 },
+                { "b", 2 }
+            }.ToImmutableSortedDictionary();
+
+            ref readonly var valueRef = ref dictionary.ValueRef("a");
+            Assert.Equal(1, valueRef);
+        }
+
+        [Fact]
+        public void ValueRef_NonExistentKey()
+        {
+            var dictionary = new Dictionary<string, int>()
+            {
+                { "a", 1 },
+                { "b", 2 }
+            }.ToImmutableSortedDictionary();
+
+            Assert.Throws<KeyNotFoundException>(() => dictionary.ValueRef("c"));
+        }
+
         protected override IImmutableDictionary<TKey, TValue> Empty<TKey, TValue>()
         {
             return ImmutableSortedDictionaryTest.Empty<TKey, TValue>();

--- a/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests
@@ -488,8 +489,14 @@ namespace System.Collections.Immutable.Tests
                 { "b", 2 }
             }.ToImmutableSortedDictionary();
 
-            ref readonly var valueRef = ref dictionary.ValueRef("a");
-            Assert.Equal(1, valueRef);
+            ref readonly var safeRef = ref dictionary.ValueRef("a");
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
+
+            Assert.Equal(1, dictionary.ValueRef("a"));
+
+            unsafeRef = 5;
+
+            Assert.Equal(5, dictionary.ValueRef("a"));
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests
@@ -382,8 +383,14 @@ namespace System.Collections.Immutable.Tests
             var array = new[] { 1, 2, 3 }.ToImmutableSortedSet();
             var builder = new ImmutableSortedSet<int>.Builder(array);
 
-            ref readonly var itemRef = ref builder.ItemRef(1);
-            Assert.Equal(2, itemRef);
+            ref readonly var safeRef = ref builder.ItemRef(1);
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
+
+            Assert.Equal(2, builder.ItemRef(1));
+
+            unsafeRef = 4;
+
+            Assert.Equal(4, builder.ItemRef(1));
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
@@ -375,5 +375,24 @@ namespace System.Collections.Immutable.Tests
             TargetInvocationException tie = Assert.Throws<TargetInvocationException>(() => Activator.CreateInstance(proxyType, (object)null));
             Assert.IsType<ArgumentNullException>(tie.InnerException);
         }
+
+        [Fact]
+        public void ItemRef()
+        {
+            var array = new[] { 1, 2, 3 }.ToImmutableSortedSet();
+            var builder = new ImmutableSortedSet<int>.Builder(array);
+
+            ref readonly var itemRef = ref builder.ItemRef(1);
+            Assert.Equal(2, itemRef);
+        }
+
+        [Fact]
+        public void ItemRef_OutOfBounds()
+        {
+            var array = new[] { 1, 2, 3 }.ToImmutableSortedSet();
+            var builder = new ImmutableSortedSet<int>.Builder(array);
+
+            Assert.Throws<ArgumentOutOfRangeException> (() => builder.ItemRef(5));
+        }
     }
 }

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests
@@ -412,8 +413,14 @@ namespace System.Collections.Immutable.Tests
         {
             var array = new[] { 1, 2, 3 }.ToImmutableSortedSet();
 
-            ref readonly var itemRef = ref array.ItemRef(1);
-            Assert.Equal(2, itemRef);
+            ref readonly var safeRef = ref array.ItemRef(1);
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
+
+            Assert.Equal(2, array.ItemRef(1));
+
+            unsafeRef = 4;
+
+            Assert.Equal(4, array.ItemRef(1));
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
@@ -407,6 +407,23 @@ namespace System.Collections.Immutable.Tests
             CollectionAssertAreEquivalent(expectedSet.ToList(), actualSet.ToList());
         }
 
+        [Fact]
+        public void ItemRef()
+        {
+            var array = new[] { 1, 2, 3 }.ToImmutableSortedSet();
+
+            ref readonly var itemRef = ref array.ItemRef(1);
+            Assert.Equal(2, itemRef);
+        }
+
+        [Fact]
+        public void ItemRef_OutOfBounds()
+        {
+            var array = new[] { 1, 2, 3 }.ToImmutableSortedSet();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => array.ItemRef(5));
+        }
+
         protected override IImmutableSet<T> Empty<T>()
         {
             return ImmutableSortedSet<T>.Empty;

--- a/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
@@ -274,6 +274,26 @@ namespace System.Collections.Immutable.Tests
             Assert.IsType<ArgumentNullException>(tie.InnerException);
         }
 
+        [Fact]
+        public void PeekRef()
+        {
+            var stack = ImmutableStack<int>.Empty
+                .Push(1)
+                .Push(2)
+                .Push(3);
+
+            ref readonly var peekRef = ref stack.PeekRef();
+            Assert.Equal(3, peekRef);
+        }
+
+        [Fact]
+        public void PeekRef_Empty()
+        {
+            var stack = ImmutableStack<int>.Empty;
+
+            Assert.Throws<InvalidOperationException>(() => stack.PeekRef());
+        }
+
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)
         {
             var stack = ImmutableStack<T>.Empty;

--- a/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Collections.Immutable.Tests
@@ -282,8 +283,14 @@ namespace System.Collections.Immutable.Tests
                 .Push(2)
                 .Push(3);
 
-            ref readonly var peekRef = ref stack.PeekRef();
-            Assert.Equal(3, peekRef);
+            ref readonly var safeRef = ref stack.PeekRef();
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
+
+            Assert.Equal(3, stack.PeekRef());
+
+            unsafeRef = 4;
+
+            Assert.Equal(4, stack.PeekRef());
         }
 
         [Fact]


### PR DESCRIPTION
Contributes to #25189

* Adds `ItemRef()` to `ImmutableArray<V>` and `ImmutableArray<V>.Builder`.
* Adds `ItemRef()` to `ImmutableList<V>` and `ImmutableList<V>.Builder`.
* Adds `ItemRef()` to `ImmutableSortedSet<V>` and `ImmutableSortedSet<V>.Builder`.
* Adds `PeekRef()` to `ImmutableQueue<V>` and `ImmutableStack<V>`.
* Adds `ValueRef()` to `ImmutableSortedDictionary<V>` and `ImmutableSortedDictionary<V>.Builder`.