### PR TITLE
Only set Headers.ContentLength if it isn't already correct

### DIFF
--- a/src/System.Net.Http/src/uap/System/Net/HttpHandlerToFilter.cs
+++ b/src/System.Net.Http/src/uap/System/Net/HttpHandlerToFilter.cs
@@ -383,6 +383,8 @@ namespace System.Net.Http
             {
                 content.Headers.ContentLength = null;
             }
+            //Only re-assign content.Headers.ContentLength if necessary, as setting an existing header's value under UWP
+            //causes (ultimately harmless) com exceptions to be raised. See GitHub Issue #26051.
             else if (content.Headers.ContentLength != content.Headers.ContentLength)
             {
                 // Trigger delayed header generation via TryComputeLength. This code is needed due to an outstanding

--- a/src/System.Net.Http/src/uap/System/Net/HttpHandlerToFilter.cs
+++ b/src/System.Net.Http/src/uap/System/Net/HttpHandlerToFilter.cs
@@ -383,7 +383,7 @@ namespace System.Net.Http
             {
                 content.Headers.ContentLength = null;
             }
-            else
+            else if (content.Headers.ContentLength != content.Headers.ContentLength)
             {
                 // Trigger delayed header generation via TryComputeLength. This code is needed due to an outstanding
                 // bug in HttpContentHeaders.ContentLength. See GitHub Issue #5523.


### PR DESCRIPTION
A (handled) unmanaged COM exception is thrown by Windows.Web.Http.dll when an
attempt to set an already-present header is made. This particular line
is in the hot path and is almost always invoked on outgoing requests
causing these COM exceptions to be thrown all the time. Avoiding
downstream exceptions should make things faster and result in fewer
pipeline flushes, etc.

The unmanaged exception stack trace under Windows 10 build 17063:

```
>	KernelBase.dll!RaiseException()	Unknown	Symbols loaded.
 	combase.dll!SendReport(HRESULT error=0x8000000b, unsigned int cchMax=0, const wchar_t * message=0x00007ff854b2d8e4, unsigned short pSid=0x0000000000000000, void * pExceptionObject=0x0000000000000000, IUnknown *) Line 438	C++	Symbols loaded.
 	combase.dll!RoOriginateError(HRESULT error=0x8000000b, HSTRING__ * message) Line 590	C++	Symbols loaded.
 	Windows.Web.Http.dll!Windows::Foundation::Collections::Internal::HashMap<struct HSTRING__ *,struct HSTRING__ *,struct StringCaseInsensitiveHash,struct StringCaseInsensitiveEquals,struct Windows::Foundation::Collections::Internal::DefaultLifetimeTraits<struct HSTRING__ *>,struct Windows::Foundation::Collections::Internal::DefaultLifetimeTraits<struct HSTRING__ *>,struct Windows::Foundation::Collections::Internal::HashMapOptions<struct HSTRING__ *,struct HSTRING__ *,struct Windows::Foundation::Collections::Internal::DefaultLifetimeTraits<struct HSTRING__ *>,0,1,0> >::Remove(struct HSTRING__ *)	Unknown	Symbols loaded.
 	Windows.Web.Http.dll!HttpHeaderCollectionBase::Remove(struct HSTRING__ *)	Unknown	Symbols loaded.
 	Windows.Web.Http.dll!HttpHeaderCollectionBase::TryRemoveHeaderValueInfo(struct HSTRING__ *)	Unknown	Symbols loaded.
 	Windows.Web.Http.dll!HttpHeaderCollectionBase::SetParsedValue(unsigned short const *,struct IInspectable *)	Unknown	Symbols loaded.
 	[Managed to Native Transition]		Annotated Frame
 	System.Net.Http.dll!System.Net.Http.HttpHandlerToFilter.CreateRequestContentAsync(System.Net.Http.HttpRequestMessage request = {System.Net.Http.HttpRequestMessage}, Windows.Web.Http.Headers.HttpRequestHeaderCollection rtHeaderCollection = {Windows.Web.Http.Headers.HttpRequestHeaderCollection}) Line 390	C#	Symbols loaded.
 	System.Net.Http.dll!System.Net.Http.HttpHandlerToFilter.ConvertRequestAsync(System.Net.Http.HttpRequestMessage request = {System.Net.Http.HttpRequestMessage}, System.Net.Http.HttpMethod httpMethod = {System.Net.Http.HttpMethod}, bool skipRequestContentIfPresent = false) Line 333	C#	Symbols loaded.
 	System.Net.Http.dll!System.Net.Http.HttpHandlerToFilter.SendAsync(System.Net.Http.HttpRequestMessage request = {System.Net.Http.HttpRequestMessage}, System.Threading.CancellationToken cancel = IsCancellationRequested = false) Line 78	C#	Symbols loaded.
 	System.Net.Http.dll!System.Net.Http.HttpClientHandler.SendAsync(System.Net.Http.HttpRequestMessage request = {System.Net.Http.HttpRequestMessage}, System.Threading.CancellationToken cancellationToken = IsCancellationRequested = false) Line 596	C#	Symbols loaded.
 	System.Net.Http.dll!System.Net.Http.HttpMessageInvoker.SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) Line 51	C#	Symbols loaded.
 	System.Net.Http.dll!System.Net.Http.HttpClient.SendAsync(System.Net.Http.HttpRequestMessage request = {System.Net.Http.HttpRequestMessage}, System.Net.Http.HttpCompletionOption completionOption = ResponseHeadersRead, System.Threading.CancellationToken cancellationToken) Line 433	C#	Symbols loaded.
 	System.Net.Requests.dll!System.Net.HttpWebRequest.SendRequest() Line 1222	C#	Symbols loaded.
 	System.Net.Requests.dll!System.Net.HttpWebRequest.BeginGetResponse(System.AsyncCallback callback = {System.AsyncCallback}, object state = {System.Net.HttpWebRequest}) Line 1234	C#	Symbols loaded.
 	System.Private.CoreLib.dll!System.Threading.Tasks.TaskFactory<System.Net.WebResponse>.FromAsyncImpl(System.Func<System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, System.Net.WebResponse> endFunction = {System.Func<System.IAsyncResult, System.Net.WebResponse>}, System.Action<System.IAsyncResult> endAction = null, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) Line 810	C#	Symbols loaded.
 	System.Net.Requests.dll!System.Net.WebRequest.GetResponseAsync.AnonymousMethod__68_0() Line 548	C#	Symbols loaded.
 	System.Private.CoreLib.dll!System.Threading.Tasks.Task<System.Threading.Tasks.Task<System.Net.WebResponse>>.InnerInvoke() Line 611	C#	Symbols loaded.
 	System.Private.CoreLib.dll!System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object state) Line 145	C#	Symbols loaded.
 	System.Private.CoreLib.dll!System.Threading.Tasks.Task.ExecuteWithThreadLocal(ref System.Threading.Tasks.Task currentTaskSlot = Id = 3321, Status = Running, Method = Inspecting the state of an object in the debuggee of type System.Delegate is not supported in this context., Result = Cannot evaluate expression because a native frame is on the top of the call stack.) Line 2449	C#	Symbols loaded.
 	System.Private.CoreLib.dll!System.Threading.ThreadPoolWorkQueue.Dispatch() Line 582	C#	Symbols loaded.
 	[Native to Managed Transition]		Annotated Frame
 	kernel32.dll!00007ff853204354()	Unknown	No symbols loaded.
 	ntdll.dll!RtlUserThreadStart()	Unknown	Symbols loaded.
```

I don't have access to the source code for `Windows.Web.Http.dll` so this workaround is the best I can offer.