### PR TITLE
Dispose of process streams if they are not referenced by the user.

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -67,7 +67,7 @@ namespace System.Diagnostics
 
         private static object s_createProcessLock = new object();
 
-        private bool _inputStreamAccessed;
+        private bool _standardInputAccessed;
 
         private StreamReadMode _outputStreamReadMode;
         private StreamReadMode _errorStreamReadMode;
@@ -693,7 +693,7 @@ namespace System.Diagnostics
                     throw new InvalidOperationException(SR.CantGetStandardIn);
                 }
 
-                _inputStreamAccessed = true;
+                _standardInputAccessed = true;
                 return _standardInput;
             }
         }
@@ -855,15 +855,23 @@ namespace System.Diagnostics
                 {
                     if (_standardOutput != null && (_outputStreamReadMode == StreamReadMode.AsyncMode || _outputStreamReadMode == StreamReadMode.Undefined))
                     {
-                    _standardOutput.Close();
+                        if (_outputStreamReadMode == StreamReadMode.AsyncMode)
+                        {
+                            _output.CancelOperation();
+                        }
+                        _standardOutput.Close();
                     }
 
                     if (_standardError != null && (_errorStreamReadMode == StreamReadMode.AsyncMode || _errorStreamReadMode == StreamReadMode.Undefined))
                     {
+                        if (_errorStreamReadMode == StreamReadMode.AsyncMode)
+                        {
+                            _error.CancelOperation();
+                        }
                         _standardError.Close();
                     }
 
-                    if (_standardInput != null && !_inputStreamAccessed) 
+                    if (_standardInput != null && !_standardInputAccessed)
                     {
                         _standardInput.Close();
                     }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -67,7 +67,7 @@ namespace System.Diagnostics
 
         private static object s_createProcessLock = new object();
 
-        private boolean _inputStreamAccessed;
+        private bool _inputStreamAccessed;
 
         private StreamReadMode _outputStreamReadMode;
         private StreamReadMode _errorStreamReadMode;

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -229,9 +229,9 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        public void TestClosingStreamsDoesNotThrow()
+        public void TestClosingStreamsAsyncDoesNotThrow()
         {
-            Process p = CreateProcessPortable(RemotelyInvokable.WriteLinesSlowlyToOutputAndError);
+            Process p = CreateProcessPortable(RemotelyInvokable.WriteLinesAfterClose);
             p.StartInfo.RedirectStandardOutput = true;
             p.StartInfo.RedirectStandardError = true;
 
@@ -243,6 +243,37 @@ namespace System.Diagnostics.Tests
             p.BeginErrorReadLine();
 
             p.Close();
+        }
+
+        [Fact]
+        public void TestClosingStreamsUndefinedDoesNotThrow()
+        {
+            Process p = CreateProcessPortable(RemotelyInvokable.WriteLinesAfterClose);
+            p.StartInfo.RedirectStandardOutput = true;
+            p.StartInfo.RedirectStandardError = true;
+
+            p.Start();
+            p.Close();
+            RemotelyInvokable.FireClosedEvent();
+        }
+
+        [Fact]
+        public void TestClosingSyncModeDoesNotCloseStreams()
+        {
+            Process p = CreateProcessPortable(RemotelyInvokable.WriteLinesAfterClose);
+            p.StartInfo.RedirectStandardOutput = true;
+            p.StartInfo.RedirectStandardError = true;
+
+            p.Start();
+
+            var output = p.StandardOutput;
+            var error = p.StandardError;
+
+            p.Close();
+            RemotelyInvokable.FireClosedEvent();
+
+            output.ReadToEnd();
+            error.ReadToEnd();
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -237,8 +237,8 @@ namespace System.Diagnostics.Tests
 
             // On netfx, the handler is called once with the EventArgs as null, even if the process writes nothing to the pipe.
             // That's fine, so we'll ignore it here.
-            p.OutputDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && e == null, "OutputDataReceived called after closing the process"); };
-            p.ErrorDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && e == null, "ErrorDataReceived called after closing the process"); };
+            p.OutputDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && string.IsNullOrWhiteSpace(e?.Data), "OutputDataReceived called after closing the process"); };
+            p.ErrorDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && string.IsNullOrWhiteSpace(e?.Data), "ErrorDataReceived called after closing the process"); };
 
             p.Start();
             p.BeginOutputReadLine();

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -237,8 +237,8 @@ namespace System.Diagnostics.Tests
 
             // On netfx, the handler is called once with the EventArgs as null, even if the process writes nothing to the pipe.
             // That's fine, so we'll ignore it here.
