### PR TITLE
General code clean up of System.Memory

### DIFF
--- a/src/System.Memory/src/System/Number/Number.NumberBuffer.cs
+++ b/src/System.Memory/src/System/Number/Number.NumberBuffer.cs
@@ -31,9 +31,9 @@ namespace System
         public int Scale;
         public bool IsNegative;
 
-        public unsafe Span<byte> Digits => new Span<byte>(Unsafe.AsPointer<byte>(ref _b0), BufferSize);
+        public unsafe Span<byte> Digits => new Span<byte>(Unsafe.AsPointer(ref _b0), BufferSize);
 
-        public unsafe byte* UnsafeDigits => (byte*)Unsafe.AsPointer<byte>(ref _b0);
+        public unsafe byte* UnsafeDigits => (byte*)Unsafe.AsPointer(ref _b0);
 
         public int NumDigits => Digits.IndexOf<byte>(0);
 

--- a/src/System.Memory/src/System/SpanHelpers.Clear.cs
+++ b/src/System.Memory/src/System/SpanHelpers.Clear.cs
@@ -96,7 +96,7 @@ namespace System
             }
         }
 
-        public unsafe static void ClearPointerSizedWithReferences(ref IntPtr ip, UIntPtr pointerSizeLength)
+        public static void ClearPointerSizedWithReferences(ref IntPtr ip, UIntPtr pointerSizeLength)
         {
             // TODO: Perhaps do switch casing to improve small size perf
 

--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -175,7 +175,7 @@ namespace System
             return -1;
         }
 
-        public static unsafe int LastIndexOf<T>(ref T searchSpace, T value, int length)
+        public static int LastIndexOf<T>(ref T searchSpace, T value, int length)
             where T : IEquatable<T>
         {
             Debug.Assert(length >= 0);
@@ -243,7 +243,7 @@ namespace System
             return length + 7;
         }
 
-        public static unsafe int LastIndexOfAny<T>(ref T searchSpace, T value0, T value1, int length)
+        public static int LastIndexOfAny<T>(ref T searchSpace, T value0, T value1, int length)
             where T : IEquatable<T>
         {
             Debug.Assert(length >= 0);
@@ -325,7 +325,7 @@ namespace System
             return length + 7;
         }
 
