### PR TITLE
disable MulticastInterface_Set_AnyInterface_Succeeds 

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -87,6 +87,11 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public async Task MulticastInterface_Set_AnyInterface_Succeeds()
         {
+             if (PlatformDetection.IsFedora || PlatformDetection.IsRedHatFamily7)
+             {
+                return; // [ActiveIssue(24114)]
+             }
+
             // On all platforms, index 0 means "any interface"
             await MulticastInterface_Set_Helper(0);
         }


### PR DESCRIPTION
while investigating failures on Fedora 25, Redhat 7.2 and 7.3 (#24114)
They are probably caused by environment - packet filter rules as previous failures. 

