### PR TITLE
Update byref of custom S.L.Expressions convert method in interpreter

### DIFF
--- a/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -16808,7 +16808,8 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(5, x); // Refness is lost on lifting.
         }
 
-        private static void CustomConversionNotStandardNameFromByRef(bool useInterpreter)
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CustomConversionNotStandardNameFromByRef(bool useInterpreter)
         {
             var param = Expression.Parameter(typeof(int).MakeByRefType());
             MethodInfo method = typeof(CustomConversions).GetMethod(nameof(CustomConversions.ConvertFromRefInt));
@@ -16819,20 +16820,6 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(5, func(ref x).Value);
             Assert.Equal(6, x);
         }
-
-        [Fact, ActiveIssue(18445)]
-        public static void CustomConversionNotStandardNameFromByRefInterpreter()
-        {
-            CustomConversionNotStandardNameFromByRef(useInterpreter: true);
-        }
-
-#if FEATURE_COMPILE
-        [Fact]
-        public static void CustomConversionNotStandardNameFromByRefCompiler()
-        {
-            CustomConversionNotStandardNameFromByRef(useInterpreter: false);
-        }
-#endif
 
         [Fact]
         public static void CustomConversionNotStandardNameToWrongType()


### PR DESCRIPTION
While conversion operators cannot normally use methods with `ref` parameters, Expressions does allow them if the method in question is explicitly requested. The interpreter however does not write-back the parameter of the call.

Correct this.

Fixes #18445