### PR TITLE
Revert "Update Sgen Package Version to 1.1.0"

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/dir.props
+++ b/src/Microsoft.XmlSerializer.Generator/dir.props
@@ -3,7 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <PreReleaseLabel>preview1</PreReleaseLabel>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.0.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion)</AssemblyFileVersion>


### PR DESCRIPTION
Reverts dotnet/corefx#25769

This change appears to have caused this in official builds: https://github.com/dotnet/core-eng/issues/2242