### PR TITLE
Adding netfx.force.conflicts.dll to 471 Support package

### DIFF
--- a/external/netfx-conflicts/netfx-conflicts.depproj
+++ b/external/netfx-conflicts/netfx-conflicts.depproj
@@ -19,12 +19,15 @@
     <_contract Include="System.ComponentModel.Annotations"/>
     <_contract Include="System.ComponentModel"/>
     <_contract Include="System.ComponentModel.EventBasedAsync"/>
+    <_contract Include="System.Data.Common"/>
     <_contract Include="System.Diagnostics.Contracts"/>
     <_contract Include="System.Diagnostics.Debug"/>
+    <_contract Include="System.Diagnostics.StackTrace"/>
     <_contract Include="System.Diagnostics.Tools"/>
     <_contract Include="System.Diagnostics.Tracing"/>
     <_contract Include="System.Dynamic.Runtime"/>
     <_contract Include="System.Globalization"/>
+    <_contract Include="System.Globalization.Extensions"/>
     <_contract Include="System.IO"/>
     <_contract Include="System.IO.Compression"/>
     <_contract Include="System.Linq"/>
@@ -35,6 +38,7 @@
     <_contract Include="System.Net.NetworkInformation"/>
     <_contract Include="System.Net.Primitives"/>
     <_contract Include="System.Net.Requests"/>
+    <_contract Include="System.Net.Sockets"/>
     <_contract Include="System.Net.WebHeaderCollection"/>
     <_contract Include="System.ObjectModel"/>
     <_contract Include="System.Reflection"/>
@@ -54,7 +58,9 @@
     <_contract Include="System.Runtime.Serialization.Json"/>
     <_contract Include="System.Runtime.Serialization.Primitives"/>
     <_contract Include="System.Runtime.Serialization.Xml"/>
+    <_contract Include="System.Security.Cryptography.Algorithms"/>
     <_contract Include="System.Security.Principal"/>
+    <_contract Include="System.Security.SecureString"/>
     <_contract Include="System.ServiceModel.Duplex"/>
     <_contract Include="System.ServiceModel.Http"/>
     <_contract Include="System.ServiceModel.NetTcp"/>
@@ -64,12 +70,14 @@
     <_contract Include="System.Text.Encoding.Extensions"/>
     <_contract Include="System.Text.RegularExpressions"/>
     <_contract Include="System.Threading"/>
+    <_contract Include="System.Threading.Overlapped"/>
     <_contract Include="System.Threading.Tasks"/>
     <_contract Include="System.Threading.Tasks.Parallel"/>
     <_contract Include="System.Threading.Timer"/>
     <_contract Include="System.Xml.ReaderWriter"/>
     <_contract Include="System.Xml.XDocument"/>
     <_contract Include="System.Xml.XmlSerializer"/>
+    <_contract Include="System.Xml.XPath.XDocument"/>
     <PackageReference Include="@(_contract)">
       <Version>4.3.0</Version>
     </PackageReference>

--- a/src/netfx.force.conflict/src/Configurations.props
+++ b/src/netfx.force.conflict/src/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netfx;
+      net471;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/netfx.force.conflict/src/TypeForwards.471.cs
+++ b/src/netfx.force.conflict/src/TypeForwards.471.cs
@@ -4,11 +4,28 @@
 
 using System.Runtime.CompilerServices;
 
+// System.Data.Common
+[assembly: TypeForwardedTo(typeof(System.Data.Common.DbColumn))]
+// System.Diagnostics.StackTrace
+[assembly: TypeForwardedTo(typeof(System.Diagnostics.StackTrace))]
 // System.Diagnostics.Tracing
 [assembly: TypeForwardedTo(typeof(System.Diagnostics.Tracing.EventSource))]
+// System.Globalization.Extensions
+[assembly: TypeForwardedTo(typeof(System.Globalization.GlobalizationExtensions))]
 // System.IO.Compression
 [assembly: TypeForwardedTo(typeof(System.IO.Compression.GZipStream))]
-//  System.Net.Http
+// System.Net.Http
 [assembly: TypeForwardedTo(typeof(System.Net.Http.HttpClient))]
-//  System.Runtime.Serialization.Primitives
+// System.Net.Sockets
+[assembly: TypeForwardedTo(typeof(System.Net.Sockets.Socket))]
+// System.Runtime.Serialization.Primitives
 [assembly: TypeForwardedTo(typeof(System.Runtime.Serialization.DataContractAttribute))]
+// System.Security.Cryptography.Algorithms
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Aes))]
+// System.Security.SecureString
+[assembly: TypeForwardedTo(typeof(System.Security.SecureString))]
+// System.Threading.Overlapped
+[assembly: TypeForwardedTo(typeof(System.Threading.PreAllocatedOverlapped))]
+// System.Xml.XPath.XDocument
+[assembly: TypeForwardedTo(typeof(System.Xml.XPath.Extensions))]
+

--- a/src/netfx.force.conflict/src/TypeForwards.471.cs
+++ b/src/netfx.force.conflict/src/TypeForwards.471.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+// System.Diagnostics.Tracing
+[assembly: TypeForwardedTo(typeof(System.Diagnostics.Tracing.EventSource))]
+// System.IO.Compression
+[assembly: TypeForwardedTo(typeof(System.IO.Compression.GZipStream))]
+//  System.Net.Http
+[assembly: TypeForwardedTo(typeof(System.Net.Http.HttpClient))]
+//  System.Runtime.Serialization.Primitives
+[assembly: TypeForwardedTo(typeof(System.Runtime.Serialization.DataContractAttribute))]

--- a/src/netfx.force.conflict/src/netfx.force.conflicts.csproj
+++ b/src/netfx.force.conflict/src/netfx.force.conflicts.csproj
@@ -7,8 +7,11 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netfx-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='net471-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='net471-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="TypeForwards.cs" />
+    <Compile Include="TypeForwards.cs" Condition="'$(TargetGroup)' == 'netfx'"/>
+    <Compile Include="TypeForwards.471.cs" Condition="'$(TargetGroup)' == 'net471'"/>
     <ProjectReference Include="..\..\..\external\netfx-conflicts\netfx-conflicts.depproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -17,6 +17,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipManagedPackageBuild)' != 'true'" >
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\NETStandard.Library.NETFramework\NETStandard.Library.NETFramework.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
     <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.Private.PackageBaseline\Microsoft.Private.PackageBaseline.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>


### PR DESCRIPTION
cc: @weshaggard @AlexGhiondea @dsplaisted @livarcocc @ericstj @Petermarcu 

Updating the support package so that it will also contain the file netfx.force.conflicts.dll for 4.7.1 so that we can cause binding redirects to get generated automatically when a user targets 4.7.1 and has a reference to a netstandard-based component.