### PR TITLE
fix [System.Diagnostics.Process]::GetProcesses(computer)

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -205,7 +205,7 @@ namespace System.Diagnostics
             private void Init()
             {
 #if FEATURE_REGISTRY
-                if (_machineName != "." && String.Compare(_machineName, PerformanceCounterLib.ComputerName, StringComparison.OrdinalIgnoreCase) != 0)
+                if (_machineName != "." && ProcessManager.IsRemoteMachine(_machineName))
                 {
                     _perfDataKey = RegistryKey.OpenRemoteBaseKey(RegistryHive.PerformanceData, _machineName);
                 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -205,7 +205,7 @@ namespace System.Diagnostics
             private void Init()
             {
 #if FEATURE_REGISTRY
-                if (_machineName != "." && ProcessManager.IsRemoteMachine(_machineName))
+                if (ProcessManager.IsRemoteMachine(_machineName))
                 {
                     _perfDataKey = RegistryKey.OpenRemoteBaseKey(RegistryHive.PerformanceData, _machineName);
                 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -205,7 +205,14 @@ namespace System.Diagnostics
             private void Init()
             {
 #if FEATURE_REGISTRY
-                _perfDataKey = Registry.PerformanceData;
+                if (_machineName != "." && String.Compare(_machineName, PerformanceCounterLib.ComputerName, StringComparison.OrdinalIgnoreCase) != 0)
+                {
+                    _perfDataKey = RegistryKey.OpenRemoteBaseKey(RegistryHive.PerformanceData, _machineName);
+                }
+                else
+                {
+                    _perfDataKey = Registry.PerformanceData;
+                }
 #endif
             }
 

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -927,6 +927,13 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public void GetProcesses_RemoteMachinePath_ReturnsExpected()
+        {
+            Process[] processes = Process.GetProcesses(Environment.MachineName + "." + Domain.GetComputerDomain());
+            Assert.NotEmpty(processes);
+        }
+
+        [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Retrieving information about local processes is not supported on uap")]
         public void GetProcessesByName_ProcessName_ReturnsExpected()
         {

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -930,8 +930,19 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void GetProcesses_RemoteMachinePath_ReturnsExpected()
         {
-            Process[] processes = Process.GetProcesses(Environment.MachineName + "." + Domain.GetComputerDomain());
-            Assert.NotEmpty(processes);
+            try
+            {
+                Process[] processes = Process.GetProcesses(Environment.MachineName + "." + Domain.GetComputerDomain());
+                Assert.NotEmpty(processes);
+            }
+            catch (ActiveDirectoryObjectNotFoundException)
+            {
+                //This will be thrown when the executing machine is not domain-joined, i.e. in CI
+            }
+            catch (PlatformNotSupportedException)
+            {
+                //System.DirectoryServices is not supported on all platforms
+            }
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.DirectoryServices.ActiveDirectory;
 using System.IO;
 using System.Linq;
 using System.Net;

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -921,6 +921,12 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public void GetProcesses_InvalidMachineName_ThrowsInvalidOperationException()
+        {
+            Assert.Throws<InvalidOperationException>(() => Process.GetProcesses(Guid.NewGuid().ToString()));
+        }
+
+        [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Retrieving information about local processes is not supported on uap")]
         public void GetProcessesByName_ProcessName_ReturnsExpected()
         {


### PR DESCRIPTION
for https://github.com/dotnet/corefx/issues/24357

CC @stephentoub @joperezr @SteveL-MSFT

Local testing confirmed we get the correct processes for a remote machine with this change, but without multi-machine testing in CI we can't automate testing for this, so I just added a test for the negative case.