### PR TITLE
Update ILLink version.

### DIFF
--- a/external/ILLink/ILLink.depproj
+++ b/external/ILLink/ILLink.depproj
@@ -9,7 +9,7 @@
     <NugetRuntimeIdentifier>$(ToolRuntimeRID)</NugetRuntimeIdentifier>
     <RidSpecificAssets>true</RidSpecificAssets>
     <ILLinkTasksPackageId>illink.tasks</ILLinkTasksPackageId>
-    <ILLinkTasksPackageVersion>0.1.4-preview-981901</ILLinkTasksPackageVersion>
+    <ILLinkTasksPackageVersion>0.1.4-preview-1222833</ILLinkTasksPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="$(ILLinkTasksPackageId)">

--- a/illink.targets
+++ b/illink.targets
@@ -71,6 +71,8 @@
       <ILLinkArgs>$(ILLinkArgs) -v true</ILLinkArgs>
       <!-- reflection heuristics to apply -->
       <ILLinkArgs>$(ILLinkArgs) -h LdtokenTypeMethods,InstanceConstructors</ILLinkArgs>
+      <!-- add a linker step to clear initlocals flag on all assemblies before the output step -->
+      <ILLinkArgs Condition="'$(ILLinkClearInitLocals)' == 'true'">$(ILLinkArgs) -s ILLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps:OutputStep</ILLinkArgs>
     </PropertyGroup>
 
     <MakeDir Directories="$(ILLinkTrimInputPath)" />


### PR DESCRIPTION
I verified that this causes no assembly trimming diffs.

This change also exposes a new ILLink capability.
Setting `ILLinkClearInitLocals=true` will cause the linker to clear
initlocals flag on all methods. This is off by default and is exposed
for perf experiments.