### PR TITLE
Fix ServiceController tests

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
@@ -74,8 +74,7 @@ namespace System.ServiceProcess.Tests
 
         protected override void OnStart(string[] args)
         {
-            if (File.Exists(GetLogPath(ServiceName)))
-                File.Delete(GetLogPath(ServiceName));
+            File.Delete(GetLogPath(ServiceName));
 
             WriteLog(nameof(OnStart) + " args=" + string.Join(",", args));
             base.OnStart(args);

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
@@ -33,8 +33,8 @@ namespace System.ServiceProcess.Tests
 
         public static string GetLogPath(string serviceName)
         {
-            return Assembly.GetEntryAssembly().Location + "." + serviceName + ".log";
-        }        
+            return typeof(TestService).Assembly.Location + "." + serviceName + ".log";
+        }
 
         protected override void OnContinue()
         {
@@ -74,6 +74,9 @@ namespace System.ServiceProcess.Tests
 
         protected override void OnStart(string[] args)
         {
+            if (File.Exists(GetLogPath(ServiceName)))
+                File.Delete(GetLogPath(ServiceName));
+
             WriteLog(nameof(OnStart) + " args=" + string.Join(",", args));
             base.OnStart(args);
         }


### PR DESCRIPTION
The log path was being determined differently in the service and the xunit process.
Also, clear the log on start, as the code did before.

This time I found a machine on which I could successfully run the tests.

Fix https://github.com/dotnet/corefx/issues/26157