-        public static unsafe int LastIndexOfAny<T>(ref T searchSpace, T value0, T value1, T value2, int length)
+        public static int LastIndexOfAny<T>(ref T searchSpace, T value0, T value1, T value2, int length)
             where T : IEquatable<T>
         {
             Debug.Assert(length >= 0);

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -437,7 +437,7 @@ namespace System
 
                 while ((byte*)nLength > (byte*)index)
                 {
-                    var vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
+                    Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
                     var vMatches = Vector.BitwiseOr(
                                     Vector.Equals(vData, values0),
                                     Vector.Equals(vData, values1));
@@ -572,7 +572,7 @@ namespace System
                 Vector<byte> values2 = GetVector(value2);
                 while ((byte*)nLength > (byte*)index)
                 {
-                    var vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
+                    Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
 
                     var vMatches = Vector.BitwiseOr(
                                     Vector.BitwiseOr(
@@ -707,7 +707,7 @@ namespace System
 
                 while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
                 {
-                    var vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count));
+                    Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count));
                     var vMatches = Vector.BitwiseOr(
                                     Vector.Equals(vData, values0),
                                     Vector.Equals(vData, values1));
@@ -837,7 +837,7 @@ namespace System
                 Vector<byte> values2 = GetVector(value2);
                 while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
                 {
-                    var vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count));
+                    Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count));
 
                     var vMatches = Vector.BitwiseOr(
                                     Vector.BitwiseOr(

--- a/src/System.Memory/tests/Base64/Base64TestHelper.cs
+++ b/src/System.Memory/tests/Base64/Base64TestHelper.cs
@@ -87,7 +87,7 @@ namespace System.Buffers.Text.Tests
         [Fact]
         public static void GenerateEncodingMapAndVerify()
         {
-            var data = new byte[64]; // Base64
+            byte[] data = new byte[64]; // Base64
             for (int i = 0; i < s_characters.Length; i++)
             {
                 data[i] = (byte)s_characters[i];
@@ -98,7 +98,7 @@ namespace System.Buffers.Text.Tests
         [Fact]
         public static void GenerateDecodingMapAndVerify()
         {
-            var data = new sbyte[256]; // 0 to byte.MaxValue (255)
+            sbyte[] data = new sbyte[256]; // 0 to byte.MaxValue (255)
             for (int i = 0; i < data.Length; i++)
             {
                 data[i] = s_invalidByte;

--- a/src/System.Memory/tests/Binary/BinaryReaderUnitTests.cs
+++ b/src/System.Memory/tests/Binary/BinaryReaderUnitTests.cs
@@ -375,7 +375,7 @@ namespace System.Buffers.Binary.Tests
 
             ReadOnlySpan<byte> readOnlySpanBE = new ReadOnlySpan<byte>(spanBE.ToArray());
 
-            var readStructAndReverse = ReadMachineEndian<TestHelpers.TestStructExplicit>(spanBE);
+            TestHelpers.TestStructExplicit readStructAndReverse = ReadMachineEndian<TestHelpers.TestStructExplicit>(spanBE);
             if (BitConverter.IsLittleEndian)
             {
                 readStructAndReverse.S0 = ReverseEndianness(readStructAndReverse.S0);
@@ -408,7 +408,7 @@ namespace System.Buffers.Binary.Tests
                 UL1 = ReadUInt64BigEndian(spanBE.Slice(48))
             };
 
-            var readStructAndReverseFromReadOnlySpan = ReadMachineEndian<TestHelpers.TestStructExplicit>(readOnlySpanBE);
+            TestHelpers.TestStructExplicit readStructAndReverseFromReadOnlySpan = ReadMachineEndian<TestHelpers.TestStructExplicit>(readOnlySpanBE);
             if (BitConverter.IsLittleEndian)
             {
                 readStructAndReverseFromReadOnlySpan.S0 = ReverseEndianness(readStructAndReverseFromReadOnlySpan.S0);

--- a/src/System.Memory/tests/Performance/Perf.Base64EncodeDecode.cs
+++ b/src/System.Memory/tests/Performance/Perf.Base64EncodeDecode.cs
@@ -22,7 +22,7 @@ namespace System.Buffers.Text.Tests
             Base64TestHelper.InitalizeBytes(source);
             Span<byte> destination = new byte[Base64.GetMaxEncodedToUtf8Length(numberOfBytes)];
 
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -47,7 +47,7 @@ namespace System.Buffers.Text.Tests
             Base64TestHelper.InitalizeBytes(source);
             Span<byte> destination = new byte[Base64.GetMaxEncodedToUtf8Length(numberOfBytes) - 1];
 
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -68,7 +68,7 @@ namespace System.Buffers.Text.Tests
             Base64TestHelper.InitalizeBytes(source.AsSpan());
             var destination = new char[Base64.GetMaxEncodedToUtf8Length(numberOfBytes)];
 
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -90,7 +90,7 @@ namespace System.Buffers.Text.Tests
             Span<byte> encoded = new byte[Base64.GetMaxEncodedToUtf8Length(numberOfBytes)];
             Base64.EncodeToUtf8(source, encoded, out _, out _);
 
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -118,7 +118,7 @@ namespace System.Buffers.Text.Tests
 
             source = source.Slice(0, source.Length - 1);
 
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -139,7 +139,7 @@ namespace System.Buffers.Text.Tests
             Base64TestHelper.InitalizeBytes(source);
             ReadOnlySpan<char> encoded = Convert.ToBase64String(source.ToArray()).ToCharArray();
 
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -164,7 +164,7 @@ namespace System.Buffers.Text.Tests
             Span<byte> backupSpan = decodedSpan.ToArray();
 
             int bytesWritten = 0;
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -193,7 +193,7 @@ namespace System.Buffers.Text.Tests
             Span<byte> backupSpan = decodedSpan.ToArray();
 
             int bytesWritten = 0;
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 backupSpan.CopyTo(decodedSpan);
                 using (iteration.StartMeasurement())
@@ -223,7 +223,7 @@ namespace System.Buffers.Text.Tests
             Span<byte> backupSpan = encodedSpan.ToArray();
 
             int bytesWritten = 0;
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -248,7 +248,7 @@ namespace System.Buffers.Text.Tests
             Span<byte> encodedSpan = new byte[length];
 
             int bytesWritten = 0;
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 Base64.EncodeToUtf8(source, encodedSpan, out _, out _);
                 using (iteration.StartMeasurement())

--- a/src/System.Memory/tests/Performance/Perf.MemorySlice.cs
+++ b/src/System.Memory/tests/Performance/Perf.MemorySlice.cs
@@ -30,7 +30,7 @@ namespace System.Memory.Tests
                     {
                         for (int j = 0; j < numberOfSlices; j++)
                         {
-                            var span = memory.Slice(10, 1).Span;
+                            Span<byte> span = memory.Slice(10, 1).Span;
                             localInt ^= span[0];
                         }
                     }
@@ -56,7 +56,7 @@ namespace System.Memory.Tests
                     {
                         for (int j = 0; j < numberOfSlices; j++)
                         {
-                            var span = memory.Span.Slice(10, 1);
+                            Span<byte> span = memory.Span.Slice(10, 1);
                             localInt ^= span[0];
                         }
                     }
@@ -83,7 +83,7 @@ namespace System.Memory.Tests
                     {
                         for (int j = 0; j < numberOfSlices; j++)
                         {
-                            var span = memory.Span.Slice(10, 1);
+                            ReadOnlySpan<byte> span = memory.Span.Slice(10, 1);
                             localInt ^= span[0];
                         }
                     }
@@ -110,7 +110,7 @@ namespace System.Memory.Tests
                     {
                         for (int j = 0; j < numberOfSlices; j++)
                         {
-                            var span = memory.Span.Slice(10, 1);
+                            ReadOnlySpan<char> span = memory.Span.Slice(10, 1);
                             localInt ^= span[0];
                         }
                     }

--- a/src/System.Memory/tests/Performance/Perf.Span.BinaryReadAndWrite.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.BinaryReadAndWrite.cs
@@ -20,7 +20,7 @@ namespace System.Buffers.Binary.Tests
             Span<byte> spanBE = TestHelpers.GetSpanBE();
 
             var readStruct = new TestHelpers.TestStructExplicit();
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -55,7 +55,7 @@ namespace System.Buffers.Binary.Tests
             Span<byte> spanLE = TestHelpers.GetSpanLE();
 
             var readStruct = new TestHelpers.TestStructExplicit();
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -90,7 +90,7 @@ namespace System.Buffers.Binary.Tests
             Span<byte> spanBE = TestHelpers.GetSpanBE();
 
             var readStruct = new TestHelpers.TestStructExplicit();
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -124,7 +124,7 @@ namespace System.Buffers.Binary.Tests
             Span<byte> spanLE = TestHelpers.GetSpanLE();
 
             var readStruct = new TestHelpers.TestStructExplicit();
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -159,7 +159,7 @@ namespace System.Buffers.Binary.Tests
             byte[] arrayLE = spanLE.ToArray();
 
             var readStruct = new TestHelpers.TestStructExplicit();
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -194,7 +194,7 @@ namespace System.Buffers.Binary.Tests
             byte[] arrayBE = spanBE.ToArray();
 
             var readStruct = new TestHelpers.TestStructExplicit();
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -242,7 +242,7 @@ namespace System.Buffers.Binary.Tests
         {
             var myArray = new int[1000];
 
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -262,7 +262,7 @@ namespace System.Buffers.Binary.Tests
         {
             var myArray = new int[1000];
 
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {

--- a/src/System.Memory/tests/Performance/Perf.Span.Clear.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.Clear.cs
@@ -37,7 +37,7 @@ namespace System.Memory.Tests
         {
             var a = new int[size];
             var span = new Span<int>(a);
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {

--- a/src/System.Memory/tests/Performance/Perf.Span.Fill.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.Fill.cs
@@ -37,7 +37,7 @@ namespace System.Memory.Tests
         {
             var a = new int[size];
             var span = new Span<int>(a);
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {

--- a/src/System.Memory/tests/Performance/Perf.Span.StartsWith.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.StartsWith.cs
@@ -42,7 +42,7 @@ namespace System.Memory.Tests
             }
             var span = new Span<int>(a);
             var value = new Span<int>(b);
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -87,7 +87,7 @@ namespace System.Memory.Tests
             }
             var span = new Span<byte>(a);
             var value = new Span<byte>(b);
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -132,7 +132,7 @@ namespace System.Memory.Tests
             }
             var span = new Span<string>(a);
             var value = new Span<string>(b);
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {

--- a/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
+++ b/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
@@ -30,5 +30,8 @@
       <Name>PerfRunner</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
@@ -173,8 +173,8 @@ namespace System.SpanTests
 
                         for (int count = 0; count < GuidCount; ++count)
                         {
-                            var guidfirst = Unsafe.Add(ref memoryFirst, count);
-                            var guidSecond = Unsafe.Add(ref memorySecond, count);
+                            Guid guidfirst = Unsafe.Add(ref memoryFirst, count);
+                            Guid guidSecond = Unsafe.Add(ref memorySecond, count);
                             Assert.Equal(guidfirst, guidSecond);
                         }
                     }

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
@@ -29,7 +29,7 @@ namespace System.SpanTests
                 for (int i = 0; i < length; i++)
                 {
                     byte target0 = default;
-                    int idx = span.IndexOf<byte>(target0);
+                    int idx = span.IndexOf(target0);
                     Assert.Equal(0, idx);
                 }
             }
@@ -50,7 +50,7 @@ namespace System.SpanTests
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
                 {
                     byte target = a[targetIndex];
-                    int idx = span.IndexOf<byte>(target);
+                    int idx = span.IndexOf(target);
                     Assert.Equal(targetIndex, idx);
                 }
             }
@@ -71,7 +71,7 @@ namespace System.SpanTests
                 }
                 ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
 
-                int idx = span.IndexOf<byte>(target);
+                int idx = span.IndexOf(target);
                 Assert.Equal(-1, idx);
             }
         }
@@ -83,11 +83,11 @@ namespace System.SpanTests
             for (var i = 0; i < Vector<byte>.Count; i++)
             {
                 var span = new ReadOnlySpan<byte>(array, i, 3 * Vector<byte>.Count);
-                int idx = span.IndexOf<byte>((byte)'1');
+                int idx = span.IndexOf((byte)'1');
                 Assert.Equal(-1, idx);
 
                 span = new ReadOnlySpan<byte>(array, i, 3 * Vector<byte>.Count - 3);
-                idx = span.IndexOf<byte>((byte)'1');
+                idx = span.IndexOf((byte)'1');
                 Assert.Equal(-1, idx);
             }
         }
@@ -177,7 +177,7 @@ namespace System.SpanTests
             var index = -1;
             if (searchFor.Length == 1)
             {
-                index = span.IndexOf<byte>((byte)searchFor[0]);
+                index = span.IndexOf((byte)searchFor[0]);
             }
             else if (searchFor.Length == 2)
             {

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
@@ -169,10 +169,10 @@ namespace System.SpanTests
         [InlineData("/localhost:5000/PATH/PATH2/ HTTP/1.1", " %?", ' ', 27)]
         public static void IndexOfAnyStrings_Byte(string raw, string search, char expectResult, int expectIndex)
         {
-            var buffers = Encoding.UTF8.GetBytes(raw);
+            byte[] buffers = Encoding.UTF8.GetBytes(raw);
             var span = new ReadOnlySpan<byte>(buffers);
-            var searchFor = search.ToCharArray();
-            var searchForBytes = Encoding.UTF8.GetBytes(searchFor);
+            char[] searchFor = search.ToCharArray();
+            byte[] searchForBytes = Encoding.UTF8.GetBytes(searchFor);
 
             var index = -1;
             if (searchFor.Length == 1)

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOfSequence.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOfSequence.byte.cs
@@ -13,7 +13,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 5, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 5, 1, 77 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(0, index);
         }
 
@@ -22,7 +22,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 1, 2, 3, 1, 2, 3, 1, 2, 3 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 2, 3 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(1, index);
         }
 
@@ -31,7 +31,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 77, 77, 88 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(10, index);
         }
 
@@ -40,7 +40,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 77, 77, 88, 99 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(-1, index);
         }
 
@@ -49,7 +49,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 100, 77, 88, 99 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(-1, index);
         }
 
@@ -58,7 +58,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 3, 4, 5 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(3, index);
         }
 
@@ -67,7 +67,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 3, 4, 5 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(-1, index);
         }
 
