### PR TITLE
Add support for Arm64 PE files to System.Reflection.Metadata

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/Machine.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/Machine.cs
@@ -125,5 +125,10 @@ namespace System.Reflection.PortableExecutable
         /// M32R little-endian
         /// </summary>
         M32R = 0x9041,
+
+        /// <summary>
+        /// ARM64
+        /// </summary>
+        Arm64 = 0xAA64,
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedPEBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedPEBuilder.cs
@@ -221,7 +221,7 @@ namespace System.Reflection.PortableExecutable
             builder.WriteUInt32((((uint)entryPointAddress + 2) / 0x1000) * 0x1000);
             builder.WriteUInt32((machine == Machine.IA64) ? 14u : 12u);
             uint offsetWithinPage = ((uint)entryPointAddress + 2) % 0x1000;
-            uint relocType = (machine == Machine.Amd64 || machine == Machine.IA64) ? 10u : 3u;
+            uint relocType = (machine == Machine.Amd64 || machine == Machine.IA64 || machine == Machine.Arm64) ? 10u : 3u;
             ushort s = (ushort)((relocType << 12) | offsetWithinPage);
             builder.WriteUInt16(s);
             if (machine == Machine.IA64)

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedTextSection.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedTextSection.cs
@@ -91,7 +91,7 @@ namespace System.Reflection.PortableExecutable
         /// If set, the module contains instructions that assume a 64 bit instruction set. For example it may depend on an address being 64 bits.
         /// This may be true even if the module contains only IL instructions because of PlatformInvoke and COM interop.
         /// </summary>
-        internal bool Requires64bits => Machine == Machine.Amd64 || Machine == Machine.IA64;
+        internal bool Requires64bits => Machine == Machine.Amd64 || Machine == Machine.IA64 || Machine == Machine.Arm64;
 
         public bool Is32Bit => !Requires64bits;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEHeaderBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEHeaderBuilder.cs
@@ -106,7 +106,7 @@ namespace System.Reflection.PortableExecutable
             return new PEHeaderBuilder(imageCharacteristics: Characteristics.Dll);
         }
 
-        internal bool Is32Bit => Machine != Machine.Amd64 && Machine != Machine.IA64;
+        internal bool Is32Bit => Machine != Machine.Amd64 && Machine != Machine.IA64 && Machine != Machine.Arm64;
 
         internal int ComputeSizeOfPEHeaders(int sectionCount) =>
             PEBuilder.DosHeaderSize +

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEBuilderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEBuilderTests.cs
@@ -98,11 +98,6 @@ namespace System.Reflection.PortableExecutable.Tests
         public static IEnumerable<object> AllMachineTypes()
         {
             return ((Machine[])Enum.GetValues(typeof(Machine))).Select(m => new object[]{(object)m});
-/*            foreach (object enumValue in Enum.GetValues(typeof(Machine)))
-            {
-                yield return new object[]{enumValue}; 
-            }
-*/
         }
 
         #endregion

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEBuilderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEBuilderTests.cs
@@ -17,7 +17,7 @@ namespace System.Reflection.PortableExecutable.Tests
     {
         #region Helpers
 
-        private void VerifyPE(Stream peStream, byte[] expectedSignature = null)
+        private void VerifyPE(Stream peStream, Machine machine, byte[] expectedSignature = null)
         {
             peStream.Position = 0;
 
@@ -32,6 +32,11 @@ namespace System.Reflection.PortableExecutable.Tests
 
                 Assert.Equal(s_contentId.Stamp, unchecked((uint)peReader.PEHeaders.CoffHeader.TimeDateStamp));
                 Assert.Equal(s_guid, mdReader.GetGuid(mdReader.GetModuleDefinition().Mvid));
+
+                if (machine == Machine.Unknown) // Unknown machine type translates into AnyCpu, which is marked as I386 in the PE file
+                    Assert.Equal(Machine.I386, headers.CoffHeader.Machine);
+                else 
+                    Assert.Equal(machine, headers.CoffHeader.Machine);
             }
         }
 
