### PR TITLE
Removed 2 extra allocations on SqlBulkCopy(string)

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
@@ -256,7 +256,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        public SqlBulkCopy(string connectionString) : this(new SqlConnection(connectionString))
+        public SqlBulkCopy(string connectionString)
         {
             if (connectionString == null)
             {


### PR DESCRIPTION
Calling SqlBulkCopy(string) would call SqlBulkCopy(SqlConnection) and both constructors would create instances of SqlConnection and SqlBulkCopyColumnMappingCollection.

Removed call to this(SqlConnection) thus removing two extra object allocations.