### PR TITLE
Reenable Alpine optional CI

### DIFF
--- a/buildpipeline/alpine.3.6.groovy
+++ b/buildpipeline/alpine.3.6.groovy
@@ -24,10 +24,17 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-2017111
         sh "./build-managed.sh -runtimeos=alpine.3.6 -- /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true /p:PortableBuild=false"
     }
     stage ('Sync') {
-        sh "./sync.sh -p -runtimeos=alpine.3.6 -BuildTests=false -- /p:ArchGroup=x64 /p:PortableBuild=false"
+        sh "./sync.sh -p -runtimeos=alpine.3.6 -- /p:ArchGroup=x64 /p:PortableBuild=false"
     }
     stage ('Build Product') {
-        sh "./build.sh -buildArch=x64 -runtimeos=alpine.3.6 -${params.CGroup} -BuildTests=false -- /p:PortableBuild=false"
+        sh "./build.sh -buildArch=x64 -runtimeos=alpine.3.6 -${params.CGroup} -- /p:PortableBuild=false"
+    }
+    stage ('Build Tests') {
+        def additionalArgs = ''
+        if (params.TestOuter) {
+            additionalArgs = '-Outerloop'
+        }
+        sh "./build-tests.sh -buildArch=x64 -${params.CGroup} -SkipTests ${additionalArgs} -- /p:ArchiveTests=true /p:EnableDumpling=true /p:PortableBuild=false"
     }
 
     // TODO: Add submission for Helix testing once we have queue for Alpine Linux working


### PR DESCRIPTION
After fixing the issue with the CI build of tests, I am re-enabling the
CI again. Still as optional only, I will update it to automatic one
after testing it manually.