### PR TITLE
Implement non-trailing named arguments in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -67,6 +67,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_DuplicateNamedArgument = 1740,
         ERR_NamedArgumentUsedInPositional = 1744,
         ERR_BadNamedArgumentForDelegateInvoke = 1746,
-        ERR_NonInvocableMemberCalled = 1955
+        ERR_NonInvocableMemberCalled = 1955,
+        ERR_BadNonTrailingNamedArgument = 8323
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -63,7 +63,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_AssgReadonly2 = 1648,
         ERR_AssgReadonlyStatic2 = 1650,
         ERR_BadCtorArgCount = 1729,
-        ERR_NamedArgumentSpecificationBeforeFixedArgument = 1738,
         ERR_BadNamedArgument = 1739,
         ERR_DuplicateNamedArgument = 1740,
         ERR_NamedArgumentUsedInPositional = 1744,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -63,11 +63,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_AssgReadonly2 = 1648,
         ERR_AssgReadonlyStatic2 = 1650,
         ERR_BadCtorArgCount = 1729,
-        ERR_NonInvocableMemberCalled = 1955,
-        ERR_NamedArgumentSpecificationBeforeFixedArgument = 5002,
-        ERR_BadNamedArgument = 5003,
-        ERR_BadNamedArgumentForDelegateInvoke = 5004,
-        ERR_DuplicateNamedArgument = 5005,
-        ERR_NamedArgumentUsedInPositional = 5006,
+        ERR_NamedArgumentSpecificationBeforeFixedArgument = 1738,
+        ERR_BadNamedArgument = 1739,
+        ERR_DuplicateNamedArgument = 1740,
+        ERR_NamedArgumentUsedInPositional = 1744,
+        ERR_BadNamedArgumentForDelegateInvoke = 1746,
+        ERR_NonInvocableMemberCalled = 1955
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -188,9 +188,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case ErrorCode.ERR_NonInvocableMemberCalled:
                     codeStr = SR.NonInvocableMemberCalled;
                     break;
-                case ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument:
-                    codeStr = SR.NamedArgumentSpecificationBeforeFixedArgument;
-                    break;
                 case ErrorCode.ERR_BadNamedArgument:
                     codeStr = SR.BadNamedArgument;
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -200,6 +200,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case ErrorCode.ERR_NamedArgumentUsedInPositional:
                     codeStr = SR.NamedArgumentUsedInPositional;
                     break;
+                case ErrorCode.ERR_BadNonTrailingNamedArgument:
+                    codeStr = SR.BadNonTrailingNamedArgument;
+                    break;
+
                 default:
                     // means missing resources match the code entry
                     Debug.Assert(false, "Missing resources for the error " + code.ToString());

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
@@ -137,6 +137,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(!(args.prgexpr[i] is ExprNamedArgumentSpecification));
             }
 #endif
+            // If we've no args we can skip. If the last argument isn't named then either we
+            // have no named arguments, and we can skip, or we have non-trailing named arguments
+            // and we MUST skip!
+            if (args.carg == 0 || !(args.prgexpr[args.carg - 1] is ExprNamedArgumentSpecification))
+            {
+                return pta;
+            }
 
             CType type = pTypeThrough != null ? pTypeThrough : mpwi.GetType();
             CType[] typeList = new CType[pta.Count];

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -889,8 +889,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // fixed arguments.
             bool seenNamed = VerifyNamedArgumentsAfterFixed(args);
 
-            MethPropWithInst mpwiBest = BindMethodGroupToArgumentsCore(bindFlags, grp, args, carg, seenNamed)
-                .GetBestResult();
+            MethPropWithInst mpwiBest = BindMethodGroupToArgumentsCore(bindFlags, grp, args, carg, seenNamed).BestResult;
             if (grp.SymKind == SYMKIND.SK_PropertySymbol)
             {
                 Debug.Assert((grp.Flags & EXPRFLAG.EXF_INDEXER) != 0);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1338,8 +1338,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             }
                             index++;
                         }
-                        //TODO: Put this assertion back when non-trailing named args fully implemented.
-                        //Debug.Assert(index != mp.Params.Count);
+
+                        Debug.Assert(index != mp.Params.Count);
                         CType substDestType = GetTypes().SubstType(@params[index], type, pTypeArgs);
 
                         // If we cant convert the argument and we're the param array argument, then deal with it.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -859,7 +859,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         ////////////////////////////////////////////////////////////////////////////////
         // Given a method group or indexer group, bind it to the arguments for an 
         // invocation.
-        private GroupToArgsBinderResult BindMethodGroupToArgumentsCore(BindingFlag bindFlags, ExprMemberGroup grp, Expr args, int carg, bool bHasNamedArgumentSpecifiers)
+        private GroupToArgsBinderResult BindMethodGroupToArgumentsCore(BindingFlag bindFlags, ExprMemberGroup grp, Expr args, int carg, NamedArgumentsType namedArgumentsType)
         {
             ArgInfos pargInfo = new ArgInfos {carg = carg};
             FillInArgInfoFromArgList(pargInfo, args);
@@ -867,7 +867,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             ArgInfos pOriginalArgInfo = new ArgInfos {carg = carg};
             FillInArgInfoFromArgList(pOriginalArgInfo, args);
 
-            GroupToArgsBinder binder = new GroupToArgsBinder(this, bindFlags, grp, pargInfo, pOriginalArgInfo, bHasNamedArgumentSpecifiers);
+            GroupToArgsBinder binder = new GroupToArgsBinder(this, bindFlags, grp, pargInfo, pOriginalArgInfo, namedArgumentsType);
             binder.Bind();
 
             return binder.GetResultsOfBind();
@@ -885,11 +885,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             Debug.Assert(grp.Name != null);
 
-            // If we have named arguments specified, make sure we have them all appearing after
-            // fixed arguments.
-            bool seenNamed = VerifyNamedArgumentsAfterFixed(args);
+            // Do we have named arguments specified, are they after fixed arguments (can position) or
+            // non-trailing (can rule out methods only).
+            NamedArgumentsType namedType = FindNamedArgumentsType(args);
 
-            MethPropWithInst mpwiBest = BindMethodGroupToArgumentsCore(bindFlags, grp, args, carg, seenNamed).BestResult;
+            MethPropWithInst mpwiBest = BindMethodGroupToArgumentsCore(bindFlags, grp, args, carg, namedType).BestResult;
             if (grp.SymKind == SYMKIND.SK_PropertySymbol)
             {
                 Debug.Assert((grp.Flags & EXPRFLAG.EXF_INDEXER) != 0);
@@ -903,10 +903,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        private bool VerifyNamedArgumentsAfterFixed(Expr args)
+        public enum NamedArgumentsType
+        {
+            None,
+            Positioning,
+            NonTrailing
+        }
+
+        private static NamedArgumentsType FindNamedArgumentsType(Expr args)
         {
             Expr list = args;
-            bool seenNamed = false;
             while (list != null)
             {
                 Expr arg;
@@ -924,18 +930,30 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(arg != null);
                 if (arg is ExprNamedArgumentSpecification)
                 {
-                    seenNamed = true;
-                }
-                else
-                {
-                    if (seenNamed)
+                    while (list != null)
                     {
-                        throw GetErrorContext().Error(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument);
+                        if (list is ExprList nextList)
+                        {
+                            arg = nextList.OptionalElement;
+                            list = nextList.OptionalNextListNode;
+                        }
+                        else
+                        {
+                            arg = list;
+                            list = null;
+                        }
+
+                        if (!(arg is ExprNamedArgumentSpecification))
+                        {
+                            return NamedArgumentsType.NonTrailing;
+                        }
                     }
+
+                    return NamedArgumentsType.Positioning;
                 }
             }
 
-            return seenNamed;
+            return NamedArgumentsType.None;
         }
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -1320,7 +1338,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             }
                             index++;
                         }
-                        Debug.Assert(index != mp.Params.Count);
+                        //TODO: Put this assertion back when non-trailing named args fully implemented.
+                        //Debug.Assert(index != mp.Params.Count);
                         CType substDestType = GetTypes().SubstType(@params[index], type, pTypeArgs);
 
                         // If we cant convert the argument and we're the param array argument, then deal with it.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -859,7 +859,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         ////////////////////////////////////////////////////////////////////////////////
         // Given a method group or indexer group, bind it to the arguments for an 
         // invocation.
