### PR TITLE
Add System.Net.WebSocket.Protocol netstandard package.

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2884,6 +2884,11 @@
         "4.0.1.0": "4.3.0"
       }
     },
+    "System.Net.WebSockets.WebSocketProtocol": {
+      "AssemblyVersionInPackageVersion": {
+        "4.0.0.0": "4.5.0"
+      }
+    },
     "System.Numerics": {
       "InboxOn": {
         "netcoreapp2.0": "4.0.0.0",

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -1040,6 +1040,13 @@
     ]
   },
   {
+    "Name": "System.Net.WebSockets.WebSocketProtocol",
+    "Description": "Provides the WebSocketProtocol class, which allows creating a websocket from a connected stream using WebSocketsProtocol.CreateFromConnectedStream.",
+    "CommonTypes": [
+      "System.Net.WebSockets.WebSocketProtocol"
+    ]
+  },
+  {
     "Name": "System.Net.Http.WinHttpHandler",
     "Description": "Provides a message handler for HttpClient based on the WinHTTP interface of Windows. While similar to HttpClientHandler, it provides developers more granular control over the application's HTTP communication than the HttpClientHandler.",
     "CommonTypes": [

--- a/src/System.Net.WebSockets.WebSocketProtocol/System.Net.WebSockets.WebSocketProtocol.sln
+++ b/src/System.Net.WebSockets.WebSocketProtocol/System.Net.WebSockets.WebSocketProtocol.sln
@@ -1,0 +1,55 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27214.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.WebSockets.WebSocketProtocol", "src\System.Net.WebSockets.WebSocketProtocol.csproj", "{747BE014-7C1D-4460-95AF-B41C35717165}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D5A36F24-E27C-43DF-8658-10C5290423E0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{9D10D7AD-2F8C-4F7A-B0FA-E5EB3ECE287F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.WebSockets.WebSocketProtocol", "ref\System.Net.WebSockets.WebSocketProtocol.csproj", "{4EDBE9F5-D10A-4553-AE24-2E0E946B15B0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{F47347C3-433C-4D3B-90F9-487FE7F4F444}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.WebSockets.WebSocketProtocol.Tests", "tests\System.Net.WebSockets.WebSocketProtocol.Tests.csproj", "{CF73547B-07D2-4290-A14A-CA2A354F4D21}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		netstandard-Debug|Any CPU = netstandard-Debug|Any CPU
+		netstandard-Release|Any CPU = netstandard-Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{747BE014-7C1D-4460-95AF-B41C35717165}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{747BE014-7C1D-4460-95AF-B41C35717165}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{747BE014-7C1D-4460-95AF-B41C35717165}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{747BE014-7C1D-4460-95AF-B41C35717165}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{747BE014-7C1D-4460-95AF-B41C35717165}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{747BE014-7C1D-4460-95AF-B41C35717165}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{4EDBE9F5-D10A-4553-AE24-2E0E946B15B0}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{4EDBE9F5-D10A-4553-AE24-2E0E946B15B0}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{4EDBE9F5-D10A-4553-AE24-2E0E946B15B0}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{4EDBE9F5-D10A-4553-AE24-2E0E946B15B0}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{4EDBE9F5-D10A-4553-AE24-2E0E946B15B0}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{4EDBE9F5-D10A-4553-AE24-2E0E946B15B0}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{CF73547B-07D2-4290-A14A-CA2A354F4D21}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{CF73547B-07D2-4290-A14A-CA2A354F4D21}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{CF73547B-07D2-4290-A14A-CA2A354F4D21}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{CF73547B-07D2-4290-A14A-CA2A354F4D21}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{CF73547B-07D2-4290-A14A-CA2A354F4D21}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{CF73547B-07D2-4290-A14A-CA2A354F4D21}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{747BE014-7C1D-4460-95AF-B41C35717165} = {D5A36F24-E27C-43DF-8658-10C5290423E0}
+		{4EDBE9F5-D10A-4553-AE24-2E0E946B15B0} = {9D10D7AD-2F8C-4F7A-B0FA-E5EB3ECE287F}
+		{CF73547B-07D2-4290-A14A-CA2A354F4D21} = {F47347C3-433C-4D3B-90F9-487FE7F4F444}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6618B298-BA53-4E58-9795-756C6DC1BA38}
+	EndGlobalSection
+EndGlobal

--- a/src/System.Net.WebSockets.WebSocketProtocol/dir.props
+++ b/src/System.Net.WebSockets.WebSocketProtocol/dir.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyKey>Open</AssemblyKey>
+  </PropertyGroup>
+</Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/pkg/System.Net.WebSockets.WebSocketProtocol.pkgproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/pkg/System.Net.WebSockets.WebSocketProtocol.pkgproj
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Net.WebSockets.WebSocketProtocol.csproj">
+      <SupportedFramework>net461;netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Net.WebSockets.WebSocketProtocol.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/ref/Configurations.props
+++ b/src/System.Net.WebSockets.WebSocketProtocol/ref/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/ref/System.Net.WebSockets.WebSocketProtocol.cs
+++ b/src/System.Net.WebSockets.WebSocketProtocol/ref/System.Net.WebSockets.WebSocketProtocol.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System.IO;
+
+namespace System.Net.WebSockets
+{
+    public static class WebSocketProtocol
+    {
+        public static WebSocket CreateFromStream(Stream stream, bool isServer, string subProtocol, TimeSpan keepAliveInterval, Memory<byte> buffer = default) { throw null; }
+    }
+}

--- a/src/System.Net.WebSockets.WebSocketProtocol/ref/System.Net.WebSockets.WebSocketProtocol.csproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/ref/System.Net.WebSockets.WebSocketProtocol.csproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System.Net.WebSockets.WebSocketProtocol.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\System.Memory\ref\System.Memory.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/Configurations.props
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/Configurations.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+      netcoreapp;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/Resources/Strings.resx
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/Resources/Strings.resx
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="net_WebSockets_InvalidEmptySubProtocol" xml:space="preserve">
+    <value>Empty string is not a valid subprotocol value. Please use \"null\" to specify no value.</value>
+  </data>
+  <data name="net_WebSockets_InvalidState" xml:space="preserve">
+    <value>The WebSocket is in an invalid state ('{0}') for this operation. Valid states are: '{1}'</value>
+  </data>
+  <data name="net_WebSockets_InvalidCharInProtocolString" xml:space="preserve">
+    <value>The WebSocket protocol '{0}' is invalid because it contains the invalid character '{1}'.</value>
+  </data>
+  <data name="net_WebSockets_ReasonNotNull" xml:space="preserve">
+    <value>The close status description '{0}' is invalid. When using close status code '{1}' the description must be null.</value>
+  </data>
+  <data name="net_WebSockets_InvalidCloseStatusCode" xml:space="preserve">
+    <value>The close status code '{0}' is reserved for system use only and cannot be specified when calling this method.</value>
+  </data>
+  <data name="net_WebSockets_InvalidCloseStatusDescription" xml:space="preserve">
+    <value>The close status description '{0}' is too long. The UTF8-representation of the status description must not be longer than {1} bytes.</value>
+  </data>
+  <data name="net_WebSockets_UnsupportedPlatform" xml:space="preserve">
+    <value>The WebSocket protocol is not supported on this platform.</value>
+  </data>
+  <data name="net_WebSockets_Argument_InvalidMessageType" xml:space="preserve">
+    <value>The message type '{0}' is not allowed for the '{1}' operation. Valid message types are: '{2}, {3}'. To close the WebSocket, use the '{4}' operation instead. </value>
+  </data>
+  <data name="net_Websockets_AlreadyOneOutstandingOperation" xml:space="preserve">
+    <value>There is already one outstanding '{0}' call for this WebSocket instance. ReceiveAsync and SendAsync can be called simultaneously, but at most one outstanding operation for each of them is allowed at the same time.</value>
+  </data>
+  <data name="NotReadableStream" xml:space="preserve">
+    <value>The base stream is not readable.</value>
+  </data>
+  <data name="NotWriteableStream" xml:space="preserve">
+    <value>The base stream is not writeable.</value>
+  </data>
+  <data name="net_WebSockets_ArgumentOutOfRange_TooSmall" xml:space="preserve">
+    <value>The argument must be a value greater than {0}.</value>
+  </data>
+</root>

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Net.WebSockets.WebSocketProtocol</AssemblyName>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <ProjectGuid>{747BE014-7C1D-4460-95AF-B41C35717165}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="$(CommonPath)\System\Net\WebSockets\ManagedWebSocket.cs">
+      <Link>Common\System\Net\WebSockets\ManagedWebSocket.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\WebSockets\WebSocketValidate.cs">
+      <Link>Common\System\Net\WebSockets\WebSocketValidate.cs</Link>
+    </Compile>
+    <Compile Include="System\Net\WebSockets\ManagedWebSocket.netstandard.cs" />
+    <Compile Include="System\Net\WebSockets\WebSocketProtocol.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+    <Compile Include="System\Net\WebSockets\ManagedWebSocketExtensions.cs" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Memory" />
+    <Reference Include="Microsoft.Win32.Primitives" />
+    <Reference Include="System.Security.Cryptography.Algorithms" />
+    <Reference Include="System.Diagnostics.Debug" />
+    <Reference Include="System.Buffers" />
+    <Reference Include="System.Net.WebSockets" />
+    <Reference Include="System.Numerics.Vectors" />
+    <Reference Include="System.Resources.ResourceManager" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Text.Encoding.Extensions" />
+    <Reference Include="System.Threading" />
+    <Reference Include="System.Threading.Tasks" />
+    <Reference Include="System.Threading.Tasks.Extensions" />
+    <Reference Include="System.Threading.Timer" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System/Net/WebSockets/ManagedWebSocket.netstandard.cs
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System/Net/WebSockets/ManagedWebSocket.netstandard.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.WebSockets
+{
+    internal sealed partial class ManagedWebSocket : WebSocket
+    {
+        private Task ValidateAndReceiveAsync(Task receiveTask, byte[] buffer, CancellationToken cancellationToken)
+        {
+            if (receiveTask == null ||
+                (receiveTask.Status == TaskStatus.RanToCompletion &&
+                !(receiveTask is Task<WebSocketReceiveResult> wsrr && wsrr.Result.MessageType == WebSocketMessageType.Close)))
+            {
+                receiveTask = ReceiveAsyncPrivate<WebSocketReceiveResultGetter, WebSocketReceiveResult>(new ArraySegment<byte>(buffer), cancellationToken).AsTask();
+            }
+
+            return receiveTask;
+        }
+    }
+}

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System/Net/WebSockets/ManagedWebSocketExtensions.cs
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System/Net/WebSockets/ManagedWebSocketExtensions.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.WebSockets
+{
+    internal static class ManagedWebSocketExtensions
+    {
+        internal static unsafe string GetString(this UTF8Encoding encoding, Span<byte> bytes)
+        {
+            fixed (byte* b = &MemoryMarshal.GetReference(bytes))
+            {
+                return encoding.GetString(b, bytes.Length);
+            }
+        }
+
+        internal static Task<int> ReadAsync(this Stream stream, Memory<byte> destination, CancellationToken cancellationToken)
+        {
+            if (destination.TryGetArray(out ArraySegment<byte> array))
+            {
+                return stream.ReadAsync(array.Array, array.Offset, array.Count, cancellationToken);
+            }
+            else
+            {
+                byte[] buffer = ArrayPool<byte>.Shared.Rent(destination.Length);
+                return FinishReadAsync(stream.ReadAsync(buffer, 0, destination.Length, cancellationToken), buffer, destination);
+
+                async Task<int> FinishReadAsync(Task<int> readTask, byte[] localBuffer, Memory<byte> localDestination)
+                {
+                    try
+                    {
+                        int result = await readTask.ConfigureAwait(false);
+                        new Span<byte>(localBuffer, 0, result).CopyTo(localDestination.Span);
+                        return result;
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(localBuffer);
+                    }
+                }
+            }
+        }
+    }
+
+    internal static class BitConverter
+    {
+        internal static unsafe int ToInt32(ReadOnlySpan<byte> value)
+        {
+            if (value.Length < sizeof(int))
+                throw new ArgumentOutOfRangeException(nameof(value));
+            return Unsafe.ReadUnaligned<int>(ref MemoryMarshal.GetReference(value));
+        }
+    }
+}

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System/Net/WebSockets/ManagedWebSocketExtensions.cs
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System/Net/WebSockets/ManagedWebSocketExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -54,8 +55,7 @@ namespace System.Net.WebSockets
     {
         internal static unsafe int ToInt32(ReadOnlySpan<byte> value)
         {
-            if (value.Length < sizeof(int))
-                throw new ArgumentOutOfRangeException(nameof(value));
+            Debug.Assert(value.Length >= sizeof(int));
             return Unsafe.ReadUnaligned<int>(ref MemoryMarshal.GetReference(value));
         }
     }

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System/Net/WebSockets/WebSocketProtocol.cs
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System/Net/WebSockets/WebSocketProtocol.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Threading;
+
+namespace System.Net.WebSockets
+{
+    public static class WebSocketProtocol
+    {
+        public static WebSocket CreateFromStream(
+            Stream stream,
+            bool isServer,
+            string subProtocol,
+            TimeSpan keepAliveInterval,
+            Memory<byte> buffer = default)
+        {
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            if (!stream.CanRead || !stream.CanWrite)
+            {
+                throw new ArgumentException(!stream.CanRead ? SR.NotReadableStream : SR.NotWriteableStream, nameof(stream));
+            }
+
+            if (subProtocol != null)
+            {
+                WebSocketValidate.ValidateSubprotocol(subProtocol);
+            }
+
+            if (keepAliveInterval != Timeout.InfiniteTimeSpan && keepAliveInterval < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(keepAliveInterval), keepAliveInterval,
+                    SR.Format(SR.net_WebSockets_ArgumentOutOfRange_TooSmall,
+                    0));
+            }
+
+            return ManagedWebSocket.CreateFromConnectedStream(stream, isServer, subProtocol, keepAliveInterval, buffer);
+        }
+    }
+}

--- a/src/System.Net.WebSockets.WebSocketProtocol/tests/Configurations.props
+++ b/src/System.Net.WebSockets.WebSocketProtocol/tests/Configurations.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+      netcoreapp;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/tests/System.Net.WebSockets.WebSocketProtocol.Tests.csproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/tests/System.Net.WebSockets.WebSocketProtocol.Tests.csproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup>
+    <ProjectGuid>{CF73547B-07D2-4290-A14A-CA2A354F4D21}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+      <Link>Common\System\Net\Configuration.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.WebSockets.cs">
+      <Link>Common\System\Net\Configuration.WebSockets.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+      <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
+    </Compile>
+    <Compile Include="WebSocketProtocolTests.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/tests/WebSocketProtocolTests.cs
+++ b/src/System.Net.WebSockets.WebSocketProtocol/tests/WebSocketProtocolTests.cs
@@ -1,0 +1,165 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.WebSockets.Tests
+{
+    using Configuration = System.Net.Test.Common.Configuration;
+
+    public sealed class WebSocketProtocolTests
+    {
+        [Fact]
+        public void CreateFromStream_InvalidArguments_Throws()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("stream",
+                () => WebSocketProtocol.CreateFromStream(null, true, "subProtocol", TimeSpan.FromSeconds(30), default(Memory<byte>)));
+            AssertExtensions.Throws<ArgumentException>("stream",
+                () => WebSocketProtocol.CreateFromStream(new MemoryStream(new byte[100], writable: false), true, "subProtocol", TimeSpan.FromSeconds(30), default(Memory<byte>)));
+            AssertExtensions.Throws<ArgumentException>("stream",
+                () => WebSocketProtocol.CreateFromStream(new UnreadableStream(), true, "subProtocol", TimeSpan.FromSeconds(30), default(Memory<byte>)));
+
+            AssertExtensions.Throws<ArgumentException>("subProtocol",
+                () => WebSocketProtocol.CreateFromStream(new MemoryStream(), true, "    ", TimeSpan.FromSeconds(30), default(Memory<byte>)));
+            AssertExtensions.Throws<ArgumentException>("subProtocol",
+                () => WebSocketProtocol.CreateFromStream(new MemoryStream(), true, "\xFF", TimeSpan.FromSeconds(30), default(Memory<byte>)));
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("keepAliveInterval", () =>
+                WebSocketProtocol.CreateFromStream(new MemoryStream(), true, "subProtocol", TimeSpan.FromSeconds(-2), default(Memory<byte>)));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(14)]
+        [InlineData(4096)]
+        public void CreateFromStream_ValidBufferSizes_Succeed(int bufferSize)
+        {
+            Assert.NotNull(WebSocketProtocol.CreateFromStream(new MemoryStream(), false, null, Timeout.InfiniteTimeSpan, new Memory<byte>(new byte[bufferSize])));
+            Assert.NotNull(WebSocketProtocol.CreateFromStream(new MemoryStream(), true, null, Timeout.InfiniteTimeSpan, new Memory<byte>(new byte[bufferSize])));
+        }
+
+        [OuterLoop] // Connects to external server.
+        [Theory]
+        [MemberData(nameof(EchoServers))]
+        public async Task WebSocketProtocol_CreateFromConnectedStream_Succeeds(Uri echoUri)
+        {
+            Uri uri = new UriBuilder(echoUri) { Scheme = (echoUri.Scheme == "ws") ? "http" : "https" }.Uri;
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+            KeyValuePair<string, string> secKeyAndSecWebSocketAccept = CreateSecKeyAndSecWebSocketAccept();
+            AddWebSocketHeaders(request, secKeyAndSecWebSocketAccept.Key);
+            DirectManagedHttpClientHandler handler = DirectManagedHttpClientHandler.CreateHandler();
+            using (HttpResponseMessage response = await handler.SendAsync(request, CancellationToken.None).ConfigureAwait(false))
+            {
+                Assert.Equal(HttpStatusCode.SwitchingProtocols, response.StatusCode);
+                using (Stream connectedStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                {
+                    Assert.True(connectedStream.CanRead);
+                    Assert.True(connectedStream.CanWrite);
+                    using (WebSocket socket = WebSocketProtocol.CreateFromStream(connectedStream, false, null, TimeSpan.FromSeconds(10)))
+                    {
+                        Assert.NotNull(socket);
+                        Assert.Equal(WebSocketState.Open, socket.State);
+
+                        string expected = "Hello World!";
+                        ArraySegment<byte> buffer = new ArraySegment<byte>(Encoding.UTF8.GetBytes(expected));
+                        await socket.SendAsync(buffer, WebSocketMessageType.Text, true, CancellationToken.None);
+
+                        buffer = new ArraySegment<byte>(new byte[buffer.Count]);
+                        await socket.ReceiveAsync(buffer, CancellationToken.None);
+
+                        Assert.Equal(expected, Encoding.UTF8.GetString(buffer.Array));
+                    }
+                }
+            }
+        }
+
+        public static readonly object[][] EchoServers = System.Net.Test.Common.Configuration.WebSockets.EchoServers;
+
+        /// <summary>GUID appended by the server as part of the security key response.  Defined in the RFC.</summary>
+        private const string WSServerGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+        private static KeyValuePair<string, string> CreateSecKeyAndSecWebSocketAccept()
+        {
+            string secKey = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
+            using (SHA1 sha = SHA1.Create())
+            {
+                return new KeyValuePair<string, string>(
+                    secKey,
+                    Convert.ToBase64String(sha.ComputeHash(Encoding.ASCII.GetBytes(secKey + WSServerGuid))));
+            }
+        }
+
+        private static void AddWebSocketHeaders(HttpRequestMessage request, string secKey)
+        {
+            request.Headers.TryAddWithoutValidation(HttpKnownHeaderNames.Connection, HttpKnownHeaderNames.Upgrade);
+            request.Headers.TryAddWithoutValidation(HttpKnownHeaderNames.Upgrade, "websocket");
+            request.Headers.TryAddWithoutValidation(HttpKnownHeaderNames.SecWebSocketVersion, "13");
+            request.Headers.TryAddWithoutValidation(HttpKnownHeaderNames.SecWebSocketKey, secKey);
+        }
+
+        private sealed class UnreadableStream : Stream
+        {
+            public override bool CanRead => false;
+            public override bool CanSeek => true;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotImplementedException();
+            public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public override void Flush() => throw new NotImplementedException();
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+            public override void SetLength(long value) => throw new NotImplementedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+        }
+
+        private sealed class DirectManagedHttpClientHandler : HttpClientHandler
+        {
+            private const string ManagedHandlerEnvVar = "COMPlus_UseManagedHttpClientHandler";
+            private static readonly LocalDataStoreSlot s_managedHandlerSlot = GetSlot();
+            private static readonly object s_true = true;
+
+            private static LocalDataStoreSlot GetSlot()
+            {
+                LocalDataStoreSlot slot = Thread.GetNamedDataSlot(ManagedHandlerEnvVar);
+                if (slot != null)
+                {
+                    return slot;
+                }
+
+                try
+                {
+                    return Thread.AllocateNamedDataSlot(ManagedHandlerEnvVar);
+                }
+                catch (ArgumentException) // in case of a race condition where multiple threads all try to allocate the slot concurrently
+                {
+                    return Thread.GetNamedDataSlot(ManagedHandlerEnvVar);
+                }
+            }
+
+            public static DirectManagedHttpClientHandler CreateHandler()
+            {
+                Thread.SetData(s_managedHandlerSlot, s_true);
+                try
+                {
+                    return new DirectManagedHttpClientHandler();
+                }
+                finally { Thread.SetData(s_managedHandlerSlot, null); }
+            }
+
+            public new Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken) =>
+                base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/System.Net.WebSockets/src/System.Net.WebSockets.csproj
+++ b/src/System.Net.WebSockets/src/System.Net.WebSockets.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="System\Net\WebSockets\ManagedWebSocket.cs" />
+    <Compile Include="System\Net\WebSockets\ManagedWebSocket.netcoreapp.cs" />
     <Compile Include="System\Net\WebSockets\ValueWebSocketReceiveResult.cs" />
     <Compile Include="System\Net\WebSockets\WebSocket.cs" />
     <Compile Include="System\Net\WebSockets\WebSocketCloseStatus.cs" />
@@ -23,6 +23,9 @@
     <Compile Include="System\Net\WebSockets\WebSocketState.cs" />
     <Compile Include="$(CommonPath)\System\Net\WebSockets\WebSocketValidate.cs">
       <Link>Common\System\Net\WebSockets\WebSocketValidate.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\WebSockets\ManagedWebSocket.cs">
+      <Link>Common\System\Net\WebSockets\ManagedWebSocket.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.netcoreapp.cs
+++ b/src/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.netcoreapp.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.WebSockets
+{
+    internal sealed partial class ManagedWebSocket : WebSocket
+    {
+        public override Task SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+        {
+            return SendPrivateAsync(buffer, messageType, endOfMessage, cancellationToken);
+        }
+
+        public override ValueTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        {
+            try
+            {
+                WebSocketValidate.ThrowIfInvalidState(_state, _disposed, s_validReceiveStates);
+
+                Debug.Assert(!Monitor.IsEntered(StateUpdateLock), $"{nameof(StateUpdateLock)} must never be held when acquiring {nameof(ReceiveAsyncLock)}");
+                lock (ReceiveAsyncLock) // synchronize with receives in CloseAsync
+                {
+                    ThrowIfOperationInProgress(_lastReceiveAsync);
+                    ValueTask<ValueWebSocketReceiveResult> t = ReceiveAsyncPrivate<ValueWebSocketReceiveResultGetter, ValueWebSocketReceiveResult>(buffer, cancellationToken);
+                    _lastReceiveAsync =
+                        t.IsCompletedSuccessfully ? (t.Result.MessageType == WebSocketMessageType.Close ? s_cachedCloseTask : Task.CompletedTask) :
+                        t.AsTask();
+                    return t;
+                }
+            }
+            catch (Exception exc)
+            {
+                return new ValueTask<ValueWebSocketReceiveResult>(Task.FromException<ValueWebSocketReceiveResult>(exc));
+            }
+        }
+
+        private Task ValidateAndReceiveAsync(Task receiveTask, byte[] buffer, CancellationToken cancellationToken)
+        {
+            if (receiveTask == null ||
+                        (receiveTask.IsCompletedSuccessfully &&
+                         !(receiveTask is Task<WebSocketReceiveResult> wsrr && wsrr.Result.MessageType == WebSocketMessageType.Close) &&
+                         !(receiveTask is Task<ValueWebSocketReceiveResult> vwsrr && vwsrr.Result.MessageType == WebSocketMessageType.Close)))
+            {
+                ValueTask<ValueWebSocketReceiveResult> vt = ReceiveAsyncPrivate<ValueWebSocketReceiveResultGetter, ValueWebSocketReceiveResult>(buffer, cancellationToken);
+                receiveTask =
+                    vt.IsCompletedSuccessfully ? (vt.Result.MessageType == WebSocketMessageType.Close ? s_cachedCloseTask : Task.CompletedTask) :
+                    vt.AsTask();
+            }
+
+            return receiveTask;
+        }
+
+        /// <summary><see cref="IWebSocketReceiveResultGetter{TResult}"/> implementation for <see cref="ValueWebSocketReceiveResult"/>.</summary>
+        private readonly struct ValueWebSocketReceiveResultGetter : IWebSocketReceiveResultGetter<ValueWebSocketReceiveResult>
+        {
+            public ValueWebSocketReceiveResult GetResult(int count, WebSocketMessageType messageType, bool endOfMessage, WebSocketCloseStatus? closeStatus, string closeDescription) =>
+                new ValueWebSocketReceiveResult(count, messageType, endOfMessage); // closeStatus/closeDescription are ignored
+        }
+    }
+}


### PR DESCRIPTION
fixes #21537 

cc @karelz @stephentoub @wfurt 

cc @weshaggard @ericstj Can you please take a look at the packaging changes for oob assembly..

Short summary:
--------------------
Split the ```ManagedWebSocket``` class into 3 files: ```ManagedWebSocket.netstandard.cs``` and ```ManagedWebSocket.netcoreapp.cs```. I tried to put the common code in ```ManagedWebSocket.Common.cs```. Refactoring out common parts seemed like a backward effort, where all the Span/Memory enhancements may have to be abandoned. So I prioritized enhancements over common code, where the change was tricky to make. Needless to say, the ```*.netcoreapp.cs``` file contains Span/Memory stuff, and the ```*.netstandard.cs``` contains ArraySegment/byte[] stuff.

Testing:
-----------------
I was not able to get a successful test with ```WebSocket.ReceiveAsync```, it fails in ReceiveAsync, because the response from the server is not in the right format. So the code fails with ```ProtocolError``` in ```ReceiveAsync```. The behavior is same with and without this refactoring. Hence didn't include ```ReceiveAsync``` in the ```WebSocketProtocol_CreateFromConnectedStream_Succeeds``` outerloop test.