### PR TITLE
Fix tests for path validation changes on Windows And Unix

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -33,7 +33,6 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => Create(string.Empty));
         }
 
-        [ActiveIssue(25665)]
         [Theory, MemberData(nameof(PathsWithInvalidCharacters))]
         public void PathWithInvalidCharactersAsPath_ThrowsArgumentException(string invalidPath)
         {

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -49,7 +49,6 @@ namespace System.IO.Tests
             Assert.True(Exists(path));
         }
 
-	[ActiveIssue(25665)]
         [Theory, MemberData(nameof(PathsWithInvalidCharacters))]
         public void PathWithInvalidCharactersAsPath_ReturnsFalse(string invalidPath)
         {

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -47,7 +47,6 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => GetEntries(string.Empty));
         }
 
-        [ActiveIssue(25665)]
         [Fact]
         public void InvalidFileNames()
         {
@@ -180,7 +179,6 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [ActiveIssue(25665)]
         [Fact]
         public void InvalidPath()
         {

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -904,6 +904,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ActiveIssue(25665)]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix-invalid sarch patterns throw ArgumentException
         public void UnixSearchPatternInvalid()
         {

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -904,12 +904,11 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue(25665)]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix-invalid sarch patterns throw ArgumentException
+        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix-invalid search patterns throws no exception 
         public void UnixSearchPatternInvalid()
         {
-            Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, "\0"));
-            Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, string.Format("te{0}st", "\0".ToString())));
+            GetEntries(TestDirectory, "\0");
+            GetEntries(TestDirectory, string.Format("te{0}st", "\0".ToString()));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -903,7 +903,6 @@ namespace System.IO.Tests
             });
         }
 
-        [ActiveIssue(25665)]
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix-invalid sarch patterns throw ArgumentException
         public void UnixSearchPatternInvalid()

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -84,7 +84,6 @@ namespace System.IO.Tests
             Assert.Throws<IOException>(() => Copy(testFileSource, testFileDest));
         }
 
-        [ActiveIssue(25665)]
         [Fact]
         public void InvalidFileNames()
         {

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -225,7 +225,6 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => Create(path));
         }
 
-        [ActiveIssue(25665)]
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void CreateNullThrows_Unix()

--- a/src/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists.cs
@@ -48,7 +48,6 @@ namespace System.IO.Tests
             Assert.True(Exists(path));
         }
 
-        [ActiveIssue(25665)]
         [Theory, MemberData(nameof(PathsWithInvalidCharacters))]
         public void PathWithInvalidCharactersAsPath_ReturnsFalse(string invalidPath)
         {

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -43,7 +43,6 @@ namespace System.IO.Tests
             Assert.Throws<FileNotFoundException>(() => Move(Path.Combine(TestDirectory, GetTestFileName(), GetTestFileName()), testFile.FullName));
         }
 