-        private GroupToArgsBinderResult BindMethodGroupToArgumentsCore(BindingFlag bindFlags, ExprMemberGroup grp, Expr args, int carg, NamedArgumentsType namedArgumentsType)
+        private GroupToArgsBinderResult BindMethodGroupToArgumentsCore(BindingFlag bindFlags, ExprMemberGroup grp, Expr args, int carg, NamedArgumentsKind namedArgumentsKind)
         {
             ArgInfos pargInfo = new ArgInfos {carg = carg};
             FillInArgInfoFromArgList(pargInfo, args);
@@ -867,7 +867,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             ArgInfos pOriginalArgInfo = new ArgInfos {carg = carg};
             FillInArgInfoFromArgList(pOriginalArgInfo, args);
 
-            GroupToArgsBinder binder = new GroupToArgsBinder(this, bindFlags, grp, pargInfo, pOriginalArgInfo, namedArgumentsType);
+            GroupToArgsBinder binder = new GroupToArgsBinder(this, bindFlags, grp, pargInfo, pOriginalArgInfo, namedArgumentsKind);
             binder.Bind();
 
             return binder.GetResultsOfBind();
@@ -887,14 +887,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             // Do we have named arguments specified, are they after fixed arguments (can position) or
             // non-trailing (can rule out methods only).
-            NamedArgumentsType namedType = FindNamedArgumentsType(args);
+            NamedArgumentsKind namedKind = FindNamedArgumentsType(args);
 
-            MethPropWithInst mpwiBest = BindMethodGroupToArgumentsCore(bindFlags, grp, args, carg, namedType).BestResult;
+            MethPropWithInst mpwiBest = BindMethodGroupToArgumentsCore(bindFlags, grp, args, carg, namedKind).BestResult;
             if (grp.SymKind == SYMKIND.SK_PropertySymbol)
             {
                 Debug.Assert((grp.Flags & EXPRFLAG.EXF_INDEXER) != 0);
-                //PropWithType pwt = new PropWithType(mpwiBest.Prop(), mpwiBest.GetType());
-
                 return BindToProperty(grp.OptionalObject, new PropWithType(mpwiBest), bindFlags, args, grp);
             }
 
@@ -903,14 +901,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        public enum NamedArgumentsType
+        public enum NamedArgumentsKind
         {
             None,
             Positioning,
             NonTrailing
         }
 
-        private static NamedArgumentsType FindNamedArgumentsType(Expr args)
+        private static NamedArgumentsKind FindNamedArgumentsType(Expr args)
         {
             Expr list = args;
             while (list != null)
@@ -945,15 +943,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                         if (!(arg is ExprNamedArgumentSpecification))
                         {
-                            return NamedArgumentsType.NonTrailing;
+                            return NamedArgumentsKind.NonTrailing;
                         }
                     }
 
-                    return NamedArgumentsType.Positioning;
+                    return NamedArgumentsKind.Positioning;
                 }
             }
 
-            return NamedArgumentsType.None;
+            return NamedArgumentsKind.None;
         }
 
         ////////////////////////////////////////////////////////////////////////////////

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // iterator will only return propsyms (or methsyms, or whatever)
                 symbmask_t mask = (symbmask_t)(1 << (int)_pGroup.SymKind);
 
-                CMemberLookupResults.CMethodIterator iterator = _pGroup.MemberLookupResults.GetMethodIterator(GetSemanticChecker(), GetSymbolLoader(), GetTypeQualifier(_pGroup), _pExprBinder.ContextForMemberLookup(), _pGroup.TypeArgs.Count, _pGroup.Flags, mask);
+                CMemberLookupResults.CMethodIterator iterator = _pGroup.MemberLookupResults.GetMethodIterator(GetSemanticChecker(), GetSymbolLoader(), GetTypeQualifier(_pGroup), _pExprBinder.ContextForMemberLookup(), _pGroup.TypeArgs.Count, _pGroup.Flags, mask, _namedArgumentsType == NamedArgumentsType.NonTrailing ? _pOriginalArguments : null);
                 while (true)
                 {
                     bool bFoundExpanded;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -1169,7 +1169,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     List<Name> paramNames = _misnamed.MethProp().ParameterNames;
                     for (int i = 0; ; ++i)
                     {
-                        Debug.Assert(i != _pOriginalArguments.carg);
+                        if (i == _pOriginalArguments.carg)
+                        {
+                            // If we're here we had the correct name used for the first params argument.
+                            // Report it as not matching the correct number of arguments below.
+                            break;
+                        }
+
                         if (_pOriginalArguments.prgexpr[i] is ExprNamedArgumentSpecification named)
                         {
                             Name name = named.Name;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -1014,13 +1014,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                 }
                             }
 
-                            if (_pCurrentSym is MethodSymbol meth)
-                            {
-                                // Do not store the result if we have an extension method and the instance 
-                                // parameter isn't convertible.
-
-                                _results.AddInconvertibleResult(meth, _pCurrentType, _pCurrentTypeArgs);
-                            }
                             return false;
                         }
                     }
@@ -1033,18 +1026,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         // If we're an instance method then mark us down.
                         _results.UninferableResult.Set(meth, _pCurrentType, _pCurrentTypeArgs);
                     }
-                }
-                else
-                {
-                    if (_pCurrentSym is MethodSymbol meth)
-                    {
-                        // Do not store the result if we have an extension method and the instance 
-                        // parameter isn't convertible.
 
-                        _results.AddInconvertibleResult(meth, _pCurrentType, _pCurrentTypeArgs);
-                    }
+                    return false;
                 }
-                return !containsErrorSym;
+
+                return true;
             }
 
             private void UpdateArguments()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private readonly ExprMemberGroup _pGroup;
             private readonly ArgInfos _pArguments;
             private readonly ArgInfos _pOriginalArguments;
-            private readonly NamedArgumentsType _namedArgumentsType;
+            private readonly NamedArgumentsKind _namedArgumentsKind;
             private AggregateType _pCurrentType;
             private MethodOrPropertySymbol _pCurrentSym;
             private TypeArray _pCurrentTypeArgs;
@@ -57,7 +57,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private readonly List<CType> _HiddenTypes;
             private bool _bArgumentsChangedForNamedOrOptionalArguments;
 
