### PR TITLE
Temporarily removing use of ReadOnlySpan indexer.

### DIFF
--- a/src/Common/src/System/Memory/FixedBufferExtensions.cs
+++ b/src/Common/src/System/Memory/FixedBufferExtensions.cs
@@ -35,17 +35,21 @@ namespace System
             if (value == null || value.Length > span.Length)
                 return false;
 
-            int i = 0;
-            for (; i < value.Length; i++)
+            fixed (char* spanPtr = &span.DangerousGetPinnableReference())
             {
-                // Strings with embedded nulls can never match as the fixed buffer always null terminates.
-                if (value[i] == '\0' || value[i] != span[i])
-                    return false;
-            }
+                var readWriteSpan = new Span<char>(spanPtr, span.Length);
+                int i = 0;
+                for (; i < value.Length; i++)
+                {
+                    // Strings with embedded nulls can never match as the fixed buffer always null terminates.
+                    if (value[i] == '\0' || value[i] != readWriteSpan[i])
+                        return false;
+                }
 
-            // If we've maxed out the buffer or reached the
-            // null terminator, we're equal.
-            return i == span.Length || span[i] == '\0';
+                // If we've maxed out the buffer or reached the
+                // null terminator, we're equal.
+                return i == span.Length || readWriteSpan[i] == '\0';
+            }
         }
     }
 }

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -3212,16 +3212,20 @@ namespace System.Xml
             }
         }
 
