### PR TITLE
Implement basic cancellation for the async IO in sslstream.

### DIFF
--- a/src/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
+++ b/src/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
@@ -73,6 +73,21 @@ namespace System.Net.Test.Common
             _isFlushed = true;
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                if (disposing)
+                {
+                    _network.Dispose(_isServer);
+                }
+            }
+            finally
+            {
+                base.Dispose(disposing);
+            }
+        }
+
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
             if (_flushTcs != null)

--- a/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
+++ b/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
@@ -53,7 +53,7 @@ namespace System.Net
                 int remainingCount = request.Count, offset = request.Offset;
                 do
                 {
-                    int bytes = await transport.ReadAsync(request.Buffer, offset, remainingCount, CancellationToken.None).ConfigureAwait(false);
+                    int bytes = await transport.ReadAsync(request.Buffer, offset, remainingCount, request.CancellationToken).ConfigureAwait(false);
                     if (bytes == 0)
                     {
                         if (remainingCount != request.Count)

--- a/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
+++ b/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
@@ -34,12 +34,15 @@ namespace System.Net
         public LazyAsyncResult UserAsyncResult;
         public int Result;
         public object AsyncState;
+        public readonly CancellationToken CancellationToken;
 
         public byte[] Buffer; // Temporary buffer reused by a protocol.
         public int Offset;
         public int Count;
 
-        public AsyncProtocolRequest(LazyAsyncResult userAsyncResult)
+        public AsyncProtocolRequest(LazyAsyncResult userAsyncResult) : this(userAsyncResult, CancellationToken.None) { }
+
+        public AsyncProtocolRequest(LazyAsyncResult userAsyncResult, CancellationToken cancellationToken)
         {
             if (userAsyncResult == null)
             {
@@ -50,6 +53,7 @@ namespace System.Net
                 NetEventSource.Fail(this, "userAsyncResult is already completed.");
             }
             UserAsyncResult = userAsyncResult;
+            CancellationToken = cancellationToken;
         }
 
         public void Reset(LazyAsyncResult userAsyncResult)

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -547,7 +547,7 @@ namespace System.Net.Security
         // This method assumes that a SSPI context is already in a good shape.
         // For example it is either a fresh context or already authenticated context that needs renegotiation.
         //
-        internal void ProcessAuthentication(LazyAsyncResult lazyResult)
+        internal void ProcessAuthentication(LazyAsyncResult lazyResult, CancellationToken cancellationToken)
         {
             if (Interlocked.Exchange(ref _nestedAuth, 1) == 1)
             {
@@ -560,7 +560,7 @@ namespace System.Net.Security
                 AsyncProtocolRequest asyncRequest = null;
                 if (lazyResult != null)
                 {
-                    asyncRequest = new AsyncProtocolRequest(lazyResult);
+                    asyncRequest = new AsyncProtocolRequest(lazyResult, cancellationToken);
                     asyncRequest.Buffer = null;
 #if DEBUG
                     lazyResult._debugAsyncChain = asyncRequest;
@@ -769,7 +769,7 @@ namespace System.Net.Security
                 else
                 {
                     asyncRequest.AsyncState = message;
-                    Task t = InnerStream.WriteAsync(message.Payload, 0, message.Size);
+                    Task t = InnerStream.WriteAsync(message.Payload, 0, message.Size, asyncRequest.CancellationToken);
                     if (t.IsCompleted)
                     {
                         t.GetAwaiter().GetResult();
@@ -982,7 +982,7 @@ namespace System.Net.Security
             else
             {
                 asyncRequest.AsyncState = exception;
-                Task t = InnerStream.WriteAsync(message.Payload, 0, message.Size);
+                Task t = InnerStream.WriteAsync(message.Payload, 0, message.Size, asyncRequest.CancellationToken);
                 if (t.IsCompleted)
                 {
                     t.GetAwaiter().GetResult();

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -185,7 +185,7 @@ namespace System.Net.Security
             _sslState.ValidateCreateContext(sslClientAuthenticationOptions);
 
             LazyAsyncResult result = new LazyAsyncResult(_sslState, asyncState, asyncCallback);
-            _sslState.ProcessAuthentication(result);
+            _sslState.ProcessAuthentication(result, cancellationToken);
             return result;
         }
 
@@ -239,7 +239,7 @@ namespace System.Net.Security
             _sslState.ValidateCreateContext(sslServerAuthenticationOptions);
 
             LazyAsyncResult result = new LazyAsyncResult(_sslState, asyncState, asyncCallback);
-            _sslState.ProcessAuthentication(result);
+            _sslState.ProcessAuthentication(result, cancellationToken);
             return result;
         }
 
@@ -307,7 +307,7 @@ namespace System.Net.Security
             sslClientAuthenticationOptions._certSelectionDelegate = _certSelectionDelegate;
 
             _sslState.ValidateCreateContext(sslClientAuthenticationOptions);
-            _sslState.ProcessAuthentication(null);
+            _sslState.ProcessAuthentication(null, CancellationToken.None);
         }
 
         public virtual void AuthenticateAsServer(X509Certificate serverCertificate)
@@ -343,7 +343,7 @@ namespace System.Net.Security
             sslServerAuthenticationOptions._certValidationDelegate = _certValidationDelegate;
 
             _sslState.ValidateCreateContext(sslServerAuthenticationOptions);
-            _sslState.ProcessAuthentication(null);
+            _sslState.ProcessAuthentication(null, CancellationToken.None);
         }
         #endregion
 

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
@@ -183,7 +183,7 @@ namespace System.Net.Security
         // This method assumes that a SSPI context is already in a good shape.
         // For example it is either a fresh context or already authenticated context that needs renegotiation.
         //
-        internal void ProcessAuthentication(LazyAsyncResult lazyResult)
+        internal void ProcessAuthentication(LazyAsyncResult lazyResult, CancellationToken cancellationToken)
         {
         }
 


### PR DESCRIPTION
cc @stephentoub @wfurt @karelz 

@Drawaes @Tratcher  Can you help running this commit with the asp.net benchmark runs, to ensure this change doesn't cause perf issues?

fixes #25206 