### PR TITLE
Added native support for the HTTP PATCH verb.

### DIFF
--- a/src/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/System.Net.Http/ref/System.Net.Http.cs
@@ -62,6 +62,10 @@ namespace System.Net.Http
         public System.Threading.Tasks.Task<System.IO.Stream> GetStreamAsync(System.Uri requestUri) { throw null; }
         public System.Threading.Tasks.Task<string> GetStringAsync(string requestUri) { throw null; }
         public System.Threading.Tasks.Task<string> GetStringAsync(System.Uri requestUri) { throw null; }
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> PatchAsync(string requestUri, System.Net.Http.HttpContent content) { throw null; }
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> PatchAsync(string requestUri, System.Net.Http.HttpContent content, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> PatchAsync(System.Uri requestUri, System.Net.Http.HttpContent content) { throw null; }
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> PatchAsync(System.Uri requestUri, System.Net.Http.HttpContent content, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> PostAsync(string requestUri, System.Net.Http.HttpContent content) { throw null; }
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> PostAsync(string requestUri, System.Net.Http.HttpContent content, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> PostAsync(System.Uri requestUri, System.Net.Http.HttpContent content) { throw null; }
@@ -150,6 +154,7 @@ namespace System.Net.Http
         public static System.Net.Http.HttpMethod Head { get { throw null; } }
         public string Method { get { throw null; } }
         public static System.Net.Http.HttpMethod Options { get { throw null; } }
+        public static System.Net.Http.HttpMethod Patch { get { throw null; } }
         public static System.Net.Http.HttpMethod Post { get { throw null; } }
         public static System.Net.Http.HttpMethod Put { get { throw null; } }
         public static System.Net.Http.HttpMethod Trace { get { throw null; } }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -351,6 +351,30 @@ namespace System.Net.Http
             return SendAsync(request, cancellationToken);
         }
 
+        public Task<HttpResponseMessage> PatchAsync(string requestUri, HttpContent content)
+        {
+            return PatchAsync(CreateUri(requestUri), content);
+        }
+
+        public Task<HttpResponseMessage> PatchAsync(Uri requestUri, HttpContent content)
+        {
+            return PatchAsync(requestUri, content, CancellationToken.None);
+        }
+
+        public Task<HttpResponseMessage> PatchAsync(string requestUri, HttpContent content,
+            CancellationToken cancellationToken)
+        {
+            return PatchAsync(CreateUri(requestUri), content, cancellationToken);
+        }
+
+        public Task<HttpResponseMessage> PatchAsync(Uri requestUri, HttpContent content,
+            CancellationToken cancellationToken)
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Patch, requestUri);
+            request.Content = content;
+            return SendAsync(request, cancellationToken);
+        }
+
         public Task<HttpResponseMessage> DeleteAsync(string requestUri)
         {
             return DeleteAsync(CreateUri(requestUri));

--- a/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
@@ -18,6 +18,7 @@ namespace System.Net.Http
         private static readonly HttpMethod s_headMethod = new HttpMethod("HEAD");
         private static readonly HttpMethod s_optionsMethod = new HttpMethod("OPTIONS");
         private static readonly HttpMethod s_traceMethod = new HttpMethod("TRACE");
+        private static readonly HttpMethod s_patchMethod = new HttpMethod("PATCH");
 
         // Don't expose CONNECT as static property, since it's used by the transport to connect to a proxy.
         // CONNECT is not used by users directly.
@@ -55,6 +56,11 @@ namespace System.Net.Http
         public static HttpMethod Trace
         {
             get { return s_traceMethod; }
+        }
+
+        public static HttpMethod Patch
+        {
+            get { return s_patchMethod; }
         }
 
         public string Method

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -257,7 +257,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public async Task GetPutPostDeleteAsync_Canceled_Throws()
+        public async Task GetPutPostDeletePatchAsync_Canceled_Throws()
         {
             using (var client = new HttpClient(new CustomResponseHandler((r, c) => WhenCanceled<HttpResponseMessage>(c))))
             {
@@ -269,6 +269,7 @@ namespace System.Net.Http.Functional.Tests
                 Task t3 = client.PostAsync(CreateFakeUri(), content, cts.Token);
                 Task t4 = client.PutAsync(CreateFakeUri(), content, cts.Token);
                 Task t5 = client.DeleteAsync(CreateFakeUri(), cts.Token);
+                Task t6 = client.PatchAsync(CreateFakeUri(), content, cts.Token);
 
                 cts.Cancel();
 
@@ -277,11 +278,12 @@ namespace System.Net.Http.Functional.Tests
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t3);
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t4);
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t5);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t6);
             }
         }
 
         [Fact]