@@ -77,7 +77,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(Array.Empty<byte>());
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(0, index);
         }
 
@@ -86,7 +86,7 @@ namespace System.SpanTests
         {
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(Array.Empty<byte>());
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 1, 2, 3 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(-1, index);
         }
 
@@ -96,7 +96,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 2 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(2, index);
         }
 
@@ -106,7 +106,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 5 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(5, index);
         }
 
@@ -116,7 +116,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 5 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(-1, index);
         }
     }

--- a/src/System.Memory/tests/ReadOnlySpan/LastIndexOfAny.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/LastIndexOfAny.byte.cs
@@ -31,10 +31,10 @@ namespace System.SpanTests
         [InlineData("/localhost:5000/PATH/PATH2/ HTTP/1.1", " %?", ' ', 27)]
         public static void LastIndexOfAnyStrings_Byte(string raw, string search, char expectResult, int expectIndex)
         {
-            var buffers = Encoding.UTF8.GetBytes(raw);
+            byte[] buffers = Encoding.UTF8.GetBytes(raw);
             var span = new ReadOnlySpan<byte>(buffers);
-            var searchFor = search.ToCharArray();
-            var searchForBytes = Encoding.UTF8.GetBytes(searchFor);
+            char[] searchFor = search.ToCharArray();
+            byte[] searchForBytes = Encoding.UTF8.GetBytes(searchFor);
 
             var index = -1;
             if (searchFor.Length == 1)

--- a/src/System.Memory/tests/Span/CopyTo.cs
+++ b/src/System.Memory/tests/Span/CopyTo.cs
@@ -242,8 +242,8 @@ namespace System.SpanTests
 
                         for (int count = 0; count < GuidCount; ++count)
                         {
-                            var guidfirst = Unsafe.Add(ref memoryFirst, count);
-                            var guidSecond = Unsafe.Add(ref memorySecond, count);
+                            Guid guidfirst = Unsafe.Add(ref memoryFirst, count);
+                            Guid guidSecond = Unsafe.Add(ref memorySecond, count);
                             Assert.Equal(guidfirst, guidSecond);
                         }
                     }

