### PR TITLE
Fix Set-Cookie header parsing in CookieContainer

### DIFF
--- a/src/Common/src/System/Net/CookieParser.cs
+++ b/src/Common/src/System/Net/CookieParser.cs
@@ -905,5 +905,10 @@ namespace System.Net
 
             return value.Length == 2 ? string.Empty : value.Substring(1, value.Length - 2);
         }
+        
+        internal bool EndofHeader()
+        {
+            return _tokenizer.Eof;
+        }
     }
 }

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -675,7 +675,11 @@ namespace System.Net
 
                     if (cookie == null)
                     {
-                        break;
+                        if (parser.EndofHeader())
+                        {
+                            break;
+                        }
+                        continue;
                     }
 
                     // Parser marks invalid cookies this way

--- a/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
@@ -154,7 +154,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // RFC 2965 (no path)
 
-            yield return new object[] {
+            yield return new object[]
+            {
                 uSecure,
                 "name98=value98; name98=value98; comment=comment; comment=comment2; commentURL=http://url.com; commentURL=commentURL2; discard; discard; domain=.uri.com; domain=domain2; max-age=400; max-age=400; path=/; path=path; port=\"80, 90, 443\"; port=port2; path=path; expires=Wed, 09 Jun 2021 10:18:14 GMT; expires=expires2; secure; secure; httponly; httponly; Version=100; Version=100, name99=value99",
                 new Cookie[]
@@ -164,7 +165,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Double entries
 
-            yield return new object[] {
+            yield return new object[]
+            {
                 u,
                 "name98=value98; commentURL=invalidurl",
                 new Cookie[]
@@ -173,7 +175,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Ignore invalid comment url
 
-            yield return new object[] {
+            yield return new object[]
+            {
                 u6,
                 "name98=value98; unknown1; unknown2=unknown",
                 new Cookie[]
@@ -182,7 +185,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Ignore unknown tokens
 
-            yield return new object[] {
+            yield return new object[]
+            {
                 u6,
                 "name98=value98; =; token=",
                 new Cookie[]
@@ -191,7 +195,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Ignore invalid tokens
 
-            yield return new object[] {
+            yield return new object[]
+            {
                 u6,
                 "name98=\"value; domain=\".domain\"; max-age=\"400\"",
                 new Cookie[]
@@ -200,7 +205,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Use escaped values (1)
 
-            yield return new object[] {
+            yield return new object[]
+            {
                 u6,
                 "name98=\"\"",
                 new Cookie[]
@@ -209,7 +215,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Use escaped values (2)
             
-            yield return new object[] {
+            yield return new object[]
+            {
                 u,
                 "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
                 new Cookie[]
@@ -221,7 +228,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Normal case
             
-            yield return new object[] {
+            yield return new object[]
+            {
                 uSecure,
                 "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
                 new Cookie[]
@@ -233,7 +241,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Normal case with secure URI
             
-            yield return new object[] {
+            yield return new object[]
+            {
                 u,
                 ",locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
                 new Cookie[]
@@ -245,7 +254,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Empty header at the beginning
             
-            yield return new object[] {
+            yield return new object[]
+            {
                 uSecure,
                 "          ,locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
                 new Cookie[]
@@ -257,7 +267,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Empty header composed by spaces at the beginning
             
-            yield return new object[] {
+            yield return new object[]
+            {
                 u,
                 "locale=en,, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
                 new Cookie[]
@@ -269,7 +280,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Empty header in the middle
             
-            yield return new object[] {
+            yield return new object[]
+            {
                 uSecure,
                 "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46,       , country=US, _m_ask_fm_session=session1",
                 new Cookie[]
@@ -281,7 +293,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Empty header composed by spaces in the middle
             
-            yield return new object[] {
+            yield return new object[]
+            {
                 u,
                 "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1,",
                 new Cookie[]
@@ -293,7 +306,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Empty header at the end
             
-            yield return new object[] {
+            yield return new object[]
+            {
                 u,
                 "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1,   ",
                 new Cookie[]
@@ -305,7 +319,8 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // Empty header composed by spaces at the end
             
-            yield return new object[] {
+            yield return new object[]
+            {
                 uSecure,
                 "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1,   ,",
                 new Cookie[]

--- a/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
@@ -244,6 +244,7 @@ namespace System.Net.Primitives.Unit.Tests
                     new Cookie("_m_ask_fm_session", "session1")
                 }
             }; // Empty header at the beginning
+            
             yield return new object[] {
                 uSecure,
                 "          ,locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
@@ -255,6 +256,7 @@ namespace System.Net.Primitives.Unit.Tests
                     new Cookie("_m_ask_fm_session", "session1")
                 }
             }; // Empty header composed by spaces at the beginning
+            
             yield return new object[] {
                 u,
                 "locale=en,, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
@@ -266,6 +268,7 @@ namespace System.Net.Primitives.Unit.Tests
                     new Cookie("_m_ask_fm_session", "session1")
                 }
             }; // Empty header in the middle
+            
             yield return new object[] {
                 uSecure,
                 "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46,       , country=US, _m_ask_fm_session=session1",
@@ -277,6 +280,7 @@ namespace System.Net.Primitives.Unit.Tests
                     new Cookie("_m_ask_fm_session", "session1")
                 }
             }; // Empty header composed by spaces in the middle
+            
             yield return new object[] {
                 u,
                 "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1,",
@@ -300,6 +304,7 @@ namespace System.Net.Primitives.Unit.Tests
                     new Cookie("_m_ask_fm_session", "session1")
                 }
             }; // Empty header composed by spaces at the end
+            
             yield return new object[] {
                 uSecure,
                 "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1,   ,",

--- a/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
@@ -143,7 +143,9 @@ namespace System.Net.Primitives.Unit.Tests
                 }
             }; // RFC 2965
 
-            yield return new object[] { u,
+            yield return new object[]
+            {
+                u,
                 "name98=value98; port=\"80, 90\", name99=value99",
                 new Cookie[]
                 {
@@ -206,6 +208,109 @@ namespace System.Net.Primitives.Unit.Tests
                     new Cookie("name98", "\"\"")
                 }
             }; // Use escaped values (2)
+            
+            yield return new object[] {
+                u,
+                "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
+                new Cookie[]
+                {
+                    new Cookie("locale", "en"),
+                    new Cookie("uuid", "4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46"),
+                    new Cookie("country", "US"),
+                    new Cookie("_m_ask_fm_session", "session1")
+                }
+            }; // Normal case
+            
+            yield return new object[] {
+                uSecure,
+                "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
+                new Cookie[]
+                {
+                    new Cookie("locale", "en"),
+                    new Cookie("uuid", "4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46"),
+                    new Cookie("country", "US"),
+                    new Cookie("_m_ask_fm_session", "session1")
+                }
+            }; // Normal case with secure URI
+            
+            yield return new object[] {
+                u,
+                ",locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
+                new Cookie[]
+                {
+                    new Cookie("locale", "en"),
+                    new Cookie("uuid", "4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46"),
+                    new Cookie("country", "US"),
+                    new Cookie("_m_ask_fm_session", "session1")
+                }
+            }; // Empty header at the beginning
+            yield return new object[] {
+                uSecure,
+                "          ,locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
+                new Cookie[]
+                {
+                    new Cookie("locale", "en"),
+                    new Cookie("uuid", "4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46"),
+                    new Cookie("country", "US"),
+                    new Cookie("_m_ask_fm_session", "session1")
+                }
+            }; // Empty header composed by spaces at the beginning
+            yield return new object[] {
+                u,
+                "locale=en,, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1",
+                new Cookie[]
+                {
+                    new Cookie("locale", "en"),
+                    new Cookie("uuid", "4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46"),
+                    new Cookie("country", "US"),
+                    new Cookie("_m_ask_fm_session", "session1")
+                }
+            }; // Empty header in the middle
+            yield return new object[] {
+                uSecure,
+                "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46,       , country=US, _m_ask_fm_session=session1",
+                new Cookie[]
+                {
+                    new Cookie("locale", "en"),
+                    new Cookie("uuid", "4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46"),
+                    new Cookie("country", "US"),
+                    new Cookie("_m_ask_fm_session", "session1")
+                }
+            }; // Empty header composed by spaces in the middle
+            yield return new object[] {
+                u,
+                "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1,",
+                new Cookie[]
+                {
+                    new Cookie("locale", "en"),
+                    new Cookie("uuid", "4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46"),
+                    new Cookie("country", "US"),
+                    new Cookie("_m_ask_fm_session", "session1")
+                }
+            }; // Empty header at the end
+            
+            yield return new object[] {
+                u,
+                "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1,   ",
+                new Cookie[]
+                {
+                    new Cookie("locale", "en"),
+                    new Cookie("uuid", "4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46"),
+                    new Cookie("country", "US"),
+                    new Cookie("_m_ask_fm_session", "session1")
+                }
+            }; // Empty header composed by spaces at the end
+            yield return new object[] {
+                uSecure,
+                "locale=en, uuid=4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46, country=US, _m_ask_fm_session=session1,   ,",
+                new Cookie[]
+                {
+                    new Cookie("locale", "en"),
+                    new Cookie("uuid", "4b8b2dd7-d91a-49ee-80c6-8cb7df1fae46"),
+                    new Cookie("country", "US"),
+                    new Cookie("_m_ask_fm_session", "session1")
+                }
+            }; // Empty header followed by another empty header at the end
         }
 
         [Theory]
@@ -218,6 +323,7 @@ namespace System.Net.Primitives.Unit.Tests
 
         [Theory]
         [MemberData(nameof(SetCookiesData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Requires fix shipping in .NET 4.7.2")]
         public void SetCookies_Success(Uri uri, string cookieHeader, Cookie[] expected)
         {
             CookieContainer cc = CreateCount11Container();

--- a/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
@@ -265,7 +265,7 @@ namespace System.Net.Primitives.Unit.Tests
                     new Cookie("country", "US"),
                     new Cookie("_m_ask_fm_session", "session1")
                 }
-            }; // Empty header composed by spaces at the beginning
+            }; // Empty header composed of spaces at the beginning
             
             yield return new object[]
             {
@@ -291,7 +291,7 @@ namespace System.Net.Primitives.Unit.Tests
                     new Cookie("country", "US"),
                     new Cookie("_m_ask_fm_session", "session1")
                 }
-            }; // Empty header composed by spaces in the middle
+            }; // Empty header composed of spaces in the middle
             
             yield return new object[]
             {
@@ -317,7 +317,7 @@ namespace System.Net.Primitives.Unit.Tests
                     new Cookie("country", "US"),
                     new Cookie("_m_ask_fm_session", "session1")
                 }
-            }; // Empty header composed by spaces at the end
+            }; // Empty header composed of spaces at the end
             
             yield return new object[]
             {


### PR DESCRIPTION
When server responds with following response headers: 

Set-Cookie: mobile_view=false; path=/ 
Set-Cookie: 
Set-Cookie: language_id=17; path=/; expires=Fri, 26-Feb-2016 11:26:05 GMT 

CookieParser in .NET stops parsing headers at second, empty, Set-Cookie header. 

This PR is to make sure that CookieContainer continues parsing until reaching the end of the entire Set-Cookie header.

This issue was reported in internal bug 143892.