### PR TITLE
Ensure System.Uri normalizes Unicode hosts when "file://" scheme is present

### DIFF
--- a/src/System.Private.Uri/System.Private.Uri.sln
+++ b/src/System.Private.Uri/System.Private.Uri.sln
@@ -1,8 +1,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.30319.200
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.Uri.ExtendedFunctional.Tests", "tests\ExtendedFunctionalTests\System.Private.Uri.ExtendedFunctional.Tests.csproj", "{0FEBE054-68AC-446F-B999-9068736D3CEC}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.Uri.ExtendedFunctional.Tests", "tests\ExtendedFunctionalTests\System.Private.Uri.ExtendedFunctional.Tests.csproj", "{0febe054-68ac-446f-b999-9068736d3cec}"
 	ProjectSection(ProjectDependencies) = postProject
 		{4AC5343E-6E31-4BA5-A795-0493AE7E9008} = {4AC5343E-6E31-4BA5-A795-0493AE7E9008}
 	EndProjectSection
@@ -29,10 +29,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{0febe054-68ac-446f-b999-9068736d3cec}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{0febe054-68ac-446f-b999-9068736d3cec}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{0febe054-68ac-446f-b999-9068736d3cec}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{0febe054-68ac-446f-b999-9068736d3cec}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
@@ -50,12 +50,9 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{0FEBE054-68AC-446F-B999-9068736D3CEC} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{0febe054-68ac-446f-b999-9068736d3cec} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{96AF3242-A368-4F13-B006-A722CC3B8517} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{4AC5343E-6E31-4BA5-A795-0493AE7E9008} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {E3D9B56D-9E4F-4BC3-9284-63443FE79FBC}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Private.Uri/System.Private.Uri.sln
+++ b/src/System.Private.Uri/System.Private.Uri.sln
@@ -1,8 +1,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.30319.200
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.Uri.ExtendedFunctional.Tests", "tests\ExtendedFunctionalTests\System.Private.Uri.ExtendedFunctional.Tests.csproj", "{0febe054-68ac-446f-b999-9068736d3cec}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.Uri.ExtendedFunctional.Tests", "tests\ExtendedFunctionalTests\System.Private.Uri.ExtendedFunctional.Tests.csproj", "{0FEBE054-68AC-446F-B999-9068736D3CEC}"
 	ProjectSection(ProjectDependencies) = postProject
 		{4AC5343E-6E31-4BA5-A795-0493AE7E9008} = {4AC5343E-6E31-4BA5-A795-0493AE7E9008}
 	EndProjectSection
@@ -29,10 +29,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{0febe054-68ac-446f-b999-9068736d3cec}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{0febe054-68ac-446f-b999-9068736d3cec}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{0febe054-68ac-446f-b999-9068736d3cec}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{0febe054-68ac-446f-b999-9068736d3cec}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
@@ -50,9 +50,12 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{0febe054-68ac-446f-b999-9068736d3cec} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{0FEBE054-68AC-446F-B999-9068736D3CEC} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{96AF3242-A368-4F13-B006-A722CC3B8517} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{4AC5343E-6E31-4BA5-A795-0493AE7E9008} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E3D9B56D-9E4F-4BC3-9284-63443FE79FBC}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -4191,7 +4191,15 @@ namespace System
                 if (UncNameHelper.IsValid(pString, start, ref end, StaticNotAny(flags, Flags.ImplicitFile)))
                 {
                     if (end - start <= UncNameHelper.MaximumInternetNameLength)
+                    {
                         flags |= Flags.UncHostType;
+                        if (hasUnicode && iriParsing && hostNotUnicodeNormalized)
+                        {
+                            newHost += new string(pString, start, end - start);
+                            flags |= Flags.HostUnicodeNormalized;
+                            justNormalized = true;
+                        }
+                    }
                 }
             }
 

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -534,10 +534,5 @@ namespace System.PrivateUri.Tests
             Assert.Equal(authority, fileTwoSlashes.Authority); // Two slashes must be followed by an authority
             Assert.Equal(authority, fileFourSlashes.Authority); // More than three slashes looks like a UNC share
         }
