### PR TITLE
Temporarily removing leftover use of ReadOnlySpan indexer.

### DIFF
--- a/src/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -547,7 +547,7 @@ namespace System.Globalization
                 return false;
             }
 
-            private static bool TrailingZeros(ReadOnlySpan<char> s, int index)
+            private static unsafe bool TrailingZeros(ReadOnlySpan<char> s, int index)
             {
                 fixed (char* sPtr = &s.DangerousGetPinnableReference())
                 {
@@ -640,7 +640,7 @@ namespace System.Globalization
             {
                 fixed (char* formatPtr = &format.DangerousGetPinnableReference())
                 {
-                    var formatSpan = new Span<char>(formatPtr, span.Length);
+                    var formatSpan = new Span<char>(formatPtr, format.Length);
                     char c = default;
                     if (format.Length > 0)
                     {

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
@@ -113,12 +113,13 @@ namespace System.IO
         private unsafe static string CombineNoChecksInternal(ReadOnlySpan<char> first, ReadOnlySpan<char> second)
         {
             Debug.Assert(first.Length > 0 && second.Length > 0, "should have dealt with empty paths");
-
-            bool hasSeparator = PathInternal.IsDirectorySeparator(first[first.Length - 1])
-                || PathInternal.IsDirectorySeparator(second[0]);
-
             fixed (char* f = &first.DangerousGetPinnableReference(), s = &second.DangerousGetPinnableReference())
             {
+                var firstSpan = new Span<char>(f, first.Length);
+                var secondSpan = new Span<char>(s, second.Length);
+                bool hasSeparator = PathInternal.IsDirectorySeparator(firstSpan[first.Length - 1])
+                    || PathInternal.IsDirectorySeparator(secondSpan[0]);
+                
                 return string.Create(
                     first.Length + second.Length + (hasSeparator ? 0 : 1),
                     (First: (IntPtr)f, FirstLength: first.Length, Second: (IntPtr)s, SecondLength: second.Length, HasSeparator: hasSeparator),
@@ -136,14 +137,17 @@ namespace System.IO
         private unsafe static string CombineNoChecksInternal(ReadOnlySpan<char> first, ReadOnlySpan<char> second, ReadOnlySpan<char> third)
         {
             Debug.Assert(first.Length > 0 && second.Length > 0 && third.Length > 0, "should have dealt with empty paths");
-
-            bool firstHasSeparator = PathInternal.IsDirectorySeparator(first[first.Length - 1])
-                || PathInternal.IsDirectorySeparator(second[0]);
-            bool thirdHasSeparator = PathInternal.IsDirectorySeparator(second[second.Length - 1])
-                || PathInternal.IsDirectorySeparator(third[0]);
-
             fixed (char* f = &first.DangerousGetPinnableReference(), s = &second.DangerousGetPinnableReference(), t = &third.DangerousGetPinnableReference())
             {
+                var firstSpan = new Span<char>(f, first.Length);
+                var secondSpan = new Span<char>(s, second.Length);
+                var thirdSpan = new Span<char>(t, third.Length);
+
+                bool firstHasSeparator = PathInternal.IsDirectorySeparator(firstSpan[first.Length - 1])
+                    || PathInternal.IsDirectorySeparator(secondSpan[0]);
+                bool thirdHasSeparator = PathInternal.IsDirectorySeparator(secondSpan[second.Length - 1])
+                    || PathInternal.IsDirectorySeparator(thirdSpan[0]);
+
                 return string.Create(
                     first.Length + second.Length + third.Length + (firstHasSeparator ? 0 : 1) + (thirdHasSeparator ? 0 : 1),
                     (First: (IntPtr)f, FirstLength: first.Length, Second: (IntPtr)s, SecondLength: second.Length,
@@ -167,9 +171,13 @@ namespace System.IO
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool IsDotOrDotDot(ReadOnlySpan<char> fileName)
         {
-            return !(fileName.Length > 2
-                || fileName[0] != '.'
-                || (fileName.Length == 2 && fileName[1] != '.'));
+            fixed (char* fileNamePtr = &fileName.DangerousGetPinnableReference())
+            {
+                var fileNameSpan = new Span<char>(fileNamePtr, fileName.Length);
+                return !(fileName.Length > 2
+                    || fileNameSpan[0] != '.'
+                    || (fileName.Length == 2 && fileNameSpan[1] != '.'));
+            }
         }
 
         public static unsafe ReadOnlySpan<char> GetDirectoryNameNoChecks(ReadOnlySpan<char> path)


### PR DESCRIPTION
Related to:
https://github.com/dotnet/corefx/pull/25326
https://github.com/dotnet/corefx/pull/25881

Removing the use of the ReadOnlySpan indexer to help the implementation change go through with the least disabling of tests.

This is a temporary workaround that is required to reduce the number of failing tests that would need to be disabled due to the change to ReadOnlySpan indexer to return ref readonly (in coreclr and in .NET Native)

cc @weshaggard, @stephentoub, @KrzysztofCwalina, @jkotas, @botaberg, @zamont 

**This change should be reverted once the change propagates**