### PR TITLE
Don't use FileStream in FileVersionInfo test for temp .dll

### DIFF
--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
@@ -107,13 +107,19 @@ namespace System.Diagnostics.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFX throws ArgumentException in this case")]
         public void FileVersionInfo_RelativePath_CorrectFilePath()
         {
-            File.WriteAllText("kernelbase.dll", "bogus kernelbase.dll");
-            FileVersionInfo fvi = FileVersionInfo.GetVersionInfo("kernelbase.dll");
-            //File name should be the full path to the local kernelbase.dll, not the relative path or the path to the system .dll
-            Assert.Equal(Path.GetFullPath("kernelbase.dll"), fvi.FileName);
-            //FileDescription should be null in the local kernelbase.dll
-            Assert.Equal(null, fvi.FileDescription);
-            File.Delete("kernelbase.dll");
+            try
+            {
+                File.WriteAllText("kernelbase.dll", "bogus kernelbase.dll");
+                FileVersionInfo fvi = FileVersionInfo.GetVersionInfo("kernelbase.dll");
+                // File name should be the full path to the local kernelbase.dll, not the relative path or the path to the system .dll
+                Assert.Equal(Path.GetFullPath("kernelbase.dll"), fvi.FileName);
+                // FileDescription should be null in the local kernelbase.dll
+                Assert.Equal(null, fvi.FileDescription);
+            }
+            finally
+            {
+                File.Delete("kernelbase.dll");
+            }
         }
 
         // Additional Tests Wanted:

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
@@ -107,14 +107,13 @@ namespace System.Diagnostics.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFX throws ArgumentException in this case")]
         public void FileVersionInfo_RelativePath_CorrectFilePath()
         {
-            using (new FileStream("kernelbase.dll", FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
-            {
-                FileVersionInfo fvi = FileVersionInfo.GetVersionInfo("kernelbase.dll");
-                //File name should be the full path to the local kernelbase.dll, not the relative path or the path to the system .dll
-                Assert.Equal(Path.GetFullPath("kernelbase.dll"), fvi.FileName);
-                //FileDescription should be null in the local kernelbase.dll
-                Assert.Equal(null, fvi.FileDescription);
-            }
+            File.WriteAllText("kernelbase.dll", "bogus kernelbase.dll");
+            FileVersionInfo fvi = FileVersionInfo.GetVersionInfo("kernelbase.dll");
+            //File name should be the full path to the local kernelbase.dll, not the relative path or the path to the system .dll
+            Assert.Equal(Path.GetFullPath("kernelbase.dll"), fvi.FileName);
+            //FileDescription should be null in the local kernelbase.dll
+            Assert.Equal(null, fvi.FileDescription);
+            File.Delete("kernelbase.dll");
         }
 
         // Additional Tests Wanted:


### PR DESCRIPTION
Attempts to resolve https://github.com/dotnet/corefx/issues/26122 by removing the usage of FileStream & FileShare.None from FileVersionInfo tests. 

@danmosemsft is this what you had in mind?