### PR TITLE
Fix pre-build cleanup step.

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
@@ -18,7 +18,7 @@
         "scriptName": "",
         "arguments": "-path $(build.SourcesDirectory)\\corefx",
         "workingFolder": "",
-        "inlineScript": "param($path)\n\nif (Test-Path $path){\n    Stop-Process -processname msbuild -ErrorAction Ignore -Verbose\n    Stop-Process -processname dotnet -ErrorAction Ignore -Verbose\n    Stop-Process -processname vbcscompiler -ErrorAction Ignore -Verbose\n    # this will print out an error each time a file can't be deleted.\n    Remove-Item -Recurse -Force $path\n }\n",
+        "inlineScript": "param($path)\n\nif (Test-Path $path){\n    Stop-Process -processname msbuild -ErrorAction Ignore -Verbose\n    Stop-Process -processname dotnet -ErrorAction Ignore -Verbose\n    Stop-Process -processname vbcscompiler -ErrorAction Ignore -Verbose\n    # this will print out an error each time a file can't be deleted.\n    # Remove-Item -Recurse has a known issue (https://docs.microsoft.com/en-us/powershell/module/Microsoft.PowerShell.Management/Remove-Item?view=powershell-6).\n    # Instead, get all the items, sort by full path length so we delete innermost children first, then delete them.\n    Get-ChildItem $path -Recurse | Sort-Object -Property FullName -Descending | Remove-Item -Force\n }\n",
         "failOnStandardError": "true"
       }
     },

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
@@ -18,7 +18,7 @@
         "scriptName": "",
         "arguments": "-path $(build.SourcesDirectory)\\corefx",
         "workingFolder": "",
-        "inlineScript": "param($path)\n\nif (Test-Path $path){\n    Stop-Process -processname msbuild -ErrorAction Ignore -Verbose\n    Stop-Process -processname dotnet -ErrorAction Ignore -Verbose\n    Stop-Process -processname vbcscompiler -ErrorAction Ignore -Verbose\n    # this will print out an error each time a file can't be deleted.\n    # Remove-Item -Recurse has a known issue (https://docs.microsoft.com/en-us/powershell/module/Microsoft.PowerShell.Management/Remove-Item?view=powershell-6).\n    # Instead, get all the items, sort by full path length so we delete innermost children first, then delete them.\n    Get-ChildItem $path -Recurse | Sort-Object -Property FullName -Descending | Remove-Item -Force\n }\n",
+        "inlineScript": "param($path, $rootPath)\n\nif (Test-Path $path){\n    Remove-Item -Recurse -Force $path\n\n    if(Test-Path $path){\n        $DeleteFolder = \"$rootPath\\deleteme\"\n        if((Test-Path $DeleteFolder ) -eq 0) {\n            New-Item -ItemType Directory -Force -Path $DeleteFolder\n        }\n        robocopy $DeleteFolder $path /purge\n        Remove-Item -Recurse -Force $path\n    }\n }",
         "failOnStandardError": "true"
       }
     },

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -18,7 +18,7 @@
         "scriptName": "",
         "arguments": "-path $(build.SourcesDirectory)\\corefx",
         "workingFolder": "",
-        "inlineScript": "param($path)\n\nif (Test-Path $path){\n    Stop-Process -processname msbuild -ErrorAction Ignore -Verbose\n    Stop-Process -processname dotnet -ErrorAction Ignore -Verbose\n    Stop-Process -processname vbcscompiler -ErrorAction Ignore -Verbose\n    # this will print out an error each time a file can't be deleted.\n    # Remove-Item -Recurse has a known issue (https://docs.microsoft.com/en-us/powershell/module/Microsoft.PowerShell.Management/Remove-Item?view=powershell-6).\n    # Instead, get all the items, sort by full path length so we delete innermost children first, then delete them.\n    Get-ChildItem $path -Recurse | Sort-Object -Property FullName -Descending | Remove-Item -Force\n }\n",
+        "inlineScript": "param($path, $rootPath)\n\nif (Test-Path $path){\n    Remove-Item -Recurse -Force $path\n\n    if(Test-Path $path){\n        $DeleteFolder = \"$rootPath\\deleteme\"\n        if((Test-Path $DeleteFolder ) -eq 0) {\n            New-Item -ItemType Directory -Force -Path $DeleteFolder\n        }\n        robocopy $DeleteFolder $path /purge\n        Remove-Item -Recurse -Force $path\n    }\n }",
         "failOnStandardError": "true"
       }
     },

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -18,7 +18,7 @@
         "scriptName": "",
         "arguments": "-path $(build.SourcesDirectory)\\corefx",
         "workingFolder": "",
-        "inlineScript": "param($path)\n\nif (Test-Path $path){\n    Stop-Process -processname msbuild -ErrorAction Ignore -Verbose\n    Stop-Process -processname dotnet -ErrorAction Ignore -Verbose\n    Stop-Process -processname vbcscompiler -ErrorAction Ignore -Verbose\n    # this will print out an error each time a file can't be deleted.\n    Remove-Item -Recurse -Force $path\n }",
+        "inlineScript": "param($path)\n\nif (Test-Path $path){\n    Stop-Process -processname msbuild -ErrorAction Ignore -Verbose\n    Stop-Process -processname dotnet -ErrorAction Ignore -Verbose\n    Stop-Process -processname vbcscompiler -ErrorAction Ignore -Verbose\n    # this will print out an error each time a file can't be deleted.\n    # Remove-Item -Recurse has a known issue (https://docs.microsoft.com/en-us/powershell/module/Microsoft.PowerShell.Management/Remove-Item?view=powershell-6).\n    # Instead, get all the items, sort by full path length so we delete innermost children first, then delete them.\n    Get-ChildItem $path -Recurse | Sort-Object -Property FullName -Descending | Remove-Item -Force\n }\n",
         "failOnStandardError": "true"
       }
     },


### PR DESCRIPTION
skip ci please
This is an official build change only.
"Remove-Item -Recurse" has a known issue (https://docs.microsoft.com/en-us/powershell/module/Microsoft.PowerShell.Management/Remove-Item?view=powershell-6).
This causes builds to have errors like this trying to run the cleanup:
[error]Remove-Item : Cannot remove item E:\A\_work\742\s\corefx: The directory is not empty.
This change makes us do the recursive delete ourselves by enumerating the files, sorting them so the longest filenames occur first, and then deleting them.