### PR TITLE
Remove Microsoft.CSharp's BindBinaryAssignmentFailedNullReference

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ArgumentObject.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ArgumentObject.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace Microsoft.CSharp.RuntimeBinder
 {
@@ -15,6 +16,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         public ArgumentObject(object value, CSharpArgumentInfo info, Type type)
         {
+            Debug.Assert(type != null);
             Value = value;
             Info = info;
             Type = type;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
@@ -36,11 +36,6 @@ namespace Microsoft.CSharp.RuntimeBinder
         internal static Exception BindStaticRequiresType(string paramName) =>
             new ArgumentException(SR.TypeArgumentRequiredForStaticCall, paramName);
 
-        internal static Exception BindBinaryAssignmentFailedNullReference()
-        {
-            return new RuntimeBinderException(SR.BindBinaryAssignmentFailedNullReference);
-        }
-
         internal static Exception NullReferenceOnMemberException()
         {
             return new RuntimeBinderException(SR.NullReferenceOnMemberException);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1421,6 +1421,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             LocalVariableSymbol[] locals)
         {
             Debug.Assert(arguments.Length >= 2);
+            Debug.Assert(arguments.All(a => a.Type != null));
 
             string name = payload.Name;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1445,12 +1445,6 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             int indexOfLast = arguments.Length - 1;
             Expr rhs = CreateArgumentEXPR(arguments[indexOfLast], locals[indexOfLast]);
-
-            if (arguments[0].Type == null)
-            {
-                throw Error.BindBinaryAssignmentFailedNullReference();
-            }
-
             return _binder.BindAssignment(lhs, rhs, bIsCompound);
         }
         #endregion

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -73,9 +73,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>Cannot invoke a non-delegate type</value>
   </data>
-  <data name="BindBinaryAssignmentFailedNullReference" xml:space="preserve">
-    <value>Cannot perform member assignment on a null reference</value>
-  </data>
   <data name="NullReferenceOnMemberException" xml:space="preserve">
     <value>Cannot perform runtime binding on a null reference</value>
   </data>


### PR DESCRIPTION
Uncallable as `arguments[0].Type` can never be null (and would have thrown 4 lines previous if it ever was).