### PR TITLE
Fix rounding edge-case behavior in Uf8Parser.ParseDecimal

### DIFF
--- a/src/System.Memory/src/System/Number/Number.NumberBuffer.cs
+++ b/src/System.Memory/src/System/Number/Number.NumberBuffer.cs
@@ -87,10 +87,10 @@ namespace System
             return sb.ToString();
         }
 
-        public const int BufferSize = 32;
+        public const int BufferSize = 50 + 1; // Matches https://github.com/dotnet/coreclr/blob/097e68658c5249eaefff33bd92b044e9ba22c819/src/classlibnative/bcltype/number.h#L15
 
         //
-        // 32 bytes of ASCII digits ('0'..'9'). (Not using "fixed byte[]" as this breaks the VS debugging experience.) 
+        // 50+1 bytes of ASCII digits ('0'..'9'). (Not using "fixed byte[]" as this breaks the VS debugging experience.) 
         // That's enough room to store the worst case Decimal and double.
         //
         // A NUL terminator (not to be confused with '0') marks the end of the digits. 
@@ -135,5 +135,24 @@ namespace System
         private byte _b29;
         private byte _b30;
         private byte _b31;
+        private byte _b32;
+        private byte _b33;
+        private byte _b34;
+        private byte _b35;
+        private byte _b36;
+        private byte _b37;
+        private byte _b38;
+        private byte _b39;
+        private byte _b40;
+        private byte _b41;
+        private byte _b42;
+        private byte _b43;
+        private byte _b44;
+        private byte _b45;
+        private byte _b46;
+        private byte _b47;
+        private byte _b48;
+        private byte _b49;
+        private byte _b50;
     }
 }

--- a/src/System.Memory/tests/ParsersAndFormatters/TestData.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/TestData.cs
@@ -483,6 +483,9 @@ namespace System.Buffers.Text.Tests
                 yield return "1.79769313486233E+308";   //Just over Double.MaxValue
                 yield return "-1.79769313486232E+308";  //Double.MinValue
                 yield return "-1.79769313486233E+308";  //Just under Double.MinValue
+
+                // Ensures that the NumberBuffer capacity is consistent with Desktop's.
+                yield return ".2222222222222222222222222222500000000000000000001";
             }
         }
 


### PR DESCRIPTION
Fixed by making the NumberBuffer's capacity match that of
its counterpart in the desktop. Decimal only has 28 digits
of decimal precision but the rounding algorithm
looks ahead up to another 20 digits beyond that for the
"round the 5" case.