### PR TITLE
Update comment in S.D.SqlClient about why GC.KeepAlive isn't needed.

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -1011,7 +1011,7 @@ namespace System.Data.SqlClient
                     return false;
                 }
             }
-            // does not require GC.KeepAlive(this) because of OnStateChange
+            // does not require GC.KeepAlive(this) because of ReRegisterForFinalize below.
 
             var tdsInnerConnection = (SqlInternalConnectionTds)InnerConnection;
 


### PR DESCRIPTION
The comment says it isn't needed because of `OnStateChange`, but this appears outdated. It's still not needed though because the `ReRegisterForFinalize` below it will keep it rooted.

Closes #6116