### PR TITLE
Fix Alpine CI build last issue

### DIFF
--- a/buildpipeline/alpine.3.6.groovy
+++ b/buildpipeline/alpine.3.6.groovy
@@ -40,13 +40,4 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-2017111
     // TODO: Add submission for Helix testing once we have queue for Alpine Linux working
 }
 
-stage ('Execute Tests') {
-    def contextBase
-    if (params.TestOuter) {
-        contextBase = "Alpine.3.6 x64 Tests w/outer - ${params.CGroup}"
-    }
-    else {
-        contextBase = "Alpine.3.6 x64 Tests - ${params.CGroup}"
-    }
-    waitForHelixRuns(submittedHelixJson, contextBase)
-}
+// TODO: Add "Execute tests" stage once we have queue for Alpine Linux working


### PR DESCRIPTION
By accident, I've put in the stage for executing tests although we
cannot do that until we have Alpine queue in Helix working.
This change removes that, which should be the last thing preventing the
CI from succeeding.