### PR TITLE
Add license headers.

### DIFF
--- a/src/Common/perf/PerfRunner/PerfRunner.cs
+++ b/src/Common/perf/PerfRunner/PerfRunner.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.IO;
 using System.Reflection;
 using System.Collections.Generic;

--- a/src/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/Common/tests/System/Xml/ModuleCore/XunitTestCase.cs
+++ b/src/Common/tests/System/Xml/ModuleCore/XunitTestCase.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ArgumentObject.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ArgumentObject.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace Microsoft.CSharp.RuntimeBinder

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ICSharpBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ICSharpBinder.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 

--- a/src/SharedFrameworkValidation/RestoreSDKProject/Dummy.cs
+++ b/src/SharedFrameworkValidation/RestoreSDKProject/Dummy.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace Dummy
 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Node.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/System.Collections.Specialized/tests/StringDictionary/StringDictionary.GetEnumeratorTests.cs
+++ b/src/System.Collections.Specialized/tests/StringDictionary/StringDictionary.GetEnumeratorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.---
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Composition.TypedParts/tests/ReflectionTests.cs
+++ b/src/System.Composition.TypedParts/tests/ReflectionTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Concurrent;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
 using System.Composition.Hosting;
 using System.Threading;
 using Xunit;

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/SpecialSettingAttribute.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/SpecialSettingAttribute.cs
@@ -1,7 +1,8 @@
-﻿using System;
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace System.Configuration
 {

--- a/src/System.Data.Common/tests/System/Data/Common/DataColumnMappingTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DataColumnMappingTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Data.Common;
 using Xunit;
 

--- a/src/System.Data.Odbc/ref/System.Data.Odbc.cs
+++ b/src/System.Data.Odbc/ref/System.Data.Odbc.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Data.Odbc
 {
     public sealed partial class OdbcCommand : System.Data.Common.DbCommand, System.ICloneable

--- a/src/System.Data.Odbc/src/Common/System/Data/Common/SafeNativeMethods.cs
+++ b/src/System.Data.Odbc/src/Common/System/Data/Common/SafeNativeMethods.cs
@@ -1,4 +1,8 @@
-﻿using System.Runtime.InteropServices;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
 
 namespace System.Data
 {

--- a/src/System.Data.Odbc/tests/ConnectionStrings.Unix.cs
+++ b/src/System.Data.Odbc/tests/ConnectionStrings.Unix.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Data.Odbc.Tests
 {
     public static class ConnectionStrings

--- a/src/System.Data.Odbc/tests/ConnectionStrings.Windows.cs
+++ b/src/System.Data.Odbc/tests/ConnectionStrings.Windows.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Data.Odbc.Tests
 {
     public static class ConnectionStrings

--- a/src/System.Data.Odbc/tests/Helpers.cs
+++ b/src/System.Data.Odbc/tests/Helpers.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/System.Data.Odbc/tests/IntegrationTestBase.cs
+++ b/src/System.Data.Odbc/tests/IntegrationTestBase.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Data.Odbc.Tests
 {

--- a/src/System.Data.Odbc/tests/OdbcParameterTests.cs
+++ b/src/System.Data.Odbc/tests/OdbcParameterTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Data.SqlClient;
 using System.Text;
 using Xunit;

--- a/src/System.Data.Odbc/tests/ReaderTests.cs
+++ b/src/System.Data.Odbc/tests/ReaderTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Data.Odbc.Tests
 {

--- a/src/System.Data.Odbc/tests/SmokeTest.cs
+++ b/src/System.Data.Odbc/tests/SmokeTest.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Data.Odbc.Tests
 {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -1,4 +1,8 @@
-﻿using System.Data.Common;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Data.Common;
 using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Reflection;

--- a/src/System.Diagnostics.Debug/tests/DebuggerBrowsableAttributeTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebuggerBrowsableAttributeTests.cs
@@ -1,4 +1,5 @@
-﻿// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Xunit;

--- a/src/System.Diagnostics.Debug/tests/DebuggerDisplayAttributeTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebuggerDisplayAttributeTests.cs
@@ -1,4 +1,5 @@
-﻿// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Xunit;

--- a/src/System.Diagnostics.Debug/tests/DebuggerTypeProxyAttributeTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebuggerTypeProxyAttributeTests.cs
@@ -1,4 +1,5 @@
-﻿// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Xunit;

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Diagnostics
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics
 {
     public abstract partial class DiagnosticSource
     {

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityDateTimeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityDateTimeTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Threading;
 using Xunit;
 

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;

--- a/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Concurrent;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/CertificateCollectionDeltas.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/CertificateCollectionDeltas.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/ValueList.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/ValueList.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Diagnostics;
 using System.Collections;

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/ValueListEnumerator.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/ValueListEnumerator.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Diagnostics;
 using System.Collections;

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/config.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/config.cs
@@ -1,4 +1,6 @@
-
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // 
 // This file controls whether we're building for Longhorn or Whidbey.

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/testobj.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/testobj.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 #if TESTHOOK
 
 using System;

--- a/src/System.DirectoryServices.Protocols/ref/System.DirectoryServices.Protocols.cs
+++ b/src/System.DirectoryServices.Protocols/ref/System.DirectoryServices.Protocols.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace System.DirectoryServices.Protocols {
   public partial class AddRequest : System.DirectoryServices.Protocols.DirectoryRequest {

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Unsafe/Conformance.dynamic.unsafe.PointerOperator.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Unsafe/Conformance.dynamic.unsafe.PointerOperator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 #if CAP_TypeOfPointer
 

--- a/src/System.IO/tests/BinaryReader/BinaryReaderTests.netcoreapp.cs
+++ b/src/System.IO/tests/BinaryReader/BinaryReaderTests.netcoreapp.cs
@@ -1,4 +1,8 @@
-﻿using System.Linq;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
 using System.Text;
 using Xunit;
 

--- a/src/System.IO/tests/TestDataProvider/TestDataProvider.cs
+++ b/src/System.IO/tests/TestDataProvider/TestDataProvider.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/System.Linq.Queryable/tests/AppendPrependTests.cs
+++ b/src/System.Linq.Queryable/tests/AppendPrependTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Memory/tests/AllocationHelper.cs
+++ b/src/System.Memory/tests/AllocationHelper.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.InteropServices;
 using System.Threading;
 

--- a/src/System.Memory/tests/ReadOnlySpan/Overlaps.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/Overlaps.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Xunit;
 
 namespace System.SpanTests

--- a/src/System.Net.HttpListener/tests/InvalidClientRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/InvalidClientRequestTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
 using System.Text;

--- a/src/System.Private.Uri/src/System/Uri.Unix.cs
+++ b/src/System.Private.Uri/src/System/Uri.Unix.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System
 {
     public partial class Uri

--- a/src/System.Private.Uri/src/System/Uri.Windows.cs
+++ b/src/System.Private.Uri/src/System/Uri.Windows.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System
 {
     public partial class Uri

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompilerTests.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompilerTests.cs
@@ -1,4 +1,8 @@
-﻿using System.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
 using System.Xml.Xsl;
 using Xunit;
 

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
@@ -1,4 +1,3 @@
-
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.StreamWriter.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.StreamWriter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the.NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Runtime.Extensions/tests/System/Environment.UserDomainName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.UserDomainName.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Tests
 {

--- a/src/System.Runtime.Extensions/tests/System/Environment.UserName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.UserName.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Tests
 {

--- a/src/System.Runtime.Extensions/tests/System/UnloadingAndProcessExitTests.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/UnloadingAndProcessExitTests.netcoreapp.cs
@@ -1,4 +1,8 @@
-﻿using System.Diagnostics;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Xunit;

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTestData.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTestData.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/Collections.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/Collections.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/ComparisonHelper.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/ComparisonHelper.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections;
 using System.Diagnostics;
 using System.Reflection;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DCRImplVariations.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DCRImplVariations.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Runtime.Serialization;
 using System.Xml;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DCRSampleType.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DCRSampleType.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Xml;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DCRTypeLibrary.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DCRTypeLibrary.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DataContract.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DataContract.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DataContractResolverLibrary.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DataContractResolverLibrary.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Xml;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/InheritenceCases.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/InheritenceCases.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Runtime.Serialization;
 
 namespace SerializationTestTypes

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/InheritenceObjectRef.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/InheritenceObjectRef.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/ObjRefSample.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/ObjRefSample.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Runtime.Serialization;
 
 namespace SerializationTestTypes

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/Primitives.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/Primitives.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/SampleIObjectRef.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/SampleIObjectRef.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Runtime.Serialization;
 
 namespace SerializationTestTypes

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/SampleTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/SampleTypes.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/SelfRefAndCycles.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/SelfRefAndCycles.cs
@@ -1,4 +1,8 @@
-﻿using System.Runtime.Serialization;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
 
 namespace SerializationTestTypes
 {

--- a/src/System.Runtime/tests/Performance/Perf.String.netcoreapp.cs
+++ b/src/System.Runtime/tests/Performance/Perf.String.netcoreapp.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 using Microsoft.Xunit.Performance;
 using Xunit;
 

--- a/src/System.Runtime/tests/System/Reflection/TypeDelegatorTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Reflection/TypeDelegatorTests.netcoreapp.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Runtime/tests/System/Reflection/TypeInfoTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Reflection/TypeInfoTests.netcoreapp.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/System.ServiceModel.Syndication/tests/Utils/CompareHelper.cs
+++ b/src/System.ServiceModel.Syndication/tests/Utils/CompareHelper.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/System.ServiceModel.Syndication/tests/Utils/XmlDiff.cs
+++ b/src/System.ServiceModel.Syndication/tests/Utils/XmlDiff.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/src/System.ServiceModel.Syndication/tests/Utils/XmlDiffDocument.cs
+++ b/src/System.ServiceModel.Syndication/tests/Utils/XmlDiffDocument.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
 using System.Diagnostics;
 using System.IO;
 using System.Text;

--- a/src/System.ServiceModel.Syndication/tests/Utils/XmlDiffOption.cs
+++ b/src/System.ServiceModel.Syndication/tests/Utils/XmlDiffOption.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 
 namespace System.ServiceModel.Syndication.Tests
 {

--- a/src/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
+++ b/src/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
@@ -1,5 +1,4 @@
-﻿
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/Program.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/Program.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/src/System.Transactions.Local/tests/TransactionTracingEventListener.cs
+++ b/src/System.Transactions.Local/tests/TransactionTracingEventListener.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;


### PR DESCRIPTION
Realised I'd neglected this in a file, and found some others.

Any *.cs file found without the usual license header has it added except:

1. Files that note they are auto-generated.
2. Files with a different header (unless it is very close to the usual, in which case adjust for typos and old versions).
3. FxCopBaseline.cs files.

Any usual licenses that didn't start on the first line were moved up.