### PR TITLE
Allow RangeAttribute use to request InvariantCulture conversions.

### DIFF
--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -204,9 +204,11 @@ namespace System.ComponentModel.DataAnnotations
         public RangeAttribute(double minimum, double maximum) { }
         public RangeAttribute(int minimum, int maximum) { }
         public RangeAttribute(System.Type type, string minimum, string maximum) { }
+        public bool ConvertValueInInvariantCulture { get { throw null; } set { } }
         public object Maximum { get { throw null; } }
         public object Minimum { get { throw null; } }
         public System.Type OperandType { get { throw null; } }
+        public bool ParseLimitsInInvariantCulture { get { throw null; } set { } }
         public override string FormatErrorMessage(string name) { throw null; }
         public override bool IsValid(object value) { throw null; }
     }

--- a/src/System.ComponentModel.Annotations/tests/RangeAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/RangeAttributeTests.cs
@@ -183,7 +183,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalRanges))]
+        [Theory, MemberData(nameof(DotDecimalRanges)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void ParseDotSeparatorExtremaInCommaSeparatorCultures(Type type, string min, string max)
         {
             using (new TempCulture("en-US"))
@@ -198,7 +198,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalRanges))]
+        [Theory, MemberData(nameof(DotDecimalRanges)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void ParseDotSeparatorInvariantExtremaInCommaSeparatorCultures(Type type, string min, string max)
         {
             using (new TempCulture("en-US"))
@@ -220,7 +220,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalRanges))]
+        [Theory, MemberData(nameof(CommaDecimalRanges)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void ParseCommaSeparatorExtremaInCommaSeparatorCultures(Type type, string min, string max)
         {
             using (new TempCulture("en-US"))
@@ -235,7 +235,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalRanges))]
+        [Theory, MemberData(nameof(CommaDecimalRanges)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void ParseCommaSeparatorInvariantExtremaInCommaSeparatorCultures(Type type, string min, string max)
         {
             using (new TempCulture("en-US"))
@@ -250,7 +250,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalValidValues))]
+        [Theory, MemberData(nameof(DotDecimalValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndValues(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -265,7 +265,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalValidValues))]
+        [Theory, MemberData(nameof(DotDecimalValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndValuesInvariantParse(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -287,7 +287,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalValidValues))]
+        [Theory, MemberData(nameof(DotDecimalValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndValuesInvariantConvert(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -309,7 +309,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalValidValues))]
+        [Theory, MemberData(nameof(DotDecimalValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndValuesInvariantBoth(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -333,7 +333,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalNonStringValidValues))]
+        [Theory, MemberData(nameof(DotDecimalNonStringValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndNonStringValues(Type type, string min, string max, object value)
         {
             using (new TempCulture("en-US"))
@@ -348,7 +348,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalNonStringValidValues))]
+        [Theory, MemberData(nameof(DotDecimalNonStringValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndNonStringValuesInvariantParse(Type type, string min, string max, object value)
         {
             using (new TempCulture("en-US"))
@@ -370,7 +370,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalNonStringValidValues))]
+        [Theory, MemberData(nameof(DotDecimalNonStringValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndNonStringValuesInvariantConvert(Type type, string min, string max, object value)
         {
             using (new TempCulture("en-US"))
@@ -392,7 +392,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalNonStringValidValues))]
+        [Theory, MemberData(nameof(DotDecimalNonStringValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndNonStringValuesInvariantBoth(Type type, string min, string max, object value)
         {
             using (new TempCulture("en-US"))
@@ -416,7 +416,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalNonStringValidValues))]
+        [Theory, MemberData(nameof(CommaDecimalNonStringValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndNonStringValues(Type type, string min, string max, object value)
         {
             using (new TempCulture("en-US"))
@@ -431,7 +431,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalNonStringValidValues))]
+        [Theory, MemberData(nameof(CommaDecimalNonStringValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndNonStringValuesInvariantParse(Type type, string min, string max, object value)
         {
             using (new TempCulture("en-US"))
@@ -453,7 +453,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalNonStringValidValues))]
+        [Theory, MemberData(nameof(CommaDecimalNonStringValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndNonStringValuesInvariantConvert(Type type, string min, string max, object value)
         {
             using (new TempCulture("en-US"))
@@ -475,7 +475,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalNonStringValidValues))]
+        [Theory, MemberData(nameof(CommaDecimalNonStringValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndNonStringValuesInvariantBoth(Type type, string min, string max, object value)
         {
             using (new TempCulture("en-US"))
@@ -499,7 +499,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalInvalidValues))]
+        [Theory, MemberData(nameof(DotDecimalInvalidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndInvalidValues(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -514,7 +514,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalInvalidValues))]
+        [Theory, MemberData(nameof(DotDecimalInvalidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndInvalidValuesInvariantParse(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -536,7 +536,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalInvalidValues))]
+        [Theory, MemberData(nameof(DotDecimalInvalidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndInvalidValuesInvariantConvert(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -558,7 +558,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(DotDecimalInvalidValues))]
+        [Theory, MemberData(nameof(DotDecimalInvalidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void DotDecimalExtremaAndInvalidValuesInvariantBoth(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -582,7 +582,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalValidValues))]
+        [Theory, MemberData(nameof(CommaDecimalValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndValues(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -597,7 +597,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalValidValues))]
+        [Theory, MemberData(nameof(CommaDecimalValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndValuesInvariantParse(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -619,7 +619,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalValidValues))]
+        [Theory, MemberData(nameof(CommaDecimalValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndValuesInvariantConvert(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -641,7 +641,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalValidValues))]
+        [Theory, MemberData(nameof(CommaDecimalValidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndValuesInvariantBoth(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -665,7 +665,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalInvalidValues))]
+        [Theory, MemberData(nameof(CommaDecimalInvalidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndInvalidValues(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -680,7 +680,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalInvalidValues))]
+        [Theory, MemberData(nameof(CommaDecimalInvalidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndInvalidValuesInvariantParse(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -702,7 +702,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalInvalidValues))]
+        [Theory, MemberData(nameof(CommaDecimalInvalidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndInvalidValuesInvariantConvert(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))
@@ -724,7 +724,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CommaDecimalInvalidValues))]
+        [Theory, MemberData(nameof(CommaDecimalInvalidValues)), SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "2648 not fixed on NetFX")]
         public static void CommaDecimalExtremaAndInvalidValuesInvariantBoth(Type type, string min, string max, string value)
         {
             using (new TempCulture("en-US"))

--- a/src/System.ComponentModel.Annotations/tests/RangeAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/RangeAttributeTests.cs
@@ -194,7 +194,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             using (new TempCulture("fr-FR"))
             {
                 RangeAttribute range = new RangeAttribute(type, min, max);
-                Assert.Throws<Exception>(() => range.IsValid(null));
+                Assert.Throws<ArgumentException>(() => range.IsValid(null));
             }
         }
 
@@ -226,7 +226,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             using (new TempCulture("en-US"))
             {
                 RangeAttribute range = new RangeAttribute(type, min, max);
-                Assert.Throws<Exception>(() => range.IsValid(null));
+                Assert.Throws<ArgumentException>(() => range.IsValid(null));
             }
 
             using (new TempCulture("fr-FR"))
@@ -241,7 +241,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             using (new TempCulture("en-US"))
             {
                 RangeAttribute range = new RangeAttribute(type, min, max);
-                Assert.Throws<Exception>(() => range.IsValid(null));
+                Assert.Throws<ArgumentException>(() => range.IsValid(null));
             }
 
             using (new TempCulture("fr-FR"))
@@ -261,7 +261,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             using (new TempCulture("fr-FR"))
             {
                 RangeAttribute range = new RangeAttribute(type, min, max);
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -283,7 +283,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -305,7 +305,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -344,7 +344,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             using (new TempCulture("fr-FR"))
             {
                 RangeAttribute range = new RangeAttribute(type, min, max);
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -388,7 +388,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -422,7 +422,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             using (new TempCulture("en-US"))
             {
                 RangeAttribute range = new RangeAttribute(type, min, max);
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -440,7 +440,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -449,7 +449,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -462,7 +462,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -485,7 +485,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                     ConvertValueInInvariantCulture = true,
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -495,7 +495,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                     ConvertValueInInvariantCulture = true,
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -510,7 +510,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             using (new TempCulture("fr-FR"))
             {
                 RangeAttribute range = new RangeAttribute(type, min, max);
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -532,7 +532,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -554,7 +554,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -588,7 +588,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             using (new TempCulture("en-US"))
             {
                 RangeAttribute range = new RangeAttribute(type, min, max);
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -606,7 +606,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -615,7 +615,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -628,7 +628,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -637,7 +637,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -651,7 +651,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                     ConvertValueInInvariantCulture = true,
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -661,7 +661,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                     ConvertValueInInvariantCulture = true,
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -671,7 +671,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             using (new TempCulture("en-US"))
             {
                 RangeAttribute range = new RangeAttribute(type, min, max);
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -689,7 +689,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -698,7 +698,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -711,7 +711,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -720,7 +720,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 {
                     ConvertValueInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 
@@ -734,7 +734,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                     ConvertValueInInvariantCulture = true,
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
 
             using (new TempCulture("fr-FR"))
@@ -744,7 +744,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
                     ConvertValueInInvariantCulture = true,
                     ParseLimitsInInvariantCulture = true
                 };
-                Assert.Throws<Exception>(() => range.IsValid(value));
+                Assert.Throws<ArgumentException>(() => range.IsValid(value));
             }
         }
 


### PR DESCRIPTION
Adds a `ParseLimitsInInvariantCulture` that affects the interpretation of the extrema set, and `ConvertValueInInvariantCulture` that affects the interpretation of values.

Separate properties allows for e.g. a component assuming a dot-decimal-separator culture defining a property with the attribute (so invariant culture should be used) the use of the property is done in a comma-decimal-separator (so the current culture should be used), or any permutation of the two booleans.

Fixes #2648

CC @lajones 