### PR TITLE
Add SqlCommand Begin and EndExecuteXmlReader functions

### DIFF
--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -416,6 +416,9 @@ namespace System.Data.SqlClient
         public System.Xml.XmlReader ExecuteXmlReader() { throw null; }
         public System.Threading.Tasks.Task<System.Xml.XmlReader> ExecuteXmlReaderAsync() { throw null; }
         public System.Threading.Tasks.Task<System.Xml.XmlReader> ExecuteXmlReaderAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.IAsyncResult BeginExecuteXmlReader() { throw null; }
+        public System.IAsyncResult BeginExecuteXmlReader(System.AsyncCallback callback, object stateObject) { throw null; }
+        public System.Xml.XmlReader EndExecuteXmlReader(System.IAsyncResult asyncResult) { throw null; }
         public override void Prepare() { }
         public System.Data.Sql.SqlNotificationRequest Notification { get { throw null; } set { } }
         public void ResetCommandTimeout() { }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -1223,7 +1223,12 @@ namespace System.Data.SqlClient
         }
 
 
-        private IAsyncResult BeginExecuteXmlReader(AsyncCallback callback, object stateObject)
+        public IAsyncResult BeginExecuteXmlReader()
+        {
+            return BeginExecuteXmlReader(null, null);
+        }
+
+        public IAsyncResult BeginExecuteXmlReader(AsyncCallback callback, object stateObject)
         {
             // Reset _pendingCancel upon entry into any Execute - used to synchronize state
             // between entry into Execute* API and the thread obtaining the stateObject.
@@ -1302,7 +1307,7 @@ namespace System.Data.SqlClient
         }
 
 