@@ -59,10 +64,14 @@ namespace System.Reflection.PortableExecutable.Tests
             MethodDefinitionHandle entryPointHandle,
             Blob mvidFixup = default(Blob),
             byte[] privateKeyOpt = null,
-            bool publicSigned = false)
+            bool publicSigned = false,
+            Machine machine = 0)
         {
+            var peHeaderBuilder = new PEHeaderBuilder(imageCharacteristics : entryPointHandle.IsNil ? Characteristics.Dll : Characteristics.ExecutableImage,
+                                                      machine : machine);
+
             var peBuilder = new ManagedPEBuilder(
-                entryPointHandle.IsNil ? PEHeaderBuilder.CreateLibraryHeader() : PEHeaderBuilder.CreateExecutableHeader(),
+                peHeaderBuilder,
                 new MetadataRootBuilder(metadataBuilder),
                 ilBuilder,
                 entryPoint: entryPointHandle,
@@ -86,6 +95,23 @@ namespace System.Reflection.PortableExecutable.Tests
             peBlob.WriteContentTo(peStream);
         }
 
+        public static IEnumerable<object[]> AllMachineTypes()
+        {
+            foreach (object enumValue in Enum.GetValues(typeof(Machine)))
+            {
+                yield return new object[]{enumValue};
+            }
+        }
+
+        public static IEnumerable<object[]> CommonMachineTypes()
+        {
+            yield return new object[] { Machine.Unknown };
+            yield return new object[] { Machine.I386 };
+            yield return new object[] { Machine.Amd64 };
+            yield return new object[] { Machine.Arm64 };
+            yield return new object[] { Machine.ArmThumb2 };
+        }
+
         #endregion
 
         [Fact]
@@ -101,21 +127,22 @@ namespace System.Reflection.PortableExecutable.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => new ManagedPEBuilder(hdr, ms, il, strongNameSignatureSize: -1));
         }
 
-        [Fact]
-        public void BasicValidation()
+        [Theory] // Do BasicValidation on all machine types listed in the Machine enum
+        [MemberData(nameof(AllMachineTypes))]
+        public void BasicValidation(Machine machine)
         {
             using (var peStream = new MemoryStream())
             {
                 var ilBuilder = new BlobBuilder();
                 var metadataBuilder = new MetadataBuilder();
                 var entryPoint = BasicValidationEmit(metadataBuilder, ilBuilder);
-                WritePEImage(peStream, metadataBuilder, ilBuilder, entryPoint, publicSigned: true);
+                WritePEImage(peStream, metadataBuilder, ilBuilder, entryPoint, publicSigned: true, machine: machine);
 
                 peStream.Position = 0;
                 var actualChecksum = new PEHeaders(peStream).PEHeader.CheckSum;
                 Assert.Equal(0U, actualChecksum);
 
-                VerifyPE(peStream);
+                VerifyPE(peStream, machine);
             }
         }
 
@@ -137,7 +164,7 @@ namespace System.Reflection.PortableExecutable.Tests
                 var actualChecksum = new PEHeaders(peStream).PEHeader.CheckSum;
                 Assert.Equal(0x0000319cU, actualChecksum);
 
