### PR TITLE
Fix compat issues for inconsistent readonly/ref annotations

### DIFF
--- a/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -667,6 +667,7 @@ namespace System.Reflection.Metadata
     public readonly partial struct EventAccessors
     {
         public System.Reflection.Metadata.MethodDefinitionHandle Adder { get { throw null; } }
+        public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.MethodDefinitionHandle> Others { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Raiser { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Remover { get { throw null; } }
     }
@@ -1893,6 +1894,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.GuidHandle GenerationId { get { throw null; } }
         public System.Reflection.Metadata.GuidHandle Mvid { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
+        public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ModuleDefinitionHandle : System.IEquatable<System.Reflection.Metadata.ModuleDefinitionHandle>
@@ -2039,6 +2041,7 @@ namespace System.Reflection.Metadata
     public readonly partial struct PropertyAccessors
     {
         public System.Reflection.Metadata.MethodDefinitionHandle Getter { get { throw null; } }
+        public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.MethodDefinitionHandle> Others { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Setter { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -3174,7 +3177,7 @@ namespace System.Reflection.PortableExecutable
         public System.Reflection.Metadata.BlobContentId Serialize(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         protected abstract System.Reflection.Metadata.BlobBuilder SerializeSection(string name, System.Reflection.PortableExecutable.SectionLocation location);
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        protected partial struct Section
+        protected readonly partial struct Section
         {
             public readonly System.Reflection.PortableExecutable.SectionCharacteristics Characteristics;
             public readonly string Name;

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -6547,7 +6547,9 @@ namespace System.Runtime.CompilerServices
     }
     public static partial class RuntimeFeature
     {
+#if FEATURE_DEFAULT_INTERFACES
         public const string DefaultImplementationsOfInterfaces = "DefaultImplementationsOfInterfaces";
+#endif
         public static bool IsSupported(string feature) { throw null; }
     }
     public static partial class RuntimeHelpers

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -99,7 +99,7 @@ namespace System
         public static string TargetFrameworkName { get { throw null; } }
         public static object GetData(string name) { throw null; }
         public static void SetSwitch(string switchName, bool isEnabled) { }
-        public static bool TryGetSwitch(string switchName, out bool isEnabled) { isEnabled = default(bool); throw null; }
+        public static bool TryGetSwitch(string switchName, out bool isEnabled) { throw null; }
     }
     public partial class ApplicationException : System.Exception
     {
@@ -266,11 +266,10 @@ namespace System
         int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
         public static bool TrueForAll<T>(T[] array, System.Predicate<T> match) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ArraySegment<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
     {
-        public ArraySegment(T[] array) { throw null;}
-        public ArraySegment(T[] array, int offset, int count) { throw null;}
+        public ArraySegment(T[] array) { throw null; }
+        public ArraySegment(T[] array, int offset, int count) { throw null; }
         public T[] Array { get { throw null; } }
         public int Count { get { throw null; } }
         public static System.ArraySegment<T> Empty { get { throw null; } }
@@ -302,7 +301,6 @@ namespace System
         void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public T[] ToArray() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
         {
             public T Current { get { throw null; } }
@@ -404,7 +402,6 @@ namespace System
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Boolean : System.IComparable, System.IComparable<bool>, System.IConvertible, System.IEquatable<bool>
     {
         public static readonly string FalseString;
@@ -434,9 +431,9 @@ namespace System
         ulong System.IConvertible.ToUInt64(System.IFormatProvider provider) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider provider) { throw null; }
-        public System.Boolean TryFormat(System.Span<char> destination, out int charsWritten) { charsWritten = default(int); throw null; }
-        public static System.Boolean TryParse(System.ReadOnlySpan<char> value, out System.Boolean result) { result = default(bool); throw null; }
-        public static System.Boolean TryParse(string value, out System.Boolean result) { result = default(bool); throw null; }
+        public System.Boolean TryFormat(System.Span<char> destination, out int charsWritten) { throw null; }
+        public static System.Boolean TryParse(System.ReadOnlySpan<char> value, out System.Boolean result) { throw null; }
+        public static System.Boolean TryParse(string value, out System.Boolean result) { throw null; }
     }
     public static partial class Buffer
     {
@@ -449,7 +446,6 @@ namespace System
         public unsafe static void MemoryCopy(void* source, void* destination, ulong destinationSizeInBytes, ulong sourceBytesToCopy) { }
         public static void SetByte(System.Array array, int index, byte value) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Byte : System.IComparable, System.IComparable<byte>, System.IConvertible, System.IEquatable<byte>, System.IFormattable
     {
         public const byte MaxValue = (byte)255;
@@ -484,13 +480,12 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Byte result) { result = default(byte); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Byte result) { result = default(byte); throw null; }
-        public static bool TryParse(string s, out System.Byte result) { result = default(byte); throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Byte result) { result = default(byte); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Byte result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Byte result) { throw null; }
+        public static bool TryParse(string s, out System.Byte result) { throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Byte result) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Char : System.IComparable, System.IComparable<char>, System.IConvertible, System.IEquatable<char>
     {
         public const char MaxValue = '\uFFFF';
@@ -563,7 +558,7 @@ namespace System
         public static System.Char ToUpper(System.Char c) { throw null; }
         public static System.Char ToUpper(System.Char c, System.Globalization.CultureInfo culture) { throw null; }
         public static System.Char ToUpperInvariant(System.Char c) { throw null; }
-        public static bool TryParse(string s, out System.Char result) { result = default(char); throw null; }
+        public static bool TryParse(string s, out System.Char result) { throw null; }
     }
     public sealed partial class CharEnumerator : System.Collections.Generic.IEnumerator<char>, System.Collections.IEnumerator, System.ICloneable, System.IDisposable
     {
@@ -583,23 +578,22 @@ namespace System
     }
     public delegate int Comparison<in T>(T x, T y);
     public delegate TOutput Converter<in TInput, out TOutput>(TInput input);
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public readonly partial struct DateTime : System.IComparable, System.IComparable<System.DateTime>, System.IConvertible, System.IEquatable<System.DateTime>, System.IFormattable, System.Runtime.Serialization.ISerializable
     {
         public static readonly System.DateTime MaxValue;
         public static readonly System.DateTime MinValue;
         public static readonly System.DateTime UnixEpoch;
-        public DateTime(int year, int month, int day) { throw null;}
-        public DateTime(int year, int month, int day, System.Globalization.Calendar calendar) { throw null;}
-        public DateTime(int year, int month, int day, int hour, int minute, int second) { throw null;}
-        public DateTime(int year, int month, int day, int hour, int minute, int second, System.DateTimeKind kind) { throw null;}
-        public DateTime(int year, int month, int day, int hour, int minute, int second, System.Globalization.Calendar calendar) { throw null;}
-        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond) { throw null;}
-        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.DateTimeKind kind) { throw null;}
-        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar) { throw null;}
-        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar, System.DateTimeKind kind) { throw null;}
-        public DateTime(long ticks) { throw null;}
-        public DateTime(long ticks, System.DateTimeKind kind) { throw null;}
+        public DateTime(int year, int month, int day) { throw null; }
+        public DateTime(int year, int month, int day, System.Globalization.Calendar calendar) { throw null; }
+        public DateTime(int year, int month, int day, int hour, int minute, int second) { throw null; }
+        public DateTime(int year, int month, int day, int hour, int minute, int second, System.DateTimeKind kind) { throw null; }
+        public DateTime(int year, int month, int day, int hour, int minute, int second, System.Globalization.Calendar calendar) { throw null; }
+        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond) { throw null; }
+        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.DateTimeKind kind) { throw null; }
+        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar) { throw null; }
+        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar, System.DateTimeKind kind) { throw null; }
+        public DateTime(long ticks) { throw null; }
+        public DateTime(long ticks, System.DateTimeKind kind) { throw null; }
         public System.DateTime Date { get { throw null; } }
         public int Day { get { throw null; } }
         public System.DayOfWeek DayOfWeek { get { throw null; } }
@@ -697,15 +691,15 @@ namespace System
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
         public System.DateTime ToUniversalTime() { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.DateTime result) { result = default(System.DateTime); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { result = default(System.DateTime); throw null; }
-        public static bool TryParse(string s, out System.DateTime result) { result = default(System.DateTime); throw null; }
-        public static bool TryParse(string s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { result = default(System.DateTime); throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { result = default(System.DateTime); throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { result = default(System.DateTime); throw null; }
-        public static bool TryParseExact(string s, string format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { result = default(System.DateTime); throw null; }
-        public static bool TryParseExact(string s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { result = default(System.DateTime); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.DateTime result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { throw null; }
+        public static bool TryParse(string s, out System.DateTime result) { throw null; }
+        public static bool TryParse(string s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
+        public static bool TryParseExact(string s, string format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
+        public static bool TryParseExact(string s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
     }
     public enum DateTimeKind
     {
@@ -713,18 +707,17 @@ namespace System
         Unspecified = 0,
         Utc = 1,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public partial struct DateTimeOffset : System.IComparable, System.IComparable<System.DateTimeOffset>, System.IEquatable<System.DateTimeOffset>, System.IFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         public static readonly System.DateTimeOffset MaxValue;
         public static readonly System.DateTimeOffset MinValue;
         public static readonly System.DateTimeOffset UnixEpoch;
-        public DateTimeOffset(System.DateTime dateTime) { throw null;}
-        public DateTimeOffset(System.DateTime dateTime, System.TimeSpan offset) { throw null;}
-        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar, System.TimeSpan offset) { throw null;}
-        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, System.TimeSpan offset) { throw null;}
-        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, System.TimeSpan offset) { throw null;}
-        public DateTimeOffset(long ticks, System.TimeSpan offset) { throw null;}
+        public DateTimeOffset(System.DateTime dateTime) { throw null; }
+        public DateTimeOffset(System.DateTime dateTime, System.TimeSpan offset) { throw null; }
+        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar, System.TimeSpan offset) { throw null; }
+        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, System.TimeSpan offset) { throw null; }
+        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, System.TimeSpan offset) { throw null; }
+        public DateTimeOffset(long ticks, System.TimeSpan offset) { throw null; }
         public System.DateTime Date { get { throw null; } }
         public System.DateTime DateTime { get { throw null; } }
         public int Day { get { throw null; } }
@@ -797,15 +790,15 @@ namespace System
         public System.DateTimeOffset ToUniversalTime() { throw null; }
         public long ToUnixTimeMilliseconds() { throw null; }
         public long ToUnixTimeSeconds() { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider formatProvider=null) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> input, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
-        public static bool TryParse(string input, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
-        public static bool TryParse(string input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
-        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
-        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider formatProvider=null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParse(string input, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParse(string input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
     }
     public enum DayOfWeek
     {
@@ -841,7 +834,6 @@ namespace System
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider provider) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Decimal : System.IComparable, System.IComparable<decimal>, System.IConvertible, System.IEquatable<decimal>, System.IFormattable, System.Runtime.Serialization.IDeserializationCallback
     {
         [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)0, (uint)4294967295, (uint)4294967295, (uint)4294967295)]
@@ -854,16 +846,16 @@ namespace System
         public static readonly decimal One;
         [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)0, (uint)0, (uint)0, (uint)0)]
         public static readonly decimal Zero;
-        public Decimal(double value) { throw null;}
-        public Decimal(int value) { throw null;}
-        public Decimal(int lo, int mid, int hi, bool isNegative, byte scale) { throw null;}
-        public Decimal(int[] bits) { throw null;}
-        public Decimal(long value) { throw null;}
-        public Decimal(float value) { throw null;}
+        public Decimal(double value) { throw null; }
+        public Decimal(int value) { throw null; }
+        public Decimal(int lo, int mid, int hi, bool isNegative, byte scale) { throw null; }
+        public Decimal(int[] bits) { throw null; }
+        public Decimal(long value) { throw null; }
+        public Decimal(float value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public Decimal(uint value) { throw null;}
+        public Decimal(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public Decimal(ulong value) { throw null;}
+        public Decimal(ulong value) { throw null; }
         public static System.Decimal Add(System.Decimal d1, System.Decimal d2) { throw null; }
         public static System.Decimal Ceiling(System.Decimal d) { throw null; }
         public static int Compare(System.Decimal d1, System.Decimal d2) { throw null; }
@@ -972,11 +964,11 @@ namespace System
         [System.CLSCompliantAttribute(false)]
         public static ulong ToUInt64(System.Decimal d) { throw null; }
         public static System.Decimal Truncate(System.Decimal d) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Decimal result) { result = default(decimal); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Decimal result) { result = default(decimal); throw null; }
-        public static bool TryParse(string s, out System.Decimal result) { result = default(decimal); throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Decimal result) { result = default(decimal); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Decimal result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Decimal result) { throw null; }
+        public static bool TryParse(string s, out System.Decimal result) { throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Decimal result) { throw null; }
     }
     public abstract partial class Delegate : System.ICloneable, System.Runtime.Serialization.ISerializable
     {
@@ -1018,15 +1010,14 @@ namespace System
         public DivideByZeroException(string message) { }
         public DivideByZeroException(string message, System.Exception innerException) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Double : System.IComparable, System.IComparable<double>, System.IConvertible, System.IEquatable<double>, System.IFormattable
     {
-        //public const double Epsilon = 4.94065645841247E-324;
-        //public const double MaxValue = 1.7976931348623157E+308;
-        //public const double MinValue = -1.7976931348623157E+308;
-        //public const double NaN = 0.0 / 0.0;
-        //public const double NegativeInfinity = -1.0 / 0.0;
-        //public const double PositiveInfinity = 1.0 / 0.0;
+        //public const double Epsilon = 4.94065645841247E-324;     -- defined in System.Runtime.Manual.cs
+        //public const double MaxValue = 1.7976931348623157E+308;  -- defined in System.Runtime.Manual.cs
+        //public const double MinValue = -1.7976931348623157E+308; -- defined in System.Runtime.Manual.cs
+        //public const double NaN = 0.0 / 0.0;                     -- defined in System.Runtime.Manual.cs
+        //public const double NegativeInfinity = -1.0 / 0.0;       -- defined in System.Runtime.Manual.cs
+        //public const double PositiveInfinity = 1.0 / 0.0;        -- defined in System.Runtime.Manual.cs
         public int CompareTo(System.Double value) { throw null; }
         public int CompareTo(object value) { throw null; }
         public bool Equals(System.Double obj) { throw null; }
@@ -1071,11 +1062,11 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Double result) { result = default(double); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Double result) { result = default(double); throw null; }
-        public static bool TryParse(string s, out System.Double result) { result = default(double); throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Double result) { result = default(double); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Double result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Double result) { throw null; }
+        public static bool TryParse(string s, out System.Double result) { throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Double result) { throw null; }
     }
     public partial class DuplicateWaitObjectException : System.ArgumentException, System.Runtime.Serialization.ISerializable
     {
@@ -1145,10 +1136,10 @@ namespace System
         public string ToString(string format) { throw null; }
         [System.ObsoleteAttribute("The provider argument is not used. Please use ToString(String).")]
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public static bool TryParse(System.Type enumType, string value, bool ignoreCase, out object result) { result = default(object); throw null; }
-        public static bool TryParse(System.Type enumType, string value, out object result) { result = default(object); throw null; }
-        public static bool TryParse<TEnum>(string value, bool ignoreCase, out TEnum result) where TEnum : struct { result = default(TEnum); throw null; }
-        public static bool TryParse<TEnum>(string value, out TEnum result) where TEnum : struct { result = default(TEnum); throw null; }
+        public static bool TryParse(System.Type enumType, string value, bool ignoreCase, out object result) { throw null; }
+        public static bool TryParse(System.Type enumType, string value, out object result) { throw null; }
+        public static bool TryParse<TEnum>(string value, bool ignoreCase, out TEnum result) where TEnum : struct { throw null; }
+        public static bool TryParse<TEnum>(string value, out TEnum result) where TEnum : struct { throw null; }
     }
     public partial class EventArgs
     {
@@ -1309,17 +1300,16 @@ namespace System
     {
         public GopherStyleUriParser() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.IFormattable
     {
         public static readonly System.Guid Empty;
-        public Guid(byte[] b) { throw null;}
-        public Guid(int a, short b, short c, byte d, byte e, byte f, byte g, byte h, byte i, byte j, byte k) { throw null;}
-        public Guid(int a, short b, short c, byte[] d) { throw null;}
-        public Guid(System.ReadOnlySpan<byte> b) { throw null;}
-        public Guid(string g) { throw null;}
+        public Guid(byte[] b) { throw null; }
+        public Guid(int a, short b, short c, byte d, byte e, byte f, byte g, byte h, byte i, byte j, byte k) { throw null; }
+        public Guid(int a, short b, short c, byte[] d) { throw null; }
+        public Guid(System.ReadOnlySpan<byte> b) { throw null; }
+        public Guid(string g) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public Guid(uint a, ushort b, ushort c, byte d, byte e, byte f, byte g, byte h, byte i, byte j, byte k) { throw null;}
+        public Guid(uint a, ushort b, ushort c, byte d, byte e, byte f, byte g, byte h, byte i, byte j, byte k) { throw null; }
         public int CompareTo(System.Guid value) { throw null; }
         public int CompareTo(object value) { throw null; }
         public bool Equals(System.Guid g) { throw null; }
@@ -1336,14 +1326,13 @@ namespace System
         public override string ToString() { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>)) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> input, out System.Guid result) { result = default(System.Guid); throw null; }
-        public static bool TryParse(string input, out System.Guid result) { result = default(System.Guid); throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, out System.Guid result) { result = default(System.Guid); throw null; }
-        public static bool TryParseExact(string input, string format, out System.Guid result) { result = default(System.Guid); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>)) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, out System.Guid result) { throw null; }
+        public static bool TryParse(string input, out System.Guid result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, out System.Guid result) { throw null; }
+        public static bool TryParseExact(string input, string format, out System.Guid result) { throw null; }
         public bool TryWriteBytes(System.Span<byte> destination) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public partial struct HashCode
     {
         public void Add<T>(T value) { }
@@ -1356,14 +1345,12 @@ namespace System
         public static int Combine<T1, T2, T3, T4, T5, T6>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) { throw null; }
         public static int Combine<T1, T2, T3, T4, T5, T6, T7>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7) { throw null; }
         public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8) { throw null; }
-#pragma warning disable 0809
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("HashCode is a mutable struct and should not be compared with other HashCodes.", true)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", true)]
         public override int GetHashCode() { throw null; }
-#pragma warning restore 0809
         public int ToHashCode() { throw null; }
     }
     public partial class HttpStyleUriParser : System.UriParser
@@ -1448,7 +1435,6 @@ namespace System
         public InsufficientMemoryException(string message) { }
         public InsufficientMemoryException(string message, System.Exception innerException) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Int16 : System.IComparable, System.IComparable<short>, System.IConvertible, System.IEquatable<short>, System.IFormattable
     {
         public const short MaxValue = (short)32767;
@@ -1483,13 +1469,12 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int16 result) { result = default(short); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int16 result) { result = default(short); throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int16 result) { result = default(short); throw null; }
-        public static bool TryParse(string s, out System.Int16 result) { result = default(short); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int16 result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int16 result) { throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int16 result) { throw null; }
+        public static bool TryParse(string s, out System.Int16 result) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Int32 : System.IComparable, System.IComparable<int>, System.IConvertible, System.IEquatable<int>, System.IFormattable
     {
         public const int MaxValue = 2147483647;
@@ -1524,13 +1509,12 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out System.Int32 charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int32 result) { result = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int32 result) { result = default(int); throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int32 result) { result = default(int); throw null; }
-        public static bool TryParse(string s, out System.Int32 result) { result = default(int); throw null; }
+        public bool TryFormat(System.Span<char> destination, out System.Int32 charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int32 result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int32 result) { throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int32 result) { throw null; }
+        public static bool TryParse(string s, out System.Int32 result) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Int64 : System.IComparable, System.IComparable<long>, System.IConvertible, System.IEquatable<long>, System.IFormattable
     {
         public const long MaxValue = (long)9223372036854775807;
@@ -1565,20 +1549,19 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int64 result) { result = default(long); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int64 result) { result = default(long); throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int64 result) { result = default(long); throw null; }
-        public static bool TryParse(string s, out System.Int64 result) { result = default(long); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int64 result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int64 result) { throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int64 result) { throw null; }
+        public static bool TryParse(string s, out System.Int64 result) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct IntPtr : System.IEquatable<System.IntPtr>, System.Runtime.Serialization.ISerializable
     {
         public static readonly System.IntPtr Zero;
-        public IntPtr(int value) { throw null;}
-        public IntPtr(long value) { throw null;}
+        public IntPtr(int value) { throw null; }
+        public IntPtr(long value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public unsafe IntPtr(void* value) { throw null;}
+        public unsafe IntPtr(void* value) { throw null; }
         public static int Size { get { throw null; } }
         public static System.IntPtr Add(System.IntPtr pointer, int offset) { throw null; }
         public override bool Equals(object obj) { throw null; }
@@ -1688,11 +1671,10 @@ namespace System
         public MemberAccessException(string message) { }
         public MemberAccessException(string message, System.Exception inner) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public readonly partial struct Memory<T>
     {
-        public Memory(T[] array) { throw null;}
-        public Memory(T[] array, int start, int length) { throw null;}
+        public Memory(T[] array) { throw null; }
+        public Memory(T[] array, int start, int length) { throw null; }
         public static System.Memory<T> Empty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public int Length { get { throw null; } }
@@ -1711,7 +1693,7 @@ namespace System
         public System.Memory<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
         public bool TryCopyTo(System.Memory<T> destination) { throw null; }
-        public bool TryGetArray(out System.ArraySegment<T> arraySegment) { arraySegment = default(System.ArraySegment<T>); throw null; }
+        public bool TryGetArray(out System.ArraySegment<T> arraySegment) { throw null; }
     }
     public partial class MethodAccessException : System.MemberAccessException
     {
@@ -1756,7 +1738,6 @@ namespace System
         public MissingMethodException(string className, string methodName) { }
         public override string Message { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public partial struct ModuleHandle
     {
         public static readonly System.ModuleHandle EmptyHandle;
@@ -1850,10 +1831,9 @@ namespace System
         public static bool Equals<T>(System.Nullable<T> n1, System.Nullable<T> n2) where T : struct { throw null; }
         public static System.Type GetUnderlyingType(System.Type nullableType) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Nullable<T> where T : struct
     {
-        public Nullable(T value) { throw null;}
+        public Nullable(T value) { throw null; }
         public bool HasValue { get { throw null; } }
         public T Value { get { throw null; } }
         public override bool Equals(object other) { throw null; }
@@ -1936,11 +1916,10 @@ namespace System
         public RankException(string message) { }
         public RankException(string message, System.Exception innerException) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public readonly partial struct ReadOnlyMemory<T>
     {
-        public ReadOnlyMemory(T[] array) { throw null;}
-        public ReadOnlyMemory(T[] array, int start, int length) { throw null;}
+        public ReadOnlyMemory(T[] array) { throw null; }
+        public ReadOnlyMemory(T[] array, int start, int length) { throw null; }
         public static System.ReadOnlyMemory<T> Empty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public int Length { get { throw null; } }
@@ -1959,13 +1938,12 @@ namespace System
         public T[] ToArray() { throw null; }
         public bool TryCopyTo(System.Memory<T> destination) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly ref partial struct ReadOnlySpan<T>
     {
         [System.CLSCompliantAttribute(false)]
-        public unsafe ReadOnlySpan(void* pointer, int length) { throw null;}
-        public ReadOnlySpan(T[] array) { throw null;}
-        public ReadOnlySpan(T[] array, int start, int length) { throw null;}
+        public unsafe ReadOnlySpan(void* pointer, int length) { throw null; }
+        public ReadOnlySpan(T[] array) { throw null; }
+        public ReadOnlySpan(T[] array, int start, int length) { throw null; }
         public static System.ReadOnlySpan<T> Empty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public ref readonly T this[int index] { get { throw null; } }
@@ -1973,7 +1951,6 @@ namespace System
         public void CopyTo(System.Span<T> destination) { }
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public static System.ReadOnlySpan<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
-#pragma warning disable 0809
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("Equals() on ReadOnlySpan will always throw an exception. Use == instead.")]
         public override bool Equals(object obj) { throw null; }
@@ -1981,7 +1958,6 @@ namespace System
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("GetHashCode() on ReadOnlySpan will always throw an exception.")]
         public override int GetHashCode() { throw null; }
-#pragma warning restore 0809
         public static bool operator ==(System.ReadOnlySpan<T> left, System.ReadOnlySpan<T> right) { throw null; }
         public static implicit operator System.ReadOnlySpan<T> (System.ArraySegment<T> arraySegment) { throw null; }
         public static implicit operator System.ReadOnlySpan<T> (T[] array) { throw null; }
@@ -1990,7 +1966,6 @@ namespace System
         public System.ReadOnlySpan<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
         public bool TryCopyTo(System.Span<T> destination) { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
         public ref partial struct Enumerator
         {
             public ref readonly T Current { get { throw null; } }
@@ -2004,11 +1979,9 @@ namespace System
         public string Name { get { throw null; } }
         public System.Reflection.Assembly RequestingAssembly { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct RuntimeArgumentHandle
     {
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct RuntimeFieldHandle : System.Runtime.Serialization.ISerializable
     {
         public System.IntPtr Value { get { throw null; } }
@@ -2019,7 +1992,6 @@ namespace System
         public static bool operator ==(System.RuntimeFieldHandle left, System.RuntimeFieldHandle right) { throw null; }
         public static bool operator !=(System.RuntimeFieldHandle left, System.RuntimeFieldHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct RuntimeMethodHandle : System.Runtime.Serialization.ISerializable
     {
         public System.IntPtr Value { get { throw null; } }
@@ -2031,7 +2003,6 @@ namespace System
         public static bool operator ==(System.RuntimeMethodHandle left, System.RuntimeMethodHandle right) { throw null; }
         public static bool operator !=(System.RuntimeMethodHandle left, System.RuntimeMethodHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct RuntimeTypeHandle : System.Runtime.Serialization.ISerializable
     {
         public System.IntPtr Value { get { throw null; } }
@@ -2046,7 +2017,6 @@ namespace System
         public static bool operator !=(System.RuntimeTypeHandle left, object right) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SByte : System.IComparable, System.IComparable<sbyte>, System.IConvertible, System.IEquatable<sbyte>, System.IFormattable
     {
         public const sbyte MaxValue = (sbyte)127;
@@ -2086,30 +2056,29 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.SByte result) { result = default(sbyte); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.SByte result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.SByte result) { result = default(sbyte); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.SByte result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.SByte result) { result = default(sbyte); throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.SByte result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, out System.SByte result) { result = default(sbyte); throw null; }
+        public static bool TryParse(string s, out System.SByte result) { throw null; }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(4124), Inherited=false)]
     public sealed partial class SerializableAttribute : System.Attribute
     {
         public SerializableAttribute() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Single : System.IComparable, System.IComparable<float>, System.IConvertible, System.IEquatable<float>, System.IFormattable
     {
-        //public const float Epsilon = 1.401298E-45f;
-        //public const float MaxValue = 3.40282347E+38f;
-        //public const float MinValue = -3.40282347E+38f;
-        //public const float NaN = 0.0f / 0.0f;
-        //public const float NegativeInfinity = -1.0f / 0.0f;
-        //public const float PositiveInfinity = 1.0f / 0.0f;
+        //public const float Epsilon = 1.401298E-45f;         -- defined in System.Runtime.Manual.cs
+        //public const float MaxValue = 3.40282347E+38f;      -- defined in System.Runtime.Manual.cs
+        //public const float MinValue = -3.40282347E+38f;     -- defined in System.Runtime.Manual.cs
+        //public const float NaN = 0.0f / 0.0f;               -- defined in System.Runtime.Manual.cs
+        //public const float NegativeInfinity = -1.0f / 0.0f; -- defined in System.Runtime.Manual.cs
+        //public const float PositiveInfinity = 1.0f / 0.0f;  -- defined in System.Runtime.Manual.cs
         public int CompareTo(object value) { throw null; }
         public int CompareTo(System.Single value) { throw null; }
         public override bool Equals(object obj) { throw null; }
@@ -2154,19 +2123,18 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Single result) { result = default(float); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Single result) { result = default(float); throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Single result) { result = default(float); throw null; }
-        public static bool TryParse(string s, out System.Single result) { result = default(float); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Single result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Single result) { throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Single result) { throw null; }
+        public static bool TryParse(string s, out System.Single result) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly ref partial struct Span<T>
     {
         [System.CLSCompliantAttribute(false)]
-        public unsafe Span(void* pointer, int length) { throw null;}
-        public Span(T[] array) { throw null;}
-        public Span(T[] array, int start, int length) { throw null;}
+        public unsafe Span(void* pointer, int length) { throw null; }
+        public Span(T[] array) { throw null; }
+        public Span(T[] array, int start, int length) { throw null; }
         public static System.Span<T> Empty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public ref T this[int index] { get { throw null; } }
@@ -2175,7 +2143,6 @@ namespace System
         public void CopyTo(System.Span<T> destination) { }
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public static System.Span<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
-#pragma warning disable 0809
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("Equals() on Span will always throw an exception. Use == instead.")]
         public override bool Equals(object obj) { throw null; }
@@ -2184,7 +2151,6 @@ namespace System
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("GetHashCode() on Span will always throw an exception.")]
         public override int GetHashCode() { throw null; }
-#pragma warning restore 0809
         public static bool operator ==(System.Span<T> left, System.Span<T> right) { throw null; }
         public static implicit operator System.Span<T> (System.ArraySegment<T> arraySegment) { throw null; }
         public static implicit operator System.ReadOnlySpan<T> (System.Span<T> span) { throw null; }
@@ -2194,7 +2160,6 @@ namespace System
         public System.Span<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
         public bool TryCopyTo(System.Span<T> destination) { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
         public ref partial struct Enumerator
         {
             public ref T Current { get { throw null; } }
@@ -2429,7 +2394,6 @@ namespace System
         public TimeoutException(string message) { }
         public TimeoutException(string message, System.Exception innerException) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct TimeSpan : System.IComparable, System.IComparable<System.TimeSpan>, System.IEquatable<System.TimeSpan>, System.IFormattable
     {
         public static readonly System.TimeSpan MaxValue;
@@ -2440,10 +2404,10 @@ namespace System
         public const long TicksPerMinute = (long)600000000;
         public const long TicksPerSecond = (long)10000000;
         public static readonly System.TimeSpan Zero;
-        public TimeSpan(int hours, int minutes, int seconds) { throw null;}
-        public TimeSpan(int days, int hours, int minutes, int seconds) { throw null;}
-        public TimeSpan(int days, int hours, int minutes, int seconds, int milliseconds) { throw null;}
-        public TimeSpan(long ticks) { throw null;}
+        public TimeSpan(int hours, int minutes, int seconds) { throw null; }
+        public TimeSpan(int days, int hours, int minutes, int seconds) { throw null; }
+        public TimeSpan(int days, int hours, int minutes, int seconds, int milliseconds) { throw null; }
+        public TimeSpan(long ticks) { throw null; }
         public int Days { get { throw null; } }
         public int Hours { get { throw null; } }
         public int Milliseconds { get { throw null; } }
@@ -2501,19 +2465,19 @@ namespace System
         public override string ToString() { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider formatProvider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
-        public static bool TryParse(string input, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
-        public static bool TryParse(string s, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
-        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
-        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
-        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
-        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.TimeSpan result) { throw null; }
+        public static bool TryParse(string input, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
+        public static bool TryParse(string s, out System.TimeSpan result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
+        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { throw null; }
+        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
+        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { throw null; }
+        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
     }
     [System.ObsoleteAttribute("System.TimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo instead.")]
     public abstract partial class TimeZone
@@ -2588,7 +2552,6 @@ namespace System
             void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
             void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public readonly partial struct TransitionTime : System.IEquatable<System.TimeZoneInfo.TransitionTime>, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
         {
             public int Day { get { throw null; } }
@@ -2628,27 +2591,27 @@ namespace System
     }
     public static partial class TupleExtensions
     {
-        public static void Deconstruct<T1>(this System.Tuple<T1> value, out T1 item1) { item1 = default(T1); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); item17 = default(T17); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); item17 = default(T17); item18 = default(T18); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); item17 = default(T17); item18 = default(T18); item19 = default(T19); }
-        public static void Deconstruct<T1, T2>(this System.Tuple<T1, T2> value, out T1 item1, out T2 item2) { item1 = default(T1); item2 = default(T2); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19, T20>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); item17 = default(T17); item18 = default(T18); item19 = default(T19); item20 = default(T20); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19, T20, T21>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20, out T21 item21) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); item17 = default(T17); item18 = default(T18); item19 = default(T19); item20 = default(T20); item21 = default(T21); }
-        public static void Deconstruct<T1, T2, T3>(this System.Tuple<T1, T2, T3> value, out T1 item1, out T2 item2, out T3 item3) { item1 = default(T1); item2 = default(T2); item3 = default(T3); }
-        public static void Deconstruct<T1, T2, T3, T4>(this System.Tuple<T1, T2, T3, T4> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); }
-        public static void Deconstruct<T1, T2, T3, T4, T5>(this System.Tuple<T1, T2, T3, T4, T5> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6>(this System.Tuple<T1, T2, T3, T4, T5, T6> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); }
+        public static void Deconstruct<T1>(this System.Tuple<T1> value, out T1 item1) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19) { throw null; }
+        public static void Deconstruct<T1, T2>(this System.Tuple<T1, T2> value, out T1 item1, out T2 item2) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19, T20>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19, T20, T21>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20, out T21 item21) { throw null; }
+        public static void Deconstruct<T1, T2, T3>(this System.Tuple<T1, T2, T3> value, out T1 item1, out T2 item2, out T3 item3) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4>(this System.Tuple<T1, T2, T3, T4> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5>(this System.Tuple<T1, T2, T3, T4, T5> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6>(this System.Tuple<T1, T2, T3, T4, T5, T6> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8) { throw null; }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9) { throw null; }
         public static System.Tuple<T1> ToTuple<T1>(this System.ValueTuple<T1> value) { throw null; }
         public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10>> value) { throw null; }
         public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11>> value) { throw null; }
@@ -3053,7 +3016,6 @@ namespace System
         UInt64 = 12,
     }
     [System.CLSCompliantAttribute(false)]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct TypedReference
     {
         public override bool Equals(object o) { throw null; }
@@ -3090,7 +3052,6 @@ namespace System
         public TypeUnloadedException(string message, System.Exception innerException) { }
     }
     [System.CLSCompliantAttribute(false)]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct UInt16 : System.IComparable, System.IComparable<ushort>, System.IConvertible, System.IEquatable<ushort>, System.IFormattable
     {
         public const ushort MaxValue = (ushort)65535;
@@ -3130,18 +3091,17 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt16 result) { result = default(ushort); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt16 result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt16 result) { result = default(ushort); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt16 result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt16 result) { result = default(ushort); throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt16 result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, out System.UInt16 result) { result = default(ushort); throw null; }
+        public static bool TryParse(string s, out System.UInt16 result) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct UInt32 : System.IComparable, System.IComparable<uint>, System.IConvertible, System.IEquatable<uint>, System.IFormattable
     {
         public const uint MaxValue = (uint)4294967295;
@@ -3181,18 +3141,17 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt32 result) { result = default(uint); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt32 result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt32 result) { result = default(uint); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt32 result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt32 result) { result = default(uint); throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt32 result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, out System.UInt32 result) { result = default(uint); throw null; }
+        public static bool TryParse(string s, out System.UInt32 result) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct UInt64 : System.IComparable, System.IComparable<ulong>, System.IConvertible, System.IEquatable<ulong>, System.IFormattable
     {
         public const ulong MaxValue = (ulong)18446744073709551615;
@@ -3232,25 +3191,24 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt64 result) { result = default(ulong); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt64 result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt64 result) { result = default(ulong); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt64 result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt64 result) { result = default(ulong); throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt64 result) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, out System.UInt64 result) { result = default(ulong); throw null; }
+        public static bool TryParse(string s, out System.UInt64 result) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct UIntPtr : System.IEquatable<System.UIntPtr>, System.Runtime.Serialization.ISerializable
     {
         public static readonly System.UIntPtr Zero;
-        public UIntPtr(uint value) { throw null;}
-        public UIntPtr(ulong value) { throw null;}
+        public UIntPtr(uint value) { throw null; }
+        public UIntPtr(ulong value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public unsafe UIntPtr(void* value) { throw null;}
+        public unsafe UIntPtr(void* value) { throw null; }
         public static int Size { get { throw null; } }
         public static System.UIntPtr Add(System.UIntPtr pointer, int offset) { throw null; }
         public override bool Equals(object obj) { throw null; }
@@ -3375,9 +3333,9 @@ namespace System
         protected virtual void Parse() { }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override string ToString() { throw null; }
-        public static bool TryCreate(string uriString, System.UriKind uriKind, out System.Uri result) { result = default(System.Uri); throw null; }
-        public static bool TryCreate(System.Uri baseUri, string relativeUri, out System.Uri result) { result = default(System.Uri); throw null; }
-        public static bool TryCreate(System.Uri baseUri, System.Uri relativeUri, out System.Uri result) { result = default(System.Uri); throw null; }
+        public static bool TryCreate(string uriString, System.UriKind uriKind, out System.Uri result) { throw null; }
+        public static bool TryCreate(System.Uri baseUri, string relativeUri, out System.Uri result) { throw null; }
+        public static bool TryCreate(System.Uri baseUri, System.Uri relativeUri, out System.Uri result) { throw null; }
         [System.ObsoleteAttribute("The method has been deprecated. Please use GetComponents() or static UnescapeDataString() to unescape a Uri component or a string. http://go.microsoft.com/fwlink/?linkid=14202")]
         protected virtual string Unescape(string path) { throw null; }
         public static string UnescapeDataString(string stringToUnescape) { throw null; }
@@ -3435,14 +3393,14 @@ namespace System
     {
         protected UriParser() { }
         protected virtual string GetComponents(System.Uri uri, System.UriComponents components, System.UriFormat format) { throw null; }
-        protected virtual void InitializeAndValidate(System.Uri uri, out System.UriFormatException parsingError) { parsingError = default(System.UriFormatException); }
+        protected virtual void InitializeAndValidate(System.Uri uri, out System.UriFormatException parsingError) { throw null; }
         protected virtual bool IsBaseOf(System.Uri baseUri, System.Uri relativeUri) { throw null; }
         public static bool IsKnownScheme(string schemeName) { throw null; }
         protected virtual bool IsWellFormedOriginalString(System.Uri uri) { throw null; }
         protected virtual System.UriParser OnNewUri() { throw null; }
         protected virtual void OnRegister(string schemeName, int defaultPort) { }
         public static void Register(System.UriParser uriParser, string schemeName, int defaultPort) { }
-        protected virtual string Resolve(System.Uri baseUri, System.Uri relativeUri, out System.UriFormatException parsingError) { parsingError = default(System.UriFormatException); throw null; }
+        protected virtual string Resolve(System.Uri baseUri, System.Uri relativeUri, out System.UriFormatException parsingError) { throw null; }
     }
     public enum UriPartial
     {
@@ -3451,7 +3409,6 @@ namespace System
         Query = 3,
         Scheme = 0,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public partial struct ValueTuple : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple>, System.IEquatable<System.ValueTuple>, System.Runtime.CompilerServices.ITuple
     {
         object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
@@ -3475,11 +3432,10 @@ namespace System
         int System.IComparable.CompareTo(object other) { throw null; }
         public override string ToString() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ValueTuple<T1> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple<T1>>, System.IEquatable<System.ValueTuple<T1>>, System.Runtime.CompilerServices.ITuple
     {
         public T1 Item1;
-        public ValueTuple(T1 item1) { throw null;}
+        public ValueTuple(T1 item1) { throw null; }
         object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public int CompareTo(System.ValueTuple<T1> other) { throw null; }
@@ -3496,7 +3452,7 @@ namespace System
     {
         public T1 Item1;
         public T2 Item2;
-        public ValueTuple(T1 item1, T2 item2) { throw null;}
+        public ValueTuple(T1 item1, T2 item2) { throw null; }
         object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public int CompareTo(System.ValueTuple<T1, T2> other) { throw null; }
@@ -3514,7 +3470,7 @@ namespace System
         public T1 Item1;
         public T2 Item2;
         public T3 Item3;
-        public ValueTuple(T1 item1, T2 item2, T3 item3) { throw null;}
+        public ValueTuple(T1 item1, T2 item2, T3 item3) { throw null; }
         object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public int CompareTo(System.ValueTuple<T1, T2, T3> other) { throw null; }
@@ -3533,7 +3489,7 @@ namespace System
         public T2 Item2;
         public T3 Item3;
         public T4 Item4;
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4) { throw null;}
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4) { throw null; }
         object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public int CompareTo(System.ValueTuple<T1, T2, T3, T4> other) { throw null; }
@@ -3553,7 +3509,7 @@ namespace System
         public T3 Item3;
         public T4 Item4;
         public T5 Item5;
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) { throw null;}
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) { throw null; }
         object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public int CompareTo(System.ValueTuple<T1, T2, T3, T4, T5> other) { throw null; }
@@ -3574,7 +3530,7 @@ namespace System
         public T4 Item4;
         public T5 Item5;
         public T6 Item6;
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) { throw null;}
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) { throw null; }
         object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public int CompareTo(System.ValueTuple<T1, T2, T3, T4, T5, T6> other) { throw null; }
@@ -3596,7 +3552,7 @@ namespace System
         public T5 Item5;
         public T6 Item6;
         public T7 Item7;
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) { throw null;}
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) { throw null; }
         object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public int CompareTo(System.ValueTuple<T1, T2, T3, T4, T5, T6, T7> other) { throw null; }
@@ -3619,7 +3575,7 @@ namespace System
         public T6 Item6;
         public T7 Item7;
         public TRest Rest;
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) { throw null;}
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) { throw null; }
         object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public int CompareTo(System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other) { throw null; }
@@ -3668,12 +3624,11 @@ namespace System
         public static System.Version Parse(string input) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(int fieldCount) { throw null; }
-        public bool TryFormat(System.Span<char> destination, int fieldCount, out int charsWritten) { charsWritten = default(int); throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten) { charsWritten = default(int); throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> input, out System.Version result) { result = default(System.Version); throw null; }
-        public static bool TryParse(string input, out System.Version result) { result = default(System.Version); throw null; }
+        public bool TryFormat(System.Span<char> destination, int fieldCount, out int charsWritten) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, out System.Version result) { throw null; }
+        public static bool TryParse(string input, out System.Version result) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public partial struct Void
     {
     }
@@ -3695,7 +3650,7 @@ namespace System
         ~WeakReference() { }
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public void SetTarget(T target) { }
-        public bool TryGetTarget(out T target) { target = default(T); throw null; }
+        public bool TryGetTarget(out T target) { throw null; }
     }
 }
 namespace System.Buffers
@@ -3705,11 +3660,10 @@ namespace System.Buffers
         bool Release();
         void Retain();
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public partial struct MemoryHandle : System.IDisposable
     {
         [System.CLSCompliantAttribute(false)]
-        public unsafe MemoryHandle(System.Buffers.IRetainable owner, void* pointer=null, System.Runtime.InteropServices.GCHandle handle=default(System.Runtime.InteropServices.GCHandle)) { throw null;}
+        public unsafe MemoryHandle(System.Buffers.IRetainable owner, void* pointer=null, System.Runtime.InteropServices.GCHandle handle=default(System.Runtime.InteropServices.GCHandle)) { throw null; }
         public bool HasPointer { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
         public unsafe void* Pointer { get { throw null; } }
@@ -3735,14 +3689,13 @@ namespace System.Buffers
 }
 namespace System.Collections
 {
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct DictionaryEntry
     {
-        public DictionaryEntry(object key, object value) { throw null;}
+        public DictionaryEntry(object key, object value) { throw null; }
         public object Key { get { throw null; } set { } }
         public object Value { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
-        public void Deconstruct(out object key, out object value) { key = default(object); value = default(object); }
+        public void Deconstruct(out object key, out object value) { throw null; }
     }
     public partial interface ICollection : System.Collections.IEnumerable
     {
@@ -3899,14 +3852,13 @@ namespace System.Collections.Generic
     {
         public static System.Collections.Generic.KeyValuePair<TKey, TValue> Create<TKey, TValue>(TKey key, TValue value) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct KeyValuePair<TKey, TValue>
     {
-        public KeyValuePair(TKey key, TValue value) { throw null;}
+        public KeyValuePair(TKey key, TValue value) { throw null; }
         public TKey Key { get { throw null; } }
         public TValue Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
-        public void Deconstruct(out TKey key, out TValue value) { key = default(TKey); value = default(TValue); }
+        public void Deconstruct(out TKey key, out TValue value) { throw null; }
         public override string ToString() { throw null; }
     }
 }
@@ -5510,11 +5462,10 @@ namespace System.Reflection
         public CustomAttributeFormatException(string message) { }
         public CustomAttributeFormatException(string message, System.Exception inner) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CustomAttributeNamedArgument
     {
-        public CustomAttributeNamedArgument(System.Reflection.MemberInfo memberInfo, object value) { throw null;}
-        public CustomAttributeNamedArgument(System.Reflection.MemberInfo memberInfo, System.Reflection.CustomAttributeTypedArgument typedArgument) { throw null;}
+        public CustomAttributeNamedArgument(System.Reflection.MemberInfo memberInfo, object value) { throw null; }
+        public CustomAttributeNamedArgument(System.Reflection.MemberInfo memberInfo, System.Reflection.CustomAttributeTypedArgument typedArgument) { throw null; }
         public bool IsField { get { throw null; } }
         public System.Reflection.MemberInfo MemberInfo { get { throw null; } }
         public string MemberName { get { throw null; } }
@@ -5525,11 +5476,10 @@ namespace System.Reflection
         public static bool operator !=(System.Reflection.CustomAttributeNamedArgument left, System.Reflection.CustomAttributeNamedArgument right) { throw null; }
         public override string ToString() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CustomAttributeTypedArgument
     {
-        public CustomAttributeTypedArgument(object value) { throw null;}
-        public CustomAttributeTypedArgument(System.Type argumentType, object value) { throw null;}
+        public CustomAttributeTypedArgument(object value) { throw null; }
+        public CustomAttributeTypedArgument(System.Type argumentType, object value) { throw null; }
         public System.Type ArgumentType { get { throw null; } }
         public object Value { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -5685,7 +5635,6 @@ namespace System.Reflection
         I386 = 332,
         IA64 = 512,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct InterfaceMapping
     {
         public System.Reflection.MethodInfo[] InterfaceMethods;
@@ -5925,7 +5874,7 @@ namespace System.Reflection
         public System.Reflection.MethodInfo[] GetMethods() { throw null; }
         public virtual System.Reflection.MethodInfo[] GetMethods(System.Reflection.BindingFlags bindingFlags) { throw null; }
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public virtual void GetPEKind(out System.Reflection.PortableExecutableKinds peKind, out System.Reflection.ImageFileMachine machine) { peKind = default(System.Reflection.PortableExecutableKinds); machine = default(System.Reflection.ImageFileMachine); }
+        public virtual void GetPEKind(out System.Reflection.PortableExecutableKinds peKind, out System.Reflection.ImageFileMachine machine) { throw null; }
         public virtual System.Type GetType(string className) { throw null; }
         public virtual System.Type GetType(string className, bool ignoreCase) { throw null; }
         public virtual System.Type GetType(string className, bool throwOnError, bool ignoreCase) { throw null; }
@@ -6011,10 +5960,9 @@ namespace System.Reflection
         public virtual bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
         public override string ToString() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ParameterModifier
     {
-        public ParameterModifier(int parameterCount) { throw null;}
+        public ParameterModifier(int parameterCount) { throw null; }
         public bool this[int index] { get { throw null; } set { } }
     }
     [System.CLSCompliantAttribute(false)]
@@ -6334,7 +6282,6 @@ namespace System.Runtime.CompilerServices
     {
         public AsyncStateMachineAttribute(System.Type stateMachineType) : base (default(System.Type)) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public partial struct AsyncValueTaskMethodBuilder<TResult>
     {
         public System.Threading.Tasks.ValueTask<TResult> Task { get { throw null; } }
@@ -6395,14 +6342,12 @@ namespace System.Runtime.CompilerServices
         public bool Remove(TKey key) { throw null; }
         System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public bool TryGetValue(TKey key, out TValue value) { value = default(TValue); throw null; }
+        public bool TryGetValue(TKey key, out TValue value) { throw null; }
         public delegate TValue CreateValueCallback(TKey key);
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ConfiguredTaskAwaitable
     {
         public System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter GetAwaiter() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public readonly partial struct ConfiguredTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
             public bool IsCompleted { get { throw null; } }
@@ -6411,11 +6356,9 @@ namespace System.Runtime.CompilerServices
             public void UnsafeOnCompleted(System.Action continuation) { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ConfiguredTaskAwaitable<TResult>
     {
         public System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter GetAwaiter() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public readonly partial struct ConfiguredTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
             public bool IsCompleted { get { throw null; } }
@@ -6424,11 +6367,9 @@ namespace System.Runtime.CompilerServices
             public void UnsafeOnCompleted(System.Action continuation) { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public readonly partial struct ConfiguredValueTaskAwaitable<TResult>
     {
         public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<TResult>.ConfiguredValueTaskAwaiter GetAwaiter() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
         public readonly partial struct ConfiguredValueTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
             public bool IsCompleted { get { throw null; } }
@@ -6667,7 +6608,6 @@ namespace System.Runtime.CompilerServices
     {
         public SuppressIldasmAttribute() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct TaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
     {
         public bool IsCompleted { get { throw null; } }
@@ -6675,7 +6615,6 @@ namespace System.Runtime.CompilerServices
         public void OnCompleted(System.Action continuation) { }
         public void UnsafeOnCompleted(System.Action continuation) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct TaskAwaiter<TResult> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
     {
         public bool IsCompleted { get { throw null; } }
@@ -6707,7 +6646,6 @@ namespace System.Runtime.CompilerServices
     {
         public UnsafeValueTypeAttribute() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ValueTaskAwaiter<TResult> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
     {
         public bool IsCompleted { get { throw null; } }
@@ -6716,11 +6654,9 @@ namespace System.Runtime.CompilerServices
         public void UnsafeOnCompleted(System.Action continuation) { }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public readonly partial struct YieldAwaitable
     {
         public System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter GetAwaiter() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
         public readonly partial struct YieldAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
             public bool IsCompleted { get { throw null; } }
@@ -6829,7 +6765,6 @@ namespace System.Runtime.InteropServices
         public FieldOffsetAttribute(int offset) { }
         public int Value { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct GCHandle
     {
         public bool IsAllocated { get { throw null; } }
@@ -6973,7 +6908,6 @@ namespace System.Runtime.Serialization
         public System.Runtime.Serialization.StreamingContext StreamingContext { get { throw null; } }
         public void AddSerializedState(System.Runtime.Serialization.ISafeSerializationData serializedState) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SerializationEntry
     {
         public string Name { get { throw null; } }
@@ -7053,11 +6987,10 @@ namespace System.Runtime.Serialization
         public bool MoveNext() { throw null; }
         public void Reset() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct StreamingContext
     {
-        public StreamingContext(System.Runtime.Serialization.StreamingContextStates state) { throw null;}
-        public StreamingContext(System.Runtime.Serialization.StreamingContextStates state, object additional) { throw null;}
+        public StreamingContext(System.Runtime.Serialization.StreamingContextStates state) { throw null; }
+        public StreamingContext(System.Runtime.Serialization.StreamingContextStates state, object additional) { throw null; }
         public object Context { get { throw null; } }
         public System.Runtime.Serialization.StreamingContextStates State { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -7104,9 +7037,7 @@ namespace System.Security
     public sealed partial class SecurityCriticalAttribute : System.Attribute
     {
         public SecurityCriticalAttribute() { }
-#pragma warning disable 0618
         public SecurityCriticalAttribute(System.Security.SecurityCriticalScope scope) { }
-#pragma warning restore 0618
         [System.ObsoleteAttribute("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
         public System.Security.SecurityCriticalScope Scope { get { throw null; } }
     }
@@ -7204,9 +7135,9 @@ namespace System.Text
         public System.Text.DecoderFallback Fallback { get { throw null; } set { } }
         public System.Text.DecoderFallbackBuffer FallbackBuffer { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        public unsafe virtual void Convert(byte* bytes, int byteCount, char* chars, int charCount, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { bytesUsed = default(int); charsUsed = default(int); completed = default(bool); }
-        public virtual void Convert(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex, int charCount, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { bytesUsed = default(int); charsUsed = default(int); completed = default(bool); }
-        public virtual void Convert(System.ReadOnlySpan<byte> bytes, System.Span<char> chars, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { bytesUsed = default(int); charsUsed = default(int); completed = default(bool); }
+        public unsafe virtual void Convert(byte* bytes, int byteCount, char* chars, int charCount, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { throw null; }
+        public virtual void Convert(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex, int charCount, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { throw null; }
+        public virtual void Convert(System.ReadOnlySpan<byte> bytes, System.Span<char> chars, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe virtual int GetCharCount(byte* bytes, int count, bool flush) { throw null; }
         public abstract int GetCharCount(byte[] bytes, int index, int count);
@@ -7286,9 +7217,9 @@ namespace System.Text
         public System.Text.EncoderFallback Fallback { get { throw null; } set { } }
         public System.Text.EncoderFallbackBuffer FallbackBuffer { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        public unsafe virtual void Convert(char* chars, int charCount, byte* bytes, int byteCount, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { charsUsed = default(int); bytesUsed = default(int); completed = default(bool); }
-        public virtual void Convert(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex, int byteCount, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { charsUsed = default(int); bytesUsed = default(int); completed = default(bool); }
-        public virtual void Convert(System.ReadOnlySpan<char> chars, System.Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { charsUsed = default(int); bytesUsed = default(int); completed = default(bool); }
+        public unsafe virtual void Convert(char* chars, int charCount, byte* bytes, int byteCount, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { throw null; }
+        public virtual void Convert(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex, int byteCount, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { throw null; }
+        public virtual void Convert(System.ReadOnlySpan<char> chars, System.Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe virtual int GetByteCount(char* chars, int count, bool flush) { throw null; }
         public abstract int GetByteCount(char[] chars, int index, int count, bool flush);
@@ -7563,10 +7494,9 @@ namespace System.Text
 }
 namespace System.Threading
 {
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CancellationToken
     {
-        public CancellationToken(bool canceled) { throw null;}
+        public CancellationToken(bool canceled) { throw null; }
         public bool CanBeCanceled { get { throw null; } }
         public bool IsCancellationRequested { get { throw null; } }
         public static System.Threading.CancellationToken None { get { throw null; } }
@@ -7582,7 +7512,6 @@ namespace System.Threading
         public System.Threading.CancellationTokenRegistration Register(System.Action<object> callback, object state, bool useSynchronizationContext) { throw null; }
         public void ThrowIfCancellationRequested() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CancellationTokenRegistration : System.IDisposable, System.IEquatable<System.Threading.CancellationTokenRegistration>
     {
         public System.Threading.CancellationToken Token { get { throw null; } }
@@ -7964,11 +7893,10 @@ namespace System.Threading.Tasks
         public void SetObserved() { }
     }
     [System.Runtime.CompilerServices.AsyncMethodBuilderAttribute(typeof(System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder<>))]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public readonly partial struct ValueTask<TResult> : System.IEquatable<System.Threading.Tasks.ValueTask<TResult>>
     {
-        public ValueTask(System.Threading.Tasks.Task<TResult> task) { throw null;}
-        public ValueTask(TResult result) { throw null;}
+        public ValueTask(System.Threading.Tasks.Task<TResult> task) { throw null; }
+        public ValueTask(TResult result) { throw null; }
         public bool IsCanceled { get { throw null; } }
         public bool IsCompleted { get { throw null; } }
         public bool IsCompletedSuccessfully { get { throw null; } }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -6370,7 +6370,7 @@ namespace System.Runtime.CompilerServices
     public readonly partial struct ConfiguredValueTaskAwaitable<TResult>
     {
         public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<TResult>.ConfiguredValueTaskAwaiter GetAwaiter() { throw null; }
-        public readonly partial struct ConfiguredValueTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+        public partial struct ConfiguredValueTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
             public bool IsCompleted { get { throw null; } }
             public TResult GetResult() { throw null; }
@@ -6646,7 +6646,7 @@ namespace System.Runtime.CompilerServices
     {
         public UnsafeValueTypeAttribute() { }
     }
-    public readonly partial struct ValueTaskAwaiter<TResult> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+    public partial struct ValueTaskAwaiter<TResult> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
     {
         public bool IsCompleted { get { throw null; } }
         public TResult GetResult() { throw null; }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -316,7 +316,7 @@ namespace System
         public static bool TrueForAll<T>(T[] array, System.Predicate<T> match) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ArraySegment<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+    public readonly partial struct ArraySegment<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
     {
         public ArraySegment(T[] array) { throw null; }
         public ArraySegment(T[] array, int offset, int count) { throw null; }
@@ -2097,7 +2097,7 @@ namespace System
         public static bool TryParse(ReadOnlySpan<char> s, out float result) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly ref struct Span<T>
+    public readonly ref partial struct Span<T>
     {
         public static Span<T> Empty { get { throw null; } }
         public Span(T[] array) { throw null; }
@@ -2511,7 +2511,7 @@ namespace System
             void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct TransitionTime : System.IEquatable<System.TimeZoneInfo.TransitionTime>, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
+        public readonly partial struct TransitionTime : System.IEquatable<System.TimeZoneInfo.TransitionTime>, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
         {
             public int Day { get { throw null; } }
             public System.DayOfWeek DayOfWeek { get { throw null; } }
@@ -3818,11 +3818,11 @@ namespace System.Runtime.InteropServices
 namespace System.Runtime.CompilerServices
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ConfiguredTaskAwaitable
+    public readonly partial struct ConfiguredTaskAwaitable
     {
         public System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter GetAwaiter() { throw null; }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct ConfiguredTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+        public readonly partial struct ConfiguredTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
             public bool IsCompleted { get { throw null; } }
             public void GetResult() { }
@@ -3831,11 +3831,11 @@ namespace System.Runtime.CompilerServices
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct ConfiguredTaskAwaitable<TResult>
+    public readonly partial struct ConfiguredTaskAwaitable<TResult>
     {
         public System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter GetAwaiter() { throw null; }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct ConfiguredTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+        public readonly partial struct ConfiguredTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
             public bool IsCompleted { get { throw null; } }
             public TResult GetResult() { throw null; }
@@ -3857,7 +3857,7 @@ namespace System.Runtime.CompilerServices
         object this[int index] { get; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct TaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+    public readonly partial struct TaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
     {
         public bool IsCompleted { get { throw null; } }
         public void GetResult() { }
@@ -3865,7 +3865,7 @@ namespace System.Runtime.CompilerServices
         public void UnsafeOnCompleted(System.Action continuation) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct TaskAwaiter<TResult> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+    public readonly partial struct TaskAwaiter<TResult> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
     {
         public bool IsCompleted { get { throw null; } }
         public TResult GetResult() { throw null; }
@@ -3880,11 +3880,11 @@ namespace System.Runtime.CompilerServices
         public System.Collections.Generic.IList<string> TransformNames { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size = 1)]
-    public partial struct YieldAwaitable
+    public readonly partial struct YieldAwaitable
     {
         public System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter GetAwaiter() { throw null; }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size = 1)]
-        public partial struct YieldAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+        public readonly partial struct YieldAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
             public bool IsCompleted { get { throw null; } }
             public void GetResult() { }
@@ -6823,7 +6823,7 @@ namespace System.Runtime.CompilerServices
     public static class RuntimeFeature
     {
 #if FEATURE_DEFAULT_INTERFACES
-        public const string DefaultImplementationsOfInterfaces = nameof(DefaultImplementationsOfInterfaces); 
+        public const string DefaultImplementationsOfInterfaces = nameof(DefaultImplementationsOfInterfaces);
 #endif
         public static bool IsSupported(string feature) { throw null; }
     }
@@ -7170,7 +7170,7 @@ namespace System.Security
     public sealed partial class SecurityCriticalAttribute : System.Attribute
     {
         public SecurityCriticalAttribute() { }
-#pragma warning disable 0618        
+#pragma warning disable 0618
         public SecurityCriticalAttribute(System.Security.SecurityCriticalScope scope) { }
 #pragma warning restore 0618
         [System.ObsoleteAttribute("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
@@ -7618,7 +7618,7 @@ namespace System.Text
 namespace System.Threading
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CancellationToken
+    public readonly partial struct CancellationToken
     {
         public CancellationToken(bool canceled) { throw null; }
         public bool CanBeCanceled { get { throw null; } }
@@ -7637,7 +7637,7 @@ namespace System.Threading
         public void ThrowIfCancellationRequested() { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct CancellationTokenRegistration : System.IDisposable, System.IEquatable<System.Threading.CancellationTokenRegistration>
+    public readonly partial struct CancellationTokenRegistration : System.IDisposable, System.IEquatable<System.Threading.CancellationTokenRegistration>
     {
         public void Dispose() { }
         public override bool Equals(object obj) { throw null; }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -9,39 +9,45 @@ namespace Microsoft.Win32.SafeHandles
 {
     public abstract partial class CriticalHandleMinusOneIsInvalid : System.Runtime.InteropServices.CriticalHandle
     {
-        protected CriticalHandleMinusOneIsInvalid() : base(System.IntPtr.Zero) { }
+        protected CriticalHandleMinusOneIsInvalid() : base (default(System.IntPtr)) { }
         public override bool IsInvalid { get { throw null; } }
     }
     public abstract partial class CriticalHandleZeroOrMinusOneIsInvalid : System.Runtime.InteropServices.CriticalHandle
     {
-        protected CriticalHandleZeroOrMinusOneIsInvalid() : base(System.IntPtr.Zero) { }
+        protected CriticalHandleZeroOrMinusOneIsInvalid() : base (default(System.IntPtr)) { }
         public override bool IsInvalid { get { throw null; } }
     }
     public sealed partial class SafeFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
-        public SafeFileHandle(System.IntPtr preexistingHandle, bool ownsHandle) : base(default(bool)) { }
+        public SafeFileHandle(System.IntPtr preexistingHandle, bool ownsHandle) : base (default(bool)) { }
         public override bool IsInvalid { get { throw null; } }
         protected override bool ReleaseHandle() { throw null; }
     }
     public abstract partial class SafeHandleMinusOneIsInvalid : System.Runtime.InteropServices.SafeHandle
     {
-        protected SafeHandleMinusOneIsInvalid(bool ownsHandle) : base(System.IntPtr.Zero, ownsHandle) { }
+        protected SafeHandleMinusOneIsInvalid(bool ownsHandle) : base (default(System.IntPtr), default(bool)) { }
         public override bool IsInvalid { get { throw null; } }
     }
     public abstract partial class SafeHandleZeroOrMinusOneIsInvalid : System.Runtime.InteropServices.SafeHandle
     {
-        protected SafeHandleZeroOrMinusOneIsInvalid(bool ownsHandle) : base(System.IntPtr.Zero, ownsHandle) { }
+        protected SafeHandleZeroOrMinusOneIsInvalid(bool ownsHandle) : base (default(System.IntPtr), default(bool)) { }
         public override bool IsInvalid { get { throw null; } }
     }
     public sealed partial class SafeWaitHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
-        public SafeWaitHandle(System.IntPtr existingHandle, bool ownsHandle) : base(ownsHandle) { }
+        public SafeWaitHandle(System.IntPtr existingHandle, bool ownsHandle) : base (default(bool)) { }
         protected override bool ReleaseHandle() { throw null; }
     }
 }
-
 namespace System
 {
+    public partial class AccessViolationException : System.SystemException
+    {
+        public AccessViolationException() { }
+        protected AccessViolationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public AccessViolationException(string message) { }
+        public AccessViolationException(string message, System.Exception innerException) { }
+    }
     public delegate void Action();
     public delegate void Action<in T>(T obj);
     public delegate void Action<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10);
@@ -62,93 +68,23 @@ namespace System
     public static partial class Activator
     {
         public static object CreateInstance(System.Type type) { throw null; }
-        public static object CreateInstance(System.Type type, System.Boolean nonPublic) { throw null; }
+        public static object CreateInstance(System.Type type, bool nonPublic) { throw null; }
         public static object CreateInstance(System.Type type, params object[] args) { throw null; }
         public static object CreateInstance(System.Type type, object[] args, object[] activationAttributes) { throw null; }
         public static object CreateInstance(System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture) { throw null; }
         public static object CreateInstance(System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw null; }
         public static T CreateInstance<T>() { throw null; }
     }
-
-    public static partial class AppContext
-    {
-        public static string BaseDirectory { get { throw null; } }
-        public static void SetSwitch(string switchName, bool isEnabled) { }
-        public static bool TryGetSwitch(string switchName, out bool isEnabled) { throw null; }
-        public static string TargetFrameworkName { get { throw null; } }
-        public static object GetData(string name) { throw null; }
-    }
-
-    public partial class EntryPointNotFoundException : System.TypeLoadException
-    {
-        public EntryPointNotFoundException() { }
-        public EntryPointNotFoundException(string message) { }
-        public EntryPointNotFoundException(string message, Exception inner) { }
-        protected EntryPointNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-    }
-
-    public sealed partial class StackOverflowException : System.SystemException
-    {
-        public StackOverflowException() { }
-        public StackOverflowException(string message) { }
-        public StackOverflowException(string message, Exception innerException) { }
-    }
-
-    public partial class NotFiniteNumberException : System.ArithmeticException
-    {
-        public NotFiniteNumberException() { }
-        public NotFiniteNumberException(double offendingNumber) { }
-        public NotFiniteNumberException(string message) { }
-        public NotFiniteNumberException(string message, double offendingNumber) { }
-        public NotFiniteNumberException(string message, Exception innerException) { }
-        public NotFiniteNumberException(string message, double offendingNumber, Exception innerException) { }
-        protected NotFiniteNumberException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-        public double OffendingNumber { get; }
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    }
-
-    public partial class AccessViolationException : System.SystemException
-    {
-        public AccessViolationException() { }
-        public AccessViolationException(string message) { }
-        public AccessViolationException(string message, Exception innerException) { }
-        protected AccessViolationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-    }
-
-    public partial class ApplicationException : System.Exception
-    {
-        public ApplicationException() { }
-        public ApplicationException(string message) { }
-        public ApplicationException(string message, Exception innerException) { }
-        protected ApplicationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-    }
-
-    public partial class SystemException : System.Exception
-    {
-        public SystemException() { }
-        public SystemException(string message) { }
-        public SystemException(string message, Exception innerException) { }
-        protected SystemException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-    }
-
-    [ObsoleteAttribute("This type previously indicated an unspecified fatal error in the runtime. The runtime no longer raises this exception so this type is obsolete.")]
-    public sealed partial class ExecutionEngineException : System.SystemException
-    {
-        public ExecutionEngineException() { }
-        public ExecutionEngineException(string message) { }
-        public ExecutionEngineException(string message, Exception innerException) { }
-    }
-
     public partial class AggregateException : System.Exception
     {
         public AggregateException() { }
         public AggregateException(System.Collections.Generic.IEnumerable<System.Exception> innerExceptions) { }
         public AggregateException(params System.Exception[] innerExceptions) { }
+        protected AggregateException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public AggregateException(string message) { }
         public AggregateException(string message, System.Collections.Generic.IEnumerable<System.Exception> innerExceptions) { }
         public AggregateException(string message, System.Exception innerException) { }
         public AggregateException(string message, params System.Exception[] innerExceptions) { }
-        protected AggregateException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public System.Collections.ObjectModel.ReadOnlyCollection<System.Exception> InnerExceptions { get { throw null; } }
         public override string Message { get { throw null; } }
         public System.AggregateException Flatten() { throw null; }
@@ -157,14 +93,29 @@ namespace System
         public void Handle(System.Func<System.Exception, bool> predicate) { }
         public override string ToString() { throw null; }
     }
+    public static partial class AppContext
+    {
+        public static string BaseDirectory { get { throw null; } }
+        public static string TargetFrameworkName { get { throw null; } }
+        public static object GetData(string name) { throw null; }
+        public static void SetSwitch(string switchName, bool isEnabled) { }
+        public static bool TryGetSwitch(string switchName, out bool isEnabled) { isEnabled = default(bool); throw null; }
+    }
+    public partial class ApplicationException : System.Exception
+    {
+        public ApplicationException() { }
+        protected ApplicationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public ApplicationException(string message) { }
+        public ApplicationException(string message, System.Exception innerException) { }
+    }
     public partial class ArgumentException : System.SystemException, System.Runtime.Serialization.ISerializable
     {
         public ArgumentException() { }
+        protected ArgumentException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ArgumentException(string message) { }
         public ArgumentException(string message, System.Exception innerException) { }
         public ArgumentException(string message, string paramName) { }
         public ArgumentException(string message, string paramName, System.Exception innerException) { }
-        protected ArgumentException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public override string Message { get { throw null; } }
         public virtual string ParamName { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
@@ -172,19 +123,19 @@ namespace System
     public partial class ArgumentNullException : System.ArgumentException
     {
         public ArgumentNullException() { }
+        protected ArgumentNullException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ArgumentNullException(string paramName) { }
         public ArgumentNullException(string message, System.Exception innerException) { }
         public ArgumentNullException(string paramName, string message) { }
-        protected ArgumentNullException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public partial class ArgumentOutOfRangeException : System.ArgumentException, System.Runtime.Serialization.ISerializable
     {
         public ArgumentOutOfRangeException() { }
+        protected ArgumentOutOfRangeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ArgumentOutOfRangeException(string paramName) { }
         public ArgumentOutOfRangeException(string message, System.Exception innerException) { }
         public ArgumentOutOfRangeException(string paramName, object actualValue, string message) { }
         public ArgumentOutOfRangeException(string paramName, string message) { }
-        protected ArgumentOutOfRangeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public virtual object ActualValue { get { throw null; } }
         public override string Message { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
@@ -192,9 +143,9 @@ namespace System
     public partial class ArithmeticException : System.SystemException
     {
         public ArithmeticException() { }
+        protected ArithmeticException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ArithmeticException(string message) { }
         public ArithmeticException(string message, System.Exception innerException) { }
-        protected ArithmeticException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public abstract partial class Array : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.ICloneable
     {
@@ -213,10 +164,10 @@ namespace System
         public static int BinarySearch(System.Array array, int index, int length, object value, System.Collections.IComparer comparer) { throw null; }
         public static int BinarySearch(System.Array array, object value) { throw null; }
         public static int BinarySearch(System.Array array, object value, System.Collections.IComparer comparer) { throw null; }
-        public static int BinarySearch<T>(T[] array, T value) { throw null; }
-        public static int BinarySearch<T>(T[] array, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
         public static int BinarySearch<T>(T[] array, int index, int length, T value) { throw null; }
         public static int BinarySearch<T>(T[] array, int index, int length, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+        public static int BinarySearch<T>(T[] array, T value) { throw null; }
+        public static int BinarySearch<T>(T[] array, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
         public static void Clear(System.Array array, int index, int length) { }
         public object Clone() { throw null; }
         public static void ConstrainedCopy(System.Array sourceArray, int sourceIndex, System.Array destinationArray, int destinationIndex, int length) { }
@@ -235,17 +186,17 @@ namespace System
         public static System.Array CreateInstance(System.Type elementType, params long[] lengths) { throw null; }
         public static T[] Empty<T>() { throw null; }
         public static bool Exists<T>(T[] array, System.Predicate<T> match) { throw null; }
-        public static void Fill<T>(T[] array, T value) { throw null; }
-        public static void Fill<T>(T[] array, T value, int startIndex, int count) { throw null; }
-        public static T Find<T>(T[] array, System.Predicate<T> match) { throw null; }
+        public static void Fill<T>(T[] array, T value) { }
+        public static void Fill<T>(T[] array, T value, int startIndex, int count) { }
         public static T[] FindAll<T>(T[] array, System.Predicate<T> match) { throw null; }
         public static int FindIndex<T>(T[] array, int startIndex, int count, System.Predicate<T> match) { throw null; }
         public static int FindIndex<T>(T[] array, int startIndex, System.Predicate<T> match) { throw null; }
         public static int FindIndex<T>(T[] array, System.Predicate<T> match) { throw null; }
-        public static T FindLast<T>(T[] array, System.Predicate<T> match) { throw null; }
         public static int FindLastIndex<T>(T[] array, int startIndex, int count, System.Predicate<T> match) { throw null; }
         public static int FindLastIndex<T>(T[] array, int startIndex, System.Predicate<T> match) { throw null; }
         public static int FindLastIndex<T>(T[] array, System.Predicate<T> match) { throw null; }
+        public static T FindLast<T>(T[] array, System.Predicate<T> match) { throw null; }
+        public static T Find<T>(T[] array, System.Predicate<T> match) { throw null; }
         public static void ForEach<T>(T[] array, System.Action<T> action) { }
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public int GetLength(int dimension) { throw null; }
@@ -318,29 +269,28 @@ namespace System
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ArraySegment<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
     {
-        public ArraySegment(T[] array) { throw null; }
-        public ArraySegment(T[] array, int offset, int count) { throw null; }
+        public ArraySegment(T[] array) { throw null;}
+        public ArraySegment(T[] array, int offset, int count) { throw null;}
         public T[] Array { get { throw null; } }
         public int Count { get { throw null; } }
-        public static ArraySegment<T> Empty { get { throw null; } }
-        public int Offset { get { throw null; } }
+        public static System.ArraySegment<T> Empty { get { throw null; } }
         public T this[int index] { get { throw null; } set { } }
+        public int Offset { get { throw null; } }
         bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
         T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
         T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
-        public void CopyTo(T[] destination) { throw null; }
-        public void CopyTo(T[] destination, int destinationIndex) { throw null; }
-        public void CopyTo(ArraySegment<T> destination) { throw null; }
+        public void CopyTo(System.ArraySegment<T> destination) { }
+        public void CopyTo(T[] destination) { }
+        public void CopyTo(T[] destination, int destinationIndex) { }
         public bool Equals(System.ArraySegment<T> obj) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public Enumerator GetEnumerator() { throw null; }
+        public System.ArraySegment<T>.Enumerator GetEnumerator() { throw null; }
         public override int GetHashCode() { throw null; }
-        public ArraySegment<T> Slice(int index) { throw null; }
-        public ArraySegment<T> Slice(int index, int count) { throw null; }
-        public T[] ToArray() { throw null; }
         public static bool operator ==(System.ArraySegment<T> a, System.ArraySegment<T> b) { throw null; }
-        public static implicit operator ArraySegment<T>(T[] array) { throw null; }
+        public static implicit operator System.ArraySegment<T> (T[] array) { throw null; }
         public static bool operator !=(System.ArraySegment<T> a, System.ArraySegment<T> b) { throw null; }
+        public System.ArraySegment<T> Slice(int index) { throw null; }
+        public System.ArraySegment<T> Slice(int index, int count) { throw null; }
         void System.Collections.Generic.ICollection<T>.Add(T item) { }
         void System.Collections.Generic.ICollection<T>.Clear() { }
         bool System.Collections.Generic.ICollection<T>.Contains(T item) { throw null; }
@@ -351,6 +301,7 @@ namespace System
         void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
         void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public T[] ToArray() { throw null; }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
         {
@@ -364,20 +315,17 @@ namespace System
     public partial class ArrayTypeMismatchException : System.SystemException
     {
         public ArrayTypeMismatchException() { }
+        protected ArrayTypeMismatchException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ArrayTypeMismatchException(string message) { }
         public ArrayTypeMismatchException(string message, System.Exception innerException) { }
-        protected ArrayTypeMismatchException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public delegate void AsyncCallback(System.IAsyncResult ar);
-    [System.AttributeUsageAttribute((System.AttributeTargets)(32767), Inherited = true, AllowMultiple = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(32767), Inherited=true, AllowMultiple=false)]
     public abstract partial class Attribute
     {
         protected Attribute() { }
-        public override bool Equals(object obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public virtual bool IsDefaultAttribute() { throw null; }
-        public virtual bool Match(object obj) { throw null; }
         public virtual object TypeId { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
         public static System.Attribute GetCustomAttribute(System.Reflection.Assembly element, System.Type attributeType) { throw null; }
         public static System.Attribute GetCustomAttribute(System.Reflection.Assembly element, System.Type attributeType, bool inherit) { throw null; }
         public static System.Attribute GetCustomAttribute(System.Reflection.MemberInfo element, System.Type attributeType) { throw null; }
@@ -402,6 +350,8 @@ namespace System
         public static System.Attribute[] GetCustomAttributes(System.Reflection.ParameterInfo element, bool inherit) { throw null; }
         public static System.Attribute[] GetCustomAttributes(System.Reflection.ParameterInfo element, System.Type attributeType) { throw null; }
         public static System.Attribute[] GetCustomAttributes(System.Reflection.ParameterInfo element, System.Type attributeType, bool inherit) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public virtual bool IsDefaultAttribute() { throw null; }
         public static bool IsDefined(System.Reflection.Assembly element, System.Type attributeType) { throw null; }
         public static bool IsDefined(System.Reflection.Assembly element, System.Type attributeType, bool inherit) { throw null; }
         public static bool IsDefined(System.Reflection.MemberInfo element, System.Type attributeType) { throw null; }
@@ -410,6 +360,7 @@ namespace System
         public static bool IsDefined(System.Reflection.Module element, System.Type attributeType, bool inherit) { throw null; }
         public static bool IsDefined(System.Reflection.ParameterInfo element, System.Type attributeType) { throw null; }
         public static bool IsDefined(System.Reflection.ParameterInfo element, System.Type attributeType, bool inherit) { throw null; }
+        public virtual bool Match(object obj) { throw null; }
     }
     [System.FlagsAttribute]
     public enum AttributeTargets
@@ -431,7 +382,7 @@ namespace System
         ReturnValue = 8192,
         Struct = 8,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(4), Inherited = true)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4), Inherited=true)]
     public sealed partial class AttributeUsageAttribute : System.Attribute
     {
         public AttributeUsageAttribute(System.AttributeTargets validOn) { }
@@ -442,11 +393,11 @@ namespace System
     public partial class BadImageFormatException : System.SystemException
     {
         public BadImageFormatException() { }
+        protected BadImageFormatException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public BadImageFormatException(string message) { }
         public BadImageFormatException(string message, System.Exception inner) { }
         public BadImageFormatException(string message, string fileName) { }
         public BadImageFormatException(string message, string fileName, System.Exception inner) { }
-        protected BadImageFormatException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public string FileName { get { throw null; } }
         public string FusionLog { get { throw null; } }
         public override string Message { get { throw null; } }
@@ -458,15 +409,15 @@ namespace System
     {
         public static readonly string FalseString;
         public static readonly string TrueString;
-        public int CompareTo(bool value) { throw null; }
-        public bool Equals(bool obj) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static bool Parse(string value) { throw null; }
-        public static bool Parse(System.ReadOnlySpan<char> value) { throw null; }
+        public int CompareTo(System.Boolean value) { throw null; }
         public int CompareTo(object obj) { throw null; }
+        public System.Boolean Equals(System.Boolean obj) { throw null; }
+        public override System.Boolean Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
-        bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
+        public static System.Boolean Parse(System.ReadOnlySpan<char> value) { throw null; }
+        public static System.Boolean Parse(string value) { throw null; }
+        System.Boolean System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
         System.DateTime System.IConvertible.ToDateTime(System.IFormatProvider provider) { throw null; }
@@ -477,15 +428,15 @@ namespace System
         long System.IConvertible.ToInt64(System.IFormatProvider provider) { throw null; }
         sbyte System.IConvertible.ToSByte(System.IFormatProvider provider) { throw null; }
         float System.IConvertible.ToSingle(System.IFormatProvider provider) { throw null; }
-        public string ToString(System.IFormatProvider provider) { throw null; }
         object System.IConvertible.ToType(System.Type type, System.IFormatProvider provider) { throw null; }
         ushort System.IConvertible.ToUInt16(System.IFormatProvider provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider provider) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten) { throw null; }
-        public static bool TryParse(string value, out bool result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> value, out bool result) { throw null; }
+        public string ToString(System.IFormatProvider provider) { throw null; }
+        public System.Boolean TryFormat(System.Span<char> destination, out int charsWritten) { charsWritten = default(int); throw null; }
+        public static System.Boolean TryParse(System.ReadOnlySpan<char> value, out System.Boolean result) { result = default(bool); throw null; }
+        public static System.Boolean TryParse(string value, out System.Boolean result) { result = default(bool); throw null; }
     }
     public static partial class Buffer
     {
@@ -493,9 +444,9 @@ namespace System
         public static int ByteLength(System.Array array) { throw null; }
         public static byte GetByte(System.Array array, int index) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static unsafe void MemoryCopy(void* source, void* destination, long destinationSizeInBytes, long sourceBytesToCopy) { }
+        public unsafe static void MemoryCopy(void* source, void* destination, long destinationSizeInBytes, long sourceBytesToCopy) { }
         [System.CLSCompliantAttribute(false)]
-        public static unsafe void MemoryCopy(void* source, void* destination, ulong destinationSizeInBytes, ulong sourceBytesToCopy) { }
+        public unsafe static void MemoryCopy(void* source, void* destination, ulong destinationSizeInBytes, ulong sourceBytesToCopy) { }
         public static void SetByte(System.Array array, int index, byte value) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -503,19 +454,19 @@ namespace System
     {
         public const byte MaxValue = (byte)255;
         public const byte MinValue = (byte)0;
-        public int CompareTo(byte value) { throw null; }
-        public bool Equals(byte obj) { throw null; }
+        public int CompareTo(System.Byte value) { throw null; }
+        public int CompareTo(object value) { throw null; }
+        public bool Equals(System.Byte obj) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static byte Parse(string s) { throw null; }
-        public static byte Parse(string s, System.Globalization.NumberStyles style) { throw null; }
-        public static byte Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        public static byte Parse(string s, System.IFormatProvider provider) { throw null; }
-        public static byte Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        public int CompareTo(object value) { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static System.Byte Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        public static System.Byte Parse(string s) { throw null; }
+        public static System.Byte Parse(string s, System.Globalization.NumberStyles style) { throw null; }
+        public static System.Byte Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        public static System.Byte Parse(string s, System.IFormatProvider provider) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
-        byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
+        System.Byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
         System.DateTime System.IConvertible.ToDateTime(System.IFormatProvider provider) { throw null; }
         decimal System.IConvertible.ToDecimal(System.IFormatProvider provider) { throw null; }
@@ -533,64 +484,64 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
-        public static bool TryParse(string s, out byte result) { throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out byte result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out byte result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out byte result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Byte result) { result = default(byte); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Byte result) { result = default(byte); throw null; }
+        public static bool TryParse(string s, out System.Byte result) { result = default(byte); throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Byte result) { result = default(byte); throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Char : System.IComparable, System.IComparable<char>, System.IConvertible, System.IEquatable<char>
     {
         public const char MaxValue = '\uFFFF';
         public const char MinValue = '\0';
-        public int CompareTo(char value) { throw null; }
+        public int CompareTo(System.Char value) { throw null; }
+        public int CompareTo(object value) { throw null; }
         public static string ConvertFromUtf32(int utf32) { throw null; }
-        public static int ConvertToUtf32(char highSurrogate, char lowSurrogate) { throw null; }
+        public static int ConvertToUtf32(System.Char highSurrogate, System.Char lowSurrogate) { throw null; }
         public static int ConvertToUtf32(string s, int index) { throw null; }
-        public bool Equals(char obj) { throw null; }
+        public bool Equals(System.Char obj) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static double GetNumericValue(char c) { throw null; }
+        public static double GetNumericValue(System.Char c) { throw null; }
         public static double GetNumericValue(string s, int index) { throw null; }
-        public static System.Globalization.UnicodeCategory GetUnicodeCategory(char c) { throw null; }
-        public static System.Globalization.UnicodeCategory GetUnicodeCategory(string s, int index) { throw null; }
-        public static bool IsControl(char c) { throw null; }
-        public static bool IsControl(string s, int index) { throw null; }
-        public static bool IsDigit(char c) { throw null; }
-        public static bool IsDigit(string s, int index) { throw null; }
-        public static bool IsHighSurrogate(char c) { throw null; }
-        public static bool IsHighSurrogate(string s, int index) { throw null; }
-        public static bool IsLetter(char c) { throw null; }
-        public static bool IsLetter(string s, int index) { throw null; }
-        public static bool IsLetterOrDigit(char c) { throw null; }
-        public static bool IsLetterOrDigit(string s, int index) { throw null; }
-        public static bool IsLower(char c) { throw null; }
-        public static bool IsLower(string s, int index) { throw null; }
-        public static bool IsLowSurrogate(char c) { throw null; }
-        public static bool IsLowSurrogate(string s, int index) { throw null; }
-        public static bool IsNumber(char c) { throw null; }
-        public static bool IsNumber(string s, int index) { throw null; }
-        public static bool IsPunctuation(char c) { throw null; }
-        public static bool IsPunctuation(string s, int index) { throw null; }
-        public static bool IsSeparator(char c) { throw null; }
-        public static bool IsSeparator(string s, int index) { throw null; }
-        public static bool IsSurrogate(char c) { throw null; }
-        public static bool IsSurrogate(string s, int index) { throw null; }
-        public static bool IsSurrogatePair(char highSurrogate, char lowSurrogate) { throw null; }
-        public static bool IsSurrogatePair(string s, int index) { throw null; }
-        public static bool IsSymbol(char c) { throw null; }
-        public static bool IsSymbol(string s, int index) { throw null; }
-        public static bool IsUpper(char c) { throw null; }
-        public static bool IsUpper(string s, int index) { throw null; }
-        public static bool IsWhiteSpace(char c) { throw null; }
-        public static bool IsWhiteSpace(string s, int index) { throw null; }
-        public static char Parse(string s) { throw null; }
-        public int CompareTo(object value) { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static System.Globalization.UnicodeCategory GetUnicodeCategory(System.Char c) { throw null; }
+        public static System.Globalization.UnicodeCategory GetUnicodeCategory(string s, int index) { throw null; }
+        public static bool IsControl(System.Char c) { throw null; }
+        public static bool IsControl(string s, int index) { throw null; }
+        public static bool IsDigit(System.Char c) { throw null; }
+        public static bool IsDigit(string s, int index) { throw null; }
+        public static bool IsHighSurrogate(System.Char c) { throw null; }
+        public static bool IsHighSurrogate(string s, int index) { throw null; }
+        public static bool IsLetter(System.Char c) { throw null; }
+        public static bool IsLetter(string s, int index) { throw null; }
+        public static bool IsLetterOrDigit(System.Char c) { throw null; }
+        public static bool IsLetterOrDigit(string s, int index) { throw null; }
+        public static bool IsLower(System.Char c) { throw null; }
+        public static bool IsLower(string s, int index) { throw null; }
+        public static bool IsLowSurrogate(System.Char c) { throw null; }
+        public static bool IsLowSurrogate(string s, int index) { throw null; }
+        public static bool IsNumber(System.Char c) { throw null; }
+        public static bool IsNumber(string s, int index) { throw null; }
+        public static bool IsPunctuation(System.Char c) { throw null; }
+        public static bool IsPunctuation(string s, int index) { throw null; }
+        public static bool IsSeparator(System.Char c) { throw null; }
+        public static bool IsSeparator(string s, int index) { throw null; }
+        public static bool IsSurrogate(System.Char c) { throw null; }
+        public static bool IsSurrogate(string s, int index) { throw null; }
+        public static bool IsSurrogatePair(System.Char highSurrogate, System.Char lowSurrogate) { throw null; }
+        public static bool IsSurrogatePair(string s, int index) { throw null; }
+        public static bool IsSymbol(System.Char c) { throw null; }
+        public static bool IsSymbol(string s, int index) { throw null; }
+        public static bool IsUpper(System.Char c) { throw null; }
+        public static bool IsUpper(string s, int index) { throw null; }
+        public static bool IsWhiteSpace(System.Char c) { throw null; }
+        public static bool IsWhiteSpace(string s, int index) { throw null; }
+        public static System.Char Parse(string s) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
-        char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
+        System.Char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
         System.DateTime System.IConvertible.ToDateTime(System.IFormatProvider provider) { throw null; }
         decimal System.IConvertible.ToDecimal(System.IFormatProvider provider) { throw null; }
         double System.IConvertible.ToDouble(System.IFormatProvider provider) { throw null; }
@@ -599,20 +550,20 @@ namespace System
         long System.IConvertible.ToInt64(System.IFormatProvider provider) { throw null; }
         sbyte System.IConvertible.ToSByte(System.IFormatProvider provider) { throw null; }
         float System.IConvertible.ToSingle(System.IFormatProvider provider) { throw null; }
-        public string ToString(System.IFormatProvider provider) { throw null; }
         object System.IConvertible.ToType(System.Type type, System.IFormatProvider provider) { throw null; }
         ushort System.IConvertible.ToUInt16(System.IFormatProvider provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider provider) { throw null; }
-        public static char ToLower(char c) { throw null; }
-        public static char ToLower(char c, System.Globalization.CultureInfo culture) { throw null; }
-        public static char ToLowerInvariant(char c) { throw null; }
+        public static System.Char ToLower(System.Char c) { throw null; }
+        public static System.Char ToLower(System.Char c, System.Globalization.CultureInfo culture) { throw null; }
+        public static System.Char ToLowerInvariant(System.Char c) { throw null; }
         public override string ToString() { throw null; }
-        public static string ToString(char c) { throw null; }
-        public static char ToUpper(char c) { throw null; }
-        public static char ToUpper(char c, System.Globalization.CultureInfo culture) { throw null; }
-        public static char ToUpperInvariant(char c) { throw null; }
-        public static bool TryParse(string s, out char result) { throw null; }
+        public static string ToString(System.Char c) { throw null; }
+        public string ToString(System.IFormatProvider provider) { throw null; }
+        public static System.Char ToUpper(System.Char c) { throw null; }
+        public static System.Char ToUpper(System.Char c, System.Globalization.CultureInfo culture) { throw null; }
+        public static System.Char ToUpperInvariant(System.Char c) { throw null; }
+        public static bool TryParse(string s, out System.Char result) { result = default(char); throw null; }
     }
     public sealed partial class CharEnumerator : System.Collections.Generic.IEnumerator<char>, System.Collections.IEnumerator, System.ICloneable, System.IDisposable
     {
@@ -624,7 +575,7 @@ namespace System
         public bool MoveNext() { throw null; }
         public void Reset() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(32767), Inherited = true, AllowMultiple = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(32767), Inherited=true, AllowMultiple=false)]
     public sealed partial class CLSCompliantAttribute : System.Attribute
     {
         public CLSCompliantAttribute(bool isCompliant) { }
@@ -632,22 +583,23 @@ namespace System
     }
     public delegate int Comparison<in T>(T x, T y);
     public delegate TOutput Converter<in TInput, out TOutput>(TInput input);
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public readonly partial struct DateTime : System.IComparable, System.IComparable<System.DateTime>, System.IConvertible, System.IEquatable<System.DateTime>, System.IFormattable, System.Runtime.Serialization.ISerializable
     {
         public static readonly System.DateTime MaxValue;
         public static readonly System.DateTime MinValue;
         public static readonly System.DateTime UnixEpoch;
-        public DateTime(int year, int month, int day) { throw null; }
-        public DateTime(int year, int month, int day, System.Globalization.Calendar calendar) { throw null; }
-        public DateTime(int year, int month, int day, int hour, int minute, int second) { throw null; }
-        public DateTime(int year, int month, int day, int hour, int minute, int second, System.DateTimeKind kind) { throw null; }
-        public DateTime(int year, int month, int day, int hour, int minute, int second, System.Globalization.Calendar calendar) { throw null; }
-        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond) { throw null; }
-        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.DateTimeKind kind) { throw null; }
-        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar) { throw null; }
-        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar, System.DateTimeKind kind) { throw null; }
-        public DateTime(long ticks) { throw null; }
-        public DateTime(long ticks, System.DateTimeKind kind) { throw null; }
+        public DateTime(int year, int month, int day) { throw null;}
+        public DateTime(int year, int month, int day, System.Globalization.Calendar calendar) { throw null;}
+        public DateTime(int year, int month, int day, int hour, int minute, int second) { throw null;}
+        public DateTime(int year, int month, int day, int hour, int minute, int second, System.DateTimeKind kind) { throw null;}
+        public DateTime(int year, int month, int day, int hour, int minute, int second, System.Globalization.Calendar calendar) { throw null;}
+        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond) { throw null;}
+        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.DateTimeKind kind) { throw null;}
+        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar) { throw null;}
+        public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar, System.DateTimeKind kind) { throw null;}
+        public DateTime(long ticks) { throw null;}
+        public DateTime(long ticks, System.DateTimeKind kind) { throw null;}
         public System.DateTime Date { get { throw null; } }
         public int Day { get { throw null; } }
         public System.DayOfWeek DayOfWeek { get { throw null; } }
@@ -701,15 +653,15 @@ namespace System
         public static bool operator <=(System.DateTime t1, System.DateTime t2) { throw null; }
         public static System.TimeSpan operator -(System.DateTime d1, System.DateTime d2) { throw null; }
         public static System.DateTime operator -(System.DateTime d, System.TimeSpan t) { throw null; }
+        public static System.DateTime Parse(System.ReadOnlySpan<char> s, System.IFormatProvider provider=null, System.Globalization.DateTimeStyles styles=(System.Globalization.DateTimeStyles)(0)) { throw null; }
         public static System.DateTime Parse(string s) { throw null; }
         public static System.DateTime Parse(string s, System.IFormatProvider provider) { throw null; }
         public static System.DateTime Parse(string s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles) { throw null; }
-        public static System.DateTime Parse(System.ReadOnlySpan<char> s, System.IFormatProvider provider = null, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.DateTime ParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style=(System.Globalization.DateTimeStyles)(0)) { throw null; }
+        public static System.DateTime ParseExact(System.ReadOnlySpan<char> s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style=(System.Globalization.DateTimeStyles)(0)) { throw null; }
         public static System.DateTime ParseExact(string s, string format, System.IFormatProvider provider) { throw null; }
         public static System.DateTime ParseExact(string s, string format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style) { throw null; }
         public static System.DateTime ParseExact(string s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style) { throw null; }
-        public static System.DateTime ParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
-        public static System.DateTime ParseExact(System.ReadOnlySpan<char> s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.DateTime SpecifyKind(System.DateTime value, System.DateTimeKind kind) { throw null; }
         public System.TimeSpan Subtract(System.DateTime value) { throw null; }
         public System.DateTime Subtract(System.TimeSpan value) { throw null; }
@@ -745,15 +697,15 @@ namespace System
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
         public System.DateTime ToUniversalTime() { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
-        public static bool TryParse(string s, out System.DateTime result) { throw null; }
-        public static bool TryParse(string s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.DateTime result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { throw null; }
-        public static bool TryParseExact(string s, string format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
-        public static bool TryParseExact(string s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.DateTime result) { result = default(System.DateTime); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { result = default(System.DateTime); throw null; }
+        public static bool TryParse(string s, out System.DateTime result) { result = default(System.DateTime); throw null; }
+        public static bool TryParse(string s, System.IFormatProvider provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { result = default(System.DateTime); throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { result = default(System.DateTime); throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { result = default(System.DateTime); throw null; }
+        public static bool TryParseExact(string s, string format, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { result = default(System.DateTime); throw null; }
+        public static bool TryParseExact(string s, string[] formats, System.IFormatProvider provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { result = default(System.DateTime); throw null; }
     }
     public enum DateTimeKind
     {
@@ -761,17 +713,18 @@ namespace System
         Unspecified = 0,
         Utc = 1,
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public partial struct DateTimeOffset : System.IComparable, System.IComparable<System.DateTimeOffset>, System.IEquatable<System.DateTimeOffset>, System.IFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         public static readonly System.DateTimeOffset MaxValue;
         public static readonly System.DateTimeOffset MinValue;
         public static readonly System.DateTimeOffset UnixEpoch;
-        public DateTimeOffset(System.DateTime dateTime) { throw null; }
-        public DateTimeOffset(System.DateTime dateTime, System.TimeSpan offset) { throw null; }
-        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar, System.TimeSpan offset) { throw null; }
-        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, System.TimeSpan offset) { throw null; }
-        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, System.TimeSpan offset) { throw null; }
-        public DateTimeOffset(long ticks, System.TimeSpan offset) { throw null; }
+        public DateTimeOffset(System.DateTime dateTime) { throw null;}
+        public DateTimeOffset(System.DateTime dateTime, System.TimeSpan offset) { throw null;}
+        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar, System.TimeSpan offset) { throw null;}
+        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, System.TimeSpan offset) { throw null;}
+        public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, System.TimeSpan offset) { throw null;}
+        public DateTimeOffset(long ticks, System.TimeSpan offset) { throw null;}
         public System.DateTime Date { get { throw null; } }
         public System.DateTime DateTime { get { throw null; } }
         public int Day { get { throw null; } }
@@ -814,21 +767,21 @@ namespace System
         public static bool operator ==(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
         public static bool operator >(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
         public static bool operator >=(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
-        public static implicit operator System.DateTimeOffset(System.DateTime dateTime) { throw null; }
+        public static implicit operator System.DateTimeOffset (System.DateTime dateTime) { throw null; }
         public static bool operator !=(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
         public static bool operator <(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
         public static bool operator <=(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
         public static System.TimeSpan operator -(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
         public static System.DateTimeOffset operator -(System.DateTimeOffset dateTimeOffset, System.TimeSpan timeSpan) { throw null; }
+        public static System.DateTimeOffset Parse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider=null, System.Globalization.DateTimeStyles styles=(System.Globalization.DateTimeStyles)(0)) { throw null; }
         public static System.DateTimeOffset Parse(string input) { throw null; }
         public static System.DateTimeOffset Parse(string input, System.IFormatProvider formatProvider) { throw null; }
         public static System.DateTimeOffset Parse(string input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles) { throw null; }
-        public static System.DateTimeOffset Parse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider = null, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.DateTimeOffset ParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles=(System.Globalization.DateTimeStyles)(0)) { throw null; }
+        public static System.DateTimeOffset ParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles=(System.Globalization.DateTimeStyles)(0)) { throw null; }
         public static System.DateTimeOffset ParseExact(string input, string format, System.IFormatProvider formatProvider) { throw null; }
         public static System.DateTimeOffset ParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles) { throw null; }
         public static System.DateTimeOffset ParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles) { throw null; }
-        public static System.DateTimeOffset ParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
-        public static System.DateTimeOffset ParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
         public System.TimeSpan Subtract(System.DateTimeOffset value) { throw null; }
         public System.DateTimeOffset Subtract(System.TimeSpan value) { throw null; }
         int System.IComparable.CompareTo(object obj) { throw null; }
@@ -844,15 +797,15 @@ namespace System
         public System.DateTimeOffset ToUniversalTime() { throw null; }
         public long ToUnixTimeMilliseconds() { throw null; }
         public long ToUnixTimeSeconds() { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider formatProvider = null) { throw null; }
-        public static bool TryParse(string input, out System.DateTimeOffset result) { throw null; }
-        public static bool TryParse(string input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
-        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
-        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> input, out System.DateTimeOffset result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider formatProvider=null) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
+        public static bool TryParse(string input, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
+        public static bool TryParse(string input, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
+        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
+        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { result = default(System.DateTimeOffset); throw null; }
     }
     public enum DayOfWeek
     {
@@ -901,94 +854,93 @@ namespace System
         public static readonly decimal One;
         [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)0, (uint)0, (uint)0, (uint)0)]
         public static readonly decimal Zero;
-        public Decimal(double value) { throw null; }
-        public Decimal(int value) { throw null; }
-        public Decimal(int lo, int mid, int hi, bool isNegative, byte scale) { throw null; }
-        public Decimal(int[] bits) { throw null; }
-        public Decimal(long value) { throw null; }
-        public Decimal(float value) { throw null; }
+        public Decimal(double value) { throw null;}
+        public Decimal(int value) { throw null;}
+        public Decimal(int lo, int mid, int hi, bool isNegative, byte scale) { throw null;}
+        public Decimal(int[] bits) { throw null;}
+        public Decimal(long value) { throw null;}
+        public Decimal(float value) { throw null;}
         [System.CLSCompliantAttribute(false)]
-        public Decimal(uint value) { throw null; }
+        public Decimal(uint value) { throw null;}
         [System.CLSCompliantAttribute(false)]
-        public Decimal(ulong value) { throw null; }
-        public static decimal Add(decimal d1, decimal d2) { throw null; }
-        public static decimal Ceiling(decimal d) { throw null; }
-        public static int Compare(decimal d1, decimal d2) { throw null; }
-        public int CompareTo(decimal value) { throw null; }
-        public static decimal Divide(decimal d1, decimal d2) { throw null; }
-        public bool Equals(decimal value) { throw null; }
-        public static bool Equals(decimal d1, decimal d2) { throw null; }
-        public override bool Equals(object value) { throw null; }
-        public static decimal Floor(decimal d) { throw null; }
-        public static decimal FromOACurrency(long cy) { throw null; }
-        public static int[] GetBits(decimal d) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static decimal Multiply(decimal d1, decimal d2) { throw null; }
-        public static decimal Negate(decimal d) { throw null; }
-        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-        public static decimal operator +(decimal d1, decimal d2) { throw null; }
-        public static decimal operator --(decimal d) { throw null; }
-        public static decimal operator /(decimal d1, decimal d2) { throw null; }
-        public static bool operator ==(decimal d1, decimal d2) { throw null; }
-        public static explicit operator byte(decimal value) { throw null; }
-        public static explicit operator char(decimal value) { throw null; }
-        public static explicit operator double(decimal value) { throw null; }
-        public static explicit operator short(decimal value) { throw null; }
-        public static explicit operator int(decimal value) { throw null; }
-        public static explicit operator long(decimal value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static explicit operator sbyte(decimal value) { throw null; }
-        public static explicit operator float(decimal value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static explicit operator ushort(decimal value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static explicit operator uint(decimal value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static explicit operator ulong(decimal value) { throw null; }
-        public static explicit operator decimal(double value) { throw null; }
-        public static explicit operator decimal(float value) { throw null; }
-        public static bool operator >(decimal d1, decimal d2) { throw null; }
-        public static bool operator >=(decimal d1, decimal d2) { throw null; }
-        public static implicit operator decimal(byte value) { throw null; }
-        public static implicit operator decimal(char value) { throw null; }
-        public static implicit operator decimal(short value) { throw null; }
-        public static implicit operator decimal(int value) { throw null; }
-        public static implicit operator decimal(long value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static implicit operator decimal(sbyte value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static implicit operator decimal(ushort value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static implicit operator decimal(uint value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static implicit operator decimal(ulong value) { throw null; }
-        public static decimal operator ++(decimal d) { throw null; }
-        public static bool operator !=(decimal d1, decimal d2) { throw null; }
-        public static bool operator <(decimal d1, decimal d2) { throw null; }
-        public static bool operator <=(decimal d1, decimal d2) { throw null; }
-        public static decimal operator %(decimal d1, decimal d2) { throw null; }
-        public static decimal operator *(decimal d1, decimal d2) { throw null; }
-        public static decimal operator -(decimal d1, decimal d2) { throw null; }
-        public static decimal operator -(decimal d) { throw null; }
-        public static decimal operator +(decimal d) { throw null; }
-        public static decimal Parse(string s) { throw null; }
-        public static decimal Parse(string s, System.Globalization.NumberStyles style) { throw null; }
-        public static decimal Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        public static decimal Parse(string s, System.IFormatProvider provider) { throw null; }
-        public static decimal Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider provider = null) { throw null; }
-        public static decimal Remainder(decimal d1, decimal d2) { throw null; }
-        public static decimal Round(decimal d) { throw null; }
-        public static decimal Round(decimal d, int decimals) { throw null; }
-        public static decimal Round(decimal d, int decimals, MidpointRounding mode) { throw null; }
-        public static decimal Round(decimal d, MidpointRounding mode) { throw null; }
-        public static decimal Subtract(decimal d1, decimal d2) { throw null; }
+        public Decimal(ulong value) { throw null;}
+        public static System.Decimal Add(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static System.Decimal Ceiling(System.Decimal d) { throw null; }
+        public static int Compare(System.Decimal d1, System.Decimal d2) { throw null; }
+        public int CompareTo(System.Decimal value) { throw null; }
         public int CompareTo(object value) { throw null; }
+        public static System.Decimal Divide(System.Decimal d1, System.Decimal d2) { throw null; }
+        public bool Equals(System.Decimal value) { throw null; }
+        public static bool Equals(System.Decimal d1, System.Decimal d2) { throw null; }
+        public override bool Equals(object value) { throw null; }
+        public static System.Decimal Floor(System.Decimal d) { throw null; }
+        public static System.Decimal FromOACurrency(long cy) { throw null; }
+        public static int[] GetBits(System.Decimal d) { throw null; }
+        public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static System.Decimal Multiply(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static System.Decimal Negate(System.Decimal d) { throw null; }
+        public static System.Decimal operator +(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static System.Decimal operator --(System.Decimal d) { throw null; }
+        public static System.Decimal operator /(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static bool operator ==(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static explicit operator byte (System.Decimal value) { throw null; }
+        public static explicit operator char (System.Decimal value) { throw null; }
+        public static explicit operator double (System.Decimal value) { throw null; }
+        public static explicit operator short (System.Decimal value) { throw null; }
+        public static explicit operator int (System.Decimal value) { throw null; }
+        public static explicit operator long (System.Decimal value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static explicit operator sbyte (System.Decimal value) { throw null; }
+        public static explicit operator float (System.Decimal value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static explicit operator ushort (System.Decimal value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static explicit operator uint (System.Decimal value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static explicit operator ulong (System.Decimal value) { throw null; }
+        public static explicit operator System.Decimal (double value) { throw null; }
+        public static explicit operator System.Decimal (float value) { throw null; }
+        public static bool operator >(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static bool operator >=(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static implicit operator System.Decimal (byte value) { throw null; }
+        public static implicit operator System.Decimal (char value) { throw null; }
+        public static implicit operator System.Decimal (short value) { throw null; }
+        public static implicit operator System.Decimal (int value) { throw null; }
+        public static implicit operator System.Decimal (long value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static implicit operator System.Decimal (sbyte value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static implicit operator System.Decimal (ushort value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static implicit operator System.Decimal (uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static implicit operator System.Decimal (ulong value) { throw null; }
+        public static System.Decimal operator ++(System.Decimal d) { throw null; }
+        public static bool operator !=(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static bool operator <(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static bool operator <=(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static System.Decimal operator %(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static System.Decimal operator *(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static System.Decimal operator -(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static System.Decimal operator -(System.Decimal d) { throw null; }
+        public static System.Decimal operator +(System.Decimal d) { throw null; }
+        public static System.Decimal Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style=(System.Globalization.NumberStyles)(7), System.IFormatProvider provider=null) { throw null; }
+        public static System.Decimal Parse(string s) { throw null; }
+        public static System.Decimal Parse(string s, System.Globalization.NumberStyles style) { throw null; }
+        public static System.Decimal Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        public static System.Decimal Parse(string s, System.IFormatProvider provider) { throw null; }
+        public static System.Decimal Remainder(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static System.Decimal Round(System.Decimal d) { throw null; }
+        public static System.Decimal Round(System.Decimal d, int decimals) { throw null; }
+        public static System.Decimal Round(System.Decimal d, int decimals, System.MidpointRounding mode) { throw null; }
+        public static System.Decimal Round(System.Decimal d, System.MidpointRounding mode) { throw null; }
+        public static System.Decimal Subtract(System.Decimal d1, System.Decimal d2) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
         System.DateTime System.IConvertible.ToDateTime(System.IFormatProvider provider) { throw null; }
-        decimal System.IConvertible.ToDecimal(System.IFormatProvider provider) { throw null; }
+        System.Decimal System.IConvertible.ToDecimal(System.IFormatProvider provider) { throw null; }
         double System.IConvertible.ToDouble(System.IFormatProvider provider) { throw null; }
         short System.IConvertible.ToInt16(System.IFormatProvider provider) { throw null; }
         int System.IConvertible.ToInt32(System.IFormatProvider provider) { throw null; }
@@ -999,38 +951,38 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider provider) { throw null; }
-        public static byte ToByte(decimal value) { throw null; }
-        public static double ToDouble(decimal d) { throw null; }
-        public static short ToInt16(decimal value) { throw null; }
-        public static int ToInt32(decimal d) { throw null; }
-        public static long ToInt64(decimal d) { throw null; }
-        public static long ToOACurrency(decimal value) { throw null; }
+        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
+        public static byte ToByte(System.Decimal value) { throw null; }
+        public static double ToDouble(System.Decimal d) { throw null; }
+        public static short ToInt16(System.Decimal value) { throw null; }
+        public static int ToInt32(System.Decimal d) { throw null; }
+        public static long ToInt64(System.Decimal d) { throw null; }
+        public static long ToOACurrency(System.Decimal value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static sbyte ToSByte(decimal value) { throw null; }
-        public static float ToSingle(decimal d) { throw null; }
+        public static sbyte ToSByte(System.Decimal value) { throw null; }
+        public static float ToSingle(System.Decimal d) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static ushort ToUInt16(decimal value) { throw null; }
+        public static ushort ToUInt16(System.Decimal value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static uint ToUInt32(decimal d) { throw null; }
+        public static uint ToUInt32(System.Decimal d) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static ulong ToUInt64(decimal d) { throw null; }
-        public static decimal Truncate(decimal d) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
-        public static bool TryParse(string s, out decimal result) { throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out decimal result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out decimal result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out decimal result) { throw null; }
+        public static ulong ToUInt64(System.Decimal d) { throw null; }
+        public static System.Decimal Truncate(System.Decimal d) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Decimal result) { result = default(decimal); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Decimal result) { result = default(decimal); throw null; }
+        public static bool TryParse(string s, out System.Decimal result) { result = default(decimal); throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Decimal result) { result = default(decimal); throw null; }
     }
     public abstract partial class Delegate : System.ICloneable, System.Runtime.Serialization.ISerializable
     {
         protected Delegate(object target, string method) { }
         protected Delegate(System.Type target, string method) { }
         public System.Reflection.MethodInfo Method { get { throw null; } }
-        internal Delegate() { }
         public object Target { get { throw null; } }
         public virtual object Clone() { throw null; }
         public static System.Delegate Combine(System.Delegate a, System.Delegate b) { throw null; }
@@ -1062,44 +1014,50 @@ namespace System
     public partial class DivideByZeroException : System.ArithmeticException
     {
         public DivideByZeroException() { }
+        protected DivideByZeroException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public DivideByZeroException(string message) { }
         public DivideByZeroException(string message, System.Exception innerException) { }
-        protected DivideByZeroException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Double : System.IComparable, System.IComparable<double>, System.IConvertible, System.IEquatable<double>, System.IFormattable
     {
-        public int CompareTo(double value) { throw null; }
-        public bool Equals(double obj) { throw null; }
+        //public const double Epsilon = 4.94065645841247E-324;
+        //public const double MaxValue = 1.7976931348623157E+308;
+        //public const double MinValue = -1.7976931348623157E+308;
+        //public const double NaN = 0.0 / 0.0;
+        //public const double NegativeInfinity = -1.0 / 0.0;
+        //public const double PositiveInfinity = 1.0 / 0.0;
+        public int CompareTo(System.Double value) { throw null; }
+        public int CompareTo(object value) { throw null; }
+        public bool Equals(System.Double obj) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static bool IsFinite(double d) { throw null; }
-        public static bool IsInfinity(double d) { throw null; }
-        public static bool IsNaN(double d) { throw null; }
-        public static bool IsNegative(double d) { throw null; }
-        public static bool IsNegativeInfinity(double d) { throw null; }
-        public static bool IsNormal(double d) { throw null; }
-        public static bool IsPositiveInfinity(double d) { throw null; }
-        public static bool IsSubnormal(double d) { throw null; }
-        public static bool operator ==(double left, double right) { throw null; }
-        public static bool operator >(double left, double right) { throw null; }
-        public static bool operator >=(double left, double right) { throw null; }
-        public static bool operator !=(double left, double right) { throw null; }
-        public static bool operator <(double left, double right) { throw null; }
-        public static bool operator <=(double left, double right) { throw null; }
-        public static double Parse(string s) { throw null; }
-        public static double Parse(string s, System.Globalization.NumberStyles style) { throw null; }
-        public static double Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        public static double Parse(string s, System.IFormatProvider provider) { throw null; }
-        public static double Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider provider = null) { throw null; }
-        public int CompareTo(object value) { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsFinite(System.Double d) { throw null; }
+        public static bool IsInfinity(System.Double d) { throw null; }
+        public static bool IsNaN(System.Double d) { throw null; }
+        public static bool IsNegative(System.Double d) { throw null; }
+        public static bool IsNegativeInfinity(System.Double d) { throw null; }
+        public static bool IsNormal(System.Double d) { throw null; }
+        public static bool IsPositiveInfinity(System.Double d) { throw null; }
+        public static bool IsSubnormal(System.Double d) { throw null; }
+        public static bool operator ==(System.Double left, System.Double right) { throw null; }
+        public static bool operator >(System.Double left, System.Double right) { throw null; }
+        public static bool operator >=(System.Double left, System.Double right) { throw null; }
+        public static bool operator !=(System.Double left, System.Double right) { throw null; }
+        public static bool operator <(System.Double left, System.Double right) { throw null; }
+        public static bool operator <=(System.Double left, System.Double right) { throw null; }
+        public static System.Double Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style=(System.Globalization.NumberStyles)(7), System.IFormatProvider provider=null) { throw null; }
+        public static System.Double Parse(string s) { throw null; }
+        public static System.Double Parse(string s, System.Globalization.NumberStyles style) { throw null; }
+        public static System.Double Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        public static System.Double Parse(string s, System.IFormatProvider provider) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
         System.DateTime System.IConvertible.ToDateTime(System.IFormatProvider provider) { throw null; }
         decimal System.IConvertible.ToDecimal(System.IFormatProvider provider) { throw null; }
-        double System.IConvertible.ToDouble(System.IFormatProvider provider) { throw null; }
+        System.Double System.IConvertible.ToDouble(System.IFormatProvider provider) { throw null; }
         short System.IConvertible.ToInt16(System.IFormatProvider provider) { throw null; }
         int System.IConvertible.ToInt32(System.IFormatProvider provider) { throw null; }
         long System.IConvertible.ToInt64(System.IFormatProvider provider) { throw null; }
@@ -1113,19 +1071,26 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
-        public static bool TryParse(string s, out double result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out double result) { throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out double result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out double result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Double result) { result = default(double); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Double result) { result = default(double); throw null; }
+        public static bool TryParse(string s, out System.Double result) { result = default(double); throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Double result) { result = default(double); throw null; }
     }
     public partial class DuplicateWaitObjectException : System.ArgumentException, System.Runtime.Serialization.ISerializable
     {
         public DuplicateWaitObjectException() { }
+        protected DuplicateWaitObjectException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public DuplicateWaitObjectException(string parameterName) { }
-        public DuplicateWaitObjectException(string parameterName, string message) { }
         public DuplicateWaitObjectException(string message, System.Exception innerException) { }
-        protected DuplicateWaitObjectException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+        public DuplicateWaitObjectException(string parameterName, string message) { }
+    }
+    public partial class EntryPointNotFoundException : System.TypeLoadException
+    {
+        public EntryPointNotFoundException() { }
+        protected EntryPointNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public EntryPointNotFoundException(string message) { }
+        public EntryPointNotFoundException(string message, System.Exception inner) { }
     }
     public abstract partial class Enum : System.ValueType, System.IComparable, System.IConvertible, System.IFormattable
     {
@@ -1136,15 +1101,15 @@ namespace System
         public override int GetHashCode() { throw null; }
         public static string GetName(System.Type enumType, object value) { throw null; }
         public static string[] GetNames(System.Type enumType) { throw null; }
-        public TypeCode GetTypeCode() { throw null; }
+        public System.TypeCode GetTypeCode() { throw null; }
         public static System.Type GetUnderlyingType(System.Type enumType) { throw null; }
         public static System.Array GetValues(System.Type enumType) { throw null; }
         public bool HasFlag(System.Enum flag) { throw null; }
         public static bool IsDefined(System.Type enumType, object value) { throw null; }
         public static object Parse(System.Type enumType, string value) { throw null; }
         public static object Parse(System.Type enumType, string value, bool ignoreCase) { throw null; }
-        public static TEnum Parse<TEnum>(String value) where TEnum : struct { throw null; }
-        public static TEnum Parse<TEnum>(String value, bool ignoreCase) where TEnum : struct { throw null; }
+        public static TEnum Parse<TEnum>(string value) where TEnum : struct { throw null; }
+        public static TEnum Parse<TEnum>(string value, bool ignoreCase) where TEnum : struct { throw null; }
         System.TypeCode System.IConvertible.GetTypeCode() { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
@@ -1161,29 +1126,29 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider provider) { throw null; }
-        public static object ToObject(System.Type enumType, object value) { throw null; }
-        public static object ToObject(System.Type enumType, int value) { throw null; }
-        public static object ToObject(System.Type enumType, long value) { throw null; }
         public static object ToObject(System.Type enumType, byte value) { throw null; }
         public static object ToObject(System.Type enumType, short value) { throw null; }
-        [CLSCompliant(false)]
-        public static object ToObject(System.Type enumType, uint value) { throw null; }
-        [CLSCompliant(false)]
-        public static object ToObject(System.Type enumType, ulong value) { throw null; }
-        [CLSCompliant(false)]
+        public static object ToObject(System.Type enumType, int value) { throw null; }
+        public static object ToObject(System.Type enumType, long value) { throw null; }
+        public static object ToObject(System.Type enumType, object value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
         public static object ToObject(System.Type enumType, sbyte value) { throw null; }
-        [CLSCompliant(false)]
+        [System.CLSCompliantAttribute(false)]
         public static object ToObject(System.Type enumType, ushort value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static object ToObject(System.Type enumType, uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static object ToObject(System.Type enumType, ulong value) { throw null; }
         public override string ToString() { throw null; }
-        public string ToString(string format) { throw null; }
         [System.ObsoleteAttribute("The provider argument is not used. Please use ToString().")]
         public string ToString(System.IFormatProvider provider) { throw null; }
+        public string ToString(string format) { throw null; }
         [System.ObsoleteAttribute("The provider argument is not used. Please use ToString(String).")]
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public static bool TryParse(System.Type enumType, string value, out object result) { throw null; }
-        public static bool TryParse(System.Type enumType, string value, bool ignoreCase, out object result) { throw null; }
-        public static bool TryParse<TEnum>(string value, out TEnum result) where TEnum : struct { throw null; }
-        public static bool TryParse<TEnum>(string value, bool ignoreCase, out TEnum result) where TEnum : struct { throw null; }
+        public static bool TryParse(System.Type enumType, string value, bool ignoreCase, out object result) { result = default(object); throw null; }
+        public static bool TryParse(System.Type enumType, string value, out object result) { result = default(object); throw null; }
+        public static bool TryParse<TEnum>(string value, bool ignoreCase, out TEnum result) where TEnum : struct { result = default(TEnum); throw null; }
+        public static bool TryParse<TEnum>(string value, out TEnum result) where TEnum : struct { result = default(TEnum); throw null; }
     }
     public partial class EventArgs
     {
@@ -1195,11 +1160,10 @@ namespace System
     public partial class Exception : System.Runtime.Serialization.ISerializable
     {
         public Exception() { }
+        protected Exception(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public Exception(string message) { }
         public Exception(string message, System.Exception innerException) { }
-        protected Exception(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual System.Collections.IDictionary Data { get { throw null; } }
-        public new Type GetType() { throw null; }
         public virtual string HelpLink { get { throw null; } set { } }
         public int HResult { get { throw null; } protected set { } }
         public System.Exception InnerException { get { throw null; } }
@@ -1210,16 +1174,28 @@ namespace System
         protected event System.EventHandler<System.Runtime.Serialization.SafeSerializationEventArgs> SerializeObjectState { add { } remove { } }
         public virtual System.Exception GetBaseException() { throw null; }
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public new System.Type GetType() { throw null; }
         public override string ToString() { throw null; }
+    }
+    [System.ObsoleteAttribute("This type previously indicated an unspecified fatal error in the runtime. The runtime no longer raises this exception so this type is obsolete.")]
+    public sealed partial class ExecutionEngineException : System.SystemException
+    {
+        public ExecutionEngineException() { }
+        public ExecutionEngineException(string message) { }
+        public ExecutionEngineException(string message, System.Exception innerException) { }
     }
     public partial class FieldAccessException : System.MemberAccessException
     {
         public FieldAccessException() { }
+        protected FieldAccessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public FieldAccessException(string message) { }
         public FieldAccessException(string message, System.Exception inner) { }
-        protected FieldAccessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(16), Inherited = false)]
+    public partial class FileStyleUriParser : System.UriParser
+    {
+        public FileStyleUriParser() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(16), Inherited=false)]
     public partial class FlagsAttribute : System.Attribute
     {
         public FlagsAttribute() { }
@@ -1227,9 +1203,9 @@ namespace System
     public partial class FormatException : System.SystemException
     {
         public FormatException() { }
+        protected FormatException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public FormatException(string message) { }
         public FormatException(string message, System.Exception innerException) { }
-        protected FormatException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public abstract partial class FormattableString : System.IFormattable
     {
@@ -1242,6 +1218,10 @@ namespace System
         string System.IFormattable.ToString(string ignored, System.IFormatProvider formatProvider) { throw null; }
         public override string ToString() { throw null; }
         public abstract string ToString(System.IFormatProvider formatProvider);
+    }
+    public partial class FtpStyleUriParser : System.UriParser
+    {
+        public FtpStyleUriParser() { }
     }
     public delegate TResult Func<out TResult>();
     public delegate TResult Func<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, out TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9);
@@ -1272,6 +1252,7 @@ namespace System
         public static void Collect(int generation, System.GCCollectionMode mode, bool blocking, bool compacting) { }
         public static int CollectionCount(int generation) { throw null; }
         public static void EndNoGCRegion() { }
+        public static long GetAllocatedBytesForCurrentThread() { throw null; }
         public static int GetGeneration(object obj) { throw null; }
         public static int GetGeneration(System.WeakReference wo) { throw null; }
         public static long GetTotalMemory(bool forceFullCollection) { throw null; }
@@ -1289,7 +1270,6 @@ namespace System
         public static System.GCNotificationStatus WaitForFullGCComplete() { throw null; }
         public static System.GCNotificationStatus WaitForFullGCComplete(int millisecondsTimeout) { throw null; }
         public static void WaitForPendingFinalizers() { }
-        public static long GetAllocatedBytesForCurrentThread() { throw null; }
     }
     public enum GCCollectionMode
     {
@@ -1305,39 +1285,90 @@ namespace System
         Succeeded = 0,
         Timeout = 3,
     }
+    public partial class GenericUriParser : System.UriParser
+    {
+        public GenericUriParser(System.GenericUriParserOptions options) { }
+    }
+    [System.FlagsAttribute]
+    public enum GenericUriParserOptions
+    {
+        AllowEmptyAuthority = 2,
+        Default = 0,
+        DontCompressPath = 128,
+        DontConvertPathBackslashes = 64,
+        DontUnescapePathDotsAndSlashes = 256,
+        GenericAuthority = 1,
+        Idn = 512,
+        IriParsing = 1024,
+        NoFragment = 32,
+        NoPort = 8,
+        NoQuery = 16,
+        NoUserInfo = 4,
+    }
+    public partial class GopherStyleUriParser : System.UriParser
+    {
+        public GopherStyleUriParser() { }
+    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.IFormattable
     {
         public static readonly System.Guid Empty;
-        public Guid(byte[] b) { throw null; }
-        public Guid(ReadOnlySpan<byte> b) { throw null; }
-        public Guid(int a, short b, short c, byte d, byte e, byte f, byte g, byte h, byte i, byte j, byte k) { throw null; }
-        public Guid(int a, short b, short c, byte[] d) { throw null; }
-        public Guid(string g) { throw null; }
+        public Guid(byte[] b) { throw null;}
+        public Guid(int a, short b, short c, byte d, byte e, byte f, byte g, byte h, byte i, byte j, byte k) { throw null;}
+        public Guid(int a, short b, short c, byte[] d) { throw null;}
+        public Guid(System.ReadOnlySpan<byte> b) { throw null;}
+        public Guid(string g) { throw null;}
         [System.CLSCompliantAttribute(false)]
-        public Guid(uint a, ushort b, ushort c, byte d, byte e, byte f, byte g, byte h, byte i, byte j, byte k) { throw null; }
-        public int CompareTo(object value) { throw null; }
+        public Guid(uint a, ushort b, ushort c, byte d, byte e, byte f, byte g, byte h, byte i, byte j, byte k) { throw null;}
         public int CompareTo(System.Guid value) { throw null; }
+        public int CompareTo(object value) { throw null; }
         public bool Equals(System.Guid g) { throw null; }
         public override bool Equals(object o) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Guid NewGuid() { throw null; }
         public static bool operator ==(System.Guid a, System.Guid b) { throw null; }
         public static bool operator !=(System.Guid a, System.Guid b) { throw null; }
-        public static System.Guid Parse(string input) { throw null; }
         public static System.Guid Parse(System.ReadOnlySpan<char> input) { throw null; }
-        public static System.Guid ParseExact(string input, string format) { throw null; }
+        public static System.Guid Parse(string input) { throw null; }
         public static System.Guid ParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format) { throw null; }
+        public static System.Guid ParseExact(string input, string format) { throw null; }
         public byte[] ToByteArray() { throw null; }
-        public bool TryWriteBytes(Span<byte> destination) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default) { throw null; }
-        public static bool TryParse(string input, out System.Guid result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> input, out System.Guid result) { throw null; }
-        public static bool TryParseExact(string input, string format, out System.Guid result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, out System.Guid result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>)) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, out System.Guid result) { result = default(System.Guid); throw null; }
+        public static bool TryParse(string input, out System.Guid result) { result = default(System.Guid); throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, out System.Guid result) { result = default(System.Guid); throw null; }
+        public static bool TryParseExact(string input, string format, out System.Guid result) { result = default(System.Guid); throw null; }
+        public bool TryWriteBytes(System.Span<byte> destination) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+    public partial struct HashCode
+    {
+        public void Add<T>(T value) { }
+        public void Add<T>(T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public static int Combine<T1>(T1 value1) { throw null; }
+        public static int Combine<T1, T2>(T1 value1, T2 value2) { throw null; }
+        public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3) { throw null; }
+        public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4) { throw null; }
+        public static int Combine<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) { throw null; }
+        public static int Combine<T1, T2, T3, T4, T5, T6>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) { throw null; }
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7) { throw null; }
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8) { throw null; }
+#pragma warning disable 0809
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.ObsoleteAttribute("HashCode is a mutable struct and should not be compared with other HashCodes.", true)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.ObsoleteAttribute("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", true)]
+        public override int GetHashCode() { throw null; }
+#pragma warning restore 0809
+        public int ToHashCode() { throw null; }
+    }
+    public partial class HttpStyleUriParser : System.UriParser
+    {
+        public HttpStyleUriParser() { }
     }
     public partial interface IAsyncResult
     {
@@ -1422,24 +1453,24 @@ namespace System
     {
         public const short MaxValue = (short)32767;
         public const short MinValue = (short)-32768;
-        public int CompareTo(short value) { throw null; }
-        public bool Equals(short obj) { throw null; }
+        public int CompareTo(System.Int16 value) { throw null; }
+        public int CompareTo(object value) { throw null; }
+        public bool Equals(System.Int16 obj) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static short Parse(string s) { throw null; }
-        public static short Parse(string s, System.Globalization.NumberStyles style) { throw null; }
-        public static short Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        public static short Parse(string s, System.IFormatProvider provider) { throw null; }
-        public static short Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider provider = null) { throw null; }
-        public int CompareTo(object value) { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static System.Int16 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style=(System.Globalization.NumberStyles)(7), System.IFormatProvider provider=null) { throw null; }
+        public static System.Int16 Parse(string s) { throw null; }
+        public static System.Int16 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
+        public static System.Int16 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        public static System.Int16 Parse(string s, System.IFormatProvider provider) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
         System.DateTime System.IConvertible.ToDateTime(System.IFormatProvider provider) { throw null; }
         decimal System.IConvertible.ToDecimal(System.IFormatProvider provider) { throw null; }
         double System.IConvertible.ToDouble(System.IFormatProvider provider) { throw null; }
-        short System.IConvertible.ToInt16(System.IFormatProvider provider) { throw null; }
+        System.Int16 System.IConvertible.ToInt16(System.IFormatProvider provider) { throw null; }
         int System.IConvertible.ToInt32(System.IFormatProvider provider) { throw null; }
         long System.IConvertible.ToInt64(System.IFormatProvider provider) { throw null; }
         sbyte System.IConvertible.ToSByte(System.IFormatProvider provider) { throw null; }
@@ -1452,28 +1483,28 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out short result) { throw null; }
-        public static bool TryParse(string s, out short result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out short result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out short result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int16 result) { result = default(short); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int16 result) { result = default(short); throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int16 result) { result = default(short); throw null; }
+        public static bool TryParse(string s, out System.Int16 result) { result = default(short); throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Int32 : System.IComparable, System.IComparable<int>, System.IConvertible, System.IEquatable<int>, System.IFormattable
     {
         public const int MaxValue = 2147483647;
         public const int MinValue = -2147483648;
-        public int CompareTo(int value) { throw null; }
-        public bool Equals(int obj) { throw null; }
+        public System.Int32 CompareTo(System.Int32 value) { throw null; }
+        public System.Int32 CompareTo(object value) { throw null; }
+        public bool Equals(System.Int32 obj) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static int Parse(string s) { throw null; }
-        public static int Parse(string s, System.Globalization.NumberStyles style) { throw null; }
-        public static int Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        public static int Parse(string s, System.IFormatProvider provider) { throw null; }
-        public static int Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider provider = null) { throw null; }
-        public int CompareTo(object value) { throw null; }
+        public override System.Int32 GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static System.Int32 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style=(System.Globalization.NumberStyles)(7), System.IFormatProvider provider=null) { throw null; }
+        public static System.Int32 Parse(string s) { throw null; }
+        public static System.Int32 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
+        public static System.Int32 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        public static System.Int32 Parse(string s, System.IFormatProvider provider) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
@@ -1481,7 +1512,7 @@ namespace System
         decimal System.IConvertible.ToDecimal(System.IFormatProvider provider) { throw null; }
         double System.IConvertible.ToDouble(System.IFormatProvider provider) { throw null; }
         short System.IConvertible.ToInt16(System.IFormatProvider provider) { throw null; }
-        int System.IConvertible.ToInt32(System.IFormatProvider provider) { throw null; }
+        System.Int32 System.IConvertible.ToInt32(System.IFormatProvider provider) { throw null; }
         long System.IConvertible.ToInt64(System.IFormatProvider provider) { throw null; }
         sbyte System.IConvertible.ToSByte(System.IFormatProvider provider) { throw null; }
         float System.IConvertible.ToSingle(System.IFormatProvider provider) { throw null; }
@@ -1493,28 +1524,28 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out int result) { throw null; }
-        public static bool TryParse(string s, out int result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out int result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out int result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out System.Int32 charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int32 result) { result = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int32 result) { result = default(int); throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int32 result) { result = default(int); throw null; }
+        public static bool TryParse(string s, out System.Int32 result) { result = default(int); throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Int64 : System.IComparable, System.IComparable<long>, System.IConvertible, System.IEquatable<long>, System.IFormattable
     {
         public const long MaxValue = (long)9223372036854775807;
         public const long MinValue = (long)-9223372036854775808;
-        public int CompareTo(long value) { throw null; }
-        public bool Equals(long obj) { throw null; }
+        public int CompareTo(System.Int64 value) { throw null; }
+        public int CompareTo(object value) { throw null; }
+        public bool Equals(System.Int64 obj) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static long Parse(string s) { throw null; }
-        public static long Parse(string s, System.Globalization.NumberStyles style) { throw null; }
-        public static long Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        public static long Parse(string s, System.IFormatProvider provider) { throw null; }
-        public static long Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider provider = null) { throw null; }
-        public int CompareTo(object value) { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static System.Int64 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style=(System.Globalization.NumberStyles)(7), System.IFormatProvider provider=null) { throw null; }
+        public static System.Int64 Parse(string s) { throw null; }
+        public static System.Int64 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
+        public static System.Int64 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        public static System.Int64 Parse(string s, System.IFormatProvider provider) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
@@ -1523,7 +1554,7 @@ namespace System
         double System.IConvertible.ToDouble(System.IFormatProvider provider) { throw null; }
         short System.IConvertible.ToInt16(System.IFormatProvider provider) { throw null; }
         int System.IConvertible.ToInt32(System.IFormatProvider provider) { throw null; }
-        long System.IConvertible.ToInt64(System.IFormatProvider provider) { throw null; }
+        System.Int64 System.IConvertible.ToInt64(System.IFormatProvider provider) { throw null; }
         sbyte System.IConvertible.ToSByte(System.IFormatProvider provider) { throw null; }
         float System.IConvertible.ToSingle(System.IFormatProvider provider) { throw null; }
         object System.IConvertible.ToType(System.Type type, System.IFormatProvider provider) { throw null; }
@@ -1534,39 +1565,39 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out long result) { throw null; }
-        public static bool TryParse(string s, out long result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out long result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out long result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int64 result) { result = default(long); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int64 result) { result = default(long); throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Int64 result) { result = default(long); throw null; }
+        public static bool TryParse(string s, out System.Int64 result) { result = default(long); throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct IntPtr : System.Runtime.Serialization.ISerializable, IEquatable<IntPtr>
+    public partial struct IntPtr : System.IEquatable<System.IntPtr>, System.Runtime.Serialization.ISerializable
     {
         public static readonly System.IntPtr Zero;
-        public IntPtr(int value) { throw null; }
-        public IntPtr(long value) { throw null; }
+        public IntPtr(int value) { throw null;}
+        public IntPtr(long value) { throw null;}
         [System.CLSCompliantAttribute(false)]
-        public unsafe IntPtr(void* value) { throw null; }
+        public unsafe IntPtr(void* value) { throw null;}
         public static int Size { get { throw null; } }
         public static System.IntPtr Add(System.IntPtr pointer, int offset) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        bool IEquatable<IntPtr>.Equals(IntPtr other) { throw null; }
         public override int GetHashCode() { throw null; }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public static System.IntPtr operator +(System.IntPtr pointer, int offset) { throw null; }
         public static bool operator ==(System.IntPtr value1, System.IntPtr value2) { throw null; }
-        public static explicit operator System.IntPtr(int value) { throw null; }
-        public static explicit operator System.IntPtr(long value) { throw null; }
-        public static explicit operator int(System.IntPtr value) { throw null; }
-        public static explicit operator long(System.IntPtr value) { throw null; }
+        public static explicit operator System.IntPtr (int value) { throw null; }
+        public static explicit operator System.IntPtr (long value) { throw null; }
+        public static explicit operator int (System.IntPtr value) { throw null; }
+        public static explicit operator long (System.IntPtr value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static unsafe explicit operator void* (System.IntPtr value) { throw null; }
+        public unsafe static explicit operator void* (System.IntPtr value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static unsafe explicit operator System.IntPtr(void* value) { throw null; }
+        public unsafe static explicit operator System.IntPtr (void* value) { throw null; }
         public static bool operator !=(System.IntPtr value1, System.IntPtr value2) { throw null; }
         public static System.IntPtr operator -(System.IntPtr pointer, int offset) { throw null; }
         public static System.IntPtr Subtract(System.IntPtr pointer, int offset) { throw null; }
+        bool System.IEquatable<System.IntPtr>.Equals(System.IntPtr other) { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public int ToInt32() { throw null; }
         public long ToInt64() { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -1577,17 +1608,17 @@ namespace System
     public partial class InvalidCastException : System.SystemException
     {
         public InvalidCastException() { }
+        protected InvalidCastException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public InvalidCastException(string message) { }
         public InvalidCastException(string message, System.Exception innerException) { }
         public InvalidCastException(string message, int errorCode) { }
-        protected InvalidCastException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public partial class InvalidOperationException : System.SystemException
     {
         public InvalidOperationException() { }
+        protected InvalidOperationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public InvalidOperationException(string message) { }
         public InvalidOperationException(string message, System.Exception innerException) { }
-        protected InvalidOperationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public sealed partial class InvalidProgramException : System.SystemException
     {
@@ -1598,9 +1629,9 @@ namespace System
     public partial class InvalidTimeZoneException : System.Exception
     {
         public InvalidTimeZoneException() { }
+        protected InvalidTimeZoneException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public InvalidTimeZoneException(string message) { }
         public InvalidTimeZoneException(string message, System.Exception innerException) { }
-        protected InvalidTimeZoneException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public partial interface IObservable<out T>
     {
@@ -1619,15 +1650,29 @@ namespace System
     public partial class Lazy<T>
     {
         public Lazy() { }
-        public Lazy(T value) { }
         public Lazy(bool isThreadSafe) { }
         public Lazy(System.Func<T> valueFactory) { }
         public Lazy(System.Func<T> valueFactory, bool isThreadSafe) { }
         public Lazy(System.Func<T> valueFactory, System.Threading.LazyThreadSafetyMode mode) { }
         public Lazy(System.Threading.LazyThreadSafetyMode mode) { }
+        public Lazy(T value) { }
         public bool IsValueCreated { get { throw null; } }
         public T Value { get { throw null; } }
         public override string ToString() { throw null; }
+    }
+    public partial class Lazy<T, TMetadata> : System.Lazy<T>
+    {
+        public Lazy(System.Func<T> valueFactory, TMetadata metadata) { }
+        public Lazy(System.Func<T> valueFactory, TMetadata metadata, bool isThreadSafe) { }
+        public Lazy(System.Func<T> valueFactory, TMetadata metadata, System.Threading.LazyThreadSafetyMode mode) { }
+        public Lazy(TMetadata metadata) { }
+        public Lazy(TMetadata metadata, bool isThreadSafe) { }
+        public Lazy(TMetadata metadata, System.Threading.LazyThreadSafetyMode mode) { }
+        public TMetadata Metadata { get { throw null; } }
+    }
+    public partial class LdapStyleUriParser : System.UriParser
+    {
+        public LdapStyleUriParser() { }
     }
     public abstract partial class MarshalByRefObject
     {
@@ -1636,66 +1681,57 @@ namespace System
         public virtual object InitializeLifetimeService() { throw null; }
         protected System.MarshalByRefObject MemberwiseClone(bool cloneIdentity) { throw null; }
     }
-    public partial class Lazy<T, TMetadata> : System.Lazy<T>
-    {
-        public Lazy(TMetadata metadata) { }
-        public Lazy(TMetadata metadata, bool isThreadSafe) { }
-        public Lazy(TMetadata metadata, System.Threading.LazyThreadSafetyMode mode) { }
-        public Lazy(System.Func<T> valueFactory, TMetadata metadata) { }
-        public Lazy(System.Func<T> valueFactory, TMetadata metadata, bool isThreadSafe) { }
-        public Lazy(System.Func<T> valueFactory, TMetadata metadata, System.Threading.LazyThreadSafetyMode mode) { }
-        public TMetadata Metadata { get { throw null; } }
-    }
     public partial class MemberAccessException : System.SystemException
     {
         public MemberAccessException() { }
+        protected MemberAccessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public MemberAccessException(string message) { }
         public MemberAccessException(string message, System.Exception inner) { }
-        protected MemberAccessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
-    public readonly struct Memory<T>
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+    public readonly partial struct Memory<T>
     {
-        public static Memory<T> Empty { get { throw null; } }
-        public Memory(T[] array) { throw null; }
-        public Memory(T[] array, int start, int length) { throw null; }
+        public Memory(T[] array) { throw null;}
+        public Memory(T[] array, int start, int length) { throw null;}
+        public static System.Memory<T> Empty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public int Length { get { throw null; } }
-        public void CopyTo(Memory<T> destination) { }
-        public bool TryCopyTo(Memory<T> destination) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public System.Span<T> Span { get { throw null; } }
+        public void CopyTo(System.Memory<T> destination) { }
+        public bool Equals(System.Memory<T> other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(Memory<T> other) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public override int GetHashCode() { throw null; }
-        public static implicit operator Memory<T>(T[] array) { throw null; }
-        public static implicit operator Memory<T>(ArraySegment<T> arraySegment) { throw null; }
-        public static implicit operator ReadOnlyMemory<T>(Memory<T> memory) { throw null; }
-        public Memory<T> Slice(int start) { throw null; }
-        public Memory<T> Slice(int start, int length) { throw null; }
-        public Span<T> Span { get { throw null; } }
-        public unsafe Buffers.MemoryHandle Retain(bool pin = false) { throw null; }
+        public static implicit operator System.Memory<T> (System.ArraySegment<T> arraySegment) { throw null; }
+        public static implicit operator System.ReadOnlyMemory<T> (System.Memory<T> memory) { throw null; }
+        public static implicit operator System.Memory<T> (T[] array) { throw null; }
+        public System.Buffers.MemoryHandle Retain(bool pin=false) { throw null; }
+        public System.Memory<T> Slice(int start) { throw null; }
+        public System.Memory<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
-        public bool TryGetArray(out ArraySegment<T> arraySegment) { throw null; }
+        public bool TryCopyTo(System.Memory<T> destination) { throw null; }
+        public bool TryGetArray(out System.ArraySegment<T> arraySegment) { arraySegment = default(System.ArraySegment<T>); throw null; }
     }
     public partial class MethodAccessException : System.MemberAccessException
     {
         public MethodAccessException() { }
+        protected MethodAccessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public MethodAccessException(string message) { }
         public MethodAccessException(string message, System.Exception inner) { }
-        protected MethodAccessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public enum MidpointRounding
     {
-        ToEven,
-        AwayFromZero,
+        AwayFromZero = 1,
+        ToEven = 0,
     }
     public partial class MissingFieldException : System.MissingMemberException, System.Runtime.Serialization.ISerializable
     {
         public MissingFieldException() { }
+        protected MissingFieldException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public MissingFieldException(string message) { }
-        public MissingFieldException(string className, string fieldName) { }
         public MissingFieldException(string message, System.Exception inner) { }
-        protected MissingFieldException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+        public MissingFieldException(string className, string fieldName) { }
         public override string Message { get { throw null; } }
     }
     public partial class MissingMemberException : System.MemberAccessException, System.Runtime.Serialization.ISerializable
@@ -1704,40 +1740,41 @@ namespace System
         protected string MemberName;
         protected byte[] Signature;
         public MissingMemberException() { }
+        protected MissingMemberException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public MissingMemberException(string message) { }
-        public MissingMemberException(string className, string memberName) { }
         public MissingMemberException(string message, System.Exception inner) { }
-        protected MissingMemberException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+        public MissingMemberException(string className, string memberName) { }
         public override string Message { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public partial class MissingMethodException : System.MissingMemberException, System.Runtime.Serialization.ISerializable
     {
         public MissingMethodException() { }
+        protected MissingMethodException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public MissingMethodException(string message) { }
-        public MissingMethodException(string className, string methodName) { }
         public MissingMethodException(string message, System.Exception inner) { }
-        protected MissingMethodException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+        public MissingMethodException(string className, string methodName) { }
         public override string Message { get { throw null; } }
     }
-    public unsafe struct ModuleHandle
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+    public partial struct ModuleHandle
     {
         public static readonly System.ModuleHandle EmptyHandle;
         public int MDStreamVersion { get { throw null; } }
-        public override int GetHashCode() { throw null; }
+        public bool Equals(System.ModuleHandle handle) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public unsafe bool Equals(System.ModuleHandle handle) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public System.RuntimeFieldHandle GetRuntimeFieldHandleFromMetadataToken(int fieldToken) { throw null; }
+        public System.RuntimeMethodHandle GetRuntimeMethodHandleFromMetadataToken(int methodToken) { throw null; }
+        public System.RuntimeTypeHandle GetRuntimeTypeHandleFromMetadataToken(int typeToken) { throw null; }
         public static bool operator ==(System.ModuleHandle left, System.ModuleHandle right) { throw null; }
         public static bool operator !=(System.ModuleHandle left, System.ModuleHandle right) { throw null; }
-        public System.RuntimeTypeHandle GetRuntimeTypeHandleFromMetadataToken(int typeToken) { throw null; }
-        public System.RuntimeTypeHandle ResolveTypeHandle(int typeToken) { throw null; }
-        public System.RuntimeTypeHandle ResolveTypeHandle(int typeToken, System.RuntimeTypeHandle[] typeInstantiationContext, System.RuntimeTypeHandle[] methodInstantiationContext) { throw null; }
-        public System.RuntimeMethodHandle GetRuntimeMethodHandleFromMetadataToken(int methodToken) { throw null; }
-        public System.RuntimeMethodHandle ResolveMethodHandle(int methodToken) { throw null; }
-        public System.RuntimeMethodHandle ResolveMethodHandle(int methodToken, System.RuntimeTypeHandle[] typeInstantiationContext, System.RuntimeTypeHandle[] methodInstantiationContext) { throw null; }
-        public System.RuntimeFieldHandle GetRuntimeFieldHandleFromMetadataToken(int fieldToken) { throw null; }
         public System.RuntimeFieldHandle ResolveFieldHandle(int fieldToken) { throw null; }
         public System.RuntimeFieldHandle ResolveFieldHandle(int fieldToken, System.RuntimeTypeHandle[] typeInstantiationContext, System.RuntimeTypeHandle[] methodInstantiationContext) { throw null; }
+        public System.RuntimeMethodHandle ResolveMethodHandle(int methodToken) { throw null; }
+        public System.RuntimeMethodHandle ResolveMethodHandle(int methodToken, System.RuntimeTypeHandle[] typeInstantiationContext, System.RuntimeTypeHandle[] methodInstantiationContext) { throw null; }
+        public System.RuntimeTypeHandle ResolveTypeHandle(int typeToken) { throw null; }
+        public System.RuntimeTypeHandle ResolveTypeHandle(int typeToken, System.RuntimeTypeHandle[] typeInstantiationContext, System.RuntimeTypeHandle[] methodInstantiationContext) { throw null; }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(64))]
     public sealed partial class MTAThreadAttribute : System.Attribute
@@ -1746,9 +1783,8 @@ namespace System
     }
     public abstract partial class MulticastDelegate : System.Delegate
     {
-        internal MulticastDelegate() { }
-        protected MulticastDelegate(object target, string method) : base(default(object), default(string)) { }
-        protected MulticastDelegate(System.Type target, string method) : base(default(object), default(string)) { }
+        protected MulticastDelegate(object target, string method) : base (default(object), default(string)) { }
+        protected MulticastDelegate(System.Type target, string method) : base (default(object), default(string)) { }
         protected sealed override System.Delegate CombineImpl(System.Delegate follow) { throw null; }
         public sealed override bool Equals(object obj) { throw null; }
         public sealed override int GetHashCode() { throw null; }
@@ -1765,26 +1801,48 @@ namespace System
         public MulticastNotSupportedException(string message) { }
         public MulticastNotSupportedException(string message, System.Exception inner) { }
     }
-    [AttributeUsage(AttributeTargets.Field, Inherited = false)]
-    public sealed class NonSerializedAttribute : Attribute
+    public partial class NetPipeStyleUriParser : System.UriParser
     {
-        public NonSerializedAttribute()
-        {
-        }
+        public NetPipeStyleUriParser() { }
+    }
+    public partial class NetTcpStyleUriParser : System.UriParser
+    {
+        public NetTcpStyleUriParser() { }
+    }
+    public partial class NewsStyleUriParser : System.UriParser
+    {
+        public NewsStyleUriParser() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(256), Inherited=false)]
+    public sealed partial class NonSerializedAttribute : System.Attribute
+    {
+        public NonSerializedAttribute() { }
+    }
+    public partial class NotFiniteNumberException : System.ArithmeticException
+    {
+        public NotFiniteNumberException() { }
+        public NotFiniteNumberException(double offendingNumber) { }
+        protected NotFiniteNumberException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public NotFiniteNumberException(string message) { }
+        public NotFiniteNumberException(string message, double offendingNumber) { }
+        public NotFiniteNumberException(string message, double offendingNumber, System.Exception innerException) { }
+        public NotFiniteNumberException(string message, System.Exception innerException) { }
+        public double OffendingNumber { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public partial class NotImplementedException : System.SystemException
     {
         public NotImplementedException() { }
+        protected NotImplementedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public NotImplementedException(string message) { }
         public NotImplementedException(string message, System.Exception inner) { }
-        protected NotImplementedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public partial class NotSupportedException : System.SystemException
     {
         public NotSupportedException() { }
+        protected NotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public NotSupportedException(string message) { }
         public NotSupportedException(string message, System.Exception innerException) { }
-        protected NotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public static partial class Nullable
     {
@@ -1795,47 +1853,47 @@ namespace System
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Nullable<T> where T : struct
     {
-        public Nullable(T value) { throw null; }
+        public Nullable(T value) { throw null;}
         public bool HasValue { get { throw null; } }
         public T Value { get { throw null; } }
         public override bool Equals(object other) { throw null; }
         public override int GetHashCode() { throw null; }
         public T GetValueOrDefault() { throw null; }
         public T GetValueOrDefault(T defaultValue) { throw null; }
-        public static explicit operator T(System.Nullable<T> value) { throw null; }
-        public static implicit operator System.Nullable<T>(T value) { throw null; }
+        public static explicit operator T (System.Nullable<T> value) { throw null; }
+        public static implicit operator System.Nullable<T> (T value) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class NullReferenceException : System.SystemException
     {
         public NullReferenceException() { }
+        protected NullReferenceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public NullReferenceException(string message) { }
         public NullReferenceException(string message, System.Exception innerException) { }
-        protected NullReferenceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public partial class Object
     {
         public Object() { }
-        public virtual bool Equals(object obj) { throw null; }
-        public static bool Equals(object objA, object objB) { throw null; }
+        public virtual bool Equals(System.Object obj) { throw null; }
+        public static bool Equals(System.Object objA, System.Object objB) { throw null; }
         ~Object() { }
         public virtual int GetHashCode() { throw null; }
         public System.Type GetType() { throw null; }
-        protected object MemberwiseClone() { throw null; }
-        public static bool ReferenceEquals(object objA, object objB) { throw null; }
+        protected System.Object MemberwiseClone() { throw null; }
+        public static bool ReferenceEquals(System.Object objA, System.Object objB) { throw null; }
         public virtual string ToString() { throw null; }
     }
     public partial class ObjectDisposedException : System.InvalidOperationException
     {
+        protected ObjectDisposedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ObjectDisposedException(string objectName) { }
         public ObjectDisposedException(string message, System.Exception innerException) { }
         public ObjectDisposedException(string objectName, string message) { }
-        protected ObjectDisposedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public override string Message { get { throw null; } }
         public string ObjectName { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(6140), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(6140), Inherited=false)]
     public sealed partial class ObsoleteAttribute : System.Attribute
     {
         public ObsoleteAttribute() { }
@@ -1847,18 +1905,18 @@ namespace System
     public partial class OutOfMemoryException : System.SystemException
     {
         public OutOfMemoryException() { }
+        protected OutOfMemoryException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public OutOfMemoryException(string message) { }
         public OutOfMemoryException(string message, System.Exception innerException) { }
-        protected OutOfMemoryException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public partial class OverflowException : System.ArithmeticException
     {
         public OverflowException() { }
+        protected OverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public OverflowException(string message) { }
         public OverflowException(string message, System.Exception innerException) { }
-        protected OverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited = true, AllowMultiple = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=true, AllowMultiple=false)]
     public sealed partial class ParamArrayAttribute : System.Attribute
     {
         public ParamArrayAttribute() { }
@@ -1866,75 +1924,77 @@ namespace System
     public partial class PlatformNotSupportedException : System.NotSupportedException
     {
         public PlatformNotSupportedException() { }
+        protected PlatformNotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public PlatformNotSupportedException(string message) { }
         public PlatformNotSupportedException(string message, System.Exception inner) { }
-        protected PlatformNotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public delegate bool Predicate<in T>(T obj);
     public partial class RankException : System.SystemException
     {
         public RankException() { }
+        protected RankException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public RankException(string message) { }
         public RankException(string message, System.Exception innerException) { }
-        protected RankException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
-    public readonly struct ReadOnlyMemory<T>
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+    public readonly partial struct ReadOnlyMemory<T>
     {
-        public static ReadOnlyMemory<T> Empty { get { throw null; } }
-        public ReadOnlyMemory(T[] array) { throw null; }
-        public ReadOnlyMemory(T[] array, int start, int length) { throw null; }
+        public ReadOnlyMemory(T[] array) { throw null;}
+        public ReadOnlyMemory(T[] array, int start, int length) { throw null;}
+        public static System.ReadOnlyMemory<T> Empty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public int Length { get { throw null; } }
-        public void CopyTo(Memory<T> destination) { }
-        public bool TryCopyTo(Memory<T> destination) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public System.ReadOnlySpan<T> Span { get { throw null; } }
+        public void CopyTo(System.Memory<T> destination) { }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(ReadOnlyMemory<T> other) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public bool Equals(System.ReadOnlyMemory<T> other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public override int GetHashCode() { throw null; }
-        public static implicit operator ReadOnlyMemory<T>(T[] array) { throw null; }
-        public static implicit operator ReadOnlyMemory<T>(ArraySegment<T> arraySegment) { throw null; }
-        public ReadOnlyMemory<T> Slice(int start) { throw null; }
-        public ReadOnlyMemory<T> Slice(int start, int length) { throw null; }
-        public ReadOnlySpan<T> Span { get { throw null; } }
-        public unsafe Buffers.MemoryHandle Retain(bool pin = false) { throw null; }
+        public static implicit operator System.ReadOnlyMemory<T> (System.ArraySegment<T> arraySegment) { throw null; }
+        public static implicit operator System.ReadOnlyMemory<T> (T[] array) { throw null; }
+        public System.Buffers.MemoryHandle Retain(bool pin=false) { throw null; }
+        public System.ReadOnlyMemory<T> Slice(int start) { throw null; }
+        public System.ReadOnlyMemory<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
+        public bool TryCopyTo(System.Memory<T> destination) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly ref struct ReadOnlySpan<T>
+    public readonly ref partial struct ReadOnlySpan<T>
     {
-        public static ReadOnlySpan<T> Empty { get { throw null; } }
-        public ReadOnlySpan(T[] array) { throw null; }
-        public ReadOnlySpan(T[] array, int start, int length) { throw null; }
-        [CLSCompliant(false)]
-        public unsafe ReadOnlySpan(void* pointer, int length) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe ReadOnlySpan(void* pointer, int length) { throw null;}
+        public ReadOnlySpan(T[] array) { throw null;}
+        public ReadOnlySpan(T[] array, int start, int length) { throw null;}
+        public static System.ReadOnlySpan<T> Empty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public ref readonly T this[int index] { get { throw null; } }
         public int Length { get { throw null; } }
-        public void CopyTo(Span<T> destination) { }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public static ReadOnlySpan<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
+        public void CopyTo(System.Span<T> destination) { }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public static System.ReadOnlySpan<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
 #pragma warning disable 0809
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("Equals() on ReadOnlySpan will always throw an exception. Use == instead.")]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
-        public Enumerator GetEnumerator() { throw null; }
+        public System.ReadOnlySpan<T>.Enumerator GetEnumerator() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("GetHashCode() on ReadOnlySpan will always throw an exception.")]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
 #pragma warning restore 0809
-        public static bool operator ==(ReadOnlySpan<T> left, ReadOnlySpan<T> right) { throw null; }
-        public static implicit operator ReadOnlySpan<T>(T[] array) { throw null; }
-        public static implicit operator ReadOnlySpan<T>(ArraySegment<T> arraySegment) { throw null; }
-        public static bool operator !=(ReadOnlySpan<T> left, ReadOnlySpan<T> right) { throw null; }
-        public ReadOnlySpan<T> Slice(int start) { throw null; }
-        public ReadOnlySpan<T> Slice(int start, int length) { throw null; }
+        public static bool operator ==(System.ReadOnlySpan<T> left, System.ReadOnlySpan<T> right) { throw null; }
+        public static implicit operator System.ReadOnlySpan<T> (System.ArraySegment<T> arraySegment) { throw null; }
+        public static implicit operator System.ReadOnlySpan<T> (T[] array) { throw null; }
+        public static bool operator !=(System.ReadOnlySpan<T> left, System.ReadOnlySpan<T> right) { throw null; }
+        public System.ReadOnlySpan<T> Slice(int start) { throw null; }
+        public System.ReadOnlySpan<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
-        public bool TryCopyTo(Span<T> destination) { throw null; }
-        public ref struct Enumerator
+        public bool TryCopyTo(System.Span<T> destination) { throw null; }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+        public ref partial struct Enumerator
         {
-            public bool MoveNext() { throw null; }
             public ref readonly T Current { get { throw null; } }
+            public bool MoveNext() { throw null; }
         }
     }
     public partial class ResolveEventArgs : System.EventArgs
@@ -1951,39 +2011,39 @@ namespace System
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct RuntimeFieldHandle : System.Runtime.Serialization.ISerializable
     {
+        public System.IntPtr Value { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.RuntimeFieldHandle handle) { throw null; }
         public override int GetHashCode() { throw null; }
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public static bool operator ==(System.RuntimeFieldHandle left, System.RuntimeFieldHandle right) { throw null; }
         public static bool operator !=(System.RuntimeFieldHandle left, System.RuntimeFieldHandle right) { throw null; }
-        public System.IntPtr Value { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct RuntimeMethodHandle : System.Runtime.Serialization.ISerializable
     {
+        public System.IntPtr Value { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.RuntimeMethodHandle handle) { throw null; }
+        public System.IntPtr GetFunctionPointer() { throw null; }
         public override int GetHashCode() { throw null; }
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public static bool operator ==(System.RuntimeMethodHandle left, System.RuntimeMethodHandle right) { throw null; }
         public static bool operator !=(System.RuntimeMethodHandle left, System.RuntimeMethodHandle right) { throw null; }
-        public System.IntPtr Value { get { throw null; } }
-        public System.IntPtr GetFunctionPointer() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct RuntimeTypeHandle : System.Runtime.Serialization.ISerializable
     {
+        public System.IntPtr Value { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.RuntimeTypeHandle handle) { throw null; }
         public override int GetHashCode() { throw null; }
+        public System.ModuleHandle GetModuleHandle() { throw null; }
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public static bool operator ==(object left, System.RuntimeTypeHandle right) { throw null; }
         public static bool operator ==(System.RuntimeTypeHandle left, object right) { throw null; }
         public static bool operator !=(object left, System.RuntimeTypeHandle right) { throw null; }
         public static bool operator !=(System.RuntimeTypeHandle left, object right) { throw null; }
-        public System.IntPtr Value { get { throw null; } }
-        public System.ModuleHandle GetModuleHandle() { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1991,22 +2051,22 @@ namespace System
     {
         public const sbyte MaxValue = (sbyte)127;
         public const sbyte MinValue = (sbyte)-128;
-        public int CompareTo(sbyte value) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public bool Equals(sbyte obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static sbyte Parse(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static sbyte Parse(string s, System.Globalization.NumberStyles style) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static sbyte Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static sbyte Parse(string s, System.IFormatProvider provider) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static sbyte Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider provider = null) { throw null; }
         public int CompareTo(object obj) { throw null; }
+        public int CompareTo(System.SByte value) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.SByte obj) { throw null; }
+        public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.SByte Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style=(System.Globalization.NumberStyles)(7), System.IFormatProvider provider=null) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.SByte Parse(string s) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.SByte Parse(string s, System.Globalization.NumberStyles style) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.SByte Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.SByte Parse(string s, System.IFormatProvider provider) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
@@ -2016,7 +2076,7 @@ namespace System
         short System.IConvertible.ToInt16(System.IFormatProvider provider) { throw null; }
         int System.IConvertible.ToInt32(System.IFormatProvider provider) { throw null; }
         long System.IConvertible.ToInt64(System.IFormatProvider provider) { throw null; }
-        sbyte System.IConvertible.ToSByte(System.IFormatProvider provider) { throw null; }
+        System.SByte System.IConvertible.ToSByte(System.IFormatProvider provider) { throw null; }
         float System.IConvertible.ToSingle(System.IFormatProvider provider) { throw null; }
         object System.IConvertible.ToType(System.Type type, System.IFormatProvider provider) { throw null; }
         ushort System.IConvertible.ToUInt16(System.IFormatProvider provider) { throw null; }
@@ -2026,51 +2086,55 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out sbyte result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.SByte result) { result = default(sbyte); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, out sbyte result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.SByte result) { result = default(sbyte); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out sbyte result) { throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.SByte result) { result = default(sbyte); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(ReadOnlySpan<char> s, out sbyte result) { throw null; }
+        public static bool TryParse(string s, out System.SByte result) { result = default(sbyte); throw null; }
     }
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Delegate, Inherited = false)]
-    public sealed class SerializableAttribute : Attribute
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4124), Inherited=false)]
+    public sealed partial class SerializableAttribute : System.Attribute
     {
-        public SerializableAttribute()
-        {
-        }
+        public SerializableAttribute() { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Single : System.IComparable, System.IComparable<float>, System.IConvertible, System.IEquatable<float>, System.IFormattable
     {
-        public int CompareTo(float value) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public bool Equals(float obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static bool IsFinite(float f) { throw null; }
-        public static bool IsInfinity(float f) { throw null; }
-        public static bool IsNaN(float f) { throw null; }
-        public static bool IsNegative(float f) { throw null; }
-        public static bool IsNegativeInfinity(float f) { throw null; }
-        public static bool IsNormal(float f) { throw null; }
-        public static bool IsPositiveInfinity(float f) { throw null; }
-        public static bool IsSubnormal(float f) { throw null; }
-        public static bool operator ==(float left, float right) { throw null; }
-        public static bool operator >(float left, float right) { throw null; }
-        public static bool operator >=(float left, float right) { throw null; }
-        public static bool operator !=(float left, float right) { throw null; }
-        public static bool operator <(float left, float right) { throw null; }
-        public static bool operator <=(float left, float right) { throw null; }
-        public static float Parse(string s) { throw null; }
-        public static float Parse(string s, System.Globalization.NumberStyles style) { throw null; }
-        public static float Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        public static float Parse(string s, System.IFormatProvider provider) { throw null; }
-        public static float Parse(ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider provider = null) { throw null; }
+        //public const float Epsilon = 1.401298E-45f;
+        //public const float MaxValue = 3.40282347E+38f;
+        //public const float MinValue = -3.40282347E+38f;
+        //public const float NaN = 0.0f / 0.0f;
+        //public const float NegativeInfinity = -1.0f / 0.0f;
+        //public const float PositiveInfinity = 1.0f / 0.0f;
         public int CompareTo(object value) { throw null; }
+        public int CompareTo(System.Single value) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Single obj) { throw null; }
+        public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsFinite(System.Single f) { throw null; }
+        public static bool IsInfinity(System.Single f) { throw null; }
+        public static bool IsNaN(System.Single f) { throw null; }
+        public static bool IsNegative(System.Single f) { throw null; }
+        public static bool IsNegativeInfinity(System.Single f) { throw null; }
+        public static bool IsNormal(System.Single f) { throw null; }
+        public static bool IsPositiveInfinity(System.Single f) { throw null; }
+        public static bool IsSubnormal(System.Single f) { throw null; }
+        public static bool operator ==(System.Single left, System.Single right) { throw null; }
+        public static bool operator >(System.Single left, System.Single right) { throw null; }
+        public static bool operator >=(System.Single left, System.Single right) { throw null; }
+        public static bool operator !=(System.Single left, System.Single right) { throw null; }
+        public static bool operator <(System.Single left, System.Single right) { throw null; }
+        public static bool operator <=(System.Single left, System.Single right) { throw null; }
+        public static System.Single Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style=(System.Globalization.NumberStyles)(7), System.IFormatProvider provider=null) { throw null; }
+        public static System.Single Parse(string s) { throw null; }
+        public static System.Single Parse(string s, System.Globalization.NumberStyles style) { throw null; }
+        public static System.Single Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        public static System.Single Parse(string s, System.IFormatProvider provider) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
@@ -2081,7 +2145,7 @@ namespace System
         int System.IConvertible.ToInt32(System.IFormatProvider provider) { throw null; }
         long System.IConvertible.ToInt64(System.IFormatProvider provider) { throw null; }
         sbyte System.IConvertible.ToSByte(System.IFormatProvider provider) { throw null; }
-        float System.IConvertible.ToSingle(System.IFormatProvider provider) { throw null; }
+        System.Single System.IConvertible.ToSingle(System.IFormatProvider provider) { throw null; }
         object System.IConvertible.ToType(System.Type type, System.IFormatProvider provider) { throw null; }
         ushort System.IConvertible.ToUInt16(System.IFormatProvider provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider provider) { throw null; }
@@ -2090,58 +2154,65 @@ namespace System
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out float result) { throw null; }
-        public static bool TryParse(string s, out float result) { throw null; }
-        public static bool TryParse(ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out float result) { throw null; }
-        public static bool TryParse(ReadOnlySpan<char> s, out float result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Single result) { result = default(float); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Single result) { result = default(float); throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Single result) { result = default(float); throw null; }
+        public static bool TryParse(string s, out System.Single result) { result = default(float); throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly ref partial struct Span<T>
     {
-        public static Span<T> Empty { get { throw null; } }
-        public Span(T[] array) { throw null; }
-        public Span(T[] array, int start, int length) { throw null; }
-        [CLSCompliant(false)]
-        public unsafe Span(void* pointer, int length) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe Span(void* pointer, int length) { throw null;}
+        public Span(T[] array) { throw null;}
+        public Span(T[] array, int start, int length) { throw null;}
+        public static System.Span<T> Empty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public ref T this[int index] { get { throw null; } }
         public int Length { get { throw null; } }
         public void Clear() { }
-        public void Fill(T value) { }
-        public void CopyTo(Span<T> destination) { }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public static Span<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
+        public void CopyTo(System.Span<T> destination) { }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public static System.Span<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
 #pragma warning disable 0809
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("Equals() on Span will always throw an exception. Use == instead.")]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
-        public Enumerator GetEnumerator() { throw null; }
+        public void Fill(T value) { }
+        public System.Span<T>.Enumerator GetEnumerator() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("GetHashCode() on Span will always throw an exception.")]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
 #pragma warning restore 0809
-        public static bool operator ==(Span<T> left, Span<T> right) { throw null; }
-        public static implicit operator Span<T>(T[] array) { throw null; }
-        public static implicit operator Span<T>(ArraySegment<T> arraySegment) { throw null; }
-        public static implicit operator ReadOnlySpan<T>(Span<T> span) { throw null; }
-        public static bool operator !=(Span<T> left, Span<T> right) { throw null; }
-        public Span<T> Slice(int start) { throw null; }
-        public Span<T> Slice(int start, int length) { throw null; }
+        public static bool operator ==(System.Span<T> left, System.Span<T> right) { throw null; }
+        public static implicit operator System.Span<T> (System.ArraySegment<T> arraySegment) { throw null; }
+        public static implicit operator System.ReadOnlySpan<T> (System.Span<T> span) { throw null; }
+        public static implicit operator System.Span<T> (T[] array) { throw null; }
+        public static bool operator !=(System.Span<T> left, System.Span<T> right) { throw null; }
+        public System.Span<T> Slice(int start) { throw null; }
+        public System.Span<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
-        public bool TryCopyTo(Span<T> destination) { throw null; }
-        public ref struct Enumerator
+        public bool TryCopyTo(System.Span<T> destination) { throw null; }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+        public ref partial struct Enumerator
         {
-            public bool MoveNext() { throw null; }
             public ref T Current { get { throw null; } }
+            public bool MoveNext() { throw null; }
         }
+    }
+    public sealed partial class StackOverflowException : System.SystemException
+    {
+        public StackOverflowException() { }
+        public StackOverflowException(string message) { }
+        public StackOverflowException(string message, System.Exception innerException) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(64))]
     public sealed partial class STAThreadAttribute : System.Attribute
     {
         public STAThreadAttribute() { }
     }
-    public sealed partial class String : System.Collections.Generic.IEnumerable<char>, System.Collections.IEnumerable, System.IComparable, System.IComparable<string>, System.IConvertible, System.IEquatable<string>, System.ICloneable
+    public sealed partial class String : System.Collections.Generic.IEnumerable<char>, System.Collections.IEnumerable, System.ICloneable, System.IComparable, System.IComparable<string>, System.IConvertible, System.IEquatable<string>
     {
         public static readonly string Empty;
         [System.CLSCompliantAttribute(false)]
@@ -2151,143 +2222,144 @@ namespace System
         public String(char c, int count) { }
         public String(char[] value) { }
         public String(char[] value, int startIndex, int length) { }
+        public String(System.ReadOnlySpan<char> value) { }
         [System.CLSCompliantAttribute(false)]
         public unsafe String(sbyte* value) { }
         [System.CLSCompliantAttribute(false)]
         public unsafe String(sbyte* value, int startIndex, int length) { }
         [System.CLSCompliantAttribute(false)]
         public unsafe String(sbyte* value, int startIndex, int length, System.Text.Encoding enc) { }
-        public String(System.ReadOnlySpan<char> value) { }
         [System.Runtime.CompilerServices.IndexerName("Chars")]
         public char this[int index] { get { throw null; } }
         public int Length { get { throw null; } }
         public object Clone() { throw null; }
-        public static int Compare(string strA, int indexA, string strB, int indexB, int length) { throw null; }
+        public static int Compare(System.String strA, int indexA, System.String strB, int indexB, int length) { throw null; }
         public static int Compare(System.String strA, int indexA, System.String strB, int indexB, int length, bool ignoreCase) { throw null; }
-        public static int Compare(string strA, int indexA, string strB, int indexB, int length, System.StringComparison comparisonType) { throw null; }
-        public static int Compare(string strA, string strB) { throw null; }
-        public static int Compare(string strA, string strB, bool ignoreCase) { throw null; }
-        public static int Compare(System.String strA, System.String strB, bool ignoreCase, System.Globalization.CultureInfo culture) { throw null; }
-        public static int Compare(System.String strA, System.String strB, System.Globalization.CultureInfo culture, System.Globalization.CompareOptions options) { throw null; }
         public static int Compare(System.String strA, int indexA, System.String strB, int indexB, int length, bool ignoreCase, System.Globalization.CultureInfo culture) { throw null; }
         public static int Compare(System.String strA, int indexA, System.String strB, int indexB, int length, System.Globalization.CultureInfo culture, System.Globalization.CompareOptions options) { throw null; }
-        public static int Compare(string strA, string strB, System.StringComparison comparisonType) { throw null; }
-        public static int CompareOrdinal(string strA, int indexA, string strB, int indexB, int length) { throw null; }
-        public static int CompareOrdinal(string strA, string strB) { throw null; }
-        public int CompareTo(string strB) { throw null; }
-        public static string Concat(System.Collections.Generic.IEnumerable<string> values) { throw null; }
-        public static string Concat(object arg0) { throw null; }
-        public static string Concat(object arg0, object arg1) { throw null; }
-        public static string Concat(object arg0, object arg1, object arg2) { throw null; }
-        public static string Concat(params object[] args) { throw null; }
-        public static string Concat(string str0, string str1) { throw null; }
-        public static string Concat(string str0, string str1, string str2) { throw null; }
-        public static string Concat(string str0, string str1, string str2, string str3) { throw null; }
+        public static int Compare(System.String strA, int indexA, System.String strB, int indexB, int length, System.StringComparison comparisonType) { throw null; }
+        public static int Compare(System.String strA, System.String strB) { throw null; }
+        public static int Compare(System.String strA, System.String strB, bool ignoreCase) { throw null; }
+        public static int Compare(System.String strA, System.String strB, bool ignoreCase, System.Globalization.CultureInfo culture) { throw null; }
+        public static int Compare(System.String strA, System.String strB, System.Globalization.CultureInfo culture, System.Globalization.CompareOptions options) { throw null; }
+        public static int Compare(System.String strA, System.String strB, System.StringComparison comparisonType) { throw null; }
+        public static int CompareOrdinal(System.String strA, int indexA, System.String strB, int indexB, int length) { throw null; }
+        public static int CompareOrdinal(System.String strA, System.String strB) { throw null; }
+        public int CompareTo(object value) { throw null; }
+        public int CompareTo(System.String strB) { throw null; }
+        public static System.String Concat(System.Collections.Generic.IEnumerable<string> values) { throw null; }
+        public static System.String Concat(object arg0) { throw null; }
+        public static System.String Concat(object arg0, object arg1) { throw null; }
+        public static System.String Concat(object arg0, object arg1, object arg2) { throw null; }
+        public static System.String Concat(params object[] args) { throw null; }
+        public static System.String Concat(System.String str0, System.String str1) { throw null; }
+        public static System.String Concat(System.String str0, System.String str1, System.String str2) { throw null; }
+        public static System.String Concat(System.String str0, System.String str1, System.String str2, System.String str3) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static string Concat(params string[] values) { throw null; }
-        public static string Concat<T>(System.Collections.Generic.IEnumerable<T> values) { throw null; }
+        public static System.String Concat(params string[] values) { throw null; }
+        public static System.String Concat<T>(System.Collections.Generic.IEnumerable<T> values) { throw null; }
         public bool Contains(char value) { throw null; }
-        public bool Contains(char value, StringComparison comparisonType) { throw null; }
-        public bool Contains(string value) { throw null; }
-        public bool Contains(string value, StringComparison comparisonType) { throw null; }
+        public bool Contains(char value, System.StringComparison comparisonType) { throw null; }
+        public bool Contains(System.String value) { throw null; }
+        public bool Contains(System.String value, System.StringComparison comparisonType) { throw null; }
         public static System.String Copy(System.String str) { throw null; }
         public void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count) { }
-        public static string Create<TState>(int length, TState state, System.Buffers.SpanAction<char, TState> action) { throw null; }
+        public static System.String Create<TState>(int length, TState state, System.Buffers.SpanAction<char, TState> action) { throw null; }
         public bool EndsWith(char value) { throw null; }
-        public bool EndsWith(string value) { throw null; }
+        public bool EndsWith(System.String value) { throw null; }
         public bool EndsWith(System.String value, bool ignoreCase, System.Globalization.CultureInfo culture) { throw null; }
-        public bool EndsWith(string value, System.StringComparison comparisonType) { throw null; }
+        public bool EndsWith(System.String value, System.StringComparison comparisonType) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(string value) { throw null; }
-        public static bool Equals(string a, string b) { throw null; }
-        public static bool Equals(string a, string b, System.StringComparison comparisonType) { throw null; }
-        public bool Equals(string value, System.StringComparison comparisonType) { throw null; }
-        public static string Format(System.IFormatProvider provider, string format, object arg0) { throw null; }
-        public static string Format(System.IFormatProvider provider, string format, object arg0, object arg1) { throw null; }
-        public static string Format(System.IFormatProvider provider, string format, object arg0, object arg1, object arg2) { throw null; }
-        public static string Format(System.IFormatProvider provider, string format, params object[] args) { throw null; }
-        public static string Format(string format, object arg0) { throw null; }
-        public static string Format(string format, object arg0, object arg1) { throw null; }
-        public static string Format(string format, object arg0, object arg1, object arg2) { throw null; }
-        public static string Format(string format, params object[] args) { throw null; }
+        public bool Equals(System.String value) { throw null; }
+        public static bool Equals(System.String a, System.String b) { throw null; }
+        public static bool Equals(System.String a, System.String b, System.StringComparison comparisonType) { throw null; }
+        public bool Equals(System.String value, System.StringComparison comparisonType) { throw null; }
+        public static System.String Format(System.IFormatProvider provider, System.String format, object arg0) { throw null; }
+        public static System.String Format(System.IFormatProvider provider, System.String format, object arg0, object arg1) { throw null; }
+        public static System.String Format(System.IFormatProvider provider, System.String format, object arg0, object arg1, object arg2) { throw null; }
+        public static System.String Format(System.IFormatProvider provider, System.String format, params object[] args) { throw null; }
+        public static System.String Format(System.String format, object arg0) { throw null; }
+        public static System.String Format(System.String format, object arg0, object arg1) { throw null; }
+        public static System.String Format(System.String format, object arg0, object arg1, object arg2) { throw null; }
+        public static System.String Format(System.String format, params object[] args) { throw null; }
         public System.CharEnumerator GetEnumerator() { throw null; }
         public override int GetHashCode() { throw null; }
         public int GetHashCode(System.StringComparison comparisonType) { throw null; }
+        public System.TypeCode GetTypeCode() { throw null; }
         public int IndexOf(char value) { throw null; }
-        public int IndexOf(char value, StringComparison comparisonType) { throw null; }
         public int IndexOf(char value, int startIndex) { throw null; }
         public int IndexOf(char value, int startIndex, int count) { throw null; }
-        public int IndexOf(string value) { throw null; }
-        public int IndexOf(string value, int startIndex) { throw null; }
-        public int IndexOf(string value, int startIndex, int count) { throw null; }
-        public int IndexOf(string value, int startIndex, int count, System.StringComparison comparisonType) { throw null; }
-        public int IndexOf(string value, int startIndex, System.StringComparison comparisonType) { throw null; }
-        public int IndexOf(string value, System.StringComparison comparisonType) { throw null; }
+        public int IndexOf(char value, System.StringComparison comparisonType) { throw null; }
+        public int IndexOf(System.String value) { throw null; }
+        public int IndexOf(System.String value, int startIndex) { throw null; }
+        public int IndexOf(System.String value, int startIndex, int count) { throw null; }
+        public int IndexOf(System.String value, int startIndex, int count, System.StringComparison comparisonType) { throw null; }
+        public int IndexOf(System.String value, int startIndex, System.StringComparison comparisonType) { throw null; }
+        public int IndexOf(System.String value, System.StringComparison comparisonType) { throw null; }
         public int IndexOfAny(char[] anyOf) { throw null; }
         public int IndexOfAny(char[] anyOf, int startIndex) { throw null; }
         public int IndexOfAny(char[] anyOf, int startIndex, int count) { throw null; }
-        public string Insert(int startIndex, string value) { throw null; }
-        public static string Intern(string str) { throw null; }
-        public static string IsInterned(string str) { throw null; }
+        public System.String Insert(int startIndex, System.String value) { throw null; }
+        public static System.String Intern(System.String str) { throw null; }
+        public static System.String IsInterned(System.String str) { throw null; }
         public bool IsNormalized() { throw null; }
         public bool IsNormalized(System.Text.NormalizationForm normalizationForm) { throw null; }
-        public static bool IsNullOrEmpty(string value) { throw null; }
-        public static bool IsNullOrWhiteSpace(string value) { throw null; }
-        public static string Join(string separator, System.Collections.Generic.IEnumerable<string> values) { throw null; }
-        public static string Join(string separator, params object[] values) { throw null; }
-        public static string Join(string separator, params string[] value) { throw null; }
-        public static string Join(string separator, string[] value, int startIndex, int count) { throw null; }
-        public static string Join<T>(string separator, System.Collections.Generic.IEnumerable<T> values) { throw null; }
-        public static string Join(char separator, params object[] values) { throw null; }
-        public static string Join(char separator, params string[] value) { throw null; }
-        public static string Join(char separator, string[] value, int startIndex, int count) { throw null; }
-        public static string Join<T>(char separator, System.Collections.Generic.IEnumerable<T> values) { throw null; }
+        public static bool IsNullOrEmpty(System.String value) { throw null; }
+        public static bool IsNullOrWhiteSpace(System.String value) { throw null; }
+        public static System.String Join(char separator, params object[] values) { throw null; }
+        public static System.String Join(char separator, params string[] value) { throw null; }
+        public static System.String Join(char separator, string[] value, int startIndex, int count) { throw null; }
+        public static System.String Join(System.String separator, System.Collections.Generic.IEnumerable<string> values) { throw null; }
+        public static System.String Join(System.String separator, params object[] values) { throw null; }
+        public static System.String Join(System.String separator, params string[] value) { throw null; }
+        public static System.String Join(System.String separator, string[] value, int startIndex, int count) { throw null; }
+        public static System.String Join<T>(char separator, System.Collections.Generic.IEnumerable<T> values) { throw null; }
+        public static System.String Join<T>(System.String separator, System.Collections.Generic.IEnumerable<T> values) { throw null; }
         public int LastIndexOf(char value) { throw null; }
         public int LastIndexOf(char value, int startIndex) { throw null; }
         public int LastIndexOf(char value, int startIndex, int count) { throw null; }
-        public int LastIndexOf(string value) { throw null; }
-        public int LastIndexOf(string value, int startIndex) { throw null; }
-        public int LastIndexOf(string value, int startIndex, int count) { throw null; }
-        public int LastIndexOf(string value, int startIndex, int count, System.StringComparison comparisonType) { throw null; }
-        public int LastIndexOf(string value, int startIndex, System.StringComparison comparisonType) { throw null; }
-        public int LastIndexOf(string value, System.StringComparison comparisonType) { throw null; }
+        public int LastIndexOf(System.String value) { throw null; }
+        public int LastIndexOf(System.String value, int startIndex) { throw null; }
+        public int LastIndexOf(System.String value, int startIndex, int count) { throw null; }
+        public int LastIndexOf(System.String value, int startIndex, int count, System.StringComparison comparisonType) { throw null; }
+        public int LastIndexOf(System.String value, int startIndex, System.StringComparison comparisonType) { throw null; }
+        public int LastIndexOf(System.String value, System.StringComparison comparisonType) { throw null; }
         public int LastIndexOfAny(char[] anyOf) { throw null; }
         public int LastIndexOfAny(char[] anyOf, int startIndex) { throw null; }
         public int LastIndexOfAny(char[] anyOf, int startIndex, int count) { throw null; }
-        public string Normalize() { throw null; }
-        public string Normalize(System.Text.NormalizationForm normalizationForm) { throw null; }
-        public static bool operator ==(string a, string b) { throw null; }
-        public static bool operator !=(string a, string b) { throw null; }
-        public string PadLeft(int totalWidth) { throw null; }
-        public string PadLeft(int totalWidth, char paddingChar) { throw null; }
-        public string PadRight(int totalWidth) { throw null; }
-        public string PadRight(int totalWidth, char paddingChar) { throw null; }
-        public string Remove(int startIndex) { throw null; }
-        public string Remove(int startIndex, int count) { throw null; }
-        public string Replace(char oldChar, char newChar) { throw null; }
-        public string Replace(string oldValue, string newValue) { throw null; }
-        public string Replace(string oldValue, string newValue, System.StringComparison comparisonType) { throw null; }
-        public string Replace(string oldValue, string newValue, bool ignoreCase, System.Globalization.CultureInfo culture) { throw null; }
-        public string[] Split(char separator, System.StringSplitOptions options = System.StringSplitOptions.None) { throw null; }
-        public string[] Split(char separator, int count, System.StringSplitOptions options = System.StringSplitOptions.None) { throw null; }
-        public string[] Split(string separator, System.StringSplitOptions options = System.StringSplitOptions.None) { throw null; }
-        public string[] Split(string separator, int count, System.StringSplitOptions options = System.StringSplitOptions.None) { throw null; }
+        public System.String Normalize() { throw null; }
+        public System.String Normalize(System.Text.NormalizationForm normalizationForm) { throw null; }
+        public static bool operator ==(System.String a, System.String b) { throw null; }
+        public static implicit operator System.ReadOnlySpan<char> (System.String value) { throw null; }
+        public static bool operator !=(System.String a, System.String b) { throw null; }
+        public System.String PadLeft(int totalWidth) { throw null; }
+        public System.String PadLeft(int totalWidth, char paddingChar) { throw null; }
+        public System.String PadRight(int totalWidth) { throw null; }
+        public System.String PadRight(int totalWidth, char paddingChar) { throw null; }
+        public System.String Remove(int startIndex) { throw null; }
+        public System.String Remove(int startIndex, int count) { throw null; }
+        public System.String Replace(char oldChar, char newChar) { throw null; }
+        public System.String Replace(System.String oldValue, System.String newValue) { throw null; }
+        public System.String Replace(System.String oldValue, System.String newValue, bool ignoreCase, System.Globalization.CultureInfo culture) { throw null; }
+        public System.String Replace(System.String oldValue, System.String newValue, System.StringComparison comparisonType) { throw null; }
+        public string[] Split(char separator, int count, System.StringSplitOptions options=(System.StringSplitOptions)(0)) { throw null; }
+        public string[] Split(char separator, System.StringSplitOptions options=(System.StringSplitOptions)(0)) { throw null; }
         public string[] Split(params char[] separator) { throw null; }
         public string[] Split(char[] separator, int count) { throw null; }
         public string[] Split(char[] separator, int count, System.StringSplitOptions options) { throw null; }
         public string[] Split(char[] separator, System.StringSplitOptions options) { throw null; }
+        public string[] Split(System.String separator, int count, System.StringSplitOptions options=(System.StringSplitOptions)(0)) { throw null; }
+        public string[] Split(System.String separator, System.StringSplitOptions options=(System.StringSplitOptions)(0)) { throw null; }
         public string[] Split(string[] separator, int count, System.StringSplitOptions options) { throw null; }
         public string[] Split(string[] separator, System.StringSplitOptions options) { throw null; }
         public bool StartsWith(char value) { throw null; }
-        public bool StartsWith(string value) { throw null; }
+        public bool StartsWith(System.String value) { throw null; }
         public bool StartsWith(System.String value, bool ignoreCase, System.Globalization.CultureInfo culture) { throw null; }
-        public bool StartsWith(string value, System.StringComparison comparisonType) { throw null; }
-        public string Substring(int startIndex) { throw null; }
-        public string Substring(int startIndex, int length) { throw null; }
+        public bool StartsWith(System.String value, System.StringComparison comparisonType) { throw null; }
+        public System.String Substring(int startIndex) { throw null; }
+        public System.String Substring(int startIndex, int length) { throw null; }
         System.Collections.Generic.IEnumerator<char> System.Collections.Generic.IEnumerable<System.Char>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public int CompareTo(object value) { throw null; }
-        public System.TypeCode GetTypeCode() { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
@@ -2299,30 +2371,29 @@ namespace System
         long System.IConvertible.ToInt64(System.IFormatProvider provider) { throw null; }
         sbyte System.IConvertible.ToSByte(System.IFormatProvider provider) { throw null; }
         float System.IConvertible.ToSingle(System.IFormatProvider provider) { throw null; }
-        public string ToString(System.IFormatProvider provider) { throw null; }
         object System.IConvertible.ToType(System.Type type, System.IFormatProvider provider) { throw null; }
         ushort System.IConvertible.ToUInt16(System.IFormatProvider provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider provider) { throw null; }
         public char[] ToCharArray() { throw null; }
         public char[] ToCharArray(int startIndex, int length) { throw null; }
-        public string ToLower() { throw null; }
+        public System.String ToLower() { throw null; }
         public System.String ToLower(System.Globalization.CultureInfo culture) { throw null; }
-        public string ToLowerInvariant() { throw null; }
-        public override string ToString() { throw null; }
-        public string ToUpper() { throw null; }
+        public System.String ToLowerInvariant() { throw null; }
+        public override System.String ToString() { throw null; }
+        public System.String ToString(System.IFormatProvider provider) { throw null; }
+        public System.String ToUpper() { throw null; }
         public System.String ToUpper(System.Globalization.CultureInfo culture) { throw null; }
-        public string ToUpperInvariant() { throw null; }
-        public string Trim() { throw null; }
-        public string Trim(char trimChar) { throw null; }
-        public string Trim(params char[] trimChars) { throw null; }
-        public string TrimEnd() { throw null; }
-        public string TrimEnd(char trimChar) { throw null; }
-        public string TrimEnd(params char[] trimChars) { throw null; }
-        public string TrimStart() { throw null; }
-        public string TrimStart(char trimChar) { throw null; }
-        public string TrimStart(params char[] trimChars) { throw null; }
-        public static implicit operator System.ReadOnlySpan<char>(string value) { throw null; }
+        public System.String ToUpperInvariant() { throw null; }
+        public System.String Trim() { throw null; }
+        public System.String Trim(char trimChar) { throw null; }
+        public System.String Trim(params char[] trimChars) { throw null; }
+        public System.String TrimEnd() { throw null; }
+        public System.String TrimEnd(char trimChar) { throw null; }
+        public System.String TrimEnd(params char[] trimChars) { throw null; }
+        public System.String TrimStart() { throw null; }
+        public System.String TrimStart(char trimChar) { throw null; }
+        public System.String TrimStart(params char[] trimChars) { throw null; }
     }
     public enum StringComparison
     {
@@ -2339,7 +2410,14 @@ namespace System
         None = 0,
         RemoveEmptyEntries = 1,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(256), Inherited = false)]
+    public partial class SystemException : System.Exception
+    {
+        public SystemException() { }
+        protected SystemException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public SystemException(string message) { }
+        public SystemException(string message, System.Exception innerException) { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(256), Inherited=false)]
     public partial class ThreadStaticAttribute : System.Attribute
     {
         public ThreadStaticAttribute() { }
@@ -2347,9 +2425,9 @@ namespace System
     public partial class TimeoutException : System.SystemException
     {
         public TimeoutException() { }
+        protected TimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public TimeoutException(string message) { }
         public TimeoutException(string message, System.Exception innerException) { }
-        protected TimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct TimeSpan : System.IComparable, System.IComparable<System.TimeSpan>, System.IEquatable<System.TimeSpan>, System.IFormattable
@@ -2362,10 +2440,10 @@ namespace System
         public const long TicksPerMinute = (long)600000000;
         public const long TicksPerSecond = (long)10000000;
         public static readonly System.TimeSpan Zero;
-        public TimeSpan(int hours, int minutes, int seconds) { throw null; }
-        public TimeSpan(int days, int hours, int minutes, int seconds) { throw null; }
-        public TimeSpan(int days, int hours, int minutes, int seconds, int milliseconds) { throw null; }
-        public TimeSpan(long ticks) { throw null; }
+        public TimeSpan(int hours, int minutes, int seconds) { throw null;}
+        public TimeSpan(int days, int hours, int minutes, int seconds) { throw null;}
+        public TimeSpan(int days, int hours, int minutes, int seconds, int milliseconds) { throw null;}
+        public TimeSpan(long ticks) { throw null;}
         public int Days { get { throw null; } }
         public int Hours { get { throw null; } }
         public int Milliseconds { get { throw null; } }
@@ -2397,47 +2475,47 @@ namespace System
         public System.TimeSpan Multiply(double factor) { throw null; }
         public System.TimeSpan Negate() { throw null; }
         public static System.TimeSpan operator +(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
-        public static double operator /(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
         public static System.TimeSpan operator /(System.TimeSpan timeSpan, double divisor) { throw null; }
+        public static double operator /(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
         public static bool operator ==(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
         public static bool operator >(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
         public static bool operator >=(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
         public static bool operator !=(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
         public static bool operator <(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
         public static bool operator <=(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
-        public static System.TimeSpan operator -(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
-        public static System.TimeSpan operator *(System.TimeSpan timeSpan, double factor) { throw null; }
         public static System.TimeSpan operator *(double factor, System.TimeSpan timeSpan) { throw null; }
+        public static System.TimeSpan operator *(System.TimeSpan timeSpan, double factor) { throw null; }
+        public static System.TimeSpan operator -(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
         public static System.TimeSpan operator -(System.TimeSpan t) { throw null; }
         public static System.TimeSpan operator +(System.TimeSpan t) { throw null; }
+        public static System.TimeSpan Parse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider=null) { throw null; }
         public static System.TimeSpan Parse(string s) { throw null; }
         public static System.TimeSpan Parse(string input, System.IFormatProvider formatProvider) { throw null; }
-        public static System.TimeSpan Parse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider = null) { throw null; }
+        public static System.TimeSpan ParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles=(System.Globalization.TimeSpanStyles)(0)) { throw null; }
+        public static System.TimeSpan ParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles=(System.Globalization.TimeSpanStyles)(0)) { throw null; }
         public static System.TimeSpan ParseExact(string input, string format, System.IFormatProvider formatProvider) { throw null; }
         public static System.TimeSpan ParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles) { throw null; }
-        public static System.TimeSpan ParseExact(ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles = System.Globalization.TimeSpanStyles.None) { throw null; }
         public static System.TimeSpan ParseExact(string input, string[] formats, System.IFormatProvider formatProvider) { throw null; }
         public static System.TimeSpan ParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles) { throw null; }
-        public static System.TimeSpan ParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles = System.Globalization.TimeSpanStyles.None) { throw null; }
         public System.TimeSpan Subtract(System.TimeSpan ts) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider formatProvider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
-        public static bool TryParse(string input, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
-        public static bool TryParse(string s, out System.TimeSpan result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.TimeSpan result) { throw null; }
-        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { throw null; }
-        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
-        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { throw null; }
-        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, out System.TimeSpan result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public static bool TryParse(string input, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public static bool TryParse(string s, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, string[] formats, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public static bool TryParseExact(string input, string format, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
+        public static bool TryParseExact(string input, string[] formats, System.IFormatProvider formatProvider, out System.TimeSpan result) { result = default(System.TimeSpan); throw null; }
     }
-    [ObsoleteAttribute("System.TimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo instead.")]
+    [System.ObsoleteAttribute("System.TimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo instead.")]
     public abstract partial class TimeZone
     {
         protected TimeZone() { }
@@ -2451,7 +2529,7 @@ namespace System
         public virtual System.DateTime ToLocalTime(System.DateTime time) { throw null; }
         public virtual System.DateTime ToUniversalTime(System.DateTime time) { throw null; }
     }
-    public sealed partial class TimeZoneInfo : System.IEquatable<System.TimeZoneInfo>, System.Runtime.Serialization.ISerializable, System.Runtime.Serialization.IDeserializationCallback
+    public sealed partial class TimeZoneInfo : System.IEquatable<System.TimeZoneInfo>, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         internal TimeZoneInfo() { }
         public System.TimeSpan BaseUtcOffset { get { throw null; } }
@@ -2492,10 +2570,10 @@ namespace System
         public bool IsDaylightSavingTime(System.DateTime dateTime) { throw null; }
         public bool IsDaylightSavingTime(System.DateTimeOffset dateTimeOffset) { throw null; }
         public bool IsInvalidTime(System.DateTime dateTime) { throw null; }
-        public string ToSerializedString() { throw null; }
-        public override string ToString() { throw null; }
         void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public string ToSerializedString() { throw null; }
+        public override string ToString() { throw null; }
         public sealed partial class AdjustmentRule : System.IEquatable<System.TimeZoneInfo.AdjustmentRule>, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
         {
             internal AdjustmentRule() { }
@@ -2548,13 +2626,78 @@ namespace System
         public static System.Tuple<T1, T2, T3, T4, T5, T6, T7> Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) { throw null; }
         public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8>> Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8) { throw null; }
     }
-    public partial class Tuple<T1> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable
-        , System.Runtime.CompilerServices.ITuple
+    public static partial class TupleExtensions
+    {
+        public static void Deconstruct<T1>(this System.Tuple<T1> value, out T1 item1) { item1 = default(T1); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); item17 = default(T17); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); item17 = default(T17); item18 = default(T18); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); item17 = default(T17); item18 = default(T18); item19 = default(T19); }
+        public static void Deconstruct<T1, T2>(this System.Tuple<T1, T2> value, out T1 item1, out T2 item2) { item1 = default(T1); item2 = default(T2); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19, T20>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); item17 = default(T17); item18 = default(T18); item19 = default(T19); item20 = default(T20); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19, T20, T21>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20, out T21 item21) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); item10 = default(T10); item11 = default(T11); item12 = default(T12); item13 = default(T13); item14 = default(T14); item15 = default(T15); item16 = default(T16); item17 = default(T17); item18 = default(T18); item19 = default(T19); item20 = default(T20); item21 = default(T21); }
+        public static void Deconstruct<T1, T2, T3>(this System.Tuple<T1, T2, T3> value, out T1 item1, out T2 item2, out T3 item3) { item1 = default(T1); item2 = default(T2); item3 = default(T3); }
+        public static void Deconstruct<T1, T2, T3, T4>(this System.Tuple<T1, T2, T3, T4> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); }
+        public static void Deconstruct<T1, T2, T3, T4, T5>(this System.Tuple<T1, T2, T3, T4, T5> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6>(this System.Tuple<T1, T2, T3, T4, T5, T6> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); }
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9) { item1 = default(T1); item2 = default(T2); item3 = default(T3); item4 = default(T4); item5 = default(T5); item6 = default(T6); item7 = default(T7); item8 = default(T8); item9 = default(T9); }
+        public static System.Tuple<T1> ToTuple<T1>(this System.ValueTuple<T1> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15>>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16>>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16, T17>>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16, T17, T18>>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16, T17, T18, T19>>> value) { throw null; }
+        public static System.Tuple<T1, T2> ToTuple<T1, T2>(this System.ValueTuple<T1, T2> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19, T20>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16, T17, T18, T19, T20>>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19, T20, T21>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16, T17, T18, T19, T20, T21>>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3> ToTuple<T1, T2, T3>(this System.ValueTuple<T1, T2, T3> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4> ToTuple<T1, T2, T3, T4>(this System.ValueTuple<T1, T2, T3, T4> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5> ToTuple<T1, T2, T3, T4, T5>(this System.ValueTuple<T1, T2, T3, T4, T5> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6> ToTuple<T1, T2, T3, T4, T5, T6>(this System.ValueTuple<T1, T2, T3, T4, T5, T6> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7> ToTuple<T1, T2, T3, T4, T5, T6, T7>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8>> value) { throw null; }
+        public static System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9>> value) { throw null; }
+        public static System.ValueTuple<T1> ToValueTuple<T1>(this System.Tuple<T1> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15>>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16>>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16, T17>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17>>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16, T17, T18>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18>>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16, T17, T18, T19>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19>>> value) { throw null; }
+        public static System.ValueTuple<T1, T2> ToValueTuple<T1, T2>(this System.Tuple<T1, T2> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16, T17, T18, T19, T20>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19, T20>>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9, T10, T11, T12, T13, T14, System.ValueTuple<T15, T16, T17, T18, T19, T20, T21>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10, T11, T12, T13, T14, System.Tuple<T15, T16, T17, T18, T19, T20, T21>>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3> ToValueTuple<T1, T2, T3>(this System.Tuple<T1, T2, T3> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4> ToValueTuple<T1, T2, T3, T4>(this System.Tuple<T1, T2, T3, T4> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5> ToValueTuple<T1, T2, T3, T4, T5>(this System.Tuple<T1, T2, T3, T4, T5> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6> ToValueTuple<T1, T2, T3, T4, T5, T6>(this System.Tuple<T1, T2, T3, T4, T5, T6> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7> ToValueTuple<T1, T2, T3, T4, T5, T6, T7>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8>> value) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8, T9>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9>> value) { throw null; }
+    }
+    public partial class Tuple<T1> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.Runtime.CompilerServices.ITuple
     {
         public Tuple(T1 item1) { }
         public T1 Item1 { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
@@ -2563,14 +2706,13 @@ namespace System
         int System.IComparable.CompareTo(object obj) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class Tuple<T1, T2> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable
-        , System.Runtime.CompilerServices.ITuple
+    public partial class Tuple<T1, T2> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.Runtime.CompilerServices.ITuple
     {
         public Tuple(T1 item1, T2 item2) { }
         public T1 Item1 { get { throw null; } }
         public T2 Item2 { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
@@ -2579,15 +2721,14 @@ namespace System
         int System.IComparable.CompareTo(object obj) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class Tuple<T1, T2, T3> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable
-        , System.Runtime.CompilerServices.ITuple
+    public partial class Tuple<T1, T2, T3> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.Runtime.CompilerServices.ITuple
     {
         public Tuple(T1 item1, T2 item2, T3 item3) { }
         public T1 Item1 { get { throw null; } }
         public T2 Item2 { get { throw null; } }
         public T3 Item3 { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
@@ -2596,16 +2737,15 @@ namespace System
         int System.IComparable.CompareTo(object obj) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class Tuple<T1, T2, T3, T4> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable
-        , System.Runtime.CompilerServices.ITuple
+    public partial class Tuple<T1, T2, T3, T4> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.Runtime.CompilerServices.ITuple
     {
         public Tuple(T1 item1, T2 item2, T3 item3, T4 item4) { }
         public T1 Item1 { get { throw null; } }
         public T2 Item2 { get { throw null; } }
         public T3 Item3 { get { throw null; } }
         public T4 Item4 { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
@@ -2614,8 +2754,7 @@ namespace System
         int System.IComparable.CompareTo(object obj) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class Tuple<T1, T2, T3, T4, T5> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable
-        , System.Runtime.CompilerServices.ITuple
+    public partial class Tuple<T1, T2, T3, T4, T5> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.Runtime.CompilerServices.ITuple
     {
         public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) { }
         public T1 Item1 { get { throw null; } }
@@ -2623,8 +2762,8 @@ namespace System
         public T3 Item3 { get { throw null; } }
         public T4 Item4 { get { throw null; } }
         public T5 Item5 { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
@@ -2633,8 +2772,7 @@ namespace System
         int System.IComparable.CompareTo(object obj) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class Tuple<T1, T2, T3, T4, T5, T6> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable
-        , System.Runtime.CompilerServices.ITuple
+    public partial class Tuple<T1, T2, T3, T4, T5, T6> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.Runtime.CompilerServices.ITuple
     {
         public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) { }
         public T1 Item1 { get { throw null; } }
@@ -2643,8 +2781,8 @@ namespace System
         public T4 Item4 { get { throw null; } }
         public T5 Item5 { get { throw null; } }
         public T6 Item6 { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
@@ -2653,8 +2791,7 @@ namespace System
         int System.IComparable.CompareTo(object obj) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class Tuple<T1, T2, T3, T4, T5, T6, T7> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable
-        , System.Runtime.CompilerServices.ITuple
+    public partial class Tuple<T1, T2, T3, T4, T5, T6, T7> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.Runtime.CompilerServices.ITuple
     {
         public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) { }
         public T1 Item1 { get { throw null; } }
@@ -2664,8 +2801,8 @@ namespace System
         public T5 Item5 { get { throw null; } }
         public T6 Item6 { get { throw null; } }
         public T7 Item7 { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
@@ -2674,8 +2811,7 @@ namespace System
         int System.IComparable.CompareTo(object obj) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable
-        , System.Runtime.CompilerServices.ITuple
+    public partial class Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.Runtime.CompilerServices.ITuple
     {
         public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) { }
         public T1 Item1 { get { throw null; } }
@@ -2686,8 +2822,8 @@ namespace System
         public T6 Item6 { get { throw null; } }
         public T7 Item7 { get { throw null; } }
         public TRest Rest { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
@@ -2695,72 +2831,6 @@ namespace System
         int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
         int System.IComparable.CompareTo(object obj) { throw null; }
         public override string ToString() { throw null; }
-    }
-    public static class TupleExtensions
-    {
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20, out T21 item21) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(this Tuple<T1, T2, T3, T4, T5, T6, T7> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5, T6>(this Tuple<T1, T2, T3, T4, T5, T6> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4, T5>(this Tuple<T1, T2, T3, T4, T5> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5) { throw null; }
-        public static void Deconstruct<T1, T2, T3, T4>(this Tuple<T1, T2, T3, T4> value, out T1 item1, out T2 item2, out T3 item3, out T4 item4) { throw null; }
-        public static void Deconstruct<T1, T2, T3>(this Tuple<T1, T2, T3> value, out T1 item1, out T2 item2, out T3 item3) { throw null; }
-        public static void Deconstruct<T1, T2>(this Tuple<T1, T2> value, out T1 item1, out T2 item2) { throw null; }
-        public static void Deconstruct<T1>(this Tuple<T1> value, out T1 item1) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20, T21>>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20>>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19>>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18>>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17>>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16>>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15>>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> ToTuple<T1, T2, T3, T4, T5, T6, T7, T8>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7> ToTuple<T1, T2, T3, T4, T5, T6, T7>(this ValueTuple<T1, T2, T3, T4, T5, T6, T7> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5, T6> ToTuple<T1, T2, T3, T4, T5, T6>(this ValueTuple<T1, T2, T3, T4, T5, T6> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4, T5> ToTuple<T1, T2, T3, T4, T5>(this ValueTuple<T1, T2, T3, T4, T5> value) { throw null; }
-        public static Tuple<T1, T2, T3, T4> ToTuple<T1, T2, T3, T4>(this ValueTuple<T1, T2, T3, T4> value) { throw null; }
-        public static Tuple<T1, T2, T3> ToTuple<T1, T2, T3>(this ValueTuple<T1, T2, T3> value) { throw null; }
-        public static Tuple<T1, T2> ToTuple<T1, T2>(this ValueTuple<T1, T2> value) { throw null; }
-        public static Tuple<T1> ToTuple<T1>(this ValueTuple<T1> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20, T21>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15>>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>(this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7> ToValueTuple<T1, T2, T3, T4, T5, T6, T7>(this Tuple<T1, T2, T3, T4, T5, T6, T7> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6> ToValueTuple<T1, T2, T3, T4, T5, T6>(this Tuple<T1, T2, T3, T4, T5, T6> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5> ToValueTuple<T1, T2, T3, T4, T5>(this Tuple<T1, T2, T3, T4, T5> value) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4> ToValueTuple<T1, T2, T3, T4>(this Tuple<T1, T2, T3, T4> value) { throw null; }
-        public static ValueTuple<T1, T2, T3> ToValueTuple<T1, T2, T3>(this Tuple<T1, T2, T3> value) { throw null; }
-        public static ValueTuple<T1, T2> ToValueTuple<T1, T2>(this Tuple<T1, T2> value) { throw null; }
-        public static ValueTuple<T1> ToValueTuple<T1>(this Tuple<T1> value) { throw null; }
     }
     public abstract partial class Type : System.Reflection.MemberInfo, System.Reflection.IReflect
     {
@@ -2771,8 +2841,6 @@ namespace System
         public static readonly System.Reflection.MemberFilter FilterNameIgnoreCase;
         public static readonly object Missing;
         protected Type() { }
-        public static bool operator ==(System.Type left, System.Type right) { throw null; }
-        public static bool operator !=(System.Type left, System.Type right) { throw null; }
         public abstract System.Reflection.Assembly Assembly { get; }
         public abstract string AssemblyQualifiedName { get; }
         public System.Reflection.TypeAttributes Attributes { get { throw null; } }
@@ -2800,11 +2868,11 @@ namespace System
         public bool IsContextful { get { throw null; } }
         public virtual bool IsEnum { get { throw null; } }
         public bool IsExplicitLayout { get { throw null; } }
-        public virtual bool IsGenericParameter { get { throw null; } }
-        public virtual bool IsGenericTypeParameter { get { throw null; } }
         public virtual bool IsGenericMethodParameter { get { throw null; } }
+        public virtual bool IsGenericParameter { get { throw null; } }
         public virtual bool IsGenericType { get { throw null; } }
         public virtual bool IsGenericTypeDefinition { get { throw null; } }
+        public virtual bool IsGenericTypeParameter { get { throw null; } }
         public bool IsImport { get { throw null; } }
         public bool IsInterface { get { throw null; } }
         public bool IsLayoutSequential { get { throw null; } }
@@ -2827,11 +2895,11 @@ namespace System
         public virtual bool IsSerializable { get { throw null; } }
         public virtual bool IsSignatureType { get { throw null; } }
         public bool IsSpecialName { get { throw null; } }
-        public virtual bool IsTypeDefinition { get { throw null; } }
         public virtual bool IsSZArray { get { throw null; } }
-        public virtual bool IsVariableBoundArray { get { throw null; } }
+        public virtual bool IsTypeDefinition { get { throw null; } }
         public bool IsUnicodeClass { get { throw null; } }
         public bool IsValueType { get { throw null; } }
+        public virtual bool IsVariableBoundArray { get { throw null; } }
         public bool IsVisible { get { throw null; } }
         public override System.Reflection.MemberTypes MemberType { get { throw null; } }
         public abstract new System.Reflection.Module Module { get; }
@@ -2847,12 +2915,12 @@ namespace System
         public virtual System.Reflection.MemberInfo[] FindMembers(System.Reflection.MemberTypes memberType, System.Reflection.BindingFlags bindingAttr, System.Reflection.MemberFilter filter, object filterCriteria) { throw null; }
         public virtual int GetArrayRank() { throw null; }
         protected abstract System.Reflection.TypeAttributes GetAttributeFlagsImpl();
+        public System.Reflection.ConstructorInfo GetConstructor(System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
         public System.Reflection.ConstructorInfo GetConstructor(System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
         public System.Reflection.ConstructorInfo GetConstructor(System.Type[] types) { throw null; }
         protected abstract System.Reflection.ConstructorInfo GetConstructorImpl(System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers);
         public System.Reflection.ConstructorInfo[] GetConstructors() { throw null; }
         public abstract System.Reflection.ConstructorInfo[] GetConstructors(System.Reflection.BindingFlags bindingAttr);
-        public System.Reflection.ConstructorInfo GetConstructor(System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
         public virtual System.Reflection.MemberInfo[] GetDefaultMembers() { throw null; }
         public abstract System.Type GetElementType();
         public virtual string GetEnumName(object value) { throw null; }
@@ -2881,17 +2949,17 @@ namespace System
         public System.Reflection.MemberInfo[] GetMembers() { throw null; }
         public abstract System.Reflection.MemberInfo[] GetMembers(System.Reflection.BindingFlags bindingAttr);
         public System.Reflection.MethodInfo GetMethod(string name) { throw null; }
+        public System.Reflection.MethodInfo GetMethod(string name, int genericParameterCount, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
+        public System.Reflection.MethodInfo GetMethod(string name, int genericParameterCount, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
+        public System.Reflection.MethodInfo GetMethod(string name, int genericParameterCount, System.Type[] types) { throw null; }
+        public System.Reflection.MethodInfo GetMethod(string name, int genericParameterCount, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
         public System.Reflection.MethodInfo GetMethod(string name, System.Reflection.BindingFlags bindingAttr) { throw null; }
         public System.Reflection.MethodInfo GetMethod(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
         public System.Reflection.MethodInfo GetMethod(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
         public System.Reflection.MethodInfo GetMethod(string name, System.Type[] types) { throw null; }
         public System.Reflection.MethodInfo GetMethod(string name, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
-        protected abstract System.Reflection.MethodInfo GetMethodImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers);
-        public System.Reflection.MethodInfo GetMethod(string name, int genericParameterCount, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
-        public System.Reflection.MethodInfo GetMethod(string name, int genericParameterCount, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
-        public System.Reflection.MethodInfo GetMethod(string name, int genericParameterCount, System.Type[] types) { throw null; }
-        public System.Reflection.MethodInfo GetMethod(string name, int genericParameterCount, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
         protected virtual System.Reflection.MethodInfo GetMethodImpl(string name, int genericParameterCount, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
+        protected abstract System.Reflection.MethodInfo GetMethodImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers);
         public System.Reflection.MethodInfo[] GetMethods() { throw null; }
         public abstract System.Reflection.MethodInfo[] GetMethods(System.Reflection.BindingFlags bindingAttr);
         public System.Type GetNestedType(string name) { throw null; }
@@ -2915,7 +2983,7 @@ namespace System
         public static System.Type GetType(string typeName, System.Func<System.Reflection.AssemblyName, System.Reflection.Assembly> assemblyResolver, System.Func<System.Reflection.Assembly, string, bool, System.Type> typeResolver) { throw null; }
         public static System.Type GetType(string typeName, System.Func<System.Reflection.AssemblyName, System.Reflection.Assembly> assemblyResolver, System.Func<System.Reflection.Assembly, string, bool, System.Type> typeResolver, bool throwOnError) { throw null; }
         public static System.Type GetType(string typeName, System.Func<System.Reflection.AssemblyName, System.Reflection.Assembly> assemblyResolver, System.Func<System.Reflection.Assembly, string, bool, System.Type> typeResolver, bool throwOnError, bool ignoreCase) { throw null; }
-        public static System.Type[] GetTypeArray(System.Object[] args) { throw null; }
+        public static System.Type[] GetTypeArray(object[] args) { throw null; }
         public static System.TypeCode GetTypeCode(System.Type type) { throw null; }
         protected virtual System.TypeCode GetTypeCodeImpl() { throw null; }
         public static System.Type GetTypeFromCLSID(System.Guid clsid) { throw null; }
@@ -2930,7 +2998,7 @@ namespace System
         public static System.RuntimeTypeHandle GetTypeHandle(object o) { throw null; }
         protected abstract bool HasElementTypeImpl();
         public object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args) { throw null; }
-        public System.Object InvokeMember(System.String name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object target, System.Object[] args, System.Globalization.CultureInfo culture) { throw null; }
+        public object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args, System.Globalization.CultureInfo culture) { throw null; }
         public abstract object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args, System.Reflection.ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, string[] namedParameters);
         protected abstract bool IsArrayImpl();
         public virtual bool IsAssignableFrom(System.Type c) { throw null; }
@@ -2948,18 +3016,20 @@ namespace System
         public virtual System.Type MakeArrayType() { throw null; }
         public virtual System.Type MakeArrayType(int rank) { throw null; }
         public virtual System.Type MakeByRefType() { throw null; }
+        public static System.Type MakeGenericMethodParameter(int position) { throw null; }
         public virtual System.Type MakeGenericType(params System.Type[] typeArguments) { throw null; }
         public virtual System.Type MakePointerType() { throw null; }
-        public static Type MakeGenericMethodParameter(int position) { throw null; }
-        public static System.Type ReflectionOnlyGetType(System.String typeName, bool throwIfNotFound, bool ignoreCase) { throw null; }
+        public static bool operator ==(System.Type left, System.Type right) { throw null; }
+        public static bool operator !=(System.Type left, System.Type right) { throw null; }
+        public static System.Type ReflectionOnlyGetType(string typeName, bool throwIfNotFound, bool ignoreCase) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class TypeAccessException : System.TypeLoadException
     {
         public TypeAccessException() { }
+        protected TypeAccessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public TypeAccessException(string message) { }
         public TypeAccessException(string message, System.Exception inner) { }
-        protected TypeAccessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public enum TypeCode
     {
@@ -2986,15 +3056,15 @@ namespace System
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct TypedReference
     {
-        public override bool Equals(Object o) { throw null; }
+        public override bool Equals(object o) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Type GetTargetType(TypedReference value) { throw null; }
+        public static System.Type GetTargetType(System.TypedReference value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static System.TypedReference MakeTypedReference(object target, System.Reflection.FieldInfo[] flds) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public unsafe static void SetTypedReference(System.TypedReference target, object value) { }
+        public static void SetTypedReference(System.TypedReference target, object value) { }
         public static System.RuntimeTypeHandle TargetTypeToken(System.TypedReference value) { throw null; }
-        public unsafe static object ToObject(System.TypedReference value) { throw null; }
+        public static object ToObject(System.TypedReference value) { throw null; }
     }
     public sealed partial class TypeInitializationException : System.SystemException
     {
@@ -3005,9 +3075,9 @@ namespace System
     public partial class TypeLoadException : System.SystemException, System.Runtime.Serialization.ISerializable
     {
         public TypeLoadException() { }
+        protected TypeLoadException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public TypeLoadException(string message) { }
         public TypeLoadException(string message, System.Exception inner) { }
-        protected TypeLoadException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public override string Message { get { throw null; } }
         public string TypeName { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
@@ -3015,9 +3085,9 @@ namespace System
     public partial class TypeUnloadedException : System.SystemException, System.Runtime.Serialization.ISerializable
     {
         public TypeUnloadedException() { }
+        protected TypeUnloadedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public TypeUnloadedException(string message) { }
         public TypeUnloadedException(string message, System.Exception innerException) { }
-        protected TypeUnloadedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     [System.CLSCompliantAttribute(false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -3025,22 +3095,22 @@ namespace System
     {
         public const ushort MaxValue = (ushort)65535;
         public const ushort MinValue = (ushort)0;
-        public int CompareTo(ushort value) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public bool Equals(ushort obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static ushort Parse(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static ushort Parse(string s, System.Globalization.NumberStyles style) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static ushort Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static ushort Parse(string s, System.IFormatProvider provider) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static ushort Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider provider = null) { throw null; }
         public int CompareTo(object value) { throw null; }
+        public int CompareTo(System.UInt16 value) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.UInt16 obj) { throw null; }
+        public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt16 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style=(System.Globalization.NumberStyles)(7), System.IFormatProvider provider=null) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt16 Parse(string s) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt16 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt16 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt16 Parse(string s, System.IFormatProvider provider) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
@@ -3053,22 +3123,22 @@ namespace System
         sbyte System.IConvertible.ToSByte(System.IFormatProvider provider) { throw null; }
         float System.IConvertible.ToSingle(System.IFormatProvider provider) { throw null; }
         object System.IConvertible.ToType(System.Type type, System.IFormatProvider provider) { throw null; }
-        ushort System.IConvertible.ToUInt16(System.IFormatProvider provider) { throw null; }
+        System.UInt16 System.IConvertible.ToUInt16(System.IFormatProvider provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider provider) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out ushort result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt16 result) { result = default(ushort); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out ushort result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt16 result) { result = default(ushort); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, out ushort result) { throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt16 result) { result = default(ushort); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, out ushort result) { throw null; }
+        public static bool TryParse(string s, out System.UInt16 result) { result = default(ushort); throw null; }
     }
     [System.CLSCompliantAttribute(false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -3076,22 +3146,22 @@ namespace System
     {
         public const uint MaxValue = (uint)4294967295;
         public const uint MinValue = (uint)0;
-        public int CompareTo(uint value) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public bool Equals(uint obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static uint Parse(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static uint Parse(string s, System.Globalization.NumberStyles style) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static uint Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static uint Parse(string s, System.IFormatProvider provider) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static uint Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider provider = null) { throw null; }
         public int CompareTo(object value) { throw null; }
+        public int CompareTo(System.UInt32 value) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.UInt32 obj) { throw null; }
+        public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt32 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style=(System.Globalization.NumberStyles)(7), System.IFormatProvider provider=null) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt32 Parse(string s) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt32 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt32 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt32 Parse(string s, System.IFormatProvider provider) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
@@ -3105,21 +3175,21 @@ namespace System
         float System.IConvertible.ToSingle(System.IFormatProvider provider) { throw null; }
         object System.IConvertible.ToType(System.Type type, System.IFormatProvider provider) { throw null; }
         ushort System.IConvertible.ToUInt16(System.IFormatProvider provider) { throw null; }
-        uint System.IConvertible.ToUInt32(System.IFormatProvider provider) { throw null; }
+        System.UInt32 System.IConvertible.ToUInt32(System.IFormatProvider provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider provider) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out uint result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt32 result) { result = default(uint); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out uint result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt32 result) { result = default(uint); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, out uint result) { throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt32 result) { result = default(uint); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, out uint result) { throw null; }
+        public static bool TryParse(string s, out System.UInt32 result) { result = default(uint); throw null; }
     }
     [System.CLSCompliantAttribute(false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -3127,22 +3197,22 @@ namespace System
     {
         public const ulong MaxValue = (ulong)18446744073709551615;
         public const ulong MinValue = (ulong)0;
-        public int CompareTo(ulong value) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public bool Equals(ulong obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static ulong Parse(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static ulong Parse(string s, System.Globalization.NumberStyles style) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static ulong Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static ulong Parse(string s, System.IFormatProvider provider) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public static ulong Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider provider = null) { throw null; }
         public int CompareTo(object value) { throw null; }
+        public int CompareTo(System.UInt64 value) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.UInt64 obj) { throw null; }
+        public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt64 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style=(System.Globalization.NumberStyles)(7), System.IFormatProvider provider=null) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt64 Parse(string s) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt64 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt64 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.UInt64 Parse(string s, System.IFormatProvider provider) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider provider) { throw null; }
@@ -3157,49 +3227,49 @@ namespace System
         object System.IConvertible.ToType(System.Type type, System.IFormatProvider provider) { throw null; }
         ushort System.IConvertible.ToUInt16(System.IFormatProvider provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider provider) { throw null; }
-        ulong System.IConvertible.ToUInt64(System.IFormatProvider provider) { throw null; }
+        System.UInt64 System.IConvertible.ToUInt64(System.IFormatProvider provider) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default, System.IFormatProvider provider = null) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { charsWritten = default(int); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out ulong result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt64 result) { result = default(ulong); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out ulong result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt64 result) { result = default(ulong); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(string s, out ulong result) { throw null; }
+        public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.UInt64 result) { result = default(ulong); throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static bool TryParse(System.ReadOnlySpan<char> s, out ulong result) { throw null; }
+        public static bool TryParse(string s, out System.UInt64 result) { result = default(ulong); throw null; }
     }
     [System.CLSCompliantAttribute(false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct UIntPtr : System.Runtime.Serialization.ISerializable, IEquatable<UIntPtr>
+    public partial struct UIntPtr : System.IEquatable<System.UIntPtr>, System.Runtime.Serialization.ISerializable
     {
         public static readonly System.UIntPtr Zero;
-        public UIntPtr(uint value) { throw null; }
-        public UIntPtr(ulong value) { throw null; }
+        public UIntPtr(uint value) { throw null;}
+        public UIntPtr(ulong value) { throw null;}
         [System.CLSCompliantAttribute(false)]
-        public unsafe UIntPtr(void* value) { throw null; }
+        public unsafe UIntPtr(void* value) { throw null;}
         public static int Size { get { throw null; } }
         public static System.UIntPtr Add(System.UIntPtr pointer, int offset) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        bool IEquatable<UIntPtr>.Equals(UIntPtr other) { throw null; }
         public override int GetHashCode() { throw null; }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public static System.UIntPtr operator +(System.UIntPtr pointer, int offset) { throw null; }
         public static bool operator ==(System.UIntPtr value1, System.UIntPtr value2) { throw null; }
-        public static explicit operator System.UIntPtr(uint value) { throw null; }
-        public static explicit operator System.UIntPtr(ulong value) { throw null; }
-        public static explicit operator uint(System.UIntPtr value) { throw null; }
-        public static explicit operator ulong(System.UIntPtr value) { throw null; }
+        public static explicit operator System.UIntPtr (uint value) { throw null; }
+        public static explicit operator System.UIntPtr (ulong value) { throw null; }
+        public static explicit operator uint (System.UIntPtr value) { throw null; }
+        public static explicit operator ulong (System.UIntPtr value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static unsafe explicit operator void* (System.UIntPtr value) { throw null; }
+        public unsafe static explicit operator void* (System.UIntPtr value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static unsafe explicit operator System.UIntPtr(void* value) { throw null; }
+        public unsafe static explicit operator System.UIntPtr (void* value) { throw null; }
         public static bool operator !=(System.UIntPtr value1, System.UIntPtr value2) { throw null; }
         public static System.UIntPtr operator -(System.UIntPtr pointer, int offset) { throw null; }
         public static System.UIntPtr Subtract(System.UIntPtr pointer, int offset) { throw null; }
+        bool System.IEquatable<System.UIntPtr>.Equals(System.UIntPtr other) { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         [System.CLSCompliantAttribute(false)]
         public unsafe void* ToPointer() { throw null; }
         public override string ToString() { throw null; }
@@ -3209,11 +3279,10 @@ namespace System
     public partial class UnauthorizedAccessException : System.SystemException
     {
         public UnauthorizedAccessException() { }
+        protected UnauthorizedAccessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public UnauthorizedAccessException(string message) { }
         public UnauthorizedAccessException(string message, System.Exception inner) { }
-        protected UnauthorizedAccessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
-
     public partial class UnhandledExceptionEventArgs : System.EventArgs
     {
         public UnhandledExceptionEventArgs(object exception, bool isTerminating) { }
@@ -3221,7 +3290,6 @@ namespace System
         public bool IsTerminating { get { throw null; } }
     }
     public delegate void UnhandledExceptionEventHandler(object sender, System.UnhandledExceptionEventArgs e);
-
     public partial class Uri : System.Runtime.Serialization.ISerializable
     {
         public static readonly string SchemeDelimiter;
@@ -3237,9 +3305,9 @@ namespace System
         public static readonly string UriSchemeNntp;
         protected Uri(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public Uri(string uriString) { }
-        public Uri(string uriString, System.UriKind uriKind) { }
         [System.ObsoleteAttribute("The constructor has been deprecated. Please use new Uri(string). The dontEscape parameter is deprecated and is always false. http://go.microsoft.com/fwlink/?linkid=14202")]
         public Uri(string uriString, bool dontEscape) { }
+        public Uri(string uriString, System.UriKind uriKind) { }
         public Uri(System.Uri baseUri, string relativeUri) { }
         [System.ObsoleteAttribute("The constructor has been deprecated. Please new Uri(Uri, string). The dontEscape parameter is deprecated and is always false. http://go.microsoft.com/fwlink/?linkid=14202")]
         public Uri(System.Uri baseUri, string relativeUri, bool dontEscape) { }
@@ -3283,13 +3351,13 @@ namespace System
         public static int FromHex(char digit) { throw null; }
         public string GetComponents(System.UriComponents components, System.UriFormat format) { throw null; }
         public override int GetHashCode() { throw null; }
-        public bool IsBaseOf(System.Uri uri) { throw null; }
         public string GetLeftPart(System.UriPartial part) { throw null; }
         protected void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public static string HexEscape(char character) { throw null; }
         public static char HexUnescape(string pattern, ref int index) { throw null; }
         [System.ObsoleteAttribute("The method has been deprecated. It is not used by the system. http://go.microsoft.com/fwlink/?linkid=14202")]
         protected virtual bool IsBadFileSystemCharacter(char character) { throw null; }
+        public bool IsBaseOf(System.Uri uri) { throw null; }
         [System.ObsoleteAttribute("The method has been deprecated. It is not used by the system. http://go.microsoft.com/fwlink/?linkid=14202")]
         protected static bool IsExcludedCharacter(char character) { throw null; }
         public static bool IsHexDigit(char character) { throw null; }
@@ -3307,9 +3375,9 @@ namespace System
         protected virtual void Parse() { }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override string ToString() { throw null; }
-        public static bool TryCreate(string uriString, System.UriKind uriKind, out System.Uri result) { throw null; }
-        public static bool TryCreate(System.Uri baseUri, string relativeUri, out System.Uri result) { throw null; }
-        public static bool TryCreate(System.Uri baseUri, System.Uri relativeUri, out System.Uri result) { throw null; }
+        public static bool TryCreate(string uriString, System.UriKind uriKind, out System.Uri result) { result = default(System.Uri); throw null; }
+        public static bool TryCreate(System.Uri baseUri, string relativeUri, out System.Uri result) { result = default(System.Uri); throw null; }
+        public static bool TryCreate(System.Uri baseUri, System.Uri relativeUri, out System.Uri result) { result = default(System.Uri); throw null; }
         [System.ObsoleteAttribute("The method has been deprecated. Please use GetComponents() or static UnescapeDataString() to unescape a Uri component or a string. http://go.microsoft.com/fwlink/?linkid=14202")]
         protected virtual string Unescape(string path) { throw null; }
         public static string UnescapeDataString(string stringToUnescape) { throw null; }
@@ -3363,6 +3431,19 @@ namespace System
         Relative = 2,
         RelativeOrAbsolute = 0,
     }
+    public abstract partial class UriParser
+    {
+        protected UriParser() { }
+        protected virtual string GetComponents(System.Uri uri, System.UriComponents components, System.UriFormat format) { throw null; }
+        protected virtual void InitializeAndValidate(System.Uri uri, out System.UriFormatException parsingError) { parsingError = default(System.UriFormatException); }
+        protected virtual bool IsBaseOf(System.Uri baseUri, System.Uri relativeUri) { throw null; }
+        public static bool IsKnownScheme(string schemeName) { throw null; }
+        protected virtual bool IsWellFormedOriginalString(System.Uri uri) { throw null; }
+        protected virtual System.UriParser OnNewUri() { throw null; }
+        protected virtual void OnRegister(string schemeName, int defaultPort) { }
+        public static void Register(System.UriParser uriParser, string schemeName, int defaultPort) { }
+        protected virtual string Resolve(System.Uri baseUri, System.Uri relativeUri, out System.UriFormatException parsingError) { parsingError = default(System.UriFormatException); throw null; }
+    }
     public enum UriPartial
     {
         Authority = 1,
@@ -3370,197 +3451,122 @@ namespace System
         Query = 3,
         Scheme = 0,
     }
-    public abstract partial class UriParser
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+    public partial struct ValueTuple : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple>, System.IEquatable<System.ValueTuple>, System.Runtime.CompilerServices.ITuple
     {
-        protected UriParser() { }
-        protected virtual string GetComponents(System.Uri uri, System.UriComponents components, System.UriFormat format) { throw null; }
-        protected virtual void InitializeAndValidate(System.Uri uri, out System.UriFormatException parsingError) { throw null; }
-        protected virtual bool IsBaseOf(System.Uri baseUri, System.Uri relativeUri) { throw null; }
-        public static bool IsKnownScheme(string schemeName) { throw null; }
-        protected virtual bool IsWellFormedOriginalString(System.Uri uri) { throw null; }
-        protected virtual System.UriParser OnNewUri() { throw null; }
-        protected virtual void OnRegister(string schemeName, int defaultPort) { }
-        public static void Register(System.UriParser uriParser, string schemeName, int defaultPort) { }
-        protected virtual string Resolve(System.Uri baseUri, System.Uri relativeUri, out System.UriFormatException parsingError) { throw null; }
-    }
-    public partial class GenericUriParser : System.UriParser
-    {
-        public GenericUriParser(System.GenericUriParserOptions options) { }
-    }
-    [System.FlagsAttribute]
-    public enum GenericUriParserOptions
-    {
-        AllowEmptyAuthority = 2,
-        Default = 0,
-        DontCompressPath = 128,
-        DontConvertPathBackslashes = 64,
-        DontUnescapePathDotsAndSlashes = 256,
-        GenericAuthority = 1,
-        Idn = 512,
-        IriParsing = 1024,
-        NoFragment = 32,
-        NoPort = 8,
-        NoQuery = 16,
-        NoUserInfo = 4,
-    }
-    public partial class FileStyleUriParser : System.UriParser
-    {
-        public FileStyleUriParser() { }
-    }
-    public partial class FtpStyleUriParser : System.UriParser
-    {
-        public FtpStyleUriParser() { }
-    }
-    public partial class GopherStyleUriParser : System.UriParser
-    {
-        public GopherStyleUriParser() { }
-    }
-    public partial class HttpStyleUriParser : System.UriParser
-    {
-        public HttpStyleUriParser() { }
-    }
-    public partial class LdapStyleUriParser : System.UriParser
-    {
-        public LdapStyleUriParser() { }
-    }
-    public partial class NetPipeStyleUriParser : System.UriParser
-    {
-        public NetPipeStyleUriParser() { }
-    }
-    public partial class NetTcpStyleUriParser : System.UriParser
-    {
-        public NetTcpStyleUriParser() { }
-    }
-    public partial class NewsStyleUriParser : System.UriParser
-    {
-        public NewsStyleUriParser() { }
-    }
-    public struct ValueTuple
-        : IEquatable<ValueTuple>, Collections.IStructuralEquatable, Collections.IStructuralComparable, IComparable, IComparable<ValueTuple>, Runtime.CompilerServices.ITuple
-    {
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        public int CompareTo(System.ValueTuple other) { throw null; }
+        public static System.ValueTuple Create() { throw null; }
+        public static System.ValueTuple<T1> Create<T1>(T1 item1) { throw null; }
+        public static System.ValueTuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2) { throw null; }
+        public static System.ValueTuple<T1, T2, T3> Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4> Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5> Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6> Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7> Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) { throw null; }
+        public static System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, System.ValueTuple<T8>> Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(ValueTuple other) { throw null; }
-        bool Collections.IStructuralEquatable.Equals(object other, Collections.IEqualityComparer comparer) { throw null; }
-        int IComparable.CompareTo(object other) { throw null; }
-        public int CompareTo(ValueTuple other) { throw null; }
-        int Collections.IStructuralComparable.CompareTo(object other, Collections.IComparer comparer) { throw null; }
+        public bool Equals(System.ValueTuple other) { throw null; }
         public override int GetHashCode() { throw null; }
-        int Collections.IStructuralEquatable.GetHashCode(Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
+        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.IComparable.CompareTo(object other) { throw null; }
         public override string ToString() { throw null; }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
-        public static ValueTuple Create() { throw null; }
-        public static ValueTuple<T1> Create<T1>(T1 item1) { throw null; }
-        public static ValueTuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2) { throw null; }
-        public static ValueTuple<T1, T2, T3> Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4> Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5> Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6> Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7> Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) { throw null; }
-        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8) { throw null; }
     }
-    public struct ValueTuple<T1>
-        : IEquatable<ValueTuple<T1>>, Collections.IStructuralEquatable, Collections.IStructuralComparable, IComparable, IComparable<ValueTuple<T1>>, Runtime.CompilerServices.ITuple
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct ValueTuple<T1> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple<T1>>, System.IEquatable<System.ValueTuple<T1>>, System.Runtime.CompilerServices.ITuple
     {
         public T1 Item1;
-        public ValueTuple(T1 item1) { throw null; }
+        public ValueTuple(T1 item1) { throw null;}
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        public int CompareTo(System.ValueTuple<T1> other) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(ValueTuple<T1> other) { throw null; }
-        bool Collections.IStructuralEquatable.Equals(object other, Collections.IEqualityComparer comparer) { throw null; }
-        int IComparable.CompareTo(object other) { throw null; }
-        public int CompareTo(ValueTuple<T1> other) { throw null; }
-        int Collections.IStructuralComparable.CompareTo(object other, Collections.IComparer comparer) { throw null; }
+        public bool Equals(System.ValueTuple<T1> other) { throw null; }
         public override int GetHashCode() { throw null; }
-        int Collections.IStructuralEquatable.GetHashCode(Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
+        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.IComparable.CompareTo(object other) { throw null; }
         public override string ToString() { throw null; }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
     }
-    [Runtime.InteropServices.StructLayout(Runtime.InteropServices.LayoutKind.Auto)]
-    public struct ValueTuple<T1, T2>
-        : IEquatable<ValueTuple<T1, T2>>, Collections.IStructuralEquatable, Collections.IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2>>, Runtime.CompilerServices.ITuple
+    public partial struct ValueTuple<T1, T2> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple<T1, T2>>, System.IEquatable<System.ValueTuple<T1, T2>>, System.Runtime.CompilerServices.ITuple
     {
         public T1 Item1;
         public T2 Item2;
-        public ValueTuple(T1 item1, T2 item2) { throw null; }
+        public ValueTuple(T1 item1, T2 item2) { throw null;}
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        public int CompareTo(System.ValueTuple<T1, T2> other) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(ValueTuple<T1, T2> other) { throw null; }
-        bool Collections.IStructuralEquatable.Equals(object other, Collections.IEqualityComparer comparer) { throw null; }
-        int IComparable.CompareTo(object other) { throw null; }
-        public int CompareTo(ValueTuple<T1, T2> other) { throw null; }
-        int Collections.IStructuralComparable.CompareTo(object other, Collections.IComparer comparer) { throw null; }
+        public bool Equals(System.ValueTuple<T1, T2> other) { throw null; }
         public override int GetHashCode() { throw null; }
-        int Collections.IStructuralEquatable.GetHashCode(Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
+        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.IComparable.CompareTo(object other) { throw null; }
         public override string ToString() { throw null; }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
     }
-    [Runtime.InteropServices.StructLayout(Runtime.InteropServices.LayoutKind.Auto)]
-    public struct ValueTuple<T1, T2, T3>
-        : IEquatable<ValueTuple<T1, T2, T3>>, Collections.IStructuralEquatable, Collections.IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3>>, Runtime.CompilerServices.ITuple
+    public partial struct ValueTuple<T1, T2, T3> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple<T1, T2, T3>>, System.IEquatable<System.ValueTuple<T1, T2, T3>>, System.Runtime.CompilerServices.ITuple
     {
         public T1 Item1;
         public T2 Item2;
         public T3 Item3;
-        public ValueTuple(T1 item1, T2 item2, T3 item3) { throw null; }
+        public ValueTuple(T1 item1, T2 item2, T3 item3) { throw null;}
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        public int CompareTo(System.ValueTuple<T1, T2, T3> other) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(ValueTuple<T1, T2, T3> other) { throw null; }
-        bool Collections.IStructuralEquatable.Equals(object other, Collections.IEqualityComparer comparer) { throw null; }
-        int IComparable.CompareTo(object other) { throw null; }
-        public int CompareTo(ValueTuple<T1, T2, T3> other) { throw null; }
-        int Collections.IStructuralComparable.CompareTo(object other, Collections.IComparer comparer) { throw null; }
+        public bool Equals(System.ValueTuple<T1, T2, T3> other) { throw null; }
         public override int GetHashCode() { throw null; }
-        int Collections.IStructuralEquatable.GetHashCode(Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
+        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.IComparable.CompareTo(object other) { throw null; }
         public override string ToString() { throw null; }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
     }
-    [Runtime.InteropServices.StructLayout(Runtime.InteropServices.LayoutKind.Auto)]
-    public struct ValueTuple<T1, T2, T3, T4>
-        : IEquatable<ValueTuple<T1, T2, T3, T4>>, Collections.IStructuralEquatable, Collections.IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4>>, Runtime.CompilerServices.ITuple
+    public partial struct ValueTuple<T1, T2, T3, T4> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple<T1, T2, T3, T4>>, System.IEquatable<System.ValueTuple<T1, T2, T3, T4>>, System.Runtime.CompilerServices.ITuple
     {
         public T1 Item1;
         public T2 Item2;
         public T3 Item3;
         public T4 Item4;
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4) { throw null; }
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4) { throw null;}
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        public int CompareTo(System.ValueTuple<T1, T2, T3, T4> other) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(ValueTuple<T1, T2, T3, T4> other) { throw null; }
-        bool Collections.IStructuralEquatable.Equals(object other, Collections.IEqualityComparer comparer) { throw null; }
-        int IComparable.CompareTo(object other) { throw null; }
-        public int CompareTo(ValueTuple<T1, T2, T3, T4> other) { throw null; }
-        int Collections.IStructuralComparable.CompareTo(object other, Collections.IComparer comparer) { throw null; }
+        public bool Equals(System.ValueTuple<T1, T2, T3, T4> other) { throw null; }
         public override int GetHashCode() { throw null; }
-        int Collections.IStructuralEquatable.GetHashCode(Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
+        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.IComparable.CompareTo(object other) { throw null; }
         public override string ToString() { throw null; }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
     }
-    [Runtime.InteropServices.StructLayout(Runtime.InteropServices.LayoutKind.Auto)]
-    public struct ValueTuple<T1, T2, T3, T4, T5>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5>>, Collections.IStructuralEquatable, Collections.IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5>>, Runtime.CompilerServices.ITuple
+    public partial struct ValueTuple<T1, T2, T3, T4, T5> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple<T1, T2, T3, T4, T5>>, System.IEquatable<System.ValueTuple<T1, T2, T3, T4, T5>>, System.Runtime.CompilerServices.ITuple
     {
         public T1 Item1;
         public T2 Item2;
         public T3 Item3;
         public T4 Item4;
         public T5 Item5;
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) { throw null; }
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) { throw null;}
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        public int CompareTo(System.ValueTuple<T1, T2, T3, T4, T5> other) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(ValueTuple<T1, T2, T3, T4, T5> other) { throw null; }
-        bool Collections.IStructuralEquatable.Equals(object other, Collections.IEqualityComparer comparer) { throw null; }
-        int IComparable.CompareTo(object other) { throw null; }
-        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5> other) { throw null; }
-        int Collections.IStructuralComparable.CompareTo(object other, Collections.IComparer comparer) { throw null; }
+        public bool Equals(System.ValueTuple<T1, T2, T3, T4, T5> other) { throw null; }
         public override int GetHashCode() { throw null; }
-        int Collections.IStructuralEquatable.GetHashCode(Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
+        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.IComparable.CompareTo(object other) { throw null; }
         public override string ToString() { throw null; }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
     }
-    [Runtime.InteropServices.StructLayout(Runtime.InteropServices.LayoutKind.Auto)]
-    public struct ValueTuple<T1, T2, T3, T4, T5, T6>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6>>, Collections.IStructuralEquatable, Collections.IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6>>, Runtime.CompilerServices.ITuple
+    public partial struct ValueTuple<T1, T2, T3, T4, T5, T6> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple<T1, T2, T3, T4, T5, T6>>, System.IEquatable<System.ValueTuple<T1, T2, T3, T4, T5, T6>>, System.Runtime.CompilerServices.ITuple
     {
         public T1 Item1;
         public T2 Item2;
@@ -3568,22 +3574,20 @@ namespace System
         public T4 Item4;
         public T5 Item5;
         public T6 Item6;
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) { throw null; }
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) { throw null;}
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        public int CompareTo(System.ValueTuple<T1, T2, T3, T4, T5, T6> other) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6> other) { throw null; }
-        bool Collections.IStructuralEquatable.Equals(object other, Collections.IEqualityComparer comparer) { throw null; }
-        int IComparable.CompareTo(object other) { throw null; }
-        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6> other) { throw null; }
-        int Collections.IStructuralComparable.CompareTo(object other, Collections.IComparer comparer) { throw null; }
+        public bool Equals(System.ValueTuple<T1, T2, T3, T4, T5, T6> other) { throw null; }
         public override int GetHashCode() { throw null; }
-        int Collections.IStructuralEquatable.GetHashCode(Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
+        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.IComparable.CompareTo(object other) { throw null; }
         public override string ToString() { throw null; }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
     }
-    [Runtime.InteropServices.StructLayout(Runtime.InteropServices.LayoutKind.Auto)]
-    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, Collections.IStructuralEquatable, Collections.IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, Runtime.CompilerServices.ITuple
+    public partial struct ValueTuple<T1, T2, T3, T4, T5, T6, T7> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, System.IEquatable<System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, System.Runtime.CompilerServices.ITuple
     {
         public T1 Item1;
         public T2 Item2;
@@ -3592,23 +3596,20 @@ namespace System
         public T5 Item5;
         public T6 Item6;
         public T7 Item7;
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) { throw null; }
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) { throw null;}
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        public int CompareTo(System.ValueTuple<T1, T2, T3, T4, T5, T6, T7> other) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other) { throw null; }
-        bool Collections.IStructuralEquatable.Equals(object other, Collections.IEqualityComparer comparer) { throw null; }
-        int IComparable.CompareTo(object other) { throw null; }
-        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other) { throw null; }
-        int Collections.IStructuralComparable.CompareTo(object other, Collections.IComparer comparer) { throw null; }
+        public bool Equals(System.ValueTuple<T1, T2, T3, T4, T5, T6, T7> other) { throw null; }
         public override int GetHashCode() { throw null; }
-        int Collections.IStructuralEquatable.GetHashCode(Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
+        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.IComparable.CompareTo(object other) { throw null; }
         public override string ToString() { throw null; }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
     }
-    [Runtime.InteropServices.StructLayout(Runtime.InteropServices.LayoutKind.Auto)]
-    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, Collections.IStructuralEquatable, Collections.IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, Runtime.CompilerServices.ITuple
-        where TRest : struct
+    public partial struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, System.IEquatable<System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, System.Runtime.CompilerServices.ITuple where TRest : struct
     {
         public T1 Item1;
         public T2 Item2;
@@ -3618,18 +3619,18 @@ namespace System
         public T6 Item6;
         public T7 Item7;
         public TRest Rest;
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) { throw null; }
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) { throw null;}
+        object System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
+        public int CompareTo(System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other) { throw null; }
-        bool Collections.IStructuralEquatable.Equals(object other, Collections.IEqualityComparer comparer) { throw null; }
-        int IComparable.CompareTo(object other) { throw null; }
-        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other) { throw null; }
-        int Collections.IStructuralComparable.CompareTo(object other, Collections.IComparer comparer) { throw null; }
+        public bool Equals(System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other) { throw null; }
         public override int GetHashCode() { throw null; }
-        int Collections.IStructuralEquatable.GetHashCode(Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
+        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        int System.IComparable.CompareTo(object other) { throw null; }
         public override string ToString() { throw null; }
-        int Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        object Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
     }
     public abstract partial class ValueType
     {
@@ -3638,13 +3639,13 @@ namespace System
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
     }
-    public sealed partial class Version : System.IComparable, System.IComparable<System.Version>, System.IEquatable<System.Version>, System.ICloneable
+    public sealed partial class Version : System.ICloneable, System.IComparable, System.IComparable<System.Version>, System.IEquatable<System.Version>
     {
+        public Version() { }
         public Version(int major, int minor) { }
         public Version(int major, int minor, int build) { }
         public Version(int major, int minor, int build, int revision) { }
         public Version(string version) { }
-        public Version() { }
         public int Build { get { throw null; } }
         public int Major { get { throw null; } }
         public short MajorRevision { get { throw null; } }
@@ -3663,16 +3664,16 @@ namespace System
         public static bool operator !=(System.Version v1, System.Version v2) { throw null; }
         public static bool operator <(System.Version v1, System.Version v2) { throw null; }
         public static bool operator <=(System.Version v1, System.Version v2) { throw null; }
+        public static System.Version Parse(System.ReadOnlySpan<char> input) { throw null; }
         public static System.Version Parse(string input) { throw null; }
-        public static System.Version Parse(ReadOnlySpan<char> input) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(int fieldCount) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten) { throw null; }
-        public bool TryFormat(System.Span<char> destination, int fieldCount, out int charsWritten) { throw null; }
-        public static bool TryParse(string input, out System.Version result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> input, out System.Version result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, int fieldCount, out int charsWritten) { charsWritten = default(int); throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten) { charsWritten = default(int); throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> input, out System.Version result) { result = default(System.Version); throw null; }
+        public static bool TryParse(string input, out System.Version result) { result = default(System.Version); throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size = 1)]
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public partial struct Void
     {
     }
@@ -3682,10 +3683,10 @@ namespace System
         public WeakReference(object target, bool trackResurrection) { }
         protected WeakReference(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual bool IsAlive { get { throw null; } }
-        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual object Target { get { throw null; } set { } }
         public virtual bool TrackResurrection { get { throw null; } }
         ~WeakReference() { }
+        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed partial class WeakReference<T> : System.Runtime.Serialization.ISerializable where T : class
     {
@@ -3694,253 +3695,54 @@ namespace System
         ~WeakReference() { }
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public void SetTarget(T target) { }
-        public bool TryGetTarget(out T target) { throw null; }
-    }
-
-    public partial struct HashCode
-    {
-        public static int Combine<T1>(T1 value1) { throw null; }
-
-        public static int Combine<T1, T2>(T1 value1, T2 value2) { throw null; }
-
-        public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3) { throw null; }
-
-        public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4) { throw null; }
-
-        public static int Combine<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) { throw null; }
-
-        public static int Combine<T1, T2, T3, T4, T5, T6>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) { throw null; }
-
-        public static int Combine<T1, T2, T3, T4, T5, T6, T7>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7) { throw null; }
-
-        public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8) { throw null; }
-
-        public void Add<T>(T value) { }
-
-        public void Add<T>(T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
-
-        public int ToHashCode() { throw null; }
-
-#pragma warning disable 0809
-
-        [System.ObsoleteAttribute("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", error: true)]
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override int GetHashCode() { throw null; }
-
-        [System.ObsoleteAttribute("HashCode is a mutable struct and should not be compared with other HashCodes.", error: true)]
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override bool Equals(object obj) { throw null; }
-
-#pragma warning restore 0809
-    }
-}
-
-namespace System.Runtime.ConstrainedExecution
-{
-    public abstract partial class CriticalFinalizerObject
-    {
-        protected CriticalFinalizerObject() { }
-        ~CriticalFinalizerObject() { }
-    }
-
-    public enum Cer
-    {
-        MayFail = 1,
-        None = 0,
-        Success = 2,
-    }
-    public enum Consistency
-    {
-        MayCorruptAppDomain = 1,
-        MayCorruptInstance = 2,
-        MayCorruptProcess = 0,
-        WillNotCorruptState = 3,
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1133), Inherited = false)]
-    public sealed partial class ReliabilityContractAttribute : System.Attribute
-    {
-        public ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency consistencyGuarantee, System.Runtime.ConstrainedExecution.Cer cer) { }
-        public System.Runtime.ConstrainedExecution.Cer Cer { get { throw null; } }
-        public System.Runtime.ConstrainedExecution.Consistency ConsistencyGuarantee { get { throw null; } }
-    }
-    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method, Inherited = false)]
-    public sealed partial class PrePrepareMethodAttribute : System.Attribute
-    {
-        public PrePrepareMethodAttribute() { }
-    }
-}
-
-namespace System.Runtime.InteropServices
-{
-    public abstract partial class CriticalHandle : System.Runtime.ConstrainedExecution.CriticalFinalizerObject, System.IDisposable
-    {
-        protected System.IntPtr handle;
-        protected CriticalHandle(System.IntPtr invalidHandleValue) { }
-        public bool IsClosed { get { throw null; } }
-        public abstract bool IsInvalid { get; }
-        public void Close() { }
-        public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
-        ~CriticalHandle() { }
-        protected abstract bool ReleaseHandle();
-        protected void SetHandle(System.IntPtr handle) { }
-        public void SetHandleAsInvalid() { }
-    }
-    public partial class ExternalException : System.SystemException
-    {
-        public ExternalException() { }
-        public ExternalException(string message) { }
-        public ExternalException(string message, Exception inner) { }
-        public ExternalException(string message, int errorCode) { }
-        protected ExternalException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public virtual int ErrorCode { get; }
-        public override string ToString() { throw null; }
-    }
-    public abstract partial class SafeHandle : System.Runtime.ConstrainedExecution.CriticalFinalizerObject, System.IDisposable
-    {
-        protected System.IntPtr handle;
-        protected SafeHandle(System.IntPtr invalidHandleValue, bool ownsHandle) { }
-        public bool IsClosed { get { throw null; } }
-        public abstract bool IsInvalid { get; }
-        public void Close() { }
-        public void DangerousAddRef(ref bool success) { }
-        public System.IntPtr DangerousGetHandle() { throw null; }
-        public void DangerousRelease() { }
-        public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
-        ~SafeHandle() { }
-        protected abstract bool ReleaseHandle();
-        protected void SetHandle(System.IntPtr handle) { }
-        public void SetHandleAsInvalid() { }
-    }
-}
-
-namespace System.Runtime.CompilerServices
-{
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct ConfiguredTaskAwaitable
-    {
-        public System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter GetAwaiter() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public readonly partial struct ConfiguredTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
-        {
-            public bool IsCompleted { get { throw null; } }
-            public void GetResult() { }
-            public void OnCompleted(System.Action continuation) { }
-            public void UnsafeOnCompleted(System.Action continuation) { }
-        }
-    }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct ConfiguredTaskAwaitable<TResult>
-    {
-        public System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter GetAwaiter() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public readonly partial struct ConfiguredTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
-        {
-            public bool IsCompleted { get { throw null; } }
-            public TResult GetResult() { throw null; }
-            public void OnCompleted(System.Action continuation) { }
-            public void UnsafeOnCompleted(System.Action continuation) { }
-        }
-    }
-    public partial interface ICriticalNotifyCompletion : System.Runtime.CompilerServices.INotifyCompletion
-    {
-        void UnsafeOnCompleted(System.Action continuation);
-    }
-    public partial interface INotifyCompletion
-    {
-        void OnCompleted(System.Action continuation);
-    }
-    public interface ITuple
-    {
-        int Length { get; }
-        object this[int index] { get; }
-    }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct TaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
-    {
-        public bool IsCompleted { get { throw null; } }
-        public void GetResult() { }
-        public void OnCompleted(System.Action continuation) { }
-        public void UnsafeOnCompleted(System.Action continuation) { }
-    }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct TaskAwaiter<TResult> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
-    {
-        public bool IsCompleted { get { throw null; } }
-        public TResult GetResult() { throw null; }
-        public void OnCompleted(System.Action continuation) { }
-        public void UnsafeOnCompleted(System.Action continuation) { }
-    }
-    [System.CLSCompliant(false)]
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Event)]
-    public sealed class TupleElementNamesAttribute : Attribute
-    {
-        public TupleElementNamesAttribute(string[] transformNames) { throw null; }
-        public System.Collections.Generic.IList<string> TransformNames { get { throw null; } }
-    }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size = 1)]
-    public readonly partial struct YieldAwaitable
-    {
-        public System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter GetAwaiter() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size = 1)]
-        public readonly partial struct YieldAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
-        {
-            public bool IsCompleted { get { throw null; } }
-            public void GetResult() { }
-            public void OnCompleted(System.Action continuation) { }
-            public void UnsafeOnCompleted(System.Action continuation) { }
-        }
+        public bool TryGetTarget(out T target) { target = default(T); throw null; }
     }
 }
 namespace System.Buffers
 {
-    public unsafe struct MemoryHandle : IDisposable
-    {
-        [System.CLSCompliantAttribute(false)]
-        public MemoryHandle(IRetainable owner, void* pointer = null, System.Runtime.InteropServices.GCHandle handle = default(System.Runtime.InteropServices.GCHandle)) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public void* Pointer { get { throw null; } }
-        public bool HasPointer { get { throw null; } }
-        public void Dispose() { throw null; }
-    }
-
-    public interface IRetainable
+    public partial interface IRetainable
     {
         bool Release();
         void Retain();
     }
-
-    public abstract class OwnedMemory<T> : IDisposable, IRetainable
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+    public partial struct MemoryHandle : System.IDisposable
     {
-        public Memory<T> Memory { get { throw null; } }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe MemoryHandle(System.Buffers.IRetainable owner, void* pointer=null, System.Runtime.InteropServices.GCHandle handle=default(System.Runtime.InteropServices.GCHandle)) { throw null;}
+        public bool HasPointer { get { throw null; } }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe void* Pointer { get { throw null; } }
+        public void Dispose() { }
+    }
+    public abstract partial class OwnedMemory<T> : System.Buffers.IRetainable, System.IDisposable
+    {
+        protected OwnedMemory() { }
         public abstract bool IsDisposed { get; }
         protected abstract bool IsRetained { get; }
         public abstract int Length { get; }
-        public abstract Span<T> Span { get; }
-        public void Dispose() { throw null; }
+        public System.Memory<T> Memory { get { throw null; } }
+        public abstract System.Span<T> Span { get; }
+        public void Dispose() { }
         protected abstract void Dispose(bool disposing);
-        public abstract MemoryHandle Pin();
+        public abstract System.Buffers.MemoryHandle Pin();
         public abstract bool Release();
         public abstract void Retain();
-        protected internal abstract bool TryGetArray(out ArraySegment<T> arraySegment);
+        protected internal abstract bool TryGetArray(out System.ArraySegment<T> arraySegment);
     }
-}
-namespace System.Buffers
-{
-    public delegate void SpanAction<T, in TArg>(Span<T> span, TArg arg);
-    public delegate void ReadOnlySpanAction<T, in TArg>(ReadOnlySpan<T> span, TArg arg);
+    public delegate void ReadOnlySpanAction<T, in TArg>(System.ReadOnlySpan<T> span, TArg arg);
+    public delegate void SpanAction<T, in TArg>(System.Span<T> span, TArg arg);
 }
 namespace System.Collections
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct DictionaryEntry
     {
-        public DictionaryEntry(object key, object value) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public void Deconstruct(out object key, out object value) { throw null; }
+        public DictionaryEntry(object key, object value) { throw null;}
         public object Key { get { throw null; } set { } }
         public object Value { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public void Deconstruct(out object key, out object value) { key = default(object); value = default(object); }
     }
     public partial interface ICollection : System.Collections.IEnumerable
     {
@@ -4089,22 +3891,22 @@ namespace System.Collections.Generic
     public partial class KeyNotFoundException : System.SystemException, System.Runtime.Serialization.ISerializable
     {
         public KeyNotFoundException() { }
+        protected KeyNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public KeyNotFoundException(string message) { }
         public KeyNotFoundException(string message, System.Exception innerException) { }
-        protected KeyNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
-    public static class KeyValuePair
+    public static partial class KeyValuePair
     {
-        public static KeyValuePair<TKey, TValue> Create<TKey, TValue>(TKey key, TValue value) { throw null; }
+        public static System.Collections.Generic.KeyValuePair<TKey, TValue> Create<TKey, TValue>(TKey key, TValue value) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct KeyValuePair<TKey, TValue>
     {
-        public KeyValuePair(TKey key, TValue value) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public void Deconstruct(out TKey key, out TValue value) { throw null; }
+        public KeyValuePair(TKey key, TValue value) { throw null;}
         public TKey Key { get { throw null; } }
         public TValue Value { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public void Deconstruct(out TKey key, out TValue value) { key = default(TKey); value = default(TValue); }
         public override string ToString() { throw null; }
     }
 }
@@ -4190,27 +3992,27 @@ namespace System.ComponentModel
         public DefaultValueAttribute(int value) { }
         public DefaultValueAttribute(long value) { }
         public DefaultValueAttribute(object value) { }
-        public DefaultValueAttribute(float value) { }
-        public DefaultValueAttribute(string value) { }
         [System.CLSCompliantAttribute(false)]
         public DefaultValueAttribute(sbyte value) { }
+        public DefaultValueAttribute(float value) { }
+        public DefaultValueAttribute(string value) { }
+        public DefaultValueAttribute(System.Type type, string value) { }
         [System.CLSCompliantAttribute(false)]
         public DefaultValueAttribute(ushort value) { }
         [System.CLSCompliantAttribute(false)]
         public DefaultValueAttribute(uint value) { }
         [System.CLSCompliantAttribute(false)]
         public DefaultValueAttribute(ulong value) { }
-        public DefaultValueAttribute(System.Type type, string value) { }
         public virtual object Value { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        protected void SetValue(object value) { throw null; }
+        protected void SetValue(object value) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(6140))]
     public sealed partial class EditorBrowsableAttribute : System.Attribute
     {
-        public EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState state) { }
         public EditorBrowsableAttribute() { }
+        public EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState state) { }
         public System.ComponentModel.EditorBrowsableState State { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
@@ -4235,20 +4037,20 @@ namespace System.Configuration.Assemblies
     }
     public enum AssemblyVersionCompatibility
     {
+        SameDomain = 3,
         SameMachine = 1,
         SameProcess = 2,
-        SameDomain = 3,
     }
 }
 namespace System.Diagnostics
 {
-    [System.AttributeUsageAttribute((System.AttributeTargets)(68), AllowMultiple = true)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(68), AllowMultiple=true)]
     public sealed partial class ConditionalAttribute : System.Attribute
     {
         public ConditionalAttribute(string conditionString) { }
         public string ConditionString { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(3), AllowMultiple = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(3), AllowMultiple=false)]
     public sealed partial class DebuggableAttribute : System.Attribute
     {
         public DebuggableAttribute(bool isJITTrackingEnabled, bool isJITOptimizerDisabled) { }
@@ -4332,15 +4134,245 @@ namespace System.Globalization
         FirstFourDayWeek = 2,
         FirstFullWeek = 1,
     }
+    public static partial class CharUnicodeInfo
+    {
+        public static int GetDecimalDigitValue(char ch) { throw null; }
+        public static int GetDecimalDigitValue(string s, int index) { throw null; }
+        public static int GetDigitValue(char ch) { throw null; }
+        public static int GetDigitValue(string s, int index) { throw null; }
+        public static double GetNumericValue(char ch) { throw null; }
+        public static double GetNumericValue(string s, int index) { throw null; }
+        public static System.Globalization.UnicodeCategory GetUnicodeCategory(char ch) { throw null; }
+        public static System.Globalization.UnicodeCategory GetUnicodeCategory(string s, int index) { throw null; }
+    }
     public partial class ChineseLunisolarCalendar : System.Globalization.EastAsianLunisolarCalendar
     {
         public const int ChineseEra = 1;
         public ChineseLunisolarCalendar() { }
-        public override int[] Eras { get { throw null; } }
         protected override int DaysInYearBeforeMinSupportedYear { get { throw null; } }
+        public override int[] Eras { get { throw null; } }
         public override System.DateTime MaxSupportedDateTime { get { throw null; } }
         public override System.DateTime MinSupportedDateTime { get { throw null; } }
         public override int GetEra(System.DateTime time) { throw null; }
+    }
+    public partial class CompareInfo : System.Runtime.Serialization.IDeserializationCallback
+    {
+        internal CompareInfo() { }
+        public int LCID { get { throw null; } }
+        public virtual string Name { get { throw null; } }
+        public System.Globalization.SortVersion Version { get { throw null; } }
+        public virtual int Compare(string string1, int offset1, int length1, string string2, int offset2, int length2) { throw null; }
+        public virtual int Compare(string string1, int offset1, int length1, string string2, int offset2, int length2, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int Compare(string string1, int offset1, string string2, int offset2) { throw null; }
+        public virtual int Compare(string string1, int offset1, string string2, int offset2, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int Compare(string string1, string string2) { throw null; }
+        public virtual int Compare(string string1, string string2, System.Globalization.CompareOptions options) { throw null; }
+        public override bool Equals(object value) { throw null; }
+        public static System.Globalization.CompareInfo GetCompareInfo(int culture) { throw null; }
+        public static System.Globalization.CompareInfo GetCompareInfo(int culture, System.Reflection.Assembly assembly) { throw null; }
+        public static System.Globalization.CompareInfo GetCompareInfo(string name) { throw null; }
+        public static System.Globalization.CompareInfo GetCompareInfo(string name, System.Reflection.Assembly assembly) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public virtual int GetHashCode(string source, System.Globalization.CompareOptions options) { throw null; }
+        public virtual System.Globalization.SortKey GetSortKey(string source) { throw null; }
+        public virtual System.Globalization.SortKey GetSortKey(string source, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int IndexOf(string source, char value) { throw null; }
+        public virtual int IndexOf(string source, char value, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int IndexOf(string source, char value, int startIndex) { throw null; }
+        public virtual int IndexOf(string source, char value, int startIndex, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int IndexOf(string source, char value, int startIndex, int count) { throw null; }
+        public virtual int IndexOf(string source, char value, int startIndex, int count, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int IndexOf(string source, string value) { throw null; }
+        public virtual int IndexOf(string source, string value, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int IndexOf(string source, string value, int startIndex) { throw null; }
+        public virtual int IndexOf(string source, string value, int startIndex, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int IndexOf(string source, string value, int startIndex, int count) { throw null; }
+        public virtual int IndexOf(string source, string value, int startIndex, int count, System.Globalization.CompareOptions options) { throw null; }
+        public virtual bool IsPrefix(string source, string prefix) { throw null; }
+        public virtual bool IsPrefix(string source, string prefix, System.Globalization.CompareOptions options) { throw null; }
+        public static bool IsSortable(char ch) { throw null; }
+        public static bool IsSortable(string text) { throw null; }
+        public virtual bool IsSuffix(string source, string suffix) { throw null; }
+        public virtual bool IsSuffix(string source, string suffix, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int LastIndexOf(string source, char value) { throw null; }
+        public virtual int LastIndexOf(string source, char value, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int LastIndexOf(string source, char value, int startIndex) { throw null; }
+        public virtual int LastIndexOf(string source, char value, int startIndex, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int LastIndexOf(string source, char value, int startIndex, int count) { throw null; }
+        public virtual int LastIndexOf(string source, char value, int startIndex, int count, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int LastIndexOf(string source, string value) { throw null; }
+        public virtual int LastIndexOf(string source, string value, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int LastIndexOf(string source, string value, int startIndex) { throw null; }
+        public virtual int LastIndexOf(string source, string value, int startIndex, System.Globalization.CompareOptions options) { throw null; }
+        public virtual int LastIndexOf(string source, string value, int startIndex, int count) { throw null; }
+        public virtual int LastIndexOf(string source, string value, int startIndex, int count, System.Globalization.CompareOptions options) { throw null; }
+        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
+        public override string ToString() { throw null; }
+    }
+    [System.FlagsAttribute]
+    public enum CompareOptions
+    {
+        IgnoreCase = 1,
+        IgnoreKanaType = 8,
+        IgnoreNonSpace = 2,
+        IgnoreSymbols = 4,
+        IgnoreWidth = 16,
+        None = 0,
+        Ordinal = 1073741824,
+        OrdinalIgnoreCase = 268435456,
+        StringSort = 536870912,
+    }
+    public partial class CultureInfo : System.ICloneable, System.IFormatProvider
+    {
+        public CultureInfo(int culture) { }
+        public CultureInfo(int culture, bool useUserOverride) { }
+        public CultureInfo(string name) { }
+        public CultureInfo(string name, bool useUserOverride) { }
+        public virtual System.Globalization.Calendar Calendar { get { throw null; } }
+        public virtual System.Globalization.CompareInfo CompareInfo { get { throw null; } }
+        public System.Globalization.CultureTypes CultureTypes { get { throw null; } }
+        public static System.Globalization.CultureInfo CurrentCulture { get { throw null; } set { } }
+        public static System.Globalization.CultureInfo CurrentUICulture { get { throw null; } set { } }
+        public virtual System.Globalization.DateTimeFormatInfo DateTimeFormat { get { throw null; } set { } }
+        public static System.Globalization.CultureInfo DefaultThreadCurrentCulture { get { throw null; } set { } }
+        public static System.Globalization.CultureInfo DefaultThreadCurrentUICulture { get { throw null; } set { } }
+        public virtual string DisplayName { get { throw null; } }
+        public virtual string EnglishName { get { throw null; } }
+        public string IetfLanguageTag { get { throw null; } }
+        public static System.Globalization.CultureInfo InstalledUICulture { get { throw null; } }
+        public static System.Globalization.CultureInfo InvariantCulture { get { throw null; } }
+        public virtual bool IsNeutralCulture { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
+        public virtual int KeyboardLayoutId { get { throw null; } }
+        public virtual int LCID { get { throw null; } }
+        public virtual string Name { get { throw null; } }
+        public virtual string NativeName { get { throw null; } }
+        public virtual System.Globalization.NumberFormatInfo NumberFormat { get { throw null; } set { } }
+        public virtual System.Globalization.Calendar[] OptionalCalendars { get { throw null; } }
+        public virtual System.Globalization.CultureInfo Parent { get { throw null; } }
+        public virtual System.Globalization.TextInfo TextInfo { get { throw null; } }
+        public virtual string ThreeLetterISOLanguageName { get { throw null; } }
+        public virtual string ThreeLetterWindowsLanguageName { get { throw null; } }
+        public virtual string TwoLetterISOLanguageName { get { throw null; } }
+        public bool UseUserOverride { get { throw null; } }
+        public void ClearCachedData() { }
+        public virtual object Clone() { throw null; }
+        public static System.Globalization.CultureInfo CreateSpecificCulture(string name) { throw null; }
+        public override bool Equals(object value) { throw null; }
+        public System.Globalization.CultureInfo GetConsoleFallbackUICulture() { throw null; }
+        public static System.Globalization.CultureInfo GetCultureInfo(int culture) { throw null; }
+        public static System.Globalization.CultureInfo GetCultureInfo(string name) { throw null; }
+        public static System.Globalization.CultureInfo GetCultureInfo(string name, string altName) { throw null; }
+        public static System.Globalization.CultureInfo GetCultureInfoByIetfLanguageTag(string name) { throw null; }
+        public static System.Globalization.CultureInfo[] GetCultures(System.Globalization.CultureTypes types) { throw null; }
+        public virtual object GetFormat(System.Type formatType) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static System.Globalization.CultureInfo ReadOnly(System.Globalization.CultureInfo ci) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public partial class CultureNotFoundException : System.ArgumentException, System.Runtime.Serialization.ISerializable
+    {
+        public CultureNotFoundException() { }
+        protected CultureNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public CultureNotFoundException(string message) { }
+        public CultureNotFoundException(string message, System.Exception innerException) { }
+        public CultureNotFoundException(string message, int invalidCultureId, System.Exception innerException) { }
+        public CultureNotFoundException(string paramName, int invalidCultureId, string message) { }
+        public CultureNotFoundException(string paramName, string message) { }
+        public CultureNotFoundException(string message, string invalidCultureName, System.Exception innerException) { }
+        public CultureNotFoundException(string paramName, string invalidCultureName, string message) { }
+        public virtual System.Nullable<int> InvalidCultureId { get { throw null; } }
+        public virtual string InvalidCultureName { get { throw null; } }
+        public override string Message { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    [System.FlagsAttribute]
+    public enum CultureTypes
+    {
+        AllCultures = 7,
+        [System.ObsoleteAttribute("This value has been deprecated.  Please use other values in CultureTypes.")]
+        FrameworkCultures = 64,
+        InstalledWin32Cultures = 4,
+        NeutralCultures = 1,
+        ReplacementCultures = 16,
+        SpecificCultures = 2,
+        UserCustomCulture = 8,
+        [System.ObsoleteAttribute("This value has been deprecated.  Please use other values in CultureTypes.")]
+        WindowsOnlyCultures = 32,
+    }
+    public sealed partial class DateTimeFormatInfo : System.ICloneable, System.IFormatProvider
+    {
+        public DateTimeFormatInfo() { }
+        public string[] AbbreviatedDayNames { get { throw null; } set { } }
+        public string[] AbbreviatedMonthGenitiveNames { get { throw null; } set { } }
+        public string[] AbbreviatedMonthNames { get { throw null; } set { } }
+        public string AMDesignator { get { throw null; } set { } }
+        public System.Globalization.Calendar Calendar { get { throw null; } set { } }
+        public System.Globalization.CalendarWeekRule CalendarWeekRule { get { throw null; } set { } }
+        public static System.Globalization.DateTimeFormatInfo CurrentInfo { get { throw null; } }
+        public string DateSeparator { get { throw null; } set { } }
+        public string[] DayNames { get { throw null; } set { } }
+        public System.DayOfWeek FirstDayOfWeek { get { throw null; } set { } }
+        public string FullDateTimePattern { get { throw null; } set { } }
+        public static System.Globalization.DateTimeFormatInfo InvariantInfo { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
+        public string LongDatePattern { get { throw null; } set { } }
+        public string LongTimePattern { get { throw null; } set { } }
+        public string MonthDayPattern { get { throw null; } set { } }
+        public string[] MonthGenitiveNames { get { throw null; } set { } }
+        public string[] MonthNames { get { throw null; } set { } }
+        public string NativeCalendarName { get { throw null; } }
+        public string PMDesignator { get { throw null; } set { } }
+        public string RFC1123Pattern { get { throw null; } }
+        public string ShortDatePattern { get { throw null; } set { } }
+        public string[] ShortestDayNames { get { throw null; } set { } }
+        public string ShortTimePattern { get { throw null; } set { } }
+        public string SortableDateTimePattern { get { throw null; } }
+        public string TimeSeparator { get { throw null; } set { } }
+        public string UniversalSortableDateTimePattern { get { throw null; } }
+        public string YearMonthPattern { get { throw null; } set { } }
+        public object Clone() { throw null; }
+        public string GetAbbreviatedDayName(System.DayOfWeek dayofweek) { throw null; }
+        public string GetAbbreviatedEraName(int era) { throw null; }
+        public string GetAbbreviatedMonthName(int month) { throw null; }
+        public string[] GetAllDateTimePatterns() { throw null; }
+        public string[] GetAllDateTimePatterns(char format) { throw null; }
+        public string GetDayName(System.DayOfWeek dayofweek) { throw null; }
+        public int GetEra(string eraName) { throw null; }
+        public string GetEraName(int era) { throw null; }
+        public object GetFormat(System.Type formatType) { throw null; }
+        public static System.Globalization.DateTimeFormatInfo GetInstance(System.IFormatProvider provider) { throw null; }
+        public string GetMonthName(int month) { throw null; }
+        public string GetShortestDayName(System.DayOfWeek dayOfWeek) { throw null; }
+        public static System.Globalization.DateTimeFormatInfo ReadOnly(System.Globalization.DateTimeFormatInfo dtfi) { throw null; }
+        public void SetAllDateTimePatterns(string[] patterns, char format) { }
+    }
+    [System.FlagsAttribute]
+    public enum DateTimeStyles
+    {
+        AdjustToUniversal = 16,
+        AllowInnerWhite = 4,
+        AllowLeadingWhite = 1,
+        AllowTrailingWhite = 2,
+        AllowWhiteSpaces = 7,
+        AssumeLocal = 32,
+        AssumeUniversal = 64,
+        NoCurrentDateDefault = 8,
+        None = 0,
+        RoundtripKind = 128,
+    }
+    public partial class DaylightTime
+    {
+        public DaylightTime(System.DateTime start, System.DateTime end, System.TimeSpan delta) { }
+        public System.TimeSpan Delta { get { throw null; } }
+        public System.DateTime End { get { throw null; } }
+        public System.DateTime Start { get { throw null; } }
+    }
+    public enum DigitShapes
+    {
+        Context = 0,
+        NativeNational = 2,
+        None = 1,
     }
     public abstract partial class EastAsianLunisolarCalendar : System.Globalization.Calendar
     {
@@ -4461,6 +4493,20 @@ namespace System.Globalization
         public override System.DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era) { throw null; }
         public override int ToFourDigitYear(int year) { throw null; }
     }
+    public sealed partial class IdnMapping
+    {
+        public IdnMapping() { }
+        public bool AllowUnassigned { get { throw null; } set { } }
+        public bool UseStd3AsciiRules { get { throw null; } set { } }
+        public override bool Equals(object obj) { throw null; }
+        public string GetAscii(string unicode) { throw null; }
+        public string GetAscii(string unicode, int index) { throw null; }
+        public string GetAscii(string unicode, int index, int count) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public string GetUnicode(string ascii) { throw null; }
+        public string GetUnicode(string ascii, int index) { throw null; }
+        public string GetUnicode(string ascii, int index, int count) { throw null; }
+    }
     public partial class JapaneseCalendar : System.Globalization.Calendar
     {
         public JapaneseCalendar() { }
@@ -4563,304 +4609,6 @@ namespace System.Globalization
         public override System.DateTime MinSupportedDateTime { get { throw null; } }
         public override int GetEra(System.DateTime time) { throw null; }
     }
-    public partial class PersianCalendar : System.Globalization.Calendar
-    {
-        public static readonly int PersianEra;
-        public PersianCalendar() { }
-        public override System.Globalization.CalendarAlgorithmType AlgorithmType { get { throw null; } }
-        public override int[] Eras { get { throw null; } }
-        public override System.DateTime MaxSupportedDateTime { get { throw null; } }
-        public override System.DateTime MinSupportedDateTime { get { throw null; } }
-        public override int TwoDigitYearMax { get { throw null; } set { } }
-        public override System.DateTime AddMonths(System.DateTime time, int months) { throw null; }
-        public override System.DateTime AddYears(System.DateTime time, int years) { throw null; }
-        public override int GetDayOfMonth(System.DateTime time) { throw null; }
-        public override System.DayOfWeek GetDayOfWeek(System.DateTime time) { throw null; }
-        public override int GetDayOfYear(System.DateTime time) { throw null; }
-        public override int GetDaysInMonth(int year, int month, int era) { throw null; }
-        public override int GetDaysInYear(int year, int era) { throw null; }
-        public override int GetEra(System.DateTime time) { throw null; }
-        public override int GetLeapMonth(int year, int era) { throw null; }
-        public override int GetMonth(System.DateTime time) { throw null; }
-        public override int GetMonthsInYear(int year, int era) { throw null; }
-        public override int GetYear(System.DateTime time) { throw null; }
-        public override bool IsLeapDay(int year, int month, int day, int era) { throw null; }
-        public override bool IsLeapMonth(int year, int month, int era) { throw null; }
-        public override bool IsLeapYear(int year, int era) { throw null; }
-        public override System.DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era) { throw null; }
-        public override int ToFourDigitYear(int year) { throw null; }
-    }
-    public partial class TaiwanCalendar : System.Globalization.Calendar
-    {
-        public TaiwanCalendar() { }
-        public override System.Globalization.CalendarAlgorithmType AlgorithmType { get { throw null; } }
-        public override int[] Eras { get { throw null; } }
-        public override System.DateTime MaxSupportedDateTime { get { throw null; } }
-        public override System.DateTime MinSupportedDateTime { get { throw null; } }
-        public override int TwoDigitYearMax { get { throw null; } set { } }
-        public override System.DateTime AddMonths(System.DateTime time, int months) { throw null; }
-        public override System.DateTime AddYears(System.DateTime time, int years) { throw null; }
-        public override int GetDayOfMonth(System.DateTime time) { throw null; }
-        public override System.DayOfWeek GetDayOfWeek(System.DateTime time) { throw null; }
-        public override int GetDayOfYear(System.DateTime time) { throw null; }
-        public override int GetDaysInMonth(int year, int month, int era) { throw null; }
-        public override int GetDaysInYear(int year, int era) { throw null; }
-        public override int GetEra(System.DateTime time) { throw null; }
-        public override int GetLeapMonth(int year, int era) { throw null; }
-        public override int GetMonth(System.DateTime time) { throw null; }
-        public override int GetMonthsInYear(int year, int era) { throw null; }
-        public override int GetWeekOfYear(System.DateTime time, System.Globalization.CalendarWeekRule rule, System.DayOfWeek firstDayOfWeek) { throw null; }
-        public override int GetYear(System.DateTime time) { throw null; }
-        public override bool IsLeapDay(int year, int month, int day, int era) { throw null; }
-        public override bool IsLeapMonth(int year, int month, int era) { throw null; }
-        public override bool IsLeapYear(int year, int era) { throw null; }
-        public override System.DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era) { throw null; }
-        public override int ToFourDigitYear(int year) { throw null; }
-    }
-    public partial class TaiwanLunisolarCalendar : System.Globalization.EastAsianLunisolarCalendar
-    {
-        public TaiwanLunisolarCalendar() { }
-        protected override int DaysInYearBeforeMinSupportedYear { get { throw null; } }
-        public override int[] Eras { get { throw null; } }
-        public override System.DateTime MaxSupportedDateTime { get { throw null; } }
-        public override System.DateTime MinSupportedDateTime { get { throw null; } }
-        public override int GetEra(System.DateTime time) { throw null; }
-    }
-    public partial class ThaiBuddhistCalendar : System.Globalization.Calendar
-    {
-        public const int ThaiBuddhistEra = 1;
-        public ThaiBuddhistCalendar() { }
-        public override System.Globalization.CalendarAlgorithmType AlgorithmType { get { throw null; } }
-        public override int[] Eras { get { throw null; } }
-        public override System.DateTime MaxSupportedDateTime { get { throw null; } }
-        public override System.DateTime MinSupportedDateTime { get { throw null; } }
-        public override int TwoDigitYearMax { get { throw null; } set { } }
-        public override System.DateTime AddMonths(System.DateTime time, int months) { throw null; }
-        public override System.DateTime AddYears(System.DateTime time, int years) { throw null; }
-        public override int GetDayOfMonth(System.DateTime time) { throw null; }
-        public override System.DayOfWeek GetDayOfWeek(System.DateTime time) { throw null; }
-        public override int GetDayOfYear(System.DateTime time) { throw null; }
-        public override int GetDaysInMonth(int year, int month, int era) { throw null; }
-        public override int GetDaysInYear(int year, int era) { throw null; }
-        public override int GetEra(System.DateTime time) { throw null; }
-        public override int GetLeapMonth(int year, int era) { throw null; }
-        public override int GetMonth(System.DateTime time) { throw null; }
-        public override int GetMonthsInYear(int year, int era) { throw null; }
-        public override int GetWeekOfYear(System.DateTime time, System.Globalization.CalendarWeekRule rule, System.DayOfWeek firstDayOfWeek) { throw null; }
-        public override int GetYear(System.DateTime time) { throw null; }
-        public override bool IsLeapDay(int year, int month, int day, int era) { throw null; }
-        public override bool IsLeapMonth(int year, int month, int era) { throw null; }
-        public override bool IsLeapYear(int year, int era) { throw null; }
-        public override System.DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era) { throw null; }
-        public override int ToFourDigitYear(int year) { throw null; }
-    }
-    public partial class UmAlQuraCalendar : System.Globalization.Calendar
-    {
-        public const int UmAlQuraEra = 1;
-        public UmAlQuraCalendar() { }
-        public override System.Globalization.CalendarAlgorithmType AlgorithmType { get { throw null; } }
-        protected override int DaysInYearBeforeMinSupportedYear { get { throw null; } }
-        public override int[] Eras { get { throw null; } }
-        public override System.DateTime MaxSupportedDateTime { get { throw null; } }
-        public override System.DateTime MinSupportedDateTime { get { throw null; } }
-        public override int TwoDigitYearMax { get { throw null; } set { } }
-        public override System.DateTime AddMonths(System.DateTime time, int months) { throw null; }
-        public override System.DateTime AddYears(System.DateTime time, int years) { throw null; }
-        public override int GetDayOfMonth(System.DateTime time) { throw null; }
-        public override System.DayOfWeek GetDayOfWeek(System.DateTime time) { throw null; }
-        public override int GetDayOfYear(System.DateTime time) { throw null; }
-        public override int GetDaysInMonth(int year, int month, int era) { throw null; }
-        public override int GetDaysInYear(int year, int era) { throw null; }
-        public override int GetEra(System.DateTime time) { throw null; }
-        public override int GetLeapMonth(int year, int era) { throw null; }
-        public override int GetMonth(System.DateTime time) { throw null; }
-        public override int GetMonthsInYear(int year, int era) { throw null; }
-        public override int GetYear(System.DateTime time) { throw null; }
-        public override bool IsLeapDay(int year, int month, int day, int era) { throw null; }
-        public override bool IsLeapMonth(int year, int month, int era) { throw null; }
-        public override bool IsLeapYear(int year, int era) { throw null; }
-        public override System.DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era) { throw null; }
-        public override int ToFourDigitYear(int year) { throw null; }
-    }
-    public static partial class CharUnicodeInfo
-    {
-        public static int GetDecimalDigitValue(char ch) { throw null; }
-        public static int GetDecimalDigitValue(string s, int index) { throw null; }
-        public static int GetDigitValue(char ch) { throw null; }
-        public static int GetDigitValue(string s, int index) { throw null; }
-        public static double GetNumericValue(char ch) { throw null; }
-        public static double GetNumericValue(string s, int index) { throw null; }
-        public static System.Globalization.UnicodeCategory GetUnicodeCategory(char ch) { throw null; }
-        public static System.Globalization.UnicodeCategory GetUnicodeCategory(string s, int index) { throw null; }
-    }
-    [System.FlagsAttribute]
-    public enum DateTimeStyles
-    {
-        AdjustToUniversal = 16,
-        AllowInnerWhite = 4,
-        AllowLeadingWhite = 1,
-        AllowTrailingWhite = 2,
-        AllowWhiteSpaces = 7,
-        AssumeLocal = 32,
-        AssumeUniversal = 64,
-        NoCurrentDateDefault = 8,
-        None = 0,
-        RoundtripKind = 128,
-    }
-    [System.FlagsAttribute]
-    public enum NumberStyles
-    {
-        AllowCurrencySymbol = 256,
-        AllowDecimalPoint = 32,
-        AllowExponent = 128,
-        AllowHexSpecifier = 512,
-        AllowLeadingSign = 4,
-        AllowLeadingWhite = 1,
-        AllowParentheses = 16,
-        AllowThousands = 64,
-        AllowTrailingSign = 8,
-        AllowTrailingWhite = 2,
-        Any = 511,
-        Currency = 383,
-        Float = 167,
-        HexNumber = 515,
-        Integer = 7,
-        None = 0,
-        Number = 111,
-    }
-    [System.FlagsAttribute]
-    public enum TimeSpanStyles
-    {
-        AssumeNegative = 1,
-        None = 0,
-    }
-    [System.FlagsAttribute]
-    public enum CompareOptions
-    {
-        IgnoreCase = 1,
-        IgnoreKanaType = 8,
-        IgnoreNonSpace = 2,
-        IgnoreSymbols = 4,
-        IgnoreWidth = 16,
-        None = 0,
-        Ordinal = 1073741824,
-        OrdinalIgnoreCase = 268435456,
-        StringSort = 536870912,
-    }
-    public partial class CompareInfo : System.Runtime.Serialization.IDeserializationCallback
-    {
-        internal CompareInfo() { }
-        public int LCID { get { throw null; } }
-        public virtual string Name { get { throw null; } }
-        public virtual int Compare(string string1, int offset1, int length1, string string2, int offset2, int length2) { throw null; }
-        public virtual int Compare(string string1, int offset1, int length1, string string2, int offset2, int length2, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int Compare(string string1, int offset1, string string2, int offset2) { throw null; }
-        public virtual int Compare(string string1, int offset1, string string2, int offset2, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int Compare(string string1, string string2) { throw null; }
-        public virtual int Compare(string string1, string string2, System.Globalization.CompareOptions options) { throw null; }
-        public override bool Equals(object value) { throw null; }
-        public static System.Globalization.CompareInfo GetCompareInfo(int culture) { throw null; }
-        public static System.Globalization.CompareInfo GetCompareInfo(string name) { throw null; }
-        public static System.Globalization.CompareInfo GetCompareInfo(int culture, System.Reflection.Assembly assembly) { throw null; }
-        public static System.Globalization.CompareInfo GetCompareInfo(string name, System.Reflection.Assembly assembly) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public virtual int GetHashCode(string source, System.Globalization.CompareOptions options) { throw null; }
-        public virtual System.Globalization.SortKey GetSortKey(string source) { throw null; }
-        public virtual System.Globalization.SortKey GetSortKey(string source, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int IndexOf(string source, char value) { throw null; }
-        public virtual int IndexOf(string source, char value, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int IndexOf(string source, char value, int startIndex) { throw null; }
-        public virtual int IndexOf(string source, char value, int startIndex, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int IndexOf(string source, char value, int startIndex, int count) { throw null; }
-        public virtual int IndexOf(string source, char value, int startIndex, int count, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int IndexOf(string source, string value) { throw null; }
-        public virtual int IndexOf(string source, string value, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int IndexOf(string source, string value, int startIndex) { throw null; }
-        public virtual int IndexOf(string source, string value, int startIndex, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int IndexOf(string source, string value, int startIndex, int count) { throw null; }
-        public virtual int IndexOf(string source, string value, int startIndex, int count, System.Globalization.CompareOptions options) { throw null; }
-        public virtual bool IsPrefix(string source, string prefix) { throw null; }
-        public virtual bool IsPrefix(string source, string prefix, System.Globalization.CompareOptions options) { throw null; }
-        public static bool IsSortable(char ch) { throw null; }
-        public static bool IsSortable(string text) { throw null; }
-        public virtual bool IsSuffix(string source, string suffix) { throw null; }
-        public virtual bool IsSuffix(string source, string suffix, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int LastIndexOf(string source, char value) { throw null; }
-        public virtual int LastIndexOf(string source, char value, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int LastIndexOf(string source, char value, int startIndex) { throw null; }
-        public virtual int LastIndexOf(string source, char value, int startIndex, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int LastIndexOf(string source, char value, int startIndex, int count) { throw null; }
-        public virtual int LastIndexOf(string source, char value, int startIndex, int count, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int LastIndexOf(string source, string value) { throw null; }
-        public virtual int LastIndexOf(string source, string value, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int LastIndexOf(string source, string value, int startIndex, System.Globalization.CompareOptions options) { throw null; }
-        public virtual int LastIndexOf(string source, string value, int startIndex) { throw null; }
-        public virtual int LastIndexOf(string source, string value, int startIndex, int count) { throw null; }
-        public virtual int LastIndexOf(string source, string value, int startIndex, int count, System.Globalization.CompareOptions options) { throw null; }
-        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-        public override string ToString() { throw null; }
-        public SortVersion Version { get { throw null; } }
-    }
-    public sealed partial class DateTimeFormatInfo : System.ICloneable, System.IFormatProvider
-    {
-        public DateTimeFormatInfo() { }
-        public string[] AbbreviatedDayNames { get { throw null; } set { } }
-        public string[] AbbreviatedMonthGenitiveNames { get { throw null; } set { } }
-        public string[] AbbreviatedMonthNames { get { throw null; } set { } }
-        public string AMDesignator { get { throw null; } set { } }
-        public System.Globalization.Calendar Calendar { get { throw null; } set { } }
-        public System.Globalization.CalendarWeekRule CalendarWeekRule { get { throw null; } set { } }
-        public static System.Globalization.DateTimeFormatInfo CurrentInfo { get { throw null; } }
-        public string DateSeparator { get { throw null; } set { } }
-        public string[] DayNames { get { throw null; } set { } }
-        public System.DayOfWeek FirstDayOfWeek { get { throw null; } set { } }
-        public string FullDateTimePattern { get { throw null; } set { } }
-        public static System.Globalization.DateTimeFormatInfo InvariantInfo { get { throw null; } }
-        public bool IsReadOnly { get { throw null; } }
-        public string LongDatePattern { get { throw null; } set { } }
-        public string LongTimePattern { get { throw null; } set { } }
-        public string MonthDayPattern { get { throw null; } set { } }
-        public string[] MonthGenitiveNames { get { throw null; } set { } }
-        public string[] MonthNames { get { throw null; } set { } }
-        public string NativeCalendarName { get { throw null; } }
-        public string PMDesignator { get { throw null; } set { } }
-        public string RFC1123Pattern { get { throw null; } }
-        public string ShortDatePattern { get { throw null; } set { } }
-        public string[] ShortestDayNames { get { throw null; } set { } }
-        public string ShortTimePattern { get { throw null; } set { } }
-        public string SortableDateTimePattern { get { throw null; } }
-        public string TimeSeparator { get { throw null; } set { } }
-        public string UniversalSortableDateTimePattern { get { throw null; } }
-        public string YearMonthPattern { get { throw null; } set { } }
-        public object Clone() { throw null; }
-        public string GetAbbreviatedDayName(System.DayOfWeek dayofweek) { throw null; }
-        public string GetAbbreviatedEraName(int era) { throw null; }
-        public string GetAbbreviatedMonthName(int month) { throw null; }
-        public string[] GetAllDateTimePatterns() { throw null; }
-        public string[] GetAllDateTimePatterns(char format) { throw null; }
-        public string GetDayName(System.DayOfWeek dayofweek) { throw null; }
-        public int GetEra(string eraName) { throw null; }
-        public string GetEraName(int era) { throw null; }
-        public object GetFormat(System.Type formatType) { throw null; }
-        public static System.Globalization.DateTimeFormatInfo GetInstance(System.IFormatProvider provider) { throw null; }
-        public string GetMonthName(int month) { throw null; }
-        public string GetShortestDayName(System.DayOfWeek dayOfWeek) { throw null; }
-        public static System.Globalization.DateTimeFormatInfo ReadOnly(System.Globalization.DateTimeFormatInfo dtfi) { throw null; }
-        public void SetAllDateTimePatterns(string[] patterns, char format) { }
-    }
-    public partial class DaylightTime
-    {
-        public DaylightTime(System.DateTime start, System.DateTime end, System.TimeSpan delta) { }
-        public System.TimeSpan Delta { get { throw null; } }
-        public System.DateTime End { get { throw null; } }
-        public System.DateTime Start { get { throw null; } }
-    }
-    public enum DigitShapes
-    {
-        Context = 0,
-        NativeNational = 2,
-        None = 1,
-    }
     public sealed partial class NumberFormatInfo : System.ICloneable, System.IFormatProvider
     {
         public NumberFormatInfo() { }
@@ -4899,154 +4647,53 @@ namespace System.Globalization
         public static System.Globalization.NumberFormatInfo GetInstance(System.IFormatProvider formatProvider) { throw null; }
         public static System.Globalization.NumberFormatInfo ReadOnly(System.Globalization.NumberFormatInfo nfi) { throw null; }
     }
-    public partial class TextInfo : System.ICloneable, System.Runtime.Serialization.IDeserializationCallback
-    {
-        internal TextInfo() { }
-        public virtual int ANSICodePage { get { throw null; } }
-        public string CultureName { get { throw null; } }
-        public virtual int EBCDICCodePage { get { throw null; } }
-        public bool IsReadOnly { get { throw null; } }
-        public bool IsRightToLeft { get { throw null; } }
-        public int LCID { get { throw null; } }
-        public virtual string ListSeparator { get { throw null; } set { } }
-        public virtual int MacCodePage { get { throw null; } }
-        public virtual int OEMCodePage { get { throw null; } }
-        public virtual object Clone() { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static System.Globalization.TextInfo ReadOnly(System.Globalization.TextInfo textInfo) { throw null; }
-        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-        public virtual char ToLower(char c) { throw null; }
-        public virtual string ToLower(string str) { throw null; }
-        public override string ToString() { throw null; }
-        public string ToTitleCase(string str) { throw null; }
-        public virtual char ToUpper(char c) { throw null; }
-        public virtual string ToUpper(string str) { throw null; }
-    }
-    public partial class CultureInfo : System.ICloneable, System.IFormatProvider
-    {
-        public CultureInfo(int culture) { }
-        public CultureInfo(int culture, bool useUserOverride) { }
-        public CultureInfo(string name) { }
-        public CultureInfo(string name, bool useUserOverride) { }
-        public virtual System.Globalization.Calendar Calendar { get { throw null; } }
-        public virtual System.Globalization.CompareInfo CompareInfo { get { throw null; } }
-        public System.Globalization.CultureTypes CultureTypes { get { throw null; } }
-        public static System.Globalization.CultureInfo CurrentCulture { get { throw null; } set { } }
-        public static System.Globalization.CultureInfo CurrentUICulture { get { throw null; } set { } }
-        public virtual System.Globalization.DateTimeFormatInfo DateTimeFormat { get { throw null; } set { } }
-        public static System.Globalization.CultureInfo DefaultThreadCurrentCulture { get { throw null; } set { } }
-        public static System.Globalization.CultureInfo DefaultThreadCurrentUICulture { get { throw null; } set { } }
-        public virtual string DisplayName { get { throw null; } }
-        public virtual string EnglishName { get { throw null; } }
-        public string IetfLanguageTag { get { throw null; } }
-        public static System.Globalization.CultureInfo InstalledUICulture { get { throw null; } }
-        public static System.Globalization.CultureInfo InvariantCulture { get { throw null; } }
-        public virtual bool IsNeutralCulture { get { throw null; } }
-        public bool IsReadOnly { get { throw null; } }
-        public virtual int KeyboardLayoutId { get { throw null; } }
-        public virtual int LCID { get { throw null; } }
-        public virtual string Name { get { throw null; } }
-        public virtual string NativeName { get { throw null; } }
-        public virtual System.Globalization.NumberFormatInfo NumberFormat { get { throw null; } set { } }
-        public virtual System.Globalization.Calendar[] OptionalCalendars { get { throw null; } }
-        public virtual System.Globalization.CultureInfo Parent { get { throw null; } }
-        public virtual System.Globalization.TextInfo TextInfo { get { throw null; } }
-        public virtual string ThreeLetterISOLanguageName { get { throw null; } }
-        public virtual string ThreeLetterWindowsLanguageName { get { throw null; } }
-        public virtual string TwoLetterISOLanguageName { get { throw null; } }
-        public bool UseUserOverride { get { throw null; } }
-        public void ClearCachedData() { }
-        public virtual object Clone() { throw null; }
-        public static System.Globalization.CultureInfo CreateSpecificCulture(string name) { throw null; }
-        public override bool Equals(object value) { throw null; }
-        public System.Globalization.CultureInfo GetConsoleFallbackUICulture() { throw null; }
-        public static System.Globalization.CultureInfo GetCultureInfo(int culture) { throw null; }
-        public static System.Globalization.CultureInfo GetCultureInfo(string name) { throw null; }
-        public static System.Globalization.CultureInfo GetCultureInfo(string name, string altName) { throw null; }
-        public static System.Globalization.CultureInfo GetCultureInfoByIetfLanguageTag(string name) { throw null; }
-        public static System.Globalization.CultureInfo[] GetCultures(System.Globalization.CultureTypes types) { throw null; }
-        public virtual object GetFormat(System.Type formatType) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static System.Globalization.CultureInfo ReadOnly(System.Globalization.CultureInfo ci) { throw null; }
-        public override string ToString() { throw null; }
-    }
-    public sealed partial class IdnMapping
-    {
-        public IdnMapping() { }
-        public bool AllowUnassigned { get { throw null; } set { } }
-        public bool UseStd3AsciiRules { get { throw null; } set { } }
-        public override bool Equals(object obj) { throw null; }
-        public string GetAscii(string unicode) { throw null; }
-        public string GetAscii(string unicode, int index) { throw null; }
-        public string GetAscii(string unicode, int index, int count) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public string GetUnicode(string ascii) { throw null; }
-        public string GetUnicode(string ascii, int index) { throw null; }
-        public string GetUnicode(string ascii, int index, int count) { throw null; }
-    }
-    public partial class CultureNotFoundException : System.ArgumentException, System.Runtime.Serialization.ISerializable
-    {
-        public CultureNotFoundException() { }
-        public CultureNotFoundException(string message) { }
-        public CultureNotFoundException(string message, System.Exception innerException) { }
-        public CultureNotFoundException(string message, int invalidCultureId, System.Exception innerException) { }
-        public CultureNotFoundException(string paramName, int invalidCultureId, string message) { }
-        public CultureNotFoundException(string paramName, string message) { }
-        public CultureNotFoundException(string message, string invalidCultureName, System.Exception innerException) { }
-        public CultureNotFoundException(string paramName, string invalidCultureName, string message) { }
-        protected CultureNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-        public virtual System.Nullable<int> InvalidCultureId { get { throw null; } }
-        public virtual string InvalidCultureName { get { throw null; } }
-        public override string Message { get { throw null; } }
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    }
     [System.FlagsAttribute]
-    public enum CultureTypes
+    public enum NumberStyles
     {
-        AllCultures = 7,
-        [ObsoleteAttribute("This value has been deprecated.  Please use other values in CultureTypes.")]
-        FrameworkCultures = 64,
-        InstalledWin32Cultures = 4,
-        NeutralCultures = 1,
-        ReplacementCultures = 16,
-        SpecificCultures = 2,
-        UserCustomCulture = 8,
-        [ObsoleteAttribute("This value has been deprecated.  Please use other values in CultureTypes.")]
-        WindowsOnlyCultures = 32,
+        AllowCurrencySymbol = 256,
+        AllowDecimalPoint = 32,
+        AllowExponent = 128,
+        AllowHexSpecifier = 512,
+        AllowLeadingSign = 4,
+        AllowLeadingWhite = 1,
+        AllowParentheses = 16,
+        AllowThousands = 64,
+        AllowTrailingSign = 8,
+        AllowTrailingWhite = 2,
+        Any = 511,
+        Currency = 383,
+        Float = 167,
+        HexNumber = 515,
+        Integer = 7,
+        None = 0,
+        Number = 111,
     }
-    public enum UnicodeCategory
+    public partial class PersianCalendar : System.Globalization.Calendar
     {
-        ClosePunctuation = 21,
-        ConnectorPunctuation = 18,
-        Control = 14,
-        CurrencySymbol = 26,
-        DashPunctuation = 19,
-        DecimalDigitNumber = 8,
-        EnclosingMark = 7,
-        FinalQuotePunctuation = 23,
-        Format = 15,
-        InitialQuotePunctuation = 22,
-        LetterNumber = 9,
-        LineSeparator = 12,
-        LowercaseLetter = 1,
-        MathSymbol = 25,
-        ModifierLetter = 3,
-        ModifierSymbol = 27,
-        NonSpacingMark = 5,
-        OpenPunctuation = 20,
-        OtherLetter = 4,
-        OtherNotAssigned = 29,
-        OtherNumber = 10,
-        OtherPunctuation = 24,
-        OtherSymbol = 28,
-        ParagraphSeparator = 13,
-        PrivateUse = 17,
-        SpaceSeparator = 11,
-        SpacingCombiningMark = 6,
-        Surrogate = 16,
-        TitlecaseLetter = 2,
-        UppercaseLetter = 0,
+        public static readonly int PersianEra;
+        public PersianCalendar() { }
+        public override System.Globalization.CalendarAlgorithmType AlgorithmType { get { throw null; } }
+        public override int[] Eras { get { throw null; } }
+        public override System.DateTime MaxSupportedDateTime { get { throw null; } }
+        public override System.DateTime MinSupportedDateTime { get { throw null; } }
+        public override int TwoDigitYearMax { get { throw null; } set { } }
+        public override System.DateTime AddMonths(System.DateTime time, int months) { throw null; }
+        public override System.DateTime AddYears(System.DateTime time, int years) { throw null; }
+        public override int GetDayOfMonth(System.DateTime time) { throw null; }
+        public override System.DayOfWeek GetDayOfWeek(System.DateTime time) { throw null; }
+        public override int GetDayOfYear(System.DateTime time) { throw null; }
+        public override int GetDaysInMonth(int year, int month, int era) { throw null; }
+        public override int GetDaysInYear(int year, int era) { throw null; }
+        public override int GetEra(System.DateTime time) { throw null; }
+        public override int GetLeapMonth(int year, int era) { throw null; }
+        public override int GetMonth(System.DateTime time) { throw null; }
+        public override int GetMonthsInYear(int year, int era) { throw null; }
+        public override int GetYear(System.DateTime time) { throw null; }
+        public override bool IsLeapDay(int year, int month, int day, int era) { throw null; }
+        public override bool IsLeapMonth(int year, int month, int era) { throw null; }
+        public override bool IsLeapYear(int year, int era) { throw null; }
+        public override System.DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era) { throw null; }
+        public override int ToFourDigitYear(int year) { throw null; }
     }
     public partial class RegionInfo
     {
@@ -5107,6 +4754,42 @@ namespace System.Globalization
         public string SubstringByTextElements(int startingTextElement) { throw null; }
         public string SubstringByTextElements(int startingTextElement, int lengthInTextElements) { throw null; }
     }
+    public partial class TaiwanCalendar : System.Globalization.Calendar
+    {
+        public TaiwanCalendar() { }
+        public override System.Globalization.CalendarAlgorithmType AlgorithmType { get { throw null; } }
+        public override int[] Eras { get { throw null; } }
+        public override System.DateTime MaxSupportedDateTime { get { throw null; } }
+        public override System.DateTime MinSupportedDateTime { get { throw null; } }
+        public override int TwoDigitYearMax { get { throw null; } set { } }
+        public override System.DateTime AddMonths(System.DateTime time, int months) { throw null; }
+        public override System.DateTime AddYears(System.DateTime time, int years) { throw null; }
+        public override int GetDayOfMonth(System.DateTime time) { throw null; }
+        public override System.DayOfWeek GetDayOfWeek(System.DateTime time) { throw null; }
+        public override int GetDayOfYear(System.DateTime time) { throw null; }
+        public override int GetDaysInMonth(int year, int month, int era) { throw null; }
+        public override int GetDaysInYear(int year, int era) { throw null; }
+        public override int GetEra(System.DateTime time) { throw null; }
+        public override int GetLeapMonth(int year, int era) { throw null; }
+        public override int GetMonth(System.DateTime time) { throw null; }
+        public override int GetMonthsInYear(int year, int era) { throw null; }
+        public override int GetWeekOfYear(System.DateTime time, System.Globalization.CalendarWeekRule rule, System.DayOfWeek firstDayOfWeek) { throw null; }
+        public override int GetYear(System.DateTime time) { throw null; }
+        public override bool IsLeapDay(int year, int month, int day, int era) { throw null; }
+        public override bool IsLeapMonth(int year, int month, int era) { throw null; }
+        public override bool IsLeapYear(int year, int era) { throw null; }
+        public override System.DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era) { throw null; }
+        public override int ToFourDigitYear(int year) { throw null; }
+    }
+    public partial class TaiwanLunisolarCalendar : System.Globalization.EastAsianLunisolarCalendar
+    {
+        public TaiwanLunisolarCalendar() { }
+        protected override int DaysInYearBeforeMinSupportedYear { get { throw null; } }
+        public override int[] Eras { get { throw null; } }
+        public override System.DateTime MaxSupportedDateTime { get { throw null; } }
+        public override System.DateTime MinSupportedDateTime { get { throw null; } }
+        public override int GetEra(System.DateTime time) { throw null; }
+    }
     public partial class TextElementEnumerator : System.Collections.IEnumerator
     {
         internal TextElementEnumerator() { }
@@ -5116,38 +4799,138 @@ namespace System.Globalization
         public bool MoveNext() { throw null; }
         public void Reset() { }
     }
+    public partial class TextInfo : System.ICloneable, System.Runtime.Serialization.IDeserializationCallback
+    {
+        internal TextInfo() { }
+        public virtual int ANSICodePage { get { throw null; } }
+        public string CultureName { get { throw null; } }
+        public virtual int EBCDICCodePage { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
+        public bool IsRightToLeft { get { throw null; } }
+        public int LCID { get { throw null; } }
+        public virtual string ListSeparator { get { throw null; } set { } }
+        public virtual int MacCodePage { get { throw null; } }
+        public virtual int OEMCodePage { get { throw null; } }
+        public virtual object Clone() { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static System.Globalization.TextInfo ReadOnly(System.Globalization.TextInfo textInfo) { throw null; }
+        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
+        public virtual char ToLower(char c) { throw null; }
+        public virtual string ToLower(string str) { throw null; }
+        public override string ToString() { throw null; }
+        public string ToTitleCase(string str) { throw null; }
+        public virtual char ToUpper(char c) { throw null; }
+        public virtual string ToUpper(string str) { throw null; }
+    }
+    public partial class ThaiBuddhistCalendar : System.Globalization.Calendar
+    {
+        public const int ThaiBuddhistEra = 1;
+        public ThaiBuddhistCalendar() { }
+        public override System.Globalization.CalendarAlgorithmType AlgorithmType { get { throw null; } }
+        public override int[] Eras { get { throw null; } }
+        public override System.DateTime MaxSupportedDateTime { get { throw null; } }
+        public override System.DateTime MinSupportedDateTime { get { throw null; } }
+        public override int TwoDigitYearMax { get { throw null; } set { } }
+        public override System.DateTime AddMonths(System.DateTime time, int months) { throw null; }
+        public override System.DateTime AddYears(System.DateTime time, int years) { throw null; }
+        public override int GetDayOfMonth(System.DateTime time) { throw null; }
+        public override System.DayOfWeek GetDayOfWeek(System.DateTime time) { throw null; }
+        public override int GetDayOfYear(System.DateTime time) { throw null; }
+        public override int GetDaysInMonth(int year, int month, int era) { throw null; }
+        public override int GetDaysInYear(int year, int era) { throw null; }
+        public override int GetEra(System.DateTime time) { throw null; }
+        public override int GetLeapMonth(int year, int era) { throw null; }
+        public override int GetMonth(System.DateTime time) { throw null; }
+        public override int GetMonthsInYear(int year, int era) { throw null; }
+        public override int GetWeekOfYear(System.DateTime time, System.Globalization.CalendarWeekRule rule, System.DayOfWeek firstDayOfWeek) { throw null; }
+        public override int GetYear(System.DateTime time) { throw null; }
+        public override bool IsLeapDay(int year, int month, int day, int era) { throw null; }
+        public override bool IsLeapMonth(int year, int month, int era) { throw null; }
+        public override bool IsLeapYear(int year, int era) { throw null; }
+        public override System.DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era) { throw null; }
+        public override int ToFourDigitYear(int year) { throw null; }
+    }
+    [System.FlagsAttribute]
+    public enum TimeSpanStyles
+    {
+        AssumeNegative = 1,
+        None = 0,
+    }
+    public partial class UmAlQuraCalendar : System.Globalization.Calendar
+    {
+        public const int UmAlQuraEra = 1;
+        public UmAlQuraCalendar() { }
+        public override System.Globalization.CalendarAlgorithmType AlgorithmType { get { throw null; } }
+        protected override int DaysInYearBeforeMinSupportedYear { get { throw null; } }
+        public override int[] Eras { get { throw null; } }
+        public override System.DateTime MaxSupportedDateTime { get { throw null; } }
+        public override System.DateTime MinSupportedDateTime { get { throw null; } }
+        public override int TwoDigitYearMax { get { throw null; } set { } }
+        public override System.DateTime AddMonths(System.DateTime time, int months) { throw null; }
+        public override System.DateTime AddYears(System.DateTime time, int years) { throw null; }
+        public override int GetDayOfMonth(System.DateTime time) { throw null; }
+        public override System.DayOfWeek GetDayOfWeek(System.DateTime time) { throw null; }
+        public override int GetDayOfYear(System.DateTime time) { throw null; }
+        public override int GetDaysInMonth(int year, int month, int era) { throw null; }
+        public override int GetDaysInYear(int year, int era) { throw null; }
+        public override int GetEra(System.DateTime time) { throw null; }
+        public override int GetLeapMonth(int year, int era) { throw null; }
+        public override int GetMonth(System.DateTime time) { throw null; }
+        public override int GetMonthsInYear(int year, int era) { throw null; }
+        public override int GetYear(System.DateTime time) { throw null; }
+        public override bool IsLeapDay(int year, int month, int day, int era) { throw null; }
+        public override bool IsLeapMonth(int year, int month, int era) { throw null; }
+        public override bool IsLeapYear(int year, int era) { throw null; }
+        public override System.DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era) { throw null; }
+        public override int ToFourDigitYear(int year) { throw null; }
+    }
+    public enum UnicodeCategory
+    {
+        ClosePunctuation = 21,
+        ConnectorPunctuation = 18,
+        Control = 14,
+        CurrencySymbol = 26,
+        DashPunctuation = 19,
+        DecimalDigitNumber = 8,
+        EnclosingMark = 7,
+        FinalQuotePunctuation = 23,
+        Format = 15,
+        InitialQuotePunctuation = 22,
+        LetterNumber = 9,
+        LineSeparator = 12,
+        LowercaseLetter = 1,
+        MathSymbol = 25,
+        ModifierLetter = 3,
+        ModifierSymbol = 27,
+        NonSpacingMark = 5,
+        OpenPunctuation = 20,
+        OtherLetter = 4,
+        OtherNotAssigned = 29,
+        OtherNumber = 10,
+        OtherPunctuation = 24,
+        OtherSymbol = 28,
+        ParagraphSeparator = 13,
+        PrivateUse = 17,
+        SpaceSeparator = 11,
+        SpacingCombiningMark = 6,
+        Surrogate = 16,
+        TitlecaseLetter = 2,
+        UppercaseLetter = 0,
+    }
 }
 namespace System.IO
 {
     public partial class DirectoryNotFoundException : System.IO.IOException
     {
         public DirectoryNotFoundException() { }
+        protected DirectoryNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public DirectoryNotFoundException(string message) { }
         public DirectoryNotFoundException(string message, System.Exception innerException) { }
-        protected DirectoryNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-    }
-    [Flags]
-    public enum FileAccess
-    {
-        Read = 1,
-        ReadWrite = 3,
-        Write = 2,
-    }
-    public enum FileMode
-    {
-        Append = 6,
-        Create = 2,
-        CreateNew = 1,
-        Open = 3,
-        OpenOrCreate = 4,
-        Truncate = 5,
     }
     [System.FlagsAttribute]
-    public enum FileShare
+    public enum FileAccess
     {
-        Delete = 4,
-        Inheritable = 16,
-        None = 0,
         Read = 1,
         ReadWrite = 3,
         Write = 2,
@@ -5175,30 +4958,109 @@ namespace System.IO
     public partial class FileLoadException : System.IO.IOException
     {
         public FileLoadException() { }
+        protected FileLoadException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public FileLoadException(string message) { }
         public FileLoadException(string message, System.Exception inner) { }
         public FileLoadException(string message, string fileName) { }
         public FileLoadException(string message, string fileName, System.Exception inner) { }
-        protected FileLoadException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public string FileName { get { throw null; } }
         public string FusionLog { get { throw null; } }
         public override string Message { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
+    }
+    public enum FileMode
+    {
+        Append = 6,
+        Create = 2,
+        CreateNew = 1,
+        Open = 3,
+        OpenOrCreate = 4,
+        Truncate = 5,
     }
     public partial class FileNotFoundException : System.IO.IOException
     {
         public FileNotFoundException() { }
+        protected FileNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public FileNotFoundException(string message) { }
         public FileNotFoundException(string message, System.Exception innerException) { }
         public FileNotFoundException(string message, string fileName) { }
         public FileNotFoundException(string message, string fileName, System.Exception innerException) { }
-        protected FileNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public string FileName { get { throw null; } }
         public string FusionLog { get { throw null; } }
         public override string Message { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
+    }
+    [System.FlagsAttribute]
+    public enum FileOptions
+    {
+        Asynchronous = 1073741824,
+        DeleteOnClose = 67108864,
+        Encrypted = 16384,
+        None = 0,
+        RandomAccess = 268435456,
+        SequentialScan = 134217728,
+        WriteThrough = -2147483648,
+    }
+    [System.FlagsAttribute]
+    public enum FileShare
+    {
+        Delete = 4,
+        Inheritable = 16,
+        None = 0,
+        Read = 1,
+        ReadWrite = 3,
+        Write = 2,
+    }
+    public partial class FileStream : System.IO.Stream
+    {
+        public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access) { }
+        public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize) { }
+        public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize, bool isAsync) { }
+        [System.ObsoleteAttribute("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access) instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        public FileStream(System.IntPtr handle, System.IO.FileAccess access) { }
+        [System.ObsoleteAttribute("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        public FileStream(System.IntPtr handle, System.IO.FileAccess access, bool ownsHandle) { }
+        [System.ObsoleteAttribute("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        public FileStream(System.IntPtr handle, System.IO.FileAccess access, bool ownsHandle, int bufferSize) { }
+        [System.ObsoleteAttribute("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        public FileStream(System.IntPtr handle, System.IO.FileAccess access, bool ownsHandle, int bufferSize, bool isAsync) { }
+        public FileStream(string path, System.IO.FileMode mode) { }
+        public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access) { }
+        public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) { }
+        public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize) { }
+        public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
+        public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options) { }
+        public override bool CanRead { get { throw null; } }
+        public override bool CanSeek { get { throw null; } }
+        public override bool CanWrite { get { throw null; } }
+        [System.ObsoleteAttribute("This property has been deprecated.  Please use FileStream's SafeFileHandle property instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        public virtual System.IntPtr Handle { get { throw null; } }
+        public virtual bool IsAsync { get { throw null; } }
+        public override long Length { get { throw null; } }
+        public string Name { get { throw null; } }
+        public override long Position { get { throw null; } set { } }
+        public virtual Microsoft.Win32.SafeHandles.SafeFileHandle SafeFileHandle { get { throw null; } }
+        public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { throw null; }
+        public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { throw null; }
+        protected override void Dispose(bool disposing) { }
+        public override int EndRead(System.IAsyncResult asyncResult) { throw null; }
+        public override void EndWrite(System.IAsyncResult asyncResult) { }
+        ~FileStream() { }
+        public override void Flush() { }
+        public virtual void Flush(bool flushToDisk) { }
+        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual void Lock(long position, long length) { }
+        public override int Read(byte[] array, int offset, int count) { throw null; }
+        public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override int ReadByte() { throw null; }
+        public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
+        public override void SetLength(long value) { }
+        public virtual void Unlock(long position, long length) { }
+        public override void Write(byte[] array, int offset, int count) { }
+        public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override void WriteByte(byte value) { }
     }
     public enum HandleInheritability
     {
@@ -5208,17 +5070,17 @@ namespace System.IO
     public partial class IOException : System.SystemException
     {
         public IOException() { }
+        protected IOException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public IOException(string message) { }
         public IOException(string message, System.Exception innerException) { }
         public IOException(string message, int hresult) { }
-        protected IOException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public partial class PathTooLongException : System.IO.IOException
     {
         public PathTooLongException() { }
+        protected PathTooLongException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public PathTooLongException(string message) { }
         public PathTooLongException(string message, System.Exception innerException) { }
-        protected PathTooLongException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     public enum SeekOrigin
     {
@@ -5240,19 +5102,19 @@ namespace System.IO
         public virtual int WriteTimeout { get { throw null; } set { } }
         public virtual System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { throw null; }
         public virtual System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { throw null; }
+        public virtual void Close() { }
         public void CopyTo(System.IO.Stream destination) { }
         public virtual void CopyTo(System.IO.Stream destination, int bufferSize) { }
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination) { throw null; }
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize) { throw null; }
-        public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public virtual void Close() { }
+        public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, System.Threading.CancellationToken cancellationToken) { throw null; }
         [System.ObsoleteAttribute("CreateWaitHandle will be removed eventually.  Please use \"new ManualResetEvent(false)\" instead.")]
         protected virtual System.Threading.WaitHandle CreateWaitHandle() { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public virtual int EndRead(System.IAsyncResult asyncResult) { throw null; }
-        public virtual void EndWrite(System.IAsyncResult asyncResult) { throw null; }
+        public virtual void EndWrite(System.IAsyncResult asyncResult) { }
         public abstract void Flush();
         public System.Threading.Tasks.Task FlushAsync() { throw null; }
         public virtual System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
@@ -5262,7 +5124,7 @@ namespace System.IO
         public virtual int Read(System.Span<byte> destination) { throw null; }
         public System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count) { throw null; }
         public virtual System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public virtual System.Threading.Tasks.ValueTask<int> ReadAsync(Memory<byte> destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<byte> destination, System.Threading.CancellationToken cancellationToken=default(System.Threading.CancellationToken)) { throw null; }
         public virtual int ReadByte() { throw null; }
         public abstract long Seek(long offset, System.IO.SeekOrigin origin);
         public abstract void SetLength(long value);
@@ -5271,68 +5133,8 @@ namespace System.IO
         public virtual void Write(System.ReadOnlySpan<byte> source) { }
         public System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count) { throw null; }
         public virtual System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public virtual System.Threading.Tasks.Task WriteAsync(ReadOnlyMemory<byte> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task WriteAsync(System.ReadOnlyMemory<byte> source, System.Threading.CancellationToken cancellationToken=default(System.Threading.CancellationToken)) { throw null; }
         public virtual void WriteByte(byte value) { }
-    }
-    public partial class FileStream : System.IO.Stream
-    {
-        [Obsolete("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access) instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
-        public FileStream(IntPtr handle, FileAccess access) { }
-        [Obsolete("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  http://go.microsoft.com/fwlink/?linkid=14202")]
-        public FileStream(IntPtr handle, FileAccess access, bool ownsHandle) { }
-        [Obsolete("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  http://go.microsoft.com/fwlink/?linkid=14202")]
-        public FileStream(IntPtr handle, FileAccess access, bool ownsHandle, int bufferSize) { }
-        [Obsolete("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  http://go.microsoft.com/fwlink/?linkid=14202")]
-        public FileStream(IntPtr handle, FileAccess access, bool ownsHandle, int bufferSize, bool isAsync) { }
-        public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access) { }
-        public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize) { }
-        public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize, bool isAsync) { }
-        public FileStream(string path, System.IO.FileMode mode) { }
-        public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access) { }
-        public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) { }
-        public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize) { }
-        public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
-        public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options) { }
-        public override bool CanRead { get { throw null; } }
-        public override bool CanSeek { get { throw null; } }
-        public override bool CanWrite { get { throw null; } }
-        [Obsolete("This property has been deprecated.  Please use FileStream's SafeFileHandle property instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
-        public virtual System.IntPtr Handle { get { throw null; } }
-        public virtual bool IsAsync { get { throw null; } }
-        public override long Length { get { throw null; } }
-        public string Name { get { throw null; } }
-        public override long Position { get { throw null; } set { } }
-        public virtual Microsoft.Win32.SafeHandles.SafeFileHandle SafeFileHandle { get { throw null; } }
-        protected override void Dispose(bool disposing) { }
-        ~FileStream() { }
-        public override void Flush() { }
-        public virtual void Flush(bool flushToDisk) { }
-        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
-        public override int Read(byte[] array, int offset, int count) { throw null; }
-        public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) { throw null; }
-        public override int EndRead(IAsyncResult asyncResult) { throw null; }
-        public virtual void Lock(long position, long length) { }
-        public override int ReadByte() { throw null; }
-        public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
-        public override void SetLength(long value) { }
-        public override void Write(byte[] array, int offset, int count) { }
-        public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) { throw null; }
-        public override void EndWrite(IAsyncResult asyncResult) { }
-        public override void WriteByte(byte value) { }
-        public virtual void Unlock(long position, long length) { }
-    }
-    [System.FlagsAttribute]
-    public enum FileOptions
-    {
-        Asynchronous = 1073741824,
-        DeleteOnClose = 67108864,
-        Encrypted = 16384,
-        None = 0,
-        RandomAccess = 268435456,
-        SequentialScan = 134217728,
-        WriteThrough = -2147483648,
     }
 }
 namespace System.Reflection
@@ -5346,31 +5148,44 @@ namespace System.Reflection
     public abstract partial class Assembly : System.Reflection.ICustomAttributeProvider, System.Runtime.Serialization.ISerializable
     {
         protected Assembly() { }
+        public virtual string CodeBase { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.CustomAttributeData> CustomAttributes { get { throw null; } }
-        public virtual System.Collections.Generic.IEnumerable<System.Reflection.TypeInfo> DefinedTypes { get; }
+        public virtual System.Collections.Generic.IEnumerable<System.Reflection.TypeInfo> DefinedTypes { get { throw null; } }
+        public virtual System.Reflection.MethodInfo EntryPoint { get { throw null; } }
         public virtual string EscapedCodeBase { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Type> ExportedTypes { get { throw null; } }
-        public virtual MethodInfo EntryPoint { get { throw null; } }
         public virtual string FullName { get { throw null; } }
         public virtual bool GlobalAssemblyCache { get { throw null; } }
         public virtual long HostContext { get { throw null; } }
+        public virtual string ImageRuntimeVersion { get { throw null; } }
         public virtual bool IsDynamic { get { throw null; } }
         public bool IsFullyTrusted { get { throw null; } }
+        public virtual string Location { get { throw null; } }
         public virtual System.Reflection.Module ManifestModule { get { throw null; } }
-        public virtual event ModuleResolveEventHandler ModuleResolve { add { } remove { } }
-        public virtual System.Collections.Generic.IEnumerable<System.Reflection.Module> Modules { get; }
+        public virtual System.Collections.Generic.IEnumerable<System.Reflection.Module> Modules { get { throw null; } }
         public virtual bool ReflectionOnly { get { throw null; } }
         public virtual System.Security.SecurityRuleSet SecurityRuleSet { get { throw null; } }
+        public virtual event System.Reflection.ModuleResolveEventHandler ModuleResolve { add { } remove { } }
+        public object CreateInstance(string typeName) { throw null; }
+        public object CreateInstance(string typeName, bool ignoreCase) { throw null; }
+        public virtual object CreateInstance(string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw null; }
+        public static string CreateQualifiedName(string assemblyName, string typeName) { throw null; }
         public override bool Equals(object o) { throw null; }
-        public static bool operator ==(System.Reflection.Assembly left, System.Reflection.Assembly right) { throw null; }
-        public static bool operator !=(System.Reflection.Assembly left, System.Reflection.Assembly right) { throw null; }
         public static System.Reflection.Assembly GetAssembly(System.Type type) { throw null; }
         public static System.Reflection.Assembly GetCallingAssembly() { throw null; }
+        public virtual object[] GetCustomAttributes(bool inherit) { throw null; }
+        public virtual object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public virtual System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetCustomAttributesData() { throw null; }
+        public static System.Reflection.Assembly GetEntryAssembly() { throw null; }
+        public static System.Reflection.Assembly GetExecutingAssembly() { throw null; }
+        public virtual System.Type[] GetExportedTypes() { throw null; }
         public virtual System.IO.FileStream GetFile(string name) { throw null; }
         public virtual System.IO.FileStream[] GetFiles() { throw null; }
         public virtual System.IO.FileStream[] GetFiles(bool getResourceModules) { throw null; }
         public virtual System.Type[] GetForwardedTypes() { throw null; }
         public override int GetHashCode() { throw null; }
+        public System.Reflection.Module[] GetLoadedModules() { throw null; }
+        public virtual System.Reflection.Module[] GetLoadedModules(bool getResourceModules) { throw null; }
         public virtual System.Reflection.ManifestResourceInfo GetManifestResourceInfo(string resourceName) { throw null; }
         public virtual string[] GetManifestResourceNames() { throw null; }
         public virtual System.IO.Stream GetManifestResourceStream(string name) { throw null; }
@@ -5378,50 +5193,37 @@ namespace System.Reflection
         public virtual System.Reflection.Module GetModule(string name) { throw null; }
         public System.Reflection.Module[] GetModules() { throw null; }
         public virtual System.Reflection.Module[] GetModules(bool getResourceModules) { throw null; }
-        public virtual System.Reflection.AssemblyName GetName(bool copiedName) { throw null; }
         public virtual System.Reflection.AssemblyName GetName() { throw null; }
+        public virtual System.Reflection.AssemblyName GetName(bool copiedName) { throw null; }
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public virtual System.Reflection.AssemblyName[] GetReferencedAssemblies() { throw null; }
+        public virtual System.Reflection.Assembly GetSatelliteAssembly(System.Globalization.CultureInfo culture) { throw null; }
+        public virtual System.Reflection.Assembly GetSatelliteAssembly(System.Globalization.CultureInfo culture, System.Version version) { throw null; }
         public virtual System.Type GetType(string name) { throw null; }
+        public virtual System.Type GetType(string name, bool throwOnError) { throw null; }
         public virtual System.Type GetType(string name, bool throwOnError, bool ignoreCase) { throw null; }
+        public virtual System.Type[] GetTypes() { throw null; }
+        public virtual bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
         public static System.Reflection.Assembly Load(byte[] rawAssembly) { throw null; }
         public static System.Reflection.Assembly Load(byte[] rawAssembly, byte[] rawSymbolStore) { throw null; }
         public static System.Reflection.Assembly Load(System.Reflection.AssemblyName assemblyRef) { throw null; }
         public static System.Reflection.Assembly Load(string assemblyString) { throw null; }
-        public static System.Reflection.Assembly LoadFile(String path) { throw null; }
-        public static System.Reflection.Assembly LoadFrom(String assemblyFile) { throw null; }
-        public static Assembly LoadFrom(string assemblyFile, byte[] hashValue, System.Configuration.Assemblies.AssemblyHashAlgorithm hashAlgorithm) { throw null; }
-        public System.Reflection.Module LoadModule(String moduleName, byte[] rawModule) { throw null; }
-        public virtual System.Reflection.Module LoadModule(String moduleName, byte[] rawModule, byte[] rawSymbolStore) { throw null; }
-        [ObsoleteAttribute("This method has been deprecated. Please use Assembly.Load() instead. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public static Assembly LoadWithPartialName(string partialName) { throw null; }
-        public static System.Reflection.Assembly GetEntryAssembly() { throw null; }
-        public static System.Reflection.Assembly GetExecutingAssembly() { throw null; }
-        public System.Reflection.Module[] GetLoadedModules() { throw null; }
-        public virtual System.Reflection.Module[] GetLoadedModules(bool getResourceModules) { throw null; }
-        public virtual string Location { get { throw null; } }
-        public override string ToString() { throw null; }
-        public static Assembly UnsafeLoadFrom(string assemblyFile) { throw null; }
-        public virtual string CodeBase { get { throw null; } }
-        public virtual string ImageRuntimeVersion { get { throw null; } }
-        public object CreateInstance(string typeName) { throw null; }
-        public object CreateInstance(string typeName, bool ignoreCase) { throw null; }
-        public virtual object CreateInstance(string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder binder, Object[] args, System.Globalization.CultureInfo culture, Object[] activationAttributes) { throw null; }
-        public static string CreateQualifiedName(string assemblyName, string typeName) { throw null; }
-        public virtual object[] GetCustomAttributes(bool inherit) { throw null; }
-        public virtual object[] GetCustomAttributes(Type attributeType, bool inherit) { throw null; }
-        public virtual System.Collections.Generic.IList<CustomAttributeData> GetCustomAttributesData() { throw null; }
-        public virtual Type[] GetExportedTypes() { throw null; }
-        public virtual AssemblyName[] GetReferencedAssemblies() { throw null; }
-        public virtual System.Reflection.Assembly GetSatelliteAssembly(System.Globalization.CultureInfo culture) { throw null; }
-        public virtual System.Reflection.Assembly GetSatelliteAssembly(System.Globalization.CultureInfo culture, System.Version version) { throw null; }
-        public virtual Type GetType(string name, bool throwOnError) { throw null; }
-        public virtual Type[] GetTypes() { throw null; }
+        public static System.Reflection.Assembly LoadFile(string path) { throw null; }
+        public static System.Reflection.Assembly LoadFrom(string assemblyFile) { throw null; }
+        public static System.Reflection.Assembly LoadFrom(string assemblyFile, byte[] hashValue, System.Configuration.Assemblies.AssemblyHashAlgorithm hashAlgorithm) { throw null; }
+        public System.Reflection.Module LoadModule(string moduleName, byte[] rawModule) { throw null; }
+        public virtual System.Reflection.Module LoadModule(string moduleName, byte[] rawModule, byte[] rawSymbolStore) { throw null; }
+        [System.ObsoleteAttribute("This method has been deprecated. Please use Assembly.Load() instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static System.Reflection.Assembly LoadWithPartialName(string partialName) { throw null; }
+        public static bool operator ==(System.Reflection.Assembly left, System.Reflection.Assembly right) { throw null; }
+        public static bool operator !=(System.Reflection.Assembly left, System.Reflection.Assembly right) { throw null; }
         public static System.Reflection.Assembly ReflectionOnlyLoad(byte[] rawAssembly) { throw null; }
         public static System.Reflection.Assembly ReflectionOnlyLoad(string assemblyString) { throw null; }
         public static System.Reflection.Assembly ReflectionOnlyLoadFrom(string assemblyFile) { throw null; }
-        public virtual bool IsDefined(Type attributeType, bool inherit) { throw null; }
+        public override string ToString() { throw null; }
+        public static System.Reflection.Assembly UnsafeLoadFrom(string assemblyFile) { throw null; }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyAlgorithmIdAttribute : System.Attribute
     {
         public AssemblyAlgorithmIdAttribute(System.Configuration.Assemblies.AssemblyHashAlgorithm algorithmId) { }
@@ -5430,13 +5232,13 @@ namespace System.Reflection
         [System.CLSCompliantAttribute(false)]
         public uint AlgorithmId { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyCompanyAttribute : System.Attribute
     {
         public AssemblyCompanyAttribute(string company) { }
         public string Company { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyConfigurationAttribute : System.Attribute
     {
         public AssemblyConfigurationAttribute(string configuration) { }
@@ -5447,82 +5249,82 @@ namespace System.Reflection
         Default = 0,
         WindowsRuntime = 1,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyCopyrightAttribute : System.Attribute
     {
         public AssemblyCopyrightAttribute(string copyright) { }
         public string Copyright { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyCultureAttribute : System.Attribute
     {
         public AssemblyCultureAttribute(string culture) { }
         public string Culture { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyDefaultAliasAttribute : System.Attribute
     {
         public AssemblyDefaultAliasAttribute(string defaultAlias) { }
         public string DefaultAlias { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyDelaySignAttribute : System.Attribute
     {
         public AssemblyDelaySignAttribute(bool delaySign) { }
         public bool DelaySign { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyDescriptionAttribute : System.Attribute
     {
         public AssemblyDescriptionAttribute(string description) { }
         public string Description { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyFileVersionAttribute : System.Attribute
     {
         public AssemblyFileVersionAttribute(string version) { }
         public string Version { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyFlagsAttribute : System.Attribute
     {
-        [System.CLSCompliantAttribute(false)]
-        [ObsoleteAttribute("This constructor has been deprecated. Please use AssemblyFlagsAttribute(AssemblyNameFlags) instead. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public AssemblyFlagsAttribute(uint flags) { }
-        [ObsoleteAttribute("This constructor has been deprecated. Please use AssemblyFlagsAttribute(AssemblyNameFlags) instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Please use AssemblyFlagsAttribute(AssemblyNameFlags) instead. http://go.microsoft.com/fwlink/?linkid=14202")]
         public AssemblyFlagsAttribute(int assemblyFlags) { }
         public AssemblyFlagsAttribute(System.Reflection.AssemblyNameFlags assemblyFlags) { }
+        [System.CLSCompliantAttribute(false)]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Please use AssemblyFlagsAttribute(AssemblyNameFlags) instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public AssemblyFlagsAttribute(uint flags) { }
         public int AssemblyFlags { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        [ObsoleteAttribute("This property has been deprecated. Please use AssemblyFlags instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This property has been deprecated. Please use AssemblyFlags instead. http://go.microsoft.com/fwlink/?linkid=14202")]
         public uint Flags { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyInformationalVersionAttribute : System.Attribute
     {
         public AssemblyInformationalVersionAttribute(string informationalVersion) { }
         public string InformationalVersion { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyKeyFileAttribute : System.Attribute
     {
         public AssemblyKeyFileAttribute(string keyFile) { }
         public string KeyFile { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyKeyNameAttribute : System.Attribute
     {
         public AssemblyKeyNameAttribute(string keyName) { }
         public string KeyName { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = true, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=true, Inherited=false)]
     public sealed partial class AssemblyMetadataAttribute : System.Attribute
     {
         public AssemblyMetadataAttribute(string key, string value) { }
         public string Key { get { throw null; } }
         public string Value { get { throw null; } }
     }
-    public sealed partial class AssemblyName : System.ICloneable, System.Runtime.Serialization.ISerializable, System.Runtime.Serialization.IDeserializationCallback
+    public sealed partial class AssemblyName : System.ICloneable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         public AssemblyName() { }
         public AssemblyName(string assemblyName) { }
@@ -5535,20 +5337,20 @@ namespace System.Reflection
         public string FullName { get { throw null; } }
         public System.Configuration.Assemblies.AssemblyHashAlgorithm HashAlgorithm { get { throw null; } set { } }
         public System.Reflection.StrongNameKeyPair KeyPair { get { throw null; } set { } }
-        public System.Configuration.Assemblies.AssemblyVersionCompatibility VersionCompatibility { get { throw null; } set { } }
         public string Name { get { throw null; } set { } }
         public System.Reflection.ProcessorArchitecture ProcessorArchitecture { get { throw null; } set { } }
         public System.Version Version { get { throw null; } set { } }
+        public System.Configuration.Assemblies.AssemblyVersionCompatibility VersionCompatibility { get { throw null; } set { } }
         public object Clone() { throw null; }
-        public static System.Reflection.AssemblyName GetAssemblyName(System.String assemblyFile) { throw null; }
+        public static System.Reflection.AssemblyName GetAssemblyName(string assemblyFile) { throw null; }
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public byte[] GetPublicKey() { throw null; }
         public byte[] GetPublicKeyToken() { throw null; }
+        public void OnDeserialization(object sender) { }
+        public static bool ReferenceMatchesDefinition(System.Reflection.AssemblyName reference, System.Reflection.AssemblyName definition) { throw null; }
         public void SetPublicKey(byte[] publicKey) { }
         public void SetPublicKeyToken(byte[] publicKeyToken) { }
         public override string ToString() { throw null; }
-        public static bool ReferenceMatchesDefinition(System.Reflection.AssemblyName reference, System.Reflection.AssemblyName definition) { throw null; }
-        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { throw null; }
-        public void OnDeserialization(Object sender) { throw null; }
     }
     [System.FlagsAttribute]
     public enum AssemblyNameFlags
@@ -5559,32 +5361,32 @@ namespace System.Reflection
         PublicKey = 1,
         Retargetable = 256,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyProductAttribute : System.Attribute
     {
         public AssemblyProductAttribute(string product) { }
         public string Product { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false, AllowMultiple = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false, AllowMultiple=false)]
     public sealed partial class AssemblySignatureKeyAttribute : System.Attribute
     {
         public AssemblySignatureKeyAttribute(string publicKey, string countersignature) { }
         public string Countersignature { get { throw null; } }
         public string PublicKey { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyTitleAttribute : System.Attribute
     {
         public AssemblyTitleAttribute(string title) { }
         public string Title { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyTrademarkAttribute : System.Attribute
     {
         public AssemblyTrademarkAttribute(string trademark) { }
         public string Trademark { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyVersionAttribute : System.Attribute
     {
         public AssemblyVersionAttribute(string version) { }
@@ -5600,7 +5402,7 @@ namespace System.Reflection
         public abstract System.Reflection.MethodBase SelectMethod(System.Reflection.BindingFlags bindingAttr, System.Reflection.MethodBase[] match, System.Type[] types, System.Reflection.ParameterModifier[] modifiers);
         public abstract System.Reflection.PropertyInfo SelectProperty(System.Reflection.BindingFlags bindingAttr, System.Reflection.PropertyInfo[] match, System.Type returnType, System.Type[] indexes, System.Reflection.ParameterModifier[] modifiers);
     }
-    [Flags]
+    [System.FlagsAttribute]
     public enum BindingFlags
     {
         CreateInstance = 512,
@@ -5639,26 +5441,26 @@ namespace System.Reflection
         public static readonly string ConstructorName;
         public static readonly string TypeConstructorName;
         protected ConstructorInfo() { }
+        public override System.Reflection.MemberTypes MemberType { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
-        public static bool operator ==(System.Reflection.ConstructorInfo left, System.Reflection.ConstructorInfo right) { throw null; }
-        public static bool operator !=(System.Reflection.ConstructorInfo left, System.Reflection.ConstructorInfo right) { throw null; }
         public override int GetHashCode() { throw null; }
         public object Invoke(object[] parameters) { throw null; }
         public abstract object Invoke(System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] parameters, System.Globalization.CultureInfo culture);
-        public override MemberTypes MemberType { get { throw null; } }
+        public static bool operator ==(System.Reflection.ConstructorInfo left, System.Reflection.ConstructorInfo right) { throw null; }
+        public static bool operator !=(System.Reflection.ConstructorInfo left, System.Reflection.ConstructorInfo right) { throw null; }
     }
     public partial class CustomAttributeData
     {
         protected CustomAttributeData() { }
         public System.Type AttributeType { get { throw null; } }
+        public virtual System.Reflection.ConstructorInfo Constructor { get { throw null; } }
         public virtual System.Collections.Generic.IList<System.Reflection.CustomAttributeTypedArgument> ConstructorArguments { get { throw null; } }
         public virtual System.Collections.Generic.IList<System.Reflection.CustomAttributeNamedArgument> NamedArguments { get { throw null; } }
-        public virtual ConstructorInfo Constructor { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
-        public static System.Collections.Generic.IList<CustomAttributeData> GetCustomAttributes(Assembly target) { throw null; }
-        public static System.Collections.Generic.IList<CustomAttributeData> GetCustomAttributes(MemberInfo target) { throw null; }
-        public static System.Collections.Generic.IList<CustomAttributeData> GetCustomAttributes(Module target) { throw null; }
-        public static System.Collections.Generic.IList<CustomAttributeData> GetCustomAttributes(ParameterInfo target) { throw null; }
+        public static System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetCustomAttributes(System.Reflection.Assembly target) { throw null; }
+        public static System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetCustomAttributes(System.Reflection.MemberInfo target) { throw null; }
+        public static System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetCustomAttributes(System.Reflection.Module target) { throw null; }
+        public static System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetCustomAttributes(System.Reflection.ParameterInfo target) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
     }
@@ -5670,12 +5472,6 @@ namespace System.Reflection
         public static System.Attribute GetCustomAttribute(this System.Reflection.Module element, System.Type attributeType) { throw null; }
         public static System.Attribute GetCustomAttribute(this System.Reflection.ParameterInfo element, System.Type attributeType) { throw null; }
         public static System.Attribute GetCustomAttribute(this System.Reflection.ParameterInfo element, System.Type attributeType, bool inherit) { throw null; }
-        public static T GetCustomAttribute<T>(this System.Reflection.Assembly element) where T : System.Attribute { throw null; }
-        public static T GetCustomAttribute<T>(this System.Reflection.MemberInfo element) where T : System.Attribute { throw null; }
-        public static T GetCustomAttribute<T>(this System.Reflection.MemberInfo element, bool inherit) where T : System.Attribute { throw null; }
-        public static T GetCustomAttribute<T>(this System.Reflection.Module element) where T : System.Attribute { throw null; }
-        public static T GetCustomAttribute<T>(this System.Reflection.ParameterInfo element) where T : System.Attribute { throw null; }
-        public static T GetCustomAttribute<T>(this System.Reflection.ParameterInfo element, bool inherit) where T : System.Attribute { throw null; }
         public static System.Collections.Generic.IEnumerable<System.Attribute> GetCustomAttributes(this System.Reflection.Assembly element) { throw null; }
         public static System.Collections.Generic.IEnumerable<System.Attribute> GetCustomAttributes(this System.Reflection.Assembly element, System.Type attributeType) { throw null; }
         public static System.Collections.Generic.IEnumerable<System.Attribute> GetCustomAttributes(this System.Reflection.MemberInfo element) { throw null; }
@@ -5694,6 +5490,12 @@ namespace System.Reflection
         public static System.Collections.Generic.IEnumerable<T> GetCustomAttributes<T>(this System.Reflection.Module element) where T : System.Attribute { throw null; }
         public static System.Collections.Generic.IEnumerable<T> GetCustomAttributes<T>(this System.Reflection.ParameterInfo element) where T : System.Attribute { throw null; }
         public static System.Collections.Generic.IEnumerable<T> GetCustomAttributes<T>(this System.Reflection.ParameterInfo element, bool inherit) where T : System.Attribute { throw null; }
+        public static T GetCustomAttribute<T>(this System.Reflection.Assembly element) where T : System.Attribute { throw null; }
+        public static T GetCustomAttribute<T>(this System.Reflection.MemberInfo element) where T : System.Attribute { throw null; }
+        public static T GetCustomAttribute<T>(this System.Reflection.MemberInfo element, bool inherit) where T : System.Attribute { throw null; }
+        public static T GetCustomAttribute<T>(this System.Reflection.Module element) where T : System.Attribute { throw null; }
+        public static T GetCustomAttribute<T>(this System.Reflection.ParameterInfo element) where T : System.Attribute { throw null; }
+        public static T GetCustomAttribute<T>(this System.Reflection.ParameterInfo element, bool inherit) where T : System.Attribute { throw null; }
         public static bool IsDefined(this System.Reflection.Assembly element, System.Type attributeType) { throw null; }
         public static bool IsDefined(this System.Reflection.MemberInfo element, System.Type attributeType) { throw null; }
         public static bool IsDefined(this System.Reflection.MemberInfo element, System.Type attributeType, bool inherit) { throw null; }
@@ -5704,36 +5506,36 @@ namespace System.Reflection
     public partial class CustomAttributeFormatException : System.FormatException
     {
         public CustomAttributeFormatException() { }
+        protected CustomAttributeFormatException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public CustomAttributeFormatException(string message) { }
         public CustomAttributeFormatException(string message, System.Exception inner) { }
-        protected CustomAttributeFormatException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CustomAttributeNamedArgument
     {
-        public CustomAttributeNamedArgument(System.Reflection.MemberInfo memberInfo, object value) { }
-        public CustomAttributeNamedArgument(System.Reflection.MemberInfo memberInfo, System.Reflection.CustomAttributeTypedArgument typedArgument) { }
+        public CustomAttributeNamedArgument(System.Reflection.MemberInfo memberInfo, object value) { throw null;}
+        public CustomAttributeNamedArgument(System.Reflection.MemberInfo memberInfo, System.Reflection.CustomAttributeTypedArgument typedArgument) { throw null;}
         public bool IsField { get { throw null; } }
         public System.Reflection.MemberInfo MemberInfo { get { throw null; } }
         public string MemberName { get { throw null; } }
         public System.Reflection.CustomAttributeTypedArgument TypedValue { get { throw null; } }
-        public static bool operator ==(CustomAttributeNamedArgument left, CustomAttributeNamedArgument right) { throw null; }
-        public static bool operator !=(CustomAttributeNamedArgument left, CustomAttributeNamedArgument right) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Reflection.CustomAttributeNamedArgument left, System.Reflection.CustomAttributeNamedArgument right) { throw null; }
+        public static bool operator !=(System.Reflection.CustomAttributeNamedArgument left, System.Reflection.CustomAttributeNamedArgument right) { throw null; }
         public override string ToString() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CustomAttributeTypedArgument
     {
-        public CustomAttributeTypedArgument(object value) { }
-        public CustomAttributeTypedArgument(System.Type argumentType, object value) { }
+        public CustomAttributeTypedArgument(object value) { throw null;}
+        public CustomAttributeTypedArgument(System.Type argumentType, object value) { throw null;}
         public System.Type ArgumentType { get { throw null; } }
         public object Value { get { throw null; } }
-        public static bool operator ==(CustomAttributeTypedArgument left, CustomAttributeTypedArgument right) { throw null; }
-        public static bool operator !=(CustomAttributeTypedArgument left, CustomAttributeTypedArgument right) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Reflection.CustomAttributeTypedArgument left, System.Reflection.CustomAttributeTypedArgument right) { throw null; }
+        public static bool operator !=(System.Reflection.CustomAttributeTypedArgument left, System.Reflection.CustomAttributeTypedArgument right) { throw null; }
         public override string ToString() { throw null; }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1036))]
@@ -5758,43 +5560,43 @@ namespace System.Reflection
         public virtual System.Type EventHandlerType { get { throw null; } }
         public virtual bool IsMulticast { get { throw null; } }
         public bool IsSpecialName { get { throw null; } }
+        public override System.Reflection.MemberTypes MemberType { get { throw null; } }
         public virtual System.Reflection.MethodInfo RaiseMethod { get { throw null; } }
         public virtual System.Reflection.MethodInfo RemoveMethod { get { throw null; } }
         public virtual void AddEventHandler(object target, System.Delegate handler) { }
         public override bool Equals(object obj) { throw null; }
-        public static bool operator ==(System.Reflection.EventInfo left, System.Reflection.EventInfo right) { throw null; }
-        public static bool operator !=(System.Reflection.EventInfo left, System.Reflection.EventInfo right) { throw null; }
+        public System.Reflection.MethodInfo GetAddMethod() { throw null; }
+        public abstract System.Reflection.MethodInfo GetAddMethod(bool nonPublic);
         public override int GetHashCode() { throw null; }
-        public virtual void RemoveEventHandler(object target, System.Delegate handler) { }
-        public MethodInfo GetAddMethod() { throw null; }
-        public abstract MethodInfo GetAddMethod(bool nonPublic);
         public System.Reflection.MethodInfo[] GetOtherMethods() { throw null; }
         public virtual System.Reflection.MethodInfo[] GetOtherMethods(bool nonPublic) { throw null; }
-        public MethodInfo GetRaiseMethod() { throw null; }
-        public abstract MethodInfo GetRaiseMethod(bool nonPublic);
-        public MethodInfo GetRemoveMethod() { throw null; }
-        public abstract MethodInfo GetRemoveMethod(bool nonPublic);
-        public override System.Reflection.MemberTypes MemberType { get { throw null; } }
+        public System.Reflection.MethodInfo GetRaiseMethod() { throw null; }
+        public abstract System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic);
+        public System.Reflection.MethodInfo GetRemoveMethod() { throw null; }
+        public abstract System.Reflection.MethodInfo GetRemoveMethod(bool nonPublic);
+        public static bool operator ==(System.Reflection.EventInfo left, System.Reflection.EventInfo right) { throw null; }
+        public static bool operator !=(System.Reflection.EventInfo left, System.Reflection.EventInfo right) { throw null; }
+        public virtual void RemoveEventHandler(object target, System.Delegate handler) { }
     }
-    public class ExceptionHandlingClause
+    public partial class ExceptionHandlingClause
     {
         protected ExceptionHandlingClause() { }
-        public virtual System.Reflection.ExceptionHandlingClauseOptions Flags { get { throw null; } }
-        public virtual int TryOffset { get { throw null; } }
-        public virtual int TryLength { get { throw null; } }
-        public virtual int HandlerOffset { get { throw null; } }
-        public virtual int HandlerLength { get { throw null; } }
-        public virtual int FilterOffset { get { throw null; } }
         public virtual System.Type CatchType { get { throw null; } }
+        public virtual int FilterOffset { get { throw null; } }
+        public virtual System.Reflection.ExceptionHandlingClauseOptions Flags { get { throw null; } }
+        public virtual int HandlerLength { get { throw null; } }
+        public virtual int HandlerOffset { get { throw null; } }
+        public virtual int TryLength { get { throw null; } }
+        public virtual int TryOffset { get { throw null; } }
         public override string ToString() { throw null; }
     }
     [System.FlagsAttribute]
-    public enum ExceptionHandlingClauseOptions : int
+    public enum ExceptionHandlingClauseOptions
     {
         Clause = 0,
+        Fault = 4,
         Filter = 1,
         Finally = 2,
-        Fault = 4,
     }
     [System.FlagsAttribute]
     public enum FieldAttributes
@@ -5835,24 +5637,24 @@ namespace System.Reflection
         public bool IsPinvokeImpl { get { throw null; } }
         public bool IsPrivate { get { throw null; } }
         public bool IsPublic { get { throw null; } }
-        public bool IsSpecialName { get { throw null; } }
-        public bool IsStatic { get { throw null; } }
         public virtual bool IsSecurityCritical { get { throw null; } }
         public virtual bool IsSecuritySafeCritical { get { throw null; } }
         public virtual bool IsSecurityTransparent { get { throw null; } }
+        public bool IsSpecialName { get { throw null; } }
+        public bool IsStatic { get { throw null; } }
+        public override System.Reflection.MemberTypes MemberType { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
-        public static bool operator ==(System.Reflection.FieldInfo left, System.Reflection.FieldInfo right) { throw null; }
-        public static bool operator !=(System.Reflection.FieldInfo left, System.Reflection.FieldInfo right) { throw null; }
         public static System.Reflection.FieldInfo GetFieldFromHandle(System.RuntimeFieldHandle handle) { throw null; }
         public static System.Reflection.FieldInfo GetFieldFromHandle(System.RuntimeFieldHandle handle, System.RuntimeTypeHandle declaringType) { throw null; }
         public override int GetHashCode() { throw null; }
-        public virtual Type[] GetOptionalCustomModifiers() { throw null; }
+        public virtual System.Type[] GetOptionalCustomModifiers() { throw null; }
         public virtual object GetRawConstantValue() { throw null; }
-        public virtual Type[] GetRequiredCustomModifiers() { throw null; }
+        public virtual System.Type[] GetRequiredCustomModifiers() { throw null; }
         public abstract object GetValue(object obj);
         [System.CLSCompliantAttribute(false)]
         public virtual object GetValueDirect(System.TypedReference obj) { throw null; }
-        public override MemberTypes MemberType { get { throw null; } }
+        public static bool operator ==(System.Reflection.FieldInfo left, System.Reflection.FieldInfo right) { throw null; }
+        public static bool operator !=(System.Reflection.FieldInfo left, System.Reflection.FieldInfo right) { throw null; }
         public void SetValue(object obj, object value) { }
         public abstract void SetValue(object obj, object value, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Globalization.CultureInfo culture);
         [System.CLSCompliantAttribute(false)]
@@ -5870,18 +5672,18 @@ namespace System.Reflection
         SpecialConstraintMask = 28,
         VarianceMask = 3,
     }
-    public interface ICustomAttributeProvider
+    public partial interface ICustomAttributeProvider
     {
         object[] GetCustomAttributes(bool inherit);
-        object[] GetCustomAttributes(Type attributeType, bool inherit);
-        bool IsDefined(Type attributeType, bool inherit);
+        object[] GetCustomAttributes(System.Type attributeType, bool inherit);
+        bool IsDefined(System.Type attributeType, bool inherit);
     }
     public enum ImageFileMachine
     {
+        AMD64 = 34404,
+        ARM = 452,
         I386 = 332,
         IA64 = 512,
-        AMD64 = 34404,
-        ARM = 452
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct InterfaceMapping
@@ -5895,12 +5697,12 @@ namespace System.Reflection
     {
         public static System.Reflection.TypeInfo GetTypeInfo(this System.Type type) { throw null; }
     }
-    public partial class InvalidFilterCriteriaException : ApplicationException
+    public partial class InvalidFilterCriteriaException : System.ApplicationException
     {
         public InvalidFilterCriteriaException() { }
+        protected InvalidFilterCriteriaException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public InvalidFilterCriteriaException(string message) { }
-        public InvalidFilterCriteriaException(string message, Exception inner) { }
-        protected InvalidFilterCriteriaException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+        public InvalidFilterCriteriaException(string message, System.Exception inner) { }
     }
     public partial interface IReflect
     {
@@ -5936,39 +5738,39 @@ namespace System.Reflection
         public virtual System.Reflection.Assembly ReferencedAssembly { get { throw null; } }
         public virtual System.Reflection.ResourceLocation ResourceLocation { get { throw null; } }
     }
-    public delegate bool MemberFilter(MemberInfo m, object filterCriteria);
+    public delegate bool MemberFilter(System.Reflection.MemberInfo m, object filterCriteria);
     public abstract partial class MemberInfo : System.Reflection.ICustomAttributeProvider
     {
         protected MemberInfo() { }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.CustomAttributeData> CustomAttributes { get { throw null; } }
         public abstract System.Type DeclaringType { get; }
+        public abstract System.Reflection.MemberTypes MemberType { get; }
         public virtual int MetadataToken { get { throw null; } }
         public virtual System.Reflection.Module Module { get { throw null; } }
         public abstract string Name { get; }
+        public abstract System.Type ReflectedType { get; }
         public override bool Equals(object obj) { throw null; }
+        public abstract object[] GetCustomAttributes(bool inherit);
+        public abstract object[] GetCustomAttributes(System.Type attributeType, bool inherit);
+        public virtual System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetCustomAttributesData() { throw null; }
+        public override int GetHashCode() { throw null; }
+        public virtual bool HasSameMetadataDefinitionAs(System.Reflection.MemberInfo other) { throw null; }
+        public abstract bool IsDefined(System.Type attributeType, bool inherit);
         public static bool operator ==(System.Reflection.MemberInfo left, System.Reflection.MemberInfo right) { throw null; }
         public static bool operator !=(System.Reflection.MemberInfo left, System.Reflection.MemberInfo right) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public abstract MemberTypes MemberType { get; }
-        public abstract System.Type ReflectedType { get; }
-        public abstract object[] GetCustomAttributes(bool inherit);
-        public abstract object[] GetCustomAttributes(Type attributeType, bool inherit);
-        public abstract bool IsDefined(Type attributeType, bool inherit);
-        public virtual System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetCustomAttributesData() { throw null; }
-        public virtual bool HasSameMetadataDefinitionAs(System.Reflection.MemberInfo other) { throw null; }
     }
-    [Flags]
+    [System.FlagsAttribute]
     public enum MemberTypes
     {
-        Constructor = 0x01,
-        Event = 0x02,
-        Field = 0x04,
-        Method = 0x08,
-        Property = 0x10,
-        TypeInfo = 0x20,
-        Custom = 0x40,
-        NestedType = 0x80,
-        All = Constructor | Event | Field | Method | Property | TypeInfo | NestedType,
+        All = 191,
+        Constructor = 1,
+        Custom = 64,
+        Event = 2,
+        Field = 4,
+        Method = 8,
+        NestedType = 128,
+        Property = 16,
+        TypeInfo = 32,
     }
     [System.FlagsAttribute]
     public enum MethodAttributes
@@ -6006,6 +5808,7 @@ namespace System.Reflection
         public virtual bool ContainsGenericParameters { get { throw null; } }
         public bool IsAbstract { get { throw null; } }
         public bool IsAssembly { get { throw null; } }
+        public virtual bool IsConstructedGenericMethod { get { throw null; } }
         public bool IsConstructor { get { throw null; } }
         public bool IsFamily { get { throw null; } }
         public bool IsFamilyAndAssembly { get { throw null; } }
@@ -6013,41 +5816,40 @@ namespace System.Reflection
         public bool IsFinal { get { throw null; } }
         public virtual bool IsGenericMethod { get { throw null; } }
         public virtual bool IsGenericMethodDefinition { get { throw null; } }
-        public virtual bool IsConstructedGenericMethod { get { throw null; } }
         public bool IsHideBySig { get { throw null; } }
         public bool IsPrivate { get { throw null; } }
         public bool IsPublic { get { throw null; } }
-        public bool IsSpecialName { get { throw null; } }
-        public bool IsStatic { get { throw null; } }
-        public bool IsVirtual { get { throw null; } }
         public virtual bool IsSecurityCritical { get { throw null; } }
         public virtual bool IsSecuritySafeCritical { get { throw null; } }
         public virtual bool IsSecurityTransparent { get { throw null; } }
+        public bool IsSpecialName { get { throw null; } }
+        public bool IsStatic { get { throw null; } }
+        public bool IsVirtual { get { throw null; } }
         public abstract System.RuntimeMethodHandle MethodHandle { get; }
         public virtual System.Reflection.MethodImplAttributes MethodImplementationFlags { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
-        public static bool operator ==(System.Reflection.MethodBase left, System.Reflection.MethodBase right) { throw null; }
-        public static bool operator !=(System.Reflection.MethodBase left, System.Reflection.MethodBase right) { throw null; }
         public static System.Reflection.MethodBase GetCurrentMethod() { throw null; }
         public virtual System.Type[] GetGenericArguments() { throw null; }
         public override int GetHashCode() { throw null; }
         public virtual System.Reflection.MethodBody GetMethodBody() { throw null; }
         public static System.Reflection.MethodBase GetMethodFromHandle(System.RuntimeMethodHandle handle) { throw null; }
         public static System.Reflection.MethodBase GetMethodFromHandle(System.RuntimeMethodHandle handle, System.RuntimeTypeHandle declaringType) { throw null; }
+        public abstract System.Reflection.MethodImplAttributes GetMethodImplementationFlags();
         public abstract System.Reflection.ParameterInfo[] GetParameters();
         public object Invoke(object obj, object[] parameters) { throw null; }
         public abstract object Invoke(object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] parameters, System.Globalization.CultureInfo culture);
-        public abstract MethodImplAttributes GetMethodImplementationFlags();
+        public static bool operator ==(System.Reflection.MethodBase left, System.Reflection.MethodBase right) { throw null; }
+        public static bool operator !=(System.Reflection.MethodBase left, System.Reflection.MethodBase right) { throw null; }
     }
-    public class MethodBody
+    public partial class MethodBody
     {
         protected MethodBody() { }
-        public virtual int LocalSignatureMetadataToken { get { throw null; } }
-        public virtual System.Collections.Generic.IList<LocalVariableInfo> LocalVariables { get { throw null; } }
-        public virtual int MaxStackSize { get { throw null; } }
+        public virtual System.Collections.Generic.IList<System.Reflection.ExceptionHandlingClause> ExceptionHandlingClauses { get { throw null; } }
         public virtual bool InitLocals { get { throw null; } }
+        public virtual int LocalSignatureMetadataToken { get { throw null; } }
+        public virtual System.Collections.Generic.IList<System.Reflection.LocalVariableInfo> LocalVariables { get { throw null; } }
+        public virtual int MaxStackSize { get { throw null; } }
         public virtual byte[] GetILAsByteArray() { throw null; }
-        public virtual System.Collections.Generic.IList<ExceptionHandlingClause> ExceptionHandlingClauses { get { throw null; } }
     }
     public enum MethodImplAttributes
     {
@@ -6071,22 +5873,22 @@ namespace System.Reflection
     public abstract partial class MethodInfo : System.Reflection.MethodBase
     {
         protected MethodInfo() { }
-        public abstract MethodInfo GetBaseDefinition();
+        public override System.Reflection.MemberTypes MemberType { get { throw null; } }
         public virtual System.Reflection.ParameterInfo ReturnParameter { get { throw null; } }
         public virtual System.Type ReturnType { get { throw null; } }
+        public abstract System.Reflection.ICustomAttributeProvider ReturnTypeCustomAttributes { get; }
         public virtual System.Delegate CreateDelegate(System.Type delegateType) { throw null; }
         public virtual System.Delegate CreateDelegate(System.Type delegateType, object target) { throw null; }
         public override bool Equals(object obj) { throw null; }
-        public static bool operator ==(System.Reflection.MethodInfo left, System.Reflection.MethodInfo right) { throw null; }
-        public static bool operator !=(System.Reflection.MethodInfo left, System.Reflection.MethodInfo right) { throw null; }
+        public abstract System.Reflection.MethodInfo GetBaseDefinition();
         public override System.Type[] GetGenericArguments() { throw null; }
         public virtual System.Reflection.MethodInfo GetGenericMethodDefinition() { throw null; }
         public override int GetHashCode() { throw null; }
         public virtual System.Reflection.MethodInfo MakeGenericMethod(params System.Type[] typeArguments) { throw null; }
-        public override MemberTypes MemberType { get { throw null; } }
-        public abstract System.Reflection.ICustomAttributeProvider ReturnTypeCustomAttributes { get; }
+        public static bool operator ==(System.Reflection.MethodInfo left, System.Reflection.MethodInfo right) { throw null; }
+        public static bool operator !=(System.Reflection.MethodInfo left, System.Reflection.MethodInfo right) { throw null; }
     }
-    public sealed class Missing : System.Runtime.Serialization.ISerializable
+    public sealed partial class Missing : System.Runtime.Serialization.ISerializable
     {
         internal Missing() { }
         public static readonly System.Reflection.Missing Value;
@@ -6094,45 +5896,44 @@ namespace System.Reflection
     }
     public abstract partial class Module : System.Reflection.ICustomAttributeProvider, System.Runtime.Serialization.ISerializable
     {
+        public static readonly System.Reflection.TypeFilter FilterTypeName;
+        public static readonly System.Reflection.TypeFilter FilterTypeNameIgnoreCase;
         protected Module() { }
         public virtual System.Reflection.Assembly Assembly { get { throw null; } }
-        public System.ModuleHandle ModuleHandle { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.CustomAttributeData> CustomAttributes { get { throw null; } }
         public virtual string FullyQualifiedName { get { throw null; } }
         public virtual int MDStreamVersion { get { throw null; } }
         public virtual int MetadataToken { get { throw null; } }
+        public System.ModuleHandle ModuleHandle { get { throw null; } }
+        public virtual System.Guid ModuleVersionId { get { throw null; } }
         public virtual string Name { get { throw null; } }
+        public virtual string ScopeName { get { throw null; } }
         public override bool Equals(object o) { throw null; }
+        public virtual System.Type[] FindTypes(System.Reflection.TypeFilter filter, object filterCriteria) { throw null; }
+        public virtual object[] GetCustomAttributes(bool inherit) { throw null; }
+        public virtual object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public virtual System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetCustomAttributesData() { throw null; }
+        public System.Reflection.FieldInfo GetField(string name) { throw null; }
+        public virtual System.Reflection.FieldInfo GetField(string name, System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public System.Reflection.FieldInfo[] GetFields() { throw null; }
+        public virtual System.Reflection.FieldInfo[] GetFields(System.Reflection.BindingFlags bindingFlags) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public System.Reflection.MethodInfo GetMethod(string name) { throw null; }
+        public System.Reflection.MethodInfo GetMethod(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
+        public System.Reflection.MethodInfo GetMethod(string name, System.Type[] types) { throw null; }
+        protected virtual System.Reflection.MethodInfo GetMethodImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
+        public System.Reflection.MethodInfo[] GetMethods() { throw null; }
+        public virtual System.Reflection.MethodInfo[] GetMethods(System.Reflection.BindingFlags bindingFlags) { throw null; }
+        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public virtual void GetPEKind(out System.Reflection.PortableExecutableKinds peKind, out System.Reflection.ImageFileMachine machine) { peKind = default(System.Reflection.PortableExecutableKinds); machine = default(System.Reflection.ImageFileMachine); }
+        public virtual System.Type GetType(string className) { throw null; }
+        public virtual System.Type GetType(string className, bool ignoreCase) { throw null; }
+        public virtual System.Type GetType(string className, bool throwOnError, bool ignoreCase) { throw null; }
+        public virtual System.Type[] GetTypes() { throw null; }
+        public virtual bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+        public virtual bool IsResource() { throw null; }
         public static bool operator ==(System.Reflection.Module left, System.Reflection.Module right) { throw null; }
         public static bool operator !=(System.Reflection.Module left, System.Reflection.Module right) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public virtual System.Type GetType(string className, bool throwOnError, bool ignoreCase) { throw null; }
-        public override string ToString() { throw null; }
-        public static readonly TypeFilter FilterTypeName;
-        public static readonly TypeFilter FilterTypeNameIgnoreCase;
-        public virtual Guid ModuleVersionId { get { throw null; } }
-        public virtual string ScopeName { get { throw null; } }
-        public virtual Type[] FindTypes(TypeFilter filter, object filterCriteria) { throw null; }
-        public FieldInfo GetField(string name) { throw null; }
-        public virtual FieldInfo GetField(string name, BindingFlags bindingAttr) { throw null; }
-        public FieldInfo[] GetFields() { throw null; }
-        public virtual FieldInfo[] GetFields(BindingFlags bindingFlags) { throw null; }
-        public System.Reflection.MethodInfo GetMethod(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
-        public MethodInfo GetMethod(string name) { throw null; }
-        public MethodInfo GetMethod(string name, Type[] types) { throw null; }
-        protected virtual System.Reflection.MethodInfo GetMethodImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
-        public MethodInfo[] GetMethods() { throw null; }
-        public virtual MethodInfo[] GetMethods(BindingFlags bindingFlags) { throw null; }
-        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public virtual void GetPEKind(out System.Reflection.PortableExecutableKinds peKind, out System.Reflection.ImageFileMachine machine) { throw null; }
-        public virtual Type GetType(string className) { throw null; }
-        public virtual Type GetType(string className, bool ignoreCase) { throw null; }
-        public virtual Type[] GetTypes() { throw null; }
-        public virtual object[] GetCustomAttributes(bool inherit) { throw null; }
-        public virtual object[] GetCustomAttributes(Type attributeType, bool inherit) { throw null; }
-        public virtual bool IsDefined(Type attributeType, bool inherit) { throw null; }
-        public virtual bool IsResource() { throw null; }
-        public virtual System.Collections.Generic.IList<CustomAttributeData> GetCustomAttributesData() { throw null; }
         public System.Reflection.FieldInfo ResolveField(int metadataToken) { throw null; }
         public virtual System.Reflection.FieldInfo ResolveField(int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw null; }
         public System.Reflection.MemberInfo ResolveMember(int metadataToken) { throw null; }
@@ -6143,24 +5944,24 @@ namespace System.Reflection
         public virtual string ResolveString(int metadataToken) { throw null; }
         public System.Type ResolveType(int metadataToken) { throw null; }
         public virtual System.Type ResolveType(int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw null; }
+        public override string ToString() { throw null; }
     }
     public delegate System.Reflection.Module ModuleResolveEventHandler(object sender, System.ResolveEventArgs e);
-    [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
-    public sealed class ObfuscateAssemblyAttribute : System.Attribute
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false, Inherited=false)]
+    public sealed partial class ObfuscateAssemblyAttribute : System.Attribute
     {
         public ObfuscateAssemblyAttribute(bool assemblyIsPrivate) { }
         public bool AssemblyIsPrivate { get { throw null; } }
         public bool StripAfterObfuscation { get { throw null; } set { } }
     }
-    [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Method | System.AttributeTargets.Parameter | System.AttributeTargets.Field | System.AttributeTargets.Property | System.AttributeTargets.Event | System.AttributeTargets.Interface | System.AttributeTargets.Enum | System.AttributeTargets.Delegate,
-        AllowMultiple = true, Inherited = false)]
-    public sealed class ObfuscationAttribute : System.Attribute
+    [System.AttributeUsageAttribute((System.AttributeTargets)(8157), AllowMultiple=true, Inherited=false)]
+    public sealed partial class ObfuscationAttribute : System.Attribute
     {
         public ObfuscationAttribute() { }
-        public bool StripAfterObfuscation { get { throw null; } set { } }
-        public bool Exclude { get { throw null; } set { } }
         public bool ApplyToMembers { get { throw null; } set { } }
+        public bool Exclude { get { throw null; } set { } }
         public string Feature { get { throw null; } set { } }
+        public bool StripAfterObfuscation { get { throw null; } set { } }
     }
     [System.FlagsAttribute]
     public enum ParameterAttributes
@@ -6179,12 +5980,12 @@ namespace System.Reflection
     }
     public partial class ParameterInfo : System.Reflection.ICustomAttributeProvider, System.Runtime.Serialization.IObjectReference
     {
-        protected string NameImpl;
-        protected System.Type ClassImpl;
-        protected int PositionImpl;
         protected System.Reflection.ParameterAttributes AttrsImpl;
+        protected System.Type ClassImpl;
         protected object DefaultValueImpl;
         protected System.Reflection.MemberInfo MemberImpl;
+        protected string NameImpl;
+        protected int PositionImpl;
         protected ParameterInfo() { }
         public virtual System.Reflection.ParameterAttributes Attributes { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.CustomAttributeData> CustomAttributes { get { throw null; } }
@@ -6200,39 +6001,39 @@ namespace System.Reflection
         public virtual string Name { get { throw null; } }
         public virtual System.Type ParameterType { get { throw null; } }
         public virtual int Position { get { throw null; } }
-        public virtual Type[] GetOptionalCustomModifiers() { throw null; }
-        public object GetRealObject(System.Runtime.Serialization.StreamingContext context) { throw null; }
-        public virtual Type[] GetRequiredCustomModifiers() { throw null; }
         public virtual object RawDefaultValue { get { throw null; } }
         public virtual object[] GetCustomAttributes(bool inherit) { throw null; }
-        public virtual object[] GetCustomAttributes(Type attributeType, bool inherit) { throw null; }
+        public virtual object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
         public virtual System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetCustomAttributesData() { throw null; }
-        public virtual bool IsDefined(Type attributeType, bool inherit) { throw null; }
+        public virtual System.Type[] GetOptionalCustomModifiers() { throw null; }
+        public object GetRealObject(System.Runtime.Serialization.StreamingContext context) { throw null; }
+        public virtual System.Type[] GetRequiredCustomModifiers() { throw null; }
+        public virtual bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
         public override string ToString() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly struct ParameterModifier
+    public readonly partial struct ParameterModifier
     {
-        public ParameterModifier(int parameterCount) { }
+        public ParameterModifier(int parameterCount) { throw null;}
         public bool this[int index] { get { throw null; } set { } }
     }
     [System.CLSCompliantAttribute(false)]
-    public sealed class Pointer : System.Runtime.Serialization.ISerializable
+    public sealed partial class Pointer : System.Runtime.Serialization.ISerializable
     {
-        private Pointer() { }
-        public static unsafe object Box(void* ptr, System.Type type) { throw null; }
-        public static unsafe void* Unbox(object ptr) { throw null; }
-        unsafe void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        internal Pointer() { }
+        public unsafe static object Box(void* ptr, System.Type type) { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public unsafe static void* Unbox(object ptr) { throw null; }
     }
     [System.FlagsAttribute]
     public enum PortableExecutableKinds
     {
-        NotAPortableExecutableImage = 0,
         ILOnly = 1,
-        Required32Bit = 2,
+        NotAPortableExecutableImage = 0,
         PE32Plus = 4,
-        Unmanaged32Bit = 8,
         Preferred32Bit = 16,
+        Required32Bit = 2,
+        Unmanaged32Bit = 8,
     }
     public enum ProcessorArchitecture
     {
@@ -6263,30 +6064,30 @@ namespace System.Reflection
         public abstract bool CanWrite { get; }
         public virtual System.Reflection.MethodInfo GetMethod { get { throw null; } }
         public bool IsSpecialName { get { throw null; } }
+        public override System.Reflection.MemberTypes MemberType { get { throw null; } }
         public abstract System.Type PropertyType { get; }
         public virtual System.Reflection.MethodInfo SetMethod { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
-        public static bool operator ==(System.Reflection.PropertyInfo left, System.Reflection.PropertyInfo right) { throw null; }
-        public static bool operator !=(System.Reflection.PropertyInfo left, System.Reflection.PropertyInfo right) { throw null; }
+        public System.Reflection.MethodInfo[] GetAccessors() { throw null; }
+        public abstract System.Reflection.MethodInfo[] GetAccessors(bool nonPublic);
         public virtual object GetConstantValue() { throw null; }
+        public System.Reflection.MethodInfo GetGetMethod() { throw null; }
+        public abstract System.Reflection.MethodInfo GetGetMethod(bool nonPublic);
         public override int GetHashCode() { throw null; }
         public abstract System.Reflection.ParameterInfo[] GetIndexParameters();
+        public virtual System.Type[] GetOptionalCustomModifiers() { throw null; }
+        public virtual object GetRawConstantValue() { throw null; }
+        public virtual System.Type[] GetRequiredCustomModifiers() { throw null; }
+        public System.Reflection.MethodInfo GetSetMethod() { throw null; }
+        public abstract System.Reflection.MethodInfo GetSetMethod(bool nonPublic);
         public object GetValue(object obj) { throw null; }
         public virtual object GetValue(object obj, object[] index) { throw null; }
         public abstract object GetValue(object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] index, System.Globalization.CultureInfo culture);
+        public static bool operator ==(System.Reflection.PropertyInfo left, System.Reflection.PropertyInfo right) { throw null; }
+        public static bool operator !=(System.Reflection.PropertyInfo left, System.Reflection.PropertyInfo right) { throw null; }
         public void SetValue(object obj, object value) { }
         public virtual void SetValue(object obj, object value, object[] index) { }
         public abstract void SetValue(object obj, object value, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] index, System.Globalization.CultureInfo culture);
-        public override MemberTypes MemberType { get { throw null; } }
-        public MethodInfo[] GetAccessors() { throw null; }
-        public abstract MethodInfo[] GetAccessors(bool nonPublic);
-        public MethodInfo GetGetMethod() { throw null; }
-        public abstract MethodInfo GetGetMethod(bool nonPublic);
-        public MethodInfo GetSetMethod() { throw null; }
-        public abstract MethodInfo GetSetMethod(bool nonPublic);
-        public virtual Type[] GetOptionalCustomModifiers() { throw null; }
-        public virtual object GetRawConstantValue() { throw null; }
-        public virtual Type[] GetRequiredCustomModifiers() { throw null; }
     }
     public abstract partial class ReflectionContext
     {
@@ -6330,12 +6131,22 @@ namespace System.Reflection
         public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetRuntimeProperties(this System.Type type) { throw null; }
         public static System.Reflection.PropertyInfo GetRuntimeProperty(this System.Type type, string name) { throw null; }
     }
+    public partial class StrongNameKeyPair : System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
+    {
+        public StrongNameKeyPair(byte[] keyPairArray) { }
+        public StrongNameKeyPair(System.IO.FileStream keyPairFile) { }
+        protected StrongNameKeyPair(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public StrongNameKeyPair(string keyPairContainer) { }
+        public byte[] PublicKey { get { throw null; } }
+        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
     public partial class TargetException : System.ApplicationException
     {
         public TargetException() { }
+        protected TargetException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public TargetException(string message) { }
-        public TargetException(string message, Exception inner) { }
-        protected TargetException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+        public TargetException(string message, System.Exception inner) { }
     }
     public sealed partial class TargetInvocationException : System.ApplicationException
     {
@@ -6384,63 +6195,63 @@ namespace System.Reflection
         VisibilityMask = 7,
         WindowsRuntime = 16384,
     }
-    public class TypeDelegator : System.Reflection.TypeInfo
+    public partial class TypeDelegator : System.Reflection.TypeInfo
     {
         protected System.Type typeImpl;
-        public override bool IsAssignableFrom(System.Reflection.TypeInfo typeInfo) { throw null; }
         protected TypeDelegator() { }
         public TypeDelegator(System.Type delegatingType) { }
-        public override System.Guid GUID { get { throw null; } }
-        public override int MetadataToken { get { throw null; } }
-        public override object InvokeMember(System.String name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object target, System.Object[] args, System.Reflection.ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, System.String[] namedParameters) { throw null; }
-        public override System.Reflection.Module Module { get { throw null; } }
         public override System.Reflection.Assembly Assembly { get { throw null; } }
-        public override System.RuntimeTypeHandle TypeHandle { get { throw null; } }
-        public override System.String Name { get { throw null; } }
-        public override System.String FullName { get { throw null; } }
-        public override System.String Namespace { get { throw null; } }
-        public override System.String AssemblyQualifiedName { get { throw null; } }
+        public override string AssemblyQualifiedName { get { throw null; } }
         public override System.Type BaseType { get { throw null; } }
+        public override string FullName { get { throw null; } }
+        public override System.Guid GUID { get { throw null; } }
+        public override bool IsByRefLike { get { throw null; } }
+        public override bool IsConstructedGenericType { get { throw null; } }
+        public override bool IsGenericMethodParameter { get { throw null; } }
+        public override bool IsGenericTypeParameter { get { throw null; } }
+        public override bool IsSZArray { get { throw null; } }
+        public override bool IsTypeDefinition { get { throw null; } }
+        public override bool IsVariableBoundArray { get { throw null; } }
+        public override int MetadataToken { get { throw null; } }
+        public override System.Reflection.Module Module { get { throw null; } }
+        public override string Name { get { throw null; } }
+        public override string Namespace { get { throw null; } }
+        public override System.RuntimeTypeHandle TypeHandle { get { throw null; } }
+        public override System.Type UnderlyingSystemType { get { throw null; } }
+        protected override System.Reflection.TypeAttributes GetAttributeFlagsImpl() { throw null; }
         protected override System.Reflection.ConstructorInfo GetConstructorImpl(System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
         public override System.Reflection.ConstructorInfo[] GetConstructors(System.Reflection.BindingFlags bindingAttr) { throw null; }
-        protected override System.Reflection.MethodInfo GetMethodImpl(System.String name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
-        public override System.Reflection.MethodInfo[] GetMethods(System.Reflection.BindingFlags bindingAttr) { throw null; }
-        public override System.Reflection.FieldInfo GetField(System.String name, System.Reflection.BindingFlags bindingAttr) { throw null; }
-        public override System.Reflection.FieldInfo[] GetFields(System.Reflection.BindingFlags bindingAttr) { throw null; }
-        public override System.Type GetInterface(System.String name, bool ignoreCase) { throw null; }
-        public override System.Type[] GetInterfaces() { throw null; }
-        public override System.Reflection.EventInfo GetEvent(System.String name, System.Reflection.BindingFlags bindingAttr) { throw null; }
-        public override System.Reflection.EventInfo[] GetEvents() { throw null; }
-        protected override System.Reflection.PropertyInfo GetPropertyImpl(System.String name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Type returnType, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
-        public override System.Reflection.PropertyInfo[] GetProperties(System.Reflection.BindingFlags bindingAttr) { throw null; }
-        public override System.Reflection.EventInfo[] GetEvents(System.Reflection.BindingFlags bindingAttr) { throw null; }
-        public override System.Type[] GetNestedTypes(System.Reflection.BindingFlags bindingAttr) { throw null; }
-        public override System.Type GetNestedType(System.String name, System.Reflection.BindingFlags bindingAttr) { throw null; }
-        public override System.Reflection.MemberInfo[] GetMember(System.String name, System.Reflection.MemberTypes type, System.Reflection.BindingFlags bindingAttr) { throw null; }
-        public override System.Reflection.MemberInfo[] GetMembers(System.Reflection.BindingFlags bindingAttr) { throw null; }
-        public override bool IsByRefLike { get { throw null; } }
-        protected override System.Reflection.TypeAttributes GetAttributeFlagsImpl() { throw null; }
-        protected override bool IsArrayImpl() { throw null; }
-        protected override bool IsPrimitiveImpl() { throw null; }
-        protected override bool IsByRefImpl() { throw null; }
-        public override bool IsGenericTypeParameter { get { throw null; } }
-        public override bool IsGenericMethodParameter { get { throw null; } }
-        protected override bool IsPointerImpl() { throw null; }
-        protected override bool IsValueTypeImpl() { throw null; }
-        protected override bool IsCOMObjectImpl() { throw null; }
-        public override bool IsConstructedGenericType { get { throw null; } }
-        public override bool IsTypeDefinition { get { throw null; } }
-        public override bool IsSZArray { get { throw null; } }
-        public override bool IsVariableBoundArray { get { throw null; } }
+        public override object[] GetCustomAttributes(bool inherit) { throw null; }
+        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
         public override System.Type GetElementType() { throw null; }
-        protected override bool HasElementTypeImpl() { throw null; }
-        public override System.Type UnderlyingSystemType { get { throw null; } }
-        public override System.Object[] GetCustomAttributes(bool inherit) { throw null; }
-        public override System.Object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
-        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+        public override System.Reflection.EventInfo GetEvent(string name, System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Reflection.EventInfo[] GetEvents() { throw null; }
+        public override System.Reflection.EventInfo[] GetEvents(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Reflection.FieldInfo GetField(string name, System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Reflection.FieldInfo[] GetFields(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Type GetInterface(string name, bool ignoreCase) { throw null; }
         public override System.Reflection.InterfaceMapping GetInterfaceMap(System.Type interfaceType) { throw null; }
+        public override System.Type[] GetInterfaces() { throw null; }
+        public override System.Reflection.MemberInfo[] GetMember(string name, System.Reflection.MemberTypes type, System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Reflection.MemberInfo[] GetMembers(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        protected override System.Reflection.MethodInfo GetMethodImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
+        public override System.Reflection.MethodInfo[] GetMethods(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Type GetNestedType(string name, System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Type[] GetNestedTypes(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Reflection.PropertyInfo[] GetProperties(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        protected override System.Reflection.PropertyInfo GetPropertyImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Type returnType, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
+        protected override bool HasElementTypeImpl() { throw null; }
+        public override object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args, System.Reflection.ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, string[] namedParameters) { throw null; }
+        protected override bool IsArrayImpl() { throw null; }
+        public override bool IsAssignableFrom(System.Reflection.TypeInfo typeInfo) { throw null; }
+        protected override bool IsByRefImpl() { throw null; }
+        protected override bool IsCOMObjectImpl() { throw null; }
+        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+        protected override bool IsPointerImpl() { throw null; }
+        protected override bool IsPrimitiveImpl() { throw null; }
+        protected override bool IsValueTypeImpl() { throw null; }
     }
-    public delegate bool TypeFilter(Type m, Object filterCriteria);
+    public delegate bool TypeFilter(System.Type m, object filterCriteria);
     public abstract partial class TypeInfo : System.Type, System.Reflection.IReflectableType
     {
         internal TypeInfo() { }
@@ -6463,20 +6274,10 @@ namespace System.Reflection
         public virtual bool IsAssignableFrom(System.Reflection.TypeInfo typeInfo) { throw null; }
         System.Reflection.TypeInfo System.Reflection.IReflectableType.GetTypeInfo() { throw null; }
     }
-    public partial class StrongNameKeyPair : System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
-    {
-        public StrongNameKeyPair(byte[] keyPairArray) { }
-        public StrongNameKeyPair(System.IO.FileStream keyPairFile) { }
-        protected StrongNameKeyPair(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public StrongNameKeyPair(string keyPairContainer) { }
-        public byte[] PublicKey { get { throw null; } }
-        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    }
 }
 namespace System.Runtime
 {
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     public sealed partial class AssemblyTargetedPatchBandAttribute : System.Attribute
     {
         public AssemblyTargetedPatchBandAttribute(string targetedPatchBand) { }
@@ -6492,8 +6293,8 @@ namespace System.Runtime
         Batch = 0,
         Interactive = 1,
         LowLatency = 2,
+        NoGCRegion = 4,
         SustainedLowLatency = 3,
-        NoGCRegion = 4
     }
     public static partial class GCSettings
     {
@@ -6507,7 +6308,7 @@ namespace System.Runtime
         public void Dispose() { }
         ~MemoryFailPoint() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), AllowMultiple=false, Inherited=false)]
     public sealed partial class TargetedPatchingOptOutAttribute : System.Attribute
     {
         public TargetedPatchingOptOutAttribute(string reason) { }
@@ -6516,42 +6317,24 @@ namespace System.Runtime
 }
 namespace System.Runtime.CompilerServices
 {
-    [System.AttributeUsageAttribute((System.AttributeTargets)(972))]
-    public sealed partial class SpecialNameAttribute : System.Attribute
-    {
-        public SpecialNameAttribute() { }
-    }
-    public enum MethodCodeType
-    {
-        IL = System.Reflection.MethodImplAttributes.IL,
-        Native = System.Reflection.MethodImplAttributes.Native,
-        OPTIL = System.Reflection.MethodImplAttributes.OPTIL,
-        Runtime = System.Reflection.MethodImplAttributes.Runtime
-    }
-    [Flags]
-    public enum CompilationRelaxations : int
-    {
-        NoStringInterning = 0x0008, // Start in 0x0008, we had other non public flags in this enum before,
-                                    // so we'll start here just in case somebody used them. This flag is only
-                                    // valid when set for Assemblies.
-    };
     [System.AttributeUsageAttribute((System.AttributeTargets)(256))]
     public sealed partial class AccessedThroughPropertyAttribute : System.Attribute
     {
         public AccessedThroughPropertyAttribute(string propertyName) { }
         public string PropertyName { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(5148), Inherited = false, AllowMultiple = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5148), Inherited=false, AllowMultiple=false)]
     public sealed partial class AsyncMethodBuilderAttribute : System.Attribute
     {
         public AsyncMethodBuilderAttribute(System.Type builderType) { }
         public System.Type BuilderType { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited = false, AllowMultiple = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false, AllowMultiple=false)]
     public sealed partial class AsyncStateMachineAttribute : System.Runtime.CompilerServices.StateMachineAttribute
     {
-        public AsyncStateMachineAttribute(System.Type stateMachineType) : base(default(System.Type)) { }
+        public AsyncStateMachineAttribute(System.Type stateMachineType) : base (default(System.Type)) { }
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public partial struct AsyncValueTaskMethodBuilder<TResult>
     {
         public System.Threading.Tasks.ValueTask<TResult> Task { get { throw null; } }
@@ -6563,51 +6346,89 @@ namespace System.Runtime.CompilerServices
         public void SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) { }
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false)]
     public sealed partial class CallerFilePathAttribute : System.Attribute
     {
         public CallerFilePathAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false)]
     public sealed partial class CallerLineNumberAttribute : System.Attribute
     {
         public CallerLineNumberAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false)]
     public sealed partial class CallerMemberNameAttribute : System.Attribute
     {
         public CallerMemberNameAttribute() { }
+    }
+    [System.FlagsAttribute]
+    public enum CompilationRelaxations
+    {
+        NoStringInterning = 8,
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(71))]
     public partial class CompilationRelaxationsAttribute : System.Attribute
     {
         public CompilationRelaxationsAttribute(int relaxations) { }
-        public int CompilationRelaxations { get { throw null; } }
         public CompilationRelaxationsAttribute(System.Runtime.CompilerServices.CompilationRelaxations relaxations) { }
+        public int CompilationRelaxations { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(32767), Inherited = true)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(32767), Inherited=true)]
     public sealed partial class CompilerGeneratedAttribute : System.Attribute
     {
         public CompilerGeneratedAttribute() { }
     }
-    public sealed partial class ConditionalWeakTable<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> where TKey : class where TValue : class
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4))]
+    public partial class CompilerGlobalScopeAttribute : System.Attribute
+    {
+        public CompilerGlobalScopeAttribute() { }
+    }
+    public sealed partial class ConditionalWeakTable<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerable where TKey : class where TValue : class
     {
         public ConditionalWeakTable() { }
         public void Add(TKey key, TValue value) { }
         public void AddOrUpdate(TKey key, TValue value) { }
         public void Clear() { }
         ~ConditionalWeakTable() { }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public TValue GetOrCreateValue(TKey key) { throw null; }
         public TValue GetValue(TKey key, System.Runtime.CompilerServices.ConditionalWeakTable<TKey, TValue>.CreateValueCallback createValueCallback) { throw null; }
         public bool Remove(TKey key) { throw null; }
-        public bool TryGetValue(TKey key, out TValue value) { throw null; }
+        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public bool TryGetValue(TKey key, out TValue value) { value = default(TValue); throw null; }
         public delegate TValue CreateValueCallback(TKey key);
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct ConfiguredTaskAwaitable
+    {
+        public System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter GetAwaiter() { throw null; }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public readonly partial struct ConfiguredTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+        {
+            public bool IsCompleted { get { throw null; } }
+            public void GetResult() { }
+            public void OnCompleted(System.Action continuation) { }
+            public void UnsafeOnCompleted(System.Action continuation) { }
+        }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct ConfiguredTaskAwaitable<TResult>
+    {
+        public System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter GetAwaiter() { throw null; }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public readonly partial struct ConfiguredTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+        {
+            public bool IsCompleted { get { throw null; } }
+            public TResult GetResult() { throw null; }
+            public void OnCompleted(System.Action continuation) { }
+            public void UnsafeOnCompleted(System.Action continuation) { }
+        }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public readonly partial struct ConfiguredValueTaskAwaitable<TResult>
     {
         public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<TResult>.ConfiguredValueTaskAwaiter GetAwaiter() { throw null; }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
         public readonly partial struct ConfiguredValueTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
             public bool IsCompleted { get { throw null; } }
@@ -6616,19 +6437,19 @@ namespace System.Runtime.CompilerServices
             public void UnsafeOnCompleted(System.Action continuation) { }
         }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2304), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2304), Inherited=false)]
     public abstract partial class CustomConstantAttribute : System.Attribute
     {
         protected CustomConstantAttribute() { }
         public abstract object Value { get; }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2304), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2304), Inherited=false)]
     public sealed partial class DateTimeConstantAttribute : System.Runtime.CompilerServices.CustomConstantAttribute
     {
         public DateTimeConstantAttribute(long ticks) { }
         public override object Value { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2304), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2304), Inherited=false)]
     public sealed partial class DecimalConstantAttribute : System.Attribute
     {
         public DecimalConstantAttribute(byte scale, byte sign, int hi, int mid, int low) { }
@@ -6636,17 +6457,39 @@ namespace System.Runtime.CompilerServices
         public DecimalConstantAttribute(byte scale, byte sign, uint hi, uint mid, uint low) { }
         public decimal Value { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1))]
+    public sealed partial class DefaultDependencyAttribute : System.Attribute
+    {
+        public DefaultDependencyAttribute(System.Runtime.CompilerServices.LoadHint loadHintArgument) { }
+        public System.Runtime.CompilerServices.LoadHint LoadHint { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=true)]
+    public sealed partial class DependencyAttribute : System.Attribute
+    {
+        public DependencyAttribute(string dependentAssemblyArgument, System.Runtime.CompilerServices.LoadHint loadHintArgument) { }
+        public string DependentAssembly { get { throw null; } }
+        public System.Runtime.CompilerServices.LoadHint LoadHint { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false, Inherited=false)]
     public sealed partial class DisablePrivateReflectionAttribute : System.Attribute
     {
         public DisablePrivateReflectionAttribute() { }
+    }
+    public partial class DiscardableAttribute : System.Attribute
+    {
+        public DiscardableAttribute() { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(69))]
     public sealed partial class ExtensionAttribute : System.Attribute
     {
         public ExtensionAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(256), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(256))]
+    public sealed partial class FixedAddressValueTypeAttribute : System.Attribute
+    {
+        public FixedAddressValueTypeAttribute() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(256), Inherited=false)]
     public sealed partial class FixedBufferAttribute : System.Attribute
     {
         public FixedBufferAttribute(System.Type elementType, int length) { }
@@ -6662,20 +6505,40 @@ namespace System.Runtime.CompilerServices
         void MoveNext();
         void SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine stateMachine);
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(128), Inherited = true)]
+    public partial interface ICriticalNotifyCompletion : System.Runtime.CompilerServices.INotifyCompletion
+    {
+        void UnsafeOnCompleted(System.Action continuation);
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(128), Inherited=true)]
     public sealed partial class IndexerNameAttribute : System.Attribute
     {
         public IndexerNameAttribute(string indexerName) { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = true, Inherited = false)]
+    public partial interface INotifyCompletion
+    {
+        void OnCompleted(System.Action continuation);
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=true, Inherited=false)]
     public sealed partial class InternalsVisibleToAttribute : System.Attribute
     {
         public InternalsVisibleToAttribute(string assemblyName) { }
         public bool AllInternalsVisible { get { throw null; } set { } }
         public string AssemblyName { get { throw null; } }
     }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(8))]
+    [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+    public sealed partial class IsByRefLikeAttribute : System.Attribute
+    {
+        public IsByRefLikeAttribute() { }
+    }
     public static partial class IsConst
     {
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(32767), Inherited=false)]
+    [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+    public sealed partial class IsReadOnlyAttribute : System.Attribute
+    {
+        public IsReadOnlyAttribute() { }
     }
     public partial interface IStrongBox
     {
@@ -6684,19 +6547,37 @@ namespace System.Runtime.CompilerServices
     public static partial class IsVolatile
     {
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited = false, AllowMultiple = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false, AllowMultiple=false)]
     public sealed partial class IteratorStateMachineAttribute : System.Runtime.CompilerServices.StateMachineAttribute
     {
-        public IteratorStateMachineAttribute(System.Type stateMachineType) : base(default(System.Type)) { }
+        public IteratorStateMachineAttribute(System.Type stateMachineType) : base (default(System.Type)) { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(96), Inherited = false)]
+    public partial interface ITuple
+    {
+        object this[int index] { get; }
+        int Length { get; }
+    }
+    public enum LoadHint
+    {
+        Always = 1,
+        Default = 0,
+        Sometimes = 2,
+    }
+    public enum MethodCodeType
+    {
+        IL = 0,
+        Native = 1,
+        OPTIL = 2,
+        Runtime = 3,
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(96), Inherited=false)]
     public sealed partial class MethodImplAttribute : System.Attribute
     {
+        public System.Runtime.CompilerServices.MethodCodeType MethodCodeType;
         public MethodImplAttribute() { }
         public MethodImplAttribute(short value) { }
         public MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions methodImplOptions) { }
         public System.Runtime.CompilerServices.MethodImplOptions Value { get { throw null; } }
-        public System.Runtime.CompilerServices.MethodCodeType MethodCodeType;
     }
     [System.FlagsAttribute]
     public enum MethodImplOptions
@@ -6710,50 +6591,69 @@ namespace System.Runtime.CompilerServices
         Synchronized = 32,
         Unmanaged = 4,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false)]
     public sealed partial class ReferenceAssemblyAttribute : System.Attribute
     {
         public ReferenceAssemblyAttribute() { }
         public ReferenceAssemblyAttribute(string description) { }
         public string Description { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false, AllowMultiple = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false, AllowMultiple=false)]
     public sealed partial class RuntimeCompatibilityAttribute : System.Attribute
     {
         public RuntimeCompatibilityAttribute() { }
         public bool WrapNonExceptionThrows { get { throw null; } set { } }
     }
+    public static partial class RuntimeFeature
+    {
+        public const string DefaultImplementationsOfInterfaces = "DefaultImplementationsOfInterfaces";
+        public static bool IsSupported(string feature) { throw null; }
+    }
     public static partial class RuntimeHelpers
     {
-        public static new bool Equals(object o1, object o2) { throw null; }
         public static int OffsetToStringData { get { throw null; } }
         public static void EnsureSufficientExecutionStack() { }
+        public static new bool Equals(object o1, object o2) { throw null; }
+        public static void ExecuteCodeWithGuaranteedCleanup(System.Runtime.CompilerServices.RuntimeHelpers.TryCode code, System.Runtime.CompilerServices.RuntimeHelpers.CleanupCode backoutCode, object userData) { }
         public static int GetHashCode(object o) { throw null; }
         public static object GetObjectValue(object obj) { throw null; }
+        public static object GetUninitializedObject(System.Type type) { throw null; }
         public static void InitializeArray(System.Array array, System.RuntimeFieldHandle fldHandle) { }
-        public static void RunClassConstructor(System.RuntimeTypeHandle type) { }
-        public static void RunModuleConstructor(System.ModuleHandle module) { }
-        public static void ExecuteCodeWithGuaranteedCleanup(System.Runtime.CompilerServices.RuntimeHelpers.TryCode code, System.Runtime.CompilerServices.RuntimeHelpers.CleanupCode backoutCode, object userData) { }
-        public delegate void CleanupCode(object userData, bool exceptionThrown);
-        public delegate void TryCode(object userData);
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute((System.Runtime.ConstrainedExecution.Consistency)(3), (System.Runtime.ConstrainedExecution.Cer)(1))]
+        public static bool IsReferenceOrContainsReferences<T>() { throw null; }
         public static void PrepareConstrainedRegions() { }
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute((System.Runtime.ConstrainedExecution.Consistency)(3), (System.Runtime.ConstrainedExecution.Cer)(1))]
         public static void PrepareConstrainedRegionsNoOP() { }
         public static void PrepareContractedDelegate(System.Delegate d) { }
         public static void PrepareDelegate(System.Delegate d) { }
         public static void PrepareMethod(System.RuntimeMethodHandle method) { }
         public static void PrepareMethod(System.RuntimeMethodHandle method, System.RuntimeTypeHandle[] instantiation) { }
         public static void ProbeForSufficientStack() { }
+        public static void RunClassConstructor(System.RuntimeTypeHandle type) { }
+        public static void RunModuleConstructor(System.ModuleHandle module) { }
         public static bool TryEnsureSufficientExecutionStack() { throw null; }
-        public static object GetUninitializedObject(Type type) { throw null; }
-        public static bool IsReferenceOrContainsReferences<T>() { throw null; }
+        public delegate void CleanupCode(object userData, bool exceptionThrown);
+        public delegate void TryCode(object userData);
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited = false, AllowMultiple = false)]
+    public sealed partial class RuntimeWrappedException : System.Exception
+    {
+        public RuntimeWrappedException(object thrownObject) { }
+        public object WrappedException { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(972))]
+    public sealed partial class SpecialNameAttribute : System.Attribute
+    {
+        public SpecialNameAttribute() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false, AllowMultiple=false)]
     public partial class StateMachineAttribute : System.Attribute
     {
         public StateMachineAttribute(System.Type stateMachineType) { }
         public System.Type StateMachineType { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
+    public sealed partial class StringFreezingAttribute : System.Attribute
+    {
+        public StringFreezingAttribute() { }
     }
     public partial class StrongBox<T> : System.Runtime.CompilerServices.IStrongBox
     {
@@ -6762,18 +6662,41 @@ namespace System.Runtime.CompilerServices
         public StrongBox(T value) { }
         object System.Runtime.CompilerServices.IStrongBox.Value { get { throw null; } set { } }
     }
-    [System.AttributeUsage((System.AttributeTargets)(1) | (System.AttributeTargets)(2))]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(3))]
     public sealed partial class SuppressIldasmAttribute : System.Attribute
     {
         public SuppressIldasmAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(5148), Inherited = false, AllowMultiple = false)]
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct TaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+    {
+        public bool IsCompleted { get { throw null; } }
+        public void GetResult() { }
+        public void OnCompleted(System.Action continuation) { }
+        public void UnsafeOnCompleted(System.Action continuation) { }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct TaskAwaiter<TResult> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+    {
+        public bool IsCompleted { get { throw null; } }
+        public TResult GetResult() { throw null; }
+        public void OnCompleted(System.Action continuation) { }
+        public void UnsafeOnCompleted(System.Action continuation) { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(11148))]
+    [System.CLSCompliantAttribute(false)]
+    public sealed partial class TupleElementNamesAttribute : System.Attribute
+    {
+        public TupleElementNamesAttribute(string[] transformNames) { }
+        public System.Collections.Generic.IList<string> TransformNames { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5148), Inherited=false, AllowMultiple=false)]
     public sealed partial class TypeForwardedFromAttribute : System.Attribute
     {
         public TypeForwardedFromAttribute(string assemblyFullName) { }
         public string AssemblyFullName { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = true, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=true, Inherited=false)]
     public sealed partial class TypeForwardedToAttribute : System.Attribute
     {
         public TypeForwardedToAttribute(System.Type destination) { }
@@ -6792,69 +6715,52 @@ namespace System.Runtime.CompilerServices
         public void OnCompleted(System.Action continuation) { }
         public void UnsafeOnCompleted(System.Action continuation) { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(4))]
-    public partial class CompilerGlobalScopeAttribute : System.Attribute
+    [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+    public readonly partial struct YieldAwaitable
     {
-        public CompilerGlobalScopeAttribute() { }
+        public System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter GetAwaiter() { throw null; }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+        public readonly partial struct YieldAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+        {
+            public bool IsCompleted { get { throw null; } }
+            public void GetResult() { }
+            public void OnCompleted(System.Action continuation) { }
+            public void UnsafeOnCompleted(System.Action continuation) { }
+        }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1))]
-    public sealed partial class DefaultDependencyAttribute : System.Attribute
+}
+namespace System.Runtime.ConstrainedExecution
+{
+    public enum Cer
     {
-        public DefaultDependencyAttribute(System.Runtime.CompilerServices.LoadHint loadHintArgument) { }
-        public System.Runtime.CompilerServices.LoadHint LoadHint { get { throw null; } }
+        MayFail = 1,
+        None = 0,
+        Success = 2,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = true)]
-    public sealed partial class DependencyAttribute : System.Attribute
+    public enum Consistency
     {
-        public DependencyAttribute(string dependentAssemblyArgument, System.Runtime.CompilerServices.LoadHint loadHintArgument) { }
-        public string DependentAssembly { get { throw null; } }
-        public System.Runtime.CompilerServices.LoadHint LoadHint { get { throw null; } }
+        MayCorruptAppDomain = 1,
+        MayCorruptInstance = 2,
+        MayCorruptProcess = 0,
+        WillNotCorruptState = 3,
     }
-    public partial class DiscardableAttribute : System.Attribute
+    public abstract partial class CriticalFinalizerObject
     {
-        public DiscardableAttribute() { }
+        protected CriticalFinalizerObject() { }
+        ~CriticalFinalizerObject() { }
     }
-    public enum LoadHint
+    [System.AttributeUsageAttribute((System.AttributeTargets)(96), Inherited=false)]
+    public sealed partial class PrePrepareMethodAttribute : System.Attribute
     {
-        Always = 1,
-        Default = 0,
-        Sometimes = 2,
+        public PrePrepareMethodAttribute() { }
     }
-    public static class RuntimeFeature
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1133), Inherited=false)]
+    public sealed partial class ReliabilityContractAttribute : System.Attribute
     {
-#if FEATURE_DEFAULT_INTERFACES
-        public const string DefaultImplementationsOfInterfaces = nameof(DefaultImplementationsOfInterfaces);
-#endif
-        public static bool IsSupported(string feature) { throw null; }
-    }
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    [AttributeUsage(AttributeTargets.All, Inherited = false)]
-    public sealed class IsReadOnlyAttribute : Attribute
-    {
-        public IsReadOnlyAttribute() { }
-    }
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    [AttributeUsage(AttributeTargets.Struct)]
-    public sealed class IsByRefLikeAttribute : Attribute
-    {
-        public IsByRefLikeAttribute() { }
-    }
-    public sealed partial class RuntimeWrappedException : System.Exception
-    {
-        internal RuntimeWrappedException() { }
-        public RuntimeWrappedException(object thrownObject) { }
-        public object WrappedException { get { throw null; } }
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
-    public sealed partial class StringFreezingAttribute : System.Attribute
-    {
-        public StringFreezingAttribute() { }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(256))]
-    public sealed partial class FixedAddressValueTypeAttribute : System.Attribute
-    {
-        public FixedAddressValueTypeAttribute() { }
+        public ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency consistencyGuarantee, System.Runtime.ConstrainedExecution.Cer cer) { }
+        public System.Runtime.ConstrainedExecution.Cer Cer { get { throw null; } }
+        public System.Runtime.ConstrainedExecution.Consistency ConsistencyGuarantee { get { throw null; } }
     }
 }
 namespace System.Runtime.ExceptionServices
@@ -6865,17 +6771,17 @@ namespace System.Runtime.ExceptionServices
         public System.Exception SourceException { get { throw null; } }
         public static System.Runtime.ExceptionServices.ExceptionDispatchInfo Capture(System.Exception source) { throw null; }
         public void Throw() { }
-        public static void Throw(Exception source) { }
+        public static void Throw(System.Exception source) { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), AllowMultiple = false, Inherited = false)]
+    public partial class FirstChanceExceptionEventArgs : System.EventArgs
+    {
+        public FirstChanceExceptionEventArgs(System.Exception exception) { }
+        public System.Exception Exception { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), AllowMultiple=false, Inherited=false)]
     public sealed partial class HandleProcessCorruptedStateExceptionsAttribute : System.Attribute
     {
         public HandleProcessCorruptedStateExceptionsAttribute() { }
-    }
-    public partial class FirstChanceExceptionEventArgs : EventArgs
-    {
-        public FirstChanceExceptionEventArgs(Exception exception) { }
-        public Exception Exception { get { throw null; } }
     }
 }
 namespace System.Runtime.InteropServices
@@ -6887,13 +6793,37 @@ namespace System.Runtime.InteropServices
         None = 1,
         Unicode = 3,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(5597), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5597), Inherited=false)]
     public sealed partial class ComVisibleAttribute : System.Attribute
     {
         public ComVisibleAttribute(bool visibility) { }
         public bool Value { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(256), Inherited = false)]
+    public abstract partial class CriticalHandle : System.Runtime.ConstrainedExecution.CriticalFinalizerObject, System.IDisposable
+    {
+        protected System.IntPtr handle;
+        protected CriticalHandle(System.IntPtr invalidHandleValue) { }
+        public bool IsClosed { get { throw null; } }
+        public abstract bool IsInvalid { get; }
+        public void Close() { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        ~CriticalHandle() { }
+        protected abstract bool ReleaseHandle();
+        protected void SetHandle(System.IntPtr handle) { }
+        public void SetHandleAsInvalid() { }
+    }
+    public partial class ExternalException : System.SystemException
+    {
+        public ExternalException() { }
+        protected ExternalException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public ExternalException(string message) { }
+        public ExternalException(string message, System.Exception inner) { }
+        public ExternalException(string message, int errorCode) { }
+        public virtual int ErrorCode { get { throw null; } }
+        public override string ToString() { throw null; }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(256), Inherited=false)]
     public sealed partial class FieldOffsetAttribute : System.Attribute
     {
         public FieldOffsetAttribute(int offset) { }
@@ -6912,8 +6842,8 @@ namespace System.Runtime.InteropServices
         public static System.Runtime.InteropServices.GCHandle FromIntPtr(System.IntPtr value) { throw null; }
         public override int GetHashCode() { throw null; }
         public static bool operator ==(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { throw null; }
-        public static explicit operator System.Runtime.InteropServices.GCHandle(System.IntPtr value) { throw null; }
-        public static explicit operator System.IntPtr(System.Runtime.InteropServices.GCHandle value) { throw null; }
+        public static explicit operator System.Runtime.InteropServices.GCHandle (System.IntPtr value) { throw null; }
+        public static explicit operator System.IntPtr (System.Runtime.InteropServices.GCHandle value) { throw null; }
         public static bool operator !=(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { throw null; }
         public static System.IntPtr ToIntPtr(System.Runtime.InteropServices.GCHandle value) { throw null; }
     }
@@ -6924,23 +6854,40 @@ namespace System.Runtime.InteropServices
         Weak = 0,
         WeakTrackResurrection = 1,
     }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false)]
+    public sealed partial class InAttribute : System.Attribute
+    {
+        public InAttribute() { }
+    }
     public enum LayoutKind
     {
         Auto = 3,
         Explicit = 2,
         Sequential = 0,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited = false)]
-    public sealed partial class InAttribute : System.Attribute
-    {
-        public InAttribute() { }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false)]
     public sealed partial class OutAttribute : System.Attribute
     {
         public OutAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited = false)]
+    public abstract partial class SafeHandle : System.Runtime.ConstrainedExecution.CriticalFinalizerObject, System.IDisposable
+    {
+        protected System.IntPtr handle;
+        protected SafeHandle(System.IntPtr invalidHandleValue, bool ownsHandle) { }
+        public bool IsClosed { get { throw null; } }
+        public abstract bool IsInvalid { get; }
+        public void Close() { }
+        public void DangerousAddRef(ref bool success) { }
+        public System.IntPtr DangerousGetHandle() { throw null; }
+        public void DangerousRelease() { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        ~SafeHandle() { }
+        protected abstract bool ReleaseHandle();
+        protected void SetHandle(System.IntPtr handle) { }
+        public void SetHandleAsInvalid() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited=false)]
     public sealed partial class StructLayoutAttribute : System.Attribute
     {
         public System.Runtime.InteropServices.CharSet CharSet;
@@ -6953,171 +6900,72 @@ namespace System.Runtime.InteropServices
 }
 namespace System.Runtime.Serialization
 {
-    public interface IDeserializationCallback
+    public partial interface IDeserializationCallback
     {
         void OnDeserialization(object sender);
     }
-    [CLSCompliant(false)]
-    public interface IFormatterConverter
+    [System.CLSCompliantAttribute(false)]
+    public partial interface IFormatterConverter
     {
-        object Convert(object value, Type type);
-        object Convert(object value, TypeCode typeCode);
+        object Convert(object value, System.Type type);
+        object Convert(object value, System.TypeCode typeCode);
         bool ToBoolean(object value);
-        char ToChar(object value);
-        [CLSCompliant(false)]
-        sbyte ToSByte(object value);
         byte ToByte(object value);
-        short ToInt16(object value);
-        [CLSCompliant(false)]
-        ushort ToUInt16(object value);
-        int ToInt32(object value);
-        [CLSCompliant(false)]
-        uint ToUInt32(object value);
-        long ToInt64(object value);
-        [CLSCompliant(false)]
-        ulong ToUInt64(object value);
-        float ToSingle(object value);
+        char ToChar(object value);
+        System.DateTime ToDateTime(object value);
+        decimal ToDecimal(object value);
         double ToDouble(object value);
-        Decimal ToDecimal(object value);
-        DateTime ToDateTime(object value);
-        String ToString(object value);
+        short ToInt16(object value);
+        int ToInt32(object value);
+        long ToInt64(object value);
+        [System.CLSCompliantAttribute(false)]
+        sbyte ToSByte(object value);
+        float ToSingle(object value);
+        string ToString(object value);
+        [System.CLSCompliantAttribute(false)]
+        ushort ToUInt16(object value);
+        [System.CLSCompliantAttribute(false)]
+        uint ToUInt32(object value);
+        [System.CLSCompliantAttribute(false)]
+        ulong ToUInt64(object value);
     }
-    public interface IObjectReference
+    public partial interface IObjectReference
     {
-        object GetRealObject(StreamingContext context);
+        object GetRealObject(System.Runtime.Serialization.StreamingContext context);
     }
-    public interface ISerializable
+    public partial interface ISafeSerializationData
     {
-        void GetObjectData(SerializationInfo info, StreamingContext context);
+        void CompleteDeserialization(object deserialized);
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited = false)]
+    public partial interface ISerializable
+    {
+        void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context);
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
     public sealed partial class OnDeserializedAttribute : System.Attribute
     {
         public OnDeserializedAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
     public sealed partial class OnDeserializingAttribute : System.Attribute
     {
         public OnDeserializingAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
     public sealed partial class OnSerializedAttribute : System.Attribute
     {
         public OnSerializedAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
     public sealed partial class OnSerializingAttribute : System.Attribute
     {
         public OnSerializingAttribute() { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Field, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(256), Inherited=false)]
     public sealed partial class OptionalFieldAttribute : System.Attribute
     {
         public OptionalFieldAttribute() { }
         public int VersionAdded { get { throw null; } set { } }
-    }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public struct SerializationEntry
-    {
-        public string Name { get { throw null; } }
-        public Type ObjectType { get { throw null; } }
-        public object Value { get { throw null; } }
-    }
-    public partial class SerializationException : System.SystemException
-    {
-        public SerializationException() { }
-        public SerializationException(string message) { }
-        public SerializationException(string message, System.Exception innerException) { }
-        protected SerializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-    }
-    public sealed class SerializationInfo
-    {
-        [CLSCompliant(false)]
-        public SerializationInfo(Type type, IFormatterConverter converter) { }
-        [CLSCompliant(false)]
-        public SerializationInfo(Type type, IFormatterConverter converter, bool requireSameTokenInPartialTrust) { }
-        public string AssemblyName { get { throw null; } set { } }
-        public string FullTypeName { get { throw null; } set { } }
-        public int MemberCount { get { throw null; } }
-        public Type ObjectType { get { throw null; } }
-        public bool IsFullTypeNameSetExplicit { get { throw null; } }
-        public bool IsAssemblyNameSetExplicit { get { throw null; } }
-        public void AddValue(string name, bool value) { }
-        public void AddValue(string name, byte value) { }
-        public void AddValue(string name, char value) { }
-        public void AddValue(string name, DateTime value) { }
-        public void AddValue(string name, decimal value) { }
-        public void AddValue(string name, double value) { }
-        public void AddValue(string name, short value) { }
-        public void AddValue(string name, int value) { }
-        public void AddValue(string name, long value) { }
-        public void AddValue(string name, object value) { }
-        public void AddValue(string name, object value, Type type) { }
-        [CLSCompliant(false)]
-        public void AddValue(string name, sbyte value) { }
-        public void AddValue(string name, float value) { }
-        [CLSCompliant(false)]
-        public void AddValue(string name, ushort value) { }
-        [CLSCompliant(false)]
-        public void AddValue(string name, uint value) { }
-        [CLSCompliant(false)]
-        public void AddValue(string name, ulong value) { }
-        public bool GetBoolean(string name) { throw null; }
-        public byte GetByte(string name) { throw null; }
-        public char GetChar(string name) { throw null; }
-        public DateTime GetDateTime(string name) { throw null; }
-        public decimal GetDecimal(string name) { throw null; }
-        public double GetDouble(string name) { throw null; }
-        public SerializationInfoEnumerator GetEnumerator() { throw null; }
-        public short GetInt16(string name) { throw null; }
-        public int GetInt32(string name) { throw null; }
-        public long GetInt64(string name) { throw null; }
-        [CLSCompliant(false)]
-        public sbyte GetSByte(string name) { throw null; }
-        public float GetSingle(string name) { throw null; }
-        public string GetString(string name) { throw null; }
-        [CLSCompliant(false)]
-        public ushort GetUInt16(string name) { throw null; }
-        [CLSCompliant(false)]
-        public uint GetUInt32(string name) { throw null; }
-        [CLSCompliant(false)]
-        public ulong GetUInt64(string name) { throw null; }
-        public object GetValue(string name, Type type) { throw null; }
-        public void SetType(Type type) { }
-    }
-    public sealed class SerializationInfoEnumerator : System.Collections.IEnumerator
-    {
-        private SerializationInfoEnumerator() { }
-        public SerializationEntry Current { get { throw null; } }
-        public string Name { get { throw null; } }
-        public Type ObjectType { get { throw null; } }
-        object System.Collections.IEnumerator.Current { get { throw null; } }
-        public object Value { get { throw null; } }
-        public bool MoveNext() { throw null; }
-        public void Reset() { throw null; }
-    }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct StreamingContext
-    {
-        public StreamingContext(System.Runtime.Serialization.StreamingContextStates state) { }
-        public StreamingContext(System.Runtime.Serialization.StreamingContextStates state, object additional) { }
-        public override bool Equals(object obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public System.Runtime.Serialization.StreamingContextStates State { get { throw null; } }
-        public object Context { get { throw null; } }
-    }
-    [Flags]
-    public enum StreamingContextStates
-    {
-        CrossProcess = 0x01,
-        CrossMachine = 0x02,
-        File = 0x04,
-        Persistence = 0x08,
-        Remoting = 0x10,
-        Other = 0x20,
-        Clone = 0x40,
-        CrossAppDomain = 0x80,
-        All = 0xFF,
     }
     public sealed partial class SafeSerializationEventArgs : System.EventArgs
     {
@@ -7125,14 +6973,113 @@ namespace System.Runtime.Serialization
         public System.Runtime.Serialization.StreamingContext StreamingContext { get { throw null; } }
         public void AddSerializedState(System.Runtime.Serialization.ISafeSerializationData serializedState) { }
     }
-    public partial interface ISafeSerializationData
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct SerializationEntry
     {
-        void CompleteDeserialization(object deserialized);
+        public string Name { get { throw null; } }
+        public System.Type ObjectType { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public partial class SerializationException : System.SystemException
+    {
+        public SerializationException() { }
+        protected SerializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public SerializationException(string message) { }
+        public SerializationException(string message, System.Exception innerException) { }
+    }
+    public sealed partial class SerializationInfo
+    {
+        [System.CLSCompliantAttribute(false)]
+        public SerializationInfo(System.Type type, System.Runtime.Serialization.IFormatterConverter converter) { }
+        [System.CLSCompliantAttribute(false)]
+        public SerializationInfo(System.Type type, System.Runtime.Serialization.IFormatterConverter converter, bool requireSameTokenInPartialTrust) { }
+        public string AssemblyName { get { throw null; } set { } }
+        public string FullTypeName { get { throw null; } set { } }
+        public bool IsAssemblyNameSetExplicit { get { throw null; } }
+        public bool IsFullTypeNameSetExplicit { get { throw null; } }
+        public int MemberCount { get { throw null; } }
+        public System.Type ObjectType { get { throw null; } }
+        public void AddValue(string name, bool value) { }
+        public void AddValue(string name, byte value) { }
+        public void AddValue(string name, char value) { }
+        public void AddValue(string name, System.DateTime value) { }
+        public void AddValue(string name, decimal value) { }
+        public void AddValue(string name, double value) { }
+        public void AddValue(string name, short value) { }
+        public void AddValue(string name, int value) { }
+        public void AddValue(string name, long value) { }
+        public void AddValue(string name, object value) { }
+        public void AddValue(string name, object value, System.Type type) { }
+        [System.CLSCompliantAttribute(false)]
+        public void AddValue(string name, sbyte value) { }
+        public void AddValue(string name, float value) { }
+        [System.CLSCompliantAttribute(false)]
+        public void AddValue(string name, ushort value) { }
+        [System.CLSCompliantAttribute(false)]
+        public void AddValue(string name, uint value) { }
+        [System.CLSCompliantAttribute(false)]
+        public void AddValue(string name, ulong value) { }
+        public bool GetBoolean(string name) { throw null; }
+        public byte GetByte(string name) { throw null; }
+        public char GetChar(string name) { throw null; }
+        public System.DateTime GetDateTime(string name) { throw null; }
+        public decimal GetDecimal(string name) { throw null; }
+        public double GetDouble(string name) { throw null; }
+        public System.Runtime.Serialization.SerializationInfoEnumerator GetEnumerator() { throw null; }
+        public short GetInt16(string name) { throw null; }
+        public int GetInt32(string name) { throw null; }
+        public long GetInt64(string name) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public sbyte GetSByte(string name) { throw null; }
+        public float GetSingle(string name) { throw null; }
+        public string GetString(string name) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public ushort GetUInt16(string name) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public uint GetUInt32(string name) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public ulong GetUInt64(string name) { throw null; }
+        public object GetValue(string name, System.Type type) { throw null; }
+        public void SetType(System.Type type) { }
+    }
+    public sealed partial class SerializationInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal SerializationInfoEnumerator() { }
+        public System.Runtime.Serialization.SerializationEntry Current { get { throw null; } }
+        public string Name { get { throw null; } }
+        public System.Type ObjectType { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public object Value { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct StreamingContext
+    {
+        public StreamingContext(System.Runtime.Serialization.StreamingContextStates state) { throw null;}
+        public StreamingContext(System.Runtime.Serialization.StreamingContextStates state, object additional) { throw null;}
+        public object Context { get { throw null; } }
+        public System.Runtime.Serialization.StreamingContextStates State { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+    }
+    [System.FlagsAttribute]
+    public enum StreamingContextStates
+    {
+        All = 255,
+        Clone = 64,
+        CrossAppDomain = 128,
+        CrossMachine = 2,
+        CrossProcess = 1,
+        File = 4,
+        Other = 32,
+        Persistence = 8,
+        Remoting = 16,
     }
 }
 namespace System.Runtime.Versioning
 {
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false, Inherited=false)]
     public sealed partial class TargetFrameworkAttribute : System.Attribute
     {
         public TargetFrameworkAttribute(string frameworkName) { }
@@ -7140,22 +7087,9 @@ namespace System.Runtime.Versioning
         public string FrameworkName { get { throw null; } }
     }
 }
-namespace System.Security.Cryptography
-{
-    public partial class CryptographicException : System.SystemException
-    {
-        public CryptographicException() { }
-        public CryptographicException(int hr) { }
-        protected CryptographicException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public CryptographicException(string message) { }
-        public CryptographicException(string message, System.Exception inner) { }
-        public CryptographicException(string format, string insert) { }
-    }
-}
-
 namespace System.Security
 {
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false, Inherited=false)]
     public sealed partial class AllowPartiallyTrustedCallersAttribute : System.Attribute
     {
         public AllowPartiallyTrustedCallersAttribute() { }
@@ -7166,7 +7100,7 @@ namespace System.Security
         NotVisibleByDefault = 1,
         VisibleToAllHosts = 0,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(5501), AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5501), AllowMultiple=false, Inherited=false)]
     public sealed partial class SecurityCriticalAttribute : System.Attribute
     {
         public SecurityCriticalAttribute() { }
@@ -7203,7 +7137,7 @@ namespace System.Security
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false)]
     public sealed partial class SecurityRulesAttribute : System.Attribute
     {
         public SecurityRulesAttribute(System.Security.SecurityRuleSet ruleSet) { }
@@ -7216,28 +7150,28 @@ namespace System.Security
         Level2 = (byte)2,
         None = (byte)0,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(5500), AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5500), AllowMultiple=false, Inherited=false)]
     public sealed partial class SecuritySafeCriticalAttribute : System.Attribute
     {
         public SecuritySafeCriticalAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false, Inherited=false)]
     public sealed partial class SecurityTransparentAttribute : System.Attribute
     {
         public SecurityTransparentAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(5501), AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5501), AllowMultiple=false, Inherited=false)]
     [System.ObsoleteAttribute("SecurityTreatAsSafe is only used for .NET 2.0 transparency compatibility.  Please use the SecuritySafeCriticalAttribute instead.")]
     public sealed partial class SecurityTreatAsSafeAttribute : System.Attribute
     {
         public SecurityTreatAsSafeAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(5188), AllowMultiple = true, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5188), AllowMultiple=true, Inherited=false)]
     public sealed partial class SuppressUnmanagedCodeSecurityAttribute : System.Attribute
     {
         public SuppressUnmanagedCodeSecurityAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(2), AllowMultiple = true, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2), AllowMultiple=true, Inherited=false)]
     public sealed partial class UnverifiableCodeAttribute : System.Attribute
     {
         public UnverifiableCodeAttribute() { }
@@ -7250,109 +7184,29 @@ namespace System.Security
         public VerificationException(string message, System.Exception innerException) { }
     }
 }
+namespace System.Security.Cryptography
+{
+    public partial class CryptographicException : System.SystemException
+    {
+        public CryptographicException() { }
+        public CryptographicException(int hr) { }
+        protected CryptographicException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public CryptographicException(string message) { }
+        public CryptographicException(string message, System.Exception inner) { }
+        public CryptographicException(string format, string insert) { }
+    }
+}
 namespace System.Text
 {
-    public sealed partial class StringBuilder : System.Runtime.Serialization.ISerializable
-    {
-        public StringBuilder() { }
-        public StringBuilder(int capacity) { }
-        public StringBuilder(int capacity, int maxCapacity) { }
-        public StringBuilder(string value) { }
-        public StringBuilder(string value, int capacity) { }
-        public StringBuilder(string value, int startIndex, int length, int capacity) { }
-        public int Capacity { get { throw null; } set { } }
-        [System.Runtime.CompilerServices.IndexerName("Chars")]
-        public char this[int index] { get { throw null; } set { } }
-        public int Length { get { throw null; } set { } }
-        public int MaxCapacity { get { throw null; } }
-        public System.Text.StringBuilder Append(bool value) { throw null; }
-        public System.Text.StringBuilder Append(byte value) { throw null; }
-        public System.Text.StringBuilder Append(char value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public unsafe System.Text.StringBuilder Append(char* value, int valueCount) { throw null; }
-        public System.Text.StringBuilder Append(char value, int repeatCount) { throw null; }
-        public System.Text.StringBuilder Append(char[] value) { throw null; }
-        public System.Text.StringBuilder Append(char[] value, int startIndex, int charCount) { throw null; }
-        public System.Text.StringBuilder Append(decimal value) { throw null; }
-        public System.Text.StringBuilder Append(double value) { throw null; }
-        public System.Text.StringBuilder Append(short value) { throw null; }
-        public System.Text.StringBuilder Append(int value) { throw null; }
-        public System.Text.StringBuilder Append(long value) { throw null; }
-        public System.Text.StringBuilder Append(object value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public System.Text.StringBuilder Append(sbyte value) { throw null; }
-        public System.Text.StringBuilder Append(float value) { throw null; }
-        public System.Text.StringBuilder Append(string value) { throw null; }
-        public System.Text.StringBuilder Append(string value, int startIndex, int count) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public System.Text.StringBuilder Append(ushort value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public System.Text.StringBuilder Append(uint value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public System.Text.StringBuilder Append(ulong value) { throw null; }
-        public System.Text.StringBuilder Append(System.ReadOnlySpan<char> value) { throw null; }
-        public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0) { throw null; }
-        public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0, object arg1) { throw null; }
-        public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0, object arg1, object arg2) { throw null; }
-        public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, params object[] args) { throw null; }
-        public System.Text.StringBuilder AppendFormat(string format, object arg0) { throw null; }
-        public System.Text.StringBuilder AppendFormat(string format, object arg0, object arg1) { throw null; }
-        public System.Text.StringBuilder AppendFormat(string format, object arg0, object arg1, object arg2) { throw null; }
-        public System.Text.StringBuilder AppendFormat(string format, params object[] args) { throw null; }
-        public System.Text.StringBuilder AppendLine() { throw null; }
-        public System.Text.StringBuilder AppendLine(string value) { throw null; }
-        public StringBuilder AppendJoin(string separator, params object[] values) { throw null; }
-        public StringBuilder AppendJoin<T>(string separator, System.Collections.Generic.IEnumerable<T> values) { throw null; }
-        public StringBuilder AppendJoin(string separator, params string[] values) { throw null; }
-        public StringBuilder AppendJoin(char separator, params object[] values) { throw null; }
-        public StringBuilder AppendJoin<T>(char separator, System.Collections.Generic.IEnumerable<T> values) { throw null; }
-        public StringBuilder AppendJoin(char separator, params string[] values) { throw null; }
-        public System.Text.StringBuilder Clear() { throw null; }
-        public void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count) { }
-        public void CopyTo(int sourceIndex, System.Span<char> destination, int count) { }
-        public int EnsureCapacity(int capacity) { throw null; }
-        public bool Equals(System.Text.StringBuilder sb) { throw null; }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public System.Text.StringBuilder Insert(int index, bool value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, byte value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, char value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, char[] value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, char[] value, int startIndex, int charCount) { throw null; }
-        public System.Text.StringBuilder Insert(int index, System.ReadOnlySpan<char> value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, decimal value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, double value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, short value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, int value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, long value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, object value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public System.Text.StringBuilder Insert(int index, sbyte value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, float value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, string value) { throw null; }
-        public System.Text.StringBuilder Insert(int index, string value, int count) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public System.Text.StringBuilder Insert(int index, ushort value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public System.Text.StringBuilder Insert(int index, uint value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
-        public System.Text.StringBuilder Insert(int index, ulong value) { throw null; }
-        public System.Text.StringBuilder Remove(int startIndex, int length) { throw null; }
-        public System.Text.StringBuilder Replace(char oldChar, char newChar) { throw null; }
-        public System.Text.StringBuilder Replace(char oldChar, char newChar, int startIndex, int count) { throw null; }
-        public System.Text.StringBuilder Replace(string oldValue, string newValue) { throw null; }
-        public System.Text.StringBuilder Replace(string oldValue, string newValue, int startIndex, int count) { throw null; }
-        public override string ToString() { throw null; }
-        public string ToString(int startIndex, int length) { throw null; }
-    }
     public abstract partial class Decoder
     {
         protected Decoder() { }
         public System.Text.DecoderFallback Fallback { get { throw null; } set { } }
         public System.Text.DecoderFallbackBuffer FallbackBuffer { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        public unsafe virtual void Convert(byte* bytes, int byteCount, char* chars, int charCount, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { throw null; }
-        public virtual void Convert(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex, int charCount, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { throw null; }
-        public virtual void Convert(ReadOnlySpan<byte> bytes, Span<char> chars, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { throw null; }
+        public unsafe virtual void Convert(byte* bytes, int byteCount, char* chars, int charCount, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { bytesUsed = default(int); charsUsed = default(int); completed = default(bool); }
+        public virtual void Convert(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex, int charCount, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { bytesUsed = default(int); charsUsed = default(int); completed = default(bool); }
+        public virtual void Convert(System.ReadOnlySpan<byte> bytes, System.Span<char> chars, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { bytesUsed = default(int); charsUsed = default(int); completed = default(bool); }
         [System.CLSCompliantAttribute(false)]
         public unsafe virtual int GetCharCount(byte* bytes, int count, bool flush) { throw null; }
         public abstract int GetCharCount(byte[] bytes, int index, int count);
@@ -7432,9 +7286,9 @@ namespace System.Text
         public System.Text.EncoderFallback Fallback { get { throw null; } set { } }
         public System.Text.EncoderFallbackBuffer FallbackBuffer { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        public unsafe virtual void Convert(char* chars, int charCount, byte* bytes, int byteCount, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { throw null; }
-        public virtual void Convert(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex, int byteCount, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { throw null; }
-        public virtual void Convert(System.ReadOnlySpan<char> chars, System.Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { throw null; }
+        public unsafe virtual void Convert(char* chars, int charCount, byte* bytes, int byteCount, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { charsUsed = default(int); bytesUsed = default(int); completed = default(bool); }
+        public virtual void Convert(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex, int byteCount, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { charsUsed = default(int); bytesUsed = default(int); completed = default(bool); }
+        public virtual void Convert(System.ReadOnlySpan<char> chars, System.Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { charsUsed = default(int); bytesUsed = default(int); completed = default(bool); }
         [System.CLSCompliantAttribute(false)]
         public unsafe virtual int GetByteCount(char* chars, int count, bool flush) { throw null; }
         public abstract int GetByteCount(char[] chars, int index, int count, bool flush);
@@ -7531,7 +7385,7 @@ namespace System.Text
         public virtual bool IsMailNewsSave { get { throw null; } }
         public bool IsReadOnly { get { throw null; } }
         public virtual bool IsSingleByte { get { throw null; } }
-        public virtual ReadOnlySpan<byte> Preamble { get { throw null; } }
+        public virtual System.ReadOnlySpan<byte> Preamble { get { throw null; } }
         public static System.Text.Encoding Unicode { get { throw null; } }
         public static System.Text.Encoding UTF32 { get { throw null; } }
         public static System.Text.Encoding UTF7 { get { throw null; } }
@@ -7544,31 +7398,31 @@ namespace System.Text
         public override bool Equals(object value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe virtual int GetByteCount(char* chars, int count) { throw null; }
-        public virtual int GetByteCount(ReadOnlySpan<char> chars) { throw null; }
         public virtual int GetByteCount(char[] chars) { throw null; }
         public abstract int GetByteCount(char[] chars, int index, int count);
+        public virtual int GetByteCount(System.ReadOnlySpan<char> chars) { throw null; }
         public virtual int GetByteCount(string s) { throw null; }
         public int GetByteCount(string s, int index, int count) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe virtual int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
-        public virtual int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes) { throw null; }
         public virtual byte[] GetBytes(char[] chars) { throw null; }
         public virtual byte[] GetBytes(char[] chars, int index, int count) { throw null; }
         public abstract int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex);
+        public virtual int GetBytes(System.ReadOnlySpan<char> chars, System.Span<byte> bytes) { throw null; }
         public virtual byte[] GetBytes(string s) { throw null; }
         public byte[] GetBytes(string s, int index, int count) { throw null; }
         public virtual int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe virtual int GetCharCount(byte* bytes, int count) { throw null; }
-        public virtual int GetCharCount(ReadOnlySpan<byte> bytes) { throw null; }
         public virtual int GetCharCount(byte[] bytes) { throw null; }
         public abstract int GetCharCount(byte[] bytes, int index, int count);
+        public virtual int GetCharCount(System.ReadOnlySpan<byte> bytes) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe virtual int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
-        public virtual int GetChars(ReadOnlySpan<byte> bytes, Span<char> chars) { throw null; }
         public virtual char[] GetChars(byte[] bytes) { throw null; }
         public virtual char[] GetChars(byte[] bytes, int index, int count) { throw null; }
         public abstract int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex);
+        public virtual int GetChars(System.ReadOnlySpan<byte> bytes, System.Span<char> chars) { throw null; }
         public virtual System.Text.Decoder GetDecoder() { throw null; }
         public virtual System.Text.Encoder GetEncoder() { throw null; }
         public static System.Text.Encoding GetEncoding(int codepage) { throw null; }
@@ -7582,9 +7436,9 @@ namespace System.Text
         public virtual byte[] GetPreamble() { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe string GetString(byte* bytes, int byteCount) { throw null; }
-        public string GetString(ReadOnlySpan<byte> bytes) { throw null; }
         public virtual string GetString(byte[] bytes) { throw null; }
         public virtual string GetString(byte[] bytes, int index, int count) { throw null; }
+        public string GetString(System.ReadOnlySpan<byte> bytes) { throw null; }
         public bool IsAlwaysNormalized() { throw null; }
         public virtual bool IsAlwaysNormalized(System.Text.NormalizationForm form) { throw null; }
         public static void RegisterProvider(System.Text.EncodingProvider provider) { }
@@ -7614,13 +7468,105 @@ namespace System.Text
         FormKC = 5,
         FormKD = 6,
     }
+    public sealed partial class StringBuilder : System.Runtime.Serialization.ISerializable
+    {
+        public StringBuilder() { }
+        public StringBuilder(int capacity) { }
+        public StringBuilder(int capacity, int maxCapacity) { }
+        public StringBuilder(string value) { }
+        public StringBuilder(string value, int capacity) { }
+        public StringBuilder(string value, int startIndex, int length, int capacity) { }
+        public int Capacity { get { throw null; } set { } }
+        [System.Runtime.CompilerServices.IndexerName("Chars")]
+        public char this[int index] { get { throw null; } set { } }
+        public int Length { get { throw null; } set { } }
+        public int MaxCapacity { get { throw null; } }
+        public System.Text.StringBuilder Append(bool value) { throw null; }
+        public System.Text.StringBuilder Append(byte value) { throw null; }
+        public System.Text.StringBuilder Append(char value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe System.Text.StringBuilder Append(char* value, int valueCount) { throw null; }
+        public System.Text.StringBuilder Append(char value, int repeatCount) { throw null; }
+        public System.Text.StringBuilder Append(char[] value) { throw null; }
+        public System.Text.StringBuilder Append(char[] value, int startIndex, int charCount) { throw null; }
+        public System.Text.StringBuilder Append(decimal value) { throw null; }
+        public System.Text.StringBuilder Append(double value) { throw null; }
+        public System.Text.StringBuilder Append(short value) { throw null; }
+        public System.Text.StringBuilder Append(int value) { throw null; }
+        public System.Text.StringBuilder Append(long value) { throw null; }
+        public System.Text.StringBuilder Append(object value) { throw null; }
+        public System.Text.StringBuilder Append(System.ReadOnlySpan<char> value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public System.Text.StringBuilder Append(sbyte value) { throw null; }
+        public System.Text.StringBuilder Append(float value) { throw null; }
+        public System.Text.StringBuilder Append(string value) { throw null; }
+        public System.Text.StringBuilder Append(string value, int startIndex, int count) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public System.Text.StringBuilder Append(ushort value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public System.Text.StringBuilder Append(uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public System.Text.StringBuilder Append(ulong value) { throw null; }
+        public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0) { throw null; }
+        public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0, object arg1) { throw null; }
+        public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, object arg0, object arg1, object arg2) { throw null; }
+        public System.Text.StringBuilder AppendFormat(System.IFormatProvider provider, string format, params object[] args) { throw null; }
+        public System.Text.StringBuilder AppendFormat(string format, object arg0) { throw null; }
+        public System.Text.StringBuilder AppendFormat(string format, object arg0, object arg1) { throw null; }
+        public System.Text.StringBuilder AppendFormat(string format, object arg0, object arg1, object arg2) { throw null; }
+        public System.Text.StringBuilder AppendFormat(string format, params object[] args) { throw null; }
+        public System.Text.StringBuilder AppendJoin(char separator, params object[] values) { throw null; }
+        public System.Text.StringBuilder AppendJoin(char separator, params string[] values) { throw null; }
+        public System.Text.StringBuilder AppendJoin(string separator, params object[] values) { throw null; }
+        public System.Text.StringBuilder AppendJoin(string separator, params string[] values) { throw null; }
+        public System.Text.StringBuilder AppendJoin<T>(char separator, System.Collections.Generic.IEnumerable<T> values) { throw null; }
+        public System.Text.StringBuilder AppendJoin<T>(string separator, System.Collections.Generic.IEnumerable<T> values) { throw null; }
+        public System.Text.StringBuilder AppendLine() { throw null; }
+        public System.Text.StringBuilder AppendLine(string value) { throw null; }
+        public System.Text.StringBuilder Clear() { throw null; }
+        public void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count) { }
+        public void CopyTo(int sourceIndex, System.Span<char> destination, int count) { }
+        public int EnsureCapacity(int capacity) { throw null; }
+        public bool Equals(System.Text.StringBuilder sb) { throw null; }
+        public System.Text.StringBuilder Insert(int index, bool value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, byte value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, char value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, char[] value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, char[] value, int startIndex, int charCount) { throw null; }
+        public System.Text.StringBuilder Insert(int index, decimal value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, double value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, short value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, int value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, long value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, object value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, System.ReadOnlySpan<char> value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public System.Text.StringBuilder Insert(int index, sbyte value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, float value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, string value) { throw null; }
+        public System.Text.StringBuilder Insert(int index, string value, int count) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public System.Text.StringBuilder Insert(int index, ushort value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public System.Text.StringBuilder Insert(int index, uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public System.Text.StringBuilder Insert(int index, ulong value) { throw null; }
+        public System.Text.StringBuilder Remove(int startIndex, int length) { throw null; }
+        public System.Text.StringBuilder Replace(char oldChar, char newChar) { throw null; }
+        public System.Text.StringBuilder Replace(char oldChar, char newChar, int startIndex, int count) { throw null; }
+        public System.Text.StringBuilder Replace(string oldValue, string newValue) { throw null; }
+        public System.Text.StringBuilder Replace(string oldValue, string newValue, int startIndex, int count) { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public override string ToString() { throw null; }
+        public string ToString(int startIndex, int length) { throw null; }
+    }
 }
 namespace System.Threading
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CancellationToken
     {
-        public CancellationToken(bool canceled) { throw null; }
+        public CancellationToken(bool canceled) { throw null;}
         public bool CanBeCanceled { get { throw null; } }
         public bool IsCancellationRequested { get { throw null; } }
         public static System.Threading.CancellationToken None { get { throw null; } }
@@ -7639,11 +7585,11 @@ namespace System.Threading
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CancellationTokenRegistration : System.IDisposable, System.IEquatable<System.Threading.CancellationTokenRegistration>
     {
+        public System.Threading.CancellationToken Token { get { throw null; } }
         public void Dispose() { }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Threading.CancellationTokenRegistration other) { throw null; }
         public override int GetHashCode() { throw null; }
-        public CancellationToken Token { get { throw null; } }
         public static bool operator ==(System.Threading.CancellationTokenRegistration left, System.Threading.CancellationTokenRegistration right) { throw null; }
         public static bool operator !=(System.Threading.CancellationTokenRegistration left, System.Threading.CancellationTokenRegistration right) { throw null; }
     }
@@ -7663,12 +7609,12 @@ namespace System.Threading
         protected static readonly System.IntPtr InvalidHandle;
         public const int WaitTimeout = 258;
         protected WaitHandle() { }
-        public virtual void Close() { }
-        public void Dispose() { }
-        protected virtual void Dispose(bool explicitDisposing) { }
         [System.ObsoleteAttribute("Use the SafeWaitHandle property instead.")]
         public virtual System.IntPtr Handle { get { throw null; } set { } }
         public Microsoft.Win32.SafeHandles.SafeWaitHandle SafeWaitHandle { get { throw null; } set { } }
+        public virtual void Close() { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool explicitDisposing) { }
         public static bool SignalAndWait(System.Threading.WaitHandle toSignal, System.Threading.WaitHandle toWaitOn) { throw null; }
         public static bool SignalAndWait(System.Threading.WaitHandle toSignal, System.Threading.WaitHandle toWaitOn, int millisecondsTimeout, bool exitContext) { throw null; }
         public static bool SignalAndWait(System.Threading.WaitHandle toSignal, System.Threading.WaitHandle toWaitOn, System.TimeSpan timeout, bool exitContext) { throw null; }
@@ -7731,16 +7677,16 @@ namespace System.Threading.Tasks
         public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task> continuationAction, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
         public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task> continuationAction, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
         public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task> continuationAction, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, TResult> continuationFunction) { throw null; }
-        public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, TResult> continuationFunction, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, TResult> continuationFunction, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, TResult> continuationFunction, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
-        public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, TResult> continuationFunction, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
         public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state) { throw null; }
         public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
         public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
         public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, TResult> continuationFunction) { throw null; }
+        public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, TResult> continuationFunction, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, TResult> continuationFunction, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, TResult> continuationFunction, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
+        public System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(System.Func<System.Threading.Tasks.Task, TResult> continuationFunction, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
         public static System.Threading.Tasks.Task Delay(int millisecondsDelay) { throw null; }
         public static System.Threading.Tasks.Task Delay(int millisecondsDelay, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static System.Threading.Tasks.Task Delay(System.TimeSpan delay) { throw null; }
@@ -7757,12 +7703,12 @@ namespace System.Threading.Tasks
         public static System.Threading.Tasks.Task Run(System.Action action, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static System.Threading.Tasks.Task Run(System.Func<System.Threading.Tasks.Task> function) { throw null; }
         public static System.Threading.Tasks.Task Run(System.Func<System.Threading.Tasks.Task> function, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static System.Threading.Tasks.Task<TResult> Run<TResult>(System.Func<TResult> function) { throw null; }
-        public static System.Threading.Tasks.Task<TResult> Run<TResult>(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static System.Threading.Tasks.Task<TResult> Run<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> function) { throw null; }
-        public static System.Threading.Tasks.Task<TResult> Run<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> function, System.Threading.CancellationToken cancellationToken) { throw null; }
         public void RunSynchronously() { }
         public void RunSynchronously(System.Threading.Tasks.TaskScheduler scheduler) { }
+        public static System.Threading.Tasks.Task<TResult> Run<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> function) { throw null; }
+        public static System.Threading.Tasks.Task<TResult> Run<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> function, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public static System.Threading.Tasks.Task<TResult> Run<TResult>(System.Func<TResult> function) { throw null; }
+        public static System.Threading.Tasks.Task<TResult> Run<TResult>(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken) { throw null; }
         public void Start() { }
         public void Start(System.Threading.Tasks.TaskScheduler scheduler) { }
         public void Wait() { }
@@ -7789,41 +7735,6 @@ namespace System.Threading.Tasks
         public static System.Threading.Tasks.Task<System.Threading.Tasks.Task<TResult>> WhenAny<TResult>(System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<TResult>> tasks) { throw null; }
         public static System.Threading.Tasks.Task<System.Threading.Tasks.Task<TResult>> WhenAny<TResult>(params System.Threading.Tasks.Task<TResult>[] tasks) { throw null; }
         public static System.Runtime.CompilerServices.YieldAwaitable Yield() { throw null; }
-    }
-    public partial class Task<TResult> : System.Threading.Tasks.Task
-    {
-        public Task(System.Func<TResult> function) : base(default(System.Action)) { }
-        public Task(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken) : base(default(System.Action)) { }
-        public Task(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskCreationOptions creationOptions) : base(default(System.Action)) { }
-        public Task(System.Func<TResult> function, System.Threading.Tasks.TaskCreationOptions creationOptions) : base(default(System.Action)) { }
-        public Task(System.Func<object, TResult> function, object state) : base(default(System.Action)) { }
-        public Task(System.Func<object, TResult> function, object state, System.Threading.CancellationToken cancellationToken) : base(default(System.Action)) { }
-        public Task(System.Func<object, TResult> function, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskCreationOptions creationOptions) : base(default(System.Action)) { }
-        public Task(System.Func<object, TResult> function, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) : base(default(System.Action)) { }
-        public static new System.Threading.Tasks.TaskFactory<TResult> Factory { get { throw null; } }
-        public TResult Result { get { throw null; } }
-        public new System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext) { throw null; }
-        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state) { throw null; }
-        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
-        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>> continuationAction) { throw null; }
-        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>> continuationAction, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>> continuationAction, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>> continuationAction, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
-        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>> continuationAction, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, TNewResult> continuationFunction) { throw null; }
-        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, TNewResult> continuationFunction, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, TNewResult> continuationFunction, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, TNewResult> continuationFunction, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
-        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, TNewResult> continuationFunction, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state) { throw null; }
-        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
-        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public new System.Runtime.CompilerServices.TaskAwaiter<TResult> GetAwaiter() { throw null; }
     }
     [System.FlagsAttribute]
     public enum TaskContinuationOptions
@@ -7903,21 +7814,21 @@ namespace System.Threading.Tasks
         public System.Threading.Tasks.Task FromAsync(System.IAsyncResult asyncResult, System.Action<System.IAsyncResult> endMethod) { throw null; }
         public System.Threading.Tasks.Task FromAsync(System.IAsyncResult asyncResult, System.Action<System.IAsyncResult> endMethod, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
         public System.Threading.Tasks.Task FromAsync(System.IAsyncResult asyncResult, System.Action<System.IAsyncResult> endMethod, System.Threading.Tasks.TaskCreationOptions creationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task FromAsync<TArg1>(System.Func<TArg1, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, object state) { throw null; }
-        public System.Threading.Tasks.Task FromAsync<TArg1>(System.Func<TArg1, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TResult>(System.Func<System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, TResult> endMethod, object state) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TResult>(System.Func<System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, TResult> endMethod, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
+        public System.Threading.Tasks.Task FromAsync<TArg1>(System.Func<TArg1, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, object state) { throw null; }
+        public System.Threading.Tasks.Task FromAsync<TArg1>(System.Func<TArg1, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TResult>(System.IAsyncResult asyncResult, System.Func<System.IAsyncResult, TResult> endMethod) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TResult>(System.IAsyncResult asyncResult, System.Func<System.IAsyncResult, TResult> endMethod, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TResult>(System.IAsyncResult asyncResult, System.Func<System.IAsyncResult, TResult> endMethod, System.Threading.Tasks.TaskCreationOptions creationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task FromAsync<TArg1, TArg2>(System.Func<TArg1, TArg2, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, object state) { throw null; }
-        public System.Threading.Tasks.Task FromAsync<TArg1, TArg2>(System.Func<TArg1, TArg2, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TArg1, TResult>(System.Func<TArg1, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, TResult> endMethod, TArg1 arg1, object state) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TArg1, TResult>(System.Func<TArg1, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, TResult> endMethod, TArg1 arg1, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
-        public System.Threading.Tasks.Task FromAsync<TArg1, TArg2, TArg3>(System.Func<TArg1, TArg2, TArg3, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state) { throw null; }
-        public System.Threading.Tasks.Task FromAsync<TArg1, TArg2, TArg3>(System.Func<TArg1, TArg2, TArg3, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
+        public System.Threading.Tasks.Task FromAsync<TArg1, TArg2>(System.Func<TArg1, TArg2, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, object state) { throw null; }
+        public System.Threading.Tasks.Task FromAsync<TArg1, TArg2>(System.Func<TArg1, TArg2, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TArg1, TArg2, TResult>(System.Func<TArg1, TArg2, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, TResult> endMethod, TArg1 arg1, TArg2 arg2, object state) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TArg1, TArg2, TResult>(System.Func<TArg1, TArg2, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, TResult> endMethod, TArg1 arg1, TArg2 arg2, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
+        public System.Threading.Tasks.Task FromAsync<TArg1, TArg2, TArg3>(System.Func<TArg1, TArg2, TArg3, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state) { throw null; }
+        public System.Threading.Tasks.Task FromAsync<TArg1, TArg2, TArg3>(System.Func<TArg1, TArg2, TArg3, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Action<System.IAsyncResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TArg1, TArg2, TArg3, TResult>(System.Func<TArg1, TArg2, TArg3, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, TResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TArg1, TArg2, TArg3, TResult>(System.Func<TArg1, TArg2, TArg3, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, TResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
         public System.Threading.Tasks.Task StartNew(System.Action action) { throw null; }
@@ -7928,14 +7839,14 @@ namespace System.Threading.Tasks
         public System.Threading.Tasks.Task StartNew(System.Action<object> action, object state, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task StartNew(System.Action<object> action, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskCreationOptions creationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
         public System.Threading.Tasks.Task StartNew(System.Action<object> action, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
-        public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<TResult> function) { throw null; }
-        public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskCreationOptions creationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<TResult> function, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
         public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<object, TResult> function, object state) { throw null; }
         public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<object, TResult> function, object state, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<object, TResult> function, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskCreationOptions creationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
         public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<object, TResult> function, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
+        public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<TResult> function) { throw null; }
+        public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskCreationOptions creationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public System.Threading.Tasks.Task<TResult> StartNew<TResult>(System.Func<TResult> function, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
     }
     public partial class TaskFactory<TResult>
     {
@@ -7975,14 +7886,14 @@ namespace System.Threading.Tasks
         public System.Threading.Tasks.Task<TResult> FromAsync<TArg1, TArg2>(System.Func<TArg1, TArg2, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, TResult> endMethod, TArg1 arg1, TArg2 arg2, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TArg1, TArg2, TArg3>(System.Func<TArg1, TArg2, TArg3, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, TResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state) { throw null; }
         public System.Threading.Tasks.Task<TResult> FromAsync<TArg1, TArg2, TArg3>(System.Func<TArg1, TArg2, TArg3, System.AsyncCallback, object, System.IAsyncResult> beginMethod, System.Func<System.IAsyncResult, TResult> endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
-        public System.Threading.Tasks.Task<TResult> StartNew(System.Func<TResult> function) { throw null; }
-        public System.Threading.Tasks.Task<TResult> StartNew(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public System.Threading.Tasks.Task<TResult> StartNew(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskCreationOptions creationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
-        public System.Threading.Tasks.Task<TResult> StartNew(System.Func<TResult> function, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
         public System.Threading.Tasks.Task<TResult> StartNew(System.Func<object, TResult> function, object state) { throw null; }
         public System.Threading.Tasks.Task<TResult> StartNew(System.Func<object, TResult> function, object state, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task<TResult> StartNew(System.Func<object, TResult> function, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskCreationOptions creationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
         public System.Threading.Tasks.Task<TResult> StartNew(System.Func<object, TResult> function, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
+        public System.Threading.Tasks.Task<TResult> StartNew(System.Func<TResult> function) { throw null; }
+        public System.Threading.Tasks.Task<TResult> StartNew(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task<TResult> StartNew(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskCreationOptions creationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public System.Threading.Tasks.Task<TResult> StartNew(System.Func<TResult> function, System.Threading.Tasks.TaskCreationOptions creationOptions) { throw null; }
     }
     public abstract partial class TaskScheduler
     {
@@ -8010,6 +7921,41 @@ namespace System.Threading.Tasks
         WaitingForChildrenToComplete = 4,
         WaitingToRun = 2,
     }
+    public partial class Task<TResult> : System.Threading.Tasks.Task
+    {
+        public Task(System.Func<object, TResult> function, object state) : base (default(System.Action)) { }
+        public Task(System.Func<object, TResult> function, object state, System.Threading.CancellationToken cancellationToken) : base (default(System.Action)) { }
+        public Task(System.Func<object, TResult> function, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskCreationOptions creationOptions) : base (default(System.Action)) { }
+        public Task(System.Func<object, TResult> function, object state, System.Threading.Tasks.TaskCreationOptions creationOptions) : base (default(System.Action)) { }
+        public Task(System.Func<TResult> function) : base (default(System.Action)) { }
+        public Task(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken) : base (default(System.Action)) { }
+        public Task(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskCreationOptions creationOptions) : base (default(System.Action)) { }
+        public Task(System.Func<TResult> function, System.Threading.Tasks.TaskCreationOptions creationOptions) : base (default(System.Action)) { }
+        public static new System.Threading.Tasks.TaskFactory<TResult> Factory { get { throw null; } }
+        public TResult Result { get { throw null; } }
+        public new System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext) { throw null; }
+        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state) { throw null; }
+        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
+        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>> continuationAction) { throw null; }
+        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>> continuationAction, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>> continuationAction, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>> continuationAction, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
+        public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>> continuationAction, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state) { throw null; }
+        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
+        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, TNewResult> continuationFunction) { throw null; }
+        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, TNewResult> continuationFunction, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, TNewResult> continuationFunction, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, TNewResult> continuationFunction, System.Threading.Tasks.TaskContinuationOptions continuationOptions) { throw null; }
+        public System.Threading.Tasks.Task<TNewResult> ContinueWith<TNewResult>(System.Func<System.Threading.Tasks.Task<TResult>, TNewResult> continuationFunction, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
+        public new System.Runtime.CompilerServices.TaskAwaiter<TResult> GetAwaiter() { throw null; }
+    }
     public partial class UnobservedTaskExceptionEventArgs : System.EventArgs
     {
         public UnobservedTaskExceptionEventArgs(System.AggregateException exception) { }
@@ -8018,10 +7964,11 @@ namespace System.Threading.Tasks
         public void SetObserved() { }
     }
     [System.Runtime.CompilerServices.AsyncMethodBuilderAttribute(typeof(System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder<>))]
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
     public readonly partial struct ValueTask<TResult> : System.IEquatable<System.Threading.Tasks.ValueTask<TResult>>
     {
-        public ValueTask(System.Threading.Tasks.Task<TResult> task) { throw null; }
-        public ValueTask(TResult result) { throw null; }
+        public ValueTask(System.Threading.Tasks.Task<TResult> task) { throw null;}
+        public ValueTask(TResult result) { throw null;}
         public bool IsCanceled { get { throw null; } }
         public bool IsCompleted { get { throw null; } }
         public bool IsCompletedSuccessfully { get { throw null; } }

--- a/src/System.Runtime/ref/System.Runtime.csproj
+++ b/src/System.Runtime/ref/System.Runtime.csproj
@@ -5,10 +5,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsCoreAssembly>true</IsCoreAssembly>
     <ProjectGuid>{ADBCF120-3454-4A3C-9D1D-AC4293E795D6}</ProjectGuid>
-    
+    <!-- disable warnings about obsolete APIs -->
+    <NoWarn>$(NoWarn);0809;0618</NoWarn>
     <!-- Default interfaces are not officially supported in netcoreapp yet -->
-    <DefineConstants Condition="'$(IsPrerelease)' == 'true' and '$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_DEFAULT_INTERFACES</DefineConstants> 
-    
+    <DefineConstants Condition="'$(IsPrerelease)' == 'true' and '$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_DEFAULT_INTERFACES</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />

--- a/src/System.Runtime/src/ApiCompatBaseline.uap.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uap.txt
@@ -1,1 +1,0 @@
-Total Issues: 0

--- a/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
@@ -1,1 +1,2 @@
 TypeCannotChangeClassification : Type 'System.TypedReference' is a 'ref struct' in the implementation but is a 'struct' in the contract.
+TypeCannotChangeClassification : Type 'System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter' is marked as readonly in the contract so it must also be marked readonly in the implementation.

--- a/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
@@ -1,8 +1,1 @@
-Compat issues with assembly System.Runtime:
-MembersMustExist : Member 'System.GC.GetAllocatedBytesForCurrentThread()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.String.EndsWith(System.Char)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.String.Replace(System.String, System.String, System.Boolean, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.String.Replace(System.String, System.String, System.StringComparison)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.String.StartsWith(System.Char)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.String.GetHashCode(System.StringComparison)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 7
+TypeCannotChangeClassification : Type 'System.TypedReference' is a 'ref struct' in the implementation but is a 'struct' in the contract.

--- a/tools-local/DefaultGenApiDocIds.txt
+++ b/tools-local/DefaultGenApiDocIds.txt
@@ -26,6 +26,7 @@ T:System.Runtime.InteropServices.ComDefaultInterfaceAttribute
 T:System.Runtime.InteropServices.ComVisibleAttribute
 T:System.Runtime.InteropServices.GuidAttribute
 T:System.Runtime.InteropServices.InterfaceTypeAttribute
+T:System.Runtime.InteropServices.StructLayoutAttribute
 T:System.Runtime.Serialization.KnownTypeAttribute
 T:System.Security.Permissions.EnvironmentPermissionAttribute
 T:System.Security.Permissions.FileIOPermissionAttribute


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/25039. This gets the refs in corefx in-sync with the implementation with regards to ref/readonly. 

I also took the time to regenerate System.Runtime ref file with the genapi tool (ran GenerateReferenceSource target https://github.com/dotnet/corefx/blob/master/dir.targets#L115 on the ref project itsefl) to normalize it. That commit is very noisy but can be reviewed independent from the first commit. To ensure the ref matches I did an API comparison before and after the normalization. 

PTAL @jkotas @stephentoub 

I regenerated System.Reflection.Metadata ref to fix the annotations and it also picked up some other new APIs which I included. cc @tmat @nguerrera 