### PR TITLE
Command line tokenization reconciling

### DIFF
--- a/src/Common/src/System/PasteArguments.Unix.cs
+++ b/src/Common/src/System/PasteArguments.Unix.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System
+{
+    internal static partial class PasteArguments
+    {
+         /// <summary>
+        /// Repastes a set of arguments into a linear string that parses back into the originals under pre- or post-2008 VC parsing rules.
+        /// The rules for parsing the executable name (argv[0]) are special, so you must indicate whether the first argument actually is argv[0].
+        /// </summary>
+        internal static string Paste(IEnumerable<string> arguments, bool pasteFirstArgumentUsingArgV0Rules)
+        {
+            var stringBuilder = new StringBuilder();
+            foreach (string argument in arguments)
+                AppendArgument(stringBuilder, argument);
+            return stringBuilder.ToString();
+        }
+
+    }
+}

--- a/src/Common/src/System/PasteArguments.Unix.cs
+++ b/src/Common/src/System/PasteArguments.Unix.cs
@@ -10,15 +10,17 @@ namespace System
 {
     internal static partial class PasteArguments
     {
-         /// <summary>
+        /// <summary>
         /// Repastes a set of arguments into a linear string that parses back into the originals under pre- or post-2008 VC parsing rules.
-        /// The rules for parsing the executable name (argv[0]) are special, so you must indicate whether the first argument actually is argv[0].
+        /// On Unix: the rules for parsing the executable name (argv[0]) are ignored.
         /// </summary>
         internal static string Paste(IEnumerable<string> arguments, bool pasteFirstArgumentUsingArgV0Rules)
         {
             var stringBuilder = new StringBuilder();
             foreach (string argument in arguments)
+            {
                 AppendArgument(stringBuilder, argument);
+            }
             return stringBuilder.ToString();
         }
 

--- a/src/Common/src/System/PasteArguments.Windows.cs
+++ b/src/Common/src/System/PasteArguments.Windows.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System
+{
+    internal static partial class PasteArguments
+    {
+         /// <summary>
+        /// Repastes a set of arguments into a linear string that parses back into the originals under pre- or post-2008 VC parsing rules.
+        /// The rules for parsing the executable name (argv[0]) are special, so you must indicate whether the first argument actually is argv[0].
+        /// </summary>
+        internal static string Paste(IEnumerable<string> arguments, bool pasteFirstArgumentUsingArgV0Rules)
+        {
+            var stringBuilder = new StringBuilder();
+
+            foreach (string argument in arguments)
+            {
+                if (pasteFirstArgumentUsingArgV0Rules)
+                {
+                    pasteFirstArgumentUsingArgV0Rules = false;
+
+                    // Special rules for argv[0]
+                    //   - Backslash is a normal character.
+                    //   - Quotes used to include whitespace characters.
+                    //   - Parsing ends at first whitespace outside quoted region.
+                    //   - No way to get a literal quote past the parser.
+
+                    bool hasWhitespace = false;
+                    foreach (char c in argument)
+                    {
+                        if (c == Quote)
+                        {
+                            throw new ApplicationException("The argv[0] argument cannot include a double quote.");
+                        }
+                        if (char.IsWhiteSpace(c))
+                        {
+                            hasWhitespace = true;
+                        }
+                    }
+                    if (argument.Length == 0 || hasWhitespace)
+                    {
+                        stringBuilder.Append(Quote);
+                        stringBuilder.Append(argument);
+                        stringBuilder.Append(Quote);
+                    }
+                    else
+                    {
+                        stringBuilder.Append(argument);
+                    }
+                }
+                else
+                {
+                    AppendArgument(stringBuilder, argument);
+                }
+            }
+
+            return stringBuilder.ToString();
+        }
+
+    }
+}

--- a/src/Common/src/System/PasteArguments.cs
+++ b/src/Common/src/System/PasteArguments.cs
@@ -7,119 +7,77 @@ using System.Text;
 
 namespace System
 {
-    internal static class PasteArguments
+    internal static partial class PasteArguments
     {
-         /// <summary>
-        /// Repastes a set of arguments into a linear string that parses back into the originals under pre- or post-2008 VC parsing rules.
-        /// The rules for parsing the executable name (argv[0]) are special, so you must indicate whether the first argument actually is argv[0].
-        /// </summary>
-        public static string Paste(IEnumerable<string> arguments, bool pasteFirstArgumentUsingArgV0Rules)
+        private static void AppendArgument(StringBuilder stringBuilder, string argument)
         {
-            var stringBuilder = new StringBuilder();
-
-            foreach (string argument in arguments)
+            if (stringBuilder.Length != 0)
             {
-                if (pasteFirstArgumentUsingArgV0Rules)
-                {
-                    pasteFirstArgumentUsingArgV0Rules = false;
-
-                    // Special rules for argv[0]
-                    //   - Backslash is a normal character.
-                    //   - Quotes used to include whitespace characters.
-                    //   - Parsing ends at first whitespace outside quoted region.
-                    //   - No way to get a literal quote past the parser.
-
-                    bool hasWhitespace = false;
-                    foreach (char c in argument)
-                    {
-                        if (c == Quote)
-                        {
-                            throw new ApplicationException("The argv[0] argument cannot include a double quote.");
-                        }
-                        if (char.IsWhiteSpace(c))
-                        {
-                            hasWhitespace = true;
-                        }
-                    }
-                    if (argument.Length == 0 || hasWhitespace)
-                    {
-                        stringBuilder.Append(Quote);
-                        stringBuilder.Append(argument);
-                        stringBuilder.Append(Quote);
-                    }
-                    else
-                    {
-                        stringBuilder.Append(argument);
-                    }
-                }
-                else
-                {
-                    if (stringBuilder.Length != 0)
-                    {
-                        stringBuilder.Append(' ');
-                    }
-
-                    // Parsing rules for non-argv[0] arguments:
-                    //   - Backslash is a normal character except followed by a quote.
-                    //   - 2N backslashes followed by a quote ==> N literal backslashes followed by unescaped quote
-                    //   - 2N+1 backslashes followed by a quote ==> N literal backslashes followed by a literal quote
-                    //   - Parsing stops at first whitespace outside of quoted region.
-                    //   - (post 2008 rule): A closing quote followed by another quote ==> literal quote, and parsing remains in quoting mode.
-                    if (argument.Length != 0 && ContainsNoWhitespaceOrQuotes(argument))
-                    {
-                        // Simple case - no quoting or changes needed.
-                        stringBuilder.Append(argument);
-                    }
-                    else
-                    {
-                        stringBuilder.Append(Quote);
-                        int idx = 0;
-                        while (idx < argument.Length)
-                        {
-                            char c = argument[idx++];
-                            if (c == Backslash)
-                            {
-                                int numBackSlash = 1;
-                                while (idx < argument.Length && argument[idx] == Backslash)
-                                {
-                                    idx++;
-                                    numBackSlash++;
-                                }
-                                if (idx == argument.Length)
-                                {
-                                    // We'll emit an end quote after this so must double the number of backslashes.
-                                    stringBuilder.Append(Backslash, numBackSlash * 2);
-                                }
-                                else if (argument[idx] == Quote)
-                                {
-                                    // Backslashes will be followed by a quote. Must double the number of backslashes.
-                                    stringBuilder.Append(Backslash, numBackSlash * 2 + 1);
-                                    stringBuilder.Append(Quote);
-                                    idx++;
-                                }
-                                else
-                                {
-                                    // Backslash will not be followed by a quote, so emit as normal characters.
-                                    stringBuilder.Append(Backslash, numBackSlash);
-                                }
-                                continue;
-                            }
-                            if (c == Quote)
-                            {
-                                // Escape the quote so it appears as a literal. This also guarantees that we won't end up generating a closing quote followed
-                                // by another quote (which parses differently pre-2008 vs. post-2008.)
-                                stringBuilder.Append(Backslash);
-                                stringBuilder.Append(Quote);
-                                continue;
-                            }
-                            stringBuilder.Append(c);
-                        }
-                        stringBuilder.Append(Quote);
-                    }
-                }
+                stringBuilder.Append(' ');
             }
 
-            return stringBuilder.ToString();
+            // Parsing rules for non-argv[0] arguments:
+            //   - Backslash is a normal character except followed by a quote.
+            //   - 2N backslashes followed by a quote ==> N literal backslashes followed by unescaped quote
+            //   - 2N+1 backslashes followed by a quote ==> N literal backslashes followed by a literal quote
+            //   - Parsing stops at first whitespace outside of quoted region.
+            //   - (post 2008 rule): A closing quote followed by another quote ==> literal quote, and parsing remains in quoting mode.
+            if (argument.Length != 0 && ContainsNoWhitespaceOrQuotes(argument))
+            {
+                // Simple case - no quoting or changes needed.
+                stringBuilder.Append(argument);
+            }
+            else
+            {
+                stringBuilder.Append(Quote);
+                int idx = 0;
+                while (idx < argument.Length)
+                {
+                    char c = argument[idx++];
+                    if (c == Backslash)
+                    {
+                        int numBackSlash = 1;
+                        while (idx < argument.Length && argument[idx] == Backslash)
+                        {
+                            idx++;
+                            numBackSlash++;
+                        }
+
+                        if (idx == argument.Length)
+                        {
+                            // We'll emit an end quote after this so must double the number of backslashes.
+                            stringBuilder.Append(Backslash, numBackSlash * 2);
+                        }
+                        else if (argument[idx] == Quote)
+                        {
+                            // Backslashes will be followed by a quote. Must double the number of backslashes.
+                            stringBuilder.Append(Backslash, numBackSlash * 2 + 1);
+                            stringBuilder.Append(Quote);
+                            idx++;
+                        }
+                        else
+                        {
+                            // Backslash will not be followed by a quote, so emit as normal characters.
+                            stringBuilder.Append(Backslash, numBackSlash);
+                        }
+
+                        continue;
+                    }
+
+                    if (c == Quote)
+                    {
+                        // Escape the quote so it appears as a literal. This also guarantees that we won't end up generating a closing quote followed
+                        // by another quote (which parses differently pre-2008 vs. post-2008.)
+                        stringBuilder.Append(Backslash);
+                        stringBuilder.Append(Quote);
+                        continue;
+                    }
+
+                    stringBuilder.Append(c);
+                }
+
+                stringBuilder.Append(Quote);
+            }
         }
 
         private static bool ContainsNoWhitespaceOrQuotes(string s)

--- a/src/Common/src/System/PasteArguments.cs
+++ b/src/Common/src/System/PasteArguments.cs
@@ -136,7 +136,7 @@ namespace System
             return true;
         }
 
-        private const char Quote = '\"';
+        internal const char Quote = '\"';
         private const char Backslash = '\\';
     }
 }

--- a/src/Common/src/System/PasteArguments.cs
+++ b/src/Common/src/System/PasteArguments.cs
@@ -94,7 +94,7 @@ namespace System
             return true;
         }
 