--- a/src/System.Memory/tests/Span/IndexOf.byte.cs
+++ b/src/System.Memory/tests/Span/IndexOf.byte.cs
@@ -169,10 +169,10 @@ namespace System.SpanTests
         [InlineData("/localhost:5000/PATH/PATH2/ HTTP/1.1", " %?", ' ', 27)]
         public static void IndexOfAnyStrings_Byte(string raw, string search, char expectResult, int expectIndex)
         {
-            var buffers = Encoding.UTF8.GetBytes(raw);
+            byte[] buffers = Encoding.UTF8.GetBytes(raw);
             var span = new Span<byte>(buffers);
-            var searchFor = search.ToCharArray();
-            var searchForBytes = Encoding.UTF8.GetBytes(searchFor);
+            char[] searchFor = search.ToCharArray();
+            byte[] searchForBytes = Encoding.UTF8.GetBytes(searchFor);
 
             var index = -1;
             if (searchFor.Length == 1)

--- a/src/System.Memory/tests/Span/IndexOf.byte.cs
+++ b/src/System.Memory/tests/Span/IndexOf.byte.cs
@@ -29,7 +29,7 @@ namespace System.SpanTests
                 for (int i = 0; i < length; i++)
                 {
                     byte target0 = default;
-                    int idx = span.IndexOf<byte>(target0);
+                    int idx = span.IndexOf(target0);
                     Assert.Equal(0, idx);
                 }
             }