-            public GroupToArgsBinder(ExpressionBinder exprBinder, BindingFlag bindFlags, ExprMemberGroup grp, ArgInfos args, ArgInfos originalArgs, NamedArgumentsType namedArgumentsType)
+            public GroupToArgsBinder(ExpressionBinder exprBinder, BindingFlag bindFlags, ExprMemberGroup grp, ArgInfos args, ArgInfos originalArgs, NamedArgumentsKind namedArgumentsKind)
             {
                 Debug.Assert(grp != null);
                 Debug.Assert(exprBinder != null);
@@ -69,7 +69,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 _pGroup = grp;
                 _pArguments = args;
                 _pOriginalArguments = originalArgs;
-                _namedArgumentsType = namedArgumentsType;
+                _namedArgumentsKind = namedArgumentsKind;
                 _pCurrentType = null;
                 _pCurrentSym = null;
                 _pCurrentTypeArgs = null;
@@ -137,7 +137,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // iterator will only return propsyms (or methsyms, or whatever)
                 symbmask_t mask = (symbmask_t)(1 << (int)_pGroup.SymKind);
 
-                CMemberLookupResults.CMethodIterator iterator = _pGroup.MemberLookupResults.GetMethodIterator(GetSemanticChecker(), GetSymbolLoader(), GetTypeQualifier(_pGroup), _pExprBinder.ContextForMemberLookup(), _pGroup.TypeArgs.Count, _pGroup.Flags, mask, _namedArgumentsType == NamedArgumentsType.NonTrailing ? _pOriginalArguments : null);
+                CMemberLookupResults.CMethodIterator iterator = _pGroup.MemberLookupResults.GetMethodIterator(GetSemanticChecker(), GetSymbolLoader(), GetTypeQualifier(_pGroup), _pExprBinder.ContextForMemberLookup(), _pGroup.TypeArgs.Count, _pGroup.Flags, mask, _namedArgumentsKind == NamedArgumentsKind.NonTrailing ? _pOriginalArguments : null);
                 while (true)
                 {
                     bool bFoundExpanded;
@@ -173,7 +173,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     // If we have named arguments, reorder them for this method.
                     // If we don't have Exprs, its because we're doing a method group conversion.
                     // In those scenarios, we never want to add named arguments or optional arguments.
-                    if (_namedArgumentsType == NamedArgumentsType.Positioning)
+                    if (_namedArgumentsKind == NamedArgumentsKind.Positioning)
                     {
                         if (!ReOrderArgsForNamedArguments())
                         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                     // If we cant use the current symbol, then we've filtered it, so get the next one.
 
-                    if (!iterator.CanUseCurrentSymbol())
+                    if (!iterator.CanUseCurrentSymbol)
                     {
                         continue;
                     }
@@ -215,7 +215,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
 
                     // Check access.
-                    bool fCanAccess = !iterator.IsCurrentSymbolInaccessible();
+                    bool fCanAccess = !iterator.IsCurrentSymbolInaccessible;
                     if (!fCanAccess && (!_methList.IsEmpty() || _results.GetInaccessibleResult()))
                     {
                         // We'll never use this one for error reporting anyway, so just skip it.
@@ -224,7 +224,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
 
                     // Check bogus.
-                    bool fBogus = fCanAccess && iterator.IsCurrentSymbolBogus();
+                    bool fBogus = fCanAccess && iterator.IsCurrentSymbolBogus;
                     if (fBogus && (!_methList.IsEmpty() || _results.GetInaccessibleResult() || _mpwiBogus))
                     {
                         // We'll never use this one for error reporting anyway, so just skip it.
@@ -826,8 +826,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     return false;
                 }
-                _pCurrentSym = iterator.GetCurrentSymbol();
-                AggregateType type = iterator.GetCurrentType();
+                _pCurrentSym = iterator.CurrentSymbol;
+                AggregateType type = iterator.CurrentType;
 
                 // If our current type is null, this is our first iteration, so set the type.
                 // If our current type is not null, and we've got a new type now, and we've already matched
@@ -848,11 +848,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 while (_HiddenTypes.Contains(_pCurrentType))
                 {
                     // Move through this type and get the next one.
-                    for (; iterator.GetCurrentType() == _pCurrentType; iterator.MoveNext()) ;
-                    _pCurrentSym = iterator.GetCurrentSymbol();
-                    _pCurrentType = iterator.GetCurrentType();
+                    for (; iterator.CurrentType == _pCurrentType; iterator.MoveNext()) ;
+                    _pCurrentSym = iterator.CurrentSymbol;
+                    _pCurrentType = iterator.CurrentType;
 
-                    if (iterator.AtEnd())
+                    if (iterator.AtEnd)
                     {
                         return false;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private readonly ExprMemberGroup _pGroup;
             private readonly ArgInfos _pArguments;
             private readonly ArgInfos _pOriginalArguments;
-            private readonly bool _bHasNamedArguments;
+            private readonly NamedArgumentsType _namedArgumentsType;
             private AggregateType _pCurrentType;
             private MethodOrPropertySymbol _pCurrentSym;
             private TypeArray _pCurrentTypeArgs;
@@ -55,7 +55,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private readonly List<CType> _HiddenTypes;
             private bool _bArgumentsChangedForNamedOrOptionalArguments;
 
-            public GroupToArgsBinder(ExpressionBinder exprBinder, BindingFlag bindFlags, ExprMemberGroup grp, ArgInfos args, ArgInfos originalArgs, bool bHasNamedArguments)
+            public GroupToArgsBinder(ExpressionBinder exprBinder, BindingFlag bindFlags, ExprMemberGroup grp, ArgInfos args, ArgInfos originalArgs, NamedArgumentsType namedArgumentsType)
             {
                 Debug.Assert(grp != null);
                 Debug.Assert(exprBinder != null);
@@ -67,7 +67,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 _pGroup = grp;
                 _pArguments = args;
                 _pOriginalArguments = originalArgs;
-                _bHasNamedArguments = bHasNamedArguments;
+                _namedArgumentsType = namedArgumentsType;
                 _pCurrentType = null;
                 _pCurrentSym = null;
                 _pCurrentTypeArgs = null;
@@ -170,7 +170,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     // If we have named arguments, reorder them for this method.
                     // If we don't have Exprs, its because we're doing a method group conversion.
                     // In those scenarios, we never want to add named arguments or optional arguments.
-                    if (_bHasNamedArguments)
+                    if (_namedArgumentsType == NamedArgumentsType.Positioning)
                     {
                         if (!ReOrderArgsForNamedArguments())
                         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -1166,7 +1166,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     // Get exception immediately for the non-trailing named argument being misplaced.
                     // Handle below for the name not being present at all.
-                    List<Name> paramNames = _misnamed.MethProp().ParameterNames;
+                    List<Name> paramNames = FindMostDerivedMethod(_misnamed.MethProp(), _pGroup.OptionalObject).ParameterNames;
                     for (int i = 0; ; ++i)
                     {
                         if (i == _pOriginalArguments.carg)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -134,9 +134,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // iterator will only return propsyms (or methsyms, or whatever)
                 symbmask_t mask = (symbmask_t)(1 << (int)_pGroup.SymKind);
 
-                CType pTypeThrough = _pGroup.OptionalObject?.Type;
-                CMemberLookupResults.CMethodIterator iterator = _pGroup.MemberLookupResults.GetMethodIterator(GetSemanticChecker(), GetSymbolLoader(), pTypeThrough, GetTypeQualifier(_pGroup), _pExprBinder.ContextForMemberLookup(), true, // AllowBogusAndInaccessible
-                    false, _pGroup.TypeArgs.Count, _pGroup.Flags, mask);
+                CMemberLookupResults.CMethodIterator iterator = _pGroup.MemberLookupResults.GetMethodIterator(GetSemanticChecker(), GetSymbolLoader(), GetTypeQualifier(_pGroup), _pExprBinder.ContextForMemberLookup(), _pGroup.TypeArgs.Count, _pGroup.Flags, mask);
                 while (true)
                 {
                     bool bFoundExpanded;
@@ -824,7 +822,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // return false.
             private bool GetNextSym(CMemberLookupResults.CMethodIterator iterator)
             {
-                if (!iterator.MoveNext(_methList.IsEmpty()))
+                if (!iterator.MoveNext())
                 {
                     return false;
                 }
@@ -850,7 +848,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 while (_HiddenTypes.Contains(_pCurrentType))
                 {
                     // Move through this type and get the next one.
-                    for (; iterator.GetCurrentType() == _pCurrentType; iterator.MoveNext(_methList.IsEmpty())) ;
+                    for (; iterator.GetCurrentType() == _pCurrentType; iterator.MoveNext()) ;
                     _pCurrentSym = iterator.GetCurrentSymbol();
                     _pCurrentType = iterator.GetCurrentType();
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
@@ -16,38 +16,20 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         internal sealed class GroupToArgsBinderResult
         {
             public MethPropWithInst BestResult { get; set; }
+
             public MethPropWithInst AmbiguousResult { get; set; }
+
             public MethPropWithInst InaccessibleResult { get; }
+
             public MethPropWithInst UninferableResult { get; }
-            private MethPropWithInst InconvertibleResult;
+
             public GroupToArgsBinderResult()
             {
                 BestResult = new MethPropWithInst();
                 AmbiguousResult = new MethPropWithInst();
                 InaccessibleResult = new MethPropWithInst();
                 UninferableResult = new MethPropWithInst();
-                InconvertibleResult = new MethPropWithInst();
-                _inconvertibleResults = new List<MethPropWithInst>();
             }
-
-            private readonly List<MethPropWithInst> _inconvertibleResults;
-
-            /////////////////////////////////////////////////////////////////////////////////
-
-            public void AddInconvertibleResult(
-                MethodSymbol method,
-                AggregateType currentType,
-                TypeArray currentTypeArgs)
-            {
-                if (InconvertibleResult.Sym == null)
-                {
-                    // This is the first one, so set it for error reporting usage.
-                    InconvertibleResult.Set(method, currentType, currentTypeArgs);
-                }
-                _inconvertibleResults.Add(new MethPropWithInst(method, currentType, currentTypeArgs));
-            }
-
-            /////////////////////////////////////////////////////////////////////////////////
 
             private static int NumberOfErrorTypes(TypeArray pTypeArgs)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
@@ -15,14 +15,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         internal sealed class GroupToArgsBinderResult
         {
-            public MethPropWithInst BestResult;
-            public MethPropWithInst GetBestResult() { return BestResult; }
-            public MethPropWithInst AmbiguousResult;
-            public MethPropWithInst GetAmbiguousResult() { return AmbiguousResult; }
-            private MethPropWithInst InaccessibleResult;
-            public MethPropWithInst GetInaccessibleResult() { return InaccessibleResult; }
-            private MethPropWithInst UninferableResult;
-            public MethPropWithInst GetUninferableResult() { return UninferableResult; }
+            public MethPropWithInst BestResult { get; set; }
+            public MethPropWithInst AmbiguousResult { get; set; }
+            public MethPropWithInst InaccessibleResult { get; }
+            public MethPropWithInst UninferableResult { get; }
             private MethPropWithInst InconvertibleResult;
             public GroupToArgsBinderResult()
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -47,7 +47,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private Name _name;
         private int _arity;
         private MemLookFlags _flags;
-        private CMemberLookupResults _results;
 
         // For maintaining the type array. We throw the first 8 or so here.
         private readonly List<AggregateType> _rgtypeStart;
@@ -603,15 +602,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
             }
 
-            // if we are requested with extension methods
-            _results = new CMemberLookupResults(GetAllTypes(), _name);
-
             return !FError();
-        }
-
-        public CMemberLookupResults GetResults()
-        {
-            return _results;
         }
 
         // Whether there were errors.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookupResults.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookupResults.cs
@@ -22,12 +22,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 TypeArray containingTypes,
                 Name name)
         {
+            Debug.Assert(containingTypes != null);
+            Debug.Assert(containingTypes.Count != 0);
             _pName = name;
             ContainingTypes = containingTypes;
-            if (ContainingTypes == null)
-            {
-                ContainingTypes = BSYMMGR.EmptyTypeArray();
-            }
         }
 
         public CMethodIterator GetMethodIterator(

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookupResults.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookupResults.cs
@@ -29,10 +29,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         public CMethodIterator GetMethodIterator(
-            CSemanticChecker pChecker, SymbolLoader pSymLoader, CType pObject, CType pQualifyingType, AggregateDeclaration pContext, bool allowBogusAndInaccessible, bool allowExtensionMethods, int arity, EXPRFLAG flags, symbmask_t mask)
+            CSemanticChecker pChecker, SymbolLoader pSymLoader, CType pQualifyingType, AggregateDeclaration pContext, int arity, EXPRFLAG flags, symbmask_t mask)
         {
             Debug.Assert(pSymLoader != null);
-            CMethodIterator iterator = new CMethodIterator(pChecker, pSymLoader, _pName, ContainingTypes, pObject, pQualifyingType, pContext, allowBogusAndInaccessible, allowExtensionMethods, arity, flags, mask);
+            CMethodIterator iterator = new CMethodIterator(pChecker, pSymLoader, _pName, ContainingTypes, pQualifyingType, pContext, arity, flags, mask);
             return iterator;
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookupResults.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookupResults.cs
@@ -29,10 +29,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         public CMethodIterator GetMethodIterator(
-            CSemanticChecker pChecker, SymbolLoader pSymLoader, CType pQualifyingType, AggregateDeclaration pContext, int arity, EXPRFLAG flags, symbmask_t mask)
+            CSemanticChecker pChecker, SymbolLoader pSymLoader, CType pQualifyingType, AggregateDeclaration pContext, int arity, EXPRFLAG flags, symbmask_t mask, ArgInfos nonTrailingNamedArguments)
         {
             Debug.Assert(pSymLoader != null);
-            CMethodIterator iterator = new CMethodIterator(pChecker, pSymLoader, _pName, ContainingTypes, pQualifyingType, pContext, arity, flags, mask);
+            CMethodIterator iterator = new CMethodIterator(pChecker, pSymLoader, _pName, ContainingTypes, pQualifyingType, pContext, arity, flags, mask, nonTrailingNamedArguments);
             return iterator;
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // Internal state.
             private int _nCurrentTypeCount;
             private bool _bIsCheckingInstanceMethods;
-            private bool _bAtEnd;
             // Flags for the current sym.
             private bool _bCurrentSymIsBogus;
             private bool _bCurrentSymIsInaccessible;
@@ -51,7 +50,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 _mask = mask;
                 _nCurrentTypeCount = 0;
                 _bIsCheckingInstanceMethods = true;
-                _bAtEnd = false;
                 _bCurrentSymIsBogus = false;
                 _bCurrentSymIsInaccessible = false;
             }
@@ -71,28 +69,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return _bCurrentSymIsBogus;
             }
-            public bool MoveNext(bool canIncludeExtensionsInResults)
-            {
-                if (_bAtEnd)
-                {
-                    return false;
-                }
 
-                if (_pCurrentType == null && !FindNextTypeForInstanceMethods())
-                {
-                    // No instance or extensions.
+            public bool MoveNext(bool canIncludeExtensionsInResults) => (_pCurrentType != null || FindNextTypeForInstanceMethods()) && FindNextMethod();
 
-                    _bAtEnd = true;
-                    return false;
-                }
-
-                if (!FindNextMethod())
-                {
-                    _bAtEnd = true;
-                    return false;
-                }
-                return true;
-            }
             public bool AtEnd()
             {
                 return _pCurrentSym == null;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -76,14 +76,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return _pCurrentSym == null;
             }
-            private CSemanticChecker GetSemanticChecker()
-            {
-                return _pSemanticChecker;
-            }
-            private SymbolLoader GetSymbolLoader()
-            {
-                return _pSymbolLoader;
-            }
+
             public bool CanUseCurrentSymbol()
             {
                 // Make sure that whether we're seeing a ctor is consistent with the flag.
@@ -110,7 +103,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 // Check access. If Sym is not accessible, then let it through and mark it.
-                _bCurrentSymIsInaccessible = !GetSemanticChecker().CheckAccess(_pCurrentSym, _pCurrentType, _pContext, _pQualifyingType);
+                _bCurrentSymIsInaccessible = !_pSemanticChecker.CheckAccess(_pCurrentSym, _pCurrentType, _pContext, _pQualifyingType);
 
                 // Check bogus. If Sym is bogus, then let it through and mark it.
                 _bCurrentSymIsBogus = CSemanticChecker.CheckBogus(_pCurrentSym);
@@ -123,7 +116,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 while (true)
                 {
                     _pCurrentSym = (_pCurrentSym == null
-                        ? GetSymbolLoader().LookupAggMember(_pName, _pCurrentType.getAggregate(), _mask)
+                        ? _pSymbolLoader.LookupAggMember(_pName, _pCurrentType.getAggregate(), _mask)
                         : SymbolLoader.LookupNextSym(_pCurrentSym, _pCurrentType.getAggregate(), _mask)) as MethodOrPropertySymbol;
 
                     // If we couldn't find a sym, we look up the type chain and get the next type.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 if (args != null)
                 {
                     List<Name> paramNames = ExpressionBinder.GroupToArgsBinder
-                        .FindMostDerivedMethod(_symbolLoader, CurrentSymbol, CurrentSymbol.getType())
+                        .FindMostDerivedMethod(_symbolLoader, CurrentSymbol, _qualifyingType)
                         .ParameterNames;
 
                     List<Expr> argExpressions = args.prgexpr;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -101,25 +101,23 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private bool CheckArgumentNames()
             {
                 ArgInfos args = _nonTrailingNamedArguments;
-                if (args == null)
+                if (args != null)
                 {
-                    return true;
-                }
+                    List<Name> paramNames = ExpressionBinder.GroupToArgsBinder
+                        .FindMostDerivedMethod(_symbolLoader, CurrentSymbol, CurrentSymbol.getType())
+                        .ParameterNames;
 
-                List<Name> paramNames = ExpressionBinder.GroupToArgsBinder
-                    .FindMostDerivedMethod(_symbolLoader, CurrentSymbol, CurrentSymbol.getType())
-                    .ParameterNames;
-
-                List<Expr> argExpressions = args.prgexpr;
-                for (int i = 0; i < args.carg; i++)
-                {
-                    if (argExpressions[i] is ExprNamedArgumentSpecification named && paramNames[i] != named.Name)
+                    List<Expr> argExpressions = args.prgexpr;
+                    for (int i = 0; i < args.carg; i++)
                     {
-                        return false;
+                        if (argExpressions[i] is ExprNamedArgumentSpecification named && paramNames[i] != named.Name)
+                        {
+                            return true;
+                        }
                     }
                 }
 
-                return true;
+                return false;
             }
 
             private bool FindNextMethod()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(symLoader != null);
                 Debug.Assert(checker != null);
                 Debug.Assert(containingTypes != null);
+                Debug.Assert(containingTypes.Count != 0);
                 _pSemanticChecker = checker;
                 _pSymbolLoader = symLoader;
                 _pCurrentType = null;
@@ -77,26 +78,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
                 }
 
-                if (_pCurrentType == null) // First guy.
+                if (_pCurrentType == null && !FindNextTypeForInstanceMethods())
                 {
-                    if (_pContainingTypes.Count == 0)
-                    {
-                        // No instance methods, only extensions.
-                        _bIsCheckingInstanceMethods = false;
-                        _bAtEnd = true;
-                        return false;
-                    }
-                    else
-                    {
-                        if (!FindNextTypeForInstanceMethods())
-                        {
-                            // No instance or extensions.
+                    // No instance or extensions.
 
-                            _bAtEnd = true;
-                            return false;
-                        }
-                    }
+                    _bAtEnd = true;
+                    return false;
                 }
+
                 if (!FindNextMethod())
                 {
                     _bAtEnd = true;
@@ -187,26 +176,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             private bool FindNextTypeForInstanceMethods()
             {
-                // Otherwise, search through other types listed as well as our base class.
-                if (_pContainingTypes.Count > 0)
+                if (_nCurrentTypeCount >= _pContainingTypes.Count)
                 {
-                    if (_nCurrentTypeCount >= _pContainingTypes.Count)
-                    {
-                        // No more types to check.
-                        _pCurrentType = null;
-                    }
-                    else
-                    {
-                        _pCurrentType = _pContainingTypes[_nCurrentTypeCount++] as AggregateType;
-                    }
+                    // No more types to check.
+                    _pCurrentType = null;
+                    return false;
                 }
-                else
-                {
-                    // We have no more types to consider, so check out the base class.
 
-                    _pCurrentType = _pCurrentType.GetBaseClass();
-                }
-                return _pCurrentType != null;
+                _pCurrentType = _pContainingTypes[_nCurrentTypeCount++] as AggregateType;
+                return true;
             }
         }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private bool _bCurrentSymIsBogus;
             private bool _bCurrentSymIsInaccessible;
 
-            public CMethodIterator(CSemanticChecker checker, SymbolLoader symLoader, Name name, TypeArray containingTypes, CType @object, CType qualifyingType, AggregateDeclaration context, bool allowBogusAndInaccessible, bool allowExtensionMethods, int arity, EXPRFLAG flags, symbmask_t mask)
+            public CMethodIterator(CSemanticChecker checker, SymbolLoader symLoader, Name name, TypeArray containingTypes, CType qualifyingType, AggregateDeclaration context, int arity, EXPRFLAG flags, symbmask_t mask)
             {
                 Debug.Assert(name != null);
                 Debug.Assert(symLoader != null);
@@ -70,7 +70,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return _bCurrentSymIsBogus;
             }
 
-            public bool MoveNext(bool canIncludeExtensionsInResults) => (_pCurrentType != null || FindNextTypeForInstanceMethods()) && FindNextMethod();
+            public bool MoveNext() => (_pCurrentType != null || FindNextTypeForInstanceMethods()) && FindNextMethod();
 
             public bool AtEnd()
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -110,9 +110,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     List<Expr> argExpressions = args.prgexpr;
                     for (int i = 0; i < args.carg; i++)
                     {
-                        if (argExpressions[i] is ExprNamedArgumentSpecification named && paramNames[i] != named.Name)
+                        if (argExpressions[i] is ExprNamedArgumentSpecification named)
                         {
-                            return true;
+                            // Either wrong name, or correct name but we have more params arguments to follow.
+                            if (paramNames[i] != named.Name || i == paramNames.Count - 1 && i != args.carg - 1)
+                            {
+                                return true;
+                            }
                         }
                     }
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -11,16 +11,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     {
         public partial class CMethodIterator
         {
-            private SymbolLoader _pSymbolLoader;
-            private CSemanticChecker _pSemanticChecker;
+            private readonly SymbolLoader _pSymbolLoader;
+            private readonly CSemanticChecker _pSemanticChecker;
             // Inputs.
-            private AggregateDeclaration _pContext;
-            private TypeArray _pContainingTypes;
-            private CType _pQualifyingType;
-            private Name _pName;
-            private int _nArity;
-            private symbmask_t _mask;
-            private EXPRFLAG _flags;
+            private readonly AggregateDeclaration _pContext;
+            private readonly TypeArray _pContainingTypes;
+            private readonly CType _pQualifyingType;
+            private readonly Name _pName;
+            private readonly int _nArity;
+            private readonly symbmask_t _mask;
+            private readonly EXPRFLAG _flags;
             // Internal state.
             private int _nCurrentTypeCount;
 

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -221,7 +221,7 @@
     <value>The operand of an increment or decrement operator must be a variable, property or indexer</value>
   </data>
   <data name="BadArgCount" xml:space="preserve">
-    <value>No overload for method '{0}' takes '{1}' arguments</value>
+    <value>No overload for method '{0}' takes {1} arguments</value>
   </data>
   <data name="BadArgTypes" xml:space="preserve">
     <value>The best overloaded method match for '{0}' has some invalid arguments</value>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -256,9 +256,6 @@
   <data name="NonInvocableMemberCalled" xml:space="preserve">
     <value>Non-invocable member '{0}' cannot be used like a method.</value>
   </data>
-  <data name="NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>Named argument specifications must appear after all fixed arguments have been specified</value>
-  </data>
   <data name="BadNamedArgument" xml:space="preserve">
     <value>The best overload for '{0}' does not have a parameter named '{1}'</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -277,4 +277,7 @@
   <data name="BindingNameCollision" xml:space="preserve">
     <value>More than one type in the binding has the same full name.</value>
   </data>
+  <data name="BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
 </root>

--- a/src/Microsoft.CSharp/tests/BindingErrors.cs
+++ b/src/Microsoft.CSharp/tests/BindingErrors.cs
@@ -376,40 +376,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        public void NamedArgumentBeforeFixedStatic()
-        {
-            CallSite<Func<CallSite, object, object, object, object>> site =
-                CallSite<Func<CallSite, object, object, object, object>>.Create(
-                    Binder.InvokeMember(
-                        CSharpBinderFlags.None, "Equals", null, GetType(),
-                        new[]
-                        {
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "objA"),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
-                        }));
-            Func<CallSite, object, object, object, object> target = site.Target;
-            Assert.Throws<RuntimeBinderException>(() => target.Invoke(site, typeof(object), 2, 2));
-        }
-
-        [Fact]
-        public void NamedArgumentBeforeFixedInstance()
-        {
-            CallSite<Func<CallSite, object, object, object, object>> site =
-                CallSite<Func<CallSite, object, object, object, object>>.Create(
-                    Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(
-                        CSharpBinderFlags.None, "Equals", null, GetType(),
-                        new[]
-                        {
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "x"),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
-                        }));
-            Func<CallSite, object, object, object, object> target = site.Target;
-            Assert.Throws<RuntimeBinderException>(() => target.Invoke(site, EqualityComparer<int>.Default, 2, 2));
-        }
-
-        [Fact]
         public void DuplicateNamedArgument()
         {
             CallSite<Func<CallSite, object, object, object, object>> site =

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -18,6 +18,7 @@
     <Compile Include="IntegerBinaryOperationTests.cs" />
     <Compile Include="IntegerUnaryOperationTests.cs" />
     <Compile Include="IsEventTests.cs" />
+    <Compile Include="NamedArgumentTests.cs" />
     <Compile Include="NullableEnumUnaryOperationTest.cs" />
     <Compile Include="RuntimeBinderExceptionTests.cs" />
     <Compile Include="RuntimeBinderInternalCompilerExceptionTests.cs" />

--- a/src/Microsoft.CSharp/tests/NamedArgumentTests.cs
+++ b/src/Microsoft.CSharp/tests/NamedArgumentTests.cs
@@ -17,6 +17,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             public long DoStuff(long z, long a) => z * a;
 
             public int DoStuff(string s, int i) => i;
+
+            public int DoOtherStuff(int x, int y, int z) => x * y + z;
         }
 
         [Fact]
@@ -96,6 +98,107 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14)).Message;
             //  The best overload for 'DoStuff' does not have a parameter named 'nada'
             Assert.Contains("'DoStuff'", message);
+            Assert.Contains("'nada'", message);
+        }
+
+        [Fact]
+        public void NameOnlyFirstArgumentWrongPlace()
+        {
+            CallSite<Func<CallSite, object, object, object, object>> callsite =
+                CallSite<Func<CallSite, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, nameof(TypeWithMethods.DoStuff), Type.EmptyTypes, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "y"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                        }));
+            Func<CallSite, object, object, object, object> target = callsite.Target;
+            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14)).Message;
+            //  Named argument 'y' is used out-of-position but is followed by an unnamed argument
+            Assert.Contains("'y'", message);
+        }
+
+        [Fact]
+        public void NameOnlyFirstAndSecondWithSecondArgumentWrongPlace()
+        {
+            CallSite<Func<CallSite, object, object, object, object, object>> callsite =
+                CallSite<Func<CallSite, object, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, nameof(TypeWithMethods.DoOtherStuff), Type.EmptyTypes, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "x"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "z"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                        }));
+            Func<CallSite, object, object, object, object, object> target = callsite.Target;
+            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 13)).Message;
+            //  Named argument 'z' is used out-of-position but is followed by an unnamed argument
+            Assert.Contains("'z'", message);
+        }
+
+        [Fact]
+        public void NameOnlyFirstAndSecondWithSecondArgumentNotFound()
+        {
+            CallSite<Func<CallSite, object, object, object, object, object>> callsite =
+                CallSite<Func<CallSite, object, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, nameof(TypeWithMethods.DoOtherStuff), Type.EmptyTypes, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "x"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "nada"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                        }));
+            Func<CallSite, object, object, object, object, object> target = callsite.Target;
+            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 12)).Message;
+            //  The best overload for 'DoMoreStuff' does not have a parameter named 'nada'
+            Assert.Contains("'DoOtherStuff'", message);
+            Assert.Contains("'nada'", message);
+        }
+
+        [Fact]
+        public void NameOnlySecondWithSecondArgumentWrongPlace()
+        {
+            CallSite<Func<CallSite, object, object, object, object, object>> callsite =
+                CallSite<Func<CallSite, object, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, nameof(TypeWithMethods.DoOtherStuff), Type.EmptyTypes, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "z"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                        }));
+            Func<CallSite, object, object, object, object, object> target = callsite.Target;
+            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 13)).Message;
+            //  Named argument 'z' is used out-of-position but is followed by an unnamed argument
+            Assert.Contains("'z'", message);
+        }
+
+        [Fact]
+        public void NameOnlySecondWithSecondArgumentNotFound()
+        {
+            CallSite<Func<CallSite, object, object, object, object, object>> callsite =
+                CallSite<Func<CallSite, object, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, nameof(TypeWithMethods.DoOtherStuff), Type.EmptyTypes, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "nada"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                        }));
+            Func<CallSite, object, object, object, object, object> target = callsite.Target;
+            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 12)).Message;
+            //  The best overload for 'DoMoreStuff' does not have a parameter named 'nada'
+            Assert.Contains("'DoOtherStuff'", message);
             Assert.Contains("'nada'", message);
         }
     }