-        [ActiveIssue(25665)]
         [Theory, MemberData(nameof(PathsWithInvalidCharacters))]
         public void PathWithIllegalCharacters(string invalidPath)
         {

--- a/src/System.IO.FileSystem/tests/File/ReadWriteAllLines.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadWriteAllLines.cs
@@ -28,7 +28,6 @@ namespace System.IO.Tests
 
         #region UniversalTests
 
-        [ActiveIssue(25665)]
         [Fact]
         public void InvalidPath()
         {
@@ -217,7 +216,6 @@ namespace System.IO.Tests
 
         #region UniversalTests
 
-        [ActiveIssue(25665)]
         [Fact]
         public void InvalidPath()
         {

--- a/src/System.IO.FileSystem/tests/File/ReadWriteAllLinesAsync.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadWriteAllLinesAsync.cs
@@ -24,8 +24,7 @@ namespace System.IO.Tests
         #endregion
 
         #region UniversalTests
-
-        [ActiveIssue(25665)]
+        
         [Fact]
         public async Task InvalidPathAsync()
         {

--- a/src/System.IO.FileSystem/tests/File/Replace.cs
+++ b/src/System.IO.FileSystem/tests/File/Replace.cs
@@ -93,7 +93,6 @@ namespace System.IO.Tests
             Assert.Throws<FileNotFoundException>(() => Replace(src, GetTestFilePath(), null));
         }
 
-        [ActiveIssue(25665)]
         [Fact]
         public void InvalidFileNames()
         {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CopyFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CopyFileTests.cs
@@ -64,14 +64,25 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void CopyFile_RaisesInvalidPath()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.CopyFile("\0bad", "bar"));
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.CopyFile("foo", "\0bad"));
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void CopyFile_RaisesIsolatedStorageException()
+        {
+            using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
+            {
+                Assert.Throws<IsolatedStorageException>(() => isf.CopyFile("\0bad", "bar"));
+                Assert.Throws<IsolatedStorageException>(() => isf.CopyFile("foo", "\0bad"));
             }
         }
 

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateDirectoryTests.cs
@@ -49,13 +49,23 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void CreateDirectory_RaisesArgumentException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.CreateDirectory("\0bad"));
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void CreateDirectory_IsolatedStorageException()
+        {
+            using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
+            {
+                Assert.Throws<IsolatedStorageException>(() => isf.CreateDirectory("\0bad"));
             }
         }
 

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateFileTests.cs
@@ -49,13 +49,23 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void CreateFile_RaisesArgumentException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.CreateFile("\0bad"));
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void CreateFile_IsolatedStorageException()
+        {
+            using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
+            {
+                Assert.Throws<IsolatedStorageException>(() => isf.CreateFile("\0bad"));
             }
         }
 

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteDirectoryTests.cs
@@ -49,7 +49,6 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
         public void DeleteDirectory_RaisesInvalidPath()
         {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DirectoryExistsTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DirectoryExistsTests.cs
@@ -49,13 +49,23 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void DirectoryExists_RaisesArgumentException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.DirectoryExists("\0bad"));
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void DirectoryExists_False()
+        {
+            using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
+            {
+                Assert.False(isf.DirectoryExists("\0bad"));
             }
         }
 

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/FileExistsTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/FileExistsTests.cs
@@ -49,13 +49,23 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void FileExists_RaisesArgumentException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.FileExists("\0bad"));
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void FileExists_False()
+        {
+            using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
+            {
+                Assert.False(isf.FileExists("\0bad"));
             }
         }
 

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetCreationTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetCreationTimeTests.cs
@@ -49,7 +49,6 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
         public void GetCreationTime_RaisesArgumentException()
         {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastAccessTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastAccessTimeTests.cs
@@ -49,7 +49,6 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
         public void GetLastAccessTime_RaisesArgumentException()
         {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastWriteTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastWriteTimeTests.cs
@@ -49,7 +49,6 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
         public void GetLastWriteTime_RaisesArgumentException()
         {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveDirectoryTests.cs
@@ -60,14 +60,25 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void MoveDirectory_RaisesInvalidPath()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.MoveDirectory("\0bad", "bar"));
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.MoveDirectory("foo", "\0bad"));
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void MoveDirectory_IsolatedStorageException()
+        {
+            using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
+            {
+                Assert.Throws<IsolatedStorageException>(() => isf.MoveDirectory("\0bad", "bar"));
+                Assert.Throws<IsolatedStorageException>(() => isf.MoveDirectory("foo", "\0bad"));
             }
         }
 

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveFileTests.cs
@@ -61,14 +61,25 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void MoveFile_RaisesInvalidPath()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.MoveFile("\0bad", "bar"));
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.MoveFile("foo", "\0bad"));
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void MoveFile_RaisesIsolatedStorageException()
+        {
+            using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
+            {
+                Assert.Throws<IsolatedStorageException>(() => isf.MoveFile("\0bad", "bar"));
+                Assert.Throws<IsolatedStorageException>(() => isf.MoveFile("foo", "\0bad"));
             }
         }
 

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/OpenFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/OpenFileTests.cs
@@ -57,8 +57,8 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void OpenFile_RaisesArgumentException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
@@ -66,6 +66,18 @@ namespace System.IO.IsolatedStorage
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.OpenFile("\0bad", FileMode.Create));
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.OpenFile("\0bad", FileMode.Create, FileAccess.ReadWrite));
                 AssertExtensions.Throws<ArgumentException>("path", null, () => isf.OpenFile("\0bad", FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite));
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void OpenFile_RaisesIsolatedStorageException()
+        {
+            using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
+            {
+                Assert.Throws<IsolatedStorageException>(() => isf.OpenFile("\0bad", FileMode.Create));
+                Assert.Throws<IsolatedStorageException>(() => isf.OpenFile("\0bad", FileMode.Create, FileAccess.ReadWrite));
+                Assert.Throws<IsolatedStorageException>(() => isf.OpenFile("\0bad", FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite));
             }
         }
 

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
@@ -297,8 +297,8 @@ namespace System.Reflection.PortableExecutable.Tests
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void TryOpenAssociatedPortablePdb_Args()
         {
             var peStream = new MemoryStream(PortablePdbs.DocumentsDll);
@@ -311,6 +311,23 @@ namespace System.Reflection.PortableExecutable.Tests
                 Assert.Throws<ArgumentNullException>(() => reader.TryOpenAssociatedPortablePdb(@"b.dll", null, out pdbProvider, out pdbPath));
                 Assert.Throws<ArgumentNullException>(() => reader.TryOpenAssociatedPortablePdb(null, _ => null, out pdbProvider, out pdbPath));
                 AssertExtensions.Throws<ArgumentException>("peImagePath", () => reader.TryOpenAssociatedPortablePdb("C:\\a\\\0\\b", _ => null, out pdbProvider, out pdbPath));
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void TryOpenAssociatedPortablePdb_Args_Core()
+        {
+            var peStream = new MemoryStream(PortablePdbs.DocumentsDll);
+            using (var reader = new PEReader(peStream))
+            {
+                MetadataReaderProvider pdbProvider;
+                string pdbPath;
+
+                Assert.False(reader.TryOpenAssociatedPortablePdb(@"b.dll", _ => null, out pdbProvider, out pdbPath));
+                Assert.Throws<ArgumentNullException>(() => reader.TryOpenAssociatedPortablePdb(@"b.dll", null, out pdbProvider, out pdbPath));
+                Assert.Throws<ArgumentNullException>(() => reader.TryOpenAssociatedPortablePdb(null, _ => null, out pdbProvider, out pdbPath));
+                Assert.False(reader.TryOpenAssociatedPortablePdb("C:\\a\\\0\\b", _ => null, out pdbProvider, out pdbPath));
             }
         }
 

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
@@ -128,7 +128,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public static void PathIsNullWihtoutRootedAfterArgumentNull()
+        public static void PathIsNullWihtoutRooted()
         {
             //any path is null without rooted after (ANE)
             CommonCasesException<ArgumentNullException>(null);
@@ -136,14 +136,14 @@ namespace System.IO.Tests
 
         [Fact]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
-        public static void ContainsInvalidCharWithoutRootedAfterArgumentNull()
+        public static void ContainsInvalidCharWithoutRooted()
         {
             CommonCasesException<ArgumentException>("ab\0cd");
         }
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static void ContainsInvalidCharWithoutRootedAfterArgumentNull_Core()
+        public static void ContainsInvalidCharWithoutRooted_Core()
         {
             Assert.Equal("ab\0cd", Path.Combine("ab\0cd"));
         }
@@ -151,7 +151,7 @@ namespace System.IO.Tests
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Tests Windows-specific invalid paths
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
-        public static void ContainsInvalidCharWithoutRootedAfterArgumentNull_Windows()
+        public static void ContainsInvalidCharWithoutRooted_Windows()
         {
             //any path contains invalid character without rooted after (AE)
             CommonCasesException<ArgumentException>("ab|cd");
@@ -163,7 +163,7 @@ namespace System.IO.Tests
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Tests Windows-specific invalid paths
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static void ContainsInvalidCharWithoutRootedAfterArgumentNull_Windows_Core()
+        public static void ContainsInvalidCharWithoutRooted_Windows_Core()
         {
             Assert.Equal("ab|cd", Path.Combine("ab|cd"));
             Assert.Equal("ab\bcd", Path.Combine("ab\bcd"));
@@ -173,7 +173,7 @@ namespace System.IO.Tests
 
         [Fact]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
-        public static void ContainsInvalidCharWithRootedAfterArgumentNull()
+        public static void ContainsInvalidCharWithRooted()
         {
             //any path contains invalid character with rooted after (AE)
             CommonCasesException<ArgumentException>("ab\0cd", s_separator + "abc");
@@ -181,7 +181,7 @@ namespace System.IO.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static void ContainsInvalidCharWithRootedAfterArgumentNull_Core()
+        public static void ContainsInvalidCharWithRooted_Core()
         {
             Assert.Equal(s_separator + "abc", Path.Combine("ab\0cd", s_separator + "abc"));
         }
@@ -189,7 +189,7 @@ namespace System.IO.Tests
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Tests Windows-specific invalid paths
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
-        public static void ContainsInvalidCharWithRootedAfterArgumentNull_Windows()
+        public static void ContainsInvalidCharWithRooted_Windows()
         {
             //any path contains invalid character with rooted after (AE)
             CommonCasesException<ArgumentException>("ab|cd", s_separator + "abc");
@@ -200,7 +200,7 @@ namespace System.IO.Tests
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Tests Windows-specific invalid paths
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static void ContainsInvalidCharWithRootedAfterArgumentNull_Windows_core()
+        public static void ContainsInvalidCharWithRooted_Windows_core()
         {
             Assert.Equal(s_separator + "abc", Path.Combine("ab|cd", s_separator + "abc"));
             Assert.Equal(s_separator + "abc", Path.Combine("ab\bcd", s_separator + "abc"));

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
@@ -134,17 +134,23 @@ namespace System.IO.Tests
             CommonCasesException<ArgumentNullException>(null);
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public static void ContainsInvalidCharWithoutRootedAfterArgumentNull()
         {
-            //any path contains invalid character without rooted after (AE)
             CommonCasesException<ArgumentException>("ab\0cd");
         }
 
-        [ActiveIssue(25665)]
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void ContainsInvalidCharWithoutRootedAfterArgumentNull_Core()
+        {
+            Assert.Equal("ab\0cd", Path.Combine("ab\0cd"));
+        }
+
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Tests Windows-specific invalid paths
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public static void ContainsInvalidCharWithoutRootedAfterArgumentNull_Windows()
         {
             //any path contains invalid character without rooted after (AE)
@@ -154,23 +160,51 @@ namespace System.IO.Tests
             CommonCasesException<ArgumentException>("ab\tcd");
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]  // Tests Windows-specific invalid paths
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void ContainsInvalidCharWithoutRootedAfterArgumentNull_Windows_Core()
+        {
+            Assert.Equal("ab|cd", Path.Combine("ab|cd"));
+            Assert.Equal("ab\bcd", Path.Combine("ab\bcd"));
+            Assert.Equal("ab\0cd", Path.Combine("ab\0cd"));
+            Assert.Equal("ab\tcd", Path.Combine("ab\tcd"));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public static void ContainsInvalidCharWithRootedAfterArgumentNull()
         {
             //any path contains invalid character with rooted after (AE)
             CommonCasesException<ArgumentException>("ab\0cd", s_separator + "abc");
         }
 
-        [ActiveIssue(25665)]
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void ContainsInvalidCharWithRootedAfterArgumentNull_Core()
+        {
+            Assert.Equal(s_separator + "abc", Path.Combine("ab\0cd", s_separator + "abc"));
+        }
+
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Tests Windows-specific invalid paths
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public static void ContainsInvalidCharWithRootedAfterArgumentNull_Windows()
         {
             //any path contains invalid character with rooted after (AE)
             CommonCasesException<ArgumentException>("ab|cd", s_separator + "abc");
             CommonCasesException<ArgumentException>("ab\bcd", s_separator + "abc");
             CommonCasesException<ArgumentException>("ab\tcd", s_separator + "abc");
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]  // Tests Windows-specific invalid paths
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void ContainsInvalidCharWithRootedAfterArgumentNull_Windows_core()
+        {
+            Assert.Equal(s_separator + "abc", Path.Combine("ab|cd", s_separator + "abc"));
+            Assert.Equal(s_separator + "abc", Path.Combine("ab\bcd", s_separator + "abc"));
+            Assert.Equal(s_separator + "abc", Path.Combine("ab\tcd", s_separator + "abc"));
         }
 
         private static void VerifyException<T>(string[] paths) where T : Exception

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -41,10 +41,10 @@ namespace System.IO.Tests
             AssertExtensions.Throws<ArgumentException>("path", null, () => Path.GetDirectoryName(string.Empty));
         }
 
-        [ActiveIssue(25665)]
         [Theory,
             InlineData(" "),
             InlineData("\r\n")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public static void GetDirectoryName_SpaceOrControlCharsThrowOnWindows(string path)
         {
             Action action = () => Path.GetDirectoryName(path);
@@ -55,6 +55,23 @@ namespace System.IO.Tests
             else
             {
                 // These are valid paths on Unix
+                action();
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void GetDirectoryName_SpaceThrowOnWindows_Core()
+        {
+            string path = " ";
+            Action action = () => Path.GetDirectoryName(path);
+            if (PlatformDetection.IsWindows)
+            {
+                AssertExtensions.Throws<ArgumentException>("path", null, () => Path.GetDirectoryName(path));
+            }
+            else
+            {
+                // This is a valid path on Unix
                 action();
             }
         }
@@ -326,8 +343,8 @@ namespace System.IO.Tests
             }
         }
 
-        [ActiveIssue(25665)]
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public static void GetInvalidPathChars()
         {
             Assert.NotNull(Path.GetInvalidPathChars());
@@ -349,6 +366,32 @@ namespace System.IO.Tests
                 AssertExtensions.Throws<ArgumentException>(c == 124 ? null : "path", null, () => Path.GetFullPath(bad));
                 AssertExtensions.Throws<ArgumentException>("path", null, () => Path.GetPathRoot(bad));
                 AssertExtensions.Throws<ArgumentException>("path", null, () => Path.IsPathRooted(bad));
+            });
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void GetInvalidPathChars_Core()
+        {
+            Assert.NotNull(Path.GetInvalidPathChars());
+            Assert.NotSame(Path.GetInvalidPathChars(), Path.GetInvalidPathChars());
+            Assert.Equal((IEnumerable<char>)Path.GetInvalidPathChars(), Path.GetInvalidPathChars());
+            Assert.True(Path.GetInvalidPathChars().Length > 0);
+            Assert.All(Path.GetInvalidPathChars(), c =>
+            {
+                string bad = c.ToString();
+                Assert.Equal(bad + ".ok", Path.ChangeExtension(bad, "ok"));
+                Assert.Equal(bad + Path.DirectorySeparatorChar + "ok", Path.Combine(bad, "ok"));
+                Assert.Equal("ok" + Path.DirectorySeparatorChar + "ok" + Path.DirectorySeparatorChar + bad, Path.Combine("ok", "ok", bad));
+                Assert.Equal("ok" + Path.DirectorySeparatorChar + "ok" + Path.DirectorySeparatorChar + bad + Path.DirectorySeparatorChar + "ok", Path.Combine("ok", "ok", bad, "ok"));
+                Assert.Equal(bad + Path.DirectorySeparatorChar + bad + Path.DirectorySeparatorChar + bad + Path.DirectorySeparatorChar + bad + Path.DirectorySeparatorChar + bad, Path.Combine(bad, bad, bad, bad, bad));
+                Assert.Equal("", Path.GetDirectoryName(bad));
+                Assert.Equal(string.Empty, Path.GetExtension(bad));
+                Assert.Equal(bad, Path.GetFileName(bad));
+                Assert.Equal(bad, Path.GetFileNameWithoutExtension(bad));
+                AssertExtensions.Throws<ArgumentException>(c == 124 ? null : "path", null, () => Path.GetFullPath(bad));
+                Assert.Equal(string.Empty, Path.GetPathRoot(bad));
+                Assert.False(Path.IsPathRooted(bad));
             });
         }
 


### PR DESCRIPTION
The Null check was added to GetFullPath function in the coreclr. These tests are in respond to that.
Fixes #25665 