-            p.OutputDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && string.IsNullOrWhiteSpace(e?.Data), "OutputDataReceived called after closing the process"); };
-            p.ErrorDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && string.IsNullOrWhiteSpace(e?.Data), "ErrorDataReceived called after closing the process"); };
+            p.OutputDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && e.Data == null, "OutputDataReceived called after closing the process"); };
+            p.ErrorDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && e.Data == null, "ErrorDataReceived called after closing the process"); };
 
             p.Start();
             p.BeginOutputReadLine();

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -237,8 +237,8 @@ namespace System.Diagnostics.Tests
 
             // On netfx, the handler is called once with the EventArgs as null, even if the process writes nothing to the pipe.
             // That's fine, so we'll ignore it here.
-            p.OutputDataReceived += (s, e) => { if (e != null) Assert.True(false, "OutputDataReceived called after closing the process"); };
-            p.ErrorDataReceived += (s, e) => { if (e != null) Assert.True(false, "ErrorDataReceived called after closing the process"); };
+            p.OutputDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && e == null, "OutputDataReceived called after closing the process"); };
+            p.ErrorDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && e == null, "ErrorDataReceived called after closing the process"); };
 
             p.Start();
             p.BeginOutputReadLine();

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -235,8 +235,10 @@ namespace System.Diagnostics.Tests
             p.StartInfo.RedirectStandardOutput = true;
             p.StartInfo.RedirectStandardError = true;
 
-            p.OutputDataReceived += (s, e) => { Assert.True(false, "OutputDataReceived called after closing the process"); };
-            p.ErrorDataReceived += (s, e) => { Assert.True(false, "ErrorDataReceived called after closing the process"); };
+            // On netfx, the handler is called once with the EventArgs as null, even if the process writes nothing to the pipe.
+            // That's fine, so we'll ignore it here.
+            p.OutputDataReceived += (s, e) => { if (e != null) Assert.True(false, "OutputDataReceived called after closing the process"); };
+            p.ErrorDataReceived += (s, e) => { if (e != null) Assert.True(false, "ErrorDataReceived called after closing the process"); };
 
             p.Start();
             p.BeginOutputReadLine();

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -235,14 +235,15 @@ namespace System.Diagnostics.Tests
             p.StartInfo.RedirectStandardOutput = true;
             p.StartInfo.RedirectStandardError = true;
 
-            p.OutputDataReceived += (s, e) => {};
-            p.ErrorDataReceived += (s, e) => {};
+            p.OutputDataReceived += (s, e) => { Assert.True(false, "OutputDataReceived called after closing the process"); };
+            p.ErrorDataReceived += (s, e) => { Assert.True(false, "ErrorDataReceived called after closing the process"); };
 
             p.Start();
             p.BeginOutputReadLine();
             p.BeginErrorReadLine();
 
             p.Close();