-        [Fact]
-        public void Iri_FileUriUncFallback_DoesNotSupportPercentEncodedHost()
-        {
-            Assert.Throws<UriFormatException>(() => new Uri("file://_%C3%A8"));
-        }
     }
 }

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -526,6 +526,7 @@ namespace System.PrivateUri.Tests
         [InlineData("\u00E8")]
         [InlineData("_\u00E8")]
         [InlineData("_")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Requires fix shipping in .NET 4.7.2")]
         public void Iri_FileUriUncFallback_DoesSupportUnicodeHost(string authority)
         {
             Uri fileTwoSlashes = new Uri("file://" + authority);

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -522,25 +522,22 @@ namespace System.PrivateUri.Tests
             { }
         }
 
-        [Fact]
-        public void Iri_FileUriUncFallback_DoesSupportUnicodeHost()
+        [Theory]
+        [InlineData("\u00E8")]
+        [InlineData("_\u00E8")]
+        [InlineData("_")]
+        public void Iri_FileUriUncFallback_DoesSupportUnicodeHost(string authority)
         {
-            string[] authorities = { "\u00E8", "_\u00E8", "_" };
-            foreach (string authority in authorities)
-            {
-                Uri fileTwoSlashes = new Uri("file://" + authority);
-                Uri fileThreeSlashes = new Uri("file:///" + authority);
-                Uri fileFourSlashes = new Uri("file:////" + authority);
-                Assert.Equal(authority, fileTwoSlashes.Authority); // Two slashes must be followed by an authority
-                Assert.Equal(String.Empty, fileThreeSlashes.Authority); // Three slashes indicates an empty authority
-                Assert.Equal(authority, fileFourSlashes.Authority); // More than three slashes looks like a UNC share
-            }
-        }
+            Uri fileTwoSlashes = new Uri("file://" + authority);
+            Uri fileFourSlashes = new Uri("file:////" + authority);
 
+            Assert.Equal(authority, fileTwoSlashes.Authority); // Two slashes must be followed by an authority
+            Assert.Equal(authority, fileFourSlashes.Authority); // More than three slashes looks like a UNC share
+        }
         [Fact]
         public void Iri_FileUriUncFallback_DoesNotSupportPercentEncodedHost()
         {
-            Assert.Throws<UriFormatException>(() => { var invalidUri = new Uri("file://_%C3%A8"); });
+            Assert.Throws<UriFormatException>(() => new Uri("file://_%C3%A8"));
         }
     }
 }

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -521,5 +521,26 @@ namespace System.PrivateUri.Tests
             catch (FormatException)
             { }
         }
+
+        [Fact]
+        public void Iri_FileUriUncFallback_DoesSupportUnicodeHost()
+        {
+            string[] authorities = { "\u00E8", "_\u00E8", "_" };
+            foreach (string authority in authorities)
+            {
+                Uri fileTwoSlashes = new Uri("file://" + authority);
+                Uri fileThreeSlashes = new Uri("file:///" + authority);
+                Uri fileFourSlashes = new Uri("file:////" + authority);
+                Assert.Equal(authority, fileTwoSlashes.Authority); // Two slashes must be followed by an authority
+                Assert.Equal(String.Empty, fileThreeSlashes.Authority); // Three slashes indicates an empty authority
+                Assert.Equal(authority, fileFourSlashes.Authority); // More than three slashes looks like a UNC share
+            }
+        }
+
+        [Fact]
+        public void Iri_FileUriUncFallback_DoesNotSupportPercentEncodedHost()
+        {
+            Assert.Throws<UriFormatException>(() => { var invalidUri = new Uri("file://_%C3%A8"); });
+        }
     }
 }


### PR DESCRIPTION
When parsing "file:" IRIs containing Unicode, the host and path must be normalized and the results copied over to the canonical IRI string. This fix ensures that always happens.

The issue occurs when three things align:
• The URI has the scheme "file", and is followed two, or by four or more slashes
• The URI begins with a symbol that is unreserved for URIs, but is reserved for DNS names.
• The URI contains Unicode characters

This occurs because of an oversight in the normalization process. The strings that represent the URI are reduced to just the scheme, and are then built up to the canonical version based on the rules associated with that scheme, and on the contents of the remainder of the URI. For example the URI. http://abcd#123 Is reduced to the string http://, and the rules associated with http build the string up to the canonical version, http://abcd. In most cases, the code for file URIs with more than one slash is processed by the same code path that processes DNS IRIs. However, in the case that the authority was not valid for DNS IRIs (such as those beginning with an underscore), the processing would fall through to the code for processing UNC hosts. While UNC hosts are allowed to have Unicode, the code path failed to normalize the Unicode from the URI.

This process resulted in an invalid internal state for the URI. The internal string representing the canonical URI would only contain the scheme name, but the integer storing the index of the end of the authority would be set as it was before normalization. Later, a method would try to loop over the internal string until the end of the authority, and would cause an IndexOutOfRange exception.

This issue was reported in internal bug 95292.