-        internal const char Quote = '\"';
+        private const char Quote = '\"';
         private const char Backslash = '\\';
     }
 }

--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -68,11 +68,15 @@
     <Compile Include="$(CommonPath)\System\Security\IdentityHelper.cs">
       <Link>Common\System\Security\IdentityHelper.cs</Link>
     </Compile>
+    <Compile Include="..\src\System\PasteArguments.cs">
+      <Link>Common\System\PasteArguments.cs</Link>
+    </Compile>
     <Compile Include="Tests\Interop\procfsTests.cs" />
     <Compile Include="Tests\System\AssertExtensionTests.cs" />
     <Compile Include="Tests\System\CharArrayHelpersTests.cs" />
     <Compile Include="Tests\System\IO\StringParserTests.cs" />
     <Compile Include="Tests\System\MarvinTests.cs" />
+    <Compile Include="Tests\System\PasteArgumentsTests.cs" />
     <Compile Include="Tests\System\Security\IdentityHelperTests.cs" />
     <Compile Include="Tests\System\Text\ValueStringBuilderTests.cs" />
     <Compile Include="Tests\System\StringExtensions.Tests.cs" />
@@ -118,6 +122,9 @@
       <Link>Common\System\IO\Win32Marshal.cs</Link>
     </Compile>
     <Compile Include="Tests\System\IO\Win32Marshal.Tests.cs" />