--- a/src/Microsoft.CSharp/tests/NamedArgumentTests.cs
+++ b/src/Microsoft.CSharp/tests/NamedArgumentTests.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public class NamedArgumentTests
+    {
+        public class TypeWithMethods
+        {
+            public int DoStuff(int x, int y) => x + y;
+
+            public long DoStuff(long z, long a) => z * a;
+
+            public int DoStuff(string s, int i) => i;
+        }
+
+        [Fact]
+        public void OnlyNameFirstArgument()
+        {
+            CallSite<Func<CallSite, object, object, object, object>> callsite =
+                CallSite<Func<CallSite, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, nameof(TypeWithMethods.DoStuff), Type.EmptyTypes, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "x"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                        }));
+            Func<CallSite, object, object, object, object> target = callsite.Target;
+            object res = target(callsite, new TypeWithMethods(), 9, 14);
+            Assert.Equal(23, res);
+        }
+
+        [Fact]
+        public void OnlyNameFirstArgumentMatchesWrongType()
+        {
+            CallSite<Func<CallSite, object, object, object, object>> callsite =
+                CallSite<Func<CallSite, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, nameof(TypeWithMethods.DoStuff), Type.EmptyTypes, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "s"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                        }));
+            Func<CallSite, object, object, object, object> target = callsite.Target;
+            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14))
+                .Message;
+
+            // All but the (string, int) method should have been excluded from consideration, leaving the binder to
+            // complain about it not matching types.
+            Assert.Contains(
+                "'Microsoft.CSharp.RuntimeBinder.Tests.NamedArgumentTests.TypeWithMethods.DoStuff(string, int)'",
+                message);
+        }
+
+        [Fact]
+        public void ResolveThroughNameOnlyFirstArgument()
+        {
+            CallSite<Func<CallSite, object, object, object, object>> callsite =
+                CallSite<Func<CallSite, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, nameof(TypeWithMethods.DoStuff), Type.EmptyTypes, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "z"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                        }));
+            Func<CallSite, object, object, object, object> target = callsite.Target;
+            object res = target(callsite, new TypeWithMethods(), 9, 14);
+            Assert.Equal(126L, res);
+        }
+
+        [Fact]
+        public void NonExistentNameOnlyFirstArgument()
+        {
+            CallSite<Func<CallSite, object, object, object, object>> callsite =
+                CallSite<Func<CallSite, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, nameof(TypeWithMethods.DoStuff), Type.EmptyTypes, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "nada"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                        }));
+            Func<CallSite, object, object, object, object> target = callsite.Target;
+            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14)).Message;
+            //  The best overload for 'DoStuff' does not have a parameter named 'nada'
+            Assert.Contains("'DoStuff'", message);
+            Assert.Contains("'nada'", message);
+        }
+    }
+}

