### PR TITLE
Pass manifest details to PushToBlobFeed

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -214,7 +214,7 @@
       },
       "inputs": {
         "filename": "msbuild",
-        "arguments": "src\\publish.proj /t:PublishToAzureBlobFeed /p:AccountKey=$(PB_PublishBlobFeedKey) /p:ExpectedFeedUrl=$(PB_PublishBlobFeedUrl) /p:ConfigurationGroup=$(PB_ConfigurationGroup)",
+        "arguments": "src\\publish.proj /t:PublishToAzureBlobFeed $(FeedPublishArguments)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -258,7 +258,7 @@
       },
       "inputs": {
         "filename": "msbuild",
-        "arguments": "src\\publish.proj /t:PublishSymbolsToAzureBlobFeed /p:AccountKey=$(PB_PublishBlobFeedKey) /p:ExpectedFeedUrl=$(PB_PublishBlobFeedUrl) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:PublishSymbols=\"true\" ",
+        "arguments": "src\\publish.proj /t:PublishSymbolsToAzureBlobFeed /p:PublishSymbols=\"true\" $(FeedPublishArguments)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -494,6 +494,9 @@
       "value": "master",
       "allowOverride": true
     },
+    "FeedPublishArguments": {
+      "value": "$(PB_BuildOutputManifestArguments) /p:AccountKey=$(PB_PublishBlobFeedKey) /p:ExpectedFeedUrl=$(PB_PublishBlobFeedUrl) /p:ConfigurationGroup=$(PB_ConfigurationGroup)"
+    },
     "PB_AzureContainerPackageGlob": {
       "value": "*.nupkg",
       "allowOverride": true
@@ -523,6 +526,9 @@
     },
     "PB_PublishType": {
       "value": ""
+    },
+    "PB_BuildOutputManifestArguments": {
+      "value": "/p:ManifestBuildId=$(OfficialBuildId) /p:ManifestBranch=$(SourceBranch) /p:ManifestCommit=$(SourceVersion)"
     }
   },
   "retentionRules": [

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -29,18 +29,26 @@
   <PropertyGroup>
     <PackageDownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(PackagesDir)AzureTransfer\$(ConfigurationGroup)</PackageDownloadDirectory>
     <FinalPublishPattern>$(PackageDownloadDirectory)\**\*.nupkg</FinalPublishPattern>
+    <FinalPublishPrivatePattern>$(PackageDownloadDirectory)\**\*Private*.nupkg</FinalPublishPrivatePattern>
     <FinalSymbolsPackagesPattern>$(PackageDownloadDirectory)\**\*.symbols.nupkg</FinalSymbolsPackagesPattern>
   </PropertyGroup>
   
   <Target Name="PublishToAzureBlobFeed">
     <ItemGroup>
-      <ItemsToPush Include="$(FinalPublishPattern)" Exclude="$(FinalSymbolsPackagesPattern)" />
+      <ItemsToPush Include="$(FinalPublishPrivatePattern)" Exclude="$(FinalSymbolsPackagesPattern)">
+        <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
+      </ItemsToPush>
+      <ItemsToPush Include="$(FinalPublishPattern)" Exclude="@(ItemsToPush);$(FinalSymbolsPackagesPattern)" />
     </ItemGroup>
     <Error Condition="'@(ItemsToPush)'==''" Text="ItemsToPush for packages is empty." />
     <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
                     AccountKey="$(AccountKey)"
                     ItemsToPush="@(ItemsToPush)"
-                    Overwrite="$(PublishOverwrite)" />
+                    Overwrite="$(PublishOverwrite)"
+                    ManifestName="$(GitHubRepositoryName)"
+                    ManifestBuildId="$(ManifestBuildId)"
+                    ManifestBranch="$(ManifestBranch)"
+                    ManifestCommit="$(ManifestCommit)" />
   </Target>
   
   <Target Name="PublishSymbolsToAzureBlobFeed" Condition="'$(PublishSymbols)' == 'true'" >
@@ -51,6 +59,10 @@
     <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
                     AccountKey="$(AccountKey)"
                     ItemsToPush="@(ItemsToPush)"
-                    Overwrite="$(PublishOverwrite)" />
+                    Overwrite="$(PublishOverwrite)"
+                    ManifestName="$(GitHubRepositoryName)"
+                    ManifestBuildId="$(ManifestBuildId)"
+                    ManifestBranch="$(ManifestBranch)"
+                    ManifestCommit="$(ManifestCommit)" />
   </Target>
 </Project>


### PR DESCRIPTION
This makes CoreFX produce `corefx.xml` rather than `anonymous.xml` and include a few build details. Generally the same changes as https://github.com/dotnet/coreclr/pull/15705.

This marks `*Private*` as packages that won't ship to the NuGet gallery.

https://github.com/dotnet/core-eng/issues/2335
  