+    <Compile Include="..\src\System\PasteArguments.Windows.cs">
+      <Link>Common\System\PasteArguments.Windows.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
     <Compile Include="..\src\System\IO\PathInternal.Unix.cs">
@@ -129,9 +136,13 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="..\src\System\PasteArguments.Unix.cs">
+      <Link>Common\System\PasteArguments.Unix.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="CommonTest\System\" />
+    <Folder Include="Common\System\Security\Cryptography\" />
     <Folder Include="System\Net\Sockets\" />
     <Folder Include="System\Net\VirtualNetwork\" />
   </ItemGroup>

--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -142,7 +142,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="CommonTest\System\" />
-    <Folder Include="Common\System\Security\Cryptography\" />
     <Folder Include="System\Net\Sockets\" />
     <Folder Include="System\Net\VirtualNetwork\" />
   </ItemGroup>

--- a/src/Common/tests/Tests/System/PasteArgumentsTests.cs
+++ b/src/Common/tests/Tests/System/PasteArgumentsTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+using Xunit;
+
+namespace Tests.System
+{
+    public class PasteArgumentsTests
+    {
+        [Theory]
+        [InlineData(@"app.exe arg1 arg2", new[] {"app.exe", "arg1", "arg2"})]
+        [InlineData(@"""app name.exe"" arg1 arg2", new[] {"app name.exe", "arg1", "arg2"})]
+        [InlineData(@"app.exe \\ arg2", new[] {"app.exe", @"\\", "arg2"})] 
+        [InlineData(@"app.exe ""\"""" arg2", new[] {"app.exe", @"""", "arg2"})]  // literal double quotation mark character
+        [InlineData(@"app.exe ""\\\"""" arg2", new[] {"app.exe", @"\""", "arg2"})]    // 2N+1 backslashes before quote rule 
+        [InlineData(@"app.exe ""\\\\\"""" arg2", new[] {"app.exe", @"\\""", "arg2"})]  // 2N backslashes before quote rule 
+        public void Pastes(string pasteExpected ,string[] arguments)
+        {
+            Assert.Equal(pasteExpected, PasteArguments.Paste(arguments, true));
+        }
+    }
+}

--- a/src/Common/tests/Tests/System/PasteArgumentsTests.cs
+++ b/src/Common/tests/Tests/System/PasteArgumentsTests.cs
@@ -13,9 +13,29 @@ namespace Tests.System
         [InlineData(@"app.exe ""\"""" arg2", new[] {"app.exe", @"""", "arg2"})]  // literal double quotation mark character
         [InlineData(@"app.exe ""\\\"""" arg2", new[] {"app.exe", @"\""", "arg2"})]    // 2N+1 backslashes before quote rule 
         [InlineData(@"app.exe ""\\\\\"""" arg2", new[] {"app.exe", @"\\""", "arg2"})]  // 2N backslashes before quote rule 
-        public void Pastes(string pasteExpected ,string[] arguments)
+        public void Pastes(string pasteExpected, string[] arguments)
         {
-            Assert.Equal(pasteExpected, PasteArguments.Paste(arguments, true));
+            Assert.Equal(pasteExpected, PasteArguments.Paste(arguments, pasteFirstArgumentUsingArgV0Rules: true));
+        }
+
+        [Theory]
+        [InlineData(@"""dir/app\""name.exe""", new[] {@"dir/app""name.exe"})]  // no throwing on quotes, escaping quotes
+        [InlineData(@"""dir/app\\\""name.exe""", new[] {@"dir/app\""name.exe"})]  // escaping a backslash
+        [InlineData(@"""dir/app\\\\\""name.exe""", new[] {@"dir/app\\""name.exe"})]  // escaping backslashes
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void Paste_Argv0Rules_Ignored_onUnix(string pasteExpected, string[] arguments)
+        {
+            Assert.Equal(pasteExpected, PasteArguments.Paste(arguments, pasteFirstArgumentUsingArgV0Rules: true));
+        }
+
+        [Theory]
+        [InlineData(@"dir/app""name.exe")]  // throws
+        [InlineData(@"dir/app\""name.exe")]  // throws and ignores a backslash
+        [InlineData(@"dir/app\\""name.exe")]  // throws and ignores backslashes
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void Paste_Argv0Rules_ThrowsIfQuotes_OnWindows(string argv0)
+        {
+            Assert.Throws<ApplicationException>(() => PasteArguments.Paste(new []{argv0}, pasteFirstArgumentUsingArgV0Rules: true));
         }
     }
 }

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -70,6 +70,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCurrentProcess_IntPtr.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.GetCurrentProcess_IntPtr.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\System\PasteArguments.Windows.cs">
+      <Link>Common\System\PasteArguments.Windows.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs</Link>
     </Compile>
@@ -96,6 +99,9 @@
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\PasteArguments.Unix.cs">
+      <Link>Common\System\PasteArguments.Unix.cs</Link>
     </Compile>
     <Compile Include="System\AdminHelpers.Unix.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEUid.cs">

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -54,5 +54,17 @@
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
   </ItemGroup>
+  <!-- WINDOWS: Shared CoreCLR and .NET Native -->
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="..\..\Common\src\System\PasteArguments.Windows.cs">
+      <Link>Common\System\PasteArguments.Windows.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- UNIX -->
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
+    <Compile Include="..\..\Common\src\System\PasteArguments.Unix.cs">
+      <Link>Common\System\PasteArguments.Unix.cs</Link>
+    </Compile>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -99,6 +99,9 @@
   </ItemGroup>
   <!-- WINDOWS: Shared CoreCLR and .NET Native -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="..\..\Common\src\System\PasteArguments.Windows.cs">
+      <Link>Common\System\PasteArguments.Windows.cs</Link>
+    </Compile>
     <Compile Include="System\Environment.Windows.cs" />
     <Compile Include="System\Runtime\Versioning\VersioningHelper.Windows.cs" />
     <Compile Include="System\Diagnostics\Stopwatch.Windows.cs" />
@@ -245,6 +248,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Names.Unix.cs">
       <Link>Common\System\IO\PersistedFiles.Unix.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\PasteArguments.Unix.cs">
+      <Link>Common\System\PasteArguments.Unix.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -19,6 +19,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="..\..\Common\src\System\PasteArguments.cs">
+      <Link>Common\System\PasteArguments.cs</Link>
+    </Compile>
     <Compile Include="System\AppDomain.cs" />
     <Compile Include="System\AppDomainUnloadedException.cs" />
     <Compile Include="System\ApplicationId.cs" />

--- a/src/System.Runtime.Extensions/src/System/Environment.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.cs
@@ -65,35 +65,12 @@ namespace System
         {
             get
             {
-                StringBuilder sb = StringBuilderCache.Acquire();
-
-                foreach (string arg in GetCommandLineArgs())
-                {
-                    bool containsQuotes = false, containsWhitespace = false;
-                    foreach (char c in arg)
-                    {
-                        if (char.IsWhiteSpace(c))
-                        {
-                            containsWhitespace = true;
-                        }
-                        else if (c == '"')
-                        {
-                            containsQuotes = true;
-                        }
-                    }
-
-                    string quote = containsWhitespace ? "\"" : "";
-                    string formattedArg = containsQuotes && containsWhitespace ? arg.Replace("\"", "\\\"") : arg;
-
-                    sb.Append(quote).Append(formattedArg).Append(quote).Append(' ');
-                }
-
-                if (sb.Length > 0)
-                {
-                    sb.Length--;
-                }
-
-                return StringBuilderCache.GetStringAndRelease(sb);
+                var args = GetCommandLineArgs();
+                // Not to throw for quotes inside argv0. Since the input was constructed by the framework itself from the
+                // passed in command line, this shouldn't ever happen but if it ever does, throwing is a bit extreme here.
+                if (args.Length > 0 && !String.IsNullOrEmpty(args[0]))
+                    args[0].Replace(PasteArguments.Quote, '\'');
+                return PasteArguments.Paste(args, true);
             }
         }
 

--- a/src/System.Runtime.Extensions/src/System/Environment.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.cs
@@ -65,12 +65,7 @@ namespace System
         {
             get
             {
-                string[] args = GetCommandLineArgs();
-                // Not to throw for quotes inside argv0. Since the input was constructed by the framework itself from the
-                // passed in command line, this shouldn't ever happen but if it ever does, throwing is a bit extreme here.
-                if (args.Length > 0 && !string.IsNullOrEmpty(args[0]))
-                    args[0] = args[0].Replace(PasteArguments.Quote, '\'');
-                return PasteArguments.Paste(args, true);
+                return PasteArguments.Paste(GetCommandLineArgs(), true);
             }
         }
 

--- a/src/System.Runtime.Extensions/src/System/Environment.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.cs
@@ -65,7 +65,7 @@ namespace System
         {
             get
             {
-                return PasteArguments.Paste(GetCommandLineArgs(), true);
+                return PasteArguments.Paste(GetCommandLineArgs(), pasteFirstArgumentUsingArgV0Rules: true);
             }
         }
 

--- a/src/System.Runtime.Extensions/src/System/Environment.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.cs
@@ -65,11 +65,11 @@ namespace System
         {
             get
             {
-                var args = GetCommandLineArgs();
+                string[] args = GetCommandLineArgs();
                 // Not to throw for quotes inside argv0. Since the input was constructed by the framework itself from the
                 // passed in command line, this shouldn't ever happen but if it ever does, throwing is a bit extreme here.
-                if (args.Length > 0 && !String.IsNullOrEmpty(args[0]))
-                    args[0].Replace(PasteArguments.Quote, '\'');
+                if (args.Length > 0 && !string.IsNullOrEmpty(args[0]))
+                    args[0] = args[0].Replace(PasteArguments.Quote, '\'');
                 return PasteArguments.Paste(args, true);
             }
         }


### PR DESCRIPTION
Using PasteArguments from Environment to avoid code duplication while
getting command line.

Issue #21267. Command Line tokenization is done all over the place and inconsistently.