--- a/src/Microsoft.CSharp/tests/NamedArgumentTests.cs
+++ b/src/Microsoft.CSharp/tests/NamedArgumentTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -30,9 +31,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                         CSharpBinderFlags.None, nameof(TypeWithMethods.DoStuff), Type.EmptyTypes, GetType(),
                         new[]
                         {
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "x"),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
                         }));
             Func<CallSite, object, object, object, object> target = callsite.Target;
             object res = target(callsite, new TypeWithMethods(), 9, 14);
@@ -48,9 +49,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                         CSharpBinderFlags.None, nameof(TypeWithMethods.DoStuff), Type.EmptyTypes, GetType(),
                         new[]
                         {
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "s"),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
                         }));
             Func<CallSite, object, object, object, object> target = callsite.Target;
             string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14))
@@ -72,9 +73,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                         CSharpBinderFlags.None, nameof(TypeWithMethods.DoStuff), Type.EmptyTypes, GetType(),
                         new[]
                         {
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "z"),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
                         }));
             Func<CallSite, object, object, object, object> target = callsite.Target;
             object res = target(callsite, new TypeWithMethods(), 9, 14);
@@ -90,12 +91,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                         CSharpBinderFlags.None, nameof(TypeWithMethods.DoStuff), Type.EmptyTypes, GetType(),
                         new[]
                         {
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "nada"),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
                         }));
             Func<CallSite, object, object, object, object> target = callsite.Target;