-        public async Task GetPutPostDeleteAsync_Success()
+        public async Task GetPutPostDeletePatchAsync_Success()
         {
             Action<HttpResponseMessage> verify = message => { using (message) Assert.Equal(HttpStatusCode.OK, message.StatusCode); };
             using (var client = new HttpClient(new CustomResponseHandler((r, c) => Task.FromResult(new HttpResponseMessage()))))
@@ -299,6 +301,9 @@ namespace System.Net.Http.Functional.Tests
 
                 verify(await client.DeleteAsync(CreateFakeUri()));
                 verify(await client.DeleteAsync(CreateFakeUri(), CancellationToken.None));
+
+                verify(await client.PatchAsync(CreateFakeUri(), new ByteArrayContent(new byte[1])));
+                verify(await client.PatchAsync(CreateFakeUri(), new ByteArrayContent(new byte[1]), CancellationToken.None));
             }
         }
 
@@ -369,6 +374,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Throws<ObjectDisposedException>(() => { client.GetByteArrayAsync(CreateFakeUri()); });
             Assert.Throws<ObjectDisposedException>(() => { client.GetStreamAsync(CreateFakeUri()); });
             Assert.Throws<ObjectDisposedException>(() => { client.GetStringAsync(CreateFakeUri()); });
+            Assert.Throws<ObjectDisposedException>(() => { client.PatchAsync(CreateFakeUri(), new ByteArrayContent(new byte[1])); });
             Assert.Throws<ObjectDisposedException>(() => { client.PostAsync(CreateFakeUri(), new ByteArrayContent(new byte[1])); });
             Assert.Throws<ObjectDisposedException>(() => { client.PutAsync(CreateFakeUri(), new ByteArrayContent(new byte[1])); });
             Assert.Throws<ObjectDisposedException>(() => { client.SendAsync(new HttpRequestMessage(HttpMethod.Get, CreateFakeUri())); });

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public class HttpClientTest : HttpClientTestBase
+    public partial class HttpClientTest : HttpClientTestBase
     {
         [Fact]
         public void Dispose_MultipleTimes_Success()
@@ -257,7 +257,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public async Task GetPutPostDeletePatchAsync_Canceled_Throws()
+        public async Task GetPutPostDeleteAsync_Canceled_Throws()
         {
             using (var client = new HttpClient(new CustomResponseHandler((r, c) => WhenCanceled<HttpResponseMessage>(c))))
             {
@@ -269,7 +269,6 @@ namespace System.Net.Http.Functional.Tests
                 Task t3 = client.PostAsync(CreateFakeUri(), content, cts.Token);
                 Task t4 = client.PutAsync(CreateFakeUri(), content, cts.Token);
                 Task t5 = client.DeleteAsync(CreateFakeUri(), cts.Token);
-                Task t6 = client.PatchAsync(CreateFakeUri(), content, cts.Token);
 
                 cts.Cancel();
 
@@ -278,12 +277,11 @@ namespace System.Net.Http.Functional.Tests
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t3);
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t4);
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t5);
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t6);
             }
         }
 
         [Fact]
-        public async Task GetPutPostDeletePatchAsync_Success()
+        public async Task GetPutPostDeleteAsync_Success()
         {
             Action<HttpResponseMessage> verify = message => { using (message) Assert.Equal(HttpStatusCode.OK, message.StatusCode); };
             using (var client = new HttpClient(new CustomResponseHandler((r, c) => Task.FromResult(new HttpResponseMessage()))))
@@ -301,9 +299,6 @@ namespace System.Net.Http.Functional.Tests
 
                 verify(await client.DeleteAsync(CreateFakeUri()));
                 verify(await client.DeleteAsync(CreateFakeUri(), CancellationToken.None));
-
-                verify(await client.PatchAsync(CreateFakeUri(), new ByteArrayContent(new byte[1])));
-                verify(await client.PatchAsync(CreateFakeUri(), new ByteArrayContent(new byte[1]), CancellationToken.None));
             }
         }
 
@@ -374,7 +369,6 @@ namespace System.Net.Http.Functional.Tests
             Assert.Throws<ObjectDisposedException>(() => { client.GetByteArrayAsync(CreateFakeUri()); });
             Assert.Throws<ObjectDisposedException>(() => { client.GetStreamAsync(CreateFakeUri()); });
             Assert.Throws<ObjectDisposedException>(() => { client.GetStringAsync(CreateFakeUri()); });
