### PR TITLE
[release/2.0.0] Ensure HttpListener request buffer is aligned as required by the host processor

### DIFF
--- a/src/Common/src/Interop/Windows/HttpApi/Interop.HttpApi.cs
+++ b/src/Common/src/Interop/Windows/HttpApi/Interop.HttpApi.cs
@@ -786,75 +786,69 @@ internal static partial class Interop
             return GetVerb(request, 0);
         }
 
-        internal static unsafe string GetVerb(byte[] memoryBlob, IntPtr originalAddress)
+        internal static unsafe string GetVerb(IntPtr memoryBlob, IntPtr originalAddress)
         {
-            fixed (byte* pMemoryBlob = memoryBlob)
-            {
-                return GetVerb((HTTP_REQUEST*)pMemoryBlob, pMemoryBlob - (byte*)originalAddress);
-            }
+            return GetVerb((HTTP_REQUEST*)memoryBlob.ToPointer(), (byte*)memoryBlob - (byte*)originalAddress);
         }
 
         // Server API
 
-        internal static unsafe WebHeaderCollection GetHeaders(byte[] memoryBlob, IntPtr originalAddress)
+        internal static unsafe WebHeaderCollection GetHeaders(IntPtr memoryBlob, IntPtr originalAddress)
         {
             NetEventSource.Enter(null);
 
             // Return value.
             WebHeaderCollection headerCollection = new WebHeaderCollection();
-            fixed (byte* pMemoryBlob = memoryBlob)
+            byte* pMemoryBlob = (byte*)memoryBlob;       
+            HTTP_REQUEST* request = (HTTP_REQUEST*)pMemoryBlob;
+            long fixup = pMemoryBlob - (byte*)originalAddress;
+            int index;
+
+            // unknown headers
+            if (request->Headers.UnknownHeaderCount != 0)
             {
-                HTTP_REQUEST* request = (HTTP_REQUEST*)pMemoryBlob;
-                long fixup = pMemoryBlob - (byte*)originalAddress;
-                int index;
-
-                // unknown headers
-                if (request->Headers.UnknownHeaderCount != 0)
+                HTTP_UNKNOWN_HEADER* pUnknownHeader = (HTTP_UNKNOWN_HEADER*)(fixup + (byte*)request->Headers.pUnknownHeaders);
+                for (index = 0; index < request->Headers.UnknownHeaderCount; index++)
                 {
-                    HTTP_UNKNOWN_HEADER* pUnknownHeader = (HTTP_UNKNOWN_HEADER*)(fixup + (byte*)request->Headers.pUnknownHeaders);
-                    for (index = 0; index < request->Headers.UnknownHeaderCount; index++)
+                    // For unknown headers, when header value is empty, RawValueLength will be 0 and 
+                    // pRawValue will be null.
+                    if (pUnknownHeader->pName != null && pUnknownHeader->NameLength > 0)
                     {
-                        // For unknown headers, when header value is empty, RawValueLength will be 0 and 
-                        // pRawValue will be null.
-                        if (pUnknownHeader->pName != null && pUnknownHeader->NameLength > 0)
+                        string headerName = new string(pUnknownHeader->pName + fixup, 0, pUnknownHeader->NameLength);
+                        string headerValue;
+                        if (pUnknownHeader->pRawValue != null && pUnknownHeader->RawValueLength > 0)
                         {
-                            string headerName = new string(pUnknownHeader->pName + fixup, 0, pUnknownHeader->NameLength);
-                            string headerValue;
-                            if (pUnknownHeader->pRawValue != null && pUnknownHeader->RawValueLength > 0)
-                            {
-                                headerValue = new string(pUnknownHeader->pRawValue + fixup, 0, pUnknownHeader->RawValueLength);
-                            }
-                            else
-                            {
-                                headerValue = string.Empty;
-                            }
-                            headerCollection.Add(headerName, headerValue);
+                            headerValue = new string(pUnknownHeader->pRawValue + fixup, 0, pUnknownHeader->RawValueLength);
                         }
-                        pUnknownHeader++;
+                        else
+                        {
+                            headerValue = string.Empty;
+                        }
+                        headerCollection.Add(headerName, headerValue);
                     }
+                    pUnknownHeader++;
                 }
+            }
 
-                // known headers
-                HTTP_KNOWN_HEADER* pKnownHeader = &request->Headers.KnownHeaders;
-                for (index = 0; index < HttpHeaderRequestMaximum; index++)
+            // known headers
+            HTTP_KNOWN_HEADER* pKnownHeader = &request->Headers.KnownHeaders;
+            for (index = 0; index < HttpHeaderRequestMaximum; index++)
+            {
+                // For known headers, when header value is empty, RawValueLength will be 0 and 
+                // pRawValue will point to empty string ("\0")
+                if (pKnownHeader->pRawValue != null)
                 {
-                    // For known headers, when header value is empty, RawValueLength will be 0 and 
-                    // pRawValue will point to empty string ("\0")
-                    if (pKnownHeader->pRawValue != null)
-                    {
-                        string headerValue = new string(pKnownHeader->pRawValue + fixup, 0, pKnownHeader->RawValueLength);
-                        headerCollection.Add(HTTP_REQUEST_HEADER_ID.ToString(index), headerValue);
-                    }
-                    pKnownHeader++;
+                    string headerValue = new string(pKnownHeader->pRawValue + fixup, 0, pKnownHeader->RawValueLength);
+                    headerCollection.Add(HTTP_REQUEST_HEADER_ID.ToString(index), headerValue);
                 }
+                pKnownHeader++;
             }
 
             NetEventSource.Exit(null);
             return headerCollection;
         }
 
