### PR TITLE
Expose ZipArchiveEntry.Crc32 and fix crc bug

### DIFF
--- a/src/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -301,6 +301,8 @@ namespace System.IO.Compression.Tests
             }
         }
 
+        /// <param name="useSpansForWriting">Tests the Span overloads of Write</param>
+        /// <param name="writeInChunks">Writes in chunks of 5 to test Write with a nonzero offset</param>
         public static async Task CreateFromDir(string directory, Stream archiveStream, ZipArchiveMode mode, bool useSpansForWriting = false, bool writeInChunks = false)
         {
             var files = FileData.InPath(directory);

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{775727A6-DF41-4160-A7FD-180279A653C7}</ProjectGuid>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap'">$(DefineConstants);netcoreapp</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />

--- a/src/System.IO.Compression/ref/System.IO.Compression.cs
+++ b/src/System.IO.Compression/ref/System.IO.Compression.cs
@@ -93,6 +93,7 @@ namespace System.IO.Compression
         public System.DateTimeOffset LastWriteTime { get { throw null; } set { } }
         public long Length { get { throw null; } }
         public string Name { get { throw null; } }
+        public uint Crc32 { get { throw null; } }
         public void Delete() { }
         public System.IO.Stream Open() { throw null; }
         public override string ToString() { throw null; }

--- a/src/System.IO.Compression/ref/System.IO.Compression.cs
+++ b/src/System.IO.Compression/ref/System.IO.Compression.cs
@@ -93,6 +93,7 @@ namespace System.IO.Compression
         public System.DateTimeOffset LastWriteTime { get { throw null; } set { } }
         public long Length { get { throw null; } }
         public string Name { get { throw null; } }
+        [CLSCompliant(false)]
         public uint Crc32 { get { throw null; } }
         public void Delete() { }
         public System.IO.Stream Open() { throw null; }

--- a/src/System.IO.Compression/src/System/IO/Compression/Crc32Helper.ZLib.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/Crc32Helper.ZLib.cs
@@ -12,7 +12,7 @@ namespace System.IO.Compression
         public static unsafe uint UpdateCrc32(uint crc32, byte[] buffer, int offset, int length)
         {
             Debug.Assert((buffer != null) && (offset >= 0) && (length >= 0) && (offset <= buffer.Length - length));
-            fixed (byte* bufferPtr = buffer)
+            fixed (byte* bufferPtr = &buffer[offset])
             {
                 return Interop.zlib.crc32(crc32, bufferPtr, length);
             }

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -144,7 +144,8 @@ namespace System.IO.Compression
         /// The ZipArchive that this entry belongs to. If this entry has been deleted, this will return null.
         /// </summary>
         public ZipArchive Archive => _archive;
-        
+
+        [CLSCompliant(false)]
         public uint Crc32 => _crc32;
 
         /// <summary>

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -144,6 +144,8 @@ namespace System.IO.Compression
         /// The ZipArchive that this entry belongs to. If this entry has been deleted, this will return null.
         /// </summary>
         public ZipArchive Archive => _archive;
+        
+        public uint Crc32 => _crc32;
 
         /// <summary>
         /// The compressed size of the entry. If the archive that the entry belongs to is in Create mode, attempts to get this property will always throw an exception. If the archive that the entry belongs to is in update mode, this property will only be valid if the entry has not been opened.

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{BC2E1649-291D-412E-9529-EDDA94FA7AD6}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap'">$(DefineConstants);STREAM_MEMORY_OVERLOADS_AVAILABLE</DefineConstants>		
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap'">$(DefineConstants);netcoreapp;STREAM_MEMORY_OVERLOADS_AVAILABLE</DefineConstants>		
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />

--- a/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -53,17 +53,20 @@ namespace System.IO.Compression.Tests
         }
 
         [Theory]
-        [InlineData("small", false)]
-        [InlineData("normal", false)]
-        [InlineData("normal", true)]
-        [InlineData("empty", false)]
-        [InlineData("emptydir", false)]
-        public static async Task CreateNormal_Seekable(string folder, bool useSpansForWriting)
+        [InlineData("small", false, false)]
+        [InlineData("normal", false, false)]
+        [InlineData("empty", false, false)]
+        [InlineData("emptydir", false, false)]
+        [InlineData("small", true, false)]
+        [InlineData("normal", true, false)]
+        [InlineData("small", false, true)]
+        [InlineData("normal", false, true)]
+        public static async Task CreateNormal_Seekable(string folder, bool useSpansForWriting, bool writeInChunks)
         {
             using (var s = new MemoryStream())
             {
                 var testStream = new WrappedStream(s, false, true, true, null);
-                await CreateFromDir(zfolder(folder), testStream, ZipArchiveMode.Create, useSpansForWriting);
+                await CreateFromDir(zfolder(folder), testStream, ZipArchiveMode.Create, useSpansForWriting, writeInChunks);
 
                 IsZipSameAsDir(s, zfolder(folder), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
             }

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -184,6 +183,17 @@ namespace System.IO.Compression.Tests
             Assert.Throws<NotSupportedException>(() => s.ReadByte()); //"should not be able to read on disposed archive"
 
             s.Dispose();
+        }
+
+        [Fact]
+        public static async Task Crc32Test()
+        {
+            ZipArchive archive1 = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("normal.zip")), ZipArchiveMode.Read);
+            ZipArchive archive2 = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("normal.zip")), ZipArchiveMode.Read);
+            ZipArchive archive3 = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("small.zip")), ZipArchiveMode.Read);
+
+            Assert.True(archive1.Entries[0].Crc32 == archive2.Entries[0].Crc32);
+            Assert.True(archive1.Entries[0].Crc32 != archive3.Entries[0].Crc32);
         }
     }
 }

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -184,16 +184,5 @@ namespace System.IO.Compression.Tests
 
             s.Dispose();
         }
-
-        [Fact]
-        public static async Task Crc32Test()
-        {
-            ZipArchive archive1 = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("normal.zip")), ZipArchiveMode.Read);
-            ZipArchive archive2 = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("normal.zip")), ZipArchiveMode.Read);
-            ZipArchive archive3 = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("small.zip")), ZipArchiveMode.Read);
-
-            Assert.True(archive1.Entries[0].Crc32 == archive2.Entries[0].Crc32);
-            Assert.True(archive1.Entries[0].Crc32 != archive3.Entries[0].Crc32);
-        }
     }
 }


### PR DESCRIPTION
- Exposes ZipArchiveEntry.Crc32 field
- Fixes a bug in our CRC calculation
- Adds tests for the crc32 field

Progression of https://github.com/dotnet/corefx/pull/25204 by @reaction1989

resolves https://github.com/dotnet/corefx/issues/22292, https://github.com/dotnet/corefx/issues/25803

cc: @stephentoub @ViktorHofer @livarcocc 
