### PR TITLE
Fix Alpine CI step 2

### DIFF
--- a/buildpipeline/alpine.3.6.groovy
+++ b/buildpipeline/alpine.3.6.groovy
@@ -29,13 +29,6 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-2017111
     stage ('Build Product') {
         sh "./build.sh -buildArch=x64 -runtimeos=alpine.3.6 -${params.CGroup} -BuildTests=false -- /p:PortableBuild=false"
     }
-    stage ('Build Tests') {
-        def additionalArgs = ''
-        if (params.TestOuter) {
-            additionalArgs = '-Outerloop'
-        }
-        sh "./build-tests.sh -buildArch=x64 -${params.CGroup} -SkipTests ${additionalArgs} -- /p:ArchiveTests=true /p:EnableDumpling=true /p:PortableBuild=false"
-    }
 
     // TODO: Add submission for Helix testing once we have queue for Alpine Linux working
 }


### PR DESCRIPTION
I have found that the "Build tests" phase needs to be excluded too until
we can update the dotnet host package version.