-
-        internal static unsafe uint GetChunks(byte[] memoryBlob, IntPtr originalAddress, ref int dataChunkIndex, ref uint dataChunkOffset, byte[] buffer, int offset, int size)
+        internal static unsafe uint GetChunks(IntPtr memoryBlob, IntPtr originalAddress, ref int dataChunkIndex, ref uint dataChunkOffset, byte[] buffer, int offset, int size)
         {
             if (NetEventSource.IsEnabled)
             {
@@ -863,53 +857,51 @@ internal static partial class Interop
 
             // Return value.
             uint dataRead = 0;
-            fixed (byte* pMemoryBlob = memoryBlob)
+            byte* pMemoryBlob = (byte*)memoryBlob;            
+            HTTP_REQUEST* request = (HTTP_REQUEST*)pMemoryBlob;
+            long fixup = pMemoryBlob - (byte*)originalAddress;
+
+            if (request->EntityChunkCount > 0 && dataChunkIndex < request->EntityChunkCount && dataChunkIndex != -1)
             {
-                HTTP_REQUEST* request = (HTTP_REQUEST*)pMemoryBlob;
-                long fixup = pMemoryBlob - (byte*)originalAddress;
+                HTTP_DATA_CHUNK* pDataChunk = (HTTP_DATA_CHUNK*)(fixup + (byte*)&request->pEntityChunks[dataChunkIndex]);
 
-                if (request->EntityChunkCount > 0 && dataChunkIndex < request->EntityChunkCount && dataChunkIndex != -1)
+                fixed (byte* pReadBuffer = buffer)
                 {
-                    HTTP_DATA_CHUNK* pDataChunk = (HTTP_DATA_CHUNK*)(fixup + (byte*)&request->pEntityChunks[dataChunkIndex]);
+                    byte* pTo = &pReadBuffer[offset];
 
-                    fixed (byte* pReadBuffer = buffer)
+                    while (dataChunkIndex < request->EntityChunkCount && dataRead < size)
                     {
-                        byte* pTo = &pReadBuffer[offset];
-
-                        while (dataChunkIndex < request->EntityChunkCount && dataRead < size)
+                        if (dataChunkOffset >= pDataChunk->BufferLength)
                         {
-                            if (dataChunkOffset >= pDataChunk->BufferLength)
-                            {
-                                dataChunkOffset = 0;
-                                dataChunkIndex++;
-                                pDataChunk++;
-                            }
-                            else
-                            {
-                                byte* pFrom = pDataChunk->pBuffer + dataChunkOffset + fixup;
+                            dataChunkOffset = 0;
+                            dataChunkIndex++;
+                            pDataChunk++;
+                        }
+                        else
+                        {
+                            byte* pFrom = pDataChunk->pBuffer + dataChunkOffset + fixup;
 
-                                uint bytesToRead = pDataChunk->BufferLength - (uint)dataChunkOffset;
-                                if (bytesToRead > (uint)size)
-                                {
-                                    bytesToRead = (uint)size;
-                                }
-                                for (uint i = 0; i < bytesToRead; i++)
-                                {
-                                    *(pTo++) = *(pFrom++);
-                                }
-                                dataRead += bytesToRead;
-                                dataChunkOffset += bytesToRead;
+                            uint bytesToRead = pDataChunk->BufferLength - (uint)dataChunkOffset;
+                            if (bytesToRead > (uint)size)
+                            {
+                                bytesToRead = (uint)size;
                             }
+                            for (uint i = 0; i < bytesToRead; i++)
+                            {
+                                *(pTo++) = *(pFrom++);
+                            }
+                            dataRead += bytesToRead;
+                            dataChunkOffset += bytesToRead;
                         }
                     }
                 }
-                //we're finished.
-                if (dataChunkIndex == request->EntityChunkCount)
-                {
-                    dataChunkIndex = -1;
-                }
             }
-
+            //we're finished.
+            if (dataChunkIndex == request->EntityChunkCount)
+            {
+                dataChunkIndex = -1;
+            }
+            
             if (NetEventSource.IsEnabled)
             {
                 NetEventSource.Exit(null);
@@ -917,38 +909,34 @@ internal static partial class Interop
             return dataRead;
         }
 
-        internal static unsafe HTTP_VERB GetKnownVerb(byte[] memoryBlob, IntPtr originalAddress)
+        internal static unsafe HTTP_VERB GetKnownVerb(IntPtr memoryBlob, IntPtr originalAddress)
         {
             NetEventSource.Enter(null);
 
             // Return value.
             HTTP_VERB verb = HTTP_VERB.HttpVerbUnknown;
-            fixed (byte* pMemoryBlob = memoryBlob)
+
+            HTTP_REQUEST* request = (HTTP_REQUEST*)memoryBlob.ToPointer();
+            if ((int)request->Verb > (int)HTTP_VERB.HttpVerbUnparsed && (int)request->Verb < (int)HTTP_VERB.HttpVerbMaximum)
             {
-                HTTP_REQUEST* request = (HTTP_REQUEST*)pMemoryBlob;
-                if ((int)request->Verb > (int)HTTP_VERB.HttpVerbUnparsed && (int)request->Verb < (int)HTTP_VERB.HttpVerbMaximum)
-                {
-                    verb = request->Verb;
-                }
+                verb = request->Verb;
             }
 
             NetEventSource.Exit(null);
             return verb;
         }
 
-        internal static unsafe IPEndPoint GetRemoteEndPoint(byte[] memoryBlob, IntPtr originalAddress)
+        internal static unsafe IPEndPoint GetRemoteEndPoint(IntPtr memoryBlob, IntPtr originalAddress)
         {
             if (NetEventSource.IsEnabled) NetEventSource.Enter(null);
 
             SocketAddress v4address = new SocketAddress(AddressFamily.InterNetwork, IPv4AddressSize);
             SocketAddress v6address = new SocketAddress(AddressFamily.InterNetworkV6, IPv6AddressSize);
 
-            fixed (byte* pMemoryBlob = memoryBlob)
-            {
-                HTTP_REQUEST* request = (HTTP_REQUEST*)pMemoryBlob;
-                IntPtr address = request->Address.pRemoteAddress != null ? (IntPtr)(pMemoryBlob - (byte*)originalAddress + (byte*)request->Address.pRemoteAddress) : IntPtr.Zero;
-                CopyOutAddress(address, ref v4address, ref v6address);
-            }
+            byte* pMemoryBlob = (byte*)memoryBlob;       
+            HTTP_REQUEST* request = (HTTP_REQUEST*)pMemoryBlob;
+            IntPtr address = request->Address.pRemoteAddress != null ? (IntPtr)(pMemoryBlob - (byte*)originalAddress + (byte*)request->Address.pRemoteAddress) : IntPtr.Zero;
+            CopyOutAddress(address, ref v4address, ref v6address);
 
             IPEndPoint endpoint = null;
             if (v4address != null)
@@ -964,19 +952,17 @@ internal static partial class Interop
             return endpoint;
         }
 
-        internal static unsafe IPEndPoint GetLocalEndPoint(byte[] memoryBlob, IntPtr originalAddress)
+        internal static unsafe IPEndPoint GetLocalEndPoint(IntPtr memoryBlob, IntPtr originalAddress)
         {
             if (NetEventSource.IsEnabled) NetEventSource.Enter(null);
 
             SocketAddress v4address = new SocketAddress(AddressFamily.InterNetwork, IPv4AddressSize);
             SocketAddress v6address = new SocketAddress(AddressFamily.InterNetworkV6, IPv6AddressSize);
 
-            fixed (byte* pMemoryBlob = memoryBlob)
-            {
-                HTTP_REQUEST* request = (HTTP_REQUEST*)pMemoryBlob;
-                IntPtr address = request->Address.pLocalAddress != null ? (IntPtr)(pMemoryBlob - (byte*)originalAddress + (byte*)request->Address.pLocalAddress) : IntPtr.Zero;
-                CopyOutAddress(address, ref v4address, ref v6address);
-            }
+            byte* pMemoryBlob = (byte*)memoryBlob;        
+            HTTP_REQUEST* request = (HTTP_REQUEST*)pMemoryBlob;
+            IntPtr address = request->Address.pLocalAddress != null ? (IntPtr)(pMemoryBlob - (byte*)originalAddress + (byte*)request->Address.pLocalAddress) : IntPtr.Zero;
+            CopyOutAddress(address, ref v4address, ref v6address);
 
             IPEndPoint endpoint = null;
             if (v4address != null)

--- a/src/System.Net.HttpListener/src/System/Net/Windows/AsyncRequestContext.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/AsyncRequestContext.cs
@@ -38,7 +38,7 @@ namespace System.Net
 
         private Interop.HttpApi.HTTP_REQUEST* Allocate(ThreadPoolBoundHandle boundHandle, uint size)
         {
-            uint newSize = size != 0 ? size : RequestBuffer == null ? 4096 : Size;
+            uint newSize = size != 0 ? size : RequestBuffer == IntPtr.Zero ? 4096 : Size;
             if (_nativeOverlapped != null)
             {
 #if DEBUG
@@ -58,7 +58,7 @@ namespace System.Net
             _boundHandle = boundHandle;
             _nativeOverlapped = boundHandle.AllocateNativeOverlapped(ListenerAsyncResult.IOCallback, state: _result, pinData: RequestBuffer);
 
-            return (Interop.HttpApi.HTTP_REQUEST*)Marshal.UnsafeAddrOfPinnedArrayElement(RequestBuffer, 0);
+            return (Interop.HttpApi.HTTP_REQUEST*)RequestBuffer.ToPointer();
         }
 
         internal void Reset(ThreadPoolBoundHandle boundHandle, ulong requestId, uint size)

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
@@ -109,7 +109,7 @@ namespace System.Net
         // Note: RequestBuffer may get moved in memory. If you dereference a pointer from inside the RequestBuffer, 
         // you must use 'OriginalBlobAddress' below to adjust the location of the pointer to match the location of
         // RequestBuffer.
-        internal byte[] RequestBuffer
+        internal IntPtr RequestBuffer
         {
             get
             {

--- a/src/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
@@ -134,7 +134,10 @@ namespace System.Net
             _backingBufferLength = size;
 
             // Zero out the contents of the buffer.
-            new Span<byte>(_backingBuffer.ToPointer(), size).Fill(0);
+            for(int i = 0; i < size; ++i)
+            {
+                Marshal.WriteByte(_backingBuffer + i, 0);
+            }
         }
     }
 }

--- a/src/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
@@ -134,9 +134,10 @@ namespace System.Net
             _backingBufferLength = size;
 
             // Zero out the contents of the buffer.
-            for(int i = 0; i < size; ++i)
+            byte* buffer = (byte*)_backingBuffer;
+            for (int i = 0; i < size; i++)
             {
-                Marshal.WriteByte(_backingBuffer + i, 0);
+                buffer[i] = 0;
             }
         }
     }


### PR DESCRIPTION
On Windows, the HttpRecieveHttpRequest function requires a buffer with a memory alignment greater than or equal to the required alignment of the HTTP_REQUEST struct.

This fix ensures that alignment requirements are respected when allocating buffers in HttpListener RequestContextBase. Since HttpReceiveHttpRequest copies both the HTTP_REQUEST struct and the variable length request body into the buffer, we need to be able to allocate a buffer with variable size and with a set alignment. Since C# does not provide a method for specifying the alignment of byte arrays, I switched the underlying buffer to be unmanaged. This unmanaged buffer is allocated using Marshal.AllocHGlobal, which allocates memory at the maximum alignment required by the host processor. This fix differs from the 2.1.0 fix in how it zeros out allocated memory, as 2.0.0 disables support for Span.

Fixes #25289