### PR TITLE
Add XunitShowProgress to help debug the hang in S.M perf tests

### DIFF
--- a/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
+++ b/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
@@ -2,6 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
+    <XunitMaxThreads>1</XunitMaxThreads>
+    <XunitShowProgress>true</XunitShowProgress>
     <IncludePerformanceTests>true</IncludePerformanceTests>
     <ProjectGuid>{18482C55-6B57-41E8-BBC4-383B9E2C7AA2}</ProjectGuid>
   </PropertyGroup>


### PR DESCRIPTION
Cannot reproduce the performance test failures locally, and hence trying to run in CI with XunitShowProgress enabled to see where the hang is happening.

https://github.com/dotnet/corefx/issues/26265#issuecomment-357021258