### PR TITLE
Re-enable DriveInfo test on Windows Subsystem for Linux

### DIFF
--- a/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
+++ b/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
@@ -60,7 +60,6 @@ namespace System.IO.FileSystem.DriveInfoTests
             Assert.Equal(invalidDriveName, invalidDrive.VolumeLabel);   // VolumeLabel is equivalent to Name on Unix
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/dotnet/corefx/issues/11570
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void PropertiesOfValidDrive()
         {


### PR DESCRIPTION
Related https://github.com/dotnet/corefx/issues/11570