### PR TITLE
Fix for SqlConnection failure when having multiple concurrent users

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -137,19 +137,20 @@ namespace System.Data.SqlClient.SNI
                     }
 
                     connectTask = ParallelConnectAsync(serverAddresses, port);
+
+                    if (!(isInfiniteTimeOut ? connectTask.Wait(-1) : connectTask.Wait(ts)))
+                    {
+                        ReportTcpSNIError(0, SNICommon.ConnOpenFailedError, string.Empty);
+                        return;
+                    }
+
+                    _socket = connectTask.Result;
                 }
                 else
                 {
-                    connectTask = ConnectAsync(serverName, port);
+                    _socket = Connect(serverName, port, ts);
                 }
-
-                if (!(isInfiniteTimeOut ? connectTask.Wait(-1) : connectTask.Wait(ts)))
-                {
-                    ReportTcpSNIError(0, SNICommon.ConnOpenFailedError, string.Empty);
-                    return;
-                }
-
-                _socket = connectTask.Result;
+                
                 if (_socket == null || !_socket.Connected)
                 {
                     if (_socket != null)
@@ -182,31 +183,59 @@ namespace System.Data.SqlClient.SNI
             _status = TdsEnums.SNI_SUCCESS;
         }
 
-        private static async Task<Socket> ConnectAsync(string serverName, int port)
+        private static Socket Connect(string serverName, int port, TimeSpan timeout)
         {
-            IPAddress[] addresses = await Dns.GetHostAddressesAsync(serverName).ConfigureAwait(false);
-            IPAddress targetAddrV4 = Array.Find(addresses, addr => (addr.AddressFamily == AddressFamily.InterNetwork));
-            IPAddress targetAddrV6 = Array.Find(addresses, addr => (addr.AddressFamily == AddressFamily.InterNetworkV6));
-            if (targetAddrV4 != null && targetAddrV6 != null)
+            IPAddress[] ipAddresses = Dns.GetHostAddresses(serverName);
+            IPAddress serverIPv4 = null;
+            IPAddress serverIPv6 = null;
+            foreach (IPAddress ipAdress in ipAddresses)
             {
-                return await ParallelConnectAsync(new IPAddress[] { targetAddrV4, targetAddrV6 }, port).ConfigureAwait(false);
+                if (ipAdress.AddressFamily == AddressFamily.InterNetwork)
+                {
+                    serverIPv4 = ipAdress;
+                }
+                else if (ipAdress.AddressFamily == AddressFamily.InterNetworkV6)
+                {
+                    serverIPv6 = ipAdress;
+                }
             }
-            else
-            {
-                IPAddress targetAddr = (targetAddrV4 != null) ? targetAddrV4 : targetAddrV6;
-                var socket = new Socket(targetAddr.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            ipAddresses = new IPAddress[] { serverIPv4, serverIPv6 };
+            Socket[] sockets = new Socket[2];
 
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cts.CancelAfter(timeout);
+            void Cancel()
+            {
+                foreach (Socket socket in sockets)
+                {
+                    if (socket != null && !socket.Connected)
+                    {
+                        socket.Dispose();
+                    }
+                }
+            }
+            cts.Token.Register(Cancel);
+
+            Socket availableSocket = null;
+            for (int i = 0; i < sockets.Length; ++i)
+            {
                 try
                 {
-                    await socket.ConnectAsync(targetAddr, port).ConfigureAwait(false);
+                    if (ipAddresses[i] != null)
+                    {
+                        sockets[i] = new Socket(ipAddresses[i].AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                        sockets[i].Connect(ipAddresses[i], port);
+                        if (sockets[i].Connected)
+                        {
+                            availableSocket = sockets[i];
+                            break;
+                        }
+                    }
                 }
-                catch
-                {
-                    socket.Dispose();
-                    throw;
-                }
-                return socket;
+                catch { }
             }
+
+            return availableSocket;
         }
 
         private static Task<Socket> ParallelConnectAsync(IPAddress[] serverAddresses, int port)
@@ -320,7 +349,7 @@ namespace System.Data.SqlClient.SNI
 
             try
             {
-                _sslStream.AuthenticateAsClientAsync(_targetServer).GetAwaiter().GetResult();
+                _sslStream.AuthenticateAsClient(_targetServer);
                 _sslOverTdsStream.FinishHandshake();
             }
             catch (AuthenticationException aue)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -230,6 +230,10 @@ namespace System.Data.SqlClient.SNI
                             availableSocket = sockets[i];
                             break;
                         }
+                        else
+                        {
+                            sockets[i].Dispose();
+                        }
                     }
                 }
                 catch { }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -206,12 +206,17 @@ namespace System.Data.SqlClient.SNI
             cts.CancelAfter(timeout);
             void Cancel()
             {
-                foreach (Socket socket in sockets)
+                for (int i = 0; i < sockets.Length; ++i)
                 {
-                    if (socket != null && !socket.Connected)
+                    try
                     {
-                        socket.Dispose();
+                        if (sockets[i] != null && !sockets[i].Connected)
+                        {
+                            sockets[i].Dispose();
+                            sockets[i] = null;
+                        }
                     }
+                    catch { }
                 }
             }
             cts.Token.Register(Cancel);
@@ -233,6 +238,7 @@ namespace System.Data.SqlClient.SNI
                         else
                         {
                             sockets[i].Dispose();
+                            sockets[i] = null;
                         }
                     }
                 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -230,15 +230,18 @@ namespace System.Data.SqlClient.SNI
                     {
                         sockets[i] = new Socket(ipAddresses[i].AddressFamily, SocketType.Stream, ProtocolType.Tcp);
                         sockets[i].Connect(ipAddresses[i], port);
-                        if (sockets[i].Connected)
+                        if (sockets[i] != null) // sockets[i] can be null if cancel callback is executed during connect()
                         {
-                            availableSocket = sockets[i];
-                            break;
-                        }
-                        else
-                        {
-                            sockets[i].Dispose();
-                            sockets[i] = null;
+                            if (sockets[i].Connected)
+                            {
+                                availableSocket = sockets[i];
+                                break;
+                            }
+                            else
+                            {
+                                sockets[i].Dispose();
+                                sockets[i] = null;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
In .NET Core 2.0, SqlConnection failed on not many multiple concurrent users during ASP.NET web application load testing. (https://github.com/dotnet/corefx/issues/25620)
This fix resolve the issue.
