### PR TITLE
NamedPipeClient connect throws TimeoutException when appropriate 

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/Common/src/Interop/Windows/Interop.Errors.cs
@@ -26,6 +26,7 @@ internal partial class Interop
         internal const int ERROR_FILE_EXISTS = 0x50;
         internal const int ERROR_INVALID_PARAMETER = 0x57;
         internal const int ERROR_BROKEN_PIPE = 0x6D;
+        internal const int ERROR_SEM_TIMEOUT = 0x79;
         internal const int ERROR_CALL_NOT_IMPLEMENTED  = 0x78;
         internal const int ERROR_INSUFFICIENT_BUFFER = 0x7A;
         internal const int ERROR_INVALID_NAME = 0x7B;

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -65,7 +65,7 @@ namespace System.IO.Pipes
                 {
                     errorCode = Marshal.GetLastWin32Error();
 
-                    // Server is not yet created or a timeout ocurred before a pipe instance was available.
+                    // Server is not yet created or a timeout occurred before a pipe instance was available.
                     if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND ||
                         errorCode == Interop.Errors.ERROR_SEM_TIMEOUT)
                     {

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -65,24 +65,14 @@ namespace System.IO.Pipes
                 {
                     errorCode = Marshal.GetLastWin32Error();
 
-                    // Server is not yet created
-                    if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND)
+                    // Server is not yet created or a timeout ocurred before a pipe instance was available.
+                    if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND ||
+                        errorCode == Interop.Errors.ERROR_SEM_TIMEOUT)
                     {
                         return false;
                     }
 
-                    // The timeout has expired.
-                    if (errorCode == Interop.Errors.ERROR_SUCCESS)
-                    {
-                        if (cancellationToken.CanBeCanceled)
-                        {
-                            // It may not be real timeout.
-                            return false;
-                        }
-                        throw new TimeoutException();
-                    }
-
-                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, errorCode.ToString("X8"));
                 }
 
                 // Pipe server should be free.  Let's try to connect to it.

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -72,7 +72,7 @@ namespace System.IO.Pipes
                         return false;
                     }
 
-                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, errorCode.ToString("X8"));
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
                 }
 
                 // Pipe server should be free.  Let's try to connect to it.

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -628,6 +628,8 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/pull/25877 yet to be ported to netfx")]
+        [PlatformSpecific(TestPlatforms.Windows)] // Unix ignores MaxNumberOfServerInstances and second client also connects.
         public void ClientConnect_Throws_Timeout_When_Pipe_Busy()
         {
             string pipeName = GetUniquePipeName();
@@ -651,6 +653,8 @@ namespace System.IO.Pipes.Tests
 
         [Theory]
         [MemberData(nameof(GetCancellationTokens))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/pull/25877 yet to be ported to netfx")]
+        [PlatformSpecific(TestPlatforms.Windows)] // Unix ignores MaxNumberOfServerInstances and second client also connects.
         public async void ClientConnectAsync_With_Cancellation_Throws_Timeout_When_Pipe_Busy(CancellationToken cancellationToken)
         {
             string pipeName = GetUniquePipeName();

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -605,5 +605,79 @@ namespace System.IO.Pipes.Tests
             }
         }
 
+        [Fact]
+        public void ClientConnect_Throws_Timeout_When_Pipe_Not_Found()
+        {
+            string pipeName = GetUniquePipeName();
+            using (NamedPipeClientStream client = new NamedPipeClientStream(pipeName))
+            {
+                Assert.Throws<TimeoutException>(() => client.Connect(91));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCancellationTokens))]
+        public async void ClientConnectAsync_Throws_Timeout_When_Pipe_Not_Found(CancellationToken cancellationToken)
+        {
+            string pipeName = GetUniquePipeName();
+            using (NamedPipeClientStream client = new NamedPipeClientStream(pipeName))
+            {
+                Task waitingClient = client.ConnectAsync(92, cancellationToken);
+                await Assert.ThrowsAsync<TimeoutException>(() => { return waitingClient; });
+            }
+        }
+
+        [Fact]
+        public void ClientConnect_Throws_Timeout_When_Pipe_Busy()
+        {
+            string pipeName = GetUniquePipeName();
+
+            using (NamedPipeServerStream server = new NamedPipeServerStream(pipeName))
+            using (NamedPipeClientStream firstClient = new NamedPipeClientStream(pipeName))
+            using (NamedPipeClientStream secondClient = new NamedPipeClientStream(pipeName))
+            {
+                const int timeout = 10_000;
+                Task[] clientAndServerTasks = new[]
+                    {
+                        firstClient.ConnectAsync(timeout),
+                        Task.Run(() => server.WaitForConnection())
+                    };
+
+                Assert.True(Task.WaitAll(clientAndServerTasks, timeout));
+
+                Assert.Throws<TimeoutException>(() => secondClient.Connect(93));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCancellationTokens))]
+        public async void ClientConnectAsync_With_Cancellation_Throws_Timeout_When_Pipe_Busy(CancellationToken cancellationToken)
+        {
+            string pipeName = GetUniquePipeName();
+
+            using (NamedPipeServerStream server = new NamedPipeServerStream(pipeName))
+            using (NamedPipeClientStream firstClient = new NamedPipeClientStream(pipeName))
+            using (NamedPipeClientStream secondClient = new NamedPipeClientStream(pipeName))
+            {
+                const int timeout = 10_000;
+                Task[] clientAndServerTasks = new[]
+                    {
+                        firstClient.ConnectAsync(timeout),
+                        Task.Run(() => server.WaitForConnection())
+                    };
+
+                Assert.True(Task.WaitAll(clientAndServerTasks, timeout));
+
+                Task waitingClient = secondClient.ConnectAsync(94, cancellationToken);
+                await Assert.ThrowsAsync<TimeoutException>(() => { return waitingClient; });
+            }
+        }
+
+        public static IEnumerable<object[]> GetCancellationTokens =>
+            new []
+            {
+                new object[] { CancellationToken.None },
+                new object[] { new CancellationTokenSource().Token },
+            };
     }
 }


### PR DESCRIPTION
Fixes #24635

Changing the code to ERROR_SEM_TIMEOUT changes the exception from
IOException("The semaphore timeout period has expired") to a
TimeoutException when the pipe is busy.

Another change in behavior: if there was a good cancellationToken (i.e.:
CanBeCancelled was true) with a timeout larger than 50ms and the pipe
was busy it was failing with the IOException on first try (after waiting
50ms). However it was waiting for the whole user timeout if the token
could not be cancelled. This change will make it wait for the full user
timeout independently of cancellationToken.CanBeCancelled value.