### PR TITLE
Adding System.IO.Compression.ZipFile to net471 support package

### DIFF
--- a/external/netfx-conflicts/netfx-conflicts.depproj
+++ b/external/netfx-conflicts/netfx-conflicts.depproj
@@ -30,6 +30,7 @@
     <_contract Include="System.Globalization.Extensions"/>
     <_contract Include="System.IO"/>
     <_contract Include="System.IO.Compression"/>
+    <_contract Include="System.IO.Compression.ZipFile"/>
     <_contract Include="System.Linq"/>
     <_contract Include="System.Linq.Expressions"/>
     <_contract Include="System.Linq.Parallel"/>

--- a/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
+++ b/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
@@ -42,7 +42,11 @@
 
   <Target Name="IncludeNETStandardShims">
     <ItemGroup>
-      <_libFileNames Include="@(LibFile->'%(FileName)')" Condition="'%(Extension)' == '.dll'" />
+      <!-- 
+          System.IO.Compression.ZipFile is a special case because we do want to include the netstandard shim for net461, but in net471 we want to 
+          cross compile it so that we also include it on that folder for the support package. 
+      -->
+      <_libFileNames Include="@(LibFile->'%(FileName)')" Condition="'%(Extension)' == '.dll'" Exclude="System.IO.Compression.ZipFile" />
 
       <!-- remove any targeting pack assemblies that we build ourselves -->
       <_netFxReference Include="@(NetFxReference)" Exclude="@(_libFileNames)" />
@@ -106,17 +110,6 @@
       <FrameworkClosureFile Include="@(NetFxReference->'$(RefRootPath)net47/%(Identity).dll')" >
         <FileSet>runtime-net47</FileSet>
       </FrameworkClosureFile>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="AddSupressedAssembliesForNetstandard" BeforeTargets="VerifyNETStandard">
-    <!-- 
-      Adding System.IO.Compression.ZipFile to the supression list as we don't crosscompile it for net461 
-      and we only need it in 4.7.1 folder of the support package because of a unification table bug which
-      has the wrong public key for this assembly. 
-    -->
-    <ItemGroup>
-      <SuppressNETStandardMissingFile Include="System.IO.Compression.ZipFile" />
     </ItemGroup>
   </Target>
 

--- a/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
+++ b/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
@@ -109,6 +109,17 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="AddSupressedAssembliesForNetstandard" BeforeTargets="VerifyNETStandard">
+    <!-- 
+      Adding System.IO.Compression.ZipFile to the supression list as we don't crosscompile it for net461 
+      and we only need it in 4.7.1 folder of the support package because of a unification table bug which
+      has the wrong public key for this assembly. 
+    -->
+    <ItemGroup>
+      <SuppressNETStandardMissingFile Include="System.IO.Compression.ZipFile" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="ExpandClosureFilesByTargetFramework"
           AfterTargets="GetClosureFiles"
           Inputs="%(ClosureFile.FileSet)"

--- a/src/System.IO.Compression.ZipFile/dir.props
+++ b/src/System.IO.Compression.ZipFile/dir.props
@@ -6,5 +6,6 @@
     <AssemblyKey>ECMA</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>
+    <IsNetFxNETStandard>true</IsNetFxNETStandard>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Compression.ZipFile/ref/Configurations.props
+++ b/src/System.IO.Compression.ZipFile/ref/Configurations.props
@@ -4,6 +4,8 @@
     <BuildConfigurations>
       netcoreapp;
       uap;
+      netfx;
+      net471;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Compression.ZipFile/ref/Configurations.props
+++ b/src/System.IO.Compression.ZipFile/ref/Configurations.props
@@ -4,7 +4,6 @@
     <BuildConfigurations>
       netcoreapp;
       uap;
-      netfx;
       net471;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.IO.Compression.ZipFile/ref/System.IO.Compression.ZipFile.Forwards.cs
+++ b/src/System.IO.Compression.ZipFile/ref/System.IO.Compression.ZipFile.Forwards.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: TypeForwardedTo(typeof(System.IO.Compression.ZipFile))]
+[assembly: TypeForwardedTo(typeof(System.IO.Compression.ZipFileExtensions))]

--- a/src/System.IO.Compression.ZipFile/ref/System.IO.Compression.ZipFile.csproj
+++ b/src/System.IO.Compression.ZipFile/ref/System.IO.Compression.ZipFile.csproj
@@ -8,10 +8,19 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net471-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net471-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="System.IO.Compression.ZipFile.cs" />
+    <Compile Include="System.IO.Compression.ZipFile.cs" Condition="'$(TargetGroup)' != 'net471' And '$(TargetGroup)' != 'netfx'" />
+    <Compile Include="System.IO.Compression.ZipFile.Forwards.cs" Condition="'$(TargetGroup)' == 'net471' Or '$(TargetGroup)' == 'netfx'" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net471' Or '$(TargetGroup)' == 'netfx'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'net471' And '$(TargetGroup)' != 'netfx'">
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.IO\ref\System.IO.csproj" />
     <ProjectReference Include="..\..\System.IO.Compression\ref\System.IO.Compression.csproj" />

