### PR TITLE
Have S.L.Expressions accept conversions it incorrectly rejects.

### DIFF
--- a/src/Microsoft.CSharp/tests/ExplicitConversionTests.cs
+++ b/src/Microsoft.CSharp/tests/ExplicitConversionTests.cs
@@ -1,0 +1,141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public class ExplicitConversionTests
+    {
+        private enum ExpectedConversionResult
+        {
+            Succeed,
+            CompileError,
+            RuntimeError
+        }
+        private static void AssertExplicitConvert<TSource, TTarget>(TSource argument, TTarget target, ExpectedConversionResult expected)
+        {
+            CallSiteBinder binder = Binder.Convert(CSharpBinderFlags.ConvertExplicit, typeof(TTarget), typeof(ExplicitConversionTests));
+            CallSite<Func<CallSite, TSource, TTarget>> callSite =
+                CallSite<Func<CallSite, TSource, TTarget>>.Create(binder);
+            Func<CallSite, TSource, TTarget> func = callSite.Target;
+            switch (expected)
+            {
+                case ExpectedConversionResult.CompileError:
+                    Assert.Throws<RuntimeBinderException>(() => func(callSite, argument));
+                    break;
+
+                case ExpectedConversionResult.RuntimeError:
+                    Assert.Throws<InvalidCastException>(() => func(callSite, argument));
+                    break;
+
+                default:
+                    TTarget result = func(callSite, argument);
+                    Assert.Equal(target, result);
+                    break;
+            }
+
+            if (typeof(TSource) != typeof(object))
+            {
+                AssertExplicitConvert<object, TTarget>(argument, target, expected);
+            }
+        }
+
+
+        private interface IInterface
+        {
+        }
+
+        private class UnsealedClass
+        {
+        }
+
+        private sealed class SealedClass
+        {
+        }
+
+        private class ImplementingClass : IInterface
+        {
+        }
+
+        private class ImplementingSealedClass : IInterface
+        {
+        }
+
+        private class UnrelatedNonInterface
+        {
+        }
+
+        private struct Struct
+        {
+        }
+
+        private struct ImplementingStruct : IInterface
+        {
+        }
+
+        [Fact]
+        public void ClassInterfaceExplicitConversion()
+        {
+            AssertExplicitConvert(new SealedClass(), default(IInterface), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new UnsealedClass(), default(IInterface), ExpectedConversionResult.RuntimeError);
+            ImplementingClass ic = new ImplementingClass();
+            AssertExplicitConvert(ic, (IInterface)ic, ExpectedConversionResult.Succeed);
+            ImplementingSealedClass isc = new ImplementingSealedClass();
+            AssertExplicitConvert(isc, (IInterface)isc, ExpectedConversionResult.Succeed);
+            AssertExplicitConvert(new Struct(), default(IInterface), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new ImplementingStruct(), new ImplementingStruct(), ExpectedConversionResult.Succeed);
+            AssertExplicitConvert(new SealedClass(), default(UnrelatedNonInterface), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new UnsealedClass(), default(UnrelatedNonInterface), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new Struct(), default(UnrelatedNonInterface), ExpectedConversionResult.CompileError);
+        }
+
+        [Fact]
+        public void InterfaceClassExplicitConversion()
+        {
+            IInterface iif = new ImplementingClass();
+            AssertExplicitConvert(iif, default(SealedClass), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(iif, default(UnsealedClass), ExpectedConversionResult.CompileError);
+            ImplementingClass ic = new ImplementingClass();
+            AssertExplicitConvert((IInterface)ic, ic, ExpectedConversionResult.Succeed);
+            ImplementingSealedClass isc = new ImplementingSealedClass();
+            AssertExplicitConvert((IInterface)isc, isc, ExpectedConversionResult.Succeed);
+            AssertExplicitConvert(iif, default(Struct), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert((IInterface)new ImplementingStruct(), new ImplementingStruct(), ExpectedConversionResult.Succeed);
+        }
+
+        [Fact]
+        public void ClassInterfaceArrayElementExplicitConversions()
+        {
+            AssertExplicitConvert(new SealedClass[0], default(IInterface[]), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new UnsealedClass[0], default(IInterface[]), ExpectedConversionResult.RuntimeError);
+            var ic = new ImplementingClass[0];
+            AssertExplicitConvert(ic, (IInterface[])ic, ExpectedConversionResult.Succeed);
+            var isc = new ImplementingSealedClass[0];
+            AssertExplicitConvert(isc, (IInterface[])isc, ExpectedConversionResult.Succeed);
+            AssertExplicitConvert(new Struct[0], default(IInterface[]), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new SealedClass[0], default(UnrelatedNonInterface[]), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new UnsealedClass[0], default(UnrelatedNonInterface[]), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new Struct[0], default(UnrelatedNonInterface[]), ExpectedConversionResult.CompileError);
+        }
+
+        [Fact]
+        public void ClassInterfaceArrayIListElementExplicitConversions()
+        {
+            AssertExplicitConvert(new SealedClass[0], default(IList<IInterface>), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new UnsealedClass[0], default(IList<IInterface>), ExpectedConversionResult.RuntimeError);
+            var ic = new ImplementingClass[0];
+            AssertExplicitConvert(ic, (IList<IInterface>)ic, ExpectedConversionResult.Succeed);
+            var isc = new ImplementingSealedClass[0];
+            AssertExplicitConvert(isc, (IList<IInterface>)isc, ExpectedConversionResult.Succeed);
+            AssertExplicitConvert(new Struct[0], default(IList<IInterface>), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new SealedClass[0], default(IList<UnrelatedNonInterface>), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new UnsealedClass[0], default(IList<UnrelatedNonInterface>), ExpectedConversionResult.CompileError);
+            AssertExplicitConvert(new Struct[0], default(IList<UnrelatedNonInterface>), ExpectedConversionResult.CompileError);
+        }
+    }
+}

--- a/src/Microsoft.CSharp/tests/ExplicitConversionTests.cs
+++ b/src/Microsoft.CSharp/tests/ExplicitConversionTests.cs
@@ -112,7 +112,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         public void ClassInterfaceArrayElementExplicitConversions()
         {
             AssertExplicitConvert(new SealedClass[0], default(IInterface[]), ExpectedConversionResult.CompileError);
-            AssertExplicitConvert(new UnsealedClass[0], default(IInterface[]), ExpectedConversionResult.RuntimeError);
             var ic = new ImplementingClass[0];
             AssertExplicitConvert(ic, (IInterface[])ic, ExpectedConversionResult.Succeed);
             var isc = new ImplementingSealedClass[0];
@@ -121,6 +120,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             AssertExplicitConvert(new SealedClass[0], default(UnrelatedNonInterface[]), ExpectedConversionResult.CompileError);
             AssertExplicitConvert(new UnsealedClass[0], default(UnrelatedNonInterface[]), ExpectedConversionResult.CompileError);
             AssertExplicitConvert(new Struct[0], default(UnrelatedNonInterface[]), ExpectedConversionResult.CompileError);
+        }
+
+        [Fact, SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "25754 is not fixed in NetFX")]
+        public void ClassInterfaceArrayElementExplicitConversionsCoreFX()
+        {
+            AssertExplicitConvert(new UnsealedClass[0], default(IInterface[]), ExpectedConversionResult.RuntimeError);
         }
 
         [Fact]

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="AssignmentTests.cs" />
     <Compile Include="BindingErrors.cs" />
     <Compile Include="EnumUnaryOperationTests.cs" />