@@ -50,7 +50,7 @@ namespace System.SpanTests
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
                 {
                     byte target = a[targetIndex];
-                    int idx = span.IndexOf<byte>(target);
+                    int idx = span.IndexOf(target);
                     Assert.Equal(targetIndex, idx);
                 }
             }
@@ -71,7 +71,7 @@ namespace System.SpanTests
                 }
                 Span<byte> span = new Span<byte>(a);
 
-                int idx = span.IndexOf<byte>(target);
+                int idx = span.IndexOf(target);
                 Assert.Equal(-1, idx);
             }
         }
@@ -83,11 +83,11 @@ namespace System.SpanTests
             for (var i = 0; i < Vector<byte>.Count; i++)
             {
                 var span = new Span<byte>(array, i, 3 * Vector<byte>.Count);
-                int idx = span.IndexOf<byte>((byte)'1');
+                int idx = span.IndexOf((byte)'1');
                 Assert.Equal(-1, idx);
 
                 span = new Span<byte>(array, i, 3 * Vector<byte>.Count - 3);
-                idx = span.IndexOf<byte>((byte)'1');
+                idx = span.IndexOf((byte)'1');
                 Assert.Equal(-1, idx);
             }
         }
@@ -177,7 +177,7 @@ namespace System.SpanTests
             var index = -1;
             if (searchFor.Length == 1)
             {
-                index = span.IndexOf<byte>((byte)searchFor[0]);
+                index = span.IndexOf((byte)searchFor[0]);
             }
             else if (searchFor.Length == 2)
             {

--- a/src/System.Memory/tests/Span/IndexOfSequence.byte.cs
+++ b/src/System.Memory/tests/Span/IndexOfSequence.byte.cs
@@ -13,7 +13,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 5, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<byte> value = new Span<byte>(new byte[] { 5, 1, 77 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(0, index);
         }
 
@@ -22,7 +22,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 1, 2, 3, 1, 2, 3, 1, 2, 3 });
             Span<byte> value = new Span<byte>(new byte[] { 2, 3 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(1, index);
         }
 
@@ -31,7 +31,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<byte> value = new Span<byte>(new byte[] { 77, 77, 88 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(10, index);
         }
 
@@ -40,7 +40,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<byte> value = new Span<byte>(new byte[] { 77, 77, 88, 99 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(-1, index);
         }
 
@@ -49,7 +49,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<byte> value = new Span<byte>(new byte[] { 100, 77, 88, 99 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(-1, index);
         }
 
@@ -58,7 +58,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             Span<byte> value = new Span<byte>(new byte[] { 3, 4, 5 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(3, index);
         }
 
@@ -67,7 +67,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             Span<byte> value = new Span<byte>(new byte[] { 3, 4, 5 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(-1, index);
         }
 
@@ -77,7 +77,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<byte> value = new Span<byte>(Array.Empty<byte>());
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(0, index);
         }
 
@@ -86,7 +86,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(Array.Empty<byte>());
             Span<byte> value = new Span<byte>(new byte[] { 1, 2, 3 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(-1, index);
         }
 
@@ -96,7 +96,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             Span<byte> value = new Span<byte>(new byte[] { 2 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(2, index);
         }
 
@@ -106,7 +106,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             Span<byte> value = new Span<byte>(new byte[] { 5 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(5, index);
         }
 
@@ -116,7 +116,7 @@ namespace System.SpanTests
             // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             Span<byte> value = new Span<byte>(new byte[] { 5 });
-            int index = span.IndexOf<byte>(value);
+            int index = span.IndexOf(value);
             Assert.Equal(-1, index);
         }
     }

--- a/src/System.Memory/tests/Span/LastIndexOfAny.byte.cs
+++ b/src/System.Memory/tests/Span/LastIndexOfAny.byte.cs
@@ -31,10 +31,10 @@ namespace System.SpanTests
         [InlineData("/localhost:5000/PATH/PATH2/ HTTP/1.1", " %?", ' ', 27)]
         public static void LastIndexOfAnyStrings_Byte(string raw, string search, char expectResult, int expectIndex)
         {
-            var buffers = Encoding.UTF8.GetBytes(raw);
+            byte[] buffers = Encoding.UTF8.GetBytes(raw);
             var span = new Span<byte>(buffers);
-            var searchFor = search.ToCharArray();
-            var searchForBytes = Encoding.UTF8.GetBytes(searchFor);
+            char[] searchFor = search.ToCharArray();
+            byte[] searchForBytes = Encoding.UTF8.GetBytes(searchFor);
 
             var index = -1;
             if (searchFor.Length == 1)

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -175,5 +175,8 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -225,7 +225,7 @@ namespace System.Net.NetworkInformation
             return OperationalStatus.Unknown;
         }
 
-        // Maps values from /sys/class/net/<interface>/operstate to OperationStatus values.
+        // Maps values from /sys/class/net/<interface>/operstate to OperationalStatus values.
         private static OperationalStatus MapState(string state)
         {
             //


### PR DESCRIPTION
- Use explicit type instead of var where type can't be inferred easily.
- Removing unnecessary use of 'unsafe' keyword and generic type specifiers.

As an aside, change comment in LinuxNetworkInterface.cs to the right type - OperationalStatus (to avoid confusion with OperationStatus)

cc @KrzysztofCwalina, @jkotas, @stephentoub