### PR TITLE
Microsoft.CSharp: Set temporary unchecked context correctly.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BindingContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BindingContext.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public BindingContext(BindingContext parent)
             : this(parent.SemanticChecker, parent.ExprFactory)
         {
+            // We copy the context object, but leave checking false.
             ContextForMemberLookup = parent.ContextForMemberLookup;
-            Checked = parent.Checked;
         }
 
         //The SymbolLoader can be retrieved from SemanticChecker,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1251,6 +1251,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return BindLiftedStandardUnop(ek, flags, pArgument, uofs);
             }
 
+            if (pArgument.isCONSTANT_OK())
+            {
+                // Wrap the constant in an identity cast, to force the later casts to not be optimised out.
+                // The ExpressionTreeRewriter will remove this again.
+                pArgument = ExprFactory.CreateCast(pArgument.Type, pArgument);
+            }
+
             // Try the conversion - if it fails, do a cast without user defined casts.
             Expr arg = tryConvert(pArgument, uofs.GetType());
             if (arg == null)

--- a/src/Microsoft.CSharp/tests/AssignmentTests.cs
+++ b/src/Microsoft.CSharp/tests/AssignmentTests.cs
@@ -1,0 +1,229 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public class AssignmentTests
+    {
+        public static object[][] Additions =
+        {
+            new object[]{1, 2, 3},
+            new object[]{1L, 2, 3L},
+            new object[]{1, 2L, 3L},
+            new object[]{1U, 2U, 3U},
+            new object[]{1, 2U, 3L},
+            new object[]{1, 2M, 3M},
+            new object[]{1.0, 2, 3.0},
+            new object[]{1, 2.0, 3.0}
+        };
+
+        private sealed class HasProperty<T>
+        {
+            public T Prop { get; set; }
+        }
+
+        private static HasProperty<T> GetHasProperty<T>(T initial) => new HasProperty<T>{ Prop = initial };
+
+        public static object[][] PropertyAdditions =
+        {
+            new object[]{GetHasProperty(1), 2, 3},
+            new object[]{GetHasProperty(1L), 2, 3L},
+            new object[]{GetHasProperty(1), 2L, 3},
+            new object[]{GetHasProperty(1U), 2U, 3U},
+            new object[]{GetHasProperty(1), 2U, 3},
+            new object[]{GetHasProperty(1), 2M, 3},
+            new object[]{GetHasProperty(1.0), 2, 3.0},
+            new object[]{GetHasProperty(1), 2.0, 3}
+        };
+
+        public static object[][] PropertyAssigments =
+        {
+            new object[]{GetHasProperty(1), 2, 2},
+            new object[]{GetHasProperty(1L), 2, 2L},
+            new object[]{GetHasProperty(1), 2L, 2},
+            new object[]{GetHasProperty(1U), 2U, 2U},
+            new object[]{GetHasProperty(1), 2U, 2},
+            new object[]{GetHasProperty(1), 2M, 2},
+            new object[]{GetHasProperty(1.0), 2, 2.0},
+            new object[]{GetHasProperty(1), 2.0, 2}
+        };
+
+        public static object[][] PropertyBadAssigments =
+        {
+            new object[]{GetHasProperty(1), decimal.MaxValue, true, false},
+            new object[]{GetHasProperty(1), DateTime.MinValue, false, false},
+            new object[]{GetHasProperty(2), "hello", false, false},
+            new object[]{GetHasProperty(1), null, false, false},
+            new object[]{GetHasProperty(true), 2, false, false},
+            new object[]{GetHasProperty(2.0), false, false, false},
+            new object[]{GetHasProperty("abc"), 2.0, false, false},
+            new object[]{GetHasProperty("abc"), new object(), false, true},
+            new object[]{GetHasProperty(2), new object(), false, true}
+        };
+
+        public static IEnumerable<object[]> PropertyBadCheckedAssigments =
+            new[]
+            {
+                new object[] {GetHasProperty(1), long.MaxValue, true, false},
+                new object[] {GetHasProperty(1), (double)long.MaxValue, true, false},
+                new object[] {GetHasProperty(1U), -1, true, false},
+                new object[] {GetHasProperty(1), uint.MaxValue, true, false},
+                new object[] {GetHasProperty(default(short)), int.MaxValue, true, false},
+                new object[]{GetHasProperty(2UL), -1, true, false}
+            }.Concat(PropertyBadAssigments);
+
+        [Theory, MemberData(nameof(Additions))]
+        public void AddAssignment(dynamic lhs, dynamic rhs, object expected)
+        {
+            lhs += rhs;
+            Assert.Equal(expected, lhs);
+            Assert.IsType(expected.GetType(), lhs);
+        }
+
+        [Theory, MemberData(nameof(PropertyAdditions))]
+        public void PropertyAddAssignment(dynamic lhs, dynamic rhs, object expected)
+        {
+            lhs.Prop += rhs;
+            Assert.Equal(expected, lhs.Prop);
+        }
+
+        [Theory, MemberData(nameof(PropertyAssigments))]
+        public void PropertyAddResultAssigment(object lhs, object rhs, object expected)
+        {
+            CallSite<Func<CallSite, object, object, object>> callSite =
+                CallSite<Func<CallSite, object, object, object>>.Create(
+                    Binder.SetMember(
+                        CSharpBinderFlags.ValueFromCompoundAssignment, "Prop", GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            object result = callSite.Target(callSite, lhs, rhs);
+            Assert.Equal(expected, result);
+            Assert.Equal(expected, ((dynamic)lhs).Prop);
+        }
+
+        [Theory, MemberData(nameof(PropertyAssigments))]
+        public void PropertyAddConstantResultAssigment(object lhs, object rhs, object expected)
+        {
+            CallSite<Func<CallSite, object, object, object>> callSite =
+                CallSite<Func<CallSite, object, object, object>>.Create(
+                    Binder.SetMember(
+                        CSharpBinderFlags.ValueFromCompoundAssignment, "Prop", GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.Constant, null)
+                        }));
+            object result = callSite.Target(callSite, lhs, rhs);
+            Assert.Equal(expected, result);
+            Assert.Equal(expected, ((dynamic)lhs).Prop);
+        }
+
+        [Theory, MemberData(nameof(PropertyBadAssigments))]
+        public void PropertyIncompatibleAssigment(object lhs, object rhs, bool overflow, bool invalidCast)
+        {
+            CallSite<Func<CallSite, object, object, object>> callSite =
+                CallSite<Func<CallSite, object, object, object>>.Create(
+                    Binder.SetMember(
+                        CSharpBinderFlags.ValueFromCompoundAssignment, "Prop", GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            if (invalidCast) // Invalid cast at runtime
+            {
+                Assert.Throws<InvalidCastException>(() => callSite.Target(callSite, lhs, rhs));
+            }
+            else if (overflow) // Overflows at runtime, rather than fail at bind time
+            {
+                Assert.Throws<OverflowException>(() => callSite.Target(callSite, lhs, rhs));
+            }
+            else
+            {
+                Assert.Throws<RuntimeBinderException>(() => callSite.Target(callSite, lhs, rhs));
+            }
+        }
+
+        [Theory, MemberData(nameof(PropertyBadAssigments))]
+        public void PropertyIncompatibleConstantAssigment(object lhs, object rhs, bool _, bool invalidCast)
+        {
+            CallSite<Func<CallSite, object, object, object>> callSite =
+                CallSite<Func<CallSite, object, object, object>>.Create(
+                    Binder.SetMember(
+                        CSharpBinderFlags.ValueFromCompoundAssignment, "Prop", GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.Constant, null)
+                        }));
+            if (invalidCast)
+            {
+                Assert.Throws<InvalidCastException>(() => callSite.Target(callSite, lhs, rhs));
+            }
+            else
+            {
+                Assert.Throws<RuntimeBinderException>(() => callSite.Target(callSite, lhs, rhs));
+            }
+        }
+
+        [Theory, MemberData(nameof(PropertyBadCheckedAssigments))]
+        public void PropertyIncompatibleCheckedAssigment(object lhs, object rhs, bool overflow, bool invalidCast)
+        {
+            CallSite<Func<CallSite, object, object, object>> callSite =
+                CallSite<Func<CallSite, object, object, object>>.Create(
+                    Binder.SetMember(
+                        CSharpBinderFlags.ValueFromCompoundAssignment | CSharpBinderFlags.CheckedContext, "Prop",
+                        GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            if (invalidCast)
+            {
+                Assert.Throws<InvalidCastException>(() => callSite.Target(callSite, lhs, rhs));
+            }
+            else if (overflow) // Overflows at runtime, rather than fail at bind time
+            {
+                Assert.Throws<OverflowException>(() => callSite.Target(callSite, lhs, rhs));
+            }
+            else
+            {
+                Assert.Throws<RuntimeBinderException>(() => callSite.Target(callSite, lhs, rhs));
+            }
+        }
+
+        [Theory, MemberData(nameof(PropertyBadCheckedAssigments))]
+        public void PropertyIncompatibleConstantCheckedAssigment(object lhs, object rhs, bool _, bool invalidCast)
+        {
+            CallSite<Func<CallSite, object, object, object>> callSite =
+                CallSite<Func<CallSite, object, object, object>>.Create(
+                    Binder.SetMember(
+                        CSharpBinderFlags.ValueFromCompoundAssignment | CSharpBinderFlags.CheckedContext, "Prop",
+                        GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.Constant, null)
+                        }));
+            if (invalidCast) // Invalid cast at runtime
+            {
+                Assert.Throws<InvalidCastException>(() => callSite.Target(callSite, lhs, rhs));
+            }
+            else
+            {
+                Assert.Throws<RuntimeBinderException>(() => callSite.Target(callSite, lhs, rhs));
+            }
+        }
+    }
+}

