### PR TITLE
SpanHelpers IndexOfAny-methods use sentinel-value

### DIFF
--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -63,7 +63,7 @@ namespace System
             for (int i = 0; i < valueLength; i++)
             {
                 var tempIndex = LastIndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
-                index = (index > tempIndex) ? index : tempIndex;
+                if (tempIndex > index) index = tempIndex;
             }
             return index;
         }

--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -59,13 +59,13 @@ namespace System
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
-            int index = int.MinValue;
+            int index = -1;
             for (int i = 0; i < valueLength; i++)
             {
                 var tempIndex = LastIndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
-                index = (tempIndex == -1 || index > tempIndex) ? index : tempIndex;
+                index = (index > tempIndex) ? index : tempIndex;
             }
-            return index == int.MinValue ? -1 : index;
+            return index;
         }
 
         public static unsafe int IndexOf<T>(ref T searchSpace, T value, int length)

--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -59,16 +59,13 @@ namespace System
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
-            int index = -1;
+            int index = int.MinValue;
             for (int i = 0; i < valueLength; i++)
             {
                 var tempIndex = LastIndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
-                if (tempIndex != -1)
-                {
-                    index = (index == -1 || index < tempIndex) ? tempIndex : index;
-                }
+                index = (tempIndex == -1 || index > tempIndex) ? index : tempIndex;
             }
-            return index;
+            return index == int.MinValue ? -1 : index;
         }
 
         public static unsafe int IndexOf<T>(ref T searchSpace, T value, int length)

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -64,7 +64,7 @@ namespace System
             for (int i = 0; i < valueLength; i++)
             {
                 var tempIndex = IndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
-                index = (tempIndex == -1 || tempIndex > index) ? index : tempIndex;
+                if ((uint)tempIndex < (uint)index) index = tempIndex;
             }
             return index == int.MaxValue ? -1 : index;
         }
@@ -81,7 +81,7 @@ namespace System
             for (int i = 0; i < valueLength; i++)
             {
                 var tempIndex = LastIndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
-                index = (index > tempIndex) ? index : tempIndex;
+                if (tempIndex > index) index = tempIndex;
             }
             return index;
         }

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -60,13 +60,13 @@ namespace System
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
-            int index = int.MaxValue;
+            int index = -1;
             for (int i = 0; i < valueLength; i++)
             {
                 var tempIndex = IndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
                 if ((uint)tempIndex < (uint)index) index = tempIndex;
             }
-            return index == int.MaxValue ? -1 : index;
+            return index;
         }
 
         public static int LastIndexOfAny(ref byte searchSpace, int searchSpaceLength, ref byte value, int valueLength)

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -60,16 +60,13 @@ namespace System
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
-            int index = -1;
+            int index = int.MaxValue;
             for (int i = 0; i < valueLength; i++)
             {
                 var tempIndex = IndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
-                if (tempIndex != -1)
-                {
-                    index = (index == -1 || index > tempIndex) ? tempIndex : index;
-                }
+                index = (tempIndex == -1 || tempIndex > index) ? index : tempIndex;
             }
-            return index;
+            return index == int.MaxValue ? -1 : index;
         }
 
         public static int LastIndexOfAny(ref byte searchSpace, int searchSpaceLength, ref byte value, int valueLength)
@@ -80,16 +77,13 @@ namespace System
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
-            int index = -1;
+            int index = int.MinValue;
             for (int i = 0; i < valueLength; i++)
             {
                 var tempIndex = LastIndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
-                if (tempIndex != -1)
-                {
-                    index = (index == -1 || index < tempIndex) ? tempIndex : index;
-                }
+                index = (tempIndex == -1 || index > tempIndex) ? index : tempIndex;
             }
-            return index;
+            return index == int.MinValue ? -1 : index;
         }
 
         public static unsafe int IndexOf(ref byte searchSpace, byte value, int length)

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -77,13 +77,13 @@ namespace System
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
-            int index = int.MinValue;
+            int index = -1;
             for (int i = 0; i < valueLength; i++)
             {
                 var tempIndex = LastIndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
-                index = (tempIndex == -1 || index > tempIndex) ? index : tempIndex;
+                index = (index > tempIndex) ? index : tempIndex;
             }
-            return index == int.MinValue ? -1 : index;
+            return index;
         }
 
         public static unsafe int IndexOf(ref byte searchSpace, byte value, int length)


### PR DESCRIPTION
Instead of having _valueLength_-times an if-check in the loop, a sentinel value is used and hence only one final checks needs to done.

Perf-win depends on the size of _valueLength_, the greater the more win.
