### PR TITLE
Add regression test for GetHashCode of default handles

### DIFF
--- a/src/System.Runtime/tests/System/HandleTests.cs
+++ b/src/System.Runtime/tests/System/HandleTests.cs
@@ -20,11 +20,29 @@ public static class HandleTests
     }
 
     [Fact]
+    public static void DefaultRuntimeFieldHandleHashCodeTest()
+    {
+        RuntimeFieldHandle rfh1 = new RuntimeFieldHandle();
+        RuntimeFieldHandle rfh2 = new RuntimeFieldHandle();
+
+        Assert.Equal(rfh1.GetHashCode(), rfh2.GetHashCode());
+    }
+
+    [Fact]
     public static void  RuntimeMethodHandleTest()
     {
         MethodInfo mi1 = typeof(Base).GetMethod(nameof(Base.MyMethod));
         MethodInfo mi2 = (MethodInfo)MethodBase.GetMethodFromHandle(mi1.MethodHandle);
         Assert.Equal(mi1, mi2);
+    }
+
+    [Fact]
+    public static void DefaultRuntimeMethodHandleHashCodeTest()
+    {
+        RuntimeMethodHandle rmh1 = new RuntimeMethodHandle();
+        RuntimeMethodHandle rmh2 = new RuntimeMethodHandle();
+
+        Assert.Equal(rmh1.GetHashCode(), rmh2.GetHashCode());
     }
 
     [Fact]


### PR DESCRIPTION
Regression tests for dotnet/corert#5216.

This is a port of these CoreCLR tests:

https://github.com/dotnet/coreclr/blob/180a3c80b1d193f4c63b265e21bd29277b81cbcd/tests/src/CoreMangLib/cti/system/runtimemethodhandle/runtimemethodhanldegethashcode.cs
https://github.com/dotnet/coreclr/blob/180a3c80b1d193f4c63b265e21bd29277b81cbcd/tests/src/CoreMangLib/cti/system/runtimefieldhandle/runtimefieldhandlegethashcode.cs

(It's the first half of both tests, since the second half makes no sense.)