### PR TITLE
Reenable automatic Alpine leg in CI

### DIFF
--- a/buildpipeline/alpine.3.6.groovy
+++ b/buildpipeline/alpine.3.6.groovy
@@ -6,14 +6,10 @@
 // CGroup - Build configuration.
 // TestOuter - If true, runs outerloop, if false runs just innerloop
 
-def submittedHelixJson = null
-
 simpleDockerNode('microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-20171119021156') {
     stage ('Checkout source') {
         checkoutRepo()
     }
-
-    def logFolder = getLogFolder()
 
     stage ('Initialize tools') {
         // Init tools

--- a/buildpipeline/pipelinejobs.groovy
+++ b/buildpipeline/pipelinejobs.groovy
@@ -23,7 +23,7 @@ def winPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'build
 def configurations = [
     ['TGroup':"netcoreapp", 'Pipeline':linPipeline, 'Name':'Linux' ,'ForPR':"Release-x64", 'Arch':['x64']],
     ['TGroup':"netcoreapp", 'Pipeline':centos6Pipeline, 'Name':'CentOS.6' ,'ForPR':"", 'Arch':['x64']],
-    ['TGroup':"netcoreapp", 'Pipeline':alpine36Pipeline, 'Name':'Alpine.3.6' ,'ForPR':"", 'Arch':['x64']],
+    ['TGroup':"netcoreapp", 'Pipeline':alpine36Pipeline, 'Name':'Alpine.3.6' ,'ForPR':"Debug-x64", 'Arch':['x64']],
     ['TGroup':"netcoreapp", 'Pipeline':osxPipeline, 'Name':'OSX', 'ForPR':"Debug-x64", 'Arch':['x64']],
     ['TGroup':"netcoreapp", 'Pipeline':winPipeline, 'Name':'Windows' , 'ForPR':"Debug-x64|Release-x86"],
     ['TGroup':"netfx",      'Pipeline':winPipeline, 'Name':'NETFX', 'ForPR':"Release-x86"],


### PR DESCRIPTION
This change reenables automatic running of Alpine tests on every PR. It
also removed two unused variables in the alpine.3.6.groovy file.