### PR TITLE
Make ArgumentException to blame correct parameter for invalid input

### DIFF
--- a/src/System.Net.Mail/src/System/Net/Mime/HeaderCollection.cs
+++ b/src/System.Net.Mail/src/System/Net/Mime/HeaderCollection.cs
@@ -137,7 +137,7 @@ namespace System.Net.Mime
 
             if (value == string.Empty)
             {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(value)), nameof(name));
+                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(value)), nameof(value));
             }
 
             if (!MimeBasePart.IsAscii(name, false))
@@ -183,7 +183,7 @@ namespace System.Net.Mime
             }
             if (value == string.Empty)
             {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(value)), nameof(name));
+                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(value)), nameof(value));
             }
 
             MailBnfHelper.ValidateHeaderName(name);

--- a/src/System.Net.Mail/tests/Functional/HeaderCollectionTest.cs
+++ b/src/System.Net.Mail/tests/Functional/HeaderCollectionTest.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Net.Mail;
+using Xunit;
+
+namespace System.Net.Mime.Tests
+{
+    public class HeaderCollectionTest
+    {
+        private MailMessage mail = new MailMessage();
+        
+        [Fact]
+        public void Set_ValidNameAndValue_Success()
+        {
+          string validName = "foo";
+          string validValue = "bar";
+          mail.Headers.Set(validName, validValue);
+          Assert.Equal(validValue, mail.Headers.Get(validName));
+          mail.Headers.Remove(validName);
+        }
+        
+        [Fact]
+        public void Set_EmptyName_Throws()
+        {
+          AssertExtensions.Throws<ArgumentException>("name", () => mail.Headers.Set(string.Empty, "value"));
+        }
+        
+        [Fact]
+        public void Set_EmptyValue_Throws()
+        {
+          AssertExtensions.Throws<ArgumentException>("value", () => mail.Headers.Set("name", string.Empty));
+        }
+        
+        [Fact]
+        public void Add_ValidNameAndValue_Success()
+        {
+          string validName = "foo";
+          string validValue = "bar";
+          mail.Headers.Add(validName, validValue);
+          Assert.Equal(validValue, mail.Headers.Get(validName));
+          mail.Headers.Remove(validName);
+        }
+        
+        [Fact]
+        public void Add_EmptyName_Throws()
+        {
+          AssertExtensions.Throws<ArgumentException>("name", () => mail.Headers.Add(string.Empty, "value"));
+        }
+        
+        [Fact]
+        public void Add_EmptyValue_Throws()
+        {
+          AssertExtensions.Throws<ArgumentException>("value", () => mail.Headers.Add("name", string.Empty));
+        }
+    }
+}

--- a/src/System.Net.Mail/tests/Functional/HeaderCollectionTest.cs
+++ b/src/System.Net.Mail/tests/Functional/HeaderCollectionTest.cs
@@ -23,12 +23,14 @@ namespace System.Net.Mime.Tests
         }
         
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Requires fix shipping in .NET 4.7.2")]
         public void Set_EmptyName_Throws()
         {
           AssertExtensions.Throws<ArgumentException>("name", () => mail.Headers.Set(string.Empty, "value"));
         }
         
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Requires fix shipping in .NET 4.7.2")]
         public void Set_EmptyValue_Throws()
         {
           AssertExtensions.Throws<ArgumentException>("value", () => mail.Headers.Set("name", string.Empty));
@@ -45,12 +47,14 @@ namespace System.Net.Mime.Tests
         }
         
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Requires fix shipping in .NET 4.7.2")]
         public void Add_EmptyName_Throws()
         {
           AssertExtensions.Throws<ArgumentException>("name", () => mail.Headers.Add(string.Empty, "value"));
         }
         
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Requires fix shipping in .NET 4.7.2")]
         public void Add_EmptyValue_Throws()
         {
           AssertExtensions.Throws<ArgumentException>("value", () => mail.Headers.Add("name", string.Empty));

--- a/src/System.Net.Mail/tests/Functional/System.Net.Mail.Functional.Tests.csproj
+++ b/src/System.Net.Mail/tests/Functional/System.Net.Mail.Functional.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="AttachmentTest.cs" />
     <Compile Include="ContentDispositionTest.cs" />
     <Compile Include="ContentTypeTest.cs" />
+    <Compile Include="HeaderCollectionTest.cs" />
     <Compile Include="LinkedResourceCollectionTest.cs" />
     <Compile Include="LinkedResourceTest.cs" />
     <Compile Include="LoggingTest.cs" />


### PR DESCRIPTION
Attempts to set or add an empty string value to a System.Net.Mime.HeaderCollection results in an ArgumentException. This is expected behavior. However, the ArgumentException thrown from HeaderCollection.Set and HeaderCollection.Add in this case indicates that `name` is empty instead of `value`. 

This PR is to make ArgumentException to blame correct parameter for invalid input.

This issue was reported in internal bug 116743.