### PR TITLE
Hotfix for the Alpine CI issue

### DIFF
--- a/buildpipeline/alpine.3.6.groovy
+++ b/buildpipeline/alpine.3.6.groovy
@@ -24,10 +24,10 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-2017111
         sh "./build-managed.sh -runtimeos=alpine.3.6 -- /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true /p:PortableBuild=false"
     }
     stage ('Sync') {
-        sh "./sync.sh -p -runtimeos=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false"
+        sh "./sync.sh -p -runtimeos=alpine.3.6 -BuildTests=false -- /p:ArchGroup=x64 /p:PortableBuild=false"
     }
     stage ('Build Product') {
-        sh "./build.sh -buildArch=x64 -runtimeos=alpine.3.6 -${params.CGroup} -- /p:PortableBuild=false"
+        sh "./build.sh -buildArch=x64 -runtimeos=alpine.3.6 -${params.CGroup} -BuildTests=false -- /p:PortableBuild=false"
     }
     stage ('Build Tests') {
         def additionalArgs = ''


### PR DESCRIPTION
The Alpine CI is failing due to an old version of dotnet host package
specified in the dependencies.props file. There are no Alpine packages
for that version. However, updating that version causes Invariant.Tests
tests to fail for an unclear reason.
So I am making this change that disables building tests for Alpine in
the CI. That means we will still build both native and managed code of
corefx. This change is temporary until the Invariant test issue is
understood and fixed.