### PR TITLE
Fix for SqlConnection failure when having multiple concurrent users

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -221,12 +221,15 @@ namespace System.Data.SqlClient.SNI
             {
                 try
                 {
-                    sockets[i] = new Socket(ipAddresses[i].AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-                    sockets[i].Connect(ipAddresses[i], port);
-                    if (sockets[i].Connected)
+                    if (ipAddresses[i] != null)
                     {
-                        availableSocket = sockets[i];
-                        break;
+                        sockets[i] = new Socket(ipAddresses[i].AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                        sockets[i].Connect(ipAddresses[i], port);
+                        if (sockets[i].Connected)
+                        {
+                            availableSocket = sockets[i];
+                            break;
+                        }
                     }
                 }
                 catch { }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -137,19 +137,21 @@ namespace System.Data.SqlClient.SNI
                     }
 
                     connectTask = ParallelConnectAsync(serverAddresses, port);
+
+                    if (!(isInfiniteTimeOut ? connectTask.Wait(-1) : connectTask.Wait(ts)))
+                    {
+                        ReportTcpSNIError(0, SNICommon.ConnOpenFailedError, string.Empty);
+                        return;
+                    }
+
+                    _socket = connectTask.Result;
                 }
                 else
                 {
-                    connectTask = ConnectAsync(serverName, port);
+                    //connectTask = ConnectAsync(serverName, port);
+                    _socket = Connect(serverName, port, ts);
                 }
 
-                if (!(isInfiniteTimeOut ? connectTask.Wait(-1) : connectTask.Wait(ts)))
-                {
-                    ReportTcpSNIError(0, SNICommon.ConnOpenFailedError, string.Empty);
-                    return;
-                }
-
-                _socket = connectTask.Result;
                 if (_socket == null || !_socket.Connected)
                 {
                     if (_socket != null)
@@ -182,31 +184,56 @@ namespace System.Data.SqlClient.SNI
             _status = TdsEnums.SNI_SUCCESS;
         }
 
-        private static async Task<Socket> ConnectAsync(string serverName, int port)
+        private static Socket Connect(string serverName, int port, TimeSpan timeout)
         {
-            IPAddress[] addresses = await Dns.GetHostAddressesAsync(serverName).ConfigureAwait(false);
-            IPAddress targetAddrV4 = Array.Find(addresses, addr => (addr.AddressFamily == AddressFamily.InterNetwork));
-            IPAddress targetAddrV6 = Array.Find(addresses, addr => (addr.AddressFamily == AddressFamily.InterNetworkV6));
-            if (targetAddrV4 != null && targetAddrV6 != null)
+            IPAddress[] ipAddresses = Dns.GetHostAddresses(serverName);
+            IPAddress serverIPv4 = null;
+            IPAddress serverIPv6 = null;
+            foreach (IPAddress ipAdress in ipAddresses)
             {
-                return await ParallelConnectAsync(new IPAddress[] { targetAddrV4, targetAddrV6 }, port).ConfigureAwait(false);
+                if (ipAdress.AddressFamily == AddressFamily.InterNetwork)
+                {
+                    serverIPv4 = ipAdress;
+                }
+                else if (ipAdress.AddressFamily == AddressFamily.InterNetworkV6)
+                {
+                    serverIPv6 = ipAdress;
+                }
             }
-            else
-            {
-                IPAddress targetAddr = (targetAddrV4 != null) ? targetAddrV4 : targetAddrV6;
-                var socket = new Socket(targetAddr.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            ipAddresses = new IPAddress[] { serverIPv4, serverIPv6 };
+            Socket[] sockets = new Socket[2];
 
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cts.CancelAfter(timeout);
+            void Cancel()
+            {
+                foreach (Socket socket in sockets)
+                {
+                    if (socket != null && !socket.Connected)
+                    {
+                        socket.Dispose();
+                    }
+                }
+            }
+            cts.Token.Register(Cancel);
+
+            Socket availableSocket = null;
+            for (int i = 0; i < sockets.Length; ++i)
+            {
                 try
                 {
-                    await socket.ConnectAsync(targetAddr, port).ConfigureAwait(false);
+                    sockets[i] = new Socket(ipAddresses[i].AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                    sockets[i].Connect(ipAddresses[i], port);
+                    if (sockets[i].Connected)
+                    {
+                        availableSocket = sockets[i];
+                        break;
+                    }
                 }
-                catch
-                {
-                    socket.Dispose();
-                    throw;
-                }
-                return socket;
+                catch { }
             }
+
+            return availableSocket;
         }
 
         private static Task<Socket> ParallelConnectAsync(IPAddress[] serverAddresses, int port)
@@ -320,7 +347,7 @@ namespace System.Data.SqlClient.SNI
 
             try
             {
-                _sslStream.AuthenticateAsClientAsync(_targetServer).GetAwaiter().GetResult();
+                _sslStream.AuthenticateAsClient(_targetServer);
                 _sslOverTdsStream.FinishHandshake();
             }
             catch (AuthenticationException aue)
@@ -374,8 +401,6 @@ namespace System.Data.SqlClient.SNI
         public override void SetBufferSize(int bufferSize)
         {
             _bufferSize = bufferSize;
-            _socket.SendBufferSize = bufferSize;
-            _socket.ReceiveBufferSize = bufferSize;
         }
 
         /// <summary>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -148,7 +148,6 @@ namespace System.Data.SqlClient.SNI
                 }
                 else
                 {
-                    //connectTask = ConnectAsync(serverName, port);
                     _socket = Connect(serverName, port, ts);
                 }
 


### PR DESCRIPTION
In .NET Core 2.0, SqlConnection failed on not many multiple concurrent users during ASP.NET web application load testing. (https://github.com/dotnet/corefx/issues/25620)
This fix resolve the issue.
