### PR TITLE
Add missing install statement to Cryptography.Native.Apple

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -50,3 +50,4 @@ target_link_libraries(System.Security.Cryptography.Native.Apple
 )
 
 install_library_and_symbols (System.Security.Cryptography.Native.Apple)
+install (TARGETS System.Security.Cryptography.Native.Apple-Static DESTINATION .)


### PR DESCRIPTION
The generated static lib Cryptography.Native.Apple was not being output in CoreFX packages. Added missing statement.