### PR TITLE
Include Code of Conduct in GitHub-recognised manner.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project has adopted the code of conduct defined by the Contributor Covenant
+to clarify expected behavior in our community.
+For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).


### PR DESCRIPTION
This is just a link to the code of conduct at http://www.dotnetfoundation.org/code-of-conduct which is already linked to in the readme.

Putting it at this location just has github recognise it as such (https://github.com/dotnet/corefx/community)

The text is the same as that used at https://github.com/dotnet/docs/blob/master/CODE_OF_CONDUCT.md