-        private void EatPreamble()
+        private unsafe void EatPreamble()
         {
             ReadOnlySpan<byte> preamble = _ps.encoding.Preamble;
             int preambleLen = preamble.Length;
             int i;
-            for (i = 0; i < preambleLen && i < _ps.bytesUsed; i++)
+            fixed (byte* preamblePtr = &preamble.DangerousGetPinnableReference())
             {
-                if (_ps.bytes[i] != preamble[i])
+                var preambleSpan = new Span<byte>(preamblePtr, preambleLen);
+                for (i = 0; i < preambleLen && i < _ps.bytesUsed; i++)
                 {
-                    break;
+                    if (_ps.bytes[i] != preambleSpan[i])
+                    {
+                        break;
+                    }
                 }
             }
             if (i == preambleLen)

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -256,209 +256,213 @@ namespace System.Numerics
         {
         }
 
-        public BigInteger(ReadOnlySpan<byte> value, bool isUnsigned=false, bool isBigEndian=false)
+        public unsafe BigInteger(ReadOnlySpan<byte> value, bool isUnsigned=false, bool isBigEndian=false)
         {
-            int byteCount = value.Length;
-
-            bool isNegative;
-            if (byteCount > 0)
+            fixed (byte* valuePtr = &value.DangerousGetPinnableReference())
             {
-                byte mostSignificantByte = isBigEndian ? value[0] : value[byteCount - 1];
-                isNegative = (mostSignificantByte & 0x80) != 0 && !isUnsigned;
+                var valueSpan = new Span<byte>(valuePtr, value.Length);
+                int byteCount = valueSpan.Length;
 
-                if (mostSignificantByte == 0)
+                bool isNegative;
+                if (byteCount > 0)
                 {
-                    // Try to conserve space as much as possible by checking for wasted leading byte[] entries 
+                    byte mostSignificantByte = isBigEndian ? valueSpan[0] : valueSpan[byteCount - 1];
+                    isNegative = (mostSignificantByte & 0x80) != 0 && !isUnsigned;
+
+                    if (mostSignificantByte == 0)
+                    {
+                        // Try to conserve space as much as possible by checking for wasted leading byte[] entries 
+                        if (isBigEndian)
+                        {
+                            int offset = 1;
+
+                            while (offset < byteCount && valueSpan[offset] == 0)
+                            {
+                                offset++;
+                            }
+
+                            valueSpan = valueSpan.Slice(offset);
+                            byteCount = valueSpan.Length;
+                        }
+                        else
+                        {
+                            byteCount -= 2;
+
+                            while (byteCount >= 0 && valueSpan[byteCount] == 0)
+                            {
+                                byteCount--;
+                            }
+
+                            byteCount++;
+                        }
+                    }
+                }
+                else
+                {
+                    isNegative = false;
+                }
+
+                if (byteCount == 0)
+                {
+                    // BigInteger.Zero
+                    _sign = 0;
+                    _bits = null;
+                    AssertValid();
+                    return;
+                }
+
+                if (byteCount <= 4)
+                {
+                    _sign = isNegative ? unchecked((int)0xffffffff) : 0;
+
                     if (isBigEndian)
                     {
-                        int offset = 1;
-
-                        while (offset < byteCount && value[offset] == 0)
+                        for (int i = 0; i < byteCount; i++)
                         {
-                            offset++;
+                            _sign = (_sign << 8) | valueSpan[i];
                         }
-
-                        value = value.Slice(offset);
-                        byteCount = value.Length;
                     }
                     else
                     {
-                        byteCount -= 2;
-
-                        while (byteCount >= 0 && value[byteCount] == 0)
+                        for (int i = byteCount - 1; i >= 0; i--)
                         {
-                            byteCount--;
+                            _sign = (_sign << 8) | valueSpan[i];
                         }
-
-                        byteCount++;
                     }
-                }
-            }
-            else
-            {
-                isNegative = false;
-            }
 
-            if (byteCount == 0)
-            {
-                // BigInteger.Zero
-                _sign = 0;
-                _bits = null;
-                AssertValid();
-                return;
-            }
-
-            if (byteCount <= 4)
-            {
-                _sign = isNegative ? unchecked((int)0xffffffff) : 0;
-
-                if (isBigEndian)
-                {
-                    for (int i = 0; i < byteCount; i++)
+                    _bits = null;
+                    if (_sign < 0 && !isNegative)
                     {
-                        _sign = (_sign << 8) | value[i];
+                        // Int32 overflow
+                        // Example: Int64 value 2362232011 (0xCB, 0xCC, 0xCC, 0x8C, 0x0)
+                        // can be naively packed into 4 bytes (due to the leading 0x0)
+                        // it overflows into the int32 sign bit
+                        _bits = new uint[1] { unchecked((uint)_sign) };
+                        _sign = +1;
+                    }
+                    if (_sign == int.MinValue)
+                    {
+                        this = s_bnMinInt;
                     }
                 }
                 else
                 {
-                    for (int i = byteCount - 1; i >= 0; i--)
+                    int unalignedBytes = byteCount % 4;
+                    int dwordCount = byteCount / 4 + (unalignedBytes == 0 ? 0 : 1);
+                    uint[] val = new uint[dwordCount];
+                    int byteCountMinus1 = byteCount - 1;
+
+                    // Copy all dwords, except don't do the last one if it's not a full four bytes
+                    int curDword, curByte;
+
+                    if (isBigEndian)
                     {
-                        _sign = (_sign << 8) | value[i];
-                    }
-                }
-
-                _bits = null;
-                if (_sign < 0 && !isNegative)
-                {
-                    // Int32 overflow
-                    // Example: Int64 value 2362232011 (0xCB, 0xCC, 0xCC, 0x8C, 0x0)
-                    // can be naively packed into 4 bytes (due to the leading 0x0)
-                    // it overflows into the int32 sign bit
-                    _bits = new uint[1] { unchecked((uint)_sign) };
-                    _sign = +1;
-                }
-                if (_sign == int.MinValue)
-                {
-                    this = s_bnMinInt;
-                }
-            }
-            else
-            {
-                int unalignedBytes = byteCount % 4;
-                int dwordCount = byteCount / 4 + (unalignedBytes == 0 ? 0 : 1);
-                uint[] val = new uint[dwordCount];
-                int byteCountMinus1 = byteCount - 1;
-
-                // Copy all dwords, except don't do the last one if it's not a full four bytes
-                int curDword, curByte;
-
-                if (isBigEndian)
-                {
-                    curByte = byteCount - sizeof(int);
-                    for (curDword = 0; curDword < dwordCount - (unalignedBytes == 0 ? 0 : 1); curDword++)
-                    {
-                        for (int byteInDword = 0; byteInDword < 4; byteInDword++)
+                        curByte = byteCount - sizeof(int);
+                        for (curDword = 0; curDword < dwordCount - (unalignedBytes == 0 ? 0 : 1); curDword++)
                         {
-                            byte curByteValue = value[curByte];
-                            val[curDword] = (val[curDword] << 8) | curByteValue;
-                            curByte++;
+                            for (int byteInDword = 0; byteInDword < 4; byteInDword++)
+                            {
+                                byte curByteValue = valueSpan[curByte];
+                                val[curDword] = (val[curDword] << 8) | curByteValue;
+                                curByte++;
+                            }
+
+                            curByte -= 8;
+                        }
+                    }
+                    else
+                    {
+                        curByte = sizeof(int) - 1;
+                        for (curDword = 0; curDword < dwordCount - (unalignedBytes == 0 ? 0 : 1); curDword++)
+                        {
+                            for (int byteInDword = 0; byteInDword < 4; byteInDword++)
+                            {
+                                byte curByteValue = valueSpan[curByte];
+                                val[curDword] = (val[curDword] << 8) | curByteValue;
+                                curByte--;
+                            }
+
+                            curByte += 8;
+                        }
+                    }
+
+                    // Copy the last dword specially if it's not aligned
+                    if (unalignedBytes != 0)
+                    {
+                        if (isNegative)
+                        {
+                            val[dwordCount - 1] = 0xffffffff;
                         }
 
-                        curByte -= 8;
-                    }
-                }
-                else
-                {
-                    curByte = sizeof(int) - 1;
-                    for (curDword = 0; curDword < dwordCount - (unalignedBytes == 0 ? 0 : 1); curDword++)
-                    {
-                        for (int byteInDword = 0; byteInDword < 4; byteInDword++)
+                        if (isBigEndian)
                         {
-                            byte curByteValue = value[curByte];
-                            val[curDword] = (val[curDword] << 8) | curByteValue;
-                            curByte--;
+                            for (curByte = 0; curByte < unalignedBytes; curByte++)
+                            {
+                                byte curByteValue = valueSpan[curByte];
+                                val[curDword] = (val[curDword] << 8) | curByteValue;
+                            }
                         }
-
-                        curByte += 8;
+                        else
+                        {
+                            for (curByte = byteCountMinus1; curByte >= byteCount - unalignedBytes; curByte--)
+                            {
+                                byte curByteValue = valueSpan[curByte];
+                                val[curDword] = (val[curDword] << 8) | curByteValue;
+                            }
+                        }
                     }
-                }
 
-                // Copy the last dword specially if it's not aligned
-                if (unalignedBytes != 0)
-                {
                     if (isNegative)
                     {
-                        val[dwordCount - 1] = 0xffffffff;
-                    }
+                        NumericsHelpers.DangerousMakeTwosComplement(val); // Mutates val
 
-                    if (isBigEndian)
-                    {
-                        for (curByte = 0; curByte < unalignedBytes; curByte++)
+                        // Pack _bits to remove any wasted space after the twos complement
+                        int len = val.Length - 1;
+                        while (len >= 0 && val[len] == 0) len--;
+                        len++;
+
+                        if (len == 1)
                         {
-                            byte curByteValue = value[curByte];
-                            val[curDword] = (val[curDword] << 8) | curByteValue;
-                        }
-                    }
-                    else
-                    {
-                        for (curByte = byteCountMinus1; curByte >= byteCount - unalignedBytes; curByte--)
-                        {
-                            byte curByteValue = value[curByte];
-                            val[curDword] = (val[curDword] << 8) | curByteValue;
-                        }
-                    }
-                }
-
-                if (isNegative)
-                {
-                    NumericsHelpers.DangerousMakeTwosComplement(val); // Mutates val
-
-                    // Pack _bits to remove any wasted space after the twos complement
-                    int len = val.Length - 1;
-                    while (len >= 0 && val[len] == 0) len--;
-                    len++;
-
-                    if (len == 1)
-                    {
-                        switch (val[0])
-                        {
-                            case 1: // abs(-1)
-                                this = s_bnMinusOneInt;
-                                return;
-
-                            case kuMaskHighBit: // abs(Int32.MinValue)
-                                this = s_bnMinInt;
-                                return;
-
-                            default:
-                                if (unchecked((int)val[0]) > 0)
-                                {
-                                    _sign = (-1) * ((int)val[0]);
-                                    _bits = null;
-                                    AssertValid();
+                            switch (val[0])
+                            {
+                                case 1: // abs(-1)
+                                    this = s_bnMinusOneInt;
                                     return;
-                                }
 
-                                break;
+                                case kuMaskHighBit: // abs(Int32.MinValue)
+                                    this = s_bnMinInt;
+                                    return;
+
+                                default:
+                                    if (unchecked((int)val[0]) > 0)
+                                    {
+                                        _sign = (-1) * ((int)val[0]);
+                                        _bits = null;
+                                        AssertValid();
+                                        return;
+                                    }
+
+                                    break;
+                            }
                         }
-                    }
 
-                    if (len != val.Length)
-                    {
-                        _sign = -1;
-                        _bits = new uint[len];
-                        Array.Copy(val, 0, _bits, 0, len);
+                        if (len != val.Length)
+                        {
+                            _sign = -1;
+                            _bits = new uint[len];
+                            Array.Copy(val, 0, _bits, 0, len);
+                        }
+                        else
+                        {
+                            _sign = -1;
+                            _bits = val;
+                        }
                     }
                     else
                     {
-                        _sign = -1;
+                        _sign = +1;
                         _bits = val;
                     }
-                }
-                else
-                {
-                    _sign = +1;
-                    _bits = val;
                 }
             }
             AssertValid();

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -469,7 +469,7 @@ namespace System.Numerics
         }
 
         // This function is consistent with VM\COMNumber.cpp!COMNumber::ParseFormatSpecifier
-        internal static char ParseFormatSpecifier(ReadOnlySpan<char> format, out int digits)
+        internal static unsafe char ParseFormatSpecifier(ReadOnlySpan<char> format, out int digits)
         {
             digits = -1;
             if (format.Length == 0)
@@ -477,27 +477,31 @@ namespace System.Numerics
                 return 'R';
             }
 
-            int i = 0;
-            char ch = format[i];
-            if (ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z')
+            fixed (char* formatPtr = &format.DangerousGetPinnableReference())
             {
-                i++;
-                int n = -1;
+                var formatSpan = new Span<char>(formatPtr, format.Length);
+                int i = 0;
+                char ch = formatSpan[i];
+                if (ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z')
+                {
+                    i++;
+                    int n = -1;
 
-                if (i < format.Length && format[i] >= '0' && format[i] <= '9')
-                {
-                    n = format[i++] - '0';
-                    while (i < format.Length && format[i] >= '0' && format[i] <= '9')
+                    if (i < format.Length && formatSpan[i] >= '0' && formatSpan[i] <= '9')
                     {
-                        n = n * 10 + (format[i++] - '0');
-                        if (n >= 10)
-                            break;
+                        n = formatSpan[i++] - '0';
+                        while (i < format.Length && formatSpan[i] >= '0' && formatSpan[i] <= '9')
+                        {
+                            n = n * 10 + (formatSpan[i++] - '0');
+                            if (n >= 10)
+                                break;
+                        }
                     }
-                }
-                if (i >= format.Length || format[i] == '\0')
-                {
-                    digits = n;
-                    return ch;
+                    if (i >= format.Length || formatSpan[i] == '\0')
+                    {
+                        digits = n;
+                        return ch;
+                    }
                 }
             }
             return (char)0; // Custom format


### PR DESCRIPTION
Related to https://github.com/dotnet/corefx/pull/25326

Removing the use of the ReadOnlySpan indexer to help the implementation change go through with the least disabling of tests.

This is a temporary workaround that is required to reduce the number of failing tests that would need to be disabled due to the change to ReadOnlySpan indexer to return ref readonly (in coreclr and in .NET Native)

cc @weshaggard, @stephentoub, @KrzysztofCwalina, @jkotas, @botaberg, @zamont 

**This change should be reverted once the change propagates**