### PR TITLE
Queue<T> optimization of (Try)Dequeue

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -376,11 +376,12 @@ namespace System.Collections.Generic
             // It is tempting to use the remainder operator here but it is actually much slower
             // than a simple comparison and a rarely taken branch.
             // JIT produces better code than with ternary operator ?:
-            index++;
-            if (index == _array.Length)
+            int tmp = index + 1;
+            if (tmp == _array.Length)
             {
-                index = 0;
+                tmp = 0;
             }
+            index = tmp;
         }
 
         private void ThrowForEmptyQueue()

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -234,15 +234,18 @@ namespace System.Collections.Generic
         // InvalidOperationException.
         public T Dequeue()
         {
-            if (_size == 0)
+            int head = _head;
+            T[] array = _array;
+            
+            if (_size == 0 || (uint)head >= (uint)array.Length)
             {
                 ThrowForEmptyQueue();
             }
 
-            T removed = _array[_head];
+            T removed = array[head];
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                _array[_head] = default(T);
+                array[head] = default;
             }
             MoveNext(ref _head);
             _size--;
@@ -252,16 +255,19 @@ namespace System.Collections.Generic
 
         public bool TryDequeue(out T result)
         {
-            if (_size == 0)
+            int head = _head;
+            T[] array = _array;
+
+            if (_size == 0 || (uint)head >= (uint)array.Length)
             {
-            	result = default(T);
+            	result = default;
             	return false;
             }
 
-            result = _array[_head];
+            result = array[head];
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                _array[_head] = default(T);
+                array[head] = default;
             }
             MoveNext(ref _head);
             _size--;
@@ -367,10 +373,14 @@ namespace System.Collections.Generic
         // Increments the index wrapping it if necessary.
         private void MoveNext(ref int index)
         {
-            // It is tempting to use the remainder operator here but it is actually much slower 
-            // than a simple comparison and a rarely taken branch.   
-            int tmp = index + 1;
-            index = (tmp == _array.Length) ? 0 : tmp;
+            // It is tempting to use the remainder operator here but it is actually much slower
+            // than a simple comparison and a rarely taken branch.
+            // JIT produces better code than with ternary operator ?:
+            index++;
+            if (index == _array.Length)
+            {
+                index = 0;
+            }
         }
 
         private void ThrowForEmptyQueue()

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -237,7 +237,7 @@ namespace System.Collections.Generic
             int head = _head;
             T[] array = _array;
             
-            if (_size == 0 || (uint)head >= (uint)array.Length)
+            if (_size == 0)
             {
                 ThrowForEmptyQueue();
             }
@@ -258,7 +258,7 @@ namespace System.Collections.Generic
             int head = _head;
             T[] array = _array;
 
-            if (_size == 0 || (uint)head >= (uint)array.Length)
+            if (_size == 0)
             {
             	result = default;
             	return false;


### PR DESCRIPTION
# Description

* enabled RCE on array-access
* in MoveNext the JIT can produce better code (see https://github.com/dotnet/corefx/pull/25970#discussion_r157375261)

By _Dequeue_ the effect on value types is not so big, than for reference types (two array accesses).

This PR is a kind of extension to #17318, similar to https://github.com/dotnet/corefx/pull/26086

# Benchmarks

## Notes

Code for benchmarks lives [here](https://github.com/gfoidl/Benchmarks/tree/master/corefx/System/Collections/Generic/Queue/source/QueueBenchmarks)

Due the use of http://benchmarkdotnet.org the benchmarks were done a couple of times, because some crazy results with perf x2 were reported and this seems too strange. The results shown here are the more realistic ones. Individual results are in the linked repo above.
The changes from this PR never showed a decrease in perf.

## Dequeue

``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 16.04
Processor=Intel Xeon CPU 2.60GHz, ProcessorCount=2
.NET Core SDK=2.1.3
  [Host]     : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT


```
|          Method |      Mean |     Error |    StdDev | Scaled | ScaledSD |
|---------------- |----------:|----------:|----------:|-------:|---------:|
| Dequeue_Default | 0.9702 ns | 0.1013 ns | 0.1421 ns |   1.00 |     0.00 |
|     Dequeue_New | 0.8880 ns | 0.1042 ns | 0.1770 ns |   0.93 |     0.22 |

## TryDequeue

``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 16.04
Processor=Intel Xeon CPU 2.60GHz, ProcessorCount=2
.NET Core SDK=2.1.3
  [Host]     : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.4 (Framework 4.6.0.0), 64bit RyuJIT


```
|             Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |
|------------------- |---------:|----------:|----------:|-------:|---------:|
| TryDequeue_Default | 3.990 ns | 0.1666 ns | 0.2545 ns |   1.00 |     0.00 |
|     TryDequeue_New | 3.559 ns | 0.1585 ns | 0.2273 ns |   0.90 |     0.08 |

# Notes

## Enqueue

Didn't find a way to improve perf, besides the effect of better JIT-codegen in _MoveNext_.
Remained Untouched.

## (Try)Peek

Didn't find a way to improve perf, and "RCE-if" does not bring a win, it's getting rather slower, because the code gets bigger. I didn't keep benchmark-records for this case.
Remained untouched.
