### PR TITLE
Port: Switch WaitNamedPipe and CreateNamedPipeClient invocation ordering & TryConnect Errors

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/Common/src/Interop/Windows/Interop.Errors.cs
@@ -26,6 +26,7 @@ internal partial class Interop
         internal const int ERROR_FILE_EXISTS = 0x50;
         internal const int ERROR_INVALID_PARAMETER = 0x57;
         internal const int ERROR_BROKEN_PIPE = 0x6D;
+        internal const int ERROR_SEM_TIMEOUT = 0x79;
         internal const int ERROR_CALL_NOT_IMPLEMENTED  = 0x78;
         internal const int ERROR_INSUFFICIENT_BUFFER = 0x7A;
         internal const int ERROR_INVALID_NAME = 0x7B;

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -33,31 +33,6 @@ namespace System.IO.Pipes
                 _pipeFlags |= (((int)_impersonationLevel - 1) << 16);
             }
 
-            if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath, timeout))
-            {
-                int errorCode = Marshal.GetLastWin32Error();
-
-                // Server is not yet created
-                if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND)
-                {
-                    return false;
-                }
-
-                // The timeout has expired.
-                if (errorCode == Interop.Errors.ERROR_SUCCESS)
-                {
-                    if (cancellationToken.CanBeCanceled)
-                    {
-                        // It may not be real timeout.
-                        return false;
-                    }
-                    throw new TimeoutException();
-                }
-
-                throw Win32Marshal.GetExceptionForWin32Error(errorCode);
-            }
-
-            // Pipe server should be free.  Let's try to connect to it.
             int access = 0;
             if ((PipeDirection.In & _direction) != 0)
             {
@@ -67,6 +42,8 @@ namespace System.IO.Pipes
             {
                 access |= Interop.Kernel32.GenericOperations.GENERIC_WRITE;
             }
+
+            // Let's try to connect first
             SafePipeHandle handle = Interop.Kernel32.CreateNamedPipeClient(_normalizedPipePath,
                                         access,           // read and write access
                                         0,                  // sharing: none
@@ -79,14 +56,48 @@ namespace System.IO.Pipes
             {
                 int errorCode = Marshal.GetLastWin32Error();
 
-                // Handle the possible race condition of someone else connecting to the server 
-                // between our calls to WaitNamedPipe & CreateFile.
-                if (errorCode == Interop.Errors.ERROR_PIPE_BUSY)
+                if (errorCode != Interop.Errors.ERROR_PIPE_BUSY &&
+                    errorCode != Interop.Errors.ERROR_FILE_NOT_FOUND)
                 {
-                    return false;
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
                 }
 
-                throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath, timeout))
+                {
+                    errorCode = Marshal.GetLastWin32Error();
+
+                    // Server is not yet created or a timeout occurred before a pipe instance was available.
+                    if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND ||
+                        errorCode == Interop.Errors.ERROR_SEM_TIMEOUT)
+                    {
+                        return false;
+                    }
+
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                }
+
+                // Pipe server should be free.  Let's try to connect to it.
+                handle = Interop.Kernel32.CreateNamedPipeClient(_normalizedPipePath,
+                                            access,           // read and write access
+                                            0,                  // sharing: none
+                                            ref secAttrs,           // security attributes
+                                            FileMode.Open,      // open existing 
+                                            _pipeFlags,         // impersonation flags
+                                            IntPtr.Zero);  // template file: null
+
+                if (handle.IsInvalid)
+                {
+                    errorCode = Marshal.GetLastWin32Error();
+
+                    // Handle the possible race condition of someone else connecting to the server 
+                    // between our calls to WaitNamedPipe & CreateFile.
+                    if (errorCode == Interop.Errors.ERROR_PIPE_BUSY)
+                    {
+                        return false;
+                    }
+
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                }
             }
 
             // Success! 

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Threading;
@@ -457,5 +458,83 @@ namespace System.IO.Pipes.Tests
             }
         }
 
+        [Fact]
+        public void ClientConnect_Throws_Timeout_When_Pipe_Not_Found()
+        {
+            string pipeName = GetUniquePipeName();
+            using (NamedPipeClientStream client = new NamedPipeClientStream(pipeName))
+            {
+                Assert.Throws<TimeoutException>(() => client.Connect(91));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCancellationTokens))]
+        public async void ClientConnectAsync_Throws_Timeout_When_Pipe_Not_Found(CancellationToken cancellationToken)
+        {
+            string pipeName = GetUniquePipeName();
+            using (NamedPipeClientStream client = new NamedPipeClientStream(pipeName))
+            {
+                Task waitingClient = client.ConnectAsync(92, cancellationToken);
+                await Assert.ThrowsAsync<TimeoutException>(() => { return waitingClient; });
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/pull/25877 yet to be ported to netfx")]
+        [PlatformSpecific(TestPlatforms.Windows)] // Unix ignores MaxNumberOfServerInstances and second client also connects.
+        public void ClientConnect_Throws_Timeout_When_Pipe_Busy()
+        {
+            string pipeName = GetUniquePipeName();
+
+            using (NamedPipeServerStream server = new NamedPipeServerStream(pipeName))
+            using (NamedPipeClientStream firstClient = new NamedPipeClientStream(pipeName))
+            using (NamedPipeClientStream secondClient = new NamedPipeClientStream(pipeName))
+            {
+                const int timeout = 10_000;
+                Task[] clientAndServerTasks = new[]
+                    {
+                        firstClient.ConnectAsync(timeout),
+                        Task.Run(() => server.WaitForConnection())
+                    };
+
+                Assert.True(Task.WaitAll(clientAndServerTasks, timeout));
+
+                Assert.Throws<TimeoutException>(() => secondClient.Connect(93));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCancellationTokens))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/pull/25877 yet to be ported to netfx")]
+        [PlatformSpecific(TestPlatforms.Windows)] // Unix ignores MaxNumberOfServerInstances and second client also connects.
+        public async void ClientConnectAsync_With_Cancellation_Throws_Timeout_When_Pipe_Busy(CancellationToken cancellationToken)
+        {
+            string pipeName = GetUniquePipeName();
+
+            using (NamedPipeServerStream server = new NamedPipeServerStream(pipeName))
+            using (NamedPipeClientStream firstClient = new NamedPipeClientStream(pipeName))
+            using (NamedPipeClientStream secondClient = new NamedPipeClientStream(pipeName))
+            {
+                const int timeout = 10_000;
+                Task[] clientAndServerTasks = new[]
+                    {
+                        firstClient.ConnectAsync(timeout),
+                        Task.Run(() => server.WaitForConnection())
+                    };
+
+                Assert.True(Task.WaitAll(clientAndServerTasks, timeout));
+
+                Task waitingClient = secondClient.ConnectAsync(94, cancellationToken);
+                await Assert.ThrowsAsync<TimeoutException>(() => { return waitingClient; });
+            }
+        }
+
+        public static IEnumerable<object[]> GetCancellationTokens =>
+            new []
+            {
+                new object[] { CancellationToken.None },
+                new object[] { new CancellationTokenSource().Token },
+            };
     }
 }


### PR DESCRIPTION
Fixes #24594 (per @jiria request we are going to closed it after we get it on the service release).

It also ports back #22014 (same change as #24594) and #24635 (handling of timeout error).

For some reference see prior PRs #24616, #22014, and #25323.