### PR TITLE
enable MulticastInterface_Set_AnyInterface_Succeeds again after infrastructure fixes

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -87,11 +87,6 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public async Task MulticastInterface_Set_AnyInterface_Succeeds()
         {
-             if (PlatformDetection.IsFedora || PlatformDetection.IsRedHatFamily7)
-             {
-                return; // [ActiveIssue(24114)]
-             }
-
             // On all platforms, index 0 means "any interface"
             await MulticastInterface_Set_Helper(0);
         }


### PR DESCRIPTION
fixes #24114
Failures were caused by packet filter rules. This changed after some infrastructure changes where machines (redhat clones (without RH6))  no longer reboot during deployment.  


@dotnet-bot test outerloop linux x64 debug build please