### PR TITLE
Remove System.Runtime.CompilerServices.Unsafe from netcoreapp

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -3482,10 +3482,7 @@
         "4.4.0"
       ],
       "BaselineVersion": "4.4.0",
-      "InboxOn": {
-        "netcoreapp2.1": "4.0.4.0",
-        "uap10.0.15138": "4.0.4.0"
-      },
+      "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.2.0": "4.3.0",

--- a/src/System.Runtime.CompilerServices.Unsafe/dir.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/dir.props
@@ -4,7 +4,5 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp>true</IsNETCoreApp>
-    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
@@ -7,15 +7,6 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
-
-    <!-- Since UAP and .NETCoreApp are package based we still want to enable
-         OOBing libraries that happen to overlap with their framework package.
-         This avoids us having to lock the API in our NuGet packages just 
-         to match what shipped inbox: since we can provide a new library 
-         we can update it to add API without raising the netstandard version. -->
-    <ValidatePackageSuppression Include="TreatAsOutOfBox">
-      <Value>.NETCoreApp;UAP</Value>
-    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/Configurations.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/Configurations.props
@@ -4,7 +4,6 @@
     <BuildConfigurations>
       netstandard1.0;
       netstandard;
-      netcoreapp;
     </BuildConfigurations>  
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/24090

As part of https://github.com/dotnet/corefx/issues/24090#issuecomment-351041295, removing System.Runtime.CompilerServices.Unsafe from netcoreapp, and making it a purely OOB library.

Related PRs:
- https://github.com/dotnet/coreclr/pull/15497
- https://github.com/dotnet/coreclr/pull/15510
- https://github.com/dotnet/coreclr/pull/15527
- https://github.com/dotnet/corefx/pull/25929

cc @jkotas, @KrzysztofCwalina, @terrajobst, @weshaggard, @joshfree, @ericstj, @JeremyKuhne, @Petermarcu, @eerhardt 