-            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14)).Message;
+            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14))
+                .Message;
+
             //  The best overload for 'DoStuff' does not have a parameter named 'nada'
             Assert.Contains("'DoStuff'", message);
             Assert.Contains("'nada'", message);
@@ -110,12 +113,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                         CSharpBinderFlags.None, nameof(TypeWithMethods.DoStuff), Type.EmptyTypes, GetType(),
                         new[]
                         {
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "y"),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
                         }));
             Func<CallSite, object, object, object, object> target = callsite.Target;
-            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14)).Message;
+            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14))
+                .Message;
+
             //  Named argument 'y' is used out-of-position but is followed by an unnamed argument
             Assert.Contains("'y'", message);
         }
@@ -129,13 +134,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                         CSharpBinderFlags.None, nameof(TypeWithMethods.DoOtherStuff), Type.EmptyTypes, GetType(),
                         new[]
                         {
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "x"),
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "z"),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
                         }));
             Func<CallSite, object, object, object, object, object> target = callsite.Target;
-            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 13)).Message;
+            string message = Assert
+                .Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 13))
+                .Message;
+
             //  Named argument 'z' is used out-of-position but is followed by an unnamed argument
             Assert.Contains("'z'", message);
         }
@@ -149,13 +157,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                         CSharpBinderFlags.None, nameof(TypeWithMethods.DoOtherStuff), Type.EmptyTypes, GetType(),
                         new[]
                         {
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "x"),
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "nada"),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
                         }));
             Func<CallSite, object, object, object, object, object> target = callsite.Target;
-            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 12)).Message;
+            string message = Assert
+                .Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 12))
+                .Message;
+
             //  The best overload for 'DoMoreStuff' does not have a parameter named 'nada'
             Assert.Contains("'DoOtherStuff'", message);
             Assert.Contains("'nada'", message);
@@ -170,13 +181,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                         CSharpBinderFlags.None, nameof(TypeWithMethods.DoOtherStuff), Type.EmptyTypes, GetType(),
                         new[]
                         {
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "z"),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
                         }));
             Func<CallSite, object, object, object, object, object> target = callsite.Target;
-            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 13)).Message;
+            string message = Assert
+                .Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 13))
+                .Message;
+
             //  Named argument 'z' is used out-of-position but is followed by an unnamed argument
             Assert.Contains("'z'", message);
         }
@@ -190,16 +204,982 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                         CSharpBinderFlags.None, nameof(TypeWithMethods.DoOtherStuff), Type.EmptyTypes, GetType(),
                         new[]
                         {
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, ""),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "nada"),
-                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, "")
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
                         }));
             Func<CallSite, object, object, object, object, object> target = callsite.Target;
-            string message = Assert.Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 12)).Message;
+            string message = Assert
+                .Throws<RuntimeBinderException>(() => target(callsite, new TypeWithMethods(), 9, 14, 12))
+                .Message;
+
             //  The best overload for 'DoMoreStuff' does not have a parameter named 'nada'
             Assert.Contains("'DoOtherStuff'", message);
             Assert.Contains("'nada'", message);
