### PR TITLE
Use generic test handling for remote server failures.

### DIFF
--- a/src/Common/tests/System/Net/RemoteServerQuery.cs
+++ b/src/Common/tests/System/Net/RemoteServerQuery.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Test.Common
+{
+    internal class RemoteServerException : Exception
+    {
+        private const string Description = "Likely external issue with remote server";
+
+        public RemoteServerException()
+            : this(null, null) { }
+
+        public RemoteServerException(string server)
+            : this(server, null) { }
+
+        public RemoteServerException(string server, Exception inner)
+            : base(GetMessage(server), inner) { }
+
+        public static string GetMessage(string server)
+        {
+            if (server == null)
+                return Description;
+
+            return $"{Description} : {server}";
+        }
+    }
+
+    internal static class RemoteServerQuery
+    {
+        internal static async Task<TResult> Run<TResult>(Func<Task<TResult>> testCode, Func<Exception, bool> remoteExceptionWrapper, string serverName)
+        {
+            try
+            {
+                return await testCode();
+            }
+            catch (Exception actualException)
+            {
+                if (remoteExceptionWrapper(actualException))
+                {
+                    throw new RemoteServerException(serverName, actualException);
+                }
+
+                throw;
+            }
+        }
+
+        internal static async Task ThrowsAsync<T>(Func<Task> testCode, Func<Exception, bool> remoteExceptionWrapper, string serverName)
+            where T : Exception
+        {
+            try
+            {
+                await testCode();
+                Assert.Throws<T>(() => { });
+            }
+            catch (Exception actualException)
+            {
+                if (remoteExceptionWrapper(actualException))
+                {
+                    throw new RemoteServerException(serverName, actualException);
+                }
+
+                if (typeof(T).Equals(actualException.GetType()))
+                {
+                    return;
+                }
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/Common/tests/System/Net/RemoteServerQuery.cs
+++ b/src/Common/tests/System/Net/RemoteServerQuery.cs
@@ -14,13 +14,10 @@ namespace System.Net.Test.Common
         public RemoteServerException()
             : this(null, null) { }
 
-        public RemoteServerException(string server)
-            : this(server, null) { }
-
         public RemoteServerException(string server, Exception inner)
             : base(GetMessage(server), inner) { }
 
-        public static string GetMessage(string server)
+        private static string GetMessage(string server)
         {
             if (server == null)
                 return Description;
@@ -48,24 +45,17 @@ namespace System.Net.Test.Common
             }
         }
 
-        internal static async Task ThrowsAsync<T>(Func<Task> testCode, Func<Exception, bool> remoteExceptionWrapper, string serverName)
-            where T : Exception
+        internal static async Task Run(Func<Task> testCode, Func<Exception, bool> remoteExceptionWrapper, string serverName)
         {
             try
             {
                 await testCode();
-                Assert.Throws<T>(() => { });
             }
             catch (Exception actualException)
             {
                 if (remoteExceptionWrapper(actualException))
                 {
                     throw new RemoteServerException(serverName, actualException);
-                }
-
-                if (typeof(T).Equals(actualException.GetType()))
-                {
-                    return;
                 }
 
                 throw;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -124,7 +124,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        public static readonly object [][] SupportedSSLVersionServers =
+        public static readonly object[][] SupportedSSLVersionServers =
         {
             new object[] {SslProtocols.Tls, Configuration.Http.TLSv10RemoteServer},
             new object[] {SslProtocols.Tls11, Configuration.Http.TLSv11RemoteServer},
@@ -205,7 +205,7 @@ namespace System.Net.Http.Functional.Tests
 
             using (HttpClient client = CreateHttpClient())
             {
-                await RemoteServerQuery.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url), remoteServerExceptionWrapper, url);
+                await Assert.ThrowsAsync<HttpRequestException>(() => RemoteServerQuery.Run(() => client.GetAsync(url), remoteServerExceptionWrapper, url));
             }
         }
 
@@ -213,7 +213,8 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact(nameof(SslDefaultsToTls12))]
         public async Task GetAsync_NoSpecifiedProtocol_DefaultsToTls12()
         {
-            if (!BackendSupportsSslConfiguration) return;
+            if (!BackendSupportsSslConfiguration)
+                return;
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (var client = new HttpClient(handler))
             {
@@ -242,7 +243,8 @@ namespace System.Net.Http.Functional.Tests
         public async Task GetAsync_AllowedSSLVersionDiffersFromServer_ThrowsException(
             SslProtocols allowedProtocol, SslProtocols acceptedProtocol, Type exceptedServerException)
         {
-            if (!BackendSupportsSslConfiguration) return;
+            if (!BackendSupportsSslConfiguration)
+                return;
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (var client = new HttpClient(handler))
             {

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -30,6 +30,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\DelegateStream.cs">
       <Link>Common\System\IO\DelegateStream.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\RemoteServerQuery.cs">
+      <Link>Common\System\Net\RemoteServerQuery.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
       <Link>Common\System\Net\Configuration.Certificates.cs</Link>
     </Compile>


### PR DESCRIPTION
cc @karelz @wfurt @davidsh 

fixes #25878 
fixes #25892 

When any test with remote server dependency fails, it will output something like this:

```
System.Net.Http.Functional.Tests.HttpClientHandler_SslProtocols_Test.GetAsync_UnsupportedSSLVersion_Throws(name: \"SSLv2\", url: \"https://www.ssllabs.com:10200/\") [FAIL]
System.Net.Test.Common.RemoteServerException : Likely external issue with remote server : https://www.ssllabs.com:10200/
---- System.Net.Http.HttpRequestException : An error occurred while sending the request.
-------- System.Net.Http.WinHttpException : A connection with the server could not be established
Stack Trace:
   E:\corefx\src\Common\tests\System\Net\RemoteServerQuery.cs(65,0): at System.Net.Test.Common.RemoteServerQuery.<ThrowsAsync>d__1`1.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
   E:\corefx\src\System.Net.Http\tests\FunctionalTests\HttpClientHandlerTest.SslProtocols.cs(220,0): at System.Net.Http.Functional.Tests.HttpClientHandler_SslProtocols_Test.<GetAsync_UnsupportedSSLVersion_Throws>d__9.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
   --- End of stack trace from previous location where exception was thrown ---
   --- End of stack trace from previous location where exception was thrown ---
   ----- Inner Stack Trace -----
   E:\corefx\src\System.Net.Http\src\System\Net\Http\HttpClient.cs(464,0): at System.Net.Http.HttpClient.<FinishSendAsyncBuffered>d__58.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
   E:\corefx\src\Common\tests\System\Net\RemoteServerQuery.cs(56,0): at System.Net.Test.Common.RemoteServerQuery.<ThrowsAsync>d__1`1.MoveNext()
   ----- Inner Stack Trace -----
   E:\corefx\src\System.Runtime.Extensions\src\System\Environment.cs(176,0): at System.Environment.get_StackTrace()
   E:\corefx\src\Common\src\System\Runtime\ExceptionServices\ExceptionStackTrace.cs(23,0): at System.Runtime.ExceptionServices.ExceptionStackTrace.AddCurrentStack(Exception exception)
   E:\corefx\src\Common\src\System\Net\Http\WinHttpException.cs(56,0): at System.Net.Http.WinHttpException.CreateExceptionUsingError(Int32 error)
   E:\corefx\src\System.Net.Http.WinHttpHandler\src\System\Net\Http\WinHttpRequestCallback.cs(324,0): at System.Net.Http.WinHttpRequestCallback.OnRequestError(WinHttpRequestState state, WINHTTP_ASYNC_RESULT asyncResult)
   E:\corefx\src\System.Net.Http.WinHttpHandler\src\System\Net\Http\WinHttpRequestCallback.cs(104,0): at System.Net.Http.WinHttpRequestCallback.RequestCallback(IntPtr handle, WinHttpRequestState state, UInt32 internetStatus, IntPtr statusInformation, UInt32 statusInformationLength)
   E:\corefx\src\System.Net.Http.WinHttpHandler\src\System\Net\Http\WinHttpRequestCallback.cs(47,0): at System.Net.Http.WinHttpRequestCallback.WinHttpCallback(IntPtr handle, IntPtr context, UInt32 internetStatus, IntPtr statusInformation, UInt32 statusInformationLength)
   --- End of stack trace from AddCurrentStack ---
   E:\corefx\src\Common\src\System\Threading\Tasks\RendezvousAwaitable.cs(62,0): at System.Threading.Tasks.RendezvousAwaitable`1.GetResult()
   E:\corefx\src\System.Net.Http.WinHttpHandler\src\System\Net\Http\WinHttpHandler.cs(856,0): at System.Net.Http.WinHttpHandler.<StartRequest>d__105.MoveNext()
```