-        private XmlReader EndExecuteXmlReader(IAsyncResult asyncResult)
+        public XmlReader EndExecuteXmlReader(IAsyncResult asyncResult)
         {
             Exception asyncException = ((Task)asyncResult).Exception;
             if (asyncException != null)

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/XmlReaderAsyncTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/XmlReaderAsyncTest.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Xunit;
+
+namespace System.Data.SqlClient.ManualTesting.Tests
+{
+    public static class XmlReaderAsyncTest
+    {
+        private static string commandText =
+            "SELECT * from dbo.Customers FOR XML AUTO, XMLDATA;";
+
+        [CheckConnStrSetupFact]
+        public static void ExecuteTest()
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                try
+                {
+                    SqlCommand command = new SqlCommand(commandText, connection);
+                    connection.Open();
+
+                    IAsyncResult result = command.BeginExecuteXmlReader();
+                    while (!result.IsCompleted)
+                    {
+                        System.Threading.Thread.Sleep(100);
+                    }
+
+                    XmlReader reader = command.EndExecuteXmlReader(result);
+
+                    reader.ReadToDescendant("dbo.Customers");
+                    Assert.Equal("ALFKI", reader["CustomerID"]);
+                }
+                catch (SqlException ex)
+                {
+                    Console.WriteLine("Error ({0}): {1}", ex.Number, ex.Message);
+                    Assert.Null(ex);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    Console.WriteLine("Error: {0}", ex.Message);
+                    Assert.Null(ex);
+                }
+                catch (Exception ex)
+                {
+                    // You might want to pass these errors
+                    // back out to the caller.
+                    Console.WriteLine("Error: {0}", ex.Message);
+                    Assert.Null(ex);
+                }
+            }
+        }
+
+        [CheckConnStrSetupFact]
+        public static void FailureTest()
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                bool caughtException = false;
+                SqlCommand command = new SqlCommand(commandText, connection);
+                connection.Open();
+
+                //Try to execute a synchronous query on same command
+                IAsyncResult result = command.BeginExecuteXmlReader();
+                try
+                {
+                    command.ExecuteXmlReader();
+                }
+                catch (Exception ex)
+                {
+                    Assert.True(ex is InvalidOperationException, "FAILED: Thrown exception for BeginExecuteXmlReader was not an InvalidOperationException");
+                    caughtException = true;
+                }
+
+                Assert.True(caughtException, "FAILED: No exception thrown after trying second BeginExecuteXmlReader.");
+                caughtException = false;
+
+                while (!result.IsCompleted)
+                {
+                    System.Threading.Thread.Sleep(100);
+                }
+
+                Assert.True(result.IsCompleted, "FAILED: ExecuteXmlReaderAsync Task did not complete successfully.");
+
+                XmlReader reader = command.EndExecuteXmlReader(result);
+
+                reader.ReadToDescendant("dbo.Customers");
+                Assert.Equal("ALFKI", reader["CustomerID"]);
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/XmlReaderAsyncTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/XmlReaderAsyncTest.cs
@@ -18,72 +18,39 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         {
             using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
             {
-                try
-                {
-                    SqlCommand command = new SqlCommand(commandText, connection);
-                    connection.Open();
-
-                    IAsyncResult result = command.BeginExecuteXmlReader();
-                    while (!result.IsCompleted)
-                    {
-                        System.Threading.Thread.Sleep(100);
-                    }
-
-                    XmlReader reader = command.EndExecuteXmlReader(result);
-
-                    reader.ReadToDescendant("dbo.Customers");
-                    Assert.Equal("ALFKI", reader["CustomerID"]);
-                }
-                catch (SqlException ex)
-                {
-                    Console.WriteLine("Error ({0}): {1}", ex.Number, ex.Message);
-                    Assert.Null(ex);
-                }
-                catch (InvalidOperationException ex)
-                {
-                    Console.WriteLine("Error: {0}", ex.Message);
-                    Assert.Null(ex);
-                }
-                catch (Exception ex)
-                {
-                    // You might want to pass these errors
-                    // back out to the caller.
-                    Console.WriteLine("Error: {0}", ex.Message);
-                    Assert.Null(ex);
-                }
-            }
-        }
-
-        [CheckConnStrSetupFact]
-        public static void FailureTest()
-        {
-            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
-            {
-                bool caughtException = false;
                 SqlCommand command = new SqlCommand(commandText, connection);
                 connection.Open();
 
-                //Try to execute a synchronous query on same command
                 IAsyncResult result = command.BeginExecuteXmlReader();
-                try
-                {
-                    command.ExecuteXmlReader();
-                }
-                catch (Exception ex)
-                {
-                    Assert.True(ex is InvalidOperationException, "FAILED: Thrown exception for BeginExecuteXmlReader was not an InvalidOperationException");
-                    caughtException = true;
-                }
-
-                Assert.True(caughtException, "FAILED: No exception thrown after trying second BeginExecuteXmlReader.");
-                caughtException = false;
-
                 while (!result.IsCompleted)
                 {
                     System.Threading.Thread.Sleep(100);
                 }
 
-                Assert.True(result.IsCompleted, "FAILED: ExecuteXmlReaderAsync Task did not complete successfully.");
+                XmlReader reader = command.EndExecuteXmlReader(result);
+
+                reader.ReadToDescendant("dbo.Customers");
+                Assert.Equal("ALFKI", reader["CustomerID"]);
+            }
+        }
+
+        [CheckConnStrSetupFact]
+        public static void ExceptionTest()
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                SqlCommand command = new SqlCommand(commandText, connection);
+                connection.Open();
+
+                //Try to execute a synchronous query on same command
+                IAsyncResult result = command.BeginExecuteXmlReader();
+
+                Assert.Throws<InvalidOperationException>( delegate { command.ExecuteXmlReader(); });
+
+                while (!result.IsCompleted)
+                {
+                    System.Threading.Thread.Sleep(100);
+                }
 
                 XmlReader reader = command.EndExecuteXmlReader(result);
 

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="DataCommon\CheckConnStrSetupFactAttribute.cs" />
     <Compile Include="SQL\AdapterTest\AdapterTest.cs" />
     <Compile Include="SQL\AsyncTest\BeginExecAsyncTest.cs" />
+    <Compile Include="SQL\AsyncTest\XmlReaderAsyncTest.cs" />
     <Compile Include="SQL\Common\AsyncDebugScope.cs" />
     <Compile Include="SQL\Common\ConnectionPoolWrapper.cs" />
     <Compile Include="SQL\Common\InternalConnectionWrapper.cs" />


### PR DESCRIPTION
This PR follows a request in #17126 to finish exposing the BeginExecuteXmlReader and EndExecuteXmlReader functionality. These functions have been made public, and an overload has been added for BeginExecuteXmlReader. Tests for these changes have been added based off of the similar PR #26016 as recommended in the original issue. 