### PR TITLE
Fix System.Net.NetworkInformation.NetworkChange deadlock

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
@@ -16,7 +16,7 @@ namespace System.Net.NetworkInformation
         [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
         public static void RegisterNetworkChange(NetworkChange nc) { }
         
-        static private object globalLock = new object();
+        private static object s_globalLock = new object();
 
         public static event NetworkAvailabilityChangedEventHandler NetworkAvailabilityChanged
         {
@@ -57,7 +57,7 @@ namespace System.Net.NetworkInformation
 
             private static void ChangedAddress(object sender, EventArgs eventArgs)
             {
-                lock (globalLock)
+                lock (s_globalLock)
                 {
                     bool isAvailableNow = SystemNetworkInterface.InternalGetIsNetworkAvailable();
 
@@ -86,7 +86,7 @@ namespace System.Net.NetworkInformation
 
             internal static void Start(NetworkAvailabilityChangedEventHandler caller)
             {
-                lock (globalLock)
+                lock (s_globalLock)
                 {
                     if (s_availabilityCallerArray.Count == 0)
                     {
@@ -103,7 +103,7 @@ namespace System.Net.NetworkInformation
 
             internal static void Stop(NetworkAvailabilityChangedEventHandler caller)
             {
-                lock (globalLock)
+                lock (s_globalLock)
                 {
                     s_availabilityCallerArray.Remove(caller);
                     if (s_availabilityCallerArray.Count == 0)
@@ -133,7 +133,7 @@ namespace System.Net.NetworkInformation
             // Callback fired when an address change occurs.
             private static void AddressChangedCallback(object stateObject, bool signaled)
             {
-                lock (globalLock)
+                lock (s_globalLock)
                 {
                     // The listener was canceled, which would only happen if we aren't listening for more events.
                     s_isPending = false;
@@ -190,7 +190,7 @@ namespace System.Net.NetworkInformation
 
             private static void StartHelper(NetworkAddressChangedEventHandler caller, bool captureContext, StartIPOptions startIPOptions)
             {
-                lock (globalLock)
+                lock (s_globalLock)
                 {
                     // Setup changedEvent and native overlapped struct.
                     if (s_ipv4Socket == null)
@@ -316,7 +316,7 @@ namespace System.Net.NetworkInformation
 
             internal static void Stop(NetworkAddressChangedEventHandler caller)
             {
-                lock (globalLock)
+                lock (s_globalLock)
                 {
                     s_callerArray.Remove(caller);
                     if (s_callerArray.Count == 0 && s_isListening)

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
@@ -16,7 +16,7 @@ namespace System.Net.NetworkInformation
         [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
         public static void RegisterNetworkChange(NetworkChange nc) { }
         
-        private static object s_globalLock = new object();
+        private static readonly object s_globalLock = new object();
 
         public static event NetworkAvailabilityChangedEventHandler NetworkAvailabilityChanged
         {

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
@@ -57,7 +57,7 @@ namespace System.Net.NetworkInformation
 
             private static void ChangedAddress(object sender, EventArgs eventArgs)
             {
-                Dictionary<NetworkAvailabilityChangedEventHandler, ExecutionContext> s_copy = null;
+                Dictionary<NetworkAvailabilityChangedEventHandler, ExecutionContext> copy = null;
 
                 lock (s_globalLock)
                 {
@@ -68,17 +68,18 @@ namespace System.Net.NetworkInformation
                     {
                         s_isAvailable = isAvailableNow;
 
-                        s_copy =
+                        copy =
                             new Dictionary<NetworkAvailabilityChangedEventHandler, ExecutionContext>(s_availabilityCallerArray);
                     }
                 }
 
                 // Executing user callbacks if Availability Change event occured.
-                if (s_copy != null)
+                if (copy != null)
                 {
-                    foreach (var handler in s_copy.Keys)
+                    foreach (var entry in copy)
                     {
-                        ExecutionContext context = s_copy[handler];
+                        NetworkAvailabilityChangedEventHandler handler = entry.Key;
+                        ExecutionContext context = entry.Value;
                         if (context == null)
                         {
                             handler(null, new NetworkAvailabilityEventArgs(s_isAvailable));
@@ -171,9 +172,10 @@ namespace System.Net.NetworkInformation
                 // Release the lock before calling into user callback.
                 if (copy.Count > 0)
                 {
-                    foreach (var handler in copy.Keys)
+                    foreach (var entry in copy)
                     {
-                        ExecutionContext context = copy[handler];
+                        NetworkAddressChangedEventHandler handler = entry.Key;
+                        ExecutionContext context = entry.Value;
                         if (context == null)
                         {
                             handler(null, EventArgs.Empty);


### PR DESCRIPTION
User code can subscribe to the NetworkAvailabilityChanged event. If a Network Address changed event get triggered while 
the user code is unsubscribing from the NetworkAvailabilityChanged event, there will be a deadlock.

The deadlock can happen because two threads are holding two different locks for AddressChangeListener and AvailabilityChangeListener,
and they are waiting for each other to release its lock first. The fix is using a global lock to replace two locks, so that we don’t 
allow operations on AddressChangeListener and AvailabilityChangeListener happen at the same time.

Without fixing this, users can frequently see the deadlock when they put their computer to sleep, re-awaken it, 
then call the code that unsubscribes from NetworkAvailabilityChanged event.

This deadlock is only specific to Windows implementation. For Unix implementations (Linux & OSX), their current implementation is
to use a global lock object to protect both NetworkAddressChangedEventHandler & NetworkAvailabilityChangedEventHandler.

This issue was reported in internal bug 162830.