### PR TITLE
Make TestService log deletion robust

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System;
 using System.Collections;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Text;
 using System.Runtime.InteropServices;
@@ -29,6 +30,11 @@ namespace System.ServiceProcess.Tests
             this.CanHandleSessionChangeEvent = false;
             this.CanHandlePowerEvent = false;
         }
+
+        public static string GetLogPath(string serviceName)
+        {
+            return Assembly.GetEntryAssembly().Location + "." + serviceName + ".log";
+        }        
 
         protected override void OnContinue()
         {
@@ -76,26 +82,11 @@ namespace System.ServiceProcess.Tests
         {
             WriteLog(nameof(OnStop));
             base.OnStop();
-
-            if (_log != null)
-            {
-                _log.Dispose();
-                _log = null;
-            }
         }
-
-        private StreamWriter _log;
 
         private void WriteLog(string msg)
         {
-            if (_log == null)
-            {
-                string path = System.Reflection.Assembly.GetEntryAssembly().Location + "." + ServiceName + ".log";
-                _log = new StreamWriter(path);
-                _log.AutoFlush = true;
-;            }
-
-            _log.WriteLine(msg);
+             File.AppendAllText(GetLogPath(ServiceName), msg + Environment.NewLine);
         }
     }
 }

--- a/src/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
@@ -100,7 +100,7 @@ namespace System.ServiceProcess.Tests
                     {
                         File.Delete(LogPath);
                     }
-                    catch(IOException)
+                    catch (IOException)
                     {
                         // Don't fail simply because the service was not fully cleaned up
                         // and is still holding a handle to the log file

--- a/src/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
@@ -96,7 +96,15 @@ namespace System.ServiceProcess.Tests
 
                 if (File.Exists(LogPath))
                 {
-                    File.Delete(LogPath);
+                    try
+                    {
+                        File.Delete(LogPath);
+                    }
+                    catch(IOException)
+                    {
+                        // Don't fail simply because the service was not fully cleaned up
+                        // and is still holding a handle to the log file
+                    }
                 }
             }
             finally
@@ -110,7 +118,7 @@ namespace System.ServiceProcess.Tests
             }
         }
 
-        private string LogPath => typeof(TestService).Assembly.Location + "." + TestServiceName + ".log";
+        private string LogPath => TestService.GetLogPath(TestServiceName);
 
         public string GetServiceOutput()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/26133

We were having issues reliably stopping the test service - seemingly a bug in OpenService - so in f900762 we ignored failures stopping it. The issue is now manifesting further along when we try to delete the log file - when the service isn't successfully stopped, it is still holding on to its log file.

Fixed this by making the service not hold the log file open; but in case that still isn't sufficient, also catch the exception when deleting the log file.