### PR TITLE
Make test asynchronous.

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -125,7 +125,7 @@
     <None Include="..\Scripts\Unix\kdc.conf.opensuse">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <Compile Include="NegotiateStreamTestForUnix.cs" />
+    <Compile Include="NegotiateStreamTest.Linux.cs" />
     <Compile Include="UnixGssFakeNegotiateStream.cs" />
     <Compile Include="UnixGssFakeStreamFramer.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">


### PR DESCRIPTION
Remove task.waitall from test, that may cause sporadic CI test failures.

cc @wfurt @karelz 