--- a/src/Microsoft.CSharp/tests/EnumUnaryOperationTests.cs
+++ b/src/Microsoft.CSharp/tests/EnumUnaryOperationTests.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public class EnumUnaryOperationTests
+    {
+        public enum ByteEnum : byte
+        {
+            A,
+            B,
+            C,
+            D,
+            E
+        }
+
+        public enum SByteEnum : sbyte
+        {
+            A,
+            B,
+            C,
+            D,
+            E,
+            Z = -1
+        }
+
+        public enum Int32Enum
+        {
+            A,
+            B,
+            C,
+            D,
+            E,
+            Z = -1
+        }
+
+        public enum UInt32Enum : uint
+        {
+            A,
+            B,
+            C,
+            D,
+            E
+        }
+
+        public enum Int64Enum : long
+        {
+            A,
+            B,
+            C,
+            D,
+            E,
+            Z = -1
+        }
+
+        public static IEnumerable<object[]> ByteEnums() => Enum.GetValues(typeof(ByteEnum))
+            .Cast<ByteEnum>()
+            .Select(x => new object[] { x, ~x });
+
+        public static IEnumerable<object[]> SByteEnums() => Enum.GetValues(typeof(SByteEnum))
+            .Cast<ByteEnum>()
+            .Select(x => new object[] { x, ~x });
+
+        public static IEnumerable<object[]> Int32Enums() => Enum.GetValues(typeof(Int32Enum))
+            .Cast<Int32Enum>()
+            .Select(x => new object[] { x, ~x });
+
+        public static IEnumerable<object[]> UInt32Enums() => Enum.GetValues(typeof(UInt32Enum))
+            .Cast<UInt32Enum>()
+            .Select(x => new object[] { x, ~x });
+
+        public static IEnumerable<object[]> Int64Enums() => Enum.GetValues(typeof(Int64Enum))
+            .Cast<Int64Enum>()
+            .Select(x => new object[] { x, ~x });
+
+        [Theory]
+        [MemberData(nameof(ByteEnums))]
+        [MemberData(nameof(SByteEnums))]
+        [MemberData(nameof(Int32Enums))]
+        [MemberData(nameof(UInt32Enums))]
+        [MemberData(nameof(Int64Enums))]
+        public void EnumOnesComplement(dynamic operand, dynamic result)
+        {
+            unchecked
+            {
+                Assert.Equal(result, ~operand);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ByteEnums))]
+        [MemberData(nameof(SByteEnums))]
+        [MemberData(nameof(Int32Enums))]
+        [MemberData(nameof(UInt32Enums))]
+        [MemberData(nameof(Int64Enums))]
+        public void CheckedEnumOnesComplement(dynamic operand, dynamic result)
+        {
+            checked
+            {
+                Assert.Equal(result, ~operand);
+            }
+        }
+    }
+}

