### PR TITLE
RemoteExecutorTestBase.Process.cs always requires RemoteExecutorConsoleApp.exe 

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
@@ -55,8 +55,8 @@ namespace System.Diagnostics
             string passedArgs = pasteArguments ? PasteArguments.Paste(args, pasteFirstArgumentUsingArgV0Rules: false) : string.Join(" ", args);
             string testConsoleAppArgs = ExtraParameter + " " + metadataArgs + " " + passedArgs;
 
-            if (!File.Exists(TestConsoleApp))
-                throw new IOException("RemoteExecutorConsoleApp test app isn't present in the test runtime directory.");
+            if (!File.Exists(HostRunner))
+                throw new IOException($"{HostRunner} test app isn't present in the test runtime directory.");
 
             psi.FileName = HostRunner;
             psi.Arguments = testConsoleAppArgs;


### PR DESCRIPTION
RemoteExecutorTestBase.Process
before executing an executable `HostRunner` it checks if `TestConsoleApp` exists ([a const](https://github.com/dotnet/corefx/blob/master/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs#L23) equals to "RemoteExecutorConsoleApp.exe") - it's OK for netcore, netfx and uapaot since `HostRunner` actually equals to TestConsoleApp, see:
[RemoteExecutorTestBase.netfx.cs](https://github.com/dotnet/corefx/blob/master/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.netfx.cs#L13)
[RemoteExecutorTestBase.uapaot.cs](https://github.com/dotnet/corefx/blob/master/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.uapaot.cs#L13)
[RemoteExecutorTestBase.netcore.cs](https://github.com/dotnet/corefx/blob/master/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.netcore.cs#L14) (it eqauls to TestConsoleApp, isn't it?)

we want to use these files in mono but we have a different name for the executable (e.g. a name that contains current mono profile) but currently it's hardcoded to RemoteExecutorConsoleApp.exe