-            Assert.Throws<ObjectDisposedException>(() => { client.PatchAsync(CreateFakeUri(), new ByteArrayContent(new byte[1])); });
             Assert.Throws<ObjectDisposedException>(() => { client.PostAsync(CreateFakeUri(), new ByteArrayContent(new byte[1])); });
             Assert.Throws<ObjectDisposedException>(() => { client.PutAsync(CreateFakeUri(), new ByteArrayContent(new byte[1])); });
             Assert.Throws<ObjectDisposedException>(() => { client.SendAsync(new HttpRequestMessage(HttpMethod.Get, CreateFakeUri())); });

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.netcoreapp.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.netcoreapp.cs
@@ -1,0 +1,46 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public partial class HttpClientTest
+    {
+        [Fact]
+        public async Task PatchAsync_Canceled_Throws()
+        {
+            using (var client = new HttpClient(new CustomResponseHandler((r, c) => WhenCanceled<HttpResponseMessage>(c))))
+            {
+                var content = new ByteArrayContent(new byte[1]);
+                var cts = new CancellationTokenSource();
+                
+                Task t1 = client.PatchAsync(CreateFakeUri(), content, cts.Token);
+
+                cts.Cancel();
+                
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t1);
+            }
+        }
+
+        [Fact]
+        public async Task PatchAsync_Success()
+        {
+            Action<HttpResponseMessage> verify = message => { using (message) Assert.Equal(HttpStatusCode.OK, message.StatusCode); };
+            using (var client = new HttpClient(new CustomResponseHandler((r, c) => Task.FromResult(new HttpResponseMessage()))))
+            {
+                verify(await client.PatchAsync(CreateFakeUri(), new ByteArrayContent(new byte[1])));
+                verify(await client.PatchAsync(CreateFakeUri(), new ByteArrayContent(new byte[1]), CancellationToken.None));
+            }
+        }
+
+        [Fact]
+        public void Dispose_UsePatchAfterDispose_Throws()
+        {
+            HttpClient client = CreateHttpClient();
+            client.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => { client.PatchAsync(CreateFakeUri(), new ByteArrayContent(new byte[1])); });
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.netcoreapp.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.netcoreapp.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.cs
@@ -11,21 +11,27 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public class HttpMethodTest
+    public partial class HttpMethodTest
     {
-        private static readonly object[][] s_staticHttpMethods =
-        {
-            new object[] { HttpMethod.Get },
-            new object[] { HttpMethod.Put },
-            new object[] { HttpMethod.Post },
-            new object[] { HttpMethod.Delete },
-            new object[] { HttpMethod.Head },
-            new object[] { HttpMethod.Options },
-            new object[] { HttpMethod.Trace },
-            new object[] { HttpMethod.Patch }
-        };
+        public static IEnumerable<object[]> StaticHttpMethods { get;  }
 
-        public static IEnumerable<object[]> StaticHttpMethods { get { return s_staticHttpMethods; } }
+        static HttpMethodTest()
+        {
+            List<object[]> staticHttpMethods = new List<object[]>
+            {
+                new object[] { HttpMethod.Get },
+                new object[] { HttpMethod.Put },
+                new object[] { HttpMethod.Post },
+                new object[] { HttpMethod.Delete },
+                new object[] { HttpMethod.Head },
+                new object[] { HttpMethod.Options },
+                new object[] { HttpMethod.Trace }
+            };
+            AddStaticHttpMethods(staticHttpMethods);
+            StaticHttpMethods = staticHttpMethods;
+        }
+
+        static partial void AddStaticHttpMethods(List<object[]> staticHttpMethods); 
 
         [Fact]
         public void StaticProperties_VerifyValues_PropertyNameMatchesHttpMethodName()
@@ -37,7 +43,6 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal("HEAD", HttpMethod.Head.Method);
             Assert.Equal("OPTIONS", HttpMethod.Options.Method);
             Assert.Equal("TRACE", HttpMethod.Trace.Method);
-            Assert.Equal("PATCH", HttpMethod.Patch.Method);
         }
 
         [Fact]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.cs
@@ -21,7 +21,8 @@ namespace System.Net.Http.Functional.Tests
             new object[] { HttpMethod.Delete },
             new object[] { HttpMethod.Head },
             new object[] { HttpMethod.Options },
-            new object[] { HttpMethod.Trace }
+            new object[] { HttpMethod.Trace },
+            new object[] { HttpMethod.Patch }
         };
 
         public static IEnumerable<object[]> StaticHttpMethods { get { return s_staticHttpMethods; } }
@@ -36,6 +37,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal("HEAD", HttpMethod.Head.Method);
             Assert.Equal("OPTIONS", HttpMethod.Options.Method);
             Assert.Equal("TRACE", HttpMethod.Trace.Method);
+            Assert.Equal("PATCH", HttpMethod.Patch.Method);
         }
 
         [Fact]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.netcoreapp.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.netcoreapp.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public partial class HttpMethodTest
+    {
+        [Fact]
+        public void Patch_VerifyValue_PropertyNameMatchesHttpMethodName()
+        {
+            Assert.Equal("PATCH", HttpMethod.Patch.Method);
+        }
+
+        static partial void AddStaticHttpMethods(List<object[]> staticHttpMethods)
+        {
+            staticHttpMethods.Add(new object[] { HttpMethod.Patch });
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.netcoreapp.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.netcoreapp.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 
 using Xunit;
 

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -113,6 +113,8 @@
     <Compile Include="ManagedHandlerTest.cs" />
     <Compile Include="HttpClientHandlerTest.AcceptAllCerts.cs" />
     <Compile Include="ReadOnlyMemoryContentTest.cs" />
+    <Compile Include="HttpClientTest.netcoreapp.cs" />
+    <Compile Include="HttpMethodTest.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="$(CommonTestPath)\System\IO\StreamSpanExtensions.netstandard.cs">


### PR DESCRIPTION
Added native support for the HTTP PATCH verb.

I didn't see any existing tests for the other verbs equivalent methods and properties so no unit tests are included.

Closes #17299