### PR TITLE
UnixNetworkInterface: when no physical address, use PhysicalAddress.None and ensure index is set

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
@@ -11,9 +11,9 @@ namespace System.Net.NetworkInformation
     internal abstract class UnixNetworkInterface : NetworkInterface
     {
         protected string _name;
-        protected int _index;
+        protected int _index = -1;
         protected NetworkInterfaceType _networkInterfaceType = NetworkInterfaceType.Unknown;
-        protected PhysicalAddress _physicalAddress;
+        protected PhysicalAddress _physicalAddress = PhysicalAddress.None;
         protected List<IPAddress> _addresses = new List<IPAddress>();
         protected Dictionary<IPAddress, IPAddress> _netMasks = new Dictionary<IPAddress, IPAddress>();
         // If this is an ipv6 device, contains the Scope ID.
@@ -32,11 +32,7 @@ namespace System.Net.NetworkInformation
 
         public sealed override NetworkInterfaceType NetworkInterfaceType { get { return _networkInterfaceType; } }
 
-        public sealed override PhysicalAddress GetPhysicalAddress()
-        {
-            Debug.Assert(_physicalAddress != null, "_physicalAddress was never initialized. This means no address with type AF_PACKET was discovered.");
-            return _physicalAddress;
-        }
+        public sealed override PhysicalAddress GetPhysicalAddress() { return _physicalAddress; }
 
         public override bool Supports(NetworkInterfaceComponent networkInterfaceComponent)
         {
@@ -76,6 +72,7 @@ namespace System.Net.NetworkInformation
             IPAddress netMaskAddress = IPAddressUtil.GetIPAddressFromNativeInfo(netMask);
             AddAddress(ipAddress);
             _netMasks[ipAddress] = netMaskAddress;
+            _index = addressInfo->InterfaceIndex;
         }
 
         protected unsafe void ProcessIpv6Address(Interop.Sys.IpAddressInfo* addressInfo, uint scopeId)
@@ -84,6 +81,7 @@ namespace System.Net.NetworkInformation
             address.ScopeId = scopeId;
             AddAddress(address);
             _ipv6ScopeId = scopeId;
+            _index = addressInfo->InterfaceIndex;
         }
 
         protected unsafe void ProcessLinkLayerAddress(Interop.Sys.LinkLayerAddressInfo* llAddr)


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/25264