### PR TITLE
Stack<T> optimization of (Try)Peek, (Try)Pop and Push

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -202,22 +202,28 @@ namespace System.Collections.Generic
         // is empty, Peek throws an InvalidOperationException.
         public T Peek()
         {
-            if (_size == 0)
+            int size = _size - 1;
+            T[] array = _array;
+
+            if ((uint)size >= (uint)array.Length)
             {
                 ThrowForEmptyStack();
             }
             
-            return _array[_size - 1];
+            return array[size];
         }
 
         public bool TryPeek(out T result)
         {
-            if (_size == 0)
+            int size = _size - 1;
+            T[] array = _array;
+
+            if ((uint)size >= (uint)array.Length)
             {
-                result = default(T);
+                result = default;
                 return false;
             }
-            result = _array[_size - 1];
+            result = array[size];
             return true;
         }
 
@@ -247,17 +253,21 @@ namespace System.Collections.Generic
 
         public bool TryPop(out T result)
         {
-            if (_size == 0)
+            int size = _size - 1;
+            T[] array = _array;
+
+            if ((uint)size >= (uint)array.Length)
             {
-                result = default(T);
+                result = default;
                 return false;
             }
 
             _version++;
-            result = _array[--_size];
+            _size = size;
+            result = array[size];
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                _array[_size] = default(T);     // Free memory quicker.
+                array[size] = default;     // Free memory quicker.
             }
             return true;
         }