+    <Compile Include="ExplicitConversionTests.cs" />
     <Compile Include="ImplicitConversionTests.cs" />
     <Compile Include="CSharpArgumentInfoTests.cs" />
     <Compile Include="DefaultParameterTests.cs" />

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -10,6 +11,12 @@ namespace System.Dynamic.Utils
 {
     internal static class TypeUtils
     {
+        private static readonly Type[] s_arrayAssignableInterfaces =
+        {
+            typeof(IList<>), typeof(ICollection<>), typeof(IEnumerable<>), typeof(IReadOnlyList<>),
+            typeof(IReadOnlyCollection<>)
+        };
+
         public static Type GetNonNullableType(this Type type) => IsNullableType(type) ? type.GetGenericArguments()[0] : type;
 
         public static Type GetNullableType(this Type type)
@@ -274,8 +281,139 @@ namespace System.Dynamic.Utils
                 return true;
             }
 
-            // Object conversion
-            return source == typeof(object) || dest == typeof(object);
+            // Object conversion handled by assignable above.
+            Debug.Assert(source != typeof(object) && dest != typeof(object));
+
+            return (source.IsArray || dest.IsArray) && StrictHasReferenceConversionTo(source, dest, true);
+        }
+
+        private static bool StrictHasReferenceConversionTo(this Type source, Type dest, bool skipNonArray)
+        {
+            // HasReferenceConversionTo was both too strict and too lax. It was too strict in prohibiting
+            // some valid conversions involving arrays, and too lax in allowing casts between interfaces
+            // and sealed classes that don't implement them. Unfortunately fixing the lax cases would be
+            // a breaking change, especially since such expressions will even work if only given null
+            // arguments.
+            // This method catches the cases that were incorrectly disallowed, but when it needs to
+            // examine possible conversions of element or type parameters it applies stricter rules.
+
+            for(;;)
+            { 
+                if (!skipNonArray) // Skip if we just came from HasReferenceConversionTo and have just tested these
+                {
+                    if (source.IsValueType | dest.IsValueType)
+                    {
+                        return false;
+                    }
+
+                    // Includes to case of either being typeof(object)
+                    if (source.IsAssignableFrom(dest) || dest.IsAssignableFrom(source))
+                    {
+                        return true;
+                    }
+
+                    if (source.IsInterface)
+                    {
+                        if (dest.IsInterface || dest.IsClass && !dest.IsSealed)
+                        {
+                            return true;
+                        }
+                    }
+                    else if (dest.IsInterface)
+                    {
+                        if (source.IsClass && !source.IsSealed)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                if (source.IsArray)
+                {
+                    if (dest.IsArray)
+                    {
+                        if (source.GetArrayRank() != dest.GetArrayRank() || source.IsSZArray != dest.IsSZArray)
+                        {
+                            return false;
+                        }
+
+                        source = source.GetElementType();
+                        dest = dest.GetElementType();
+                        skipNonArray = false;
+                    }
+                    else
+                    {
+                        return HasArrayToInterfaceConversion(source, dest);
+                    }
+                }
+                else if (dest.IsArray)
+                {
+                    if (HasInterfaceToArrayConversion(source, dest))
+                    {
+                        return true;
+                    }
+
+                    return IsImplicitReferenceConversion(typeof(Array), source);
+                }
+                else
+                {
+                    return IsLegalExplicitVariantDelegateConversion(source, dest);
+                }
+            }
+        }
+
+        private static bool HasArrayToInterfaceConversion(Type source, Type dest)
+        {
+            Debug.Assert(source.IsArray);
+            if (!source.IsSZArray || !dest.IsInterface || !dest.IsGenericType)
+            {
+                return false;
+            }
+
+            Type[] destParams = dest.GetGenericArguments();
+            if (destParams.Length != 1)
+            {
+                return false;
+            }
+
+            Type destGen = dest.GetGenericTypeDefinition();
+
+            foreach (Type iface in s_arrayAssignableInterfaces)
+            {
+                if (AreEquivalent(destGen, iface))
+                {
+                    return StrictHasReferenceConversionTo(source.GetElementType(), destParams[0], false);
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasInterfaceToArrayConversion(Type source, Type dest)
+        {
+            Debug.Assert(dest.IsSZArray);
+            if (!dest.IsSZArray || !source.IsInterface || !source.IsGenericType)
+            {
+                return false;
+            }
+
+            Type[] sourceParams = source.GetGenericArguments();
+            if (sourceParams.Length != 1)
+            {
+                return false;
+            }
+
+            Type sourceGen = source.GetGenericTypeDefinition();
+
+            foreach (Type iface in s_arrayAssignableInterfaces)
+            {
+                if (AreEquivalent(sourceGen, iface))
+                {
+                    return StrictHasReferenceConversionTo(sourceParams[0], dest.GetElementType(), false);
+                }
+            }
+
+            return false;
         }
 
         private static bool IsCovariant(Type t)

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -11,11 +11,10 @@ namespace System.Dynamic.Utils
 {
     internal static class TypeUtils
     {
-        private static readonly Type[] s_arrayAssignableInterfaces =
-        {
-            typeof(IList<>), typeof(ICollection<>), typeof(IEnumerable<>), typeof(IReadOnlyList<>),
-            typeof(IReadOnlyCollection<>)
-        };
+        private static readonly Type[] s_arrayAssignableInterfaces = typeof(int[]).GetInterfaces()
+            .Where(i => i.IsGenericType)
+            .Select(i => i.GetGenericTypeDefinition())
+            .ToArray();
 
         public static Type GetNonNullableType(this Type type) => IsNullableType(type) ? type.GetGenericArguments()[0] : type;
 

--- a/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
@@ -18458,5 +18458,169 @@ namespace System.Linq.Expressions.Tests
                 .Compile(useInterpreter);
             act();
         }
+
+        interface IInterface
+        {
+        }
+
+        class NonSealed
+        {
+        }
+
+        class Derived : NonSealed, IInterface
+        {
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void NonSealedArrayToIfaceArray(bool useInterpreter)
+        {
+            checked
+            {
+                Expression<Func<NonSealed[][], IInterface[][]>> e = a => (IInterface[][])a;
+                Func<NonSealed[][], IInterface[][]> f = e.Compile(useInterpreter);
+                Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+                Assert.Same(arr, f(arr));
+                Assert.Null(f(null));
+                Assert.Throws<InvalidCastException>(() => f(Array.Empty<NonSealed[]>()));
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void IfaceArrayToNonSealedArray(bool useInterpreter)
+        {
+            checked
+            {
+                Expression<Func<IInterface[][], NonSealed[][]>> e = a => (NonSealed[][])a;
+                Func<IInterface[][], NonSealed[][]> f = e.Compile(useInterpreter);
+                Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+                Assert.Same(arr, f(arr));
+                Assert.Null(f(null));
+                Assert.Throws<InvalidCastException>(() => f(Array.Empty<IInterface[]>()));
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void NonSealedICollectionToIfaceArray(bool useInterpreter)
+        {
+            checked
+            {
+                Expression<Func<ICollection<NonSealed[]>, IInterface[][]>> e = a => (IInterface[][])a;
+                Func<ICollection<NonSealed[]>, IInterface[][]> f = e.Compile(useInterpreter);
+                Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+                Assert.Same(arr, f(arr));
+                Assert.Null(f(null));
+                Assert.Throws<InvalidCastException>(() => f(Array.Empty<NonSealed[]>()));
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void IfaceArrayToNonSealedIList(bool useInterpreter)
+        {
+            checked
+            {
+                Expression<Func<IInterface[][], IList<NonSealed>[]>> e = a => (IList<NonSealed>[])a;
+                Func<IInterface[][], IList<NonSealed>[]> f = e.Compile(useInterpreter);
+                Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+                Assert.Same(arr, f(arr));
+                Assert.Null(f(null));
+                Assert.Throws<InvalidCastException>(() => f(Array.Empty<IInterface[]>()));
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void NonSealedArrayToIfaceIEnumerable(bool useInterpreter)
+        {
+            checked
+            {
+                Expression<Func<NonSealed[][], IEnumerable<IInterface>[]>> e = a => (IEnumerable<IInterface>[])a;
+                Func<NonSealed[][], IEnumerable<IInterface>[]> f = e.Compile(useInterpreter);
+                Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+                Assert.Same(arr, f(arr));
+                Assert.Null(f(null));
+                Assert.Throws<InvalidCastException>(() => f(Array.Empty<NonSealed[]>()));
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void IfaceIReadonlyCollectionToNonSealedArray(bool useInterpreter)
+        {
+            checked
+            {
+                Expression<Func<IReadOnlyCollection<IInterface>[], NonSealed[][]>> e = a => (NonSealed[][])a;
+                Func<IReadOnlyCollection<IInterface>[], NonSealed[][]> f = e.Compile(useInterpreter);
+                Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+                Assert.Same(arr, f(arr));
+                Assert.Null(f(null));
+                Assert.Throws<InvalidCastException>(() => f(Array.Empty<IInterface[]>()));
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void IFaceIListToObjectArray(bool useInterpreter)
+        {
+            checked
+            {
+                Expression<Func<IList<IInterface[]>, object[][]>> e = a => (object[][])a;
+                Func<IList<IInterface[]>, object[][]> f = e.Compile(useInterpreter);
+                Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+                Assert.Same(arr, f(arr));
+                Assert.Null(f(null));
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ObjectIListToIFaceArray(bool useInterpreter)
+        {
+            checked
+            {
+                Expression<Func<IList<object[]>, IInterface[][]>> e = a => (IInterface[][])a;
+                Func<IList<object[]>, IInterface[][]> f = e.Compile(useInterpreter);
+                Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+                Assert.Same(arr, f(arr));
+                Assert.Null(f(null));
+                Assert.Throws<InvalidCastException>(() => f(Array.Empty<string[]>()));
+            }
+        }
+
+        [Fact]
+        public static void IfaceToNonSZArray()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.ConvertChecked(Expression.Default(typeof(IList<NonSealed>[])), typeof(NonSealed[,][])));
+        }
+
+        [Fact]
+        public static void NonSZArrayToIface()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.ConvertChecked(Expression.Default(typeof(NonSealed[,][])), typeof(IList<NonSealed>[])));
+        }
+
+        [Fact]
+        public static void ArrayToNonArrayCompatibleIFace()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.ConvertChecked(Expression.Default(typeof(NonSealed[][])), typeof(IEquatable<NonSealed>[])));
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.ConvertChecked(
+                    Expression.Default(typeof(NonSealed[][])), typeof(IDictionary<NonSealed, NonSealed>[])));
+        }
+
+        [Fact]
+        public static void NonArrayCompatibleIFaceToArray()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.ConvertChecked(Expression.Default(typeof(IEquatable<NonSealed>[])), typeof(NonSealed[][])));
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.ConvertChecked(
+                    Expression.Default(typeof(IDictionary<NonSealed, NonSealed>[])), typeof(NonSealed[][])));
+        }
+
+        [Fact]
+        public static void ArrayToNotRelated()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.ConvertChecked(Expression.Default(typeof(NonSealed[][][])), typeof(string[][])));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -16889,5 +16889,178 @@ namespace System.Linq.Expressions.Tests
                 .Compile(useInterpreter);
             act();
         }
+
+        [Fact]
+        public static void ConvertReferenceArrayToValueTypeArray()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(string[])), typeof(int[])));
+        }
+
+        [Fact]
+        public static void ConvertValueTypeArrayToValueTypeArray()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(long[])), typeof(int[])));
+        }
+
+        [Fact]
+        public static void ConvertValueTypeArrayToReferenceArray()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(StringComparison[])), typeof(string[])));
+        }
+
+        [Fact]
+        public static void ConvertSealedTypeArrayToNonImplementedInterfaceArray()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(string[])), typeof(IAsyncResult[])));
+        }
+
+        [Fact]
+        public static void ConvertNonImplementedInterfaceArrayToSealedTypeArray()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(IAsyncResult[])), typeof(string[])));
+        }
+
+        interface IInterface
+        {
+        }
+
+        class NonSealed
+        {
+        }
+
+        class Derived : NonSealed, IInterface
+        {
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void NonSealedArrayToIfaceArray(bool useInterpreter)
+        {
+            Expression<Func<NonSealed[][], IInterface[][]>> e = a => (IInterface[][])a;
+            Func<NonSealed[][], IInterface[][]> f = e.Compile(useInterpreter);
+            Derived[][] arr = new[]{new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+            Assert.Same(arr, f(arr));
+            Assert.Null(f(null));
+            Assert.Throws<InvalidCastException>(() => f(Array.Empty<NonSealed[]>()));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void IfaceArrayToNonSealedArray(bool useInterpreter)
+        {
+            Expression<Func<IInterface[][], NonSealed[][]>> e = a => (NonSealed[][])a;
+            Func<IInterface[][], NonSealed[][]> f = e.Compile(useInterpreter);
+            Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+            Assert.Same(arr, f(arr));
+            Assert.Null(f(null));
+            Assert.Throws<InvalidCastException>(() => f(Array.Empty<IInterface[]>()));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void NonSealedICollectionToIfaceArray(bool useInterpreter)
+        {
+            Expression<Func<ICollection<NonSealed[]>, IInterface[][]>> e = a => (IInterface[][])a;
+            Func<ICollection<NonSealed[]>, IInterface[][]> f = e.Compile(useInterpreter);
+            Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+            Assert.Same(arr, f(arr));
+            Assert.Null(f(null));
+            Assert.Throws<InvalidCastException>(() => f(Array.Empty<NonSealed[]>()));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void IfaceArrayToNonSealedIList(bool useInterpreter)
+        {
+            Expression<Func<IInterface[][], IList<NonSealed>[]>> e = a => (IList<NonSealed>[])a;
+            Func<IInterface[][], IList<NonSealed>[]> f = e.Compile(useInterpreter);
+            Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+            Assert.Same(arr, f(arr));
+            Assert.Null(f(null));
+            Assert.Throws<InvalidCastException>(() => f(Array.Empty<IInterface[]>()));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void NonSealedArrayToIfaceIEnumerable(bool useInterpreter)
+        {
+            Expression<Func<NonSealed[][], IEnumerable<IInterface>[]>> e = a => (IEnumerable<IInterface>[])a;
+            Func<NonSealed[][], IEnumerable<IInterface>[]> f = e.Compile(useInterpreter);
+            Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+            Assert.Same(arr, f(arr));
+            Assert.Null(f(null));
+            Assert.Throws<InvalidCastException>(() => f(Array.Empty<NonSealed[]>()));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void IfaceIReadonlyCollectionToNonSealedArray(bool useInterpreter)
+        {
+            Expression<Func<IReadOnlyCollection<IInterface>[], NonSealed[][]>> e = a => (NonSealed[][])a;
+            Func<IReadOnlyCollection<IInterface>[], NonSealed[][]> f = e.Compile(useInterpreter);
+            Derived[][] arr = new[] {new[] {new Derived(), new Derived(), new Derived(), new Derived()}};
+            Assert.Same(arr, f(arr));
+            Assert.Null(f(null));
+            Assert.Throws<InvalidCastException>(() => f(Array.Empty<IInterface[]>()));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void IFaceIListToObjectArray(bool useInterpreter)
+        {
+            Expression<Func<IList<IInterface[]>, object[][]>> e = a => (object[][])a;
+            Func<IList<IInterface[]>, object[][]> f = e.Compile(useInterpreter);
+            Derived[][] arr = new[] { new[] { new Derived(), new Derived(), new Derived(), new Derived() } };
+            Assert.Same(arr, f(arr));
+            Assert.Null(f(null));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ObjectIListToIFaceArray(bool useInterpreter)
+        {
+            Expression<Func<IList<object[]>, IInterface[][]>> e = a => (IInterface[][])a;
+            Func<IList<object[]>, IInterface[][]> f = e.Compile(useInterpreter);
+            Derived[][] arr = new[] { new[] { new Derived(), new Derived(), new Derived(), new Derived() } };
+            Assert.Same(arr, f(arr));
+            Assert.Null(f(null));
+            Assert.Throws<InvalidCastException>(() => f(Array.Empty<string[]>()));
+        }
+
+        [Fact]
+        public static void IfaceToNonSZArray()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(IList<NonSealed>[])), typeof(NonSealed[,][])));
+        }
+
+        [Fact]
+        public static void NonSZArrayToIface()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(NonSealed[,][])), typeof(IList<NonSealed>[])));
+        }
+
+        [Fact]
+        public static void ArrayToNonArrayCompatibleIFace()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(NonSealed[][])), typeof(IEquatable<NonSealed>[])));
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(NonSealed[][])), typeof(IDictionary<NonSealed, NonSealed>[])));
+        }
+
+        [Fact]
+        public static void NonArrayCompatibleIFaceToArray()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(IEquatable<NonSealed>[])), typeof(NonSealed[][])));
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(IDictionary<NonSealed, NonSealed>[])), typeof(NonSealed[][])));
+        }
+
+        [Fact]
+        public static void ArrayToNotRelated()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Expression.Convert(Expression.Default(typeof(NonSealed[][][])), typeof(string[][])));
+        }
     }
 }


### PR DESCRIPTION
Extend the conversion checks to allow array-related explicit reference conversions that were rejected by `Expression.Convert` and `Expression.CheckedConvert`.

Fixes #25760, and hence fixes #25754