### PR TITLE
Fix bad Exception formatting

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
@@ -544,7 +544,7 @@ namespace System.Reflection.Metadata
 
             if ((externalTableMask & ~validTables) != 0)
             {
-                throw new BadImageFormatException(string.Format(SR.UnknownTables, (TableMask)externalTableMask));
+                throw new BadImageFormatException(string.Format(SR.UnknownTables, externalTableMask));
             }
 
             externalTableRowCounts = ReadMetadataTableRowCounts(ref reader, externalTableMask);


### PR DESCRIPTION
An invalid External Table Mask should throw a BadImageFormatException but always throws a System.FormatException. Remove a cast to TableMask and the correct exception is thrown. Also included a test.
Fixes #26028