### PR TITLE
Ignore placeholder build configurations in build all configurations targets

### DIFF
--- a/Documentation/coding-guidelines/project-guidelines.md
+++ b/Documentation/coding-guidelines/project-guidelines.md
@@ -88,6 +88,22 @@ All supported targets with unique windows/unix build for netcoreapp:
 <PropertyGroup>
 ```
 
+### Placeholder build configurations
+Placeholder build configurations can be added to the `<BuildConfigurations>` property to indicate the build system that the specific project is inbox in that framework and that build configuration needs to be ignored.
+
+Placeholder build configurations start with _ prefix.
+
+Example:
+When we have a project that has a `netstandard` build configuration that means that this project is compatible with any build configuration. So if we do a vertical build for `netfx` this project will be built as part of the vertical because `netfx` is compatible with `netstandard`. This means that in the runtime and testhost binaries the netstandard implementation will be included, and we will test against those assets instead of testing against the framework inbox asset. In order to tell the build system to not include this project as part of the `netfx` vertical we need to add a placeholder configuration:
+```
+<PropertyGroup>
+  <BuildConfigurations>
+    netstandard;
+    _netfx;
+  </BuildConfigurations>
+</PropertyGroup>
+```
+
 ## Options for building
 
 A full or individual project build is centered around BuildConfiguration and will be setup in one of the following ways:

--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -28,7 +28,7 @@
         <AdditionalProperties>Configuration=%(Identity);%(_projectBuildConfigurations.AdditionalProperties)</AdditionalProperties>
       </_projectBuildConfigurations>
 
-      <!-- transform back to project, we need to ignore negative build configurations that start with _ -->
+      <!-- transform back to project, we need to ignore placeholder build configurations that start with _ -->
       <_projectWithConfiguration Include="@(_projectBuildConfigurations->'%(OriginalItemSpec)')" Condition="!$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
     </ItemGroup>
 
@@ -54,7 +54,7 @@
         <AdditionalProperties>Configuration=%(Identity);%(_NonPkgProjProjectReferenceBuildConfigurations.AdditionalProperties)</AdditionalProperties>
       </_NonPkgProjProjectReferenceBuildConfigurations>
 
-      <!-- transform back to project, we need to ignore negative build configurations that start with _ -->
+      <!-- transform back to project, we need to ignore placeholder build configurations that start with _ -->
       <_NonPkgProjProjectReferenceWitnConfiguration Include="@(_NonPkgProjProjectReferenceBuildConfigurations->'%(OriginalItemSpec)')" Condition="!$([System.String]::Copy('%(Identity)').StartsWith('_'))"/>
     </ItemGroup>
 
@@ -176,7 +176,7 @@
   <Target Name="_getAllBuildConfigurations">
     <ItemGroup>
       <_buildConfigurations Include="$(BuildConfigurations)" />
-      <!-- For BuildAllConfigurations we need to ignore any negative build configuration that starts with _ -->
+      <!-- For BuildAllConfigurations we need to ignore any placeholder build configuration that starts with _ -->
       <_buildConfigurations Remove="@(_buildConfigurations)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
       <_buildConfigurations Condition="'@(_buildConfigurations)' == ''" Include="$(_traversalBuildConfigurations)" />
     </ItemGroup>

--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -28,8 +28,8 @@
         <AdditionalProperties>Configuration=%(Identity);%(_projectBuildConfigurations.AdditionalProperties)</AdditionalProperties>
       </_projectBuildConfigurations>
 
-      <!-- transform back to project -->
-      <_projectWithConfiguration Include="@(_projectBuildConfigurations->'%(OriginalItemSpec)')" />
+      <!-- transform back to project, we need to ignore negative build configurations that start with _ -->
+      <_projectWithConfiguration Include="@(_projectBuildConfigurations->'%(OriginalItemSpec)')" Condition="!$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
     </ItemGroup>
 
     <ItemGroup>
@@ -54,8 +54,8 @@
         <AdditionalProperties>Configuration=%(Identity);%(_NonPkgProjProjectReferenceBuildConfigurations.AdditionalProperties)</AdditionalProperties>
       </_NonPkgProjProjectReferenceBuildConfigurations>
 
-      <!-- transform back to project -->
-      <_NonPkgProjProjectReferenceWitnConfiguration Include="@(_NonPkgProjProjectReferenceBuildConfigurations->'%(OriginalItemSpec)')" />
+      <!-- transform back to project, we need to ignore negative build configurations that start with _ -->
+      <_NonPkgProjProjectReferenceWitnConfiguration Include="@(_NonPkgProjProjectReferenceBuildConfigurations->'%(OriginalItemSpec)')" Condition="!$([System.String]::Copy('%(Identity)').StartsWith('_'))"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -176,6 +176,8 @@
   <Target Name="_getAllBuildConfigurations">
     <ItemGroup>
       <_buildConfigurations Include="$(BuildConfigurations)" />
+      <!-- For BuildAllConfigurations we need to ignore any negative build configuration that starts with _ -->
+      <_buildConfigurations Remove="@(_buildConfigurations)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
       <_buildConfigurations Condition="'@(_buildConfigurations)' == ''" Include="$(_traversalBuildConfigurations)" />
     </ItemGroup>
   </Target>

--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -28,9 +28,14 @@
         <AdditionalProperties>Configuration=%(Identity);%(_projectBuildConfigurations.AdditionalProperties)</AdditionalProperties>
       </_projectBuildConfigurations>
 
-      <!-- transform back to project, we need to ignore placeholder build configurations that start with _ -->
-      <_projectWithConfiguration Include="@(_projectBuildConfigurations->'%(OriginalItemSpec)')" Condition="!$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
+      <!-- we need to ignore placeholder build configurations that start with _ -->
+      <_projectBuildConfigurations Remove="@(_projectBuildConfigurations)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
+
+      <!-- transform back to project -->
+      <_projectWithConfiguration Include="@(_projectBuildConfigurations->'%(OriginalItemSpec)')" />
     </ItemGroup>
+
+      <Message Importance="High" Text="@@@ @(_projectBuildConfigurations) - %(Identity) - %(AdditionalProperties)" />
 
     <ItemGroup>
       <Project Remove="@(Project)" />
@@ -54,8 +59,11 @@
         <AdditionalProperties>Configuration=%(Identity);%(_NonPkgProjProjectReferenceBuildConfigurations.AdditionalProperties)</AdditionalProperties>
       </_NonPkgProjProjectReferenceBuildConfigurations>
 
-      <!-- transform back to project, we need to ignore placeholder build configurations that start with _ -->
-      <_NonPkgProjProjectReferenceWitnConfiguration Include="@(_NonPkgProjProjectReferenceBuildConfigurations->'%(OriginalItemSpec)')" Condition="!$([System.String]::Copy('%(Identity)').StartsWith('_'))"/>
+      <!-- we need to ignore placeholder build configurations that start with _ -->
+      <_NonPkgProjProjectReferenceBuildConfigurations Remove="@(_NonPkgProjProjectReferenceBuildConfigurations)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
+
+      <!-- transform back to project -->
+      <_NonPkgProjProjectReferenceWitnConfiguration Include="@(_NonPkgProjProjectReferenceBuildConfigurations->'%(OriginalItemSpec)')" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
In order to support negative build configurations we need to ignore them when building all configurations in the vertical. 

Contributes to: https://github.com/dotnet/corefx/issues/24903

I need to explore more scenarios to see if we need more changes in corefx side to support this. Still going through them but this at least will allow us to add the negative configurations for the vertical. 

cc: @danmosemsft 