### PR TITLE
Remove unnecessary "is"-"cast" sequence in IPEndPoint.Equals() (#26049)

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -148,11 +148,13 @@ namespace System.Net
 
         public override bool Equals(object comparand)
         {
-            if (!(comparand is IPEndPoint))
+            var other = comparand as IPEndPoint;
+            if (other == null)
             {
                 return false;
             }
-            return ((IPEndPoint)comparand)._address.Equals(_address) && ((IPEndPoint)comparand)._port == _port;
+
+            return other._address.Equals(_address) && other._port == _port;
         }
 
         public override int GetHashCode()

--- a/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -148,13 +148,7 @@ namespace System.Net
 
         public override bool Equals(object comparand)
         {
-            var other = comparand as IPEndPoint;
-            if (other == null)
-            {
-                return false;
-            }
-
-            return other._address.Equals(_address) && other._port == _port;
+            return comparand is IPEndPoint other && other._address.Equals(_address) && other._port == _port;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Replace unnecessary "is"-"cast" sequence in IPEndPoint.Equals() with as operator.