@@ -265,12 +275,17 @@ namespace System.Collections.Generic
         // Pushes an item to the top of the stack.
         public void Push(T item)
         {
-            if (_size == _array.Length)
+            int size = _size;
+            T[] array = _array;
+
+            if ((uint)size >= (uint)array.Length)
             {
-                Array.Resize(ref _array, (_array.Length == 0) ? DefaultCapacity : 2 * _array.Length);
+                Array.Resize(ref array, (array.Length == 0) ? DefaultCapacity : 2 * array.Length);
+                _array = array;
             }
-            _array[_size++] = item;
+            array[size++] = item;
             _version++;
+            _size = size;
         }
 
         // Copies the Stack to an array, in the same order Pop would return the items.

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -275,17 +275,12 @@ namespace System.Collections.Generic
         // Pushes an item to the top of the stack.
         public void Push(T item)
         {
-            int size = _size;
-            T[] array = _array;
-
-            if ((uint)size >= (uint)array.Length)
+            if (_size == _array.Length)
             {
-                Array.Resize(ref array, (array.Length == 0) ? DefaultCapacity : 2 * array.Length);
-                _array = array;
+                Array.Resize(ref _array, (_array.Length == 0) ? DefaultCapacity : 2 * _array.Length);
             }
-            array[size++] = item;
+            _array[_size++] = item;
             _version++;
-            _size = size;
         }
 
         // Copies the Stack to an array, in the same order Pop would return the items.

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -283,7 +283,7 @@ namespace System.Collections.Generic
             {
                 array[size] = item;
                 _version++;
-                _size++;
+                _size = size + 1;
             }
             else
             {

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -235,7 +235,8 @@ namespace System.Collections.Generic
             T[] array = _array;
             
             // if (_size == 0) is equivalent to if (size == -1), and this case
-            // is covered with (uint)size, thus allowing RCE https://github.com/dotnet/coreclr/pull/9773
+            // is covered with (uint)size, thus allowing bounds check elimination 
+            // https://github.com/dotnet/coreclr/pull/9773
             if ((uint)size >= (uint)array.Length)
             {
                 ThrowForEmptyStack();

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -203,14 +203,13 @@ namespace System.Collections.Generic
         public T Peek()
         {
             int size = _size - 1;
-            T[] array = _array;
 
-            if ((uint)size >= (uint)array.Length)
+            if ((uint)size >= (uint)_array.Length)
             {
                 ThrowForEmptyStack();
             }
             
-            return array[size];
+            return _array[size];
         }
 
         public bool TryPeek(out T result)

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -203,13 +203,14 @@ namespace System.Collections.Generic
         public T Peek()
         {
             int size = _size - 1;
+            T[] array = _array;
 
-            if ((uint)size >= (uint)_array.Length)
+            if ((uint)size >= (uint)array.Length)
             {
                 ThrowForEmptyStack();
             }
             
-            return _array[size];
+            return array[size];
         }
 
         public bool TryPeek(out T result)

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -225,16 +225,22 @@ namespace System.Collections.Generic
         // throws an InvalidOperationException.
         public T Pop()
         {
-            if (_size == 0)
+            int size = _size - 1;
+            T[] array = _array;
+            
+            // if (_size == 0) is equivalent to if (size == -1), and this case
+            // is covered with (uint)size, thus allowing RCE https://github.com/dotnet/coreclr/pull/9773
+            if ((uint)size >= (uint)array.Length)
             {
                 ThrowForEmptyStack();
             }
             
             _version++;
-            T item = _array[--_size];
+            _size = size;
+            T item = array[size];
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                _array[_size] = default(T);     // Free memory quicker.
+                array[size] = default;     // Free memory quicker.
             }
             return item;
         }

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -275,12 +275,29 @@ namespace System.Collections.Generic
         // Pushes an item to the top of the stack.
         public void Push(T item)
         {
-            if (_size == _array.Length)
+            int size = _size;
+            T[] array = _array;
+
+            if ((uint)size < (uint)array.Length)
             {
-                Array.Resize(ref _array, (_array.Length == 0) ? DefaultCapacity : 2 * _array.Length);
+                array[size] = item;
+                _version++;
+                _size++;
             }
-            _array[_size++] = item;
+            else
+            {
+                PushWithResize(item);
+            }
+        }
+        
+        // Non-inline from Stack.Push to improve its code quality as uncommon path
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void PushWithResize(T item)
+        {
+            Array.Resize(ref _array, (_array.Length == 0) ? DefaultCapacity : 2 * _array.Length);
+            _array[_size] = item;
             _version++;
+            _size++;
         }
 
         // Copies the Stack to an array, in the same order Pop would return the items.


### PR DESCRIPTION
# Description

Enabled RCE on array-access and avoided the explicit check for `_size == 0` --> this is done implicitly in the "RCE-if". So some `cmp`s can be saved.

By _Pop_ the effect on value types is not so big, than for reference types (two array accesses).

This PR is a kind of extension to https://github.com/dotnet/corefx/issues/17318

# Benchmarks

## Notes

Code for benchmarks lives [here](https://github.com/gfoidl/Benchmarks/tree/master/corefx/System/Collections/Generic/Stack/source/StackBenchmarks)

Due the use of http://benchmarkdotnet.org the benchmarks were done a couple of times, because some crazy results with perf x2 were reported and this seems too strange. The results shown here are the more realistic ones. Individual results are in the linked repo above.  
The changes from this PR never showed a decrease in perf.

## Peek

``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 16.04
Processor=Intel Xeon CPU 2.60GHz, ProcessorCount=2
.NET Core SDK=2.1.3
  [Host]     : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT


```
|       Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |
|------------- |---------:|----------:|----------:|-------:|---------:|
| Peek_Default | 1.974 ns | 0.1229 ns | 0.2020 ns |   1.00 |     0.00 |
|     Peek_New | 1.600 ns | 0.1231 ns | 0.2023 ns |   0.82 |     0.13 |


## TryPeek

``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 16.04
Processor=Intel Xeon CPU 2.60GHz, ProcessorCount=2
.NET Core SDK=2.1.3
  [Host]     : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT


```
|          Method |     Mean |     Error |    StdDev |   Median | Scaled | ScaledSD |
|---------------- |---------:|----------:|----------:|---------:|-------:|---------:|
| TryPeek_Default | 5.212 ns | 0.1905 ns | 0.3977 ns | 5.178 ns |   1.00 |     0.00 |
|     TryPeek_New | 3.982 ns | 0.1716 ns | 0.4640 ns | 3.798 ns |   0.77 |     0.11 |


## Pop

``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 16.04
Processor=Intel Xeon CPU 2.60GHz, ProcessorCount=2
.NET Core SDK=2.1.3
  [Host]     : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT


```
|      Method |      Mean |     Error |    StdDev | Scaled | ScaledSD |
|------------ |----------:|----------:|----------:|-------:|---------:|
| Pop_Default | 1.0609 ns | 0.0673 ns | 0.0630 ns |   1.00 |     0.00 |
|     Pop_New | 0.8681 ns | 0.1036 ns | 0.0918 ns |   0.82 |     0.10 |


## TryPop

``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 16.04
Processor=Intel Xeon CPU 2.60GHz, ProcessorCount=2
.NET Core SDK=2.1.3
  [Host]     : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT


```
|         Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |
|--------------- |---------:|----------:|----------:|-------:|---------:|
| TryPop_Default | 3.180 ns | 0.0644 ns | 0.0571 ns |   1.00 |     0.00 |
|     TryPop_New | 2.736 ns | 0.1200 ns | 0.1123 ns |   0.86 |     0.04 |


# Notes

## Push

I did some trials for `Push` too, but the results weren't satisfying. Sometimes it was faster, sometimes slower. On Linux it was nearly always slower. So I reverted the change. 
Changes were done in the commit https://github.com/gfoidl/corefx/commit/012333094dd2b2052eaf6daebaaba2a98f25d2b1

## Inlining

`MethodImplOptions.AggressiveInlining` would give a perf win on the benchmarks, because they are micro-benchmarks. Due to inlining the callsite gets bigger and in real world scenarios the perf might decrease. I ran a benchmark where this happended, unfortunately I can't show the code because it's proprietary.

From https://github.com/dotnet/corefx/pull/12094#issuecomment-249834575

> But we shouldn't add AggressiveInlining unless there's a strong performance-motivated scenario for doing so. Getting something to inline isn't a goal in and of itself.

On the other side `List.Add` has AggressiveInlining -- cf. https://github.com/dotnet/coreclr/blob/master/src/mscorlib/shared/System/Collections/Generic/List.cs#L225

I would stick to not aggressive inline, but what to do?