-                VerifyPE(peStream, expectedSignature: new byte[] 
+                VerifyPE(peStream, Machine.Unknown, expectedSignature: new byte[] 
                 {
                     0x58, 0xD4, 0xD7, 0x88, 0x3B, 0xF9, 0x19, 0x9F, 0x3A, 0x55, 0x8F, 0x1B, 0x88, 0xBE, 0xA8, 0x42,
                     0x09, 0x2B, 0xE3, 0xB4, 0xC7, 0x09, 0xD5, 0x96, 0x35, 0x50, 0x0F, 0x3C, 0x87, 0x95, 0x6A, 0x31,
@@ -320,8 +347,9 @@ namespace System.Reflection.PortableExecutable.Tests
             return mainMethodDef;
         }
 
-        [Fact]
-        public void Complex()
+        [Theory] // Do BasicValidation on common machine types
+        [MemberData(nameof(CommonMachineTypes))]
+        public void Complex(Machine machine)
         {
             using (var peStream = new MemoryStream())
             {
@@ -330,8 +358,8 @@ namespace System.Reflection.PortableExecutable.Tests
                 Blob mvidFixup;
                 var entryPoint = ComplexEmit(metadataBuilder, ilBuilder, out mvidFixup);
 
-                WritePEImage(peStream, metadataBuilder, ilBuilder, entryPoint, mvidFixup);
-                VerifyPE(peStream);
+                WritePEImage(peStream, metadataBuilder, ilBuilder, entryPoint, mvidFixup, machine: machine);
+                VerifyPE(peStream, machine);
             }
         }
 

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEBuilderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEBuilderTests.cs
@@ -67,8 +67,8 @@ namespace System.Reflection.PortableExecutable.Tests
             bool publicSigned = false,
             Machine machine = 0)
         {
-            var peHeaderBuilder = new PEHeaderBuilder(imageCharacteristics : entryPointHandle.IsNil ? Characteristics.Dll : Characteristics.ExecutableImage,
-                                                      machine : machine);
+            var peHeaderBuilder = new PEHeaderBuilder(imageCharacteristics: entryPointHandle.IsNil ? Characteristics.Dll : Characteristics.ExecutableImage,
+                                                      machine: machine);
 
             var peBuilder = new ManagedPEBuilder(
                 peHeaderBuilder,
@@ -95,21 +95,14 @@ namespace System.Reflection.PortableExecutable.Tests
             peBlob.WriteContentTo(peStream);
         }
 
-        public static IEnumerable<object[]> AllMachineTypes()
+        public static IEnumerable<object> AllMachineTypes()
         {
-            foreach (object enumValue in Enum.GetValues(typeof(Machine)))
+            return ((Machine[])Enum.GetValues(typeof(Machine))).Select(m => new object[]{(object)m});
+/*            foreach (object enumValue in Enum.GetValues(typeof(Machine)))
             {
-                yield return new object[]{enumValue};
+                yield return new object[]{enumValue}; 
             }
-        }
-
-        public static IEnumerable<object[]> CommonMachineTypes()
-        {
-            yield return new object[] { Machine.Unknown };
-            yield return new object[] { Machine.I386 };
-            yield return new object[] { Machine.Amd64 };
-            yield return new object[] { Machine.Arm64 };
-            yield return new object[] { Machine.ArmThumb2 };
+*/
         }
 
         #endregion
@@ -348,7 +341,7 @@ namespace System.Reflection.PortableExecutable.Tests
         }
 
         [Theory] // Do BasicValidation on common machine types
-        [MemberData(nameof(CommonMachineTypes))]
+        [MemberData(nameof(AllMachineTypes))]
         public void Complex(Machine machine)
         {
             using (var peStream = new MemoryStream())

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEHeadersTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEHeadersTests.cs
@@ -24,6 +24,9 @@ namespace System.Reflection.PortableExecutable.Tests
             Assert.Equal(128 + 4 + 20 + 224 + 16, new PEHeaderBuilder(Machine.Amd64).ComputeSizeOfPEHeaders(0));
             Assert.Equal(128 + 4 + 20 + 224 + 16 + 40 * 1, new PEHeaderBuilder(Machine.Amd64).ComputeSizeOfPEHeaders(1));
             Assert.Equal(128 + 4 + 20 + 224 + 16 + 40 * 2, new PEHeaderBuilder(Machine.Amd64).ComputeSizeOfPEHeaders(2));
+            Assert.Equal(128 + 4 + 20 + 224 + 16, new PEHeaderBuilder(Machine.Arm64).ComputeSizeOfPEHeaders(0));
+            Assert.Equal(128 + 4 + 20 + 224 + 16 + 40 * 1, new PEHeaderBuilder(Machine.Arm64).ComputeSizeOfPEHeaders(1));
+            Assert.Equal(128 + 4 + 20 + 224 + 16 + 40 * 2, new PEHeaderBuilder(Machine.Arm64).ComputeSizeOfPEHeaders(2));
         }
 
         [Fact]


### PR DESCRIPTION
- PE header DWORD is 0xAA64
- Arm64 PE files are 64 bit PE