### PR TITLE
Update xUnit Performance Api version to latest

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -46,7 +46,7 @@
     <RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniPackageVersion>
 
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
-    <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0007</XunitPerfAnalysisPackageVersion>
+    <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0015</XunitPerfAnalysisPackageVersion>
     <TraceEventPackageVersion>1.0.3-alpha-experimental</TraceEventPackageVersion>
     <XunitNetcoreExtensionsVersion>2.1.0-prerelease-02402-04</XunitNetcoreExtensionsVersion>
   </PropertyGroup>

--- a/src/Common/perf/PerfRunner/PerfRunner.cs
+++ b/src/Common/perf/PerfRunner/PerfRunner.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Reflection;
 using System.Collections.Generic;
@@ -9,14 +10,25 @@ using Microsoft.Xunit.Performance.Api;
 
 public class PerfHarness
 {
-    public static void Main(string[] args)
+    public static int Main(string[] args)
     {
-        using (XunitPerformanceHarness harness = new XunitPerformanceHarness(args))
+        try
         {
-            foreach(var testName in GetTestAssemblies())
+            using (XunitPerformanceHarness harness = new XunitPerformanceHarness(args))
             {
-                harness.RunBenchmarks(GetTestAssembly(testName));
+                foreach(var testName in GetTestAssemblies())
+                {
+                    harness.RunBenchmarks(GetTestAssembly(testName));
+                }
             }
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("[ERROR] Benchmark execution failed.");
+            Console.WriteLine($"  {ex.ToString()}");
+            return 1;
         }
     }
 


### PR DESCRIPTION
This version of the Api, among other changes, have:
- A bigger Instruction Retired, and can fix the event lost errors we are getting on the concurrent perf tests
- Throws exception when a benchmark fails. Previous version will report a single iteration result, but it would not fail and as a result broken benchmarks were harder to catch