### PR TITLE
Add delegate flag to fix permissions when querying linked SQL Servers

### DIFF
--- a/src/Common/src/System/Net/ContextFlagsAdapterPal.Unix.cs
+++ b/src/Common/src/System/Net/ContextFlagsAdapterPal.Unix.cs
@@ -26,7 +26,8 @@ namespace System.Net
             new ContextFlagMapping(Interop.NetSecurityNative.GssFlags.GSS_C_IDENTIFY_FLAG, ContextFlagsPal.InitIdentify),
             new ContextFlagMapping(Interop.NetSecurityNative.GssFlags.GSS_C_MUTUAL_FLAG, ContextFlagsPal.MutualAuth),
             new ContextFlagMapping(Interop.NetSecurityNative.GssFlags.GSS_C_REPLAY_FLAG, ContextFlagsPal.ReplayDetect),
-            new ContextFlagMapping(Interop.NetSecurityNative.GssFlags.GSS_C_SEQUENCE_FLAG, ContextFlagsPal.SequenceDetect)
+            new ContextFlagMapping(Interop.NetSecurityNative.GssFlags.GSS_C_SEQUENCE_FLAG, ContextFlagsPal.SequenceDetect),
+            new ContextFlagMapping(Interop.NetSecurityNative.GssFlags.GSS_C_DELEG_FLAG, ContextFlagsPal.Delegate)
         };
 
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -105,6 +105,7 @@ namespace System.Data.SqlClient.SNI
 
             ContextFlagsPal requestedContextFlags = ContextFlagsPal.Connection
                 | ContextFlagsPal.Confidentiality
+                | ContextFlagsPal.Delegate
                 | ContextFlagsPal.MutualAuth;
 
             string serverSPN = System.Text.Encoding.UTF8.GetString(serverName);


### PR DESCRIPTION
Fixes permissions when querying linked SQL Servers, see https://github.com/dotnet/corefx/issues/21824.

This sets the `Delegate` flag when requesting a kerberos ticket for querying using `SqlClient`, so SQL Server can forward queries to linked servers with the correct authentication information.