+            RemotelyInvokable.FireClosedEvent();
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -229,6 +229,23 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public void TestClosingStreamsDoesNotThrow()
+        {
+            Process p = CreateProcessPortable(RemotelyInvokable.WriteLinesSlowlyToOutputAndError);
+            p.StartInfo.RedirectStandardOutput = true;
+            p.StartInfo.RedirectStandardError = true;
+
+            p.OutputDataReceived += (s, e) => {};
+            p.ErrorDataReceived += (s, e) => {};
+
+            p.Start();
+            p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
+
+            p.Close();
+        }
+
+        [Fact]
         public void TestStreamNegativeTests()
         {
             {

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -235,8 +235,8 @@ namespace System.Diagnostics.Tests
             p.StartInfo.RedirectStandardOutput = true;
             p.StartInfo.RedirectStandardError = true;
 
-            // On netfx, the handler is called once with the EventArgs as null, even if the process writes nothing to the pipe.
-            // That's fine, so we'll ignore it here.
+            // On netfx, the handler is called once with the Data as null, even if the process writes nothing to the pipe.
+            // That behavior is documented here https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.datareceivedeventhandler
             p.OutputDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && e.Data == null, "OutputDataReceived called after closing the process"); };
             p.ErrorDataReceived += (s, e) => { Assert.True(PlatformDetection.IsFullFramework && e.Data == null, "ErrorDataReceived called after closing the process"); };
 

--- a/src/System.Diagnostics.Process/tests/RemotelyInvokable.cs
+++ b/src/System.Diagnostics.Process/tests/RemotelyInvokable.cs
@@ -22,6 +22,8 @@ namespace System.Diagnostics.Tests
         public static readonly int SuccessExitCode = 42;
         public const int WaitInMS = 30 * 1000;
         public const string TestConsoleApp = "System.Diagnostics.Process.Tests";
+        public static event EventHandler ClosedEvent;
+
 
         public static string DummyUapCmd()
         {
@@ -161,14 +163,13 @@ namespace System.Diagnostics.Tests
             return SuccessExitCode;
         }
 
-        public static int WriteLinesSlowlyToOutputAndError()
+        public static int WriteLinesAfterClose()
         {
-            for (int i = 0; i < 50; i++)
+            ClosedEvent += (s, e) =>
             {
-                Console.WriteLine("This is line #" + i + ".");
-                Console.Error.WriteLine("This is error line #" + i + ".");
-                Thread.Sleep(100);
-            }
+                Console.WriteLine("This is a line to output.");
+                Console.Error.WriteLine("This is a line to error.");
+            };
             return SuccessExitCode;
         }
 
@@ -192,6 +193,11 @@ namespace System.Diagnostics.Tests
         {
             Process.GetCurrentProcess().Kill();
             throw new ShouldNotBeInvokedException();
+        }
+
+        public static void FireClosedEvent()
+        {
+            ClosedEvent?.Invoke(null, EventArgs.Empty);
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/RemotelyInvokable.cs
+++ b/src/System.Diagnostics.Process/tests/RemotelyInvokable.cs
@@ -173,6 +173,16 @@ namespace System.Diagnostics.Tests
             return SuccessExitCode;
         }
 
+        public static string WriteLinesAfterCloseUapCmd()
+        {
+            ClosedEvent += (s, e) =>
+            {
+                // Finish the pause
+                Console.WriteLine();
+            };
+            return "(pause > nul) & (echo This is a line to output) & (echo This is a line to error 1>&2)";
+        }
+
         public static string ConcatThreeArgumentsUapCmd(string one, string two, string three)
         {
             return $"echo {string.Join(",", one, two, three)} & exit {SuccessExitCode}";

--- a/src/System.Diagnostics.Process/tests/RemotelyInvokable.cs
+++ b/src/System.Diagnostics.Process/tests/RemotelyInvokable.cs
@@ -161,6 +161,17 @@ namespace System.Diagnostics.Tests
             return SuccessExitCode;
         }
 
+        public static int WriteLinesSlowlyToOutputAndError()
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                Console.WriteLine("This is line #" + i + ".");
+                Console.Error.WriteLine("This is error line #" + i + ".");
+                Thread.Sleep(100);
+            }
+            return SuccessExitCode;
+        }
+
         public static string ConcatThreeArgumentsUapCmd(string one, string two, string three)
         {
             return $"echo {string.Join(",", one, two, three)} & exit {SuccessExitCode}";


### PR DESCRIPTION
Partial fix to #25962 

If the process pipes for stdin/stdout/stderr are not touched by the user, dispose of them.

  