### PR TITLE
Use generic test handling for remote server failures.

### DIFF
--- a/src/Common/tests/System/Net/RemoteServerQuery.cs
+++ b/src/Common/tests/System/Net/RemoteServerQuery.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Test.Common
+{
+    internal static class RemoteServerQuery
+    {
+        internal static async Task Run(Func<Task> testCode, Type remoteServerFailExceptionType, string servername, bool mustFail = true)
+        {
+            try
+            {
+                await testCode();
+            }
+            catch (Exception actualException)
+            {
+                if (remoteServerFailExceptionType.Equals(actualException.GetType()))
+                {
+                    if (mustFail)
+                        Assert.True(false, $"External issue with remote server: {servername}");
+
+                    return;
+                }
+
+                throw;
+            }
+        }
+
+        internal static async Task<TResult> Run<TResult>(Func<Task<TResult>> testCode, Type remoteServerFailExceptionType, string servername, bool mustFail = true)
+        {
+            try
+            {
+                return await testCode();
+            }
+            catch (Exception actualException)
+            {
+                if (remoteServerFailExceptionType.Equals(actualException.GetType()))
+                {
+                    if (mustFail)
+                        Assert.True(false, $"External issue with remote server: {servername}, test threw {remoteServerFailExceptionType}");
+
+                    return default(TResult);
+                }
+
+                throw;
+            }
+        }
+
+        internal static async Task ThrowsAsync<T>(Func<Task> testCode, Type remoteServerFailExceptionType, string servername, bool mustFail = true)
+            where T : Exception
+        {
+            try
+            {
+                await testCode();
+                Assert.True(false, $"Expected: {typeof(T)}, Actual: No exception thrown.");
+            }
+            catch (Exception actualException)
+            {
+                Type actualExceptionType = actualException.GetType();
+                if (typeof(T).Equals(actualExceptionType))
+                {
+                    return;
+                }
+                else if (remoteServerFailExceptionType.Equals(actualExceptionType))
+                {
+                    if (mustFail)
+                        Assert.True(false, $"External issue with remote server: {servername}");
+
+                    return;
+                }
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Net.Security;
 using System.Net.Test.Common;
+using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Threading.Tasks;
 using Xunit;
@@ -155,7 +156,8 @@ namespace System.Net.Http.Functional.Tests
                 }
                 using (var client = new HttpClient(handler))
                 {
-                    (await client.GetAsync(url)).Dispose();
+                    Type remoteServerExceptionType = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? typeof(TaskCanceledException) : typeof(HttpRequestException);
+                    (await RemoteServerQuery.Run<HttpResponseMessage>(() => client.GetAsync(url), remoteServerExceptionType, url)).Dispose();
                 }
             }
         }
@@ -189,7 +191,8 @@ namespace System.Net.Http.Functional.Tests
 
             using (HttpClient client = CreateHttpClient())
             {
-                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
+                Type remoteServerExceptionType = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? typeof(TaskCanceledException) : typeof(HttpRequestException);
+                await RemoteServerQuery.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url), remoteServerExceptionType, url);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -30,6 +30,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\DelegateStream.cs">
       <Link>Common\System\IO\DelegateStream.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\RemoteServerQuery.cs">
+      <Link>Common\System\Net\RemoteServerQuery.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
       <Link>Common\System\Net\Configuration.Certificates.cs</Link>
     </Compile>


### PR DESCRIPTION
cc @karelz @wfurt @davidsh 

fixes #25878 