### PR TITLE
Freeze the assembly version for System.Threading.Tasks.Extensions

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -278,7 +278,7 @@
       "InboxOn": {}
     },
     "Microsoft.XmlSerializer.Generator": {
-       "StableVersions": [
+      "StableVersions": [
         "1.0.0"
       ],
       "InboxOn": {},
@@ -4860,13 +4860,13 @@
       "BaselineVersion": "4.4.0",
       "InboxOn": {
         "netcoreapp2.0": "4.1.1.0",
-        "netcoreapp2.1": "4.1.2.0"
+        "netcoreapp2.1": "4.1.2.0",
+        "uap10.0.15138": "4.1.2.0",
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.3.0",
-        "4.1.1.0": "4.4.0",
-        "4.1.2.0": "4.5.0"
+        "4.1.1.0": "4.4.0"
       }
     },
     "System.Threading.Tasks.Parallel": {

--- a/src/System.Threading.Tasks.Extensions/dir.props
+++ b/src/System.Threading.Tasks.Extensions/dir.props
@@ -6,6 +6,5 @@
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>
-    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Tasks.Extensions/pkg/System.Threading.Tasks.Extensions.pkgproj
+++ b/src/System.Threading.Tasks.Extensions/pkg/System.Threading.Tasks.Extensions.pkgproj
@@ -6,18 +6,13 @@
     <MinClientVersion>2.8.6</MinClientVersion>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\src\System.Threading.Tasks.Extensions.csproj">
+    <ProjectReference Include="..\ref\System.Threading.Tasks.Extensions.csproj">
       <SupportedFramework>net45;netcore45;netcoreapp1.0;wpa81;wp8;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
+    <ProjectReference Include="..\src\System.Threading.Tasks.Extensions.csproj" />
 
-    <!-- Since UAP and .NETCoreApp are package based we still want to enable
-         OOBing libraries that happen to overlap with their framework package.
-         This avoids us having to lock the API in our NuGet packages just 
-         to match what shipped inbox: since we can provide a new library 
-         we can update it to add API without raising the netstandard version. -->
-    <ValidatePackageSuppression Include="TreatAsOutOfBox">
-      <Value>.NETCoreApp;UAP</Value>
-    </ValidatePackageSuppression>
+    <InboxOnTargetFramework Include="netcoreapp2.0" />
+    <InboxOnTargetFramework Include="$(UAPvNextTFM)" />
 
     <!-- this package is part of the implementation closure of NETStandard.Library
          therefore it cannot reference NETStandard.Library -->

--- a/src/System.Threading.Tasks.Extensions/ref/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/ref/System.Threading.Tasks.Extensions.csproj
@@ -4,6 +4,12 @@
   <PropertyGroup>
     <ProjectGuid>{0DF7FA9A-E7D3-4CEF-862B-A37F5BBBB54C}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' Or '$(TargetGroup)' == 'uap'">true</IsPartialFacadeAssembly>
+    <!--
+      Netstandard assembly version is frozen and thus cannot adde any more APIs to it because
+      the types have been moved inbox and type-forwarded into CoreLib. The only way to add more
+      APIs is to add them directly to the particular platform.
+    -->
+    <AssemblyVersion Condition="$(TargetGroup.StartsWith('netstandard'))">4.1.1.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />

--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -7,6 +7,7 @@
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.0'">netstandard1.0;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netstandard' and '$(TargetGroup)' != 'netstandard1.0'">true</IsPartialFacadeAssembly>
     <ExcludeResourcesImport Condition="'$(IsPartialFacadeAssembly)'=='true'">true</ExcludeResourcesImport>
+    <AssemblyVersion Condition="$(TargetGroup.StartsWith('netstandard'))">4.1.1.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />


### PR DESCRIPTION
The APIs in System.Threading.Tasks.Extensions have been put inbox on
.NET Core 2.0 and UAp and also type-forwarded into System.Runtime. This
means the APIs in the contract can no longer version for the netstandard
reference. Any new API's have to be added to the platform specific reference
assembly.

This also updates the package to include the inbox placeholders for
netcoreapp and uap.

cc @ericstj @stephentoub 