### PR TITLE
Activity shouldn't capture AsyncLocals into its Timer

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.DateTime.netfx.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.DateTime.netfx.cs
@@ -42,6 +42,16 @@ namespace System.Diagnostics
         private static TimeSync timeSync = new TimeSync();
 
         // sync DateTime and Stopwatch ticks every 2 hours
-        private static Timer syncTimeUpdater = new Timer(s => { Sync(); }, null, 0, 7200000);
+        private static Timer syncTimeUpdater = InitalizeSyncTimer();
+
+        private static Timer InitalizeSyncTimer()
+        {
+            // Don't capture the current ExecutionContext and its AsyncLocals onto the timer causing them to live forever
+            ExecutionContext.SuppressFlow();
+            var timer = new Timer(s => { Sync(); }, null, 0, 7200000);
+            // Restore the current ExecutionContext
+            ExecutionContext.RestoreFlow();
+            return timer;
+        }
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.DateTime.netfx.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.DateTime.netfx.cs
@@ -44,6 +44,7 @@ namespace System.Diagnostics
         // sync DateTime and Stopwatch ticks every 2 hours
         private static Timer syncTimeUpdater = InitalizeSyncTimer();
 
+        [System.Security.SecuritySafeCritical]
         private static Timer InitalizeSyncTimer()
         {
             // Don't capture the current ExecutionContext and its AsyncLocals onto the timer causing them to live forever


### PR DESCRIPTION
Causing those AsyncLocal values to live forever

For ASP.NET Core can capture logging scope, HttpContext, ConcurrentBag items, Authentication (example #25477 (comment)); other state etc

Resolves https://github.com/dotnet/corefx/issues/26069