### PR TITLE
Add ToEnumerable extension to Memory<T>T

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -5,6 +5,8 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace System
 {
     public static partial class MemoryExtensions
@@ -62,6 +64,7 @@ namespace System
         public static bool StartsWith<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> value) where T : System.IEquatable<T> { throw null; }
         public static bool StartsWith<T>(this System.Span<T> span, System.ReadOnlySpan<T> value) where T : System.IEquatable<T> { throw null; }
         public static bool TryGetString(this System.ReadOnlyMemory<char> readOnlyMemory, out string text, out int start, out int length) { throw null; }
+        public static IEnumerable<T> ToEnumerable<T>(Memory<T> memory) { throw null; }
     }
     public readonly partial struct Memory<T>
     {

--- a/src/System.Memory/src/System/MemoryExtensions.cs
+++ b/src/System.Memory/src/System/MemoryExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -1000,10 +1001,26 @@ namespace System
         /// <typeparam name="T">The element type of the <paramref name="memory" />.</typeparam>
         /// <param name="memory">The Memory to view as an <see cref="IEnumerable{T}"/></param>
         /// <returns>An <see cref="IEnumerable{T}"/> view of the given <paramref name="memory" /></returns>
-        public static IEnumerable<T> ToEnumerable<T>(this Memory<T> memory)
+        public static IEnumerable<T> ToEnumerable<T>(Memory<T> memory) => new MemoryEnumerable<T>(memory);
+
+        internal class MemoryEnumerable<T> : IEnumerable<T>, IEnumerable, IEnumerator<T>, IEnumerator, IDisposable
         {
-            for (int i = 0; i < memory.Length; i++)
-                yield return memory.Span[i];
+            ReadOnlyMemory<T> _memory;
+            int _index;
+
+            public MemoryEnumerable(Memory<T> memory)
+            {
+                _memory = memory;
+                _index = -1;
+            }
+
+            T IEnumerator<T>.Current => _memory.Span[_index];
+            object IEnumerator.Current => _memory.Span[_index];
+            void IDisposable.Dispose() { }
+            IEnumerator<T> IEnumerable<T>.GetEnumerator() => this;
+            IEnumerator IEnumerable.GetEnumerator() => this;
+            bool IEnumerator.MoveNext() => ++_index < _memory.Length;
+            void IEnumerator.Reset() => _index = 0;
         }
     }
 }

--- a/src/System.Memory/src/System/MemoryExtensions.cs
+++ b/src/System.Memory/src/System/MemoryExtensions.cs
@@ -992,5 +992,18 @@ namespace System
                 value, comparer);
             return BinarySearch(span, comparable);
         }
+
+        /// <summary>
+        /// Creates an <see cref="IEnumerable{T}"/> view of the given <paramref name="memory" /> to allow
+        /// the <paramref name="memory" /> to be used in existing APIs that take an <see cref="IEnumerable{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The element type of the <paramref name="memory" />.</typeparam>
+        /// <param name="memory">The Memory to view as an <see cref="IEnumerable{T}"/></param>
+        /// <returns>An <see cref="IEnumerable{T}"/> view of the given <paramref name="memory" /></returns>
+        public static IEnumerable<T> ToEnumerable<T>(this Memory<T> memory)
+        {
+            for (int i = 0; i < memory.Length; i++)
+                yield return memory.Span[i];
+        }
     }
 }

--- a/src/System.Memory/tests/Memory/ToEnumerable.cs
+++ b/src/System.Memory/tests/Memory/ToEnumerable.cs
@@ -75,5 +75,15 @@ namespace System.MemoryTests
             var li = new List<int>(enumer);
             Assert.Equal(a, li);
         }
+
+        [Fact]
+        public static void ToEnumerableSameAsIEnumerator()
+        {
+            int[] a = { 91, 92, 93 };
+            var memory = new Memory<int>(a);
+            IEnumerable<int> enumer = memory.ToEnumerable();
+            IEnumerator<int> enumerat = enumer.GetEnumerator();
+            Assert.Same(enumer, enumerat);
+        }
     }
 }

--- a/src/System.Memory/tests/Memory/ToEnumerable.cs
+++ b/src/System.Memory/tests/Memory/ToEnumerable.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+using System.Linq;
+
+namespace System.MemoryTests
+{
+    public static partial class MemoryTests
+    {
+        [Fact]
+        public static void ToEnumerable()
+        {
+            int[] a = { 91, 92, 93 };
+            var memory = new Memory<int>(a);
+            IEnumerable<int> copy = memory.ToEnumerable();
+            Assert.Equal<int>(a, copy);
+        }
+
+        [Fact]
+        public static void ToEnumerableWithIndex()
+        {
+            int[] a = { 91, 92, 93, 94, 95 };
+            var memory = new Memory<int>(a);
+            IEnumerable<int> copy = memory.Slice(2).ToEnumerable();
+
+            Assert.Equal<int>(new int[] { 93, 94, 95 }, copy);
+        }
+
+        [Fact]
+        public static void ToEnumerableWithIndexAndLength()
+        {
+            int[] a = { 91, 92, 93 };
+            var memory = new Memory<int>(a, 1, 1);
+            IEnumerable<int> copy = memory.ToEnumerable();
+            Assert.Equal<int>(new int[] { 92 }, copy);
+        }
+
+        [Fact]
+        public static void ToEnumerableEmpty()
+        {
+            Memory<int> memory = Memory<int>.Empty;
+            IEnumerable<int> copy = memory.ToEnumerable();
+            Assert.Equal(0, copy.Count());
+        }
+
+        [Fact]
+        public static void ToEnumerableDefault()
+        {
+            Memory<int> memory = default;
+            IEnumerable<int> copy = memory.ToEnumerable();
+            Assert.Equal(0, copy.Count());
+        }
+
+        [Fact]
+        public static void ToEnumerableForEach()
+        {
+            int[] a = { 91, 92, 93 };
+            var memory = new Memory<int>(a);
+            int index = 0;
+            foreach (int curr in memory.ToEnumerable())
+            {
+                Assert.Equal(a[index++], curr);
+            }
+        }
+
+        [Fact]
+        public static void ToEnumerableGivenToExistingConstructor()
+        {
+            int[] a = { 91, 92, 93 };
+            var memory = new Memory<int>(a);
+            IEnumerable<int> enumer = memory.ToEnumerable();
+            var li = new List<int>(enumer);
+            Assert.Equal(a, li);
+        }
+    }
+}

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Memory\Span.cs" />
     <Compile Include="Memory\Strings.cs" />
     <Compile Include="Memory\ToArray.cs" />
+    <Compile Include="Memory\ToEnumerable.cs" />
     <Compile Include="Memory\TryGetArray.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Provides an extension method to get an IEnumerable<T> from a Memory<T> to aid use of Memory<T> in existing APIs.
- Uses iterator syntax to produce a type that implements both IEnumerable<T> and IEnumerator<T> so we don't have to allocate double when using it as an IEnumerator.
- Adds some *very* basic tests for ToEnumerable to ensure correctness.

resolves https://github.com/dotnet/corefx/issues/24854

cc: @stephentoub @KrzysztofCwalina 