--- a/src/Microsoft.CSharp/tests/EnumUnaryOperationTests.cs
+++ b/src/Microsoft.CSharp/tests/EnumUnaryOperationTests.cs
@@ -108,5 +108,35 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                 Assert.Equal(result, ~operand);
             }
         }
+
+        [Theory]
+        [MemberData(nameof(ByteEnums))]
+        [MemberData(nameof(SByteEnums))]
+        [MemberData(nameof(Int32Enums))]
+        [MemberData(nameof(UInt32Enums))]
+        [MemberData(nameof(Int64Enums))]
+        public void ConstantEnumOnesComplement(object operand, object result)
+        {
+            CallSite<Func<CallSite, object, object>> cs = CallSite<Func<CallSite, object, object>>.Create(
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.None, ExpressionType.OnesComplement, GetType(),
+                    new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.Constant, null) }));
+            Assert.Equal(result, cs.Target(cs, operand));
+        }
+
+        [Theory]
+        [MemberData(nameof(ByteEnums))]
+        [MemberData(nameof(SByteEnums))]
+        [MemberData(nameof(Int32Enums))]
+        [MemberData(nameof(UInt32Enums))]
+        [MemberData(nameof(Int64Enums))]
+        public void ConstantCheckedEnumOnesComplement(object operand, object result)
+        {
+            CallSite<Func<CallSite, object, object>> cs = CallSite<Func<CallSite, object, object>>.Create(
+                Binder.UnaryOperation(
+                    CSharpBinderFlags.CheckedContext, ExpressionType.OnesComplement, GetType(),
+                    new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.Constant, null) }));
+            Assert.Equal(result, cs.Target(cs, operand));
+        }
     }
 }

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -8,7 +8,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="ArrayHandling.cs" />
+    <Compile Include="AssignmentTests.cs" />
     <Compile Include="BindingErrors.cs" />
+    <Compile Include="EnumUnaryOperationTests.cs" />
     <Compile Include="ImplicitConversionTests.cs" />
     <Compile Include="CSharpArgumentInfoTests.cs" />
     <Compile Include="DelegateInDynamicTests.cs" />

--- a/src/Microsoft.CSharp/tests/NullableEnumUnaryOperationTest.cs
+++ b/src/Microsoft.CSharp/tests/NullableEnumUnaryOperationTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
 {
     public class NullableEnumUnaryOperationTest
     {
-        public enum Int8Enum
+        public enum Int8Enum : byte
         {
             A,
             B,
@@ -31,7 +31,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             E
         }
 
-        public enum UInt32Enum
+        public enum UInt32Enum : uint
         {
             A,
             B,


### PR DESCRIPTION
Fixes #25824

Fix also makes `ConstOutOfRange` and `ConstOutOfRangeChecked` reachable (were made erroneously unreachable by #25824), so contributes to #22470

* Don't optimise out casts in enum unary operations.

Fixes #25826