--- a/src/System.IO.Compression.ZipFile/ref/System.IO.Compression.ZipFile.csproj
+++ b/src/System.IO.Compression.ZipFile/ref/System.IO.Compression.ZipFile.csproj
@@ -10,17 +10,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net471-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net471-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="System.IO.Compression.ZipFile.cs" Condition="'$(TargetGroup)' != 'net471' And '$(TargetGroup)' != 'netfx'" />
-    <Compile Include="System.IO.Compression.ZipFile.Forwards.cs" Condition="'$(TargetGroup)' == 'net471' Or '$(TargetGroup)' == 'netfx'" />
+    <Compile Include="System.IO.Compression.ZipFile.cs" Condition="'$(TargetGroup)' != 'net471'" />
+    <Compile Include="System.IO.Compression.ZipFile.Forwards.cs" Condition="'$(TargetGroup)' == 'net471'" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net471' Or '$(TargetGroup)' == 'netfx'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net471'">
     <Reference Include="mscorlib" />
     <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'net471' And '$(TargetGroup)' != 'netfx'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net471'">
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.IO\ref\System.IO.csproj" />
     <ProjectReference Include="..\..\System.IO.Compression\ref\System.IO.Compression.csproj" />

--- a/src/System.IO.Compression.ZipFile/src/Configurations.props
+++ b/src/System.IO.Compression.ZipFile/src/Configurations.props
@@ -4,7 +4,6 @@
     <BuildConfigurations>
       uap-Windows_NT;
       netcoreapp;
-      netfx-Windows_NT;
       net471-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.IO.Compression.ZipFile/src/Configurations.props
+++ b/src/System.IO.Compression.ZipFile/src/Configurations.props
@@ -4,6 +4,8 @@
     <BuildConfigurations>
       uap-Windows_NT;
       netcoreapp;
+      netfx-Windows_NT;
+      net471-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
+++ b/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.IO.Compression.ZipFile</AssemblyName>
     <ProjectGuid>{ACF967ED-7FC9-435C-B2C9-306626B7B6C6}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net471' Or '$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net471'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
@@ -14,16 +14,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net471-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net471-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net471' And '$(TargetGroup)' != 'netfx'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net471'">
     <Compile Include="System\IO\Compression\ZipFile.cs" />
     <Compile Include="System\IO\Compression\ZipFileExtensions.cs" />
     <Compile Include="$(CommonPath)\System\IO\PathInternal.CaseSensitivity.cs">
       <Link>Common\System\IO\PathInternal.CaseSensitivity.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'net471' And '$(TargetGroup)' != 'netfx'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net471'">
     <Reference Include="System.Buffers" />
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />
@@ -37,7 +35,7 @@
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Text.Encoding" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net471' Or '$(TargetGroup)' == 'netfx'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net471'">
     <Reference Include="mscorlib" />
     <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>

--- a/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
+++ b/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
@@ -5,20 +5,25 @@
     <AssemblyName>System.IO.Compression.ZipFile</AssemblyName>
     <ProjectGuid>{ACF967ED-7FC9-435C-B2C9-306626B7B6C6}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net471' Or '$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net471-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net471-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' != 'net471' And '$(TargetGroup)' != 'netfx'">
     <Compile Include="System\IO\Compression\ZipFile.cs" />
     <Compile Include="System\IO\Compression\ZipFileExtensions.cs" />
     <Compile Include="$(CommonPath)\System\IO\PathInternal.CaseSensitivity.cs">
       <Link>Common\System\IO\PathInternal.CaseSensitivity.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'net471' And '$(TargetGroup)' != 'netfx'">
     <Reference Include="System.Buffers" />
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />
@@ -31,6 +36,10 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Text.Encoding" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net471' Or '$(TargetGroup)' == 'netfx'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/netfx.force.conflict/src/TypeForwards.471.cs
+++ b/src/netfx.force.conflict/src/TypeForwards.471.cs
@@ -12,6 +12,8 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Diagnostics.Tracing.EventSource))]
 // System.Globalization.Extensions
 [assembly: TypeForwardedTo(typeof(System.Globalization.GlobalizationExtensions))]
+// System.IO.Compression.ZipFile
+[assembly: TypeForwardedTo(typeof(System.IO.Compression.ZipFile))]
 // System.IO.Compression
 [assembly: TypeForwardedTo(typeof(System.IO.Compression.GZipStream))]
 // System.Net.Http


### PR DESCRIPTION
cc: @weshaggard @safern @AlexGhiondea 

These changes will add System.IO.Compression.ZipFile to the support package and will cause a conflict so that the right binding redirect is generated for it.