### PR TITLE
Add test for renegotiation scenario in SslStream.

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Security.cs
+++ b/src/Common/tests/System/Net/Configuration.Security.cs
@@ -20,6 +20,8 @@ namespace System.Net.Test.Common
 
             public static Uri NegotiateServer => GetUriValue("COREFX_NET_SECURITY_NEGOSERVERURI");
 
+            public static string TlsRenegotiationServer => GetValue("COREFX_NET_SECURITY_TLSREGOTIATIONSERVER", "corefx-net-tls.azurewebsites.net");
+
             // This should be set if hostnames for all certificates within corefx-testdata have been set to point to 127.0.0.1.
             // Example: 
             //      127.0.0.1 testservereku.contoso.com

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -212,7 +212,10 @@ namespace System.Net.Security
                 if (_decryptedBytesCount != 0)
                 {
                     copyBytes = CopyDecryptedData(buffer);
+
+                    _sslState.FinishRead(null);
                     _nestedRead = 0;
+
                     return copyBytes;
                 }
 
@@ -285,13 +288,19 @@ namespace System.Net.Security
                         throw new IOException(SR.net_io_decrypt, message.GetException());
                     }
                 }
-                catch (Exception e) when (!(e is IOException))
+                catch (Exception e)
                 {
+                    _sslState.FinishRead(null);
+
+                    if (e is IOException)
+                    {
+                        throw;
+                    }
+
                     throw new IOException(SR.net_io_read, e);
                 }
                 finally
                 {
-                    _sslState.FinishRead(null);
                     _nestedRead = 0;
                 }
             }

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -106,7 +106,7 @@ namespace System.Net.Security.Tests
 
                 // Do another Read, to get the HTTP response from the server, after successful renegotiation.
                 bytesRead = await ssl.ReadAsync(message, 0, message.Length);
-                Assert.Equal(84, bytesRead);
+                Assert.True(bytesRead > 0);
                 Assert.Contains("HTTP/1.1 200 OK", Encoding.UTF8.GetString(message));
             }
         }

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -90,7 +90,7 @@ namespace System.Net.Security.Tests
                 certBundle.Add(Configuration.Certificates.GetClientCertificate());
 
                 // Perform handshake to establish secure connection.
-                await ssl.AuthenticateAsClientAsync(Configuration.Security.TlsRenegotiationServer, certBundle, false);
+                await ssl.AuthenticateAsClientAsync(Configuration.Security.TlsRenegotiationServer, certBundle, SslProtocols.Tls12, false);
                 Assert.True(ssl.IsAuthenticated);
                 Assert.True(ssl.IsEncrypted);
 

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -6,6 +6,8 @@ using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -73,6 +75,40 @@ namespace System.Net.Security.Tests
             }
 
             listener.Stop();
+        }
+
+        [Fact]
+        [OuterLoop] // Test hits external azure server.
+        public async Task SslStream_NetworkStream_Renegotiation_Succeeds()
+        {
+            Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            await s.ConnectAsync(Configuration.Security.TlsRenegotiationServer, 443);
+            using (NetworkStream ns = new NetworkStream(s))
+            using (SslStream ssl = new SslStream(ns, true))
+            {
+                X509CertificateCollection certBundle = new X509CertificateCollection();
+                certBundle.Add(Configuration.Certificates.GetClientCertificate());
+
+                // Perform handshake to establish secure connection.
+                await ssl.AuthenticateAsClientAsync(Configuration.Security.TlsRenegotiationServer, certBundle, false);
+                Assert.True(ssl.IsAuthenticated);
+                Assert.True(ssl.IsEncrypted);
+
+                // Issue request that triggers regotiation from server.
+                byte[] message = Encoding.UTF8.GetBytes("GET /EchoClientCertificate.ashx HTTP/1.1\r\nHost: corefx-net-tls.azurewebsites.net\r\n\r\n");
+                await ssl.WriteAsync(message, 0, message.Length);
+
+                // Initiate Read operation, that results in starting renegotiation as per server response to the above request.
+                int bytesRead = await ssl.ReadAsync(message, 0, message.Length);
+
+                // SslStream.ReadAsync should return -1 bytes, indicating renegotiation operation is in progress.
+                Assert.Equal(-1, bytesRead);
+
+                // Do another Read, to get the HTTP response from the server, after successful renegotiation.
+                bytesRead = await ssl.ReadAsync(message, 0, message.Length);
+                Assert.Equal(84, bytesRead);
+                Assert.Contains("HTTP/1.1 200 OK", Encoding.UTF8.GetString(message));
+            }
         }
 
         private static bool ValidateServerCertificate(


### PR DESCRIPTION
Verified the test actually hits the renegotiation code path by running under the debugger.

fixes #24407 

cc @stephentoub @wfurt @karelz 