### PR TITLE
Enable Alpine Linux CI

### DIFF
--- a/buildpipeline/alpine.3.6.groovy
+++ b/buildpipeline/alpine.3.6.groovy
@@ -1,0 +1,52 @@
+@Library('dotnet-ci') _
+
+// Incoming parameters.  Access with "params.<param name>".
+// Note that the parameters will be set as env variables so we cannot use names that conflict
+// with the engineering system parameter names.
+// CGroup - Build configuration.
+// TestOuter - If true, runs outerloop, if false runs just innerloop
+
+def submittedHelixJson = null
+
+simpleDockerNode('microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-20171119021156') {
+    stage ('Checkout source') {
+        checkoutRepo()
+    }
+
+    def logFolder = getLogFolder()
+
+    stage ('Initialize tools') {
+        // Init tools
+        sh './init-tools.sh'
+    }
+    stage ('Generate version assets') {
+        // Generate the version assets.  Do we need to even do this for non-official builds?
+        sh "./build-managed.sh -runtimeos=alpine.3.6 -- /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true /p:PortableBuild=false"
+    }
+    stage ('Sync') {
+        sh "./sync.sh -p -runtimeos=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false"
+    }
+    stage ('Build Product') {
+        sh "./build.sh -buildArch=x64 -runtimeos=alpine.3.6 -${params.CGroup} -- /p:PortableBuild=false"
+    }
+    stage ('Build Tests') {
+        def additionalArgs = ''
+        if (params.TestOuter) {
+            additionalArgs = '-Outerloop'
+        }
+        sh "./build-tests.sh -buildArch=x64 -${params.CGroup} -SkipTests ${additionalArgs} -- /p:ArchiveTests=true /p:EnableDumpling=true /p:PortableBuild=false"
+    }
+
+    // TODO: Add submission for Helix testing once we have queue for Alpine Linux working
+}
+
+stage ('Execute Tests') {
+    def contextBase
+    if (params.TestOuter) {
+        contextBase = "Alpine.3.6 x64 Tests w/outer - ${params.CGroup}"
+    }
+    else {
+        contextBase = "Alpine.3.6 x64 Tests - ${params.CGroup}"
+    }
+    waitForHelixRuns(submittedHelixJson, contextBase)
+}

--- a/buildpipeline/pipelinejobs.groovy
+++ b/buildpipeline/pipelinejobs.groovy
@@ -16,12 +16,14 @@ def branch = GithubBranchName
 
 def linPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/linux.groovy')
 def centos6Pipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/centos.6.groovy')
+def alpine36Pipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/alpine.3.6.groovy')
 def osxPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/osx.groovy')
 def winPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/windows.groovy')
 
 def configurations = [
     ['TGroup':"netcoreapp", 'Pipeline':linPipeline, 'Name':'Linux' ,'ForPR':"Release-x64", 'Arch':['x64']],
     ['TGroup':"netcoreapp", 'Pipeline':centos6Pipeline, 'Name':'CentOS.6' ,'ForPR':"", 'Arch':['x64']],
+    ['TGroup':"netcoreapp", 'Pipeline':alpine36Pipeline, 'Name':'Alpine.3.6' ,'ForPR':"Debug-x64", 'Arch':['x64']],
     ['TGroup':"netcoreapp", 'Pipeline':osxPipeline, 'Name':'OSX', 'ForPR':"Debug-x64", 'Arch':['x64']],
     ['TGroup':"netcoreapp", 'Pipeline':winPipeline, 'Name':'Windows' , 'ForPR':"Debug-x64|Release-x86"],
     ['TGroup':"netfx",      'Pipeline':winPipeline, 'Name':'NETFX', 'ForPR':"Release-x86"],


### PR DESCRIPTION
This change enables CI build for Alpine Linux. It only builds the
product, but it doesn't run the test yet since there is no Alpine queue
support in Helix yet.

The Alpine build is automatically enabled for all PRs.