### PR TITLE
Use Popcnt hardware intrinsic in System.Reflection.Metadata BitArithmetic.CountBits.

### DIFF
--- a/src/System.Private.Reflection.Metadata.Ecma335/src/System.Private.Reflection.Metadata.Ecma335.csproj
+++ b/src/System.Private.Reflection.Metadata.Ecma335/src/System.Private.Reflection.Metadata.Ecma335.csproj
@@ -94,6 +94,7 @@
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\CriticalDisposableObject.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\PinnedObject.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\BitArithmetic.cs" />
+    <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\BitArithmetic.nonnetcoreapp.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\StringUtils.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\EmptyArray.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\EncodingHelper.cs" />

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -100,6 +100,8 @@
     <Compile Include="System\Reflection\Internal\MemoryBlocks\StreamConstraints.cs" />
     <Compile Include="System\Reflection\Internal\MemoryBlocks\StreamMemoryBlockProvider.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\BitArithmetic.cs" />
+    <Compile Include="System\Reflection\Internal\Utilities\BitArithmetic.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
+    <Compile Include="System\Reflection\Internal\Utilities\BitArithmetic.nonnetcoreapp.cs" Condition="'$(TargetGroup)' != 'netcoreapp'" />
     <Compile Include="System\Reflection\Internal\Utilities\StringUtils.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\EmptyArray.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\EncodingHelper.cs" Condition="'$(TargetGroup)' != 'netcoreapp'" />
@@ -269,6 +271,7 @@
     <Reference Include="System.Threading" />
     <Reference Include="System.IO.MemoryMappedFiles" Condition="'$(TargetGroup)' != 'netstandard1.1'" />
     <Reference Include="System.Buffers" Condition="'$(TargetGroup)' == 'netcoreapp'" />
+    <Reference Include="System.Runtime.Intrinsics.X86" Condition="'$(TargetGroup)' == 'netcoreapp'" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BitArithmetic.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BitArithmetic.cs
@@ -6,14 +6,14 @@ using System.Diagnostics;
 
 namespace System.Reflection.Internal
 {
-    internal static class BitArithmetic
+    internal static partial class BitArithmetic
     {
         internal static int CountBits(int v)
         {
             return CountBits(unchecked((uint)v));
         }
 
-        internal static int CountBits(uint v)
+        private static int CountBitsPrivate(uint v)
         {
             unchecked
             {
@@ -23,7 +23,7 @@ namespace System.Reflection.Internal
             }
         }
 
-        internal static int CountBits(ulong v)
+        private static int CountBitsPrivate(ulong v)
         {
             const ulong Mask01010101 = 0x5555555555555555UL;
             const ulong Mask00110011 = 0x3333333333333333UL;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BitArithmetic.netcoreapp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BitArithmetic.netcoreapp.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Intrinsics.X86;
+
+namespace System.Reflection.Internal
+{
+    internal static partial class BitArithmetic
+    {
+        internal static int CountBits(uint v)
+        {
+            if (Popcnt.IsSupported)
+            {
+                return Popcnt.PopCount(v);
+            }
+            else
+            {
+                return CountBitsPrivate(v);
+            }
+        }
+
+        internal static int CountBits(ulong v)
+        {
+            if (Popcnt.IsSupported)
+            {
+                return (int)Popcnt.PopCount(v);
+            }
+            else
+            {
+                return CountBitsPrivate(v);
+            }
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BitArithmetic.nonnetcoreapp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BitArithmetic.nonnetcoreapp.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Reflection.Internal
+{
+    internal static partial class BitArithmetic
+    {
+        internal static int CountBits(uint v)
+        {
+            return CountBitsPrivate(v);
+        }
+
+        internal static int CountBits(ulong v)
+        {
+            return CountBitsPrivate(v);
+        }
+    }
+}


### PR DESCRIPTION
I did some [Benchmark tests](https://gist.github.com/eerhardt/2228f02c4df576e90ebc3aa7306f9f35) on my machine, and got the following results:

|         Method |      Mean |     Error |    StdDev |
|--------------- |----------:|----------:|----------:|
|  PopCountInt32 |  2.265 ns | 0.0836 ns | 0.0996 ns |
|  PopCountInt64 |  2.673 ns | 0.0939 ns | 0.2080 ns |
| CountBitsInt32 | 27.530 ns | 0.7307 ns | 1.1158 ns |
| CountBitsInt64 | 31.071 ns | 0.5751 ns | 0.5098 ns |

See https://github.com/dotnet/coreclr/issues/15506#issuecomment-351494808 for this suggestion.

/cc @fiigii @tannergooding @benaadams 