+        }
+
+        // Tests based on the static tests for Roslyn.
+        class C1
+        {
+            static void M(int a, int b)
+            {
+                Console.Write($"First {a} {b}. ");
+            }
+
+            static void M(long b, long a)
+            {
+                Console.Write($"Second {b} {a}. ");
+            }
+        }
+
+        [Fact]
+        public void TestSimple()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            CallSite<Action<CallSite, Type, int, int>> callsite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C1),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "a"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                    }));
+            callsite.Target(callsite, typeof(C1), 1, 2);
+            callsite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C1),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "a")
+                    }));
+            callsite.Target(callsite, typeof(C1), 3, 4);
+            Assert.Equal("First 1 2. Second 3 4. ", console.ToString());
+        }
+
+        class C2
+        {
+            C2(int a, int b)
+            {
+                Console.Write($"{a} {b}.");
+            }
+        }
+
+        [Fact]
+        public void TestSimpleConstructor()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            CallSite<Func<CallSite, Type, int, int, C2>> callsite = CallSite<Func<CallSite, Type, int, int, C2>>.Create(
+                Binder.InvokeConstructor(
+                    CSharpBinderFlags.None, typeof(C2),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.UseCompileTimeType | CSharpArgumentInfoFlags.IsStaticType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.UseCompileTimeType | CSharpArgumentInfoFlags.NamedArgument, "a"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                    }));
+            callsite.Target(callsite, typeof(C2), 1, 2);
+            Assert.Equal("1 2.", console.ToString());
+        }
+
+        class C3
+        {
+            public delegate void MyDelegate(int a, int b);
+
+            public MyDelegate e;
+
+            static void M(int a, int b)
+            {
+                Console.Write($"{a} {b}. ");
+            }
+
+            public C3()
+            {
+                e += M;
+            }
+        }
+
+        [Fact]
+        public void TestSimpleDelegate()
+        {
+            // This test differs from its static equivalent considerably, as some event-related matters aren't as directly
+            // applicable. We can use it for checking both direct and deferred delegate invocation.
+
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            C3 targetObject = new C3();
+            CallSite<Func<CallSite, object, object>> getCallSite = CallSite<Func<CallSite, object, object>>.Create(
+                Binder.GetMember(
+                    CSharpBinderFlags.None, "e", typeof(C3),
+                    new[] {CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)}));
+            object dele = getCallSite.Target(getCallSite, targetObject);
+            CallSite<Action<CallSite, object, int, int>> invokeCallSite =
+                CallSite<Action<CallSite, object, int, int>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "Invoke", Type.EmptyTypes, typeof(C3),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                "a"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        }));
+            invokeCallSite.Target(invokeCallSite, dele, 1, 2);
+            invokeCallSite = CallSite<Action<CallSite, object, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "e", Type.EmptyTypes, typeof(C3),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "a"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                    }));
+            invokeCallSite.Target(invokeCallSite, targetObject, 1, 2);
+            Assert.Equal("1 2. 1 2. ", console.ToString());
+        }
+
+        class C4
+        {
+            int this[int a, int b]
+            {
+                get
+                {
+                    Console.Write($"Get {a} {b}. ");
+                    return 0;
+                }
+                set { Console.Write($"Set {a} {b} {value}."); }
+            }
+        }
+
+        [Fact]
+        public void TestSimpleIndexer()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            C4 targetObject = new C4();
+            CallSite<Func<CallSite, object, int, int, object>> getCallSite =
+                CallSite<Func<CallSite, object, int, int, object>>.Create(
+                    Binder.GetIndex(
+                        CSharpBinderFlags.None, typeof(C4),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.UseCompileTimeType | CSharpArgumentInfoFlags.NamedArgument,
+                                "a"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        }));
+            Assert.Equal(0, getCallSite.Target(getCallSite, targetObject, 1, 2));
+            CallSite<Func<CallSite, object, int, int, int, object>> setCallSite =
+                CallSite<Func<CallSite, object, int, int, int, object>>.Create(
+                    Binder.SetIndex(
+                        CSharpBinderFlags.None, typeof(C4),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.UseCompileTimeType | CSharpArgumentInfoFlags.NamedArgument,
+                                "a"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        }));
+            Assert.Equal(5, setCallSite.Target(setCallSite, targetObject, 3, 4, 5));
+            Assert.Equal("Get 1 2. Set 3 4 5.", console.ToString());
+        }
+
+
+        class C5
+        {
+            public C5()
+            {
+            }
+
+            int this[int a, int b]
+            {
+                get { throw null; }
+            }
+
+            C5(int a, int b)
+            {
+            }
+
+            // In the static test this is a local function on Main, but to test that without hunting
+            // for the name (likely C.<Main>g__local|3_0, but that's implementation-dependent) to
+            // push in with reflection we need the support from the compiler that we have yet to make
+            // possible. Cut out the chicken-egg problem and just test on a non-local equivalent.
+            void Method(int a, int b)
+            {
+            }
+        }
+
+        [Fact]
+        public void TestSimpleError()
+        {
+            CallSite<Func<CallSite, Type, int, int, C5>> ctorCallsite =
+                CallSite<Func<CallSite, Type, int, int, C5>>.Create(
+                    Binder.InvokeConstructor(
+                        CSharpBinderFlags.None, typeof(C5),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.UseCompileTimeType | CSharpArgumentInfoFlags.IsStaticType,
+                                null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.UseCompileTimeType | CSharpArgumentInfoFlags.NamedArgument,
+                                "b"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                        }));
+            string message = Assert
+                .Throws<RuntimeBinderException>(() => ctorCallsite.Target(ctorCallsite, typeof(C5), 1, 2))
+                .Message;
+
+            // Named argument 'b' is used out-of-position but is followed by an unnamed argument
+            Assert.Contains("'b'", message);
+            CallSite<Func<CallSite, object, int, int, object>> getCallSite =
+                CallSite<Func<CallSite, object, int, int, object>>.Create(
+                    Binder.GetIndex(
+                        CSharpBinderFlags.None, typeof(C5),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.UseCompileTimeType | CSharpArgumentInfoFlags.NamedArgument,
+                                "b"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        }));
+            message = Assert.Throws<RuntimeBinderException>(() => getCallSite.Target(getCallSite, new C5(), 1, 2))
+                .Message;
+            Assert.Contains("'b'", message);
+            CallSite<Func<CallSite, object, int, int>> invokeCallSite =
+                CallSite<Func<CallSite, object, int, int>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, nameof(TypeWithMethods.DoStuff), Type.EmptyTypes, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "b"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            message = Assert.Throws<RuntimeBinderException>(() => getCallSite.Target(invokeCallSite, new C5(), 1, 2))
+                .Message;
+            Assert.Contains("'b'", message);
+        }
+
+        class C6
+        {
+            static void M(int first, int other)
+            {
+                System.Console.Write($"{first} {other}");
+            }
+        }
+
+        [Fact]
+        public void TestPositionalUnaffected()
+        {
+            CallSite<Action<CallSite, Type, int, int>> invokeCallSite =
+                CallSite<Action<CallSite, Type, int, int>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, "M", Type.EmptyTypes, typeof(C6),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                "first")
+                        }));
+            string message = Assert
+                .Throws<RuntimeBinderException>(() => invokeCallSite.Target(invokeCallSite, typeof(C6), 1, 2))
+                .Message;
+
+            // Named argument 'first' specifies a parameter for which a positional argument has already been given
+            Assert.Contains("'first'", message);
+        }
+
+        class C7
+        {
+            static void M<T1, T2>(T1 a, T2 b)
+            {
+                System.Console.Write($"{a} {b}.");
+            }
+        }
+
+        [Fact]
+        public void TestGenericInference()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+
+            // Test with types defined fully.
+            CallSite<Action<CallSite, Type, int, string>> compileTimeTypeCallSite =
+                CallSite<Action<CallSite, Type, int, string>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", new[] {typeof(int), typeof(string)}, typeof(C7),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                "a"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                        }));
+            compileTimeTypeCallSite.Target(compileTimeTypeCallSite, typeof(C7), 1, "hi");
+            Assert.Equal("1 hi.", console.ToString());
+
+            // Test with types defined fully in delegate but generic types deduced.
+            console.GetStringBuilder().Length = 0;
+            compileTimeTypeCallSite = CallSite<Action<CallSite, Type, int, string>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C7),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "a"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                    }));
+            compileTimeTypeCallSite.Target(compileTimeTypeCallSite, typeof(C7), 1, "hi");
+            Assert.Equal("1 hi.", console.ToString());
+
+            // Test with all types deduced by the dynamic binder.
+            console.GetStringBuilder().Length = 0;
+            CallSite<Action<CallSite, Type, object, object>> runtimeTypeCallSite =
+                CallSite<Action<CallSite, Type, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C7),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "a"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                        }));
+            runtimeTypeCallSite.Target(runtimeTypeCallSite, typeof(C7), 1, "hi");
+            Assert.Equal("1 hi.", console.ToString());
+        }
+
+        class C8
+        {
+            static void M(int a, int b, int c = 1)
+            {
+                System.Console.Write($"M {a} {b}");
+            }
+        }
+
+        [Fact]
+        public void TestPositionalUnaffected2()
+        {
+            CallSite<Action<CallSite, Type, int, int>> callSite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C8),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "c"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                    }));
+            string message = Assert.Throws<RuntimeBinderException>(() => callSite.Target(callSite, typeof(C8), 1, 2))
+                .Message;
+
+            //  Named argument 'c' is used out-of-position but is followed by an unnamed argument
+            Assert.Contains("'c'", message);
+        }
+
+        class C9
+        {
+            static void M(params int[] x)
+            {
+            }
+        }
+
+        [Fact]
+        public void TestNamedParams()
+        {
+            CallSite<Action<CallSite, Type, int, int>> callSite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C9),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "x"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                    }));
+
+            string message = Assert.Throws<RuntimeBinderException>(() => callSite.Target(callSite, typeof(C9), 1, 2))
+                .Message;
+
+            // No overload for method 'M' takes 2 arguments
+            Assert.Contains("'M'", message);
+            Assert.Contains(" 2 ", message);
+        }
+
+        [Fact]
+        public void TestNamedParams2()
+        {
+            CallSite<Action<CallSite, Type, int, int>> callSite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C9),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "x")
+                    }));
+
+            string message = Assert.Throws<RuntimeBinderException>(() => callSite.Target(callSite, typeof(C9), 1, 2))
+                .Message;
+
+            // Named argument 'x' specifies a parameter for which a positional argument has already been given
+            Assert.Contains("'x'", message);
+        }
+
+        class C10
+        {
+            static void M(int x, params string[] y)
+            {
+                System.Console.Write($"{x} {string.Join(",", y)}. ");
+            }
+        }
+
+        [Fact]
+        public void TestNamedParamsVariousForms()
+        {
+            // This extends the static test in also calling with no arguments for the params section.
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+
+            CallSite<Action<CallSite, Type, int, string>> callSite0 =
+                CallSite<Action<CallSite, Type, int, string>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C10),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                "x"),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "y")
+                        }));
+            callSite0.Target(callSite0, typeof(C10), 1, "2");
+
+            callSite0 = CallSite<Action<CallSite, Type, int, string>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C10),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "x"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                    }));
+            callSite0.Target(callSite0, typeof(C10), 2, "3");
+
+            CallSite<Action<CallSite, Type, int, string[]>> callSite1 =
+                CallSite<Action<CallSite, Type, int, string[]>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C10),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                "x"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                        }));
+            callSite1.Target(callSite1, typeof(C10), 3, new[] {"4", "5"});
+
+            CallSite<Action<CallSite, Type, int>> callSite2 = CallSite<Action<CallSite, Type, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C10),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "x")
+                    }));
+            callSite2.Target(callSite2, typeof(C10), 4);
+
+            Assert.Equal("1 2. 2 3. 3 4,5. 4 . ", console.ToString());
+        }
+
+        [Fact]
+        public void TestNamedParamsVariousFormsDynamicallyDeducedTypes()
+        {
+            // This extends the static test in also calling with no arguments for the params section.
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+
+            CallSite<Action<CallSite, Type, object, object>> callSite0 =
+                CallSite<Action<CallSite, Type, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C10),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "x"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "y")
+                        }));
+            callSite0.Target(callSite0, typeof(C10), 1, "2");
+
+            callSite0 = CallSite<Action<CallSite, Type, object, object>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C10),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "x"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                    }));
+            callSite0.Target(callSite0, typeof(C10), 2, "3");
+
+            CallSite<Action<CallSite, Type, object, object>> callSite1 =
+                CallSite<Action<CallSite, Type, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C10),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "x"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            callSite1.Target(callSite1, typeof(C10), 3, new[] {"4", "5"});
+
+            CallSite<Action<CallSite, Type, object>> callSite2 = CallSite<Action<CallSite, Type, object>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C10),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "x")
+                    }));
+            callSite2.Target(callSite2, typeof(C10), 4);
+
+            Assert.Equal("1 2. 2 3. 3 4,5. 4 . ", console.ToString());
+        }
+
+        [Fact]
+        public void TestTwiceNamedParams()
+        {
+            CallSite<Action<CallSite, Type, int, int>> callSite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C9),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "x"),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "x")
+                    }));
+
+            string message = Assert.Throws<RuntimeBinderException>(() => callSite.Target(callSite, typeof(C9), 1, 2))
+                .Message;
+
+            // Named argument 'x' cannot be specified multiple times
+            Assert.Contains("'x'", message);
+        }
+
+        class C11
+        {
+            static void M(int x, params int[] y)
+            {
+            }
+        }
+
+        [Fact]
+        public void TestNamedParams3()
+        {
+            CallSite<Action<CallSite, Type, int, int>> callSite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C11),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "y"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                    }));
+
+            string message = Assert.Throws<RuntimeBinderException>(() => callSite.Target(callSite, typeof(C11), 1, 2))
+                .Message;
+
+            // Named argument 'y' is used out-of-position but is followed by an unnamed argument
+            Assert.Contains("'y'", message);
+        }
+
+        [Fact]
+        public void TestNamedParams4()
+        {
+            CallSite<Action<CallSite, Type, int, int, int>> callSite =
+                CallSite<Action<CallSite, Type, int, int, int>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C11),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                "x"),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                "y"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                        }));
+
+            string message = Assert
+                .Throws<RuntimeBinderException>(() => callSite.Target(callSite, typeof(C11), 1, 2, 3))
+                .Message;
+
+            // No overload for method 'M' takes 3 arguments
+            Assert.Contains("'M'", message);
+            Assert.Contains(" 3 ", message);
+        }
+
+        class C12
+        {
+            static void M(int x, params int[] y)
+            {
+                System.Console.Write($"x={x} y[0]={y[0]} y.Length={y.Length}");
+            }
+        }
+
+        [Fact]
+        public void TestNamedParams5()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            CallSite<Action<CallSite, Type, int, int>> callSite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C12),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "y"),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "x")
+                    }));
+            callSite.Target(callSite, typeof(C12), 1, 2);
+            Assert.Equal("x=2 y[0]=1 y.Length=1", console.ToString());
+        }
+
+        class C13
+        {
+            static void M(int a = 1, int b = 2, int c = 3)
+            {
+            }
+        }
+
+        [Fact]
+        public void TestBadNonTrailing()
+        {
+            CallSite<Action<CallSite, Type, int, int>> callSite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C13),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "c"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                    }));
+            string message = Assert.Throws<RuntimeBinderException>(() => callSite.Target(callSite, typeof(C13), 3, 2)).Message;
+            //Named argument 'c' is used out-of-position but is followed by an unnamed argument
+            Assert.Contains(" 'c' ", message);
+        }
+
+        class C14
+        {
+            static void M(int a = 1, int b = 2, int c = 3)
+            {
+            }
+            static void M(long c = 1, long b = 2)
+            {
+                System.Console.Write($"Second {c} {b}. ");
+            }
+        }
+
+        [Fact]
+        public void TestPickGoodOverload()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            CallSite<Action<CallSite, Type, int, int>> callSite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C14),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "c"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                    }));
+            callSite.Target(callSite, typeof(C14), 3, 2);
+            Assert.Equal("Second 3 2. ", console.ToString());
+        }
+
+        [Fact]
+        public void TestPickGoodOverloadDynamicallyTyped()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            CallSite<Action<CallSite, Type, object, object>> callSite =
+                CallSite<Action<CallSite, Type, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C14),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "c"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            callSite.Target(callSite, typeof(C14), 3, 2);
+            Assert.Equal("Second 3 2. ", console.ToString());
+        }
+
+        class C15
+        {
+            static void M(long a = 1, long b = 2, long c = 3)
+            {
+            }
+            static void M(int c = 1, int b = 2)
+            {
+                System.Console.Write($"Second {c} {b}.");
+            }
+        }
+
+        [Fact]
+        public void TestPickGoodOverload2()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            CallSite<Action<CallSite, Type, int, int>> callSite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C15),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "c"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                    }));
+            callSite.Target(callSite, typeof(C15), 3, 2);
+            Assert.Equal("Second 3 2.", console.ToString());
+        }
+
+        [Fact]
+        public void TestPickGoodOverload2DynamicallyTyped()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            CallSite<Action<CallSite, Type, object, object>> callSite =
+                CallSite<Action<CallSite, Type, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C15),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "c"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            callSite.Target(callSite, typeof(C15), 3, 2);
+            Assert.Equal("Second 3 2.", console.ToString());
+        }
+
+        class C16
+        {
+            static void M(int a, int b, int c = 42)
+            {
+                System.Console.Write(c);
+            }
+        }
+
+        [Fact]
+        public void TestOptionalValues()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            CallSite<Action<CallSite, Type, int, int>> callSite = CallSite<Action<CallSite, Type, int, int>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C16),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                        CSharpArgumentInfo.Create(
+                            CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType, "a"),
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                    }));
+            callSite.Target(callSite, typeof(C16), 1, 2);
+            Assert.Equal("42", console.ToString());
+        }
+
+        [Fact]
+        public void TestOptionalValuesRunTimeTypes()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            CallSite<Action<CallSite, Type, object, object>> callSite =
+                CallSite<Action<CallSite, Type, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C16),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "a"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            callSite.Target(callSite, typeof(C16), 1, 2);
+            Assert.Equal("42", console.ToString());
+        }
+
+        class C17
+        {
+            static void M(int a, int b, params int[] c)
+            {
+            }
+        }
+
+        [Fact]
+        public void TestParams()
+        {
+            CallSite<Action<CallSite, Type, int, int, int>> callSite =
+                CallSite<Action<CallSite, Type, int, int, int>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C17),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                "b"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                        }));
+            string message = Assert
+                .Throws<RuntimeBinderException>(() => callSite.Target(callSite, typeof(C17), 2, 3, 4))
+                .Message;
+            // Named argument 'b' is used out-of-position but is followed by an unnamed argument
+            Assert.Contains(" 'b' ", message);
+        }
+
+        [Fact]
+        public void TestParamsRuntimeTypes()
+        {
+            CallSite<Action<CallSite, Type, object, object, object>> callSite =
+                CallSite<Action<CallSite, Type, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C17),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "b"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            string message = Assert
+                .Throws<RuntimeBinderException>(() => callSite.Target(callSite, typeof(C17), 2, 3, 4))
+                .Message;
+
+            // Named argument 'b' is used out-of-position but is followed by an unnamed argument
+            Assert.Contains(" 'b' ", message);
+        }
+
+        class C18
+        {
+            static void M(int a, int b, params int[] c)
+            {
+                System.Console.Write($"{a} {b} {c[0]} {c[1]} Length:{c.Length}");
+            }
+        }
+
+        [Fact]
+        public void TestParams2()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            CallSite<Action<CallSite, Type, int, int, int, int>> callSite =
+                CallSite<Action<CallSite, Type, int, int, int, int>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C18),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.IsStaticType | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                            CSharpArgumentInfo.Create(
+                                CSharpArgumentInfoFlags.NamedArgument | CSharpArgumentInfoFlags.UseCompileTimeType,
+                                "b"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null)
+                        }));
+            callSite.Target(callSite, typeof(C18), 1, 2, 3, 4);
+            Assert.Equal("1 2 3 4 Length:2", console.ToString());
+        }
+
+        [Fact]
+        public void TestParams2RuntimeTypes()
+        {
+            StringWriter console = new StringWriter();
+            Console.SetOut(console);
+            CallSite<Action<CallSite, Type, object, object, object, object>> callSite =
+                CallSite<Action<CallSite, Type, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.ResultDiscarded, "M", Type.EmptyTypes, typeof(C18),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.NamedArgument, "b"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            callSite.Target(callSite, typeof(C18), 1, 2, 3, 4);
+            Assert.Equal("1 2 3 4 Length:2", console.ToString());
         }
     }
 }


### PR DESCRIPTION
Closes #25795

First few commits refactor `CMethodIterator`, `MemberLookup`, `GroupToArgsBinder` and `GroupToArgsBinderResult` to clear some complications before the implementation:

* Remove `CMethodIterator._bcanIncludeExtensionsInResults`

Always false.

* Remove `CMethodIterator._allowBogusAndInaccessible`

Always true.

* Remove `MemberLookup._results`

Never used (legacy of static compiler's extension handling).

* Remove paths for `_pContainingTypes` being empty.

Never happens. (Would be possible when static compiler was looking for extension methods).

* Remove `_bAtEnd`

Check on correct use unnecessary in internal class.

* Remove unused parameters

* Replace private field-only properties with field access.

* Getter methods to properties; auto when appropriate.

* Remove `_bIsCheckingInstanceMethods`

Always true.

* Readonly fields where possible.

* Rename Hungarian-style names and remove redundant initializers.

* `GroupToArgsBinderResult` members to auto properties.

* Remove `InconvertibleResult`/`_inconvertibleResults`

Set but never accessed.

* Match error code numbers to corresponding C# errors.

Not clear why these were ever different, but matching them makes the connection clearer.

# Now the implementation

* Add some initial (not yet passing) tests.

* Allow non-trailing arguments (remove prohibition)

* Detect misnamed arguments in iterator.

* Exclude methods from consideration if non-trailing names don't match.

* Correct error for name not found in non-trailing.

* Catch CS8328 errors.

* Return temporarily removed assertion.

* Correctly handle correctly naming the first of several `params` arguments

* Add tests based on Roslyn's tests for non-trailing named arguments.

* Fix handling when name is changed in an override.

Use the name defined on the type of the argument if `UseCompileTimeType` or the type of the object, otherwise.