### PR TITLE
Check if full-text index exists before running WarningsBeforeRowsTest.

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
@@ -47,7 +47,22 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [CheckConnStrSetupFact]
+        private static bool EmployeesTableHasFullTextIndex()
+        {
+            if (DataTestUtility.TcpConnStr == null)
+                return false;
+
+            using (SqlConnection conn = new SqlConnection(DataTestUtility.TcpConnStr))
+            using (SqlCommand cmd = conn.CreateCommand())
+            {
+                conn.Open();
+                cmd.CommandText = "SELECT object_id FROM sys.fulltext_indexes WHERE object_id = object_id('Northwind.dbo.Employees')";
+
+                return (cmd.ExecuteScalar() != null);
+            }
+        }
+
+        [ConditionalFact(nameof(EmployeesTableHasFullTextIndex))]
         public static void WarningsBeforeRowsTest()
         {
             bool hitWarnings = false;


### PR DESCRIPTION
WarningBeforeRowsTest uses some "contains()" queries for warning checking, but a full-text index is required for contains(). Since the Northwind sample DB doesn't have full-text indexed columns by default, I'm making this test optional.