### PR TITLE
Remove leftover uses of DangerousGetPinnableReference

### DIFF
--- a/src/Common/src/Interop/Windows/advapi32/Interop.CryptGetProvParam.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.CryptGetProvParam.cs
@@ -57,7 +57,7 @@ internal static partial class Interop
 
             unsafe
             {
-                fixed (byte* bytePtr = &pbData.DangerousGetPinnableReference())
+                fixed (byte* bytePtr = &MemoryMarshal.GetReference(pbData))
                 {
                     return CryptGetProvParam(safeProvHandle, dwParam, (IntPtr)bytePtr, ref dwDataLen, 0);
                 }

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
@@ -118,7 +118,7 @@ namespace System.IO
             bool hasSeparator = PathInternal.IsDirectorySeparator(first[first.Length - 1])
                 || PathInternal.IsDirectorySeparator(second[0]);
 
-            fixed (char* f = &first.DangerousGetPinnableReference(), s = &second.DangerousGetPinnableReference())
+            fixed (char* f = &MemoryMarshal.GetReference(first), s = &MemoryMarshal.GetReference(second))
             {
                 return string.Create(
                     first.Length + second.Length + (hasSeparator ? 0 : 1),
@@ -143,7 +143,7 @@ namespace System.IO
             bool thirdHasSeparator = PathInternal.IsDirectorySeparator(second[second.Length - 1])
                 || PathInternal.IsDirectorySeparator(third[0]);
 
-            fixed (char* f = &first.DangerousGetPinnableReference(), s = &second.DangerousGetPinnableReference(), t = &third.DangerousGetPinnableReference())
+            fixed (char* f = &MemoryMarshal.GetReference(first), s = &MemoryMarshal.GetReference(second), t = &MemoryMarshal.GetReference(third))
             {
                 return string.Create(
                     first.Length + second.Length + third.Length + (firstHasSeparator ? 0 : 1) + (thirdHasSeparator ? 0 : 1),

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -93,6 +93,7 @@
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
@@ -440,7 +440,7 @@ namespace Internal.Cryptography.Pal.Windows
 
             unsafe
             {
-                fixed (byte* asciiPtr = &buf.DangerousGetPinnableReference())
+                fixed (byte* asciiPtr = &MemoryMarshal.GetReference(buf))
                 {
                     return Marshal.PtrToStringAnsi((IntPtr)asciiPtr, len);
                 }


### PR DESCRIPTION
Part of:
https://github.com/dotnet/corefx/issues/25412
https://github.com/dotnet/corefx/issues/25615

Related to: https://github.com/dotnet/corefx/pull/25936

Following the staging plan from here: https://github.com/dotnet/corefx/issues/23881#issuecomment-343767740

- [x] Add MemoryExtensions.GetReference/TryGetArray
- [x] Convert all uses of DangerousGetPinnableReference/DangerousTryGetArray in coreclr, corefx, corert, corefxlab, aspnet, ... to MemoryExtensions.GetReference
- [ ] Change DangerousGetPinnableReference to whatever we like to make it fit the pinning pattern and remove DangerousTryGetArray.

Doing it this way will avoid the need for complex staging or things being on the floor for extensive periods of time.

cc @jkotas, @stephentoub, @KrzysztofCwalina
