### PR TITLE
Update references assemblies to include private fields for structs

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -231,6 +231,11 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(IsReferenceAssembly)' == 'true'">
+    <!-- disable warnings about unused fields -->
+    <NoWarn>$(NoWarn);0169;0649</NoWarn>
+  </PropertyGroup>
+
   <!-- Set up some common paths -->
   <PropertyGroup>
     <CommonPath>$(SourceDir)Common\src</CommonPath>

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -93,17 +93,14 @@ namespace System.Collections.Immutable
         public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
         public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Generic.IEnumerable<TSource> items) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ImmutableArray<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>, System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IEquatable<System.Collections.Immutable.ImmutableArray<T>>
     {
+        internal T[] array;
         public static readonly System.Collections.Immutable.ImmutableArray<T> Empty;
         public bool IsDefault { get { throw null; } }
         public bool IsDefaultOrEmpty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
-#if FEATURE_ITEMREFAPI
-        public ref readonly T ItemRef(int index) { throw null; }
-#endif
         public int Length { get { throw null; } }
         int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
         bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
@@ -139,6 +136,9 @@ namespace System.Collections.Immutable
         public System.Collections.Immutable.ImmutableArray<T> Insert(int index, T item) { throw null; }
         public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
         public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
+#if FEATURE_ITEMREFAPI
+        public ref readonly T ItemRef(int index) { throw null; }
+#endif
         public int LastIndexOf(T item) { throw null; }
         public int LastIndexOf(T item, int startIndex) { throw null; }
         public int LastIndexOf(T item, int startIndex, int count) { throw null; }
@@ -201,9 +201,6 @@ namespace System.Collections.Immutable
             public int Capacity { get { throw null; } set { } }
             public int Count { get { throw null; } set { } }
             public T this[int index] { get { throw null; } set { } }
-#if FEATURE_ITEMREFAPI
-            public ref readonly T ItemRef(int index) { throw null; }
-#endif
             bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
             public void Add(T item) { }
             public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
@@ -224,6 +221,9 @@ namespace System.Collections.Immutable
             public int IndexOf(T item, int startIndex, int count) { throw null; }
             public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
             public void Insert(int index, T item) { }
+#if FEATURE_ITEMREFAPI
+            public ref readonly T ItemRef(int index) { throw null; }
+#endif
             public int LastIndexOf(T item) { throw null; }
             public int LastIndexOf(T item, int startIndex) { throw null; }
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
@@ -241,9 +241,9 @@ namespace System.Collections.Immutable
             public T[] ToArray() { throw null; }
             public System.Collections.Immutable.ImmutableArray<T> ToImmutable() { throw null; }
         }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator
         {
+            private readonly T[] _array;
             public T Current { get { throw null; } }
             public bool MoveNext() { throw null; }
         }
@@ -326,8 +326,8 @@ namespace System.Collections.Immutable
         System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
         System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
         public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
-        public bool TryGetKey(TKey equalKey, out TKey actualKey) { actualKey = default(TKey); throw null; }
-        public bool TryGetValue(TKey key, out TValue value) { value = default(TValue); throw null; }
+        public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+        public bool TryGetValue(TKey key, out TValue value) { throw null; }
         public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
         public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
         public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
@@ -371,12 +371,12 @@ namespace System.Collections.Immutable
             void System.Collections.IDictionary.Remove(object key) { }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
             public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
-            public bool TryGetKey(TKey equalKey, out TKey actualKey) { actualKey = default(TKey); throw null; }
-            public bool TryGetValue(TKey key, out TValue value) { value = default(TValue); throw null; }
+            public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+            public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
@@ -443,7 +443,7 @@ namespace System.Collections.Immutable
         System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
         System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
         public System.Collections.Immutable.ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
-        public bool TryGetValue(T equalValue, out T actualValue) { actualValue = default(T); throw null; }
+        public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
         public System.Collections.Immutable.ImmutableHashSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
         public System.Collections.Immutable.ImmutableHashSet<T> WithComparer(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
         public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
@@ -473,9 +473,9 @@ namespace System.Collections.Immutable
             public System.Collections.Immutable.ImmutableHashSet<T> ToImmutable() { throw null; }
             public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
         }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public T Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
@@ -496,9 +496,9 @@ namespace System.Collections.Immutable
         public static bool InterlockedInitialize<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
         public static void Push<T>(ref System.Collections.Immutable.ImmutableStack<T> location, T value) { }
         public static bool TryAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static bool TryDequeue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, out T value) { value = default(T); throw null; }
-        public static bool TryPop<T>(ref System.Collections.Immutable.ImmutableStack<T> location, out T value) { value = default(T); throw null; }
-        public static bool TryRemove<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { value = default(TValue); throw null; }
+        public static bool TryDequeue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, out T value) { throw null; }
+        public static bool TryPop<T>(ref System.Collections.Immutable.ImmutableStack<T> location, out T value) { throw null; }
+        public static bool TryRemove<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
         public static bool TryUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
         public static bool Update<T>(ref T location, System.Func<T, T> transformer) where T : class { throw null; }
         public static bool Update<T, TArg>(ref T location, System.Func<T, TArg, T> transformer, TArg transformerArgument) where T : class { throw null; }
@@ -530,9 +530,6 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
-#if FEATURE_ITEMREFAPI
-        public ref readonly T ItemRef(int index) { throw null; }
-#endif
         bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
         T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
         bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
@@ -568,6 +565,9 @@ namespace System.Collections.Immutable
         public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
         public System.Collections.Immutable.ImmutableList<T> Insert(int index, T item) { throw null; }
         public System.Collections.Immutable.ImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
+#if FEATURE_ITEMREFAPI
+        public ref readonly T ItemRef(int index) { throw null; }
+#endif
         public int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
         public System.Collections.Immutable.ImmutableList<T> Remove(T value) { throw null; }
         public System.Collections.Immutable.ImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
@@ -619,9 +619,6 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public T this[int index] { get { throw null; } set { } }
-#if FEATURE_ITEMREFAPI
-            public ref readonly T ItemRef(int index) { throw null; }
-#endif
             bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
             bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
             object System.Collections.ICollection.SyncRoot { get { throw null; } }
@@ -658,6 +655,9 @@ namespace System.Collections.Immutable
             public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
             public void Insert(int index, T item) { }
             public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { }
+#if FEATURE_ITEMREFAPI
+            public ref readonly T ItemRef(int index) { throw null; }
+#endif
             public int LastIndexOf(T item) { throw null; }
             public int LastIndexOf(T item, int startIndex) { throw null; }
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
@@ -684,9 +684,9 @@ namespace System.Collections.Immutable
             public bool TrueForAll(System.Predicate<T> match) { throw null; }
         }
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(2))]
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public T Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
@@ -700,7 +700,7 @@ namespace System.Collections.Immutable
         public static System.Collections.Immutable.ImmutableQueue<T> Create<T>() { throw null; }
         public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(T item) { throw null; }
         public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableQueue<T> Dequeue<T>(this System.Collections.Immutable.IImmutableQueue<T> queue, out T value) { value = default(T); throw null; }
+        public static System.Collections.Immutable.IImmutableQueue<T> Dequeue<T>(this System.Collections.Immutable.IImmutableQueue<T> queue, out T value) { throw null; }
     }
     public sealed partial class ImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableQueue<T>
     {
@@ -709,7 +709,7 @@ namespace System.Collections.Immutable
         public bool IsEmpty { get { throw null; } }
         public System.Collections.Immutable.ImmutableQueue<T> Clear() { throw null; }
         public System.Collections.Immutable.ImmutableQueue<T> Dequeue() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue(out T value) { value = default(T); throw null; }
+        public System.Collections.Immutable.ImmutableQueue<T> Dequeue(out T value) { throw null; }
         public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
         public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
         public T Peek() { throw null; }
@@ -722,9 +722,9 @@ namespace System.Collections.Immutable
         System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Dequeue() { throw null; }
         System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Enqueue(T value) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(2))]
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator
         {
+            private object _dummy;
             public T Current { get { throw null; } }
             public bool MoveNext() { throw null; }
         }
@@ -754,9 +754,6 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public TValue this[TKey key] { get { throw null; } }
-#if FEATURE_ITEMREFAPI
-        public ref readonly TValue ValueRef(TKey key) { throw null; }
-#endif
         public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
         public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
         bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
@@ -805,8 +802,11 @@ namespace System.Collections.Immutable
         System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
         System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
         public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
-        public bool TryGetKey(TKey equalKey, out TKey actualKey) { actualKey = default(TKey); throw null; }
-        public bool TryGetValue(TKey key, out TValue value) { value = default(TValue); throw null; }
+        public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+        public bool TryGetValue(TKey key, out TValue value) { throw null; }
+#if FEATURE_ITEMREFAPI
+        public ref readonly TValue ValueRef(TKey key) { throw null; }
+#endif
         public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
         public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
         public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
@@ -814,9 +814,6 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public TValue this[TKey key] { get { throw null; } set { } }
-#if FEATURE_ITEMREFAPI
-            public ref readonly TValue ValueRef(TKey key) { throw null; }
-#endif
             public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
             public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
             bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
@@ -853,13 +850,16 @@ namespace System.Collections.Immutable
             void System.Collections.IDictionary.Remove(object key) { }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
             public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
-            public bool TryGetKey(TKey equalKey, out TKey actualKey) { actualKey = default(TKey); throw null; }
-            public bool TryGetValue(TKey key, out TValue value) { value = default(TValue); throw null; }
+            public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+            public bool TryGetValue(TKey key, out TValue value) { throw null; }
+#if FEATURE_ITEMREFAPI
+            public ref readonly TValue ValueRef(TKey key) { throw null; }
+#endif
         }
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(2))]
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
@@ -889,9 +889,6 @@ namespace System.Collections.Immutable
         public int Count { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public T this[int index] { get { throw null; } }
-#if FEATURE_ITEMREFAPI
-        public ref readonly T ItemRef(int index) { throw null; }
-#endif
         public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
         public T Max { get { throw null; } }
         public T Min { get { throw null; } }
@@ -913,6 +910,9 @@ namespace System.Collections.Immutable
         public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
         public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
         public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+#if FEATURE_ITEMREFAPI
+        public ref readonly T ItemRef(int index) { throw null; }
+#endif
         public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
         public System.Collections.Immutable.ImmutableSortedSet<T> Remove(T value) { throw null; }
         public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
@@ -947,7 +947,7 @@ namespace System.Collections.Immutable
         System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
         System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
         public System.Collections.Immutable.ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
-        public bool TryGetValue(T equalValue, out T actualValue) { actualValue = default(T); throw null; }
+        public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
         public System.Collections.Immutable.ImmutableSortedSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
         public System.Collections.Immutable.ImmutableSortedSet<T> WithComparer(System.Collections.Generic.IComparer<T> comparer) { throw null; }
         public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
@@ -955,9 +955,6 @@ namespace System.Collections.Immutable
             internal Builder() { }
             public int Count { get { throw null; } }
             public T this[int index] { get { throw null; } }
-#if FEATURE_ITEMREFAPI
-            public ref readonly T ItemRef(int index) { throw null; }
-#endif
             public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
             public T Max { get { throw null; } }
             public T Min { get { throw null; } }
@@ -974,6 +971,9 @@ namespace System.Collections.Immutable
             public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
             public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
             public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+#if FEATURE_ITEMREFAPI
+            public ref readonly T ItemRef(int index) { throw null; }
+#endif
             public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
             public bool Remove(T item) { throw null; }
             public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
@@ -988,9 +988,9 @@ namespace System.Collections.Immutable
             public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
         }
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(2))]
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public T Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
@@ -1004,7 +1004,7 @@ namespace System.Collections.Immutable
         public static System.Collections.Immutable.ImmutableStack<T> Create<T>() { throw null; }
         public static System.Collections.Immutable.ImmutableStack<T> Create<T>(T item) { throw null; }
         public static System.Collections.Immutable.ImmutableStack<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableStack<T> Pop<T>(this System.Collections.Immutable.IImmutableStack<T> stack, out T value) { value = default(T); throw null; }
+        public static System.Collections.Immutable.IImmutableStack<T> Pop<T>(this System.Collections.Immutable.IImmutableStack<T> stack, out T value) { throw null; }
     }
     public sealed partial class ImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableStack<T>
     {
@@ -1018,7 +1018,7 @@ namespace System.Collections.Immutable
         public ref readonly T PeekRef() { throw null; }
 #endif
         public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { value = default(T); throw null; }
+        public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { throw null; }
         public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }
         System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
@@ -1026,9 +1026,9 @@ namespace System.Collections.Immutable
         System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Pop() { throw null; }
         System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Push(T value) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(2))]
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator
         {
+            private object _dummy;
             public T Current { get { throw null; } }
             public bool MoveNext() { throw null; }
         }

--- a/src/System.Collections.Specialized/ref/System.Collections.Specialized.cs
+++ b/src/System.Collections.Specialized/ref/System.Collections.Specialized.cs
@@ -5,12 +5,11 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System.Collections.Specialized
 {
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct BitVector32
     {
+        private int _dummy;
         public BitVector32(System.Collections.Specialized.BitVector32 value) { throw null; }
         public BitVector32(int data) { throw null; }
         public int Data { get { throw null; } }
@@ -24,9 +23,9 @@ namespace System.Collections.Specialized
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
         public static string ToString(System.Collections.Specialized.BitVector32 value) { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public readonly partial struct Section
         {
+            private readonly int _dummy;
             public short Mask { get { throw null; } }
             public short Offset { get { throw null; } }
             public bool Equals(System.Collections.Specialized.BitVector32.Section obj) { throw null; }
@@ -87,7 +86,7 @@ namespace System.Collections.Specialized
         public void Remove(object key) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }
-    public abstract partial class NameObjectCollectionBase : System.Collections.ICollection, System.Collections.IEnumerable, System.Runtime.Serialization.ISerializable, System.Runtime.Serialization.IDeserializationCallback
+    public abstract partial class NameObjectCollectionBase : System.Collections.ICollection, System.Collections.IEnumerable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         protected NameObjectCollectionBase() { }
         protected NameObjectCollectionBase(System.Collections.IEqualityComparer equalityComparer) { }
@@ -162,7 +161,7 @@ namespace System.Collections.Specialized
         public virtual void Remove(string name) { }
         public virtual void Set(string name, string value) { }
     }
-    public partial class OrderedDictionary : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Specialized.IOrderedDictionary, System.Runtime.Serialization.ISerializable, System.Runtime.Serialization.IDeserializationCallback
+    public partial class OrderedDictionary : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Specialized.IOrderedDictionary, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         public OrderedDictionary() { }
         public OrderedDictionary(System.Collections.IEqualityComparer comparer) { }
@@ -187,10 +186,10 @@ namespace System.Collections.Specialized
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public void Insert(int index, object key, object value) { }
         protected virtual void OnDeserialization(object sender) { }
-        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
         public void Remove(object key) { }
         public void RemoveAt(int index) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
     }
     public partial class StringCollection : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
     {

--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -108,9 +108,9 @@ namespace System.Collections.Generic
         void System.Collections.IDictionary.Remove(object key) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
             System.Collections.DictionaryEntry System.Collections.IDictionaryEnumerator.Entry { get { throw null; } }
             object System.Collections.IDictionaryEnumerator.Key { get { throw null; } }
@@ -136,9 +136,9 @@ namespace System.Collections.Generic
             System.Collections.Generic.IEnumerator<TKey> System.Collections.Generic.IEnumerable<TKey>.GetEnumerator() { throw null; }
             void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public partial struct Enumerator : System.Collections.Generic.IEnumerator<TKey>, System.Collections.IEnumerator, System.IDisposable
             {
+                private object _dummy;
                 public TKey Current { get { throw null; } }
                 object System.Collections.IEnumerator.Current { get { throw null; } }
                 public void Dispose() { }
@@ -162,9 +162,9 @@ namespace System.Collections.Generic
             System.Collections.Generic.IEnumerator<TValue> System.Collections.Generic.IEnumerable<TValue>.GetEnumerator() { throw null; }
             void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public partial struct Enumerator : System.Collections.Generic.IEnumerator<TValue>, System.Collections.IEnumerator, System.IDisposable
             {
+                private object _dummy;
                 public TValue Current { get { throw null; } }
                 object System.Collections.IEnumerator.Current { get { throw null; } }
                 public void Dispose() { }
@@ -221,9 +221,9 @@ namespace System.Collections.Generic
         public void TrimExcess() { }
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
         public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public T Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
@@ -266,9 +266,9 @@ namespace System.Collections.Generic
         System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
         void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
         {
+            private object _dummy;
             public T Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
@@ -354,9 +354,9 @@ namespace System.Collections.Generic
         public T[] ToArray() { throw null; }
         public void TrimExcess() { }
         public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public T Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
@@ -386,9 +386,9 @@ namespace System.Collections.Generic
         public void TrimExcess() { }
         public bool TryDequeue(out T result) { throw null; }
         public bool TryPeek(out T result) { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public T Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
@@ -437,9 +437,9 @@ namespace System.Collections.Generic
         void System.Collections.IDictionary.Remove(object key) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
             System.Collections.DictionaryEntry System.Collections.IDictionaryEnumerator.Entry { get { throw null; } }
             object System.Collections.IDictionaryEnumerator.Key { get { throw null; } }
@@ -465,9 +465,9 @@ namespace System.Collections.Generic
             System.Collections.Generic.IEnumerator<TKey> System.Collections.Generic.IEnumerable<TKey>.GetEnumerator() { throw null; }
             void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public partial struct Enumerator : System.Collections.Generic.IEnumerator<TKey>, System.Collections.IEnumerator, System.IDisposable
             {
+                private object _dummy;
                 public TKey Current { get { throw null; } }
                 object System.Collections.IEnumerator.Current { get { throw null; } }
                 public void Dispose() { }
@@ -491,9 +491,9 @@ namespace System.Collections.Generic
             System.Collections.Generic.IEnumerator<TValue> System.Collections.Generic.IEnumerable<TValue>.GetEnumerator() { throw null; }
             void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public partial struct Enumerator : System.Collections.Generic.IEnumerator<TValue>, System.Collections.IEnumerator, System.IDisposable
             {
+                private object _dummy;
                 public TValue Current { get { throw null; } }
                 object System.Collections.IEnumerator.Current { get { throw null; } }
                 public void Dispose() { }
@@ -597,9 +597,9 @@ namespace System.Collections.Generic
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
         public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
         {
+            private object _dummy;
             public T Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
@@ -631,9 +631,9 @@ namespace System.Collections.Generic
         public void TrimExcess() { }
         public bool TryPeek(out T result) { throw null; }
         public bool TryPop(out T result) { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public T Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }

--- a/src/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.cs
+++ b/src/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.cs
@@ -7,6 +7,12 @@
 
 namespace System.ComponentModel.Composition
 {
+    public static partial class AdaptationConstants
+    {
+        public const string AdapterContractName = "System.ComponentModel.Composition.AdapterContract";
+        public const string AdapterFromContractMetadataName = "FromContract";
+        public const string AdapterToContractMetadataName = "ToContract";
+    }
     public static partial class AttributedModelServices
     {
         public static System.ComponentModel.Composition.Primitives.ComposablePart AddExportedValue<T>(this System.ComponentModel.Composition.Hosting.CompositionBatch batch, string contractName, T exportedValue) { throw null; }
@@ -17,6 +23,7 @@ namespace System.ComponentModel.Composition
         public static void ComposeParts(this System.ComponentModel.Composition.Hosting.CompositionContainer container, params object[] attributedParts) { }
         public static System.ComponentModel.Composition.Primitives.ComposablePart CreatePart(System.ComponentModel.Composition.Primitives.ComposablePartDefinition partDefinition, object attributedPart) { throw null; }
         public static System.ComponentModel.Composition.Primitives.ComposablePart CreatePart(object attributedPart) { throw null; }
+        public static System.ComponentModel.Composition.Primitives.ComposablePart CreatePart(object attributedPart, System.Reflection.ReflectionContext reflectionContext) { throw null; }
         public static System.ComponentModel.Composition.Primitives.ComposablePartDefinition CreatePartDefinition(System.Type type, System.ComponentModel.Composition.Primitives.ICompositionElement origin) { throw null; }
         public static System.ComponentModel.Composition.Primitives.ComposablePartDefinition CreatePartDefinition(System.Type type, System.ComponentModel.Composition.Primitives.ICompositionElement origin, bool ensureIsDiscoverable) { throw null; }
         public static bool Exports(this System.ComponentModel.Composition.Primitives.ComposablePartDefinition part, System.Type contractType) { throw null; }
@@ -30,6 +37,13 @@ namespace System.ComponentModel.Composition
         public static bool Imports<T>(this System.ComponentModel.Composition.Primitives.ComposablePartDefinition part) { throw null; }
         public static bool Imports<T>(this System.ComponentModel.Composition.Primitives.ComposablePartDefinition part, System.ComponentModel.Composition.Primitives.ImportCardinality importCardinality) { throw null; }
         public static System.ComponentModel.Composition.Primitives.ComposablePart SatisfyImportsOnce(this System.ComponentModel.Composition.ICompositionService compositionService, object attributedPart) { throw null; }
+        public static System.ComponentModel.Composition.Primitives.ComposablePart SatisfyImportsOnce(this System.ComponentModel.Composition.ICompositionService compositionService, object attributedPart, System.Reflection.ReflectionContext reflectionContext) { throw null; }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false, Inherited=true)]
+    public partial class CatalogReflectionContextAttribute : System.Attribute
+    {
+        public CatalogReflectionContextAttribute(System.Type reflectionContextType) { }
+        public System.Reflection.ReflectionContext CreateReflectionContext() { throw null; }
     }
     public partial class ChangeRejectedException : System.ComponentModel.Composition.CompositionException
     {
@@ -42,6 +56,7 @@ namespace System.ComponentModel.Composition
     public partial class CompositionContractMismatchException : System.Exception
     {
         public CompositionContractMismatchException() { }
+        protected CompositionContractMismatchException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public CompositionContractMismatchException(string message) { }
         public CompositionContractMismatchException(string message, System.Exception innerException) { }
     }
@@ -56,7 +71,6 @@ namespace System.ComponentModel.Composition
         public System.Exception Exception { get { throw null; } }
         public override string ToString() { throw null; }
     }
-    [System.Diagnostics.DebuggerDisplayAttribute("{Message}")]
     public partial class CompositionException : System.Exception
     {
         public CompositionException() { }
@@ -73,15 +87,15 @@ namespace System.ComponentModel.Composition
         NonShared = 2,
         Shared = 1,
     }
-    [System.AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(452), AllowMultiple=true, Inherited=false)]
     public partial class ExportAttribute : System.Attribute
     {
         public ExportAttribute() { }
         public ExportAttribute(string contractName) { }
         public ExportAttribute(string contractName, System.Type contractType) { }
         public ExportAttribute(System.Type contractType) { }
-        public string ContractName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public System.Type ContractType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string ContractName { get { throw null; } }
+        public System.Type ContractType { get { throw null; } }
     }
     public partial class ExportFactory<T>
     {
@@ -99,56 +113,56 @@ namespace System.ComponentModel.Composition
         public T Value { get { throw null; } }
         public void Dispose() { }
     }
-    [System.AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field, AllowMultiple=true, Inherited=false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1476), AllowMultiple=true, Inherited=false)]
     public sealed partial class ExportMetadataAttribute : System.Attribute
     {
         public ExportMetadataAttribute(string name, object value) { }
-        public bool IsMultiple { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public object Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool IsMultiple { get { throw null; } set { } }
+        public string Name { get { throw null; } }
+        public object Value { get { throw null; } }
     }
     public partial interface ICompositionService
     {
         void SatisfyImportsOnce(System.ComponentModel.Composition.Primitives.ComposablePart part);
     }
-    [System.AttributeUsageAttribute(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2432), AllowMultiple=false, Inherited=false)]
     public partial class ImportAttribute : System.Attribute
     {
         public ImportAttribute() { }
         public ImportAttribute(string contractName) { }
         public ImportAttribute(string contractName, System.Type contractType) { }
         public ImportAttribute(System.Type contractType) { }
-        public bool AllowDefault { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public bool AllowRecomposition { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public string ContractName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public System.Type ContractType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public System.ComponentModel.Composition.CreationPolicy RequiredCreationPolicy { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public System.ComponentModel.Composition.ImportSource Source { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool AllowDefault { get { throw null; } set { } }
+        public bool AllowRecomposition { get { throw null; } set { } }
+        public string ContractName { get { throw null; } }
+        public System.Type ContractType { get { throw null; } }
+        public System.ComponentModel.Composition.CreationPolicy RequiredCreationPolicy { get { throw null; } set { } }
+        public System.ComponentModel.Composition.ImportSource Source { get { throw null; } set { } }
     }
-    [System.Diagnostics.DebuggerDisplayAttribute("{Message}")]
     public partial class ImportCardinalityMismatchException : System.Exception
     {
         public ImportCardinalityMismatchException() { }
+        protected ImportCardinalityMismatchException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ImportCardinalityMismatchException(string message) { }
         public ImportCardinalityMismatchException(string message, System.Exception innerException) { }
     }
-    [System.AttributeUsageAttribute(AttributeTargets.Constructor, AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(32), AllowMultiple=false, Inherited=false)]
     public partial class ImportingConstructorAttribute : System.Attribute
     {
         public ImportingConstructorAttribute() { }
     }
-    [System.AttributeUsageAttribute(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2432), AllowMultiple=false, Inherited=false)]
     public partial class ImportManyAttribute : System.Attribute
     {
         public ImportManyAttribute() { }
         public ImportManyAttribute(string contractName) { }
         public ImportManyAttribute(string contractName, System.Type contractType) { }
         public ImportManyAttribute(System.Type contractType) { }
-        public bool AllowRecomposition { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public string ContractName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public System.Type ContractType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public System.ComponentModel.Composition.CreationPolicy RequiredCreationPolicy { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public System.ComponentModel.Composition.ImportSource Source { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool AllowRecomposition { get { throw null; } set { } }
+        public string ContractName { get { throw null; } }
+        public System.Type ContractType { get { throw null; } }
+        public System.ComponentModel.Composition.CreationPolicy RequiredCreationPolicy { get { throw null; } set { } }
+        public System.ComponentModel.Composition.ImportSource Source { get { throw null; } set { } }
     }
     public enum ImportSource
     {
@@ -156,7 +170,7 @@ namespace System.ComponentModel.Composition
         Local = 1,
         NonLocal = 2,
     }
-    [System.AttributeUsageAttribute(AttributeTargets.Interface | AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1028), AllowMultiple=true, Inherited=true)]
     public partial class InheritedExportAttribute : System.ComponentModel.Composition.ExportAttribute
     {
         public InheritedExportAttribute() { }
@@ -168,31 +182,31 @@ namespace System.ComponentModel.Composition
     {
         void OnImportsSatisfied();
     }
-    [System.AttributeUsageAttribute(AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4), AllowMultiple=false, Inherited=true)]
     public sealed partial class MetadataAttributeAttribute : System.Attribute
     {
         public MetadataAttributeAttribute() { }
     }
-    [System.AttributeUsageAttribute(AttributeTargets.Interface, AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1024), AllowMultiple=false, Inherited=false)]
     public sealed partial class MetadataViewImplementationAttribute : System.Attribute
     {
         public MetadataViewImplementationAttribute(System.Type implementationType) { }
-        public System.Type ImplementationType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Type ImplementationType { get { throw null; } }
     }
-    [System.AttributeUsageAttribute(AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4), AllowMultiple=false, Inherited=false)]
     public sealed partial class PartCreationPolicyAttribute : System.Attribute
     {
         public PartCreationPolicyAttribute(System.ComponentModel.Composition.CreationPolicy creationPolicy) { }
-        public System.ComponentModel.Composition.CreationPolicy CreationPolicy { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.ComponentModel.Composition.CreationPolicy CreationPolicy { get { throw null; } }
     }
-    [System.AttributeUsageAttribute(AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4), AllowMultiple=true, Inherited=false)]
     public sealed partial class PartMetadataAttribute : System.Attribute
     {
         public PartMetadataAttribute(string name, object value) { }
-        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public object Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string Name { get { throw null; } }
+        public object Value { get { throw null; } }
     }
-    [System.AttributeUsageAttribute(AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4), AllowMultiple=false, Inherited=false)]
     public sealed partial class PartNotDiscoverableAttribute : System.Attribute
     {
         public PartNotDiscoverableAttribute() { }
@@ -226,9 +240,9 @@ namespace System.ComponentModel.Composition.Hosting
     public partial class ApplicationCatalog : System.ComponentModel.Composition.Primitives.ComposablePartCatalog, System.ComponentModel.Composition.Primitives.ICompositionElement
     {
         public ApplicationCatalog() { }
+        public ApplicationCatalog(System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
         public ApplicationCatalog(System.Reflection.ReflectionContext reflectionContext) { }
         public ApplicationCatalog(System.Reflection.ReflectionContext reflectionContext, System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
-        public ApplicationCatalog(System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
         string System.ComponentModel.Composition.Primitives.ICompositionElement.DisplayName { get { throw null; } }
         System.ComponentModel.Composition.Primitives.ICompositionElement System.ComponentModel.Composition.Primitives.ICompositionElement.Origin { get { throw null; } }
         protected override void Dispose(bool disposing) { }
@@ -240,7 +254,12 @@ namespace System.ComponentModel.Composition.Hosting
     {
         public AssemblyCatalog(System.Reflection.Assembly assembly) { }
         public AssemblyCatalog(System.Reflection.Assembly assembly, System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
+        public AssemblyCatalog(System.Reflection.Assembly assembly, System.Reflection.ReflectionContext reflectionContext) { }
+        public AssemblyCatalog(System.Reflection.Assembly assembly, System.Reflection.ReflectionContext reflectionContext, System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
+        public AssemblyCatalog(string codeBase) { }
         public AssemblyCatalog(string codeBase, System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
+        public AssemblyCatalog(string codeBase, System.Reflection.ReflectionContext reflectionContext) { }
+        public AssemblyCatalog(string codeBase, System.Reflection.ReflectionContext reflectionContext, System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
         public System.Reflection.Assembly Assembly { get { throw null; } }
         string System.ComponentModel.Composition.Primitives.ICompositionElement.DisplayName { get { throw null; } }
         System.ComponentModel.Composition.Primitives.ICompositionElement System.ComponentModel.Composition.Primitives.ICompositionElement.Origin { get { throw null; } }
@@ -259,8 +278,8 @@ namespace System.ComponentModel.Composition.Hosting
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void SetValue(object key, object value) { }
-        public bool TryGetValue<T>(object key, bool localAtomicCompositionOnly, out T value) { value = default(T); throw null; }
-        public bool TryGetValue<T>(object key, out T value) { value = default(T); throw null; }
+        public bool TryGetValue<T>(object key, bool localAtomicCompositionOnly, out T value) { throw null; }
+        public bool TryGetValue<T>(object key, out T value) { throw null; }
     }
     public partial class CatalogExportProvider : System.ComponentModel.Composition.Hosting.ExportProvider, System.IDisposable
     {
@@ -281,7 +300,7 @@ namespace System.ComponentModel.Composition.Hosting
     {
         public ComposablePartCatalogChangeEventArgs(System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.ComposablePartDefinition> addedDefinitions, System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.ComposablePartDefinition> removedDefinitions, System.ComponentModel.Composition.Hosting.AtomicComposition atomicComposition) { }
         public System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.ComposablePartDefinition> AddedDefinitions { get { throw null; } }
-        public System.ComponentModel.Composition.Hosting.AtomicComposition AtomicComposition { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.ComponentModel.Composition.Hosting.AtomicComposition AtomicComposition { get { throw null; } }
         public System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.ComposablePartDefinition> RemovedDefinitions { get { throw null; } }
     }
     public partial class ComposablePartExportProvider : System.ComponentModel.Composition.Hosting.ExportProvider, System.IDisposable
@@ -368,8 +387,12 @@ namespace System.ComponentModel.Composition.Hosting
     {
         public DirectoryCatalog(string path) { }
         public DirectoryCatalog(string path, System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
+        public DirectoryCatalog(string path, System.Reflection.ReflectionContext reflectionContext) { }
+        public DirectoryCatalog(string path, System.Reflection.ReflectionContext reflectionContext, System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
         public DirectoryCatalog(string path, string searchPattern) { }
         public DirectoryCatalog(string path, string searchPattern, System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
+        public DirectoryCatalog(string path, string searchPattern, System.Reflection.ReflectionContext reflectionContext) { }
+        public DirectoryCatalog(string path, string searchPattern, System.Reflection.ReflectionContext reflectionContext, System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
         public string FullPath { get { throw null; } }
         public System.Collections.ObjectModel.ReadOnlyCollection<string> LoadedFiles { get { throw null; } }
         public string Path { get { throw null; } }
@@ -411,13 +434,13 @@ namespace System.ComponentModel.Composition.Hosting
         public System.Lazy<T, TMetadataView> GetExport<T, TMetadataView>(string contractName) { throw null; }
         protected virtual void OnExportsChanged(System.ComponentModel.Composition.Hosting.ExportsChangeEventArgs e) { }
         protected virtual void OnExportsChanging(System.ComponentModel.Composition.Hosting.ExportsChangeEventArgs e) { }
-        public bool TryGetExports(System.ComponentModel.Composition.Primitives.ImportDefinition definition, System.ComponentModel.Composition.Hosting.AtomicComposition atomicComposition, out System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.Export> exports) { exports = default(System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.Export>); throw null; }
+        public bool TryGetExports(System.ComponentModel.Composition.Primitives.ImportDefinition definition, System.ComponentModel.Composition.Hosting.AtomicComposition atomicComposition, out System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.Export> exports) { throw null; }
     }
     public partial class ExportsChangeEventArgs : System.EventArgs
     {
         public ExportsChangeEventArgs(System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.ExportDefinition> addedExports, System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.ExportDefinition> removedExports, System.ComponentModel.Composition.Hosting.AtomicComposition atomicComposition) { }
         public System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.ExportDefinition> AddedExports { get { throw null; } }
-        public System.ComponentModel.Composition.Hosting.AtomicComposition AtomicComposition { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.ComponentModel.Composition.Hosting.AtomicComposition AtomicComposition { get { throw null; } }
         public System.Collections.Generic.IEnumerable<string> ChangedContractNames { get { throw null; } }
         public System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.ExportDefinition> RemovedExports { get { throw null; } }
     }
@@ -467,6 +490,8 @@ namespace System.ComponentModel.Composition.Hosting
     {
         public TypeCatalog(System.Collections.Generic.IEnumerable<System.Type> types) { }
         public TypeCatalog(System.Collections.Generic.IEnumerable<System.Type> types, System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
+        public TypeCatalog(System.Collections.Generic.IEnumerable<System.Type> types, System.Reflection.ReflectionContext reflectionContext) { }
+        public TypeCatalog(System.Collections.Generic.IEnumerable<System.Type> types, System.Reflection.ReflectionContext reflectionContext, System.ComponentModel.Composition.Primitives.ICompositionElement definitionOrigin) { }
         public TypeCatalog(params System.Type[] types) { }
         string System.ComponentModel.Composition.Primitives.ICompositionElement.DisplayName { get { throw null; } }
         System.ComponentModel.Composition.Primitives.ICompositionElement System.ComponentModel.Composition.Primitives.ICompositionElement.Origin { get { throw null; } }
@@ -490,7 +515,7 @@ namespace System.ComponentModel.Composition.Primitives
     public abstract partial class ComposablePartCatalog : System.Collections.Generic.IEnumerable<System.ComponentModel.Composition.Primitives.ComposablePartDefinition>, System.Collections.IEnumerable, System.IDisposable
     {
         protected ComposablePartCatalog() { }
-        [System.ComponentModel.EditorBrowsableAttribute(EditorBrowsableState.Never)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public virtual System.Linq.IQueryable<System.ComponentModel.Composition.Primitives.ComposablePartDefinition> Parts { get { throw null; } }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
@@ -506,7 +531,6 @@ namespace System.ComponentModel.Composition.Primitives
         public virtual System.Collections.Generic.IDictionary<string, object> Metadata { get { throw null; } }
         public abstract System.ComponentModel.Composition.Primitives.ComposablePart CreatePart();
     }
-    [System.Diagnostics.DebuggerDisplayAttribute("{Message}")]
     public partial class ComposablePartException : System.Exception
     {
         public ComposablePartException() { }
@@ -581,12 +605,12 @@ namespace System.ComponentModel.Composition.Primitives
 }
 namespace System.ComponentModel.Composition.ReflectionModel
 {
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct LazyMemberInfo
     {
-        public LazyMemberInfo(System.Reflection.MemberInfo member) { throw null;}
-        public LazyMemberInfo(System.Reflection.MemberTypes memberType, System.Func<System.Reflection.MemberInfo[]> accessorsCreator) { throw null;}
-        public LazyMemberInfo(System.Reflection.MemberTypes memberType, params System.Reflection.MemberInfo[] accessors) { throw null;}
+        private object _dummy;
+        public LazyMemberInfo(System.Reflection.MemberInfo member) { throw null; }
+        public LazyMemberInfo(System.Reflection.MemberTypes memberType, System.Func<System.Reflection.MemberInfo[]> accessorsCreator) { throw null; }
+        public LazyMemberInfo(System.Reflection.MemberTypes memberType, params System.Reflection.MemberInfo[] accessors) { throw null; }
         public System.Reflection.MemberTypes MemberType { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public System.Reflection.MemberInfo[] GetAccessors() { throw null; }
@@ -611,6 +635,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         public static bool IsDisposalRequired(System.ComponentModel.Composition.Primitives.ComposablePartDefinition partDefinition) { throw null; }
         public static bool IsExportFactoryImportDefinition(System.ComponentModel.Composition.Primitives.ImportDefinition importDefinition) { throw null; }
         public static bool IsImportingParameter(System.ComponentModel.Composition.Primitives.ImportDefinition importDefinition) { throw null; }
-        public static bool TryMakeGenericPartDefinition(System.ComponentModel.Composition.Primitives.ComposablePartDefinition partDefinition, System.Collections.Generic.IEnumerable<System.Type> genericParameters, out System.ComponentModel.Composition.Primitives.ComposablePartDefinition specialization) { specialization = default(System.ComponentModel.Composition.Primitives.ComposablePartDefinition); throw null; }
+        public static bool TryMakeGenericPartDefinition(System.ComponentModel.Composition.Primitives.ComposablePartDefinition partDefinition, System.Collections.Generic.IEnumerable<System.Type> genericParameters, out System.ComponentModel.Composition.Primitives.ComposablePartDefinition specialization) { throw null; }
     }
 }

--- a/src/System.ComponentModel.Composition/src/System.ComponentModel.Composition.csproj
+++ b/src/System.ComponentModel.Composition/src/System.ComponentModel.Composition.csproj
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{2D694AC8-A12F-4622-9405-74E20EC40C3A}</ProjectGuid>
     <AssemblyName>System.ComponentModel.Composition</AssemblyName>
-    <!-- Workaround for issue buildtools #1784 -->
-    <RunApiCompat>false</RunApiCompat>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard'">SR.PlatformNotSupported_ComponentModel_Composition</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->

--- a/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.cs
+++ b/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.cs
@@ -1440,6 +1440,7 @@ namespace System.ComponentModel.Design.Serialization
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MemberRelationship
     {
+        private readonly object _dummy;
         public static readonly System.ComponentModel.Design.Serialization.MemberRelationship Empty;
         public MemberRelationship(object owner, System.ComponentModel.MemberDescriptor member) { throw null; }
         public bool IsEmpty { get { throw null; } }

--- a/src/System.Console/ref/System.Console.cs
+++ b/src/System.Console/ref/System.Console.cs
@@ -5,47 +5,52 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System
 {
     public static partial class Console
     {
         public static System.ConsoleColor BackgroundColor { get { throw null; } set { } }
-        public static void Beep() { }
-        public static void Beep(int frequency, int duration) { }
         public static int BufferHeight { get { throw null; } set { } }
         public static int BufferWidth { get { throw null; } set { } }
         public static bool CapsLock { get { throw null; } }
-        public static event System.ConsoleCancelEventHandler CancelKeyPress { add { } remove { } }
-        public static void Clear() { }
         public static int CursorLeft { get { throw null; } set { } }
         public static int CursorSize { get { throw null; } set { } }
         public static int CursorTop { get { throw null; } set { } }
         public static bool CursorVisible { get { throw null; } set { } }
         public static System.IO.TextWriter Error { get { throw null; } }
         public static System.ConsoleColor ForegroundColor { get { throw null; } set { } }
+        public static System.IO.TextReader In { get { throw null; } }
         public static System.Text.Encoding InputEncoding { get { throw null; } set { } }
         public static bool IsErrorRedirected { get { throw null; } }
         public static bool IsInputRedirected { get { throw null; } }
         public static bool IsOutputRedirected { get { throw null; } }
-        public static System.IO.TextReader In { get { throw null; } }
-        public static bool KeyAvailable { get { throw null; }}
+        public static bool KeyAvailable { get { throw null; } }
+        public static int LargestWindowHeight { get { throw null; } }
         public static int LargestWindowWidth { get { throw null; } }
-        public static int LargestWindowHeight { get { throw null; }}
+        public static bool NumberLock { get { throw null; } }
+        public static System.IO.TextWriter Out { get { throw null; } }
+        public static System.Text.Encoding OutputEncoding { get { throw null; } set { } }
+        public static string Title { get { throw null; } set { } }
+        public static bool TreatControlCAsInput { get { throw null; } set { } }
+        public static int WindowHeight { get { throw null; } set { } }
+        public static int WindowLeft { get { throw null; } set { } }
+        public static int WindowTop { get { throw null; } set { } }
+        public static int WindowWidth { get { throw null; } set { } }
+        public static event System.ConsoleCancelEventHandler CancelKeyPress { add { } remove { } }
+        public static void Beep() { }
+        public static void Beep(int frequency, int duration) { }
+        public static void Clear() { }
         public static void MoveBufferArea(int sourceLeft, int sourceTop, int sourceWidth, int sourceHeight, int targetLeft, int targetTop) { }
-        public static void MoveBufferArea(int sourceLeft, int sourceTop, int sourceWidth, int sourceHeight, int targetLeft, int targetTop, char sourceChar, ConsoleColor sourceForeColor, ConsoleColor sourceBackColor) { }
-        public static bool NumberLock { get { throw null; }}
+        public static void MoveBufferArea(int sourceLeft, int sourceTop, int sourceWidth, int sourceHeight, int targetLeft, int targetTop, char sourceChar, System.ConsoleColor sourceForeColor, System.ConsoleColor sourceBackColor) { }
         public static System.IO.Stream OpenStandardError() { throw null; }
         public static System.IO.Stream OpenStandardError(int bufferSize) { throw null; }
         public static System.IO.Stream OpenStandardInput() { throw null; }
         public static System.IO.Stream OpenStandardInput(int bufferSize) { throw null; }
         public static System.IO.Stream OpenStandardOutput() { throw null; }
         public static System.IO.Stream OpenStandardOutput(int bufferSize) { throw null; }
-        public static System.IO.TextWriter Out { get { throw null; } }
-        public static System.Text.Encoding OutputEncoding { get { throw null; } set { } }
         public static int Read() { throw null; }
-        public static ConsoleKeyInfo ReadKey() { throw null; }
-        public static ConsoleKeyInfo ReadKey(bool intercept) { throw null; }
+        public static System.ConsoleKeyInfo ReadKey() { throw null; }
+        public static System.ConsoleKeyInfo ReadKey(bool intercept) { throw null; }
         public static string ReadLine() { throw null; }
         public static void ResetColor() { }
         public static void SetBufferSize(int width, int height) { }
@@ -55,12 +60,6 @@ namespace System
         public static void SetOut(System.IO.TextWriter newOut) { }
         public static void SetWindowPosition(int left, int top) { }
         public static void SetWindowSize(int width, int height) { }
-        public static string Title { get { throw null; } set { } }
-        public static bool TreatControlCAsInput { get { throw null; } set { } }
-        public static int WindowHeight { get { throw null; } set { } }
-        public static int WindowWidth { get { throw null; } set { } }
-        public static int WindowLeft { get { throw null; } set { } }
-        public static int WindowTop { get { throw null; } set { } }
         public static void Write(bool value) { }
         public static void Write(char value) { }
         public static void Write(char[] buffer) { }
@@ -127,171 +126,172 @@ namespace System
         White = 15,
         Yellow = 14,
     }
-    public readonly partial struct ConsoleKeyInfo
-    {
-        public ConsoleKeyInfo(char keyChar, ConsoleKey key, bool shift, bool alt, bool control) { }
-        public char KeyChar { get { throw null; } }
-        public ConsoleKey Key { get { throw null; } }
-        public ConsoleModifiers Modifiers { get { throw null; } }
-        public bool Equals(ConsoleKeyInfo obj) { throw null; }
-        public override bool Equals(object value) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static bool operator ==(ConsoleKeyInfo a, ConsoleKeyInfo b) { throw null; }
-        public static bool operator !=(ConsoleKeyInfo a, ConsoleKeyInfo b) { throw null; }
-    }
     public enum ConsoleKey
     {
-        Backspace = 0x8,
-        Tab = 0x9,
-        Clear = 0xC,
-        Enter = 0xD,
-        Pause = 0x13,
-        Escape = 0x1B,
-        Spacebar = 0x20,
-        PageUp = 0x21,
-        PageDown = 0x22,
-        End = 0x23,
-        Home = 0x24,
-        LeftArrow = 0x25,
-        UpArrow = 0x26,
-        RightArrow = 0x27,
-        DownArrow = 0x28,
-        Select = 0x29,
-        Print = 0x2A,
-        Execute = 0x2B,
-        PrintScreen = 0x2C,
-        Insert = 0x2D,
-        Delete = 0x2E,
-        Help = 0x2F,
-        D0 = 0x30,  // 0 through 9
-        D1 = 0x31,
-        D2 = 0x32,
-        D3 = 0x33,
-        D4 = 0x34,
-        D5 = 0x35,
-        D6 = 0x36,
-        D7 = 0x37,
-        D8 = 0x38,
-        D9 = 0x39,
-        A = 0x41,
-        B = 0x42,
-        C = 0x43,
-        D = 0x44,
-        E = 0x45,
-        F = 0x46,
-        G = 0x47,
-        H = 0x48,
-        I = 0x49,
-        J = 0x4A,
-        K = 0x4B,
-        L = 0x4C,
-        M = 0x4D,
-        N = 0x4E,
-        O = 0x4F,
-        P = 0x50,
-        Q = 0x51,
-        R = 0x52,
-        S = 0x53,
-        T = 0x54,
-        U = 0x55,
-        V = 0x56,
-        W = 0x57,
-        X = 0x58,
-        Y = 0x59,
-        Z = 0x5A,
-        LeftWindows = 0x5B,
-        RightWindows = 0x5C,
-        Applications = 0x5D,
-        Sleep = 0x5F,
-        NumPad0 = 0x60,
-        NumPad1 = 0x61,
-        NumPad2 = 0x62,
-        NumPad3 = 0x63,
-        NumPad4 = 0x64,
-        NumPad5 = 0x65,
-        NumPad6 = 0x66,
-        NumPad7 = 0x67,
-        NumPad8 = 0x68,
-        NumPad9 = 0x69,
-        Multiply = 0x6A,
-        Add = 0x6B,
-        Separator = 0x6C,
-        Subtract = 0x6D,
-        Decimal = 0x6E,
-        Divide = 0x6F,
-        F1 = 0x70,
-        F2 = 0x71,
-        F3 = 0x72,
-        F4 = 0x73,
-        F5 = 0x74,
-        F6 = 0x75,
-        F7 = 0x76,
-        F8 = 0x77,
-        F9 = 0x78,
-        F10 = 0x79,
-        F11 = 0x7A,
-        F12 = 0x7B,
-        F13 = 0x7C,
-        F14 = 0x7D,
-        F15 = 0x7E,
-        F16 = 0x7F,
-        F17 = 0x80,
-        F18 = 0x81,
-        F19 = 0x82,
-        F20 = 0x83,
-        F21 = 0x84,
-        F22 = 0x85,
-        F23 = 0x86,
-        F24 = 0x87,
-        BrowserBack = 0xA6,
-        BrowserForward = 0xA7,
-        BrowserRefresh = 0xA8,
-        BrowserStop = 0xA9,
-        BrowserSearch = 0xAA,
-        BrowserFavorites = 0xAB,
-        BrowserHome = 0xAC,
-        VolumeMute = 0xAD,
-        VolumeDown = 0xAE,
-        VolumeUp = 0xAF,
-        MediaNext = 0xB0,
-        MediaPrevious = 0xB1,
-        MediaStop = 0xB2,
-        MediaPlay = 0xB3,
-        LaunchMail = 0xB4,
-        LaunchMediaSelect = 0xB5,
-        LaunchApp1 = 0xB6,
-        LaunchApp2 = 0xB7,
-        Oem1 = 0xBA,
-        OemPlus = 0xBB,
-        OemComma = 0xBC,
-        OemMinus = 0xBD,
-        OemPeriod = 0xBE,
-        Oem2 = 0xBF,
-        Oem3 = 0xC0,
-        Oem4 = 0xDB,
-        Oem5 = 0xDC,
-        Oem6 = 0xDD,
-        Oem7 = 0xDE,
-        Oem8 = 0xDF,
-        Oem102 = 0xE2,
-        Process = 0xE5,
-        Packet = 0xE7,
-        Attention = 0xF6,
-        CrSel = 0xF7,
-        ExSel = 0xF8,
-        EraseEndOfFile = 0xF9,
-        Play = 0xFA,
-        Zoom = 0xFB,
-        NoName = 0xFC,
-        Pa1 = 0xFD,
-        OemClear = 0xFE,
+        A = 65,
+        Add = 107,
+        Applications = 93,
+        Attention = 246,
+        B = 66,
+        Backspace = 8,
+        BrowserBack = 166,
+        BrowserFavorites = 171,
+        BrowserForward = 167,
+        BrowserHome = 172,
+        BrowserRefresh = 168,
+        BrowserSearch = 170,
+        BrowserStop = 169,
+        C = 67,
+        Clear = 12,
+        CrSel = 247,
+        D = 68,
+        D0 = 48,
+        D1 = 49,
+        D2 = 50,
+        D3 = 51,
+        D4 = 52,
+        D5 = 53,
+        D6 = 54,
+        D7 = 55,
+        D8 = 56,
+        D9 = 57,
+        Decimal = 110,
+        Delete = 46,
+        Divide = 111,
+        DownArrow = 40,
+        E = 69,
+        End = 35,
+        Enter = 13,
+        EraseEndOfFile = 249,
+        Escape = 27,
+        Execute = 43,
+        ExSel = 248,
+        F = 70,
+        F1 = 112,
+        F10 = 121,
+        F11 = 122,
+        F12 = 123,
+        F13 = 124,
+        F14 = 125,
+        F15 = 126,
+        F16 = 127,
+        F17 = 128,
+        F18 = 129,
+        F19 = 130,
+        F2 = 113,
+        F20 = 131,
+        F21 = 132,
+        F22 = 133,
+        F23 = 134,
+        F24 = 135,
+        F3 = 114,
+        F4 = 115,
+        F5 = 116,
+        F6 = 117,
+        F7 = 118,
+        F8 = 119,
+        F9 = 120,
+        G = 71,
+        H = 72,
+        Help = 47,
+        Home = 36,
+        I = 73,
+        Insert = 45,
+        J = 74,
+        K = 75,
+        L = 76,
+        LaunchApp1 = 182,
+        LaunchApp2 = 183,
+        LaunchMail = 180,
+        LaunchMediaSelect = 181,
+        LeftArrow = 37,
+        LeftWindows = 91,
+        M = 77,
+        MediaNext = 176,
+        MediaPlay = 179,
+        MediaPrevious = 177,
+        MediaStop = 178,
+        Multiply = 106,
+        N = 78,
+        NoName = 252,
+        NumPad0 = 96,
+        NumPad1 = 97,
+        NumPad2 = 98,
+        NumPad3 = 99,
+        NumPad4 = 100,
+        NumPad5 = 101,
+        NumPad6 = 102,
+        NumPad7 = 103,
+        NumPad8 = 104,
+        NumPad9 = 105,
+        O = 79,
+        Oem1 = 186,
+        Oem102 = 226,
+        Oem2 = 191,
+        Oem3 = 192,
+        Oem4 = 219,
+        Oem5 = 220,
+        Oem6 = 221,
+        Oem7 = 222,
+        Oem8 = 223,
+        OemClear = 254,
+        OemComma = 188,
+        OemMinus = 189,
+        OemPeriod = 190,
+        OemPlus = 187,
+        P = 80,
+        Pa1 = 253,
+        Packet = 231,
+        PageDown = 34,
+        PageUp = 33,
+        Pause = 19,
+        Play = 250,
+        Print = 42,
+        PrintScreen = 44,
+        Process = 229,
+        Q = 81,
+        R = 82,
+        RightArrow = 39,
+        RightWindows = 92,
+        S = 83,
+        Select = 41,
+        Separator = 108,
+        Sleep = 95,
+        Spacebar = 32,
+        Subtract = 109,
+        T = 84,
+        Tab = 9,
+        U = 85,
+        UpArrow = 38,
+        V = 86,
+        VolumeDown = 174,
+        VolumeMute = 173,
+        VolumeUp = 175,
+        W = 87,
+        X = 88,
+        Y = 89,
+        Z = 90,
+        Zoom = 251,
     }
-    [Flags]
+    public readonly partial struct ConsoleKeyInfo
+    {
+        private readonly int _dummy;
+        public ConsoleKeyInfo(char keyChar, System.ConsoleKey key, bool shift, bool alt, bool control) { throw null; }
+        public System.ConsoleKey Key { get { throw null; } }
+        public char KeyChar { get { throw null; } }
+        public System.ConsoleModifiers Modifiers { get { throw null; } }
+        public bool Equals(System.ConsoleKeyInfo obj) { throw null; }
+        public override bool Equals(object value) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.ConsoleKeyInfo a, System.ConsoleKeyInfo b) { throw null; }
+        public static bool operator !=(System.ConsoleKeyInfo a, System.ConsoleKeyInfo b) { throw null; }
+    }
+    [System.FlagsAttribute]
     public enum ConsoleModifiers
     {
         Alt = 1,
+        Control = 4,
         Shift = 2,
-        Control = 4
     }
     public enum ConsoleSpecialKey
     {

--- a/src/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/System.Data.Common/ref/System.Data.Common.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
@@ -52,13 +51,13 @@ namespace System.Data
     public abstract partial class Constraint
     {
         protected Constraint() { }
-        [System.CLSCompliantAttribute(false)]
-        protected virtual System.Data.DataSet _DataSet { get { throw null; } }
         [System.ComponentModel.DefaultValueAttribute("")]
         public virtual string ConstraintName { get { throw null; } set { } }
         [System.ComponentModel.BrowsableAttribute(false)]
         public System.Data.PropertyCollection ExtendedProperties { get { throw null; } }
         public abstract System.Data.DataTable Table { get; }
+        [System.CLSCompliantAttribute(false)]
+        protected virtual System.Data.DataSet _DataSet { get { throw null; } }
         protected void CheckStateForProperty() { }
         protected internal void SetDataSet(System.Data.DataSet dataSet) { }
         public override string ToString() { throw null; }
@@ -405,7 +404,6 @@ namespace System.Data
         object System.ComponentModel.ICustomTypeDescriptor.GetPropertyOwner(System.ComponentModel.PropertyDescriptor pd) { throw null; }
     }
     [System.ComponentModel.DefaultPropertyAttribute("DataSetName")]
-    [System.ComponentModel.ToolboxItemAttribute("Microsoft.VSDesigner.Data.VS.DataSetToolboxItem, Microsoft.VSDesigner, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetDataSetSchema")]
     public partial class DataSet : System.ComponentModel.MarshalByValueComponent, System.ComponentModel.IListSource, System.ComponentModel.ISupportInitialize, System.ComponentModel.ISupportInitializeNotification, System.Runtime.Serialization.ISerializable, System.Xml.Serialization.IXmlSerializable
     {
@@ -969,7 +967,7 @@ namespace System.Data
         public int RowCount { get { throw null; } }
         public void CopyToRows(System.Data.DataRow[] array) { }
         public void CopyToRows(System.Data.DataRow[] array, int arrayIndex) { }
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo si, System.Runtime.Serialization.StreamingContext context) { }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public enum DbType
     {
@@ -1308,7 +1306,7 @@ namespace System.Data
         Output = 2,
         ReturnValue = 6,
     }
-    public partial class PropertyCollection : System.Collections.Hashtable
+    public partial class PropertyCollection : System.Collections.Hashtable, System.ICloneable
     {
         public PropertyCollection() { }
         protected PropertyCollection(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
@@ -1658,30 +1656,31 @@ namespace System.Data.Common
     }
     public abstract partial class DbColumn
     {
-        public bool? AllowDBNull { get { throw null; } protected set { } }
+        protected DbColumn() { }
+        public System.Nullable<bool> AllowDBNull { get { throw null; } protected set { } }
         public string BaseCatalogName { get { throw null; } protected set { } }
         public string BaseColumnName { get { throw null; } protected set { } }
         public string BaseSchemaName { get { throw null; } protected set { } }
         public string BaseServerName { get { throw null; } protected set { } }
         public string BaseTableName { get { throw null; } protected set { } }
         public string ColumnName { get { throw null; } protected set { } }
-        public int? ColumnOrdinal { get { throw null; } protected set { } }
-        public int? ColumnSize { get { throw null; } protected set { } }
-        public bool? IsAliased { get { throw null; } protected set { } }
-        public bool? IsAutoIncrement { get { throw null; } protected set { } }
-        public bool? IsExpression { get { throw null; } protected set { } }
-        public bool? IsHidden { get { throw null; } protected set { } }
-        public bool? IsIdentity { get { throw null; } protected set { } }
-        public bool? IsKey { get { throw null; } protected set { } }
-        public bool? IsLong { get { throw null; } protected set { } }
-        public bool? IsReadOnly { get { throw null; } protected set { } }
-        public bool? IsUnique { get { throw null; } protected set { } }
-        public int? NumericPrecision { get { throw null; } protected set { } }
-        public int? NumericScale { get { throw null; } protected set { } }
-        public string UdtAssemblyQualifiedName { get { throw null; } protected set { } }
+        public System.Nullable<int> ColumnOrdinal { get { throw null; } protected set { } }
+        public System.Nullable<int> ColumnSize { get { throw null; } protected set { } }
         public System.Type DataType { get { throw null; } protected set { } }
         public string DataTypeName { get { throw null; } protected set { } }
+        public System.Nullable<bool> IsAliased { get { throw null; } protected set { } }
+        public System.Nullable<bool> IsAutoIncrement { get { throw null; } protected set { } }
+        public System.Nullable<bool> IsExpression { get { throw null; } protected set { } }
+        public System.Nullable<bool> IsHidden { get { throw null; } protected set { } }
+        public System.Nullable<bool> IsIdentity { get { throw null; } protected set { } }
+        public System.Nullable<bool> IsKey { get { throw null; } protected set { } }
+        public System.Nullable<bool> IsLong { get { throw null; } protected set { } }
+        public System.Nullable<bool> IsReadOnly { get { throw null; } protected set { } }
+        public System.Nullable<bool> IsUnique { get { throw null; } protected set { } }
         public virtual object this[string property] { get { throw null; } }
+        public System.Nullable<int> NumericPrecision { get { throw null; } protected set { } }
+        public System.Nullable<int> NumericScale { get { throw null; } protected set { } }
+        public string UdtAssemblyQualifiedName { get { throw null; } protected set { } }
     }
     public abstract partial class DbCommand : System.ComponentModel.Component, System.Data.IDbCommand, System.IDisposable
     {
@@ -1961,9 +1960,9 @@ namespace System.Data.Common
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public abstract System.Collections.IEnumerator GetEnumerator();
         public abstract System.Type GetFieldType(int ordinal);
-        public virtual T GetFieldValue<T>(int ordinal) { throw null; }
         public System.Threading.Tasks.Task<T> GetFieldValueAsync<T>(int ordinal) { throw null; }
         public virtual System.Threading.Tasks.Task<T> GetFieldValueAsync<T>(int ordinal, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual T GetFieldValue<T>(int ordinal) { throw null; }
         public abstract float GetFloat(int ordinal);
         public abstract System.Guid GetGuid(int ordinal);
         public abstract short GetInt16(int ordinal);
@@ -1994,10 +1993,10 @@ namespace System.Data.Common
         public virtual System.Threading.Tasks.Task<bool> ReadAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         System.Data.IDataReader System.Data.IDataRecord.GetData(int ordinal) { throw null; }
     }
-    public static class DbDataReaderExtensions
+    public static partial class DbDataReaderExtensions
     {
-        public static System.Collections.ObjectModel.ReadOnlyCollection<System.Data.Common.DbColumn> GetColumnSchema(this System.Data.Common.DbDataReader reader) { throw null; }
         public static bool CanGetColumnSchema(this System.Data.Common.DbDataReader reader) { throw null; }
+        public static System.Collections.ObjectModel.ReadOnlyCollection<System.Data.Common.DbColumn> GetColumnSchema(this System.Data.Common.DbDataReader reader) { throw null; }
     }
     public abstract partial class DbDataRecord : System.ComponentModel.ICustomTypeDescriptor, System.Data.IDataRecord
     {
@@ -2199,6 +2198,13 @@ namespace System.Data.Common
         protected abstract void SetParameter(int index, System.Data.Common.DbParameter value);
         protected abstract void SetParameter(string parameterName, System.Data.Common.DbParameter value);
     }
+    public static partial class DbProviderFactories
+    {
+        public static System.Data.Common.DbProviderFactory GetFactory(System.Data.Common.DbConnection connection) { throw null; }
+        public static System.Data.Common.DbProviderFactory GetFactory(System.Data.DataRow providerRow) { throw null; }
+        public static System.Data.Common.DbProviderFactory GetFactory(string providerInvariantName) { throw null; }
+        public static System.Data.DataTable GetFactoryClasses() { throw null; }
+    }
     public abstract partial class DbProviderFactory
     {
         protected DbProviderFactory() { }
@@ -2211,14 +2217,7 @@ namespace System.Data.Common
         public virtual System.Data.Common.DbDataSourceEnumerator CreateDataSourceEnumerator() { throw null; }
         public virtual System.Data.Common.DbParameter CreateParameter() { throw null; }
     }
-    public static partial class DbProviderFactories
-    {
-        public static DbProviderFactory GetFactory(string providerInvariantName) { throw null; }
-        public static DbProviderFactory GetFactory(DataRow providerRow) { throw null; }
-        public static DbProviderFactory GetFactory(DbConnection connection) { throw null; }
-        public static DataTable GetFactoryClasses() { throw null; }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple = false, Inherited = true)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=true)]
     public sealed partial class DbProviderSpecificTypePropertyAttribute : System.Attribute
     {
         public DbProviderSpecificTypePropertyAttribute(bool isProviderSpecificTypeProperty) { }
@@ -2339,9 +2338,9 @@ namespace System.Data.SqlTypes
         public SqlAlreadyFilledException(string message, System.Exception e) { }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlBinary : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private object _dummy;
         public static readonly System.Data.SqlTypes.SqlBinary Null;
         public SqlBinary(byte[] value) { throw null; }
         public bool IsNull { get { throw null; } }
@@ -2364,10 +2363,10 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlBinary operator +(System.Data.SqlTypes.SqlBinary x, System.Data.SqlTypes.SqlBinary y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlBinary x, System.Data.SqlTypes.SqlBinary y) { throw null; }
         public static explicit operator byte[] (System.Data.SqlTypes.SqlBinary x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBinary(System.Data.SqlTypes.SqlGuid x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBinary (System.Data.SqlTypes.SqlGuid x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlBinary x, System.Data.SqlTypes.SqlBinary y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlBinary x, System.Data.SqlTypes.SqlBinary y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlBinary(byte[] x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlBinary (byte[] x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlBinary x, System.Data.SqlTypes.SqlBinary y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlBinary x, System.Data.SqlTypes.SqlBinary y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlBinary x, System.Data.SqlTypes.SqlBinary y) { throw null; }
@@ -2378,9 +2377,9 @@ namespace System.Data.SqlTypes
         public override string ToString() { throw null; }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlBoolean : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummy;
         public static readonly System.Data.SqlTypes.SqlBoolean False;
         public static readonly System.Data.SqlTypes.SqlBoolean Null;
         public static readonly System.Data.SqlTypes.SqlBoolean One;
@@ -2410,20 +2409,20 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlBoolean operator |(System.Data.SqlTypes.SqlBoolean x, System.Data.SqlTypes.SqlBoolean y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlBoolean x, System.Data.SqlTypes.SqlBoolean y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ^(System.Data.SqlTypes.SqlBoolean x, System.Data.SqlTypes.SqlBoolean y) { throw null; }
-        public static explicit operator bool(System.Data.SqlTypes.SqlBoolean x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBoolean(System.Data.SqlTypes.SqlByte x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBoolean(System.Data.SqlTypes.SqlDecimal x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBoolean(System.Data.SqlTypes.SqlDouble x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBoolean(System.Data.SqlTypes.SqlInt16 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBoolean(System.Data.SqlTypes.SqlInt32 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBoolean(System.Data.SqlTypes.SqlInt64 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBoolean(System.Data.SqlTypes.SqlMoney x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBoolean(System.Data.SqlTypes.SqlSingle x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBoolean(System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator bool (System.Data.SqlTypes.SqlBoolean x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBoolean (System.Data.SqlTypes.SqlByte x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBoolean (System.Data.SqlTypes.SqlDecimal x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBoolean (System.Data.SqlTypes.SqlDouble x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBoolean (System.Data.SqlTypes.SqlInt16 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBoolean (System.Data.SqlTypes.SqlInt32 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBoolean (System.Data.SqlTypes.SqlInt64 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBoolean (System.Data.SqlTypes.SqlMoney x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBoolean (System.Data.SqlTypes.SqlSingle x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBoolean (System.Data.SqlTypes.SqlString x) { throw null; }
         public static bool operator false(System.Data.SqlTypes.SqlBoolean x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlBoolean x, System.Data.SqlTypes.SqlBoolean y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlBoolean x, System.Data.SqlTypes.SqlBoolean y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlBoolean(bool x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlBoolean (bool x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlBoolean x, System.Data.SqlTypes.SqlBoolean y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlBoolean x, System.Data.SqlTypes.SqlBoolean y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlBoolean x, System.Data.SqlTypes.SqlBoolean y) { throw null; }
@@ -2448,9 +2447,9 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlBoolean Xor(System.Data.SqlTypes.SqlBoolean x, System.Data.SqlTypes.SqlBoolean y) { throw null; }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlByte : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummy;
         public static readonly System.Data.SqlTypes.SqlByte MaxValue;
         public static readonly System.Data.SqlTypes.SqlByte MinValue;
         public static readonly System.Data.SqlTypes.SqlByte Null;
@@ -2483,19 +2482,19 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlByte operator /(System.Data.SqlTypes.SqlByte x, System.Data.SqlTypes.SqlByte y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlByte x, System.Data.SqlTypes.SqlByte y) { throw null; }
         public static System.Data.SqlTypes.SqlByte operator ^(System.Data.SqlTypes.SqlByte x, System.Data.SqlTypes.SqlByte y) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlByte(System.Data.SqlTypes.SqlBoolean x) { throw null; }
-        public static explicit operator byte(System.Data.SqlTypes.SqlByte x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlByte(System.Data.SqlTypes.SqlDecimal x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlByte(System.Data.SqlTypes.SqlDouble x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlByte(System.Data.SqlTypes.SqlInt16 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlByte(System.Data.SqlTypes.SqlInt32 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlByte(System.Data.SqlTypes.SqlInt64 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlByte(System.Data.SqlTypes.SqlMoney x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlByte(System.Data.SqlTypes.SqlSingle x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlByte(System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlByte (System.Data.SqlTypes.SqlBoolean x) { throw null; }
+        public static explicit operator byte (System.Data.SqlTypes.SqlByte x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlByte (System.Data.SqlTypes.SqlDecimal x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlByte (System.Data.SqlTypes.SqlDouble x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlByte (System.Data.SqlTypes.SqlInt16 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlByte (System.Data.SqlTypes.SqlInt32 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlByte (System.Data.SqlTypes.SqlInt64 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlByte (System.Data.SqlTypes.SqlMoney x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlByte (System.Data.SqlTypes.SqlSingle x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlByte (System.Data.SqlTypes.SqlString x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlByte x, System.Data.SqlTypes.SqlByte y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlByte x, System.Data.SqlTypes.SqlByte y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlByte(byte x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlByte (byte x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlByte x, System.Data.SqlTypes.SqlByte y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlByte x, System.Data.SqlTypes.SqlByte y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlByte x, System.Data.SqlTypes.SqlByte y) { throw null; }
@@ -2537,8 +2536,8 @@ namespace System.Data.SqlTypes
         public System.IO.Stream Stream { get { throw null; } set { } }
         public byte[] Value { get { throw null; } }
         public static System.Xml.XmlQualifiedName GetXsdType(System.Xml.Schema.XmlSchemaSet schemaSet) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBytes(System.Data.SqlTypes.SqlBinary value) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlBinary(System.Data.SqlTypes.SqlBytes value) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBytes (System.Data.SqlTypes.SqlBinary value) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlBinary (System.Data.SqlTypes.SqlBytes value) { throw null; }
         public long Read(long offset, byte[] buffer, int offsetInBuffer, int count) { throw null; }
         public void SetLength(long value) { }
         public void SetNull() { }
@@ -2564,8 +2563,8 @@ namespace System.Data.SqlTypes
         public System.Data.SqlTypes.StorageState Storage { get { throw null; } }
         public char[] Value { get { throw null; } }
         public static System.Xml.XmlQualifiedName GetXsdType(System.Xml.Schema.XmlSchemaSet schemaSet) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlChars value) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlChars(System.Data.SqlTypes.SqlString value) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlChars value) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlChars (System.Data.SqlTypes.SqlString value) { throw null; }
         public long Read(long offset, char[] buffer, int offsetInBuffer, int count) { throw null; }
         public void SetLength(long value) { }
         public void SetNull() { }
@@ -2588,9 +2587,9 @@ namespace System.Data.SqlTypes
         None = 0,
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlDateTime : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummy;
         public static readonly System.Data.SqlTypes.SqlDateTime MaxValue;
         public static readonly System.Data.SqlTypes.SqlDateTime MinValue;
         public static readonly System.Data.SqlTypes.SqlDateTime Null;
@@ -2621,11 +2620,11 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlBoolean NotEquals(System.Data.SqlTypes.SqlDateTime x, System.Data.SqlTypes.SqlDateTime y) { throw null; }
         public static System.Data.SqlTypes.SqlDateTime operator +(System.Data.SqlTypes.SqlDateTime x, System.TimeSpan t) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlDateTime x, System.Data.SqlTypes.SqlDateTime y) { throw null; }
-        public static explicit operator System.DateTime(System.Data.SqlTypes.SqlDateTime x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlDateTime(System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator System.DateTime (System.Data.SqlTypes.SqlDateTime x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlDateTime (System.Data.SqlTypes.SqlString x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlDateTime x, System.Data.SqlTypes.SqlDateTime y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlDateTime x, System.Data.SqlTypes.SqlDateTime y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDateTime(System.DateTime value) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDateTime (System.DateTime value) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlDateTime x, System.Data.SqlTypes.SqlDateTime y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlDateTime x, System.Data.SqlTypes.SqlDateTime y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlDateTime x, System.Data.SqlTypes.SqlDateTime y) { throw null; }
@@ -2639,9 +2638,9 @@ namespace System.Data.SqlTypes
         public override string ToString() { throw null; }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlDecimal : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummy;
         public static readonly byte MaxPrecision;
         public static readonly byte MaxScale;
         public static readonly System.Data.SqlTypes.SqlDecimal MaxValue;
@@ -2682,21 +2681,21 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlDecimal operator +(System.Data.SqlTypes.SqlDecimal x, System.Data.SqlTypes.SqlDecimal y) { throw null; }
         public static System.Data.SqlTypes.SqlDecimal operator /(System.Data.SqlTypes.SqlDecimal x, System.Data.SqlTypes.SqlDecimal y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlDecimal x, System.Data.SqlTypes.SqlDecimal y) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlDecimal(System.Data.SqlTypes.SqlBoolean x) { throw null; }
-        public static explicit operator decimal(System.Data.SqlTypes.SqlDecimal x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlDecimal(System.Data.SqlTypes.SqlDouble x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlDecimal(System.Data.SqlTypes.SqlSingle x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlDecimal(System.Data.SqlTypes.SqlString x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlDecimal(double x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlDecimal (System.Data.SqlTypes.SqlBoolean x) { throw null; }
+        public static explicit operator decimal (System.Data.SqlTypes.SqlDecimal x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlDecimal (System.Data.SqlTypes.SqlDouble x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlDecimal (System.Data.SqlTypes.SqlSingle x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlDecimal (System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlDecimal (double x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlDecimal x, System.Data.SqlTypes.SqlDecimal y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlDecimal x, System.Data.SqlTypes.SqlDecimal y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDecimal(System.Data.SqlTypes.SqlByte x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDecimal(System.Data.SqlTypes.SqlInt16 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDecimal(System.Data.SqlTypes.SqlInt32 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDecimal(System.Data.SqlTypes.SqlInt64 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDecimal(System.Data.SqlTypes.SqlMoney x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDecimal(decimal x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDecimal(long x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDecimal (System.Data.SqlTypes.SqlByte x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDecimal (System.Data.SqlTypes.SqlInt16 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDecimal (System.Data.SqlTypes.SqlInt32 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDecimal (System.Data.SqlTypes.SqlInt64 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDecimal (System.Data.SqlTypes.SqlMoney x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDecimal (decimal x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDecimal (long x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlDecimal x, System.Data.SqlTypes.SqlDecimal y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlDecimal x, System.Data.SqlTypes.SqlDecimal y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlDecimal x, System.Data.SqlTypes.SqlDecimal y) { throw null; }
@@ -2725,9 +2724,9 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlDecimal Truncate(System.Data.SqlTypes.SqlDecimal n, int position) { throw null; }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlDouble : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummy;
         public static readonly System.Data.SqlTypes.SqlDouble MaxValue;
         public static readonly System.Data.SqlTypes.SqlDouble MinValue;
         public static readonly System.Data.SqlTypes.SqlDouble Null;
@@ -2752,19 +2751,19 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlDouble operator +(System.Data.SqlTypes.SqlDouble x, System.Data.SqlTypes.SqlDouble y) { throw null; }
         public static System.Data.SqlTypes.SqlDouble operator /(System.Data.SqlTypes.SqlDouble x, System.Data.SqlTypes.SqlDouble y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlDouble x, System.Data.SqlTypes.SqlDouble y) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlDouble(System.Data.SqlTypes.SqlBoolean x) { throw null; }
-        public static explicit operator double(System.Data.SqlTypes.SqlDouble x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlDouble(System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlDouble (System.Data.SqlTypes.SqlBoolean x) { throw null; }
+        public static explicit operator double (System.Data.SqlTypes.SqlDouble x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlDouble (System.Data.SqlTypes.SqlString x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlDouble x, System.Data.SqlTypes.SqlDouble y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlDouble x, System.Data.SqlTypes.SqlDouble y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDouble(System.Data.SqlTypes.SqlByte x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDouble(System.Data.SqlTypes.SqlDecimal x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDouble(System.Data.SqlTypes.SqlInt16 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDouble(System.Data.SqlTypes.SqlInt32 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDouble(System.Data.SqlTypes.SqlInt64 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDouble(System.Data.SqlTypes.SqlMoney x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDouble(System.Data.SqlTypes.SqlSingle x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlDouble(double x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDouble (System.Data.SqlTypes.SqlByte x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDouble (System.Data.SqlTypes.SqlDecimal x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDouble (System.Data.SqlTypes.SqlInt16 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDouble (System.Data.SqlTypes.SqlInt32 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDouble (System.Data.SqlTypes.SqlInt64 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDouble (System.Data.SqlTypes.SqlMoney x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDouble (System.Data.SqlTypes.SqlSingle x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlDouble (double x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlDouble x, System.Data.SqlTypes.SqlDouble y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlDouble x, System.Data.SqlTypes.SqlDouble y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlDouble x, System.Data.SqlTypes.SqlDouble y) { throw null; }
@@ -2788,9 +2787,9 @@ namespace System.Data.SqlTypes
         public override string ToString() { throw null; }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlGuid : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private object _dummy;
         public static readonly System.Data.SqlTypes.SqlGuid Null;
         public SqlGuid(byte[] value) { throw null; }
         public SqlGuid(System.Guid g) { throw null; }
@@ -2810,12 +2809,12 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlBoolean LessThanOrEqual(System.Data.SqlTypes.SqlGuid x, System.Data.SqlTypes.SqlGuid y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean NotEquals(System.Data.SqlTypes.SqlGuid x, System.Data.SqlTypes.SqlGuid y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlGuid x, System.Data.SqlTypes.SqlGuid y) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlGuid(System.Data.SqlTypes.SqlBinary x) { throw null; }
-        public static explicit operator System.Guid(System.Data.SqlTypes.SqlGuid x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlGuid(System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlGuid (System.Data.SqlTypes.SqlBinary x) { throw null; }
+        public static explicit operator System.Guid (System.Data.SqlTypes.SqlGuid x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlGuid (System.Data.SqlTypes.SqlString x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlGuid x, System.Data.SqlTypes.SqlGuid y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlGuid x, System.Data.SqlTypes.SqlGuid y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlGuid(System.Guid x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlGuid (System.Guid x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlGuid x, System.Data.SqlTypes.SqlGuid y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlGuid x, System.Data.SqlTypes.SqlGuid y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlGuid x, System.Data.SqlTypes.SqlGuid y) { throw null; }
@@ -2829,9 +2828,9 @@ namespace System.Data.SqlTypes
         public override string ToString() { throw null; }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlInt16 : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummy;
         public static readonly System.Data.SqlTypes.SqlInt16 MaxValue;
         public static readonly System.Data.SqlTypes.SqlInt16 MinValue;
         public static readonly System.Data.SqlTypes.SqlInt16 Null;
@@ -2864,19 +2863,19 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlInt16 operator /(System.Data.SqlTypes.SqlInt16 x, System.Data.SqlTypes.SqlInt16 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlInt16 x, System.Data.SqlTypes.SqlInt16 y) { throw null; }
         public static System.Data.SqlTypes.SqlInt16 operator ^(System.Data.SqlTypes.SqlInt16 x, System.Data.SqlTypes.SqlInt16 y) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt16(System.Data.SqlTypes.SqlBoolean x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt16(System.Data.SqlTypes.SqlDecimal x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt16(System.Data.SqlTypes.SqlDouble x) { throw null; }
-        public static explicit operator short(System.Data.SqlTypes.SqlInt16 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt16(System.Data.SqlTypes.SqlInt32 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt16(System.Data.SqlTypes.SqlInt64 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt16(System.Data.SqlTypes.SqlMoney x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt16(System.Data.SqlTypes.SqlSingle x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt16(System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt16 (System.Data.SqlTypes.SqlBoolean x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt16 (System.Data.SqlTypes.SqlDecimal x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt16 (System.Data.SqlTypes.SqlDouble x) { throw null; }
+        public static explicit operator short (System.Data.SqlTypes.SqlInt16 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt16 (System.Data.SqlTypes.SqlInt32 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt16 (System.Data.SqlTypes.SqlInt64 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt16 (System.Data.SqlTypes.SqlMoney x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt16 (System.Data.SqlTypes.SqlSingle x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt16 (System.Data.SqlTypes.SqlString x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlInt16 x, System.Data.SqlTypes.SqlInt16 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlInt16 x, System.Data.SqlTypes.SqlInt16 y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlInt16(System.Data.SqlTypes.SqlByte x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlInt16(short x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlInt16 (System.Data.SqlTypes.SqlByte x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlInt16 (short x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlInt16 x, System.Data.SqlTypes.SqlInt16 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlInt16 x, System.Data.SqlTypes.SqlInt16 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlInt16 x, System.Data.SqlTypes.SqlInt16 y) { throw null; }
@@ -2903,9 +2902,9 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlInt16 Xor(System.Data.SqlTypes.SqlInt16 x, System.Data.SqlTypes.SqlInt16 y) { throw null; }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlInt32 : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummy;
         public static readonly System.Data.SqlTypes.SqlInt32 MaxValue;
         public static readonly System.Data.SqlTypes.SqlInt32 MinValue;
         public static readonly System.Data.SqlTypes.SqlInt32 Null;
@@ -2938,19 +2937,19 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlInt32 operator /(System.Data.SqlTypes.SqlInt32 x, System.Data.SqlTypes.SqlInt32 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlInt32 x, System.Data.SqlTypes.SqlInt32 y) { throw null; }
         public static System.Data.SqlTypes.SqlInt32 operator ^(System.Data.SqlTypes.SqlInt32 x, System.Data.SqlTypes.SqlInt32 y) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt32(System.Data.SqlTypes.SqlBoolean x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt32(System.Data.SqlTypes.SqlDecimal x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt32(System.Data.SqlTypes.SqlDouble x) { throw null; }
-        public static explicit operator int(System.Data.SqlTypes.SqlInt32 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt32(System.Data.SqlTypes.SqlInt64 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt32(System.Data.SqlTypes.SqlMoney x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt32(System.Data.SqlTypes.SqlSingle x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt32(System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt32 (System.Data.SqlTypes.SqlBoolean x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt32 (System.Data.SqlTypes.SqlDecimal x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt32 (System.Data.SqlTypes.SqlDouble x) { throw null; }
+        public static explicit operator int (System.Data.SqlTypes.SqlInt32 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt32 (System.Data.SqlTypes.SqlInt64 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt32 (System.Data.SqlTypes.SqlMoney x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt32 (System.Data.SqlTypes.SqlSingle x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt32 (System.Data.SqlTypes.SqlString x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlInt32 x, System.Data.SqlTypes.SqlInt32 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlInt32 x, System.Data.SqlTypes.SqlInt32 y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlInt32(System.Data.SqlTypes.SqlByte x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlInt32(System.Data.SqlTypes.SqlInt16 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlInt32(int x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlInt32 (System.Data.SqlTypes.SqlByte x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlInt32 (System.Data.SqlTypes.SqlInt16 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlInt32 (int x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlInt32 x, System.Data.SqlTypes.SqlInt32 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlInt32 x, System.Data.SqlTypes.SqlInt32 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlInt32 x, System.Data.SqlTypes.SqlInt32 y) { throw null; }
@@ -2977,9 +2976,9 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlInt32 Xor(System.Data.SqlTypes.SqlInt32 x, System.Data.SqlTypes.SqlInt32 y) { throw null; }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlInt64 : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummy;
         public static readonly System.Data.SqlTypes.SqlInt64 MaxValue;
         public static readonly System.Data.SqlTypes.SqlInt64 MinValue;
         public static readonly System.Data.SqlTypes.SqlInt64 Null;
@@ -3012,19 +3011,19 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlInt64 operator /(System.Data.SqlTypes.SqlInt64 x, System.Data.SqlTypes.SqlInt64 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlInt64 x, System.Data.SqlTypes.SqlInt64 y) { throw null; }
         public static System.Data.SqlTypes.SqlInt64 operator ^(System.Data.SqlTypes.SqlInt64 x, System.Data.SqlTypes.SqlInt64 y) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt64(System.Data.SqlTypes.SqlBoolean x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt64(System.Data.SqlTypes.SqlDecimal x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt64(System.Data.SqlTypes.SqlDouble x) { throw null; }
-        public static explicit operator long(System.Data.SqlTypes.SqlInt64 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt64(System.Data.SqlTypes.SqlMoney x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt64(System.Data.SqlTypes.SqlSingle x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlInt64(System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt64 (System.Data.SqlTypes.SqlBoolean x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt64 (System.Data.SqlTypes.SqlDecimal x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt64 (System.Data.SqlTypes.SqlDouble x) { throw null; }
+        public static explicit operator long (System.Data.SqlTypes.SqlInt64 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt64 (System.Data.SqlTypes.SqlMoney x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt64 (System.Data.SqlTypes.SqlSingle x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlInt64 (System.Data.SqlTypes.SqlString x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlInt64 x, System.Data.SqlTypes.SqlInt64 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlInt64 x, System.Data.SqlTypes.SqlInt64 y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlInt64(System.Data.SqlTypes.SqlByte x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlInt64(System.Data.SqlTypes.SqlInt16 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlInt64(System.Data.SqlTypes.SqlInt32 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlInt64(long x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlInt64 (System.Data.SqlTypes.SqlByte x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlInt64 (System.Data.SqlTypes.SqlInt16 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlInt64 (System.Data.SqlTypes.SqlInt32 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlInt64 (long x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlInt64 x, System.Data.SqlTypes.SqlInt64 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlInt64 x, System.Data.SqlTypes.SqlInt64 y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlInt64 x, System.Data.SqlTypes.SqlInt64 y) { throw null; }
@@ -3051,9 +3050,9 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlInt64 Xor(System.Data.SqlTypes.SqlInt64 x, System.Data.SqlTypes.SqlInt64 y) { throw null; }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlMoney : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummy;
         public static readonly System.Data.SqlTypes.SqlMoney MaxValue;
         public static readonly System.Data.SqlTypes.SqlMoney MinValue;
         public static readonly System.Data.SqlTypes.SqlMoney Null;
@@ -3081,21 +3080,21 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlMoney operator +(System.Data.SqlTypes.SqlMoney x, System.Data.SqlTypes.SqlMoney y) { throw null; }
         public static System.Data.SqlTypes.SqlMoney operator /(System.Data.SqlTypes.SqlMoney x, System.Data.SqlTypes.SqlMoney y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlMoney x, System.Data.SqlTypes.SqlMoney y) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlMoney(System.Data.SqlTypes.SqlBoolean x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlMoney(System.Data.SqlTypes.SqlDecimal x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlMoney(System.Data.SqlTypes.SqlDouble x) { throw null; }
-        public static explicit operator decimal(System.Data.SqlTypes.SqlMoney x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlMoney(System.Data.SqlTypes.SqlSingle x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlMoney(System.Data.SqlTypes.SqlString x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlMoney(double x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlMoney (System.Data.SqlTypes.SqlBoolean x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlMoney (System.Data.SqlTypes.SqlDecimal x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlMoney (System.Data.SqlTypes.SqlDouble x) { throw null; }
+        public static explicit operator decimal (System.Data.SqlTypes.SqlMoney x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlMoney (System.Data.SqlTypes.SqlSingle x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlMoney (System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlMoney (double x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlMoney x, System.Data.SqlTypes.SqlMoney y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlMoney x, System.Data.SqlTypes.SqlMoney y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlMoney(System.Data.SqlTypes.SqlByte x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlMoney(System.Data.SqlTypes.SqlInt16 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlMoney(System.Data.SqlTypes.SqlInt32 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlMoney(System.Data.SqlTypes.SqlInt64 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlMoney(decimal x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlMoney(long x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlMoney (System.Data.SqlTypes.SqlByte x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlMoney (System.Data.SqlTypes.SqlInt16 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlMoney (System.Data.SqlTypes.SqlInt32 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlMoney (System.Data.SqlTypes.SqlInt64 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlMoney (decimal x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlMoney (long x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlMoney x, System.Data.SqlTypes.SqlMoney y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlMoney x, System.Data.SqlTypes.SqlMoney y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlMoney x, System.Data.SqlTypes.SqlMoney y) { throw null; }
@@ -3135,9 +3134,9 @@ namespace System.Data.SqlTypes
         public SqlNullValueException(string message, System.Exception e) { }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlSingle : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private int _dummy;
         public static readonly System.Data.SqlTypes.SqlSingle MaxValue;
         public static readonly System.Data.SqlTypes.SqlSingle MinValue;
         public static readonly System.Data.SqlTypes.SqlSingle Null;
@@ -3163,19 +3162,19 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlSingle operator +(System.Data.SqlTypes.SqlSingle x, System.Data.SqlTypes.SqlSingle y) { throw null; }
         public static System.Data.SqlTypes.SqlSingle operator /(System.Data.SqlTypes.SqlSingle x, System.Data.SqlTypes.SqlSingle y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlSingle x, System.Data.SqlTypes.SqlSingle y) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlSingle(System.Data.SqlTypes.SqlBoolean x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlSingle(System.Data.SqlTypes.SqlDouble x) { throw null; }
-        public static explicit operator float(System.Data.SqlTypes.SqlSingle x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlSingle(System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlSingle (System.Data.SqlTypes.SqlBoolean x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlSingle (System.Data.SqlTypes.SqlDouble x) { throw null; }
+        public static explicit operator float (System.Data.SqlTypes.SqlSingle x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlSingle (System.Data.SqlTypes.SqlString x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlSingle x, System.Data.SqlTypes.SqlSingle y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlSingle x, System.Data.SqlTypes.SqlSingle y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlSingle(System.Data.SqlTypes.SqlByte x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlSingle(System.Data.SqlTypes.SqlDecimal x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlSingle(System.Data.SqlTypes.SqlInt16 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlSingle(System.Data.SqlTypes.SqlInt32 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlSingle(System.Data.SqlTypes.SqlInt64 x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlSingle(System.Data.SqlTypes.SqlMoney x) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlSingle(float x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlSingle (System.Data.SqlTypes.SqlByte x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlSingle (System.Data.SqlTypes.SqlDecimal x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlSingle (System.Data.SqlTypes.SqlInt16 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlSingle (System.Data.SqlTypes.SqlInt32 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlSingle (System.Data.SqlTypes.SqlInt64 x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlSingle (System.Data.SqlTypes.SqlMoney x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlSingle (float x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlSingle x, System.Data.SqlTypes.SqlSingle y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlSingle x, System.Data.SqlTypes.SqlSingle y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlSingle x, System.Data.SqlTypes.SqlSingle y) { throw null; }
@@ -3199,9 +3198,9 @@ namespace System.Data.SqlTypes
         public override string ToString() { throw null; }
     }
     [System.Xml.Serialization.XmlSchemaProviderAttribute("GetXsdType")]
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SqlString : System.Data.SqlTypes.INullable, System.IComparable, System.Xml.Serialization.IXmlSerializable
     {
+        private object _dummy;
         public static readonly int BinarySort;
         public static readonly int BinarySort2;
         public static readonly int IgnoreCase;
@@ -3241,21 +3240,21 @@ namespace System.Data.SqlTypes
         public static System.Data.SqlTypes.SqlBoolean NotEquals(System.Data.SqlTypes.SqlString x, System.Data.SqlTypes.SqlString y) { throw null; }
         public static System.Data.SqlTypes.SqlString operator +(System.Data.SqlTypes.SqlString x, System.Data.SqlTypes.SqlString y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator ==(System.Data.SqlTypes.SqlString x, System.Data.SqlTypes.SqlString y) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlBoolean x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlByte x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlDateTime x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlDecimal x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlDouble x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlGuid x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlInt16 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlInt32 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlInt64 x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlMoney x) { throw null; }
-        public static explicit operator System.Data.SqlTypes.SqlString(System.Data.SqlTypes.SqlSingle x) { throw null; }
-        public static explicit operator string(System.Data.SqlTypes.SqlString x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlBoolean x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlByte x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlDateTime x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlDecimal x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlDouble x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlGuid x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlInt16 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlInt32 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlInt64 x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlMoney x) { throw null; }
+        public static explicit operator System.Data.SqlTypes.SqlString (System.Data.SqlTypes.SqlSingle x) { throw null; }
+        public static explicit operator string (System.Data.SqlTypes.SqlString x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >(System.Data.SqlTypes.SqlString x, System.Data.SqlTypes.SqlString y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator >=(System.Data.SqlTypes.SqlString x, System.Data.SqlTypes.SqlString y) { throw null; }
-        public static implicit operator System.Data.SqlTypes.SqlString(string x) { throw null; }
+        public static implicit operator System.Data.SqlTypes.SqlString (string x) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator !=(System.Data.SqlTypes.SqlString x, System.Data.SqlTypes.SqlString y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <(System.Data.SqlTypes.SqlString x, System.Data.SqlTypes.SqlString y) { throw null; }
         public static System.Data.SqlTypes.SqlBoolean operator <=(System.Data.SqlTypes.SqlString x, System.Data.SqlTypes.SqlString y) { throw null; }

--- a/src/System.Diagnostics.PerformanceCounter/ref/System.Diagnostics.PerformanceCounter.cs
+++ b/src/System.Diagnostics.PerformanceCounter/ref/System.Diagnostics.PerformanceCounter.cs
@@ -31,12 +31,12 @@ namespace System.Diagnostics
         protected override void OnValidate(object value) { }
         public virtual void Remove(System.Diagnostics.CounterCreationData value) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CounterSample
     {
+        private readonly int _dummy;
         public static System.Diagnostics.CounterSample Empty;
-        public CounterSample(long rawValue, long baseValue, long counterFrequency, long systemFrequency, long timeStamp, long timeStamp100nSec, System.Diagnostics.PerformanceCounterType counterType) { throw null;}
-        public CounterSample(long rawValue, long baseValue, long counterFrequency, long systemFrequency, long timeStamp, long timeStamp100nSec, System.Diagnostics.PerformanceCounterType counterType, long counterTimeStamp) { throw null;}
+        public CounterSample(long rawValue, long baseValue, long counterFrequency, long systemFrequency, long timeStamp, long timeStamp100nSec, System.Diagnostics.PerformanceCounterType counterType) { throw null; }
+        public CounterSample(long rawValue, long baseValue, long counterFrequency, long systemFrequency, long timeStamp, long timeStamp100nSec, System.Diagnostics.PerformanceCounterType counterType, long counterTimeStamp) { throw null; }
         public long BaseValue { get { throw null; } }
         public long CounterFrequency { get { throw null; } }
         public long CounterTimeStamp { get { throw null; } }
@@ -171,7 +171,7 @@ namespace System.Diagnostics
         [System.ObsoleteAttribute("This class has been deprecated.  Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
         void System.Diagnostics.ICollectData.CloseData() { }
         [System.ObsoleteAttribute("This class has been deprecated.  Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
-        void System.Diagnostics.ICollectData.CollectData(int callIdx, System.IntPtr valueNamePtr, System.IntPtr dataPtr, int totalBytes, out System.IntPtr res) { res = default(System.IntPtr); }
+        void System.Diagnostics.ICollectData.CollectData(int callIdx, System.IntPtr valueNamePtr, System.IntPtr dataPtr, int totalBytes, out System.IntPtr res) { throw null; }
     }
     public enum PerformanceCounterType
     {

--- a/src/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
+++ b/src/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
@@ -5,7 +5,6 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System.Diagnostics
 {
     public partial class StackFrame
@@ -52,7 +51,6 @@ namespace System.Diagnostics
         public override string ToString() { throw null; }
     }
 }
-
 namespace System.Diagnostics.SymbolStore
 {
     public partial interface ISymbolBinder
@@ -172,9 +170,9 @@ namespace System.Diagnostics.SymbolStore
         NativeSectionOffset = 10,
         NativeStackRegister = 8,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SymbolToken
     {
+        private readonly object _dummy;
         public SymbolToken(int val) { throw null; }
         public bool Equals(System.Diagnostics.SymbolStore.SymbolToken obj) { throw null; }
         public override bool Equals(object obj) { throw null; }

--- a/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
+++ b/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
@@ -222,6 +222,7 @@ namespace System.Diagnostics.Tracing
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         protected internal partial struct EventData
         {
+            private int _dummy;
             public System.IntPtr DataPointer { get { throw null; } set { } }
             public int Size { get { throw null; } set { } }
         }
@@ -251,6 +252,7 @@ namespace System.Diagnostics.Tracing
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EventSourceOptions
     {
+        private int _dummy;
         public System.Diagnostics.Tracing.EventActivityOptions ActivityOptions { get { throw null; } set { } }
         public System.Diagnostics.Tracing.EventKeywords Keywords { get { throw null; } set { } }
         public System.Diagnostics.Tracing.EventLevel Level { get { throw null; } set { } }

--- a/src/System.Drawing.Common/ref/System.Drawing.Common.cs
+++ b/src/System.Drawing.Common/ref/System.Drawing.Common.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 // ------------------------------------------------------------------------------
-// Changes to this file must follow the http://aka.ms/api-review process
+// Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
 namespace System.Drawing
@@ -227,10 +227,10 @@ namespace System.Drawing
     {
         public static System.Drawing.BufferedGraphicsContext Current { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CharacterRange
     {
-        public CharacterRange(int First, int Length) { throw null;}
+        private int _dummy;
+        public CharacterRange(int First, int Length) { throw null; }
         public int First { get { throw null; } set { } }
         public int Length { get { throw null; } set { } }
         public override bool Equals(object obj) { throw null; }
@@ -280,7 +280,7 @@ namespace System.Drawing
         SourcePaint = 15597702,
         Whiteness = 16711778,
     }
-    public sealed partial class Font : System.MarshalByRefObject, System.ICloneable, System.IDisposable, Runtime.Serialization.ISerializable
+    public sealed partial class Font : System.MarshalByRefObject, System.ICloneable, System.IDisposable, System.Runtime.Serialization.ISerializable
     {
         public Font(System.Drawing.Font prototype, System.Drawing.FontStyle newStyle) { }
         public Font(System.Drawing.FontFamily family, float emSize) { }
@@ -337,7 +337,7 @@ namespace System.Drawing
         public float GetHeight() { throw null; }
         public float GetHeight(System.Drawing.Graphics graphics) { throw null; }
         public float GetHeight(float dpi) { throw null; }
-        void Runtime.Serialization.ISerializable.GetObjectData(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo si, System.Runtime.Serialization.StreamingContext context) { }
         public System.IntPtr ToHfont() { throw null; }
         public void ToLogFont(object logFont) { }
         public void ToLogFont(object logFont, System.Drawing.Graphics graphics) { }
@@ -592,7 +592,7 @@ namespace System.Drawing
         public System.Drawing.SizeF MeasureString(string text, System.Drawing.Font font, System.Drawing.PointF origin, System.Drawing.StringFormat stringFormat) { throw null; }
         public System.Drawing.SizeF MeasureString(string text, System.Drawing.Font font, System.Drawing.SizeF layoutArea) { throw null; }
         public System.Drawing.SizeF MeasureString(string text, System.Drawing.Font font, System.Drawing.SizeF layoutArea, System.Drawing.StringFormat stringFormat) { throw null; }
-        public System.Drawing.SizeF MeasureString(string text, System.Drawing.Font font, System.Drawing.SizeF layoutArea, System.Drawing.StringFormat stringFormat, out int charactersFitted, out int linesFilled) { charactersFitted = default(int); linesFilled = default(int); throw null; }
+        public System.Drawing.SizeF MeasureString(string text, System.Drawing.Font font, System.Drawing.SizeF layoutArea, System.Drawing.StringFormat stringFormat, out int charactersFitted, out int linesFilled) { throw null; }
         public System.Drawing.SizeF MeasureString(string text, System.Drawing.Font font, int width) { throw null; }
         public System.Drawing.SizeF MeasureString(string text, System.Drawing.Font font, int width, System.Drawing.StringFormat format) { throw null; }
         public void MultiplyTransform(System.Drawing.Drawing2D.Matrix matrix) { }
@@ -638,7 +638,7 @@ namespace System.Drawing
         Point = 3,
         World = 0,
     }
-    public sealed partial class Icon : System.MarshalByRefObject, System.ICloneable, System.IDisposable, Runtime.Serialization.ISerializable
+    public sealed partial class Icon : System.MarshalByRefObject, System.ICloneable, System.IDisposable, System.Runtime.Serialization.ISerializable
     {
         public Icon(System.Drawing.Icon original, System.Drawing.Size size) { }
         public Icon(System.Drawing.Icon original, int width, int height) { }
@@ -661,8 +661,8 @@ namespace System.Drawing
         public static System.Drawing.Icon ExtractAssociatedIcon(string filePath) { throw null; }
         ~Icon() { }
         public static System.Drawing.Icon FromHandle(System.IntPtr handle) { throw null; }
-        void Runtime.Serialization.ISerializable.GetObjectData(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
         public void Save(System.IO.Stream outputStream) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public System.Drawing.Bitmap ToBitmap() { throw null; }
         public override string ToString() { throw null; }
     }
@@ -672,7 +672,7 @@ namespace System.Drawing
         void ReleaseHdc();
     }
     [System.ComponentModel.ImmutableObjectAttribute(true)]
-    public abstract partial class Image : System.MarshalByRefObject, System.ICloneable, System.IDisposable, Runtime.Serialization.ISerializable
+    public abstract partial class Image : System.MarshalByRefObject, System.ICloneable, System.IDisposable, System.Runtime.Serialization.ISerializable
     {
         internal Image() { }
         [System.ComponentModel.BrowsableAttribute(false)]
@@ -716,7 +716,6 @@ namespace System.Drawing
         public System.Drawing.RectangleF GetBounds(ref System.Drawing.GraphicsUnit pageUnit) { throw null; }
         public System.Drawing.Imaging.EncoderParameters GetEncoderParameterList(System.Guid encoder) { throw null; }
         public int GetFrameCount(System.Drawing.Imaging.FrameDimension dimension) { throw null; }
-        void Runtime.Serialization.ISerializable.GetObjectData(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
         public static int GetPixelFormatSize(System.Drawing.Imaging.PixelFormat pixfmt) { throw null; }
         public System.Drawing.Imaging.PropertyItem GetPropertyItem(int propid) { throw null; }
         public System.Drawing.Image GetThumbnailImage(int thumbWidth, int thumbHeight, System.Drawing.Image.GetThumbnailImageAbort callback, System.IntPtr callbackData) { throw null; }
@@ -734,6 +733,7 @@ namespace System.Drawing
         public void SaveAdd(System.Drawing.Imaging.EncoderParameters encoderParams) { }
         public int SelectActiveFrame(System.Drawing.Imaging.FrameDimension dimension, int frameIndex) { throw null; }
         public void SetPropertyItem(System.Drawing.Imaging.PropertyItem propitem) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public delegate bool GetThumbnailImageAbort();
     }
     public sealed partial class ImageAnimator
@@ -1043,7 +1043,7 @@ namespace System.Drawing
         public object Clone() { throw null; }
         public void Dispose() { }
         ~StringFormat() { }
-        public float[] GetTabStops(out float firstTabOffset) { firstTabOffset = default(float); throw null; }
+        public float[] GetTabStops(out float firstTabOffset) { throw null; }
         public void SetDigitSubstitution(int language, System.Drawing.StringDigitSubstitute substitute) { }
         public void SetMeasurableCharacterRanges(System.Drawing.CharacterRange[] ranges) { }
         public void SetTabStops(float firstTabOffset, float[] tabStops) { }
@@ -1337,7 +1337,7 @@ namespace System.Drawing.Drawing2D
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         ~CustomLineCap() { }
-        public void GetStrokeCaps(out System.Drawing.Drawing2D.LineCap startCap, out System.Drawing.Drawing2D.LineCap endCap) { startCap = default(System.Drawing.Drawing2D.LineCap); endCap = default(System.Drawing.Drawing2D.LineCap); }
+        public void GetStrokeCaps(out System.Drawing.Drawing2D.LineCap startCap, out System.Drawing.Drawing2D.LineCap endCap) { throw null; }
         public void SetStrokeCaps(System.Drawing.Drawing2D.LineCap startCap, System.Drawing.Drawing2D.LineCap endCap) { }
     }
     public enum DashCap
@@ -1479,10 +1479,10 @@ namespace System.Drawing.Drawing2D
         ~GraphicsPathIterator() { }
         public bool HasCurve() { throw null; }
         public int NextMarker(System.Drawing.Drawing2D.GraphicsPath path) { throw null; }
-        public int NextMarker(out int startIndex, out int endIndex) { startIndex = default(int); endIndex = default(int); throw null; }
-        public int NextPathType(out byte pathType, out int startIndex, out int endIndex) { pathType = default(byte); startIndex = default(int); endIndex = default(int); throw null; }
-        public int NextSubpath(System.Drawing.Drawing2D.GraphicsPath path, out bool isClosed) { isClosed = default(bool); throw null; }
-        public int NextSubpath(out int startIndex, out int endIndex, out bool isClosed) { startIndex = default(int); endIndex = default(int); isClosed = default(bool); throw null; }
+        public int NextMarker(out int startIndex, out int endIndex) { throw null; }
+        public int NextPathType(out byte pathType, out int startIndex, out int endIndex) { throw null; }
+        public int NextSubpath(System.Drawing.Drawing2D.GraphicsPath path, out bool isClosed) { throw null; }
+        public int NextSubpath(out int startIndex, out int endIndex, out bool isClosed) { throw null; }
         public void Rewind() { }
     }
     public sealed partial class GraphicsState : System.MarshalByRefObject
@@ -2519,8 +2519,9 @@ namespace System.Drawing.Printing
     }
     public partial class InvalidPrinterException : System.SystemException
     {
-        protected InvalidPrinterException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
         public InvalidPrinterException(System.Drawing.Printing.PrinterSettings settings) { }
+        protected InvalidPrinterException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public partial class Margins : System.ICloneable
     {

--- a/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.cs
+++ b/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.cs
@@ -9,6 +9,7 @@ namespace System.Drawing
 {
     public readonly partial struct Color : System.IEquatable<System.Drawing.Color>
     {
+        private readonly object _dummy;
         public static readonly System.Drawing.Color Empty;
         public byte A { get { throw null; } }
         public static System.Drawing.Color AliceBlue { get { throw null; } }
@@ -176,205 +177,6 @@ namespace System.Drawing
         public static bool operator !=(System.Drawing.Color left, System.Drawing.Color right) { throw null; }
         public int ToArgb() { throw null; }
         public System.Drawing.KnownColor ToKnownColor() { throw null; }
-        public override string ToString() { throw null; }
-    }
-    public partial struct Point : System.IEquatable<System.Drawing.Point>
-    {
-        public static readonly System.Drawing.Point Empty;
-        public Point(System.Drawing.Size sz) { throw null; }
-        public Point(int dw) { throw null; }
-        public Point(int x, int y) { throw null; }
-        [System.ComponentModel.Browsable(false)]
-        public bool IsEmpty { get { throw null; } }
-        public int X { get { throw null; } set { } }
-        public int Y { get { throw null; } set { } }
-        public static System.Drawing.Point Add(System.Drawing.Point pt, System.Drawing.Size sz) { throw null; }
-        public static System.Drawing.Point Ceiling(System.Drawing.PointF value) { throw null; }
-        public bool Equals(System.Drawing.Point other) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public void Offset(System.Drawing.Point p) { }
-        public void Offset(int dx, int dy) { }
-        public static System.Drawing.Point operator +(System.Drawing.Point pt, System.Drawing.Size sz) { throw null; }
-        public static bool operator ==(System.Drawing.Point left, System.Drawing.Point right) { throw null; }
-        public static explicit operator System.Drawing.Size (System.Drawing.Point p) { throw null; }
-        public static implicit operator System.Drawing.PointF (System.Drawing.Point p) { throw null; }
-        public static bool operator !=(System.Drawing.Point left, System.Drawing.Point right) { throw null; }
-        public static System.Drawing.Point operator -(System.Drawing.Point pt, System.Drawing.Size sz) { throw null; }
-        public static System.Drawing.Point Round(System.Drawing.PointF value) { throw null; }
-        public static System.Drawing.Point Subtract(System.Drawing.Point pt, System.Drawing.Size sz) { throw null; }
-        public override string ToString() { throw null; }
-        public static System.Drawing.Point Truncate(System.Drawing.PointF value) { throw null; }
-    }
-    public partial struct PointF : System.IEquatable<System.Drawing.PointF>
-    {
-        public static readonly System.Drawing.PointF Empty;
-        public PointF(float x, float y) { throw null; }
-        [System.ComponentModel.Browsable(false)]
-        public bool IsEmpty { get { throw null; } }
-        public float X { get { throw null; } set { } }
-        public float Y { get { throw null; } set { } }
-        public static System.Drawing.PointF Add(System.Drawing.PointF pt, System.Drawing.Size sz) { throw null; }
-        public static System.Drawing.PointF Add(System.Drawing.PointF pt, System.Drawing.SizeF sz) { throw null; }
-        public bool Equals(System.Drawing.PointF other) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static System.Drawing.PointF operator +(System.Drawing.PointF pt, System.Drawing.Size sz) { throw null; }
-        public static System.Drawing.PointF operator +(System.Drawing.PointF pt, System.Drawing.SizeF sz) { throw null; }
-        public static bool operator ==(System.Drawing.PointF left, System.Drawing.PointF right) { throw null; }
-        public static bool operator !=(System.Drawing.PointF left, System.Drawing.PointF right) { throw null; }
-        public static System.Drawing.PointF operator -(System.Drawing.PointF pt, System.Drawing.Size sz) { throw null; }
-        public static System.Drawing.PointF operator -(System.Drawing.PointF pt, System.Drawing.SizeF sz) { throw null; }
-        public static System.Drawing.PointF Subtract(System.Drawing.PointF pt, System.Drawing.Size sz) { throw null; }
-        public static System.Drawing.PointF Subtract(System.Drawing.PointF pt, System.Drawing.SizeF sz) { throw null; }
-        public override string ToString() { throw null; }
-    }
-    public partial struct Rectangle : System.IEquatable<System.Drawing.Rectangle>
-    {
-        public static readonly System.Drawing.Rectangle Empty;
-        public Rectangle(System.Drawing.Point location, System.Drawing.Size size) { throw null; }
-        public Rectangle(int x, int y, int width, int height) { throw null; }
-        [System.ComponentModel.Browsable(false)]
-        public int Bottom { get { throw null; } }
-        public int Height { get { throw null; } set { } }
-        [System.ComponentModel.Browsable(false)]
-        public bool IsEmpty { get { throw null; } }
-        [System.ComponentModel.Browsable(false)]
-        public int Left { get { throw null; } }
-        [System.ComponentModel.Browsable(false)]
-        public System.Drawing.Point Location { get { throw null; } set { } }
-        [System.ComponentModel.Browsable(false)]
-        public int Right { get { throw null; } }
-        [System.ComponentModel.Browsable(false)]
-        public System.Drawing.Size Size { get { throw null; } set { } }
-        [System.ComponentModel.Browsable(false)]
-        public int Top { get { throw null; } }
-        public int Width { get { throw null; } set { } }
-        public int X { get { throw null; } set { } }
-        public int Y { get { throw null; } set { } }
-        public static System.Drawing.Rectangle Ceiling(System.Drawing.RectangleF value) { throw null; }
-        public bool Contains(System.Drawing.Point pt) { throw null; }
-        public bool Contains(System.Drawing.Rectangle rect) { throw null; }
-        public bool Contains(int x, int y) { throw null; }
-        public bool Equals(System.Drawing.Rectangle other) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public static System.Drawing.Rectangle FromLTRB(int left, int top, int right, int bottom) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static System.Drawing.Rectangle Inflate(System.Drawing.Rectangle rect, int x, int y) { throw null; }
-        public void Inflate(System.Drawing.Size size) { }
-        public void Inflate(int width, int height) { }
-        public void Intersect(System.Drawing.Rectangle rect) { }
-        public static System.Drawing.Rectangle Intersect(System.Drawing.Rectangle a, System.Drawing.Rectangle b) { throw null; }
-        public bool IntersectsWith(System.Drawing.Rectangle rect) { throw null; }
-        public void Offset(System.Drawing.Point pos) { }
-        public void Offset(int x, int y) { }
-        public static bool operator ==(System.Drawing.Rectangle left, System.Drawing.Rectangle right) { throw null; }
-        public static bool operator !=(System.Drawing.Rectangle left, System.Drawing.Rectangle right) { throw null; }
-        public static System.Drawing.Rectangle Round(System.Drawing.RectangleF value) { throw null; }
-        public override string ToString() { throw null; }
-        public static System.Drawing.Rectangle Truncate(System.Drawing.RectangleF value) { throw null; }
-        public static System.Drawing.Rectangle Union(System.Drawing.Rectangle a, System.Drawing.Rectangle b) { throw null; }
-    }
-    public partial struct RectangleF : System.IEquatable<System.Drawing.RectangleF>
-    {
-        public static readonly System.Drawing.RectangleF Empty;
-        public RectangleF(System.Drawing.PointF location, System.Drawing.SizeF size) { throw null; }
-        public RectangleF(float x, float y, float width, float height) { throw null; }
-        [System.ComponentModel.Browsable(false)]
-        public float Bottom { get { throw null; } }
-        public float Height { get { throw null; } set { } }
-        [System.ComponentModel.Browsable(false)]
-        public bool IsEmpty { get { throw null; } }
-        [System.ComponentModel.Browsable(false)]
-        public float Left { get { throw null; } }
-        [System.ComponentModel.Browsable(false)]
-        public System.Drawing.PointF Location { get { throw null; } set { } }
-        [System.ComponentModel.Browsable(false)]
-        public float Right { get { throw null; } }
-        [System.ComponentModel.Browsable(false)]
-        public System.Drawing.SizeF Size { get { throw null; } set { } }
-        [System.ComponentModel.Browsable(false)]
-        public float Top { get { throw null; } }
-        public float Width { get { throw null; } set { } }
-        public float X { get { throw null; } set { } }
-        public float Y { get { throw null; } set { } }
-        public bool Contains(System.Drawing.PointF pt) { throw null; }
-        public bool Contains(System.Drawing.RectangleF rect) { throw null; }
-        public bool Contains(float x, float y) { throw null; }
-        public bool Equals(System.Drawing.RectangleF other) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public static System.Drawing.RectangleF FromLTRB(float left, float top, float right, float bottom) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static System.Drawing.RectangleF Inflate(System.Drawing.RectangleF rect, float x, float y) { throw null; }
-        public void Inflate(System.Drawing.SizeF size) { }
-        public void Inflate(float x, float y) { }
-        public void Intersect(System.Drawing.RectangleF rect) { }
-        public static System.Drawing.RectangleF Intersect(System.Drawing.RectangleF a, System.Drawing.RectangleF b) { throw null; }
-        public bool IntersectsWith(System.Drawing.RectangleF rect) { throw null; }
-        public void Offset(System.Drawing.PointF pos) { }
-        public void Offset(float x, float y) { }
-        public static bool operator ==(System.Drawing.RectangleF left, System.Drawing.RectangleF right) { throw null; }
-        public static implicit operator System.Drawing.RectangleF (System.Drawing.Rectangle r) { throw null; }
-        public static bool operator !=(System.Drawing.RectangleF left, System.Drawing.RectangleF right) { throw null; }
-        public override string ToString() { throw null; }
-        public static System.Drawing.RectangleF Union(System.Drawing.RectangleF a, System.Drawing.RectangleF b) { throw null; }
-    }
-    public partial struct Size : System.IEquatable<System.Drawing.Size>
-    {
-        public static readonly System.Drawing.Size Empty;
-        public Size(System.Drawing.Point pt) { throw null; }
-        public Size(int width, int height) { throw null; }
-        public int Height { get { throw null; } set { } }
-        [System.ComponentModel.Browsable(false)]
-        public bool IsEmpty { get { throw null; } }
-        public int Width { get { throw null; } set { } }
-        public static System.Drawing.Size Add(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
-        public static System.Drawing.Size Ceiling(System.Drawing.SizeF value) { throw null; }
-        public bool Equals(System.Drawing.Size other) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static System.Drawing.Size operator +(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
-        public static System.Drawing.Size operator *(int left, System.Drawing.Size right) { throw null; }
-        public static System.Drawing.Size operator *(System.Drawing.Size left, int right) { throw null; }
-        public static System.Drawing.SizeF operator *(float left, System.Drawing.Size right) { throw null; }
-        public static System.Drawing.SizeF operator *(System.Drawing.Size left, float right) { throw null; }
-        public static System.Drawing.Size operator /(System.Drawing.Size left, int right) { throw null; }
-        public static System.Drawing.SizeF operator /(System.Drawing.Size left, float right) { throw null; }
-        public static bool operator ==(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
-        public static explicit operator System.Drawing.Point (System.Drawing.Size size) { throw null; }
-        public static implicit operator System.Drawing.SizeF (System.Drawing.Size p) { throw null; }
-        public static bool operator !=(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
-        public static System.Drawing.Size operator -(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
-        public static System.Drawing.Size Round(System.Drawing.SizeF value) { throw null; }
-        public static System.Drawing.Size Subtract(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
-        public override string ToString() { throw null; }
-        public static System.Drawing.Size Truncate(System.Drawing.SizeF value) { throw null; }
-    }
-    public partial struct SizeF : System.IEquatable<System.Drawing.SizeF>
-    {
-        public static readonly System.Drawing.SizeF Empty;
-        public SizeF(System.Drawing.PointF pt) { throw null; }
-        public SizeF(System.Drawing.SizeF size) { throw null; }
-        public SizeF(float width, float height) { throw null; }
-        public float Height { get { throw null; } set { } }
-        [System.ComponentModel.Browsable(false)]
-        public bool IsEmpty { get { throw null; } }
-        public float Width { get { throw null; } set { } }
-        public static System.Drawing.SizeF Add(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
-        public bool Equals(System.Drawing.SizeF other) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static System.Drawing.SizeF operator +(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
-        public static bool operator ==(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
-        public static explicit operator System.Drawing.PointF (System.Drawing.SizeF size) { throw null; }
-        public static bool operator !=(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
-        public static System.Drawing.SizeF operator -(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
-        public static System.Drawing.SizeF Subtract(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
-        public static System.Drawing.SizeF operator *(float left, System.Drawing.SizeF right) { throw null; }
-        public static System.Drawing.SizeF operator *(System.Drawing.SizeF left, float right) { throw null; }
-        public static System.Drawing.SizeF operator /(System.Drawing.SizeF left, float right) { throw null; }
-        public System.Drawing.PointF ToPointF() { throw null; }
-        public System.Drawing.Size ToSize() { throw null; }
         public override string ToString() { throw null; }
     }
     public enum KnownColor
@@ -553,5 +355,210 @@ namespace System.Drawing
         WindowText = 26,
         Yellow = 166,
         YellowGreen = 167,
+    }
+    public partial struct Point : System.IEquatable<System.Drawing.Point>
+    {
+        private int _dummy;
+        public static readonly System.Drawing.Point Empty;
+        public Point(System.Drawing.Size sz) { throw null; }
+        public Point(int dw) { throw null; }
+        public Point(int x, int y) { throw null; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public bool IsEmpty { get { throw null; } }
+        public int X { get { throw null; } set { } }
+        public int Y { get { throw null; } set { } }
+        public static System.Drawing.Point Add(System.Drawing.Point pt, System.Drawing.Size sz) { throw null; }
+        public static System.Drawing.Point Ceiling(System.Drawing.PointF value) { throw null; }
+        public bool Equals(System.Drawing.Point other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public void Offset(System.Drawing.Point p) { }
+        public void Offset(int dx, int dy) { }
+        public static System.Drawing.Point operator +(System.Drawing.Point pt, System.Drawing.Size sz) { throw null; }
+        public static bool operator ==(System.Drawing.Point left, System.Drawing.Point right) { throw null; }
+        public static explicit operator System.Drawing.Size (System.Drawing.Point p) { throw null; }
+        public static implicit operator System.Drawing.PointF (System.Drawing.Point p) { throw null; }
+        public static bool operator !=(System.Drawing.Point left, System.Drawing.Point right) { throw null; }
+        public static System.Drawing.Point operator -(System.Drawing.Point pt, System.Drawing.Size sz) { throw null; }
+        public static System.Drawing.Point Round(System.Drawing.PointF value) { throw null; }
+        public static System.Drawing.Point Subtract(System.Drawing.Point pt, System.Drawing.Size sz) { throw null; }
+        public override string ToString() { throw null; }
+        public static System.Drawing.Point Truncate(System.Drawing.PointF value) { throw null; }
+    }
+    public partial struct PointF : System.IEquatable<System.Drawing.PointF>
+    {
+        private int _dummy;
+        public static readonly System.Drawing.PointF Empty;
+        public PointF(float x, float y) { throw null; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public bool IsEmpty { get { throw null; } }
+        public float X { get { throw null; } set { } }
+        public float Y { get { throw null; } set { } }
+        public static System.Drawing.PointF Add(System.Drawing.PointF pt, System.Drawing.Size sz) { throw null; }
+        public static System.Drawing.PointF Add(System.Drawing.PointF pt, System.Drawing.SizeF sz) { throw null; }
+        public bool Equals(System.Drawing.PointF other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static System.Drawing.PointF operator +(System.Drawing.PointF pt, System.Drawing.Size sz) { throw null; }
+        public static System.Drawing.PointF operator +(System.Drawing.PointF pt, System.Drawing.SizeF sz) { throw null; }
+        public static bool operator ==(System.Drawing.PointF left, System.Drawing.PointF right) { throw null; }
+        public static bool operator !=(System.Drawing.PointF left, System.Drawing.PointF right) { throw null; }
+        public static System.Drawing.PointF operator -(System.Drawing.PointF pt, System.Drawing.Size sz) { throw null; }
+        public static System.Drawing.PointF operator -(System.Drawing.PointF pt, System.Drawing.SizeF sz) { throw null; }
+        public static System.Drawing.PointF Subtract(System.Drawing.PointF pt, System.Drawing.Size sz) { throw null; }
+        public static System.Drawing.PointF Subtract(System.Drawing.PointF pt, System.Drawing.SizeF sz) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public partial struct Rectangle : System.IEquatable<System.Drawing.Rectangle>
+    {
+        private int _dummy;
+        public static readonly System.Drawing.Rectangle Empty;
+        public Rectangle(System.Drawing.Point location, System.Drawing.Size size) { throw null; }
+        public Rectangle(int x, int y, int width, int height) { throw null; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public int Bottom { get { throw null; } }
+        public int Height { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public bool IsEmpty { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public int Left { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public System.Drawing.Point Location { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public int Right { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public System.Drawing.Size Size { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public int Top { get { throw null; } }
+        public int Width { get { throw null; } set { } }
+        public int X { get { throw null; } set { } }
+        public int Y { get { throw null; } set { } }
+        public static System.Drawing.Rectangle Ceiling(System.Drawing.RectangleF value) { throw null; }
+        public bool Contains(System.Drawing.Point pt) { throw null; }
+        public bool Contains(System.Drawing.Rectangle rect) { throw null; }
+        public bool Contains(int x, int y) { throw null; }
+        public bool Equals(System.Drawing.Rectangle other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public static System.Drawing.Rectangle FromLTRB(int left, int top, int right, int bottom) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static System.Drawing.Rectangle Inflate(System.Drawing.Rectangle rect, int x, int y) { throw null; }
+        public void Inflate(System.Drawing.Size size) { }
+        public void Inflate(int width, int height) { }
+        public void Intersect(System.Drawing.Rectangle rect) { }
+        public static System.Drawing.Rectangle Intersect(System.Drawing.Rectangle a, System.Drawing.Rectangle b) { throw null; }
+        public bool IntersectsWith(System.Drawing.Rectangle rect) { throw null; }
+        public void Offset(System.Drawing.Point pos) { }
+        public void Offset(int x, int y) { }
+        public static bool operator ==(System.Drawing.Rectangle left, System.Drawing.Rectangle right) { throw null; }
+        public static bool operator !=(System.Drawing.Rectangle left, System.Drawing.Rectangle right) { throw null; }
+        public static System.Drawing.Rectangle Round(System.Drawing.RectangleF value) { throw null; }
+        public override string ToString() { throw null; }
+        public static System.Drawing.Rectangle Truncate(System.Drawing.RectangleF value) { throw null; }
+        public static System.Drawing.Rectangle Union(System.Drawing.Rectangle a, System.Drawing.Rectangle b) { throw null; }
+    }
+    public partial struct RectangleF : System.IEquatable<System.Drawing.RectangleF>
+    {
+        private int _dummy;
+        public static readonly System.Drawing.RectangleF Empty;
+        public RectangleF(System.Drawing.PointF location, System.Drawing.SizeF size) { throw null; }
+        public RectangleF(float x, float y, float width, float height) { throw null; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public float Bottom { get { throw null; } }
+        public float Height { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public bool IsEmpty { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public float Left { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public System.Drawing.PointF Location { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public float Right { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public System.Drawing.SizeF Size { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public float Top { get { throw null; } }
+        public float Width { get { throw null; } set { } }
+        public float X { get { throw null; } set { } }
+        public float Y { get { throw null; } set { } }
+        public bool Contains(System.Drawing.PointF pt) { throw null; }
+        public bool Contains(System.Drawing.RectangleF rect) { throw null; }
+        public bool Contains(float x, float y) { throw null; }
+        public bool Equals(System.Drawing.RectangleF other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public static System.Drawing.RectangleF FromLTRB(float left, float top, float right, float bottom) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static System.Drawing.RectangleF Inflate(System.Drawing.RectangleF rect, float x, float y) { throw null; }
+        public void Inflate(System.Drawing.SizeF size) { }
+        public void Inflate(float x, float y) { }
+        public void Intersect(System.Drawing.RectangleF rect) { }
+        public static System.Drawing.RectangleF Intersect(System.Drawing.RectangleF a, System.Drawing.RectangleF b) { throw null; }
+        public bool IntersectsWith(System.Drawing.RectangleF rect) { throw null; }
+        public void Offset(System.Drawing.PointF pos) { }
+        public void Offset(float x, float y) { }
+        public static bool operator ==(System.Drawing.RectangleF left, System.Drawing.RectangleF right) { throw null; }
+        public static implicit operator System.Drawing.RectangleF (System.Drawing.Rectangle r) { throw null; }
+        public static bool operator !=(System.Drawing.RectangleF left, System.Drawing.RectangleF right) { throw null; }
+        public override string ToString() { throw null; }
+        public static System.Drawing.RectangleF Union(System.Drawing.RectangleF a, System.Drawing.RectangleF b) { throw null; }
+    }
+    public partial struct Size : System.IEquatable<System.Drawing.Size>
+    {
+        private int _dummy;
+        public static readonly System.Drawing.Size Empty;
+        public Size(System.Drawing.Point pt) { throw null; }
+        public Size(int width, int height) { throw null; }
+        public int Height { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public bool IsEmpty { get { throw null; } }
+        public int Width { get { throw null; } set { } }
+        public static System.Drawing.Size Add(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
+        public static System.Drawing.Size Ceiling(System.Drawing.SizeF value) { throw null; }
+        public bool Equals(System.Drawing.Size other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static System.Drawing.Size operator +(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
+        public static System.Drawing.Size operator /(System.Drawing.Size left, int right) { throw null; }
+        public static System.Drawing.SizeF operator /(System.Drawing.Size left, float right) { throw null; }
+        public static bool operator ==(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
+        public static explicit operator System.Drawing.Point (System.Drawing.Size size) { throw null; }
+        public static implicit operator System.Drawing.SizeF (System.Drawing.Size p) { throw null; }
+        public static bool operator !=(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
+        public static System.Drawing.Size operator *(System.Drawing.Size left, int right) { throw null; }
+        public static System.Drawing.SizeF operator *(System.Drawing.Size left, float right) { throw null; }
+        public static System.Drawing.Size operator *(int left, System.Drawing.Size right) { throw null; }
+        public static System.Drawing.SizeF operator *(float left, System.Drawing.Size right) { throw null; }
+        public static System.Drawing.Size operator -(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
+        public static System.Drawing.Size Round(System.Drawing.SizeF value) { throw null; }
+        public static System.Drawing.Size Subtract(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
+        public override string ToString() { throw null; }
+        public static System.Drawing.Size Truncate(System.Drawing.SizeF value) { throw null; }
+    }
+    public partial struct SizeF : System.IEquatable<System.Drawing.SizeF>
+    {
+        private int _dummy;
+        public static readonly System.Drawing.SizeF Empty;
+        public SizeF(System.Drawing.PointF pt) { throw null; }
+        public SizeF(System.Drawing.SizeF size) { throw null; }
+        public SizeF(float width, float height) { throw null; }
+        public float Height { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        public bool IsEmpty { get { throw null; } }
+        public float Width { get { throw null; } set { } }
+        public static System.Drawing.SizeF Add(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
+        public bool Equals(System.Drawing.SizeF other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static System.Drawing.SizeF operator +(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
+        public static System.Drawing.SizeF operator /(System.Drawing.SizeF left, float right) { throw null; }
+        public static bool operator ==(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
+        public static explicit operator System.Drawing.PointF (System.Drawing.SizeF size) { throw null; }
+        public static bool operator !=(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
+        public static System.Drawing.SizeF operator *(System.Drawing.SizeF left, float right) { throw null; }
+        public static System.Drawing.SizeF operator *(float left, System.Drawing.SizeF right) { throw null; }
+        public static System.Drawing.SizeF operator -(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
+        public static System.Drawing.SizeF Subtract(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
+        public System.Drawing.PointF ToPointF() { throw null; }
+        public System.Drawing.Size ToSize() { throw null; }
+        public override string ToString() { throw null; }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.cs
+++ b/src/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.cs
@@ -5,7 +5,6 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System.IO
 {
     public partial class ErrorEventArgs : System.EventArgs
@@ -33,11 +32,16 @@ namespace System.IO
         public int InternalBufferSize { get { throw null; } set { } }
         public System.IO.NotifyFilters NotifyFilter { get { throw null; } set { } }
         public string Path { get { throw null; } set { } }
+        public override System.ComponentModel.ISite Site { get { throw null; } set { } }
+        public System.ComponentModel.ISynchronizeInvoke SynchronizingObject { get { throw null; } set { } }
         public event System.IO.FileSystemEventHandler Changed { add { } remove { } }
         public event System.IO.FileSystemEventHandler Created { add { } remove { } }
         public event System.IO.FileSystemEventHandler Deleted { add { } remove { } }
         public event System.IO.ErrorEventHandler Error { add { } remove { } }
         public event System.IO.RenamedEventHandler Renamed { add { } remove { } }
+        public void BeginInit() { }
+        protected override void Dispose(bool disposing) { }
+        public void EndInit() { }
         protected void OnChanged(System.IO.FileSystemEventArgs e) { }
         protected void OnCreated(System.IO.FileSystemEventArgs e) { }
         protected void OnDeleted(System.IO.FileSystemEventArgs e) { }
@@ -45,18 +49,13 @@ namespace System.IO
         protected void OnRenamed(System.IO.RenamedEventArgs e) { }
         public System.IO.WaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType) { throw null; }
         public System.IO.WaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, int timeout) { throw null; }
-        public override System.ComponentModel.ISite Site { get { throw null; } set { } }
-        public System.ComponentModel.ISynchronizeInvoke SynchronizingObject { get { throw null; } set { } }
-        public void BeginInit() { }
-        protected override void Dispose(bool disposing) { }
-        public void EndInit() { }
     }
     public partial class InternalBufferOverflowException : System.SystemException
     {
         public InternalBufferOverflowException() { }
+        protected InternalBufferOverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public InternalBufferOverflowException(string message) { }
         public InternalBufferOverflowException(string message, System.Exception inner) { }
-        protected InternalBufferOverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     [System.FlagsAttribute]
     public enum NotifyFilters
@@ -72,13 +71,14 @@ namespace System.IO
     }
     public partial class RenamedEventArgs : System.IO.FileSystemEventArgs
     {
-        public RenamedEventArgs(System.IO.WatcherChangeTypes changeType, string directory, string name, string oldName) : base(default(System.IO.WatcherChangeTypes), default(string), default(string)) { }
+        public RenamedEventArgs(System.IO.WatcherChangeTypes changeType, string directory, string name, string oldName) : base (default(System.IO.WatcherChangeTypes), default(string), default(string)) { }
         public string OldFullPath { get { throw null; } }
         public string OldName { get { throw null; } }
     }
     public delegate void RenamedEventHandler(object sender, System.IO.RenamedEventArgs e);
-    public struct WaitForChangedResult
+    public partial struct WaitForChangedResult
     {
+        private object _dummy;
         public System.IO.WatcherChangeTypes ChangeType { get { throw null; } set { } }
         public string Name { get { throw null; } set { } }
         public string OldName { get { throw null; } set { } }

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -124,11 +124,13 @@ namespace System.Net.Security
     }
     public readonly partial struct SslApplicationProtocol : IEquatable<SslApplicationProtocol>
     {
+        private readonly object _dummy;
+
         public static readonly SslApplicationProtocol Http2;
         public static readonly SslApplicationProtocol Http11;
 
-        public SslApplicationProtocol(byte[] protocol) { }
-        public SslApplicationProtocol(string protocol) { }
+        public SslApplicationProtocol(byte[] protocol) { throw null; }
+        public SslApplicationProtocol(string protocol) { throw null; }
 
         public ReadOnlyMemory<byte> Protocol { get { throw null; } }
 

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -45,9 +45,9 @@ namespace System.Net.Sockets
         TranslateHandle = (long)3355443213,
         UnicastInterface = (long)2550136838,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct IPPacketInformation
     {
+        private object _dummy;
         public System.Net.IPAddress Address { get { throw null; } }
         public int Interface { get { throw null; } }
         public override bool Equals(object comparand) { throw null; }
@@ -389,10 +389,10 @@ namespace System.Net.Sockets
         Peek = 2,
         Truncated = 256,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public struct SocketInformation
+    public partial struct SocketInformation
     {
-        public SocketInformationOptions Options { get { throw null; } set { } }
+        private object _dummy;
+        public System.Net.Sockets.SocketInformationOptions Options { get { throw null; } set { } }
         public byte[] ProtocolInformation { get { throw null; } set { } }
     }
     [Flags]
@@ -638,9 +638,9 @@ namespace System.Net.Sockets
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes, string hostname, int port) { throw null; }
         public void AllowNatTraversal(bool allowed) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct UdpReceiveResult : System.IEquatable<System.Net.Sockets.UdpReceiveResult>
     {
+        private object _dummy;
         public UdpReceiveResult(byte[] buffer, System.Net.IPEndPoint remoteEndPoint) { throw null; }
         public byte[] Buffer { get { throw null; } }
         public System.Net.IPEndPoint RemoteEndPoint { get { throw null; } }

--- a/src/System.Net.WebSockets/ref/System.Net.WebSockets.cs
+++ b/src/System.Net.WebSockets/ref/System.Net.WebSockets.cs
@@ -5,12 +5,12 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System.Net.WebSockets
 {
     public readonly partial struct ValueWebSocketReceiveResult
     {
-        public ValueWebSocketReceiveResult(int count, System.Net.WebSockets.WebSocketMessageType messageType, bool endOfMessage) { }
+        private readonly int _dummy;
+        public ValueWebSocketReceiveResult(int count, System.Net.WebSockets.WebSocketMessageType messageType, bool endOfMessage) { throw null; }
         public int Count { get { throw null; } }
         public bool EndOfMessage { get { throw null; } }
         public System.Net.WebSockets.WebSocketMessageType MessageType { get { throw null; } }
@@ -18,27 +18,27 @@ namespace System.Net.WebSockets
     public abstract partial class WebSocket : System.IDisposable
     {
         protected WebSocket() { }
-        public static System.TimeSpan DefaultKeepAliveInterval { get { throw null; } }
         public abstract System.Nullable<System.Net.WebSockets.WebSocketCloseStatus> CloseStatus { get; }
         public abstract string CloseStatusDescription { get; }
+        public static System.TimeSpan DefaultKeepAliveInterval { get { throw null; } }
         public abstract System.Net.WebSockets.WebSocketState State { get; }
         public abstract string SubProtocol { get; }
         public abstract void Abort();
         public abstract System.Threading.Tasks.Task CloseAsync(System.Net.WebSockets.WebSocketCloseStatus closeStatus, string statusDescription, System.Threading.CancellationToken cancellationToken);
         public abstract System.Threading.Tasks.Task CloseOutputAsync(System.Net.WebSockets.WebSocketCloseStatus closeStatus, string statusDescription, System.Threading.CancellationToken cancellationToken);
         public static System.ArraySegment<byte> CreateClientBuffer(int receiveBufferSize, int sendBufferSize) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public static System.Net.WebSockets.WebSocket CreateClientWebSocket(System.IO.Stream innerStream, string subProtocol, int receiveBufferSize, int sendBufferSize, System.TimeSpan keepAliveInterval, bool useZeroMaskingKey, System.ArraySegment<byte> internalBuffer) { throw null; }
-        public static System.Net.WebSockets.WebSocket CreateFromStream(System.IO.Stream stream, bool isServer, string subProtocol, System.TimeSpan keepAliveInterval, System.Memory<byte> buffer = default) { throw null; }
+        public static System.Net.WebSockets.WebSocket CreateFromStream(System.IO.Stream stream, bool isServer, string subProtocol, System.TimeSpan keepAliveInterval, System.Memory<byte> buffer=default(System.Memory<byte>)) { throw null; }
         public static System.ArraySegment<byte> CreateServerBuffer(int receiveBufferSize) { throw null; }
         public abstract void Dispose();
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.")]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.ObsoleteAttribute("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.")]
         public static bool IsApplicationTargeting45() { throw null; }
         protected static bool IsStateTerminal(System.Net.WebSockets.WebSocketState state) { throw null; }
         public abstract System.Threading.Tasks.Task<System.Net.WebSockets.WebSocketReceiveResult> ReceiveAsync(System.ArraySegment<byte> buffer, System.Threading.CancellationToken cancellationToken);
         public virtual System.Threading.Tasks.ValueTask<System.Net.WebSockets.ValueWebSocketReceiveResult> ReceiveAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public static void RegisterPrefixes() { }
         public abstract System.Threading.Tasks.Task SendAsync(System.ArraySegment<byte> buffer, System.Net.WebSockets.WebSocketMessageType messageType, bool endOfMessage, System.Threading.CancellationToken cancellationToken);
         public virtual System.Threading.Tasks.Task SendAsync(System.ReadOnlyMemory<byte> buffer, System.Net.WebSockets.WebSocketMessageType messageType, bool endOfMessage, System.Threading.CancellationToken cancellationToken) { throw null; }
@@ -57,19 +57,19 @@ namespace System.Net.WebSockets
         PolicyViolation = 1008,
         ProtocolError = 1002,
     }
-    public abstract class WebSocketContext
+    public abstract partial class WebSocketContext
     {
-        public abstract System.Uri RequestUri { get; }
-        public abstract System.Collections.Specialized.NameValueCollection Headers { get; }
-        public abstract string Origin { get; }
-        public abstract System.Collections.Generic.IEnumerable<string> SecWebSocketProtocols { get; }
-        public abstract string SecWebSocketVersion { get; }
-        public abstract string SecWebSocketKey { get; }
         public abstract System.Net.CookieCollection CookieCollection { get; }
-        public abstract System.Security.Principal.IPrincipal User { get; }
+        public abstract System.Collections.Specialized.NameValueCollection Headers { get; }
         public abstract bool IsAuthenticated { get; }
         public abstract bool IsLocal { get; }
         public abstract bool IsSecureConnection { get; }
+        public abstract string Origin { get; }
+        public abstract System.Uri RequestUri { get; }
+        public abstract string SecWebSocketKey { get; }
+        public abstract System.Collections.Generic.IEnumerable<string> SecWebSocketProtocols { get; }
+        public abstract string SecWebSocketVersion { get; }
+        public abstract System.Security.Principal.IPrincipal User { get; }
         public abstract System.Net.WebSockets.WebSocket WebSocket { get; }
     }
     public enum WebSocketError
@@ -101,9 +101,9 @@ namespace System.Net.WebSockets
         public WebSocketException(System.Net.WebSockets.WebSocketError error, string message, System.Exception innerException) { }
         public WebSocketException(string message) { }
         public WebSocketException(string message, System.Exception innerException) { }
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public System.Net.WebSockets.WebSocketError WebSocketErrorCode { get { throw null; } }
         public override int ErrorCode { get { throw null; } }
+        public System.Net.WebSockets.WebSocketError WebSocketErrorCode { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public enum WebSocketMessageType
     {

--- a/src/System.Numerics.Vectors/ref/System.Numerics.Vectors.cs
+++ b/src/System.Numerics.Vectors/ref/System.Numerics.Vectors.cs
@@ -8,7 +8,6 @@
 
 namespace System.Numerics
 {
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Matrix3x2 : System.IEquatable<System.Numerics.Matrix3x2>
     {
         public float M11;
@@ -53,7 +52,6 @@ namespace System.Numerics
         public static System.Numerics.Matrix3x2 Subtract(System.Numerics.Matrix3x2 value1, System.Numerics.Matrix3x2 value2) { throw null; }
         public override string ToString() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Matrix4x4 : System.IEquatable<System.Numerics.Matrix4x4>
     {
         public float M11;
@@ -128,7 +126,6 @@ namespace System.Numerics
         public static System.Numerics.Matrix4x4 Transform(System.Numerics.Matrix4x4 value, System.Numerics.Quaternion rotation) { throw null; }
         public static System.Numerics.Matrix4x4 Transpose(System.Numerics.Matrix4x4 matrix) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Plane : System.IEquatable<System.Numerics.Plane>
     {
         public float D;
@@ -150,7 +147,6 @@ namespace System.Numerics
         public static System.Numerics.Plane Transform(System.Numerics.Plane plane, System.Numerics.Matrix4x4 matrix) { throw null; }
         public static System.Numerics.Plane Transform(System.Numerics.Plane plane, System.Numerics.Quaternion rotation) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Quaternion : System.IEquatable<System.Numerics.Quaternion>
     {
         public float W;
@@ -299,9 +295,9 @@ namespace System.Numerics
         public static void Widen(System.Numerics.Vector<float> source, out System.Numerics.Vector<double> dest1, out System.Numerics.Vector<double> dest2) { dest1 = default(System.Numerics.Vector<double>); dest2 = default(System.Numerics.Vector<double>); }
         public static System.Numerics.Vector<T> Xor<T>(System.Numerics.Vector<T> left, System.Numerics.Vector<T> right) where T : struct { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Vector<T> : System.IEquatable<System.Numerics.Vector<T>>, System.IFormattable where T : struct
     {
+        private int _dummy;
         public Vector(T value) { throw null; }
         public Vector(T[] values) { throw null; }
         public Vector(T[] values, int index) { throw null; }
@@ -345,7 +341,6 @@ namespace System.Numerics
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider formatProvider) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Vector2 : System.IEquatable<System.Numerics.Vector2>, System.IFormattable
     {
         public float X;
@@ -401,7 +396,6 @@ namespace System.Numerics
         public static System.Numerics.Vector2 TransformNormal(System.Numerics.Vector2 normal, System.Numerics.Matrix3x2 matrix) { throw null; }
         public static System.Numerics.Vector2 TransformNormal(System.Numerics.Vector2 normal, System.Numerics.Matrix4x4 matrix) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Vector3 : System.IEquatable<System.Numerics.Vector3>, System.IFormattable
     {
         public float X;
@@ -459,7 +453,6 @@ namespace System.Numerics
         public static System.Numerics.Vector3 Transform(System.Numerics.Vector3 value, System.Numerics.Quaternion rotation) { throw null; }
         public static System.Numerics.Vector3 TransformNormal(System.Numerics.Vector3 normal, System.Numerics.Matrix4x4 matrix) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Vector4 : System.IEquatable<System.Numerics.Vector4>, System.IFormattable
     {
         public float W;

--- a/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
+++ b/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
@@ -57,9 +57,9 @@ namespace System.Reflection.Emit
         public virtual void ThrowException(System.Type excType) { }
         public virtual void UsingNamespace(string usingNamespace) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Label
     {
+        private int _dummy;
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Emit.Label obj) { throw null; }
         public override int GetHashCode() { throw null; }

--- a/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -82,17 +82,17 @@ namespace System.Reflection
 }
 namespace System.Reflection.Metadata
 {
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ArrayShape
     {
-        public ArrayShape(int rank, System.Collections.Immutable.ImmutableArray<int> sizes, System.Collections.Immutable.ImmutableArray<int> lowerBounds) { throw null;}
+        private readonly int _dummy;
+        public ArrayShape(int rank, System.Collections.Immutable.ImmutableArray<int> sizes, System.Collections.Immutable.ImmutableArray<int> lowerBounds) { throw null; }
         public System.Collections.Immutable.ImmutableArray<int> LowerBounds { get { throw null; } }
         public int Rank { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<int> Sizes { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AssemblyDefinition
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.StringHandle Culture { get { throw null; } }
         public System.Reflection.AssemblyFlags Flags { get { throw null; } }
         public System.Reflection.AssemblyHashAlgorithm HashAlgorithm { get { throw null; } }
@@ -105,9 +105,9 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
         public System.Reflection.Metadata.DeclarativeSecurityAttributeHandleCollection GetDeclarativeSecurityAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AssemblyDefinitionHandle : System.IEquatable<System.Reflection.Metadata.AssemblyDefinitionHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.AssemblyDefinitionHandle other) { throw null; }
@@ -119,17 +119,17 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.AssemblyDefinitionHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.AssemblyDefinitionHandle left, System.Reflection.Metadata.AssemblyDefinitionHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AssemblyFile
     {
+        private readonly object _dummy;
         public bool ContainsMetadata { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle HashValue { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AssemblyFileHandle : System.IEquatable<System.Reflection.Metadata.AssemblyFileHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.AssemblyFileHandle other) { throw null; }
@@ -141,16 +141,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.AssemblyFileHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.AssemblyFileHandle left, System.Reflection.Metadata.AssemblyFileHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AssemblyFileHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.AssemblyFileHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.AssemblyFileHandle>, System.Collections.IEnumerable
     {
+        private readonly int _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.AssemblyFileHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.AssemblyFileHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.AssemblyFileHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.AssemblyFileHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private int _dummy;
             public System.Reflection.Metadata.AssemblyFileHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -158,9 +158,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AssemblyReference
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.StringHandle Culture { get { throw null; } }
         public System.Reflection.AssemblyFlags Flags { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle HashValue { get { throw null; } }
@@ -172,9 +172,9 @@ namespace System.Reflection.Metadata
 #endif
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AssemblyReferenceHandle : System.IEquatable<System.Reflection.Metadata.AssemblyReferenceHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.AssemblyReferenceHandle other) { throw null; }
@@ -186,16 +186,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.AssemblyReferenceHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.AssemblyReferenceHandle left, System.Reflection.Metadata.AssemblyReferenceHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AssemblyReferenceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.AssemblyReferenceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.AssemblyReferenceHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.AssemblyReferenceHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.AssemblyReferenceHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.AssemblyReferenceHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.AssemblyReferenceHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.AssemblyReferenceHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -203,9 +203,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct Blob
     {
+        private readonly object _dummy;
         public bool IsDefault { get { throw null; } }
         public int Length { get { throw null; } }
         public System.ArraySegment<byte> GetBytes() { throw null; }
@@ -268,9 +268,9 @@ namespace System.Reflection.Metadata
         public void WriteUTF16(char[] value) { }
         public void WriteUTF16(string value) { }
         public void WriteUTF8(string value, bool allowUnpairedSurrogates=true) { }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Blobs : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.Blob>, System.Collections.Generic.IEnumerator<System.Reflection.Metadata.Blob>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.Blob Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public System.Reflection.Metadata.BlobBuilder.Blobs GetEnumerator() { throw null; }
@@ -281,12 +281,12 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct BlobContentId : System.IEquatable<System.Reflection.Metadata.BlobContentId>
     {
-        public BlobContentId(byte[] id) { throw null;}
-        public BlobContentId(System.Collections.Immutable.ImmutableArray<byte> id) { throw null;}
-        public BlobContentId(System.Guid guid, uint stamp) { throw null;}
+        private readonly int _dummy;
+        public BlobContentId(byte[] id) { throw null; }
+        public BlobContentId(System.Collections.Immutable.ImmutableArray<byte> id) { throw null; }
+        public BlobContentId(System.Guid guid, uint stamp) { throw null; }
         public System.Guid Guid { get { throw null; } }
         public bool IsDefault { get { throw null; } }
         public uint Stamp { get { throw null; } }
@@ -299,9 +299,9 @@ namespace System.Reflection.Metadata
         public static bool operator ==(System.Reflection.Metadata.BlobContentId left, System.Reflection.Metadata.BlobContentId right) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.BlobContentId left, System.Reflection.Metadata.BlobContentId right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct BlobHandle : System.IEquatable<System.Reflection.Metadata.BlobHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.BlobHandle other) { throw null; }
@@ -311,10 +311,10 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.BlobHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.BlobHandle left, System.Reflection.Metadata.BlobHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct BlobReader
     {
-        public unsafe BlobReader(byte* buffer, int length) { throw null;}
+        private int _dummy;
+        public unsafe BlobReader(byte* buffer, int length) { throw null; }
         public unsafe byte* CurrentPointer { get { throw null; } }
         public int Length { get { throw null; } }
         public int Offset { get { throw null; } set { } }
@@ -351,16 +351,16 @@ namespace System.Reflection.Metadata
         public string ReadUTF16(int byteCount) { throw null; }
         public string ReadUTF8(int byteCount) { throw null; }
         public void Reset() { }
-        public bool TryReadCompressedInteger(out int value) { value = default(int); throw null; }
-        public bool TryReadCompressedSignedInteger(out int value) { value = default(int); throw null; }
+        public bool TryReadCompressedInteger(out int value) { throw null; }
+        public bool TryReadCompressedSignedInteger(out int value) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct BlobWriter
     {
-        public BlobWriter(byte[] buffer) { throw null;}
-        public BlobWriter(byte[] buffer, int start, int count) { throw null;}
-        public BlobWriter(int size) { throw null;}
-        public BlobWriter(System.Reflection.Metadata.Blob blob) { throw null;}
+        private object _dummy;
+        public BlobWriter(byte[] buffer) { throw null; }
+        public BlobWriter(byte[] buffer, int start, int count) { throw null; }
+        public BlobWriter(int size) { throw null; }
+        public BlobWriter(System.Reflection.Metadata.Blob blob) { throw null; }
         public System.Reflection.Metadata.Blob Blob { get { throw null; } }
         public int Length { get { throw null; } }
         public int Offset { get { throw null; } set { } }
@@ -409,16 +409,16 @@ namespace System.Reflection.Metadata
         public void WriteUTF16(string value) { }
         public void WriteUTF8(string value, bool allowUnpairedSurrogates) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct Constant
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.EntityHandle Parent { get { throw null; } }
         public System.Reflection.Metadata.ConstantTypeCode TypeCode { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Value { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ConstantHandle : System.IEquatable<System.Reflection.Metadata.ConstantHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.ConstantHandle other) { throw null; }
@@ -448,17 +448,17 @@ namespace System.Reflection.Metadata
         UInt32 = (byte)9,
         UInt64 = (byte)11,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomAttribute
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.EntityHandle Constructor { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Parent { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Value { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeValue<TType> DecodeValue<TType>(System.Reflection.Metadata.ICustomAttributeTypeProvider<TType> provider) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomAttributeHandle : System.IEquatable<System.Reflection.Metadata.CustomAttributeHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.CustomAttributeHandle other) { throw null; }
@@ -470,16 +470,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.CustomAttributeHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.CustomAttributeHandle left, System.Reflection.Metadata.CustomAttributeHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomAttributeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.CustomAttributeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.CustomAttributeHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.CustomAttributeHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.CustomAttributeHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.CustomAttributeHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.CustomAttributeHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -492,39 +492,39 @@ namespace System.Reflection.Metadata
         Field = (byte)83,
         Property = (byte)84,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomAttributeNamedArgument<TType>
     {
-        public CustomAttributeNamedArgument(string name, System.Reflection.Metadata.CustomAttributeNamedArgumentKind kind, TType type, object value) { throw null;}
+        private readonly TType _Type_k__BackingField;
+        public CustomAttributeNamedArgument(string name, System.Reflection.Metadata.CustomAttributeNamedArgumentKind kind, TType type, object value) { throw null; }
         public System.Reflection.Metadata.CustomAttributeNamedArgumentKind Kind { get { throw null; } }
         public string Name { get { throw null; } }
         public TType Type { get { throw null; } }
         public object Value { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomAttributeTypedArgument<TType>
     {
-        public CustomAttributeTypedArgument(TType type, object value) { throw null;}
+        private readonly TType _Type_k__BackingField;
+        public CustomAttributeTypedArgument(TType type, object value) { throw null; }
         public TType Type { get { throw null; } }
         public object Value { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomAttributeValue<TType>
     {
-        public CustomAttributeValue(System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeTypedArgument<TType>> fixedArguments, System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeNamedArgument<TType>> namedArguments) { throw null;}
+        private readonly int _dummy;
+        public CustomAttributeValue(System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeTypedArgument<TType>> fixedArguments, System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeNamedArgument<TType>> namedArguments) { throw null; }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeTypedArgument<TType>> FixedArguments { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.CustomAttributeNamedArgument<TType>> NamedArguments { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomDebugInformation
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.GuidHandle Kind { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Parent { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Value { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomDebugInformationHandle : System.IEquatable<System.Reflection.Metadata.CustomDebugInformationHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.CustomDebugInformationHandle other) { throw null; }
@@ -536,16 +536,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.CustomDebugInformationHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.CustomDebugInformationHandle left, System.Reflection.Metadata.CustomDebugInformationHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomDebugInformationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.CustomDebugInformationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.CustomDebugInformationHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.CustomDebugInformationHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.CustomDebugInformationHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.CustomDebugInformationHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.CustomDebugInformationHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.CustomDebugInformationHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -559,16 +559,16 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.MethodDefinitionHandle EntryPoint { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<byte> Id { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DeclarativeSecurityAttribute
     {
+        private readonly object _dummy;
         public System.Reflection.DeclarativeSecurityAction Action { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Parent { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle PermissionSet { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DeclarativeSecurityAttributeHandle : System.IEquatable<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.DeclarativeSecurityAttributeHandle other) { throw null; }
@@ -580,16 +580,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.DeclarativeSecurityAttributeHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.DeclarativeSecurityAttributeHandle left, System.Reflection.Metadata.DeclarativeSecurityAttributeHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DeclarativeSecurityAttributeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.DeclarativeSecurityAttributeHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.DeclarativeSecurityAttributeHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.DeclarativeSecurityAttributeHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -597,17 +597,17 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct Document
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.BlobHandle Hash { get { throw null; } }
         public System.Reflection.Metadata.GuidHandle HashAlgorithm { get { throw null; } }
         public System.Reflection.Metadata.GuidHandle Language { get { throw null; } }
         public System.Reflection.Metadata.DocumentNameBlobHandle Name { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DocumentHandle : System.IEquatable<System.Reflection.Metadata.DocumentHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.DocumentHandle other) { throw null; }
@@ -619,16 +619,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.DocumentHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.DocumentHandle left, System.Reflection.Metadata.DocumentHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DocumentHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.DocumentHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.DocumentHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.DocumentHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.DocumentHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.DocumentHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.DocumentHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.DocumentHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -636,9 +636,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DocumentNameBlobHandle : System.IEquatable<System.Reflection.Metadata.DocumentNameBlobHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.DocumentNameBlobHandle other) { throw null; }
@@ -648,9 +648,9 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.BlobHandle (System.Reflection.Metadata.DocumentNameBlobHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.DocumentNameBlobHandle left, System.Reflection.Metadata.DocumentNameBlobHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct EntityHandle : System.IEquatable<System.Reflection.Metadata.EntityHandle>
     {
+        private readonly int _dummy;
         public static readonly System.Reflection.Metadata.AssemblyDefinitionHandle AssemblyDefinition;
         public static readonly System.Reflection.Metadata.ModuleDefinitionHandle ModuleDefinition;
         public bool IsNil { get { throw null; } }
@@ -663,26 +663,26 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.EntityHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.EntityHandle left, System.Reflection.Metadata.EntityHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct EventAccessors
     {
+        private readonly int _dummy;
         public System.Reflection.Metadata.MethodDefinitionHandle Adder { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.MethodDefinitionHandle> Others { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Raiser { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Remover { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct EventDefinition
     {
+        private readonly object _dummy;
         public System.Reflection.EventAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Type { get { throw null; } }
         public System.Reflection.Metadata.EventAccessors GetAccessors() { throw null; }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct EventDefinitionHandle : System.IEquatable<System.Reflection.Metadata.EventDefinitionHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.EventDefinitionHandle other) { throw null; }
@@ -694,16 +694,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.EventDefinitionHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.EventDefinitionHandle left, System.Reflection.Metadata.EventDefinitionHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct EventDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.EventDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.EventDefinitionHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.EventDefinitionHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.EventDefinitionHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.EventDefinitionHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.EventDefinitionHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.EventDefinitionHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -711,9 +711,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ExceptionRegion
     {
+        private readonly int _dummy;
         public System.Reflection.Metadata.EntityHandle CatchType { get { throw null; } }
         public int FilterOffset { get { throw null; } }
         public int HandlerLength { get { throw null; } }
@@ -729,9 +729,9 @@ namespace System.Reflection.Metadata
         Filter = (ushort)1,
         Finally = (ushort)2,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ExportedType
     {
+        private readonly object _dummy;
         public System.Reflection.TypeAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Implementation { get { throw null; } }
         public bool IsForwarder { get { throw null; } }
@@ -740,9 +740,9 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.NamespaceDefinitionHandle NamespaceDefinition { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ExportedTypeHandle : System.IEquatable<System.Reflection.Metadata.ExportedTypeHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.ExportedTypeHandle other) { throw null; }
@@ -754,16 +754,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.ExportedTypeHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.ExportedTypeHandle left, System.Reflection.Metadata.ExportedTypeHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ExportedTypeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ExportedTypeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ExportedTypeHandle>, System.Collections.IEnumerable
     {
+        private readonly int _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.ExportedTypeHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.ExportedTypeHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ExportedTypeHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.ExportedTypeHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private int _dummy;
             public System.Reflection.Metadata.ExportedTypeHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -771,9 +771,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct FieldDefinition
     {
+        private readonly object _dummy;
         public System.Reflection.FieldAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Signature { get { throw null; } }
@@ -785,9 +785,9 @@ namespace System.Reflection.Metadata
         public int GetOffset() { throw null; }
         public int GetRelativeVirtualAddress() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct FieldDefinitionHandle : System.IEquatable<System.Reflection.Metadata.FieldDefinitionHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.FieldDefinitionHandle other) { throw null; }
@@ -799,16 +799,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.FieldDefinitionHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.FieldDefinitionHandle left, System.Reflection.Metadata.FieldDefinitionHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct FieldDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.FieldDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.FieldDefinitionHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.FieldDefinitionHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.FieldDefinitionHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.FieldDefinitionHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.FieldDefinitionHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.FieldDefinitionHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -816,9 +816,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct GenericParameter
     {
+        private readonly object _dummy;
         public System.Reflection.GenericParameterAttributes Attributes { get { throw null; } }
         public int Index { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
@@ -826,16 +826,16 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.GenericParameterConstraintHandleCollection GetConstraints() { throw null; }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct GenericParameterConstraint
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.GenericParameterHandle Parameter { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Type { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct GenericParameterConstraintHandle : System.IEquatable<System.Reflection.Metadata.GenericParameterConstraintHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.GenericParameterConstraintHandle other) { throw null; }
@@ -847,17 +847,17 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.GenericParameterConstraintHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.GenericParameterConstraintHandle left, System.Reflection.Metadata.GenericParameterConstraintHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct GenericParameterConstraintHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.GenericParameterConstraintHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.GenericParameterConstraintHandle>, System.Collections.Generic.IReadOnlyList<System.Reflection.Metadata.GenericParameterConstraintHandle>, System.Collections.IEnumerable
     {
+        private readonly int _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.GenericParameterConstraintHandle this[int index] { get { throw null; } }
         public System.Reflection.Metadata.GenericParameterConstraintHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.GenericParameterConstraintHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.GenericParameterConstraintHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.GenericParameterConstraintHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private int _dummy;
             public System.Reflection.Metadata.GenericParameterConstraintHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -865,9 +865,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct GenericParameterHandle : System.IEquatable<System.Reflection.Metadata.GenericParameterHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.GenericParameterHandle other) { throw null; }
@@ -879,17 +879,17 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.GenericParameterHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.GenericParameterHandle left, System.Reflection.Metadata.GenericParameterHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct GenericParameterHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.GenericParameterHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.GenericParameterHandle>, System.Collections.Generic.IReadOnlyList<System.Reflection.Metadata.GenericParameterHandle>, System.Collections.IEnumerable
     {
+        private readonly int _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.GenericParameterHandle this[int index] { get { throw null; } }
         public System.Reflection.Metadata.GenericParameterHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.GenericParameterHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.GenericParameterHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.GenericParameterHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private int _dummy;
             public System.Reflection.Metadata.GenericParameterHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -897,9 +897,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct GuidHandle : System.IEquatable<System.Reflection.Metadata.GuidHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.GuidHandle other) { throw null; }
@@ -909,9 +909,9 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.GuidHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.GuidHandle left, System.Reflection.Metadata.GuidHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct Handle : System.IEquatable<System.Reflection.Metadata.Handle>
     {
+        private readonly int _dummy;
         public static readonly System.Reflection.Metadata.AssemblyDefinitionHandle AssemblyDefinition;
         public static readonly System.Reflection.Metadata.ModuleDefinitionHandle ModuleDefinition;
         public bool IsNil { get { throw null; } }
@@ -1221,24 +1221,24 @@ namespace System.Reflection.Metadata
         public ImageFormatLimitationException(string message) { }
         public ImageFormatLimitationException(string message, System.Exception innerException) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ImportDefinition
     {
+        private readonly int _dummy;
         public System.Reflection.Metadata.BlobHandle Alias { get { throw null; } }
         public System.Reflection.Metadata.ImportDefinitionKind Kind { get { throw null; } }
         public System.Reflection.Metadata.AssemblyReferenceHandle TargetAssembly { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle TargetNamespace { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle TargetType { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ImportDefinitionCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ImportDefinition>, System.Collections.IEnumerable
     {
+        private readonly int _dummy;
         public System.Reflection.Metadata.ImportDefinitionCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.ImportDefinition> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ImportDefinition>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.ImportDefinition>, System.Collections.IEnumerator, System.IDisposable
         {
+            private int _dummy;
             public System.Reflection.Metadata.ImportDefinition Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -1258,23 +1258,23 @@ namespace System.Reflection.Metadata
         ImportType = 3,
         ImportXmlNamespace = 4,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ImportScope
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.BlobHandle ImportsBlob { get { throw null; } }
         public System.Reflection.Metadata.ImportScopeHandle Parent { get { throw null; } }
         public System.Reflection.Metadata.ImportDefinitionCollection GetImports() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ImportScopeCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ImportScopeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ImportScopeHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.ImportScopeCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.ImportScopeHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ImportScopeHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.ImportScopeHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.ImportScopeHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -1282,9 +1282,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ImportScopeHandle : System.IEquatable<System.Reflection.Metadata.ImportScopeHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.ImportScopeHandle other) { throw null; }
@@ -1296,15 +1296,15 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.ImportScopeHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.ImportScopeHandle left, System.Reflection.Metadata.ImportScopeHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct InterfaceImplementation
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.EntityHandle Interface { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct InterfaceImplementationHandle : System.IEquatable<System.Reflection.Metadata.InterfaceImplementationHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.InterfaceImplementationHandle other) { throw null; }
@@ -1316,16 +1316,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.InterfaceImplementationHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.InterfaceImplementationHandle left, System.Reflection.Metadata.InterfaceImplementationHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct InterfaceImplementationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.InterfaceImplementationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.InterfaceImplementationHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.InterfaceImplementationHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.InterfaceImplementationHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.InterfaceImplementationHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.InterfaceImplementationHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.InterfaceImplementationHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -1352,15 +1352,15 @@ namespace System.Reflection.Metadata
     {
         TType GetSZArrayType(TType elementType);
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LocalConstant
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Signature { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LocalConstantHandle : System.IEquatable<System.Reflection.Metadata.LocalConstantHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.LocalConstantHandle other) { throw null; }
@@ -1372,16 +1372,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.LocalConstantHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.LocalConstantHandle left, System.Reflection.Metadata.LocalConstantHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LocalConstantHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalConstantHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.LocalConstantHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.LocalConstantHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.LocalConstantHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalConstantHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.LocalConstantHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.LocalConstantHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -1389,9 +1389,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LocalScope
     {
+        private readonly object _dummy;
         public int EndOffset { get { throw null; } }
         public System.Reflection.Metadata.ImportScopeHandle ImportScope { get { throw null; } }
         public int Length { get { throw null; } }
@@ -1401,9 +1401,9 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.LocalConstantHandleCollection GetLocalConstants() { throw null; }
         public System.Reflection.Metadata.LocalVariableHandleCollection GetLocalVariables() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LocalScopeHandle : System.IEquatable<System.Reflection.Metadata.LocalScopeHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.LocalScopeHandle other) { throw null; }
@@ -1415,25 +1415,25 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.LocalScopeHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.LocalScopeHandle left, System.Reflection.Metadata.LocalScopeHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LocalScopeHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalScopeHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.LocalScopeHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.LocalScopeHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.LocalScopeHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalScopeHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct ChildrenEnumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.LocalScopeHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.LocalScopeHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
             void System.Collections.IEnumerator.Reset() { }
             void System.IDisposable.Dispose() { }
         }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.LocalScopeHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.LocalScopeHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -1441,9 +1441,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LocalVariable
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.LocalVariableAttributes Attributes { get { throw null; } }
         public int Index { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
@@ -1454,9 +1454,9 @@ namespace System.Reflection.Metadata
         DebuggerHidden = 1,
         None = 0,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LocalVariableHandle : System.IEquatable<System.Reflection.Metadata.LocalVariableHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.LocalVariableHandle other) { throw null; }
@@ -1468,16 +1468,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.LocalVariableHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.LocalVariableHandle left, System.Reflection.Metadata.LocalVariableHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LocalVariableHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalVariableHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.LocalVariableHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.LocalVariableHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.LocalVariableHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.LocalVariableHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.LocalVariableHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.LocalVariableHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -1485,18 +1485,18 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ManifestResource
     {
+        private readonly object _dummy;
         public System.Reflection.ManifestResourceAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Implementation { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public long Offset { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ManifestResourceHandle : System.IEquatable<System.Reflection.Metadata.ManifestResourceHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.ManifestResourceHandle other) { throw null; }
@@ -1508,16 +1508,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.ManifestResourceHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.ManifestResourceHandle left, System.Reflection.Metadata.ManifestResourceHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ManifestResourceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ManifestResourceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ManifestResourceHandle>, System.Collections.IEnumerable
     {
+        private readonly int _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.ManifestResourceHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.ManifestResourceHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ManifestResourceHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.ManifestResourceHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private int _dummy;
             public System.Reflection.Metadata.ManifestResourceHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -1525,9 +1525,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MemberReference
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle Parent { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Signature { get { throw null; } }
@@ -1536,9 +1536,9 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
         public System.Reflection.Metadata.MemberReferenceKind GetKind() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MemberReferenceHandle : System.IEquatable<System.Reflection.Metadata.MemberReferenceHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.MemberReferenceHandle other) { throw null; }
@@ -1550,16 +1550,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.MemberReferenceHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.MemberReferenceHandle left, System.Reflection.Metadata.MemberReferenceHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MemberReferenceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MemberReferenceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MemberReferenceHandle>, System.Collections.IEnumerable
     {
+        private readonly int _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.MemberReferenceHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.MemberReferenceHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MemberReferenceHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.MemberReferenceHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private int _dummy;
             public System.Reflection.Metadata.MemberReferenceHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -1687,9 +1687,9 @@ namespace System.Reflection.Metadata
         LeaveOpen = 1,
         PrefetchMetadata = 2,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MetadataStringComparer
     {
+        private readonly object _dummy;
         public bool Equals(System.Reflection.Metadata.DocumentNameBlobHandle handle, string value) { throw null; }
         public bool Equals(System.Reflection.Metadata.DocumentNameBlobHandle handle, string value, bool ignoreCase) { throw null; }
         public bool Equals(System.Reflection.Metadata.NamespaceDefinitionHandle handle, string value) { throw null; }
@@ -1719,18 +1719,18 @@ namespace System.Reflection.Metadata
         public System.Collections.Immutable.ImmutableArray<byte> GetILContent() { throw null; }
         public System.Reflection.Metadata.BlobReader GetILReader() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodDebugInformation
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.DocumentHandle Document { get { throw null; } }
         public System.Reflection.Metadata.StandaloneSignatureHandle LocalSignature { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle SequencePointsBlob { get { throw null; } }
         public System.Reflection.Metadata.SequencePointCollection GetSequencePoints() { throw null; }
         public System.Reflection.Metadata.MethodDefinitionHandle GetStateMachineKickoffMethod() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodDebugInformationHandle : System.IEquatable<System.Reflection.Metadata.MethodDebugInformationHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.MethodDebugInformationHandle other) { throw null; }
@@ -1743,16 +1743,16 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.MethodDebugInformationHandle left, System.Reflection.Metadata.MethodDebugInformationHandle right) { throw null; }
         public System.Reflection.Metadata.MethodDefinitionHandle ToDefinitionHandle() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodDebugInformationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodDebugInformationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MethodDebugInformationHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.MethodDebugInformationHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.MethodDebugInformationHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodDebugInformationHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.MethodDebugInformationHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.MethodDebugInformationHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -1760,9 +1760,9 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodDefinition
     {
+        private readonly object _dummy;
         public System.Reflection.MethodAttributes Attributes { get { throw null; } }
         public System.Reflection.MethodImplAttributes ImplAttributes { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
@@ -1776,9 +1776,9 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.MethodImport GetImport() { throw null; }
         public System.Reflection.Metadata.ParameterHandleCollection GetParameters() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodDefinitionHandle : System.IEquatable<System.Reflection.Metadata.MethodDefinitionHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.MethodDefinitionHandle other) { throw null; }
@@ -1791,16 +1791,16 @@ namespace System.Reflection.Metadata
         public static bool operator !=(System.Reflection.Metadata.MethodDefinitionHandle left, System.Reflection.Metadata.MethodDefinitionHandle right) { throw null; }
         public System.Reflection.Metadata.MethodDebugInformationHandle ToDebugInformationHandle() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MethodDefinitionHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.MethodDefinitionHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodDefinitionHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.MethodDefinitionHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.MethodDefinitionHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -1808,17 +1808,17 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodImplementation
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.EntityHandle MethodBody { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle MethodDeclaration { get { throw null; } }
         public System.Reflection.Metadata.TypeDefinitionHandle Type { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodImplementationHandle : System.IEquatable<System.Reflection.Metadata.MethodImplementationHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.MethodImplementationHandle other) { throw null; }
@@ -1830,16 +1830,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.MethodImplementationHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.MethodImplementationHandle left, System.Reflection.Metadata.MethodImplementationHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodImplementationHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodImplementationHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.MethodImplementationHandle>, System.Collections.IEnumerable
     {
+        private readonly int _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.MethodImplementationHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.MethodImplementationHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.MethodImplementationHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.MethodImplementationHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private int _dummy;
             public System.Reflection.Metadata.MethodImplementationHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -1847,34 +1847,34 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodImport
     {
+        private readonly int _dummy;
         public System.Reflection.MethodImportAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.ModuleReferenceHandle Module { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodSignature<TType>
     {
-        public MethodSignature(System.Reflection.Metadata.SignatureHeader header, TType returnType, int requiredParameterCount, int genericParameterCount, System.Collections.Immutable.ImmutableArray<TType> parameterTypes) { throw null;}
+        private readonly TType _ReturnType_k__BackingField;
+        public MethodSignature(System.Reflection.Metadata.SignatureHeader header, TType returnType, int requiredParameterCount, int genericParameterCount, System.Collections.Immutable.ImmutableArray<TType> parameterTypes) { throw null; }
         public int GenericParameterCount { get { throw null; } }
         public System.Reflection.Metadata.SignatureHeader Header { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<TType> ParameterTypes { get { throw null; } }
         public int RequiredParameterCount { get { throw null; } }
         public TType ReturnType { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodSpecification
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.EntityHandle Method { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Signature { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<TType> DecodeSignature<TType, TGenericContext>(System.Reflection.Metadata.ISignatureTypeProvider<TType, TGenericContext> provider, TGenericContext genericContext) { throw null; }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodSpecificationHandle : System.IEquatable<System.Reflection.Metadata.MethodSpecificationHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.MethodSpecificationHandle other) { throw null; }
@@ -1886,9 +1886,9 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.MethodSpecificationHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.MethodSpecificationHandle left, System.Reflection.Metadata.MethodSpecificationHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ModuleDefinition
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.GuidHandle BaseGenerationId { get { throw null; } }
         public int Generation { get { throw null; } }
         public System.Reflection.Metadata.GuidHandle GenerationId { get { throw null; } }
@@ -1896,9 +1896,9 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ModuleDefinitionHandle : System.IEquatable<System.Reflection.Metadata.ModuleDefinitionHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.ModuleDefinitionHandle other) { throw null; }
@@ -1910,15 +1910,15 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.ModuleDefinitionHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.ModuleDefinitionHandle left, System.Reflection.Metadata.ModuleDefinitionHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ModuleReference
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ModuleReferenceHandle : System.IEquatable<System.Reflection.Metadata.ModuleReferenceHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.ModuleReferenceHandle other) { throw null; }
@@ -1930,18 +1930,18 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.ModuleReferenceHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.ModuleReferenceHandle left, System.Reflection.Metadata.ModuleReferenceHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct NamespaceDefinition
     {
+        private object _dummy;
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.ExportedTypeHandle> ExportedTypes { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.NamespaceDefinitionHandle> NamespaceDefinitions { get { throw null; } }
         public System.Reflection.Metadata.NamespaceDefinitionHandle Parent { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.TypeDefinitionHandle> TypeDefinitions { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct NamespaceDefinitionHandle : System.IEquatable<System.Reflection.Metadata.NamespaceDefinitionHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.NamespaceDefinitionHandle other) { throw null; }
@@ -1951,9 +1951,9 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.NamespaceDefinitionHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.NamespaceDefinitionHandle left, System.Reflection.Metadata.NamespaceDefinitionHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct Parameter
     {
+        private readonly object _dummy;
         public System.Reflection.ParameterAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public int SequenceNumber { get { throw null; } }
@@ -1961,9 +1961,9 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.ConstantHandle GetDefaultValue() { throw null; }
         public System.Reflection.Metadata.BlobHandle GetMarshallingDescriptor() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ParameterHandle : System.IEquatable<System.Reflection.Metadata.ParameterHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.ParameterHandle other) { throw null; }
@@ -1975,16 +1975,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.ParameterHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.ParameterHandle left, System.Reflection.Metadata.ParameterHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ParameterHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ParameterHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.ParameterHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.ParameterHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.ParameterHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.ParameterHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.ParameterHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.ParameterHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -2037,16 +2037,16 @@ namespace System.Reflection.Metadata
         UIntPtr = (byte)25,
         Void = (byte)1,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct PropertyAccessors
     {
+        private readonly int _dummy;
         public System.Reflection.Metadata.MethodDefinitionHandle Getter { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.MethodDefinitionHandle> Others { get { throw null; } }
         public System.Reflection.Metadata.MethodDefinitionHandle Setter { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct PropertyDefinition
     {
+        private readonly object _dummy;
         public System.Reflection.PropertyAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.BlobHandle Signature { get { throw null; } }
@@ -2055,9 +2055,9 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
         public System.Reflection.Metadata.ConstantHandle GetDefaultValue() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct PropertyDefinitionHandle : System.IEquatable<System.Reflection.Metadata.PropertyDefinitionHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.PropertyDefinitionHandle other) { throw null; }
@@ -2069,16 +2069,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.PropertyDefinitionHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.PropertyDefinitionHandle left, System.Reflection.Metadata.PropertyDefinitionHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct PropertyDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.PropertyDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.PropertyDefinitionHandle>, System.Collections.IEnumerable
     {
+        private readonly object _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.PropertyDefinitionHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.PropertyDefinitionHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.PropertyDefinitionHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.PropertyDefinitionHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
             public System.Reflection.Metadata.PropertyDefinitionHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -2086,16 +2086,16 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ReservedBlob<THandle> where THandle : struct
     {
+        private readonly THandle _Handle_k__BackingField;
         public System.Reflection.Metadata.Blob Content { get { throw null; } }
         public THandle Handle { get { throw null; } }
         public System.Reflection.Metadata.BlobWriter CreateWriter() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SequencePoint : System.IEquatable<System.Reflection.Metadata.SequencePoint>
     {
+        private readonly int _dummy;
         public const int HiddenLine = 16707566;
         public System.Reflection.Metadata.DocumentHandle Document { get { throw null; } }
         public int EndColumn { get { throw null; } }
@@ -2108,15 +2108,15 @@ namespace System.Reflection.Metadata
         public bool Equals(System.Reflection.Metadata.SequencePoint other) { throw null; }
         public override int GetHashCode() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SequencePointCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.SequencePoint>, System.Collections.IEnumerable
     {
+        private readonly int _dummy;
         public System.Reflection.Metadata.SequencePointCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.SequencePoint> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.SequencePoint>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.SequencePoint>, System.Collections.IEnumerator, System.IDisposable
         {
+            private int _dummy;
             public System.Reflection.Metadata.SequencePoint Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -2162,12 +2162,12 @@ namespace System.Reflection.Metadata
         ThisCall = (byte)3,
         VarArgs = (byte)5,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SignatureHeader : System.IEquatable<System.Reflection.Metadata.SignatureHeader>
     {
+        private int _dummy;
         public const byte CallingConventionOrKindMask = (byte)15;
-        public SignatureHeader(byte rawValue) { throw null;}
-        public SignatureHeader(System.Reflection.Metadata.SignatureKind kind, System.Reflection.Metadata.SignatureCallingConvention convention, System.Reflection.Metadata.SignatureAttributes attributes) { throw null;}
+        public SignatureHeader(byte rawValue) { throw null; }
+        public SignatureHeader(System.Reflection.Metadata.SignatureKind kind, System.Reflection.Metadata.SignatureCallingConvention convention, System.Reflection.Metadata.SignatureAttributes attributes) { throw null; }
         public System.Reflection.Metadata.SignatureAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.SignatureCallingConvention CallingConvention { get { throw null; } }
         public bool HasExplicitThis { get { throw null; } }
@@ -2231,18 +2231,18 @@ namespace System.Reflection.Metadata
         Unknown = (byte)0,
         ValueType = (byte)17,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct StandaloneSignature
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.BlobHandle Signature { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<TType> DecodeLocalSignature<TType, TGenericContext>(System.Reflection.Metadata.ISignatureTypeProvider<TType, TGenericContext> provider, TGenericContext genericContext) { throw null; }
         public System.Reflection.Metadata.MethodSignature<TType> DecodeMethodSignature<TType, TGenericContext>(System.Reflection.Metadata.ISignatureTypeProvider<TType, TGenericContext> provider, TGenericContext genericContext) { throw null; }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
         public System.Reflection.Metadata.StandaloneSignatureKind GetKind() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct StandaloneSignatureHandle : System.IEquatable<System.Reflection.Metadata.StandaloneSignatureHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.StandaloneSignatureHandle other) { throw null; }
@@ -2259,9 +2259,9 @@ namespace System.Reflection.Metadata
         LocalVariables = 1,
         Method = 0,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct StringHandle : System.IEquatable<System.Reflection.Metadata.StringHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.StringHandle other) { throw null; }
@@ -2271,9 +2271,9 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.StringHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.StringHandle left, System.Reflection.Metadata.StringHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct TypeDefinition
     {
+        private readonly object _dummy;
         public System.Reflection.TypeAttributes Attributes { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle BaseType { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
@@ -2292,9 +2292,9 @@ namespace System.Reflection.Metadata
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.TypeDefinitionHandle> GetNestedTypes() { throw null; }
         public System.Reflection.Metadata.PropertyDefinitionHandleCollection GetProperties() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct TypeDefinitionHandle : System.IEquatable<System.Reflection.Metadata.TypeDefinitionHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.TypeDefinitionHandle other) { throw null; }
@@ -2306,16 +2306,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.TypeDefinitionHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.TypeDefinitionHandle left, System.Reflection.Metadata.TypeDefinitionHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct TypeDefinitionHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.TypeDefinitionHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.TypeDefinitionHandle>, System.Collections.IEnumerable
     {
+        private readonly int _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.TypeDefinitionHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.TypeDefinitionHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.TypeDefinitionHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.TypeDefinitionHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private int _dummy;
             public System.Reflection.Metadata.TypeDefinitionHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -2323,24 +2323,24 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct TypeLayout
     {
-        public TypeLayout(int size, int packingSize) { throw null;}
+        private readonly int _dummy;
+        public TypeLayout(int size, int packingSize) { throw null; }
         public bool IsDefault { get { throw null; } }
         public int PackingSize { get { throw null; } }
         public int Size { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct TypeReference
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.StringHandle Name { get { throw null; } }
         public System.Reflection.Metadata.StringHandle Namespace { get { throw null; } }
         public System.Reflection.Metadata.EntityHandle ResolutionScope { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct TypeReferenceHandle : System.IEquatable<System.Reflection.Metadata.TypeReferenceHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.TypeReferenceHandle other) { throw null; }
@@ -2352,16 +2352,16 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.TypeReferenceHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.TypeReferenceHandle left, System.Reflection.Metadata.TypeReferenceHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct TypeReferenceHandleCollection : System.Collections.Generic.IEnumerable<System.Reflection.Metadata.TypeReferenceHandle>, System.Collections.Generic.IReadOnlyCollection<System.Reflection.Metadata.TypeReferenceHandle>, System.Collections.IEnumerable
     {
+        private readonly int _dummy;
         public int Count { get { throw null; } }
         public System.Reflection.Metadata.TypeReferenceHandleCollection.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Reflection.Metadata.TypeReferenceHandle> System.Collections.Generic.IEnumerable<System.Reflection.Metadata.TypeReferenceHandle>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Reflection.Metadata.TypeReferenceHandle>, System.Collections.IEnumerator, System.IDisposable
         {
+            private int _dummy;
             public System.Reflection.Metadata.TypeReferenceHandle Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public bool MoveNext() { throw null; }
@@ -2369,16 +2369,16 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct TypeSpecification
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.BlobHandle Signature { get { throw null; } }
         public TType DecodeSignature<TType, TGenericContext>(System.Reflection.Metadata.ISignatureTypeProvider<TType, TGenericContext> provider, TGenericContext genericContext) { throw null; }
         public System.Reflection.Metadata.CustomAttributeHandleCollection GetCustomAttributes() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct TypeSpecificationHandle : System.IEquatable<System.Reflection.Metadata.TypeSpecificationHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.TypeSpecificationHandle other) { throw null; }
@@ -2390,9 +2390,9 @@ namespace System.Reflection.Metadata
         public static implicit operator System.Reflection.Metadata.Handle (System.Reflection.Metadata.TypeSpecificationHandle handle) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.TypeSpecificationHandle left, System.Reflection.Metadata.TypeSpecificationHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct UserStringHandle : System.IEquatable<System.Reflection.Metadata.UserStringHandle>
     {
+        private readonly int _dummy;
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Reflection.Metadata.UserStringHandle other) { throw null; }
@@ -2405,20 +2405,20 @@ namespace System.Reflection.Metadata
 }
 namespace System.Reflection.Metadata.Ecma335
 {
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ArrayShapeEncoder
     {
-        public ArrayShapeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public ArrayShapeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public void Shape(int rank, System.Collections.Immutable.ImmutableArray<int> sizes, System.Collections.Immutable.ImmutableArray<int> lowerBounds) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct BlobEncoder
     {
-        public BlobEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public BlobEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public void CustomAttributeSignature(System.Action<System.Reflection.Metadata.Ecma335.FixedArgumentsEncoder> fixedArguments, System.Action<System.Reflection.Metadata.Ecma335.CustomAttributeNamedArgumentsEncoder> namedArguments) { }
-        public void CustomAttributeSignature(out System.Reflection.Metadata.Ecma335.FixedArgumentsEncoder fixedArguments, out System.Reflection.Metadata.Ecma335.CustomAttributeNamedArgumentsEncoder namedArguments) { fixedArguments = default(System.Reflection.Metadata.Ecma335.FixedArgumentsEncoder); namedArguments = default(System.Reflection.Metadata.Ecma335.CustomAttributeNamedArgumentsEncoder); }
+        public void CustomAttributeSignature(out System.Reflection.Metadata.Ecma335.FixedArgumentsEncoder fixedArguments, out System.Reflection.Metadata.Ecma335.CustomAttributeNamedArgumentsEncoder namedArguments) { throw null; }
         public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder FieldSignature() { throw null; }
         public System.Reflection.Metadata.Ecma335.LocalVariablesEncoder LocalVariableSignature(int variableCount) { throw null; }
         public System.Reflection.Metadata.Ecma335.MethodSignatureEncoder MethodSignature(System.Reflection.Metadata.SignatureCallingConvention convention=(System.Reflection.Metadata.SignatureCallingConvention)(0), int genericParameterCount=0, bool isInstanceMethod=false) { throw null; }
@@ -2454,18 +2454,18 @@ namespace System.Reflection.Metadata.Ecma335
         public void AddFilterRegion(System.Reflection.Metadata.Ecma335.LabelHandle tryStart, System.Reflection.Metadata.Ecma335.LabelHandle tryEnd, System.Reflection.Metadata.Ecma335.LabelHandle handlerStart, System.Reflection.Metadata.Ecma335.LabelHandle handlerEnd, System.Reflection.Metadata.Ecma335.LabelHandle filterStart) { }
         public void AddFinallyRegion(System.Reflection.Metadata.Ecma335.LabelHandle tryStart, System.Reflection.Metadata.Ecma335.LabelHandle tryEnd, System.Reflection.Metadata.Ecma335.LabelHandle handlerStart, System.Reflection.Metadata.Ecma335.LabelHandle handlerEnd) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomAttributeArrayTypeEncoder
     {
-        public CustomAttributeArrayTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public CustomAttributeArrayTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.CustomAttributeElementTypeEncoder ElementType() { throw null; }
         public void ObjectArray() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomAttributeElementTypeEncoder
     {
-        public CustomAttributeElementTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public CustomAttributeElementTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public void Boolean() { }
         public void Byte() { }
@@ -2484,24 +2484,24 @@ namespace System.Reflection.Metadata.Ecma335
         public void UInt32() { }
         public void UInt64() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomAttributeNamedArgumentsEncoder
     {
-        public CustomAttributeNamedArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public CustomAttributeNamedArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.NamedArgumentsEncoder Count(int count) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CustomModifiersEncoder
     {
-        public CustomModifiersEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public CustomModifiersEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.CustomModifiersEncoder AddModifier(System.Reflection.Metadata.EntityHandle type, bool isOptional) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct EditAndContinueLogEntry : System.IEquatable<System.Reflection.Metadata.Ecma335.EditAndContinueLogEntry>
     {
-        public EditAndContinueLogEntry(System.Reflection.Metadata.EntityHandle handle, System.Reflection.Metadata.Ecma335.EditAndContinueOperation operation) { throw null;}
+        private readonly int _dummy;
+        public EditAndContinueLogEntry(System.Reflection.Metadata.EntityHandle handle, System.Reflection.Metadata.Ecma335.EditAndContinueOperation operation) { throw null; }
         public System.Reflection.Metadata.EntityHandle Handle { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.EditAndContinueOperation Operation { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -2517,9 +2517,9 @@ namespace System.Reflection.Metadata.Ecma335
         AddProperty = 4,
         Default = 0,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ExceptionRegionEncoder
     {
+        private readonly object _dummy;
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public bool HasSmallFormat { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.ExceptionRegionEncoder Add(System.Reflection.Metadata.ExceptionRegionKind kind, int tryOffset, int tryLength, int handlerOffset, int handlerLength, System.Reflection.Metadata.EntityHandle catchType=default(System.Reflection.Metadata.EntityHandle), int filterOffset=0) { throw null; }
@@ -2534,10 +2534,10 @@ namespace System.Reflection.Metadata.Ecma335
     {
         public static int GetTypeDefinitionId(this System.Reflection.Metadata.ExportedType exportedType) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct FixedArgumentsEncoder
     {
-        public FixedArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public FixedArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.LiteralEncoder AddArgument() { throw null; }
     }
@@ -2547,10 +2547,10 @@ namespace System.Reflection.Metadata.Ecma335
         HasThis = 32,
         None = 0,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct GenericTypeArgumentsEncoder
     {
-        public GenericTypeArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public GenericTypeArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder AddArgument() { throw null; }
     }
@@ -2561,10 +2561,10 @@ namespace System.Reflection.Metadata.Ecma335
         String = 1,
         UserString = 0,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct InstructionEncoder
     {
-        public InstructionEncoder(System.Reflection.Metadata.BlobBuilder codeBuilder, System.Reflection.Metadata.Ecma335.ControlFlowBuilder controlFlowBuilder=null) { throw null;}
+        private readonly object _dummy;
+        public InstructionEncoder(System.Reflection.Metadata.BlobBuilder codeBuilder, System.Reflection.Metadata.Ecma335.ControlFlowBuilder controlFlowBuilder=null) { throw null; }
         public System.Reflection.Metadata.BlobBuilder CodeBuilder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.ControlFlowBuilder ControlFlowBuilder { get { throw null; } }
         public int Offset { get { throw null; } }
@@ -2591,9 +2591,9 @@ namespace System.Reflection.Metadata.Ecma335
         public void Token(int token) { }
         public void Token(System.Reflection.Metadata.EntityHandle handle) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LabelHandle : System.IEquatable<System.Reflection.Metadata.Ecma335.LabelHandle>
     {
+        private readonly int _dummy;
         public int Id { get { throw null; } }
         public bool IsNil { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -2602,36 +2602,36 @@ namespace System.Reflection.Metadata.Ecma335
         public static bool operator ==(System.Reflection.Metadata.Ecma335.LabelHandle left, System.Reflection.Metadata.Ecma335.LabelHandle right) { throw null; }
         public static bool operator !=(System.Reflection.Metadata.Ecma335.LabelHandle left, System.Reflection.Metadata.Ecma335.LabelHandle right) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LiteralEncoder
     {
-        public LiteralEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public LiteralEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.ScalarEncoder Scalar() { throw null; }
         public void TaggedScalar(System.Action<System.Reflection.Metadata.Ecma335.CustomAttributeElementTypeEncoder> type, System.Action<System.Reflection.Metadata.Ecma335.ScalarEncoder> scalar) { }
-        public void TaggedScalar(out System.Reflection.Metadata.Ecma335.CustomAttributeElementTypeEncoder type, out System.Reflection.Metadata.Ecma335.ScalarEncoder scalar) { type = default(System.Reflection.Metadata.Ecma335.CustomAttributeElementTypeEncoder); scalar = default(System.Reflection.Metadata.Ecma335.ScalarEncoder); }
+        public void TaggedScalar(out System.Reflection.Metadata.Ecma335.CustomAttributeElementTypeEncoder type, out System.Reflection.Metadata.Ecma335.ScalarEncoder scalar) { throw null; }
         public void TaggedVector(System.Action<System.Reflection.Metadata.Ecma335.CustomAttributeArrayTypeEncoder> arrayType, System.Action<System.Reflection.Metadata.Ecma335.VectorEncoder> vector) { }
-        public void TaggedVector(out System.Reflection.Metadata.Ecma335.CustomAttributeArrayTypeEncoder arrayType, out System.Reflection.Metadata.Ecma335.VectorEncoder vector) { arrayType = default(System.Reflection.Metadata.Ecma335.CustomAttributeArrayTypeEncoder); vector = default(System.Reflection.Metadata.Ecma335.VectorEncoder); }
+        public void TaggedVector(out System.Reflection.Metadata.Ecma335.CustomAttributeArrayTypeEncoder arrayType, out System.Reflection.Metadata.Ecma335.VectorEncoder vector) { throw null; }
         public System.Reflection.Metadata.Ecma335.VectorEncoder Vector() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LiteralsEncoder
     {
-        public LiteralsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public LiteralsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.LiteralEncoder AddLiteral() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LocalVariablesEncoder
     {
-        public LocalVariablesEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public LocalVariablesEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.LocalVariableTypeEncoder AddVariable() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LocalVariableTypeEncoder
     {
-        public LocalVariableTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public LocalVariableTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.CustomModifiersEncoder CustomModifiers() { throw null; }
         public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder Type(bool isByRef=false, bool isPinned=false) { throw null; }
@@ -2641,7 +2641,7 @@ namespace System.Reflection.Metadata.Ecma335
     {
         public MetadataAggregator(System.Collections.Generic.IReadOnlyList<int> baseTableRowCounts, System.Collections.Generic.IReadOnlyList<int> baseHeapSizes, System.Collections.Generic.IReadOnlyList<System.Reflection.Metadata.MetadataReader> deltaReaders) { }
         public MetadataAggregator(System.Reflection.Metadata.MetadataReader baseReader, System.Collections.Generic.IReadOnlyList<System.Reflection.Metadata.MetadataReader> deltaReaders) { }
-        public System.Reflection.Metadata.Handle GetGenerationHandle(System.Reflection.Metadata.Handle handle, out int generation) { generation = default(int); throw null; }
+        public System.Reflection.Metadata.Handle GetGenerationHandle(System.Reflection.Metadata.Handle handle, out int generation) { throw null; }
     }
     public sealed partial class MetadataBuilder
     {
@@ -2790,8 +2790,8 @@ namespace System.Reflection.Metadata.Ecma335
         public static System.Reflection.Metadata.PropertyDefinitionHandle PropertyDefinitionHandle(int rowNumber) { throw null; }
         public static System.Reflection.Metadata.StandaloneSignatureHandle StandaloneSignatureHandle(int rowNumber) { throw null; }
         public static System.Reflection.Metadata.StringHandle StringHandle(int offset) { throw null; }
-        public static bool TryGetHeapIndex(System.Reflection.Metadata.HandleKind type, out System.Reflection.Metadata.Ecma335.HeapIndex index) { index = default(System.Reflection.Metadata.Ecma335.HeapIndex); throw null; }
-        public static bool TryGetTableIndex(System.Reflection.Metadata.HandleKind type, out System.Reflection.Metadata.Ecma335.TableIndex index) { index = default(System.Reflection.Metadata.Ecma335.TableIndex); throw null; }
+        public static bool TryGetHeapIndex(System.Reflection.Metadata.HandleKind type, out System.Reflection.Metadata.Ecma335.HeapIndex index) { throw null; }
+        public static bool TryGetTableIndex(System.Reflection.Metadata.HandleKind type, out System.Reflection.Metadata.Ecma335.TableIndex index) { throw null; }
         public static System.Reflection.Metadata.TypeDefinitionHandle TypeDefinitionHandle(int rowNumber) { throw null; }
         public static System.Reflection.Metadata.TypeReferenceHandle TypeReferenceHandle(int rowNumber) { throw null; }
         public static System.Reflection.Metadata.TypeSpecificationHandle TypeSpecificationHandle(int rowNumber) { throw null; }
@@ -2803,76 +2803,76 @@ namespace System.Reflection.Metadata.Ecma335
         InitLocals = 1,
         None = 0,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodBodyStreamEncoder
     {
-        public MethodBodyStreamEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public MethodBodyStreamEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.MethodBodyStreamEncoder.MethodBody AddMethodBody(int codeSize, int maxStack=8, int exceptionRegionCount=0, bool hasSmallExceptionRegions=true, System.Reflection.Metadata.StandaloneSignatureHandle localVariablesSignature=default(System.Reflection.Metadata.StandaloneSignatureHandle), System.Reflection.Metadata.Ecma335.MethodBodyAttributes attributes=(System.Reflection.Metadata.Ecma335.MethodBodyAttributes)(1)) { throw null; }
         public int AddMethodBody(System.Reflection.Metadata.Ecma335.InstructionEncoder instructionEncoder, int maxStack=8, System.Reflection.Metadata.StandaloneSignatureHandle localVariablesSignature=default(System.Reflection.Metadata.StandaloneSignatureHandle), System.Reflection.Metadata.Ecma335.MethodBodyAttributes attributes=(System.Reflection.Metadata.Ecma335.MethodBodyAttributes)(1)) { throw null; }
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public readonly partial struct MethodBody
         {
+            private readonly object _dummy;
             public System.Reflection.Metadata.Ecma335.ExceptionRegionEncoder ExceptionRegions { get { throw null; } }
             public System.Reflection.Metadata.Blob Instructions { get { throw null; } }
             public int Offset { get { throw null; } }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MethodSignatureEncoder
     {
-        public MethodSignatureEncoder(System.Reflection.Metadata.BlobBuilder builder, bool hasVarArgs) { throw null;}
+        private readonly object _dummy;
+        public MethodSignatureEncoder(System.Reflection.Metadata.BlobBuilder builder, bool hasVarArgs) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public bool HasVarArgs { get { throw null; } }
         public void Parameters(int parameterCount, System.Action<System.Reflection.Metadata.Ecma335.ReturnTypeEncoder> returnType, System.Action<System.Reflection.Metadata.Ecma335.ParametersEncoder> parameters) { }
-        public void Parameters(int parameterCount, out System.Reflection.Metadata.Ecma335.ReturnTypeEncoder returnType, out System.Reflection.Metadata.Ecma335.ParametersEncoder parameters) { returnType = default(System.Reflection.Metadata.Ecma335.ReturnTypeEncoder); parameters = default(System.Reflection.Metadata.Ecma335.ParametersEncoder); }
+        public void Parameters(int parameterCount, out System.Reflection.Metadata.Ecma335.ReturnTypeEncoder returnType, out System.Reflection.Metadata.Ecma335.ParametersEncoder parameters) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct NamedArgumentsEncoder
     {
-        public NamedArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public NamedArgumentsEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public void AddArgument(bool isField, System.Action<System.Reflection.Metadata.Ecma335.NamedArgumentTypeEncoder> type, System.Action<System.Reflection.Metadata.Ecma335.NameEncoder> name, System.Action<System.Reflection.Metadata.Ecma335.LiteralEncoder> literal) { }
-        public void AddArgument(bool isField, out System.Reflection.Metadata.Ecma335.NamedArgumentTypeEncoder type, out System.Reflection.Metadata.Ecma335.NameEncoder name, out System.Reflection.Metadata.Ecma335.LiteralEncoder literal) { type = default(System.Reflection.Metadata.Ecma335.NamedArgumentTypeEncoder); name = default(System.Reflection.Metadata.Ecma335.NameEncoder); literal = default(System.Reflection.Metadata.Ecma335.LiteralEncoder); }
+        public void AddArgument(bool isField, out System.Reflection.Metadata.Ecma335.NamedArgumentTypeEncoder type, out System.Reflection.Metadata.Ecma335.NameEncoder name, out System.Reflection.Metadata.Ecma335.LiteralEncoder literal) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct NamedArgumentTypeEncoder
     {
-        public NamedArgumentTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public NamedArgumentTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public void Object() { }
         public System.Reflection.Metadata.Ecma335.CustomAttributeElementTypeEncoder ScalarType() { throw null; }
         public System.Reflection.Metadata.Ecma335.CustomAttributeArrayTypeEncoder SZArray() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct NameEncoder
     {
-        public NameEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public NameEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public void Name(string name) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ParametersEncoder
     {
-        public ParametersEncoder(System.Reflection.Metadata.BlobBuilder builder, bool hasVarArgs=false) { throw null;}
+        private readonly object _dummy;
+        public ParametersEncoder(System.Reflection.Metadata.BlobBuilder builder, bool hasVarArgs=false) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public bool HasVarArgs { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.ParameterTypeEncoder AddParameter() { throw null; }
         public System.Reflection.Metadata.Ecma335.ParametersEncoder StartVarArgs() { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ParameterTypeEncoder
     {
-        public ParameterTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public ParameterTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.CustomModifiersEncoder CustomModifiers() { throw null; }
         public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder Type(bool isByRef=false) { throw null; }
         public void TypedReference() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct PermissionSetEncoder
     {
-        public PermissionSetEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public PermissionSetEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.PermissionSetEncoder AddPermission(string typeName, System.Collections.Immutable.ImmutableArray<byte> encodedArguments) { throw null; }
         public System.Reflection.Metadata.Ecma335.PermissionSetEncoder AddPermission(string typeName, System.Reflection.Metadata.BlobBuilder encodedArguments) { throw null; }
@@ -2885,42 +2885,42 @@ namespace System.Reflection.Metadata.Ecma335
         public string MetadataVersion { get { throw null; } }
         public System.Reflection.Metadata.BlobContentId Serialize(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ReturnTypeEncoder
     {
-        public ReturnTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public ReturnTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.CustomModifiersEncoder CustomModifiers() { throw null; }
         public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder Type(bool isByRef=false) { throw null; }
         public void TypedReference() { }
         public void Void() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ScalarEncoder
     {
-        public ScalarEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public ScalarEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public void Constant(object value) { }
         public void NullArray() { }
         public void SystemType(string serializedTypeName) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SignatureDecoder<TType, TGenericContext>
     {
-        public SignatureDecoder(System.Reflection.Metadata.ISignatureTypeProvider<TType, TGenericContext> provider, System.Reflection.Metadata.MetadataReader metadataReader, TGenericContext genericContext) { throw null;}
+        private readonly TGenericContext _genericContext;
+        public SignatureDecoder(System.Reflection.Metadata.ISignatureTypeProvider<TType, TGenericContext> provider, System.Reflection.Metadata.MetadataReader metadataReader, TGenericContext genericContext) { throw null; }
         public TType DecodeFieldSignature(ref System.Reflection.Metadata.BlobReader blobReader) { throw null; }
         public System.Collections.Immutable.ImmutableArray<TType> DecodeLocalSignature(ref System.Reflection.Metadata.BlobReader blobReader) { throw null; }
         public System.Reflection.Metadata.MethodSignature<TType> DecodeMethodSignature(ref System.Reflection.Metadata.BlobReader blobReader) { throw null; }
         public System.Collections.Immutable.ImmutableArray<TType> DecodeMethodSpecificationSignature(ref System.Reflection.Metadata.BlobReader blobReader) { throw null; }
         public TType DecodeType(ref System.Reflection.Metadata.BlobReader blobReader, bool allowTypeSpecifications=false) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SignatureTypeEncoder
     {
-        public SignatureTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public SignatureTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public void Array(System.Action<System.Reflection.Metadata.Ecma335.SignatureTypeEncoder> elementType, System.Action<System.Reflection.Metadata.Ecma335.ArrayShapeEncoder> arrayShape) { }
-        public void Array(out System.Reflection.Metadata.Ecma335.SignatureTypeEncoder elementType, out System.Reflection.Metadata.Ecma335.ArrayShapeEncoder arrayShape) { elementType = default(System.Reflection.Metadata.Ecma335.SignatureTypeEncoder); arrayShape = default(System.Reflection.Metadata.Ecma335.ArrayShapeEncoder); }
+        public void Array(out System.Reflection.Metadata.Ecma335.SignatureTypeEncoder elementType, out System.Reflection.Metadata.Ecma335.ArrayShapeEncoder arrayShape) { throw null; }
         public void Boolean() { }
         public void Byte() { }
         public void Char() { }
@@ -3004,10 +3004,10 @@ namespace System.Reflection.Metadata.Ecma335
         TypeRef = (byte)1,
         TypeSpec = (byte)27,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct VectorEncoder
     {
-        public VectorEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;}
+        private readonly object _dummy;
+        public VectorEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.LiteralsEncoder Count(int count) { throw null; }
     }
@@ -3032,9 +3032,9 @@ namespace System.Reflection.PortableExecutable
         System = (ushort)4096,
         UpSystemOnly = (ushort)16384,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct CodeViewDebugDirectoryData
     {
+        private readonly object _dummy;
         public int Age { get { throw null; } }
         public System.Guid Guid { get { throw null; } }
         public string Path { get { throw null; } }
@@ -3083,10 +3083,10 @@ namespace System.Reflection.PortableExecutable
         public void AddEmbeddedPortablePdbEntry(System.Reflection.Metadata.BlobBuilder debugMetadata, ushort portablePdbVersion) { }
         public void AddReproducibleEntry() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DebugDirectoryEntry
     {
-        public DebugDirectoryEntry(uint stamp, ushort majorVersion, ushort minorVersion, System.Reflection.PortableExecutable.DebugDirectoryEntryType type, int dataSize, int dataRelativeVirtualAddress, int dataPointer) { throw null;}
+        private readonly int _dummy;
+        public DebugDirectoryEntry(uint stamp, ushort majorVersion, ushort minorVersion, System.Reflection.PortableExecutable.DebugDirectoryEntryType type, int dataSize, int dataRelativeVirtualAddress, int dataPointer) { throw null; }
         public int DataPointer { get { throw null; } }
         public int DataRelativeVirtualAddress { get { throw null; } }
         public int DataSize { get { throw null; } }
@@ -3104,12 +3104,11 @@ namespace System.Reflection.PortableExecutable
         Reproducible = 16,
         Unknown = 0,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DirectoryEntry
     {
         public readonly int RelativeVirtualAddress;
         public readonly int Size;
-        public DirectoryEntry(int relativeVirtualAddress, int size) { throw null;}
+        public DirectoryEntry(int relativeVirtualAddress, int size) { throw null; }
     }
     [System.FlagsAttribute]
     public enum DllCharacteristics : ushort
@@ -3176,12 +3175,11 @@ namespace System.Reflection.PortableExecutable
         protected System.Collections.Immutable.ImmutableArray<System.Reflection.PortableExecutable.PEBuilder.Section> GetSections() { throw null; }
         public System.Reflection.Metadata.BlobContentId Serialize(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         protected abstract System.Reflection.Metadata.BlobBuilder SerializeSection(string name, System.Reflection.PortableExecutable.SectionLocation location);
-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         protected readonly partial struct Section
         {
             public readonly System.Reflection.PortableExecutable.SectionCharacteristics Characteristics;
             public readonly string Name;
-            public Section(string name, System.Reflection.PortableExecutable.SectionCharacteristics characteristics) { throw null;}
+            public Section(string name, System.Reflection.PortableExecutable.SectionCharacteristics characteristics) { throw null; }
         }
     }
     public sealed partial class PEDirectoriesBuilder
@@ -3294,16 +3292,16 @@ namespace System.Reflection.PortableExecutable
         public int PEHeaderStartOffset { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.PortableExecutable.SectionHeader> SectionHeaders { get { throw null; } }
         public int GetContainingSectionIndex(int relativeVirtualAddress) { throw null; }
-        public bool TryGetDirectoryOffset(System.Reflection.PortableExecutable.DirectoryEntry directory, out int offset) { offset = default(int); throw null; }
+        public bool TryGetDirectoryOffset(System.Reflection.PortableExecutable.DirectoryEntry directory, out int offset) { throw null; }
     }
     public enum PEMagic : ushort
     {
         PE32 = (ushort)267,
         PE32Plus = (ushort)523,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct PEMemoryBlock
     {
+        private readonly object _dummy;
         public int Length { get { throw null; } }
         public unsafe byte* Pointer { get { throw null; } }
         public System.Collections.Immutable.ImmutableArray<byte> GetContent() { throw null; }
@@ -3331,7 +3329,7 @@ namespace System.Reflection.PortableExecutable
         public System.Reflection.PortableExecutable.CodeViewDebugDirectoryData ReadCodeViewDebugDirectoryData(System.Reflection.PortableExecutable.DebugDirectoryEntry entry) { throw null; }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.PortableExecutable.DebugDirectoryEntry> ReadDebugDirectory() { throw null; }
         public System.Reflection.Metadata.MetadataReaderProvider ReadEmbeddedPortablePdbDebugDirectoryData(System.Reflection.PortableExecutable.DebugDirectoryEntry entry) { throw null; }
-        public bool TryOpenAssociatedPortablePdb(string peImagePath, System.Func<string, System.IO.Stream> pdbFileStreamProvider, out System.Reflection.Metadata.MetadataReaderProvider pdbReaderProvider, out string pdbPath) { pdbReaderProvider = default(System.Reflection.Metadata.MetadataReaderProvider); pdbPath = default(string); throw null; }
+        public bool TryOpenAssociatedPortablePdb(string peImagePath, System.Func<string, System.IO.Stream> pdbFileStreamProvider, out System.Reflection.Metadata.MetadataReaderProvider pdbReaderProvider, out string pdbPath) { throw null; }
     }
     [System.FlagsAttribute]
     public enum PEStreamOptions
@@ -3397,9 +3395,9 @@ namespace System.Reflection.PortableExecutable
         TypeOver = (uint)1024,
         TypeReg = (uint)0,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SectionHeader
     {
+        private readonly object _dummy;
         public string Name { get { throw null; } }
         public ushort NumberOfLineNumbers { get { throw null; } }
         public ushort NumberOfRelocations { get { throw null; } }
@@ -3411,10 +3409,10 @@ namespace System.Reflection.PortableExecutable
         public int VirtualAddress { get { throw null; } }
         public int VirtualSize { get { throw null; } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SectionLocation
     {
-        public SectionLocation(int relativeVirtualAddress, int pointerToRawData) { throw null;}
+        private readonly int _dummy;
+        public SectionLocation(int relativeVirtualAddress, int pointerToRawData) { throw null; }
         public int PointerToRawData { get { throw null; } }
         public int RelativeVirtualAddress { get { throw null; } }
     }

--- a/src/System.Reflection.Primitives/ref/System.Reflection.Primitives.cs
+++ b/src/System.Reflection.Primitives/ref/System.Reflection.Primitives.cs
@@ -31,9 +31,9 @@ namespace System.Reflection.Emit
         Return = 7,
         Throw = 8,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct OpCode
     {
+        private object _dummy;
         public System.Reflection.Emit.FlowControl FlowControl { get { throw null; } }
         public string Name { get { throw null; } }
         public System.Reflection.Emit.OpCodeType OpCodeType { get { throw null; } }

--- a/src/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
@@ -5,12 +5,18 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System.Runtime.InteropServices
 {
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public enum Architecture
+    {
+        Arm = 2,
+        Arm64 = 3,
+        X64 = 1,
+        X86 = 0,
+    }
     public readonly partial struct OSPlatform : System.IEquatable<System.Runtime.InteropServices.OSPlatform>
     {
+        private readonly object _dummy;
         public static System.Runtime.InteropServices.OSPlatform Linux { get { throw null; } }
         public static System.Runtime.InteropServices.OSPlatform OSX { get { throw null; } }
         public static System.Runtime.InteropServices.OSPlatform Windows { get { throw null; } }
@@ -22,21 +28,12 @@ namespace System.Runtime.InteropServices
         public static bool operator !=(System.Runtime.InteropServices.OSPlatform left, System.Runtime.InteropServices.OSPlatform right) { throw null; }
         public override string ToString() { throw null; }
     }
-
-    public enum Architecture
-    {
-        X86,
-        X64,
-        Arm,
-        Arm64
-    }
-
     public static partial class RuntimeInformation
     {
-        public static Architecture ProcessArchitecture { get { throw null; } }
-        public static Architecture OSArchitecture { get { throw null; } }
-        public static string OSDescription { get { throw null; } }
         public static string FrameworkDescription { get { throw null; } }
+        public static System.Runtime.InteropServices.Architecture OSArchitecture { get { throw null; } }
+        public static string OSDescription { get { throw null; } }
+        public static System.Runtime.InteropServices.Architecture ProcessArchitecture { get { throw null; } }
         public static bool IsOSPlatform(System.Runtime.InteropServices.OSPlatform osPlatform) { throw null; }
     }
 }

--- a/src/System.Runtime.InteropServices.WindowsRuntime/ref/System.Runtime.InteropServices.WindowsRuntime.cs
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/ref/System.Runtime.InteropServices.WindowsRuntime.cs
@@ -14,9 +14,9 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         public DefaultInterfaceAttribute(global::System.Type defaultInterface) { }
         public global::System.Type DefaultInterface { get { throw null; } }
     }
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EventRegistrationToken
     {
+        private int _dummy;
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static bool operator ==(global::System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken left, global::System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken right) { throw null; }

--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -139,9 +139,9 @@ namespace System.Runtime.InteropServices
         public AutomationProxyAttribute(bool val) { }
         public bool Value { get { throw null; } }
     }     
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ArrayWithOffset
     {
+        private object _dummy;
         public ArrayWithOffset(object array, int offset) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Runtime.InteropServices.ArrayWithOffset obj) { throw null; }
@@ -415,6 +415,7 @@ namespace System.Runtime.InteropServices
     }
     public struct HandleRef
     {
+        private object _dummy;
         public HandleRef(object wrapper, System.IntPtr handle) : this() { }
         public System.IntPtr Handle { get; }
         public object Wrapper { get; }

--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.csproj
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <!-- Don't warn about usage of obsolete API since the contract must keep its own references
          to its own obsolete API. -->
-    <NoWarn>618</NoWarn>
+    <NoWarn>$(NoWarn);618</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{B17014F1-D902-417F-89B0-271204695831}</ProjectGuid>
   </PropertyGroup>

--- a/src/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
+++ b/src/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
@@ -5,19 +5,18 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System.Numerics
 {
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct BigInteger : System.IComparable, System.IComparable<System.Numerics.BigInteger>, System.IEquatable<System.Numerics.BigInteger>, System.IFormattable
     {
+        private readonly object _dummy;
         [System.CLSCompliantAttribute(false)]
         public BigInteger(byte[] value) { throw null; }
-        public BigInteger(System.ReadOnlySpan<byte> value, bool isUnsigned=false, bool isBigEndian=false) { throw null; }
         public BigInteger(decimal value) { throw null; }
         public BigInteger(double value) { throw null; }
         public BigInteger(int value) { throw null; }
         public BigInteger(long value) { throw null; }
+        public BigInteger(System.ReadOnlySpan<byte> value, bool isUnsigned=false, bool isBigEndian=false) { throw null; }
         public BigInteger(float value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public BigInteger(uint value) { throw null; }
@@ -35,8 +34,8 @@ namespace System.Numerics
         public static System.Numerics.BigInteger Add(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         public static int Compare(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         public int CompareTo(long other) { throw null; }
-        public int CompareTo(object obj) { throw null; }
         public int CompareTo(System.Numerics.BigInteger other) { throw null; }
+        public int CompareTo(object obj) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public int CompareTo(ulong other) { throw null; }
         public static System.Numerics.BigInteger Divide(System.Numerics.BigInteger dividend, System.Numerics.BigInteger divisor) { throw null; }
@@ -46,8 +45,8 @@ namespace System.Numerics
         public override bool Equals(object obj) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public bool Equals(ulong other) { throw null; }
-        public override int GetHashCode() { throw null; }
         public int GetByteCount(bool isUnsigned=false) { throw null; }
+        public override int GetHashCode() { throw null; }
         public static System.Numerics.BigInteger GreatestCommonDivisor(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         public static double Log(System.Numerics.BigInteger value) { throw null; }
         public static double Log(System.Numerics.BigInteger value, double baseValue) { throw null; }
@@ -70,8 +69,8 @@ namespace System.Numerics
         [System.CLSCompliantAttribute(false)]
         public static bool operator ==(ulong left, System.Numerics.BigInteger right) { throw null; }
         public static System.Numerics.BigInteger operator ^(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
-        public static explicit operator System.Numerics.BigInteger(decimal value) { throw null; }
-        public static explicit operator System.Numerics.BigInteger(double value) { throw null; }
+        public static explicit operator System.Numerics.BigInteger (decimal value) { throw null; }
+        public static explicit operator System.Numerics.BigInteger (double value) { throw null; }
         public static explicit operator byte (System.Numerics.BigInteger value) { throw null; }
         public static explicit operator decimal (System.Numerics.BigInteger value) { throw null; }
         public static explicit operator double (System.Numerics.BigInteger value) { throw null; }
@@ -87,7 +86,7 @@ namespace System.Numerics
         public static explicit operator uint (System.Numerics.BigInteger value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static explicit operator ulong (System.Numerics.BigInteger value) { throw null; }
-        public static explicit operator System.Numerics.BigInteger(float value) { throw null; }
+        public static explicit operator System.Numerics.BigInteger (float value) { throw null; }
         public static bool operator >(long left, System.Numerics.BigInteger right) { throw null; }
         public static bool operator >(System.Numerics.BigInteger left, long right) { throw null; }
         public static bool operator >(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
@@ -102,18 +101,18 @@ namespace System.Numerics
         public static bool operator >=(System.Numerics.BigInteger left, ulong right) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static bool operator >=(ulong left, System.Numerics.BigInteger right) { throw null; }
-        public static implicit operator System.Numerics.BigInteger(byte value) { throw null; }
-        public static implicit operator System.Numerics.BigInteger(short value) { throw null; }
-        public static implicit operator System.Numerics.BigInteger(int value) { throw null; }
-        public static implicit operator System.Numerics.BigInteger(long value) { throw null; }
+        public static implicit operator System.Numerics.BigInteger (byte value) { throw null; }
+        public static implicit operator System.Numerics.BigInteger (short value) { throw null; }
+        public static implicit operator System.Numerics.BigInteger (int value) { throw null; }
+        public static implicit operator System.Numerics.BigInteger (long value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static implicit operator System.Numerics.BigInteger(sbyte value) { throw null; }
+        public static implicit operator System.Numerics.BigInteger (sbyte value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static implicit operator System.Numerics.BigInteger(ushort value) { throw null; }
+        public static implicit operator System.Numerics.BigInteger (ushort value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static implicit operator System.Numerics.BigInteger(uint value) { throw null; }
+        public static implicit operator System.Numerics.BigInteger (uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static implicit operator System.Numerics.BigInteger(ulong value) { throw null; }
+        public static implicit operator System.Numerics.BigInteger (ulong value) { throw null; }
         public static System.Numerics.BigInteger operator ++(System.Numerics.BigInteger value) { throw null; }
         public static bool operator !=(long left, System.Numerics.BigInteger right) { throw null; }
         public static bool operator !=(System.Numerics.BigInteger left, long right) { throw null; }
@@ -144,11 +143,11 @@ namespace System.Numerics
         public static System.Numerics.BigInteger operator -(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         public static System.Numerics.BigInteger operator -(System.Numerics.BigInteger value) { throw null; }
         public static System.Numerics.BigInteger operator +(System.Numerics.BigInteger value) { throw null; }
+        public static System.Numerics.BigInteger Parse(System.ReadOnlySpan<char> value, System.Globalization.NumberStyles style=(System.Globalization.NumberStyles)(7), System.IFormatProvider provider=null) { throw null; }
         public static System.Numerics.BigInteger Parse(string value) { throw null; }
         public static System.Numerics.BigInteger Parse(string value, System.Globalization.NumberStyles style) { throw null; }
         public static System.Numerics.BigInteger Parse(string value, System.Globalization.NumberStyles style, System.IFormatProvider provider) { throw null; }
         public static System.Numerics.BigInteger Parse(string value, System.IFormatProvider provider) { throw null; }
-        public static System.Numerics.BigInteger Parse(System.ReadOnlySpan<char> value, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider provider = null) { throw null; }
         public static System.Numerics.BigInteger Pow(System.Numerics.BigInteger value, int exponent) { throw null; }
         public static System.Numerics.BigInteger Remainder(System.Numerics.BigInteger dividend, System.Numerics.BigInteger divisor) { throw null; }
         public static System.Numerics.BigInteger Subtract(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
@@ -158,16 +157,16 @@ namespace System.Numerics
         public string ToString(System.IFormatProvider provider) { throw null; }
         public string ToString(string format) { throw null; }
         public string ToString(string format, System.IFormatProvider provider) { throw null; }
-        public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format=default(System.ReadOnlySpan<char>), System.IFormatProvider provider=null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> value, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Numerics.BigInteger result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> value, out System.Numerics.BigInteger result) { throw null; }
         public static bool TryParse(string value, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Numerics.BigInteger result) { throw null; }
         public static bool TryParse(string value, out System.Numerics.BigInteger result) { throw null; }
-        public static bool TryParse(ReadOnlySpan<char> value, out System.Numerics.BigInteger result) { throw null; }
-        public static bool TryParse(ReadOnlySpan<char> value, System.Globalization.NumberStyles style, System.IFormatProvider provider, out System.Numerics.BigInteger result) { throw null; }
         public bool TryWriteBytes(System.Span<byte> destination, out int bytesWritten, bool isUnsigned=false, bool isBigEndian=false) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Complex : System.IEquatable<System.Numerics.Complex>, System.IFormattable
     {
+        private int _dummy;
         public static readonly System.Numerics.Complex ImaginaryOne;
         public static readonly System.Numerics.Complex One;
         public static readonly System.Numerics.Complex Zero;
@@ -198,22 +197,22 @@ namespace System.Numerics
         public static System.Numerics.Complex operator +(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         public static System.Numerics.Complex operator /(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         public static bool operator ==(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
-        public static explicit operator System.Numerics.Complex(decimal value) { throw null; }
-        public static explicit operator System.Numerics.Complex(System.Numerics.BigInteger value) { throw null; }
-        public static implicit operator System.Numerics.Complex(byte value) { throw null; }
-        public static implicit operator System.Numerics.Complex(double value) { throw null; }
-        public static implicit operator System.Numerics.Complex(short value) { throw null; }
-        public static implicit operator System.Numerics.Complex(int value) { throw null; }
-        public static implicit operator System.Numerics.Complex(long value) { throw null; }
+        public static explicit operator System.Numerics.Complex (decimal value) { throw null; }
+        public static explicit operator System.Numerics.Complex (System.Numerics.BigInteger value) { throw null; }
+        public static implicit operator System.Numerics.Complex (byte value) { throw null; }
+        public static implicit operator System.Numerics.Complex (double value) { throw null; }
+        public static implicit operator System.Numerics.Complex (short value) { throw null; }
+        public static implicit operator System.Numerics.Complex (int value) { throw null; }
+        public static implicit operator System.Numerics.Complex (long value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static implicit operator System.Numerics.Complex(sbyte value) { throw null; }
-        public static implicit operator System.Numerics.Complex(float value) { throw null; }
+        public static implicit operator System.Numerics.Complex (sbyte value) { throw null; }
+        public static implicit operator System.Numerics.Complex (float value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static implicit operator System.Numerics.Complex(ushort value) { throw null; }
+        public static implicit operator System.Numerics.Complex (ushort value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static implicit operator System.Numerics.Complex(uint value) { throw null; }
+        public static implicit operator System.Numerics.Complex (uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static implicit operator System.Numerics.Complex(ulong value) { throw null; }
+        public static implicit operator System.Numerics.Complex (ulong value) { throw null; }
         public static bool operator !=(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         public static System.Numerics.Complex operator *(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         public static System.Numerics.Complex operator -(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/ref/System.Runtime.WindowsRuntime.UI.Xaml.cs
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/ref/System.Runtime.WindowsRuntime.UI.Xaml.cs
@@ -8,9 +8,9 @@
 
 namespace Windows.UI.Xaml
 {
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CornerRadius
     {
+        private int _dummy;
         public CornerRadius(double uniformRadius) { throw null; }
         public CornerRadius(double topLeft, double topRight, double bottomRight, double bottomLeft) { throw null; }
         public double BottomLeft { get { throw null; } set { } }
@@ -24,9 +24,9 @@ namespace Windows.UI.Xaml
         public static bool operator !=(global::Windows.UI.Xaml.CornerRadius cr1, global::Windows.UI.Xaml.CornerRadius cr2) { throw null; }
         public override string ToString() { throw null; }
     }
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Duration
     {
+        private int _dummy;
         public Duration(global::System.TimeSpan timeSpan) { throw null; }
         public static global::Windows.UI.Xaml.Duration Automatic { get { throw null; } }
         public static global::Windows.UI.Xaml.Duration Forever { get { throw null; } }
@@ -57,9 +57,9 @@ namespace Windows.UI.Xaml
         Forever = 2,
         TimeSpan = 1,
     }
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct GridLength
     {
+        private int _dummy;
         public GridLength(double pixels) { throw null; }
         public GridLength(double value, global::Windows.UI.Xaml.GridUnitType type) { throw null; }
         public static global::Windows.UI.Xaml.GridLength Auto { get { throw null; } }
@@ -87,9 +87,9 @@ namespace Windows.UI.Xaml
         public LayoutCycleException(string message) { }
         public LayoutCycleException(string message, global::System.Exception innerException) { }
     }
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Thickness
     {
+        private int _dummy;
         public Thickness(double uniformLength) { throw null; }
         public Thickness(double left, double top, double right, double bottom) { throw null; }
         public double Bottom { get { throw null; } set { } }
@@ -121,9 +121,9 @@ namespace Windows.UI.Xaml.Automation
 }
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct GeneratorPosition
     {
+        private int _dummy;
         public GeneratorPosition(int index, int offset) { throw null; }
         public int Index { get { throw null; } set { } }
         public int Offset { get { throw null; } set { } }
@@ -145,9 +145,9 @@ namespace Windows.UI.Xaml.Markup
 }
 namespace Windows.UI.Xaml.Media
 {
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Matrix : global::System.IFormattable
     {
+        private int _dummy;
         public Matrix(double m11, double m12, double m21, double m22, double offsetX, double offsetY) { throw null; }
         public static global::Windows.UI.Xaml.Media.Matrix Identity { get { throw null; } }
         public bool IsIdentity { get { throw null; } }
@@ -170,9 +170,9 @@ namespace Windows.UI.Xaml.Media
 }
 namespace Windows.UI.Xaml.Media.Animation
 {
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct KeyTime
     {
+        private int _dummy;
         public global::System.TimeSpan TimeSpan { get { throw null; } }
         public override bool Equals(object value) { throw null; }
         public bool Equals(global::Windows.UI.Xaml.Media.Animation.KeyTime value) { throw null; }
@@ -184,9 +184,9 @@ namespace Windows.UI.Xaml.Media.Animation
         public static bool operator !=(global::Windows.UI.Xaml.Media.Animation.KeyTime keyTime1, global::Windows.UI.Xaml.Media.Animation.KeyTime keyTime2) { throw null; }
         public override string ToString() { throw null; }
     }
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct RepeatBehavior : global::System.IFormattable
     {
+        private int _dummy;
         public RepeatBehavior(double count) { throw null; }
         public RepeatBehavior(global::System.TimeSpan duration) { throw null; }
         public double Count { get { throw null; } set { } }
@@ -214,9 +214,9 @@ namespace Windows.UI.Xaml.Media.Animation
 }
 namespace Windows.UI.Xaml.Media.Media3D
 {
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Matrix3D : global::System.IFormattable
     {
+        private int _dummy;
         public Matrix3D(double m11, double m12, double m13, double m14, double m21, double m22, double m23, double m24, double m31, double m32, double m33, double m34, double offsetX, double offsetY, double offsetZ, double m44) { throw null; }
         public bool HasInverse { get { throw null; } }
         public static global::Windows.UI.Xaml.Media.Media3D.Matrix3D Identity { get { throw null; } }

--- a/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.cs
+++ b/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.cs
@@ -145,9 +145,9 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 }
 namespace Windows.Foundation
 {
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Point
     {
+        private int _dummy;
         public Point(double x, double y) { throw null; }
         public double X { get { throw null; } set { } }
         public double Y { get { throw null; } set { } }
@@ -159,9 +159,9 @@ namespace Windows.Foundation
         public override string ToString() { throw null; }
         public string ToString(global::System.IFormatProvider provider) { throw null; }
     }
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Rect
     {
+        private int _dummy;
         public Rect(double x, double y, double width, double height) { throw null; }
         public Rect(global::Windows.Foundation.Point point1, global::Windows.Foundation.Point point2) { throw null; }
         public Rect(global::Windows.Foundation.Point location, global::Windows.Foundation.Size size) { throw null; }
@@ -187,9 +187,9 @@ namespace Windows.Foundation
         public void Union(global::Windows.Foundation.Point point) { }
         public void Union(global::Windows.Foundation.Rect rect) { }
     }
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Size
     {
+        private int _dummy;
         public Size(double width, double height) { throw null; }
         public static global::Windows.Foundation.Size Empty { get { throw null; } }
         public double Height { get { throw null; } set { } }
@@ -205,9 +205,9 @@ namespace Windows.Foundation
 }
 namespace Windows.UI
 {
-    [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Color
     {
+        private int _dummy;
         public byte A { get { throw null; } set { } }
         public byte B { get { throw null; } set { } }
         public byte G { get { throw null; } set { } }

--- a/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.csproj
@@ -11,7 +11,7 @@
                        Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' does not
                        match the output assembly name 'System.Runtime.WindowsRuntime, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.
      -->
-    <NoWarn>1698</NoWarn>
+    <NoWarn>$(NoWarn);1698</NoWarn>
     <ProjectGuid>{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />

--- a/src/System.Runtime/ref/System.Runtime.csproj
+++ b/src/System.Runtime/ref/System.Runtime.csproj
@@ -6,7 +6,7 @@
     <IsCoreAssembly>true</IsCoreAssembly>
     <ProjectGuid>{ADBCF120-3454-4A3C-9D1D-AC4293E795D6}</ProjectGuid>
     <!-- disable warnings about obsolete APIs -->
-    <NoWarn>$(NoWarn);0809;0618;0169</NoWarn>
+    <NoWarn>$(NoWarn);0809;0618</NoWarn>
     <!-- Default interfaces are not officially supported in netcoreapp yet -->
     <DefineConstants Condition="'$(IsPrerelease)' == 'true' and '$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);FEATURE_DEFAULT_INTERFACES</DefineConstants>
   </PropertyGroup>

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -5,7 +5,6 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System.Security.Cryptography
 {
     public abstract partial class Aes : System.Security.Cryptography.SymmetricAlgorithm
@@ -18,8 +17,8 @@ namespace System.Security.Cryptography
     public sealed partial class AesManaged : System.Security.Cryptography.Aes
     {
         public AesManaged() { }
-        public override int FeedbackSize { get { throw null; } set { } }
         public override int BlockSize { get { throw null; } set { } }
+        public override int FeedbackSize { get { throw null; } set { } }
         public override byte[] IV { get { throw null; } set { } }
         public override byte[] Key { get { throw null; } set { } }
         public override int KeySize { get { throw null; } set { } }
@@ -66,14 +65,6 @@ namespace System.Security.Cryptography
         public abstract void SetHashAlgorithm(string strName);
         public abstract void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key);
     }
-    public abstract partial class DeriveBytes : System.IDisposable
-    {
-        protected DeriveBytes() { }
-        public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
-        public abstract byte[] GetBytes(int cb);
-        public abstract void Reset();
-    }
     public partial class CryptoConfig
     {
         public CryptoConfig() { }
@@ -84,6 +75,14 @@ namespace System.Security.Cryptography
         public static object CreateFromName(string name, params object[] args) { throw null; }
         public static byte[] EncodeOID(string str) { throw null; }
         public static string MapNameToOID(string name) { throw null; }
+    }
+    public abstract partial class DeriveBytes : System.IDisposable
+    {
+        protected DeriveBytes() { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public abstract byte[] GetBytes(int cb);
+        public abstract void Reset();
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public abstract partial class DES : System.Security.Cryptography.SymmetricAlgorithm
@@ -117,7 +116,6 @@ namespace System.Security.Cryptography
         public virtual bool VerifyData(System.IO.Stream data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public abstract bool VerifySignature(byte[] rgbHash, byte[] rgbSignature);
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct DSAParameters
     {
         public int Counter;
@@ -145,9 +143,9 @@ namespace System.Security.Cryptography
         public override void SetHashAlgorithm(string strName) { }
         public override void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ECCurve
     {
+        private object _dummy;
         public byte[] A;
         public byte[] B;
         public byte[] Cofactor;
@@ -231,7 +229,6 @@ namespace System.Security.Cryptography
         public bool VerifyData(System.IO.Stream data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public abstract bool VerifyHash(byte[] hash, byte[] signature);
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ECParameters
     {
         public System.Security.Cryptography.ECCurve Curve;
@@ -239,7 +236,6 @@ namespace System.Security.Cryptography
         public System.Security.Cryptography.ECPoint Q;
         public void Validate() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ECPoint
     {
         public byte[] X;
@@ -252,8 +248,10 @@ namespace System.Security.Cryptography
         public override byte[] Key { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override void HashCore(System.ReadOnlySpan<byte> source) { }
         protected override byte[] HashFinal() { throw null; }
         public override void Initialize() { }
+        protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public partial class HMACSHA1 : System.Security.Cryptography.HMAC
     {
@@ -264,8 +262,10 @@ namespace System.Security.Cryptography
         public override byte[] Key { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override void HashCore(System.ReadOnlySpan<byte> source) { }
         protected override byte[] HashFinal() { throw null; }
         public override void Initialize() { }
+        protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public partial class HMACSHA256 : System.Security.Cryptography.HMAC
     {
@@ -274,30 +274,36 @@ namespace System.Security.Cryptography
         public override byte[] Key { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override void HashCore(System.ReadOnlySpan<byte> source) { }
         protected override byte[] HashFinal() { throw null; }
         public override void Initialize() { }
+        protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public partial class HMACSHA384 : System.Security.Cryptography.HMAC
     {
         public HMACSHA384() { }
         public HMACSHA384(byte[] key) { }
-        public bool ProduceLegacyHmacValues { get; set; }
         public override byte[] Key { get { throw null; } set { } }
+        public bool ProduceLegacyHmacValues { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override void HashCore(System.ReadOnlySpan<byte> source) { }
         protected override byte[] HashFinal() { throw null; }
         public override void Initialize() { }
+        protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public partial class HMACSHA512 : System.Security.Cryptography.HMAC
     {
         public HMACSHA512() { }
         public HMACSHA512(byte[] key) { }
-        public bool ProduceLegacyHmacValues { get; set; }
         public override byte[] Key { get { throw null; } set { } }
+        public bool ProduceLegacyHmacValues { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override void HashCore(System.ReadOnlySpan<byte> source) { }
         protected override byte[] HashFinal() { throw null; }
         public override void Initialize() { }
+        protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public sealed partial class IncrementalHash : System.IDisposable
     {
@@ -310,17 +316,17 @@ namespace System.Security.Cryptography
         public void Dispose() { }
         public byte[] GetHashAndReset() { throw null; }
     }
+    public abstract partial class MaskGenerationMethod
+    {
+        public abstract byte[] GenerateMask(byte[] rgbSeed, int cbReturn);
+    }
     public abstract partial class MD5 : System.Security.Cryptography.HashAlgorithm
     {
         protected MD5() { }
         public static new System.Security.Cryptography.MD5 Create() { throw null; }
         public static new System.Security.Cryptography.MD5 Create(string algName) { throw null; }
     }
-    public abstract class MaskGenerationMethod
-    {
-        public abstract byte[] GenerateMask(byte[] rgbSeed, int cbReturn);
-    }
-    public class PKCS1MaskGenerationMethod : MaskGenerationMethod
+    public partial class PKCS1MaskGenerationMethod : System.Security.Cryptography.MaskGenerationMethod
     {
         public PKCS1MaskGenerationMethod() { }
         public string HashName { get { throw null; } set { } }
@@ -346,6 +352,24 @@ namespace System.Security.Cryptography
         public override int KeySize { get { throw null; } set { } }
         public static new System.Security.Cryptography.RC2 Create() { throw null; }
         public static new System.Security.Cryptography.RC2 Create(string AlgName) { throw null; }
+    }
+    public partial class Rfc2898DeriveBytes : System.Security.Cryptography.DeriveBytes
+    {
+        public Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations) { }
+        public Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
+        public Rfc2898DeriveBytes(string password, byte[] salt) { }
+        public Rfc2898DeriveBytes(string password, byte[] salt, int iterations) { }
+        public Rfc2898DeriveBytes(string password, byte[] salt, int iterations, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
+        public Rfc2898DeriveBytes(string password, int saltSize) { }
+        public Rfc2898DeriveBytes(string password, int saltSize, int iterations) { }
+        public Rfc2898DeriveBytes(string password, int saltSize, int iterations, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
+        public System.Security.Cryptography.HashAlgorithmName HashAlgorithm { get { throw null; } }
+        public int IterationCount { get { throw null; } set { } }
+        public byte[] Salt { get { throw null; } set { } }
+        public byte[] CryptDeriveKey(string algname, string alghashname, int keySize, byte[] rgbIV) { throw null; }
+        protected override void Dispose(bool disposing) { }
+        public override byte[] GetBytes(int cb) { throw null; }
+        public override void Reset() { }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public abstract partial class Rijndael : System.Security.Cryptography.SymmetricAlgorithm
@@ -373,24 +397,6 @@ namespace System.Security.Cryptography
         public override void GenerateIV() { }
         public override void GenerateKey() { }
     }
-    public partial class Rfc2898DeriveBytes : System.Security.Cryptography.DeriveBytes
-    {
-        public Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations) { }
-        public Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm) { }
-        public Rfc2898DeriveBytes(string password, byte[] salt) { }
-        public Rfc2898DeriveBytes(string password, byte[] salt, int iterations) { }
-        public Rfc2898DeriveBytes(string password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm) { }
-        public Rfc2898DeriveBytes(string password, int saltSize) { }
-        public Rfc2898DeriveBytes(string password, int saltSize, int iterations) { }
-        public Rfc2898DeriveBytes(string password, int saltSize, int iterations, HashAlgorithmName hashAlgorithm) { }
-        public HashAlgorithmName HashAlgorithm { get { throw null; } }
-        public int IterationCount { get { throw null; } set { } }
-        public byte[] Salt { get { throw null; } set { } }
-        public byte[] CryptDeriveKey(string algname, string alghashname, int keySize, byte[] rgbIV) { throw null; }
-        protected override void Dispose(bool disposing) { }
-        public override byte[] GetBytes(int cb) { throw null; }
-        public override void Reset() { }
-    }
     public abstract partial class RSA : System.Security.Cryptography.AsymmetricAlgorithm
     {
         protected RSA() { }
@@ -398,16 +404,16 @@ namespace System.Security.Cryptography
         public override string SignatureAlgorithm { get { throw null; } }
         public static new System.Security.Cryptography.RSA Create() { throw null; }
         public static System.Security.Cryptography.RSA Create(int keySizeInBits) { throw null; }
-        public static new System.Security.Cryptography.RSA Create(string algName) { throw null; }
         public static System.Security.Cryptography.RSA Create(System.Security.Cryptography.RSAParameters parameters) { throw null; }
+        public static new System.Security.Cryptography.RSA Create(string algName) { throw null; }
         public virtual byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }
         public virtual byte[] DecryptValue(byte[] rgb) { throw null; }
         public virtual byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }
         public virtual byte[] EncryptValue(byte[] rgb) { throw null; }
         public abstract System.Security.Cryptography.RSAParameters ExportParameters(bool includePrivateParameters);
+        public override void FromXmlString(string xmlString) { }
         protected virtual byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         protected virtual byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
-        public override void FromXmlString(string xmlString) { }
         public abstract void ImportParameters(System.Security.Cryptography.RSAParameters parameters);
         public virtual byte[] SignData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
         public byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
@@ -456,12 +462,11 @@ namespace System.Security.Cryptography
         public RSAOAEPKeyExchangeFormatter(System.Security.Cryptography.AsymmetricAlgorithm key) { }
         public byte[] Parameter { get { throw null; } set { } }
         public override string Parameters { get { throw null; } }
-        public RandomNumberGenerator Rng { get { throw null; } set { } }
+        public System.Security.Cryptography.RandomNumberGenerator Rng { get { throw null; } set { } }
         public override byte[] CreateKeyExchange(byte[] rgbData) { throw null; }
         public override byte[] CreateKeyExchange(byte[] rgbData, System.Type symAlgType) { throw null; }
         public override void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct RSAParameters
     {
         public byte[] D;
@@ -477,8 +482,8 @@ namespace System.Security.Cryptography
     {
         public RSAPKCS1KeyExchangeDeformatter() { }
         public RSAPKCS1KeyExchangeDeformatter(System.Security.Cryptography.AsymmetricAlgorithm key) { }
-        public RandomNumberGenerator RNG { get { throw null; } set { } }
         public override string Parameters { get { throw null; } set { } }
+        public System.Security.Cryptography.RandomNumberGenerator RNG { get { throw null; } set { } }
         public override byte[] DecryptKeyExchange(byte[] rgbIn) { throw null; }
         public override void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key) { }
     }
@@ -487,7 +492,7 @@ namespace System.Security.Cryptography
         public RSAPKCS1KeyExchangeFormatter() { }
         public RSAPKCS1KeyExchangeFormatter(System.Security.Cryptography.AsymmetricAlgorithm key) { }
         public override string Parameters { get { throw null; } }
-        public RandomNumberGenerator Rng { get { throw null; } set { } }
+        public System.Security.Cryptography.RandomNumberGenerator Rng { get { throw null; } set { } }
         public override byte[] CreateKeyExchange(byte[] rgbData) { throw null; }
         public override byte[] CreateKeyExchange(byte[] rgbData, System.Type symAlgType) { throw null; }
         public override void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key) { }
@@ -538,8 +543,10 @@ namespace System.Security.Cryptography
         public SHA1Managed() { }
         protected sealed override void Dispose(bool disposing) { }
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) { }
+        protected sealed override void HashCore(System.ReadOnlySpan<byte> source) { }
         protected sealed override byte[] HashFinal() { throw null; }
         public sealed override void Initialize() { }
+        protected sealed override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public abstract partial class SHA256 : System.Security.Cryptography.HashAlgorithm
     {
@@ -553,8 +560,10 @@ namespace System.Security.Cryptography
         public SHA256Managed() { }
         protected sealed override void Dispose(bool disposing) { }
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) { }
+        protected sealed override void HashCore(System.ReadOnlySpan<byte> source) { }
         protected sealed override byte[] HashFinal() { throw null; }
         public sealed override void Initialize() { }
+        protected sealed override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public abstract partial class SHA384 : System.Security.Cryptography.HashAlgorithm
     {
@@ -568,8 +577,10 @@ namespace System.Security.Cryptography
         public SHA384Managed() { }
         protected sealed override void Dispose(bool disposing) { }
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) { }
+        protected sealed override void HashCore(System.ReadOnlySpan<byte> source) { }
         protected sealed override byte[] HashFinal() { throw null; }
         public sealed override void Initialize() { }
+        protected sealed override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public abstract partial class SHA512 : System.Security.Cryptography.HashAlgorithm
     {
@@ -583,16 +594,19 @@ namespace System.Security.Cryptography
         public SHA512Managed() { }
         protected sealed override void Dispose(bool disposing) { }
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) { }
+        protected sealed override void HashCore(System.ReadOnlySpan<byte> source) { }
         protected sealed override byte[] HashFinal() { throw null; }
         public sealed override void Initialize() { }
+        protected sealed override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
-    public partial class SignatureDescription {
+    public partial class SignatureDescription
+    {
         public SignatureDescription() { }
         public SignatureDescription(System.Security.SecurityElement el) { }
         public string DeformatterAlgorithm { get { throw null; } set { } }
-        public string DigestAlgorithm { get { throw null;} set { } }
-        public string FormatterAlgorithm { get { throw null;} set { } }
-        public string KeyAlgorithm { get { throw null;} set { } }
+        public string DigestAlgorithm { get { throw null; } set { } }
+        public string FormatterAlgorithm { get { throw null; } set { } }
+        public string KeyAlgorithm { get { throw null; } set { } }
         public virtual System.Security.Cryptography.AsymmetricSignatureDeformatter CreateDeformatter(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
         public virtual System.Security.Cryptography.HashAlgorithm CreateDigest() { throw null; }
         public virtual System.Security.Cryptography.AsymmetricSignatureFormatter CreateFormatter(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }

--- a/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.cs
+++ b/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.cs
@@ -5,7 +5,6 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace Microsoft.Win32.SafeHandles
 {
     public abstract partial class SafeNCryptHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
@@ -197,9 +196,9 @@ namespace System.Security.Cryptography
         None = 0,
         Signing = 2,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CngProperty : System.IEquatable<System.Security.Cryptography.CngProperty>
     {
+        private object _dummy;
         public CngProperty(string name, byte[] value, System.Security.Cryptography.CngPropertyOptions options) { throw null; }
         public string Name { get { throw null; } }
         public System.Security.Cryptography.CngPropertyOptions Options { get { throw null; } }

--- a/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.cs
+++ b/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.cs
@@ -322,9 +322,9 @@ namespace System.Security.Cryptography.Pkcs
 }
 namespace System.Security.Cryptography.Xml
 {
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct X509IssuerSerial
     {
+        private object _dummy;
         public string IssuerName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string SerialNumber { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }

--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -17,10 +17,10 @@ namespace System.Security.Cryptography
         public virtual string KeyExchangeAlgorithm { get { throw null; } }
         public virtual int KeySize { get { throw null; } set { } }
         public virtual System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
-        public static System.Security.Cryptography.AsymmetricAlgorithm Create() { throw null; }
-        public static System.Security.Cryptography.AsymmetricAlgorithm Create(string algName) { throw null; }
         public virtual string SignatureAlgorithm { get { throw null; } }
         public void Clear() { }
+        public static System.Security.Cryptography.AsymmetricAlgorithm Create() { throw null; }
+        public static System.Security.Cryptography.AsymmetricAlgorithm Create(string algName) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public virtual void FromXmlString(string xmlString) { }
@@ -51,11 +51,15 @@ namespace System.Security.Cryptography
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanWrite { get { throw null; } }
-        public void Clear() { }
         public bool HasFlushedFinalBlock { get { throw null; } }
         public override long Length { get { throw null; } }
         public override long Position { get { throw null; } set { } }
+        public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { throw null; }
+        public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { throw null; }
+        public void Clear() { }
         protected override void Dispose(bool disposing) { }
+        public override int EndRead(System.IAsyncResult asyncResult) { throw null; }
+        public override void EndWrite(System.IAsyncResult asyncResult) { }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public void FlushFinalBlock() { }
@@ -75,8 +79,8 @@ namespace System.Security.Cryptography
     }
     public abstract partial class HashAlgorithm : System.IDisposable, System.Security.Cryptography.ICryptoTransform
     {
-        protected internal byte[] HashValue;
         protected int HashSizeValue;
+        protected internal byte[] HashValue;
         protected int State;
         protected HashAlgorithm() { }
         public virtual bool CanReuseTransform { get { throw null; } }
@@ -94,17 +98,17 @@ namespace System.Security.Cryptography
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         protected abstract void HashCore(byte[] array, int ibStart, int cbSize);
-        protected virtual void HashCore(ReadOnlySpan<byte> source) { throw null; }
+        protected virtual void HashCore(System.ReadOnlySpan<byte> source) { }
         protected abstract byte[] HashFinal();
         public abstract void Initialize();
         public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) { throw null; }
         public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) { throw null; }
-        public bool TryComputeHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) { throw null; }
-        protected virtual bool TryHashFinal(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryComputeHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        protected virtual bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct HashAlgorithmName : System.IEquatable<System.Security.Cryptography.HashAlgorithmName>
     {
+        private readonly object _dummy;
         public HashAlgorithmName(string name) { throw null; }
         public static System.Security.Cryptography.HashAlgorithmName MD5 { get { throw null; } }
         public string Name { get { throw null; } }
@@ -122,15 +126,17 @@ namespace System.Security.Cryptography
     public abstract partial class HMAC : System.Security.Cryptography.KeyedHashAlgorithm
     {
         protected HMAC() { }
-        protected int BlockSizeValue { get { throw null; } set {} }
+        protected int BlockSizeValue { get { throw null; } set { } }
         public string HashName { get { throw null; } set { } }
         public override byte[] Key { get { throw null; } set { } }
         public static new System.Security.Cryptography.HMAC Create() { throw null; }
         public static new System.Security.Cryptography.HMAC Create(string algorithmName) { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override void HashCore(System.ReadOnlySpan<byte> source) { }
         protected override byte[] HashFinal() { throw null; }
         public override void Initialize() { }
+        protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public partial interface ICryptoTransform : System.IDisposable
     {
@@ -159,16 +165,16 @@ namespace System.Security.Cryptography
     }
     public enum PaddingMode
     {
+        ANSIX923 = 4,
+        ISO10126 = 5,
         None = 1,
         PKCS7 = 2,
         Zeros = 3,
-        ANSIX923 = 4,
-        ISO10126 = 5,
     }
     public abstract partial class SymmetricAlgorithm : System.IDisposable
     {
-        protected int FeedbackSizeValue;
         protected int BlockSizeValue;
+        protected int FeedbackSizeValue;
         protected byte[] IVValue;
         protected int KeySizeValue;
         protected byte[] KeyValue;
@@ -177,8 +183,8 @@ namespace System.Security.Cryptography
         protected System.Security.Cryptography.CipherMode ModeValue;
         protected System.Security.Cryptography.PaddingMode PaddingValue;
         protected SymmetricAlgorithm() { }
-        public virtual int FeedbackSize { get { throw null; } set { } }
         public virtual int BlockSize { get { throw null; } set { } }
+        public virtual int FeedbackSize { get { throw null; } set { } }
         public virtual byte[] IV { get { throw null; } set { } }
         public virtual byte[] Key { get { throw null; } set { } }
         public virtual int KeySize { get { throw null; } set { } }
@@ -186,13 +192,13 @@ namespace System.Security.Cryptography
         public virtual System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
         public virtual System.Security.Cryptography.CipherMode Mode { get { throw null; } set { } }
         public virtual System.Security.Cryptography.PaddingMode Padding { get { throw null; } set { } }
+        public void Clear() { }
         public static System.Security.Cryptography.SymmetricAlgorithm Create() { throw null; }
         public static System.Security.Cryptography.SymmetricAlgorithm Create(string algName) { throw null; }
         public virtual System.Security.Cryptography.ICryptoTransform CreateDecryptor() { throw null; }
         public abstract System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV);
         public virtual System.Security.Cryptography.ICryptoTransform CreateEncryptor() { throw null; }
         public abstract System.Security.Cryptography.ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV);
-        public void Clear() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public abstract void GenerateIV();

--- a/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -9,13 +9,11 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeX509ChainHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafeX509ChainHandle() : base(default(bool)) { }
-        public override bool IsInvalid { get { throw null; } }
+        internal SafeX509ChainHandle() : base (default(bool)) { }
         protected override void Dispose(bool disposing) { }
         protected override bool ReleaseHandle() { throw null; }
     }
 }
-
 namespace System.Security.Cryptography.X509Certificates
 {
     public sealed partial class CertificateRequest
@@ -131,7 +129,7 @@ namespace System.Security.Cryptography.X509Certificates
         public int PathLengthConstraint { get { throw null; } }
         public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
     }
-    public partial class X509Certificate : System.IDisposable, System.Runtime.Serialization.ISerializable, System.Runtime.Serialization.IDeserializationCallback
+    public partial class X509Certificate : System.IDisposable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         public X509Certificate() { }
         public X509Certificate(byte[] data) { }
@@ -166,10 +164,9 @@ namespace System.Security.Cryptography.X509Certificates
         public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, string password) { throw null; }
         protected static string FormatDate(System.DateTime date) { throw null; }
         public virtual byte[] GetCertHash() { throw null; }
-        public virtual byte[] GetCertHash(HashAlgorithmName hashAlgorithm) { throw null; }
-        public virtual bool TryGetCertHash(HashAlgorithmName hashAlgorithm, Span<byte> destination, out int bytesWritten) { throw null; }
+        public virtual byte[] GetCertHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public virtual string GetCertHashString() { throw null; }
-        public virtual string GetCertHashString(HashAlgorithmName hashAlgorithm) { throw null; }
+        public virtual string GetCertHashString(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public virtual string GetEffectiveDateString() { throw null; }
         public virtual string GetExpirationDateString() { throw null; }
         public virtual string GetFormat() { throw null; }
@@ -200,6 +197,7 @@ namespace System.Security.Cryptography.X509Certificates
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
         public virtual string ToString(bool fVerbose) { throw null; }
+        public virtual bool TryGetCertHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public partial class X509Certificate2 : System.Security.Cryptography.X509Certificates.X509Certificate
     {
@@ -256,12 +254,12 @@ namespace System.Security.Cryptography.X509Certificates
     {
         public X509Certificate2Collection() { }
         public X509Certificate2Collection(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
-        public X509Certificate2Collection(System.Security.Cryptography.X509Certificates.X509Certificate2[] certificates) { }
         public X509Certificate2Collection(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public X509Certificate2Collection(System.Security.Cryptography.X509Certificates.X509Certificate2[] certificates) { }
         public new System.Security.Cryptography.X509Certificates.X509Certificate2 this[int index] { get { throw null; } set { } }
         public int Add(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
-        public void AddRange(System.Security.Cryptography.X509Certificates.X509Certificate2[] certificates) { }
         public void AddRange(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public void AddRange(System.Security.Cryptography.X509Certificates.X509Certificate2[] certificates) { }
         public bool Contains(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
         public byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType) { throw null; }
         public byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, string password) { throw null; }
@@ -273,8 +271,8 @@ namespace System.Security.Cryptography.X509Certificates
         public void Import(string fileName, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
         public void Insert(int index, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
         public void Remove(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
-        public void RemoveRange(System.Security.Cryptography.X509Certificates.X509Certificate2[] certificates) { }
         public void RemoveRange(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public void RemoveRange(System.Security.Cryptography.X509Certificates.X509Certificate2[] certificates) { }
     }
     public sealed partial class X509Certificate2Enumerator : System.Collections.IEnumerator
     {
@@ -289,18 +287,19 @@ namespace System.Security.Cryptography.X509Certificates
     public partial class X509CertificateCollection : System.Collections.CollectionBase
     {
         public X509CertificateCollection() { }
-        public X509CertificateCollection(System.Security.Cryptography.X509Certificates.X509Certificate[] value) { }
         public X509CertificateCollection(System.Security.Cryptography.X509Certificates.X509CertificateCollection value) { }
+        public X509CertificateCollection(System.Security.Cryptography.X509Certificates.X509Certificate[] value) { }
         public System.Security.Cryptography.X509Certificates.X509Certificate this[int index] { get { throw null; } set { } }
         public int Add(System.Security.Cryptography.X509Certificates.X509Certificate value) { throw null; }
-        public void AddRange(System.Security.Cryptography.X509Certificates.X509Certificate[] value) { }
         public void AddRange(System.Security.Cryptography.X509Certificates.X509CertificateCollection value) { }
+        public void AddRange(System.Security.Cryptography.X509Certificates.X509Certificate[] value) { }
         public bool Contains(System.Security.Cryptography.X509Certificates.X509Certificate value) { throw null; }
         public void CopyTo(System.Security.Cryptography.X509Certificates.X509Certificate[] array, int index) { }
         public new System.Security.Cryptography.X509Certificates.X509CertificateCollection.X509CertificateEnumerator GetEnumerator() { throw null; }
         public override int GetHashCode() { throw null; }
         public int IndexOf(System.Security.Cryptography.X509Certificates.X509Certificate value) { throw null; }
         public void Insert(int index, System.Security.Cryptography.X509Certificates.X509Certificate value) { }
+        protected override void OnValidate(object value) { }
         public void Remove(System.Security.Cryptography.X509Certificates.X509Certificate value) { }
         public partial class X509CertificateEnumerator : System.Collections.IEnumerator
         {
@@ -318,13 +317,13 @@ namespace System.Security.Cryptography.X509Certificates
         public X509Chain() { }
         public X509Chain(bool useMachineContext) { }
         public X509Chain(System.IntPtr chainContext) { }
-        public static X509Chain Create() { throw null; }
         public System.IntPtr ChainContext { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509ChainElementCollection ChainElements { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509ChainPolicy ChainPolicy { get { throw null; } set { } }
         public System.Security.Cryptography.X509Certificates.X509ChainStatus[] ChainStatus { get { throw null; } }
         public Microsoft.Win32.SafeHandles.SafeX509ChainHandle SafeHandle { get { throw null; } }
         public bool Build(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+        public static System.Security.Cryptography.X509Certificates.X509Chain Create() { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void Reset() { }
@@ -369,9 +368,9 @@ namespace System.Security.Cryptography.X509Certificates
         public System.DateTime VerificationTime { get { throw null; } set { } }
         public void Reset() { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct X509ChainStatus
     {
+        private object _dummy;
         public System.Security.Cryptography.X509Certificates.X509ChainStatusFlags Status { get { throw null; } set { } }
         public string StatusInformation { get { throw null; } set { } }
     }

--- a/src/System.ServiceProcess.ServiceController/ref/System.ServiceProcess.ServiceController.cs
+++ b/src/System.ServiceProcess.ServiceController/ref/System.ServiceProcess.ServiceController.cs
@@ -115,9 +115,9 @@ namespace System.ServiceProcess
         Win32OwnProcess = 16,
         Win32ShareProcess = 32,
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SessionChangeDescription
     {
+        private readonly int _dummy;
         public System.ServiceProcess.SessionChangeReason Reason { get { throw null; } }
         public int SessionId { get { throw null; } }
         public override bool Equals(object obj) { throw null; }

--- a/src/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
+++ b/src/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
@@ -10,7 +10,6 @@ namespace System.Threading
 {
     [System.CLSCompliantAttribute(false)]
     public unsafe delegate void IOCompletionCallback(uint errorCode, uint numBytes, System.Threading.NativeOverlapped* pOVERLAP);
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct NativeOverlapped
     {
         public System.IntPtr EventHandle;

--- a/src/System.Threading.Tasks.Dataflow/ref/System.Threading.Tasks.Dataflow.cs
+++ b/src/System.Threading.Tasks.Dataflow/ref/System.Threading.Tasks.Dataflow.cs
@@ -31,14 +31,14 @@ namespace System.Threading.Tasks.Dataflow
         public void Complete() { }
         public System.IDisposable LinkTo(System.Threading.Tasks.Dataflow.ITargetBlock<T[]> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions linkOptions) { throw null; }
         void System.Threading.Tasks.Dataflow.IDataflowBlock.Fault(System.Exception exception) { }
-        T[] System.Threading.Tasks.Dataflow.ISourceBlock<T[]>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T[]> target, out bool messageConsumed) { messageConsumed = default(bool); throw null; }
+        T[] System.Threading.Tasks.Dataflow.ISourceBlock<T[]>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T[]> target, out bool messageConsumed) { throw null; }
         void System.Threading.Tasks.Dataflow.ISourceBlock<T[]>.ReleaseReservation(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T[]> target) { }
         bool System.Threading.Tasks.Dataflow.ISourceBlock<T[]>.ReserveMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T[]> target) { throw null; }
         System.Threading.Tasks.Dataflow.DataflowMessageStatus System.Threading.Tasks.Dataflow.ITargetBlock<T>.OfferMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, T messageValue, System.Threading.Tasks.Dataflow.ISourceBlock<T> source, bool consumeToAccept) { throw null; }
         public override string ToString() { throw null; }
         public void TriggerBatch() { }
-        public bool TryReceive(System.Predicate<T[]> filter, out T[] item) { item = default(T[]); throw null; }
-        public bool TryReceiveAll(out System.Collections.Generic.IList<T[]> items) { items = default(System.Collections.Generic.IList<T[]>); throw null; }
+        public bool TryReceive(System.Predicate<T[]> filter, out T[] item) { throw null; }
+        public bool TryReceiveAll(out System.Collections.Generic.IList<T[]> items) { throw null; }
     }
     public sealed partial class BatchedJoinBlock<T1, T2> : System.Threading.Tasks.Dataflow.IDataflowBlock, System.Threading.Tasks.Dataflow.IReceivableSourceBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>>, System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>>
     {
@@ -52,12 +52,12 @@ namespace System.Threading.Tasks.Dataflow
         public void Complete() { }
         public System.IDisposable LinkTo(System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions linkOptions) { throw null; }
         void System.Threading.Tasks.Dataflow.IDataflowBlock.Fault(System.Exception exception) { }
-        System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>> System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<System.Collections.Generic.IList<T1>,System.Collections.Generic.IList<T2>>>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>> target, out bool messageConsumed) { messageConsumed = default(bool); throw null; }
+        System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>> System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<System.Collections.Generic.IList<T1>,System.Collections.Generic.IList<T2>>>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>> target, out bool messageConsumed) { throw null; }
         void System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<System.Collections.Generic.IList<T1>,System.Collections.Generic.IList<T2>>>.ReleaseReservation(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>> target) { }
         bool System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<System.Collections.Generic.IList<T1>,System.Collections.Generic.IList<T2>>>.ReserveMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>> target) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryReceive(System.Predicate<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>> filter, out System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>> item) { item = default(System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>); throw null; }
-        public bool TryReceiveAll(out System.Collections.Generic.IList<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>> items) { items = default(System.Collections.Generic.IList<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>>); throw null; }
+        public bool TryReceive(System.Predicate<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>> filter, out System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>> item) { throw null; }
+        public bool TryReceiveAll(out System.Collections.Generic.IList<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>>> items) { throw null; }
     }
     public sealed partial class BatchedJoinBlock<T1, T2, T3> : System.Threading.Tasks.Dataflow.IDataflowBlock, System.Threading.Tasks.Dataflow.IReceivableSourceBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>>, System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>>
     {
@@ -72,12 +72,12 @@ namespace System.Threading.Tasks.Dataflow
         public void Complete() { }
         public System.IDisposable LinkTo(System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions linkOptions) { throw null; }
         void System.Threading.Tasks.Dataflow.IDataflowBlock.Fault(System.Exception exception) { }
-        System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>> System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<System.Collections.Generic.IList<T1>,System.Collections.Generic.IList<T2>,System.Collections.Generic.IList<T3>>>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>> target, out bool messageConsumed) { messageConsumed = default(bool); throw null; }
+        System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>> System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<System.Collections.Generic.IList<T1>,System.Collections.Generic.IList<T2>,System.Collections.Generic.IList<T3>>>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>> target, out bool messageConsumed) { throw null; }
         void System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<System.Collections.Generic.IList<T1>,System.Collections.Generic.IList<T2>,System.Collections.Generic.IList<T3>>>.ReleaseReservation(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>> target) { }
         bool System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<System.Collections.Generic.IList<T1>,System.Collections.Generic.IList<T2>,System.Collections.Generic.IList<T3>>>.ReserveMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>> target) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryReceive(System.Predicate<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>> filter, out System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>> item) { item = default(System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>); throw null; }
-        public bool TryReceiveAll(out System.Collections.Generic.IList<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>> items) { items = default(System.Collections.Generic.IList<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>>); throw null; }
+        public bool TryReceive(System.Predicate<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>> filter, out System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>> item) { throw null; }
+        public bool TryReceiveAll(out System.Collections.Generic.IList<System.Tuple<System.Collections.Generic.IList<T1>, System.Collections.Generic.IList<T2>, System.Collections.Generic.IList<T3>>> items) { throw null; }
     }
     public sealed partial class BroadcastBlock<T> : System.Threading.Tasks.Dataflow.IDataflowBlock, System.Threading.Tasks.Dataflow.IPropagatorBlock<T, T>, System.Threading.Tasks.Dataflow.IReceivableSourceBlock<T>, System.Threading.Tasks.Dataflow.ISourceBlock<T>, System.Threading.Tasks.Dataflow.ITargetBlock<T>
     {
@@ -87,13 +87,13 @@ namespace System.Threading.Tasks.Dataflow
         public void Complete() { }
         public System.IDisposable LinkTo(System.Threading.Tasks.Dataflow.ITargetBlock<T> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions linkOptions) { throw null; }
         void System.Threading.Tasks.Dataflow.IDataflowBlock.Fault(System.Exception exception) { }
-        bool System.Threading.Tasks.Dataflow.IReceivableSourceBlock<T>.TryReceiveAll(out System.Collections.Generic.IList<T> items) { items = default(System.Collections.Generic.IList<T>); throw null; }
-        T System.Threading.Tasks.Dataflow.ISourceBlock<T>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target, out bool messageConsumed) { messageConsumed = default(bool); throw null; }
+        bool System.Threading.Tasks.Dataflow.IReceivableSourceBlock<T>.TryReceiveAll(out System.Collections.Generic.IList<T> items) { throw null; }
+        T System.Threading.Tasks.Dataflow.ISourceBlock<T>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target, out bool messageConsumed) { throw null; }
         void System.Threading.Tasks.Dataflow.ISourceBlock<T>.ReleaseReservation(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target) { }
         bool System.Threading.Tasks.Dataflow.ISourceBlock<T>.ReserveMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target) { throw null; }
         System.Threading.Tasks.Dataflow.DataflowMessageStatus System.Threading.Tasks.Dataflow.ITargetBlock<T>.OfferMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, T messageValue, System.Threading.Tasks.Dataflow.ISourceBlock<T> source, bool consumeToAccept) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryReceive(System.Predicate<T> filter, out T item) { item = default(T); throw null; }
+        public bool TryReceive(System.Predicate<T> filter, out T item) { throw null; }
     }
     public sealed partial class BufferBlock<T> : System.Threading.Tasks.Dataflow.IDataflowBlock, System.Threading.Tasks.Dataflow.IPropagatorBlock<T, T>, System.Threading.Tasks.Dataflow.IReceivableSourceBlock<T>, System.Threading.Tasks.Dataflow.ISourceBlock<T>, System.Threading.Tasks.Dataflow.ITargetBlock<T>
     {
@@ -104,13 +104,13 @@ namespace System.Threading.Tasks.Dataflow
         public void Complete() { }
         public System.IDisposable LinkTo(System.Threading.Tasks.Dataflow.ITargetBlock<T> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions linkOptions) { throw null; }
         void System.Threading.Tasks.Dataflow.IDataflowBlock.Fault(System.Exception exception) { }
-        T System.Threading.Tasks.Dataflow.ISourceBlock<T>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target, out bool messageConsumed) { messageConsumed = default(bool); throw null; }
+        T System.Threading.Tasks.Dataflow.ISourceBlock<T>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target, out bool messageConsumed) { throw null; }
         void System.Threading.Tasks.Dataflow.ISourceBlock<T>.ReleaseReservation(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target) { }
         bool System.Threading.Tasks.Dataflow.ISourceBlock<T>.ReserveMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target) { throw null; }
         System.Threading.Tasks.Dataflow.DataflowMessageStatus System.Threading.Tasks.Dataflow.ITargetBlock<T>.OfferMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, T messageValue, System.Threading.Tasks.Dataflow.ISourceBlock<T> source, bool consumeToAccept) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryReceive(System.Predicate<T> filter, out T item) { item = default(T); throw null; }
-        public bool TryReceiveAll(out System.Collections.Generic.IList<T> items) { items = default(System.Collections.Generic.IList<T>); throw null; }
+        public bool TryReceive(System.Predicate<T> filter, out T item) { throw null; }
+        public bool TryReceiveAll(out System.Collections.Generic.IList<T> items) { throw null; }
     }
     public static partial class DataflowBlock
     {
@@ -138,7 +138,7 @@ namespace System.Threading.Tasks.Dataflow
         public static TOutput Receive<TOutput>(this System.Threading.Tasks.Dataflow.ISourceBlock<TOutput> source, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static System.Threading.Tasks.Task<bool> SendAsync<TInput>(this System.Threading.Tasks.Dataflow.ITargetBlock<TInput> target, TInput item) { throw null; }
         public static System.Threading.Tasks.Task<bool> SendAsync<TInput>(this System.Threading.Tasks.Dataflow.ITargetBlock<TInput> target, TInput item, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static bool TryReceive<TOutput>(this System.Threading.Tasks.Dataflow.IReceivableSourceBlock<TOutput> source, out TOutput item) { item = default(TOutput); throw null; }
+        public static bool TryReceive<TOutput>(this System.Threading.Tasks.Dataflow.IReceivableSourceBlock<TOutput> source, out TOutput item) { throw null; }
     }
     public partial class DataflowBlockOptions
     {
@@ -158,10 +158,10 @@ namespace System.Threading.Tasks.Dataflow
         public int MaxMessages { get { throw null; } set { } }
         public bool PropagateCompletion { get { throw null; } set { } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DataflowMessageHeader : System.IEquatable<System.Threading.Tasks.Dataflow.DataflowMessageHeader>
     {
-        public DataflowMessageHeader(long id) { throw null;}
+        private readonly int _dummy;
+        public DataflowMessageHeader(long id) { throw null; }
         public long Id { get { throw null; } }
         public bool IsValid { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -226,12 +226,12 @@ namespace System.Threading.Tasks.Dataflow
         public void Complete() { }
         public System.IDisposable LinkTo(System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<T1, T2>> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions linkOptions) { throw null; }
         void System.Threading.Tasks.Dataflow.IDataflowBlock.Fault(System.Exception exception) { }
-        System.Tuple<T1, T2> System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<T1,T2>>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<T1, T2>> target, out bool messageConsumed) { messageConsumed = default(bool); throw null; }
+        System.Tuple<T1, T2> System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<T1,T2>>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<T1, T2>> target, out bool messageConsumed) { throw null; }
         void System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<T1,T2>>.ReleaseReservation(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<T1, T2>> target) { }
         bool System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<T1,T2>>.ReserveMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<T1, T2>> target) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryReceive(System.Predicate<System.Tuple<T1, T2>> filter, out System.Tuple<T1, T2> item) { item = default(System.Tuple<T1, T2>); throw null; }
-        public bool TryReceiveAll(out System.Collections.Generic.IList<System.Tuple<T1, T2>> items) { items = default(System.Collections.Generic.IList<System.Tuple<T1, T2>>); throw null; }
+        public bool TryReceive(System.Predicate<System.Tuple<T1, T2>> filter, out System.Tuple<T1, T2> item) { throw null; }
+        public bool TryReceiveAll(out System.Collections.Generic.IList<System.Tuple<T1, T2>> items) { throw null; }
     }
     public sealed partial class JoinBlock<T1, T2, T3> : System.Threading.Tasks.Dataflow.IDataflowBlock, System.Threading.Tasks.Dataflow.IReceivableSourceBlock<System.Tuple<T1, T2, T3>>, System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<T1, T2, T3>>
     {
@@ -245,12 +245,12 @@ namespace System.Threading.Tasks.Dataflow
         public void Complete() { }
         public System.IDisposable LinkTo(System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<T1, T2, T3>> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions linkOptions) { throw null; }
         void System.Threading.Tasks.Dataflow.IDataflowBlock.Fault(System.Exception exception) { }
-        System.Tuple<T1, T2, T3> System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<T1,T2,T3>>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<T1, T2, T3>> target, out bool messageConsumed) { messageConsumed = default(bool); throw null; }
+        System.Tuple<T1, T2, T3> System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<T1,T2,T3>>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<T1, T2, T3>> target, out bool messageConsumed) { throw null; }
         void System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<T1,T2,T3>>.ReleaseReservation(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<T1, T2, T3>> target) { }
         bool System.Threading.Tasks.Dataflow.ISourceBlock<System.Tuple<T1,T2,T3>>.ReserveMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<System.Tuple<T1, T2, T3>> target) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryReceive(System.Predicate<System.Tuple<T1, T2, T3>> filter, out System.Tuple<T1, T2, T3> item) { item = default(System.Tuple<T1, T2, T3>); throw null; }
-        public bool TryReceiveAll(out System.Collections.Generic.IList<System.Tuple<T1, T2, T3>> items) { items = default(System.Collections.Generic.IList<System.Tuple<T1, T2, T3>>); throw null; }
+        public bool TryReceive(System.Predicate<System.Tuple<T1, T2, T3>> filter, out System.Tuple<T1, T2, T3> item) { throw null; }
+        public bool TryReceiveAll(out System.Collections.Generic.IList<System.Tuple<T1, T2, T3>> items) { throw null; }
     }
     public sealed partial class TransformBlock<TInput, TOutput> : System.Threading.Tasks.Dataflow.IDataflowBlock, System.Threading.Tasks.Dataflow.IPropagatorBlock<TInput, TOutput>, System.Threading.Tasks.Dataflow.IReceivableSourceBlock<TOutput>, System.Threading.Tasks.Dataflow.ISourceBlock<TOutput>, System.Threading.Tasks.Dataflow.ITargetBlock<TInput>
     {
@@ -264,13 +264,13 @@ namespace System.Threading.Tasks.Dataflow
         public void Complete() { }
         public System.IDisposable LinkTo(System.Threading.Tasks.Dataflow.ITargetBlock<TOutput> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions linkOptions) { throw null; }
         void System.Threading.Tasks.Dataflow.IDataflowBlock.Fault(System.Exception exception) { }
-        TOutput System.Threading.Tasks.Dataflow.ISourceBlock<TOutput>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<TOutput> target, out bool messageConsumed) { messageConsumed = default(bool); throw null; }
+        TOutput System.Threading.Tasks.Dataflow.ISourceBlock<TOutput>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<TOutput> target, out bool messageConsumed) { throw null; }
         void System.Threading.Tasks.Dataflow.ISourceBlock<TOutput>.ReleaseReservation(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<TOutput> target) { }
         bool System.Threading.Tasks.Dataflow.ISourceBlock<TOutput>.ReserveMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<TOutput> target) { throw null; }
         System.Threading.Tasks.Dataflow.DataflowMessageStatus System.Threading.Tasks.Dataflow.ITargetBlock<TInput>.OfferMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, TInput messageValue, System.Threading.Tasks.Dataflow.ISourceBlock<TInput> source, bool consumeToAccept) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryReceive(System.Predicate<TOutput> filter, out TOutput item) { item = default(TOutput); throw null; }
-        public bool TryReceiveAll(out System.Collections.Generic.IList<TOutput> items) { items = default(System.Collections.Generic.IList<TOutput>); throw null; }
+        public bool TryReceive(System.Predicate<TOutput> filter, out TOutput item) { throw null; }
+        public bool TryReceiveAll(out System.Collections.Generic.IList<TOutput> items) { throw null; }
     }
     public sealed partial class TransformManyBlock<TInput, TOutput> : System.Threading.Tasks.Dataflow.IDataflowBlock, System.Threading.Tasks.Dataflow.IPropagatorBlock<TInput, TOutput>, System.Threading.Tasks.Dataflow.IReceivableSourceBlock<TOutput>, System.Threading.Tasks.Dataflow.ISourceBlock<TOutput>, System.Threading.Tasks.Dataflow.ITargetBlock<TInput>
     {
@@ -284,13 +284,13 @@ namespace System.Threading.Tasks.Dataflow
         public void Complete() { }
         public System.IDisposable LinkTo(System.Threading.Tasks.Dataflow.ITargetBlock<TOutput> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions linkOptions) { throw null; }
         void System.Threading.Tasks.Dataflow.IDataflowBlock.Fault(System.Exception exception) { }
-        TOutput System.Threading.Tasks.Dataflow.ISourceBlock<TOutput>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<TOutput> target, out bool messageConsumed) { messageConsumed = default(bool); throw null; }
+        TOutput System.Threading.Tasks.Dataflow.ISourceBlock<TOutput>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<TOutput> target, out bool messageConsumed) { throw null; }
         void System.Threading.Tasks.Dataflow.ISourceBlock<TOutput>.ReleaseReservation(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<TOutput> target) { }
         bool System.Threading.Tasks.Dataflow.ISourceBlock<TOutput>.ReserveMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<TOutput> target) { throw null; }
         System.Threading.Tasks.Dataflow.DataflowMessageStatus System.Threading.Tasks.Dataflow.ITargetBlock<TInput>.OfferMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, TInput messageValue, System.Threading.Tasks.Dataflow.ISourceBlock<TInput> source, bool consumeToAccept) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryReceive(System.Predicate<TOutput> filter, out TOutput item) { item = default(TOutput); throw null; }
-        public bool TryReceiveAll(out System.Collections.Generic.IList<TOutput> items) { items = default(System.Collections.Generic.IList<TOutput>); throw null; }
+        public bool TryReceive(System.Predicate<TOutput> filter, out TOutput item) { throw null; }
+        public bool TryReceiveAll(out System.Collections.Generic.IList<TOutput> items) { throw null; }
     }
     public sealed partial class WriteOnceBlock<T> : System.Threading.Tasks.Dataflow.IDataflowBlock, System.Threading.Tasks.Dataflow.IPropagatorBlock<T, T>, System.Threading.Tasks.Dataflow.IReceivableSourceBlock<T>, System.Threading.Tasks.Dataflow.ISourceBlock<T>, System.Threading.Tasks.Dataflow.ITargetBlock<T>
     {
@@ -300,12 +300,12 @@ namespace System.Threading.Tasks.Dataflow
         public void Complete() { }
         public System.IDisposable LinkTo(System.Threading.Tasks.Dataflow.ITargetBlock<T> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions linkOptions) { throw null; }
         void System.Threading.Tasks.Dataflow.IDataflowBlock.Fault(System.Exception exception) { }
-        bool System.Threading.Tasks.Dataflow.IReceivableSourceBlock<T>.TryReceiveAll(out System.Collections.Generic.IList<T> items) { items = default(System.Collections.Generic.IList<T>); throw null; }
-        T System.Threading.Tasks.Dataflow.ISourceBlock<T>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target, out bool messageConsumed) { messageConsumed = default(bool); throw null; }
+        bool System.Threading.Tasks.Dataflow.IReceivableSourceBlock<T>.TryReceiveAll(out System.Collections.Generic.IList<T> items) { throw null; }
+        T System.Threading.Tasks.Dataflow.ISourceBlock<T>.ConsumeMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target, out bool messageConsumed) { throw null; }
         void System.Threading.Tasks.Dataflow.ISourceBlock<T>.ReleaseReservation(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target) { }
         bool System.Threading.Tasks.Dataflow.ISourceBlock<T>.ReserveMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, System.Threading.Tasks.Dataflow.ITargetBlock<T> target) { throw null; }
         System.Threading.Tasks.Dataflow.DataflowMessageStatus System.Threading.Tasks.Dataflow.ITargetBlock<T>.OfferMessage(System.Threading.Tasks.Dataflow.DataflowMessageHeader messageHeader, T messageValue, System.Threading.Tasks.Dataflow.ISourceBlock<T> source, bool consumeToAccept) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryReceive(System.Predicate<T> filter, out T item) { item = default(T); throw null; }
+        public bool TryReceive(System.Predicate<T> filter, out T item) { throw null; }
     }
 }

--- a/src/System.Threading.Tasks.Extensions/ref/System.Threading.Tasks.Extensions.cs
+++ b/src/System.Threading.Tasks.Extensions/ref/System.Threading.Tasks.Extensions.cs
@@ -15,6 +15,7 @@ namespace System.Runtime.CompilerServices
     }
     public partial struct AsyncValueTaskMethodBuilder<TResult>
     {
+        private TResult _result;
         public System.Threading.Tasks.ValueTask<TResult> Task { get { throw null; } }
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.INotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
@@ -24,20 +25,22 @@ namespace System.Runtime.CompilerServices
         public void SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) { }
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
     }
-    public partial struct ConfiguredValueTaskAwaitable<TResult>
+    public readonly partial struct ConfiguredValueTaskAwaitable<TResult>
     {
+        private readonly object _dummy;
         public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<TResult>.ConfiguredValueTaskAwaiter GetAwaiter() { throw null; }
         public partial struct ConfiguredValueTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
+            private object _dummy;
             public bool IsCompleted { get { throw null; } }
             public TResult GetResult() { throw null; }
             public void OnCompleted(System.Action continuation) { }
             public void UnsafeOnCompleted(System.Action continuation) { }
         }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ValueTaskAwaiter<TResult> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
     {
+        private object _dummy;
         public bool IsCompleted { get { throw null; } }
         public TResult GetResult() { throw null; }
         public void OnCompleted(System.Action continuation) { }
@@ -47,10 +50,11 @@ namespace System.Runtime.CompilerServices
 namespace System.Threading.Tasks
 {
     [System.Runtime.CompilerServices.AsyncMethodBuilderAttribute(typeof(System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder<>))]
-    public partial struct ValueTask<TResult> : System.IEquatable<System.Threading.Tasks.ValueTask<TResult>>
+    public readonly partial struct ValueTask<TResult> : System.IEquatable<System.Threading.Tasks.ValueTask<TResult>>
     {
-        public ValueTask(System.Threading.Tasks.Task<TResult> task) { throw null;}
-        public ValueTask(TResult result) { throw null;}
+        internal readonly TResult _result;
+        public ValueTask(System.Threading.Tasks.Task<TResult> task) { throw null; }
+        public ValueTask(TResult result) { throw null; }
         public bool IsCanceled { get { throw null; } }
         public bool IsCompleted { get { throw null; } }
         public bool IsCompletedSuccessfully { get { throw null; } }

--- a/src/System.Threading.Tasks.Parallel/ref/System.Threading.Tasks.Parallel.cs
+++ b/src/System.Threading.Tasks.Parallel/ref/System.Threading.Tasks.Parallel.cs
@@ -5,7 +5,6 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System.Threading.Tasks
 {
     public static partial class Parallel
@@ -18,10 +17,6 @@ namespace System.Threading.Tasks
         public static System.Threading.Tasks.ParallelLoopResult For(long fromInclusive, long toExclusive, System.Action<long> body) { throw null; }
         public static System.Threading.Tasks.ParallelLoopResult For(long fromInclusive, long toExclusive, System.Threading.Tasks.ParallelOptions parallelOptions, System.Action<long, System.Threading.Tasks.ParallelLoopState> body) { throw null; }
         public static System.Threading.Tasks.ParallelLoopResult For(long fromInclusive, long toExclusive, System.Threading.Tasks.ParallelOptions parallelOptions, System.Action<long> body) { throw null; }
-        public static System.Threading.Tasks.ParallelLoopResult For<TLocal>(int fromInclusive, int toExclusive, System.Func<TLocal> localInit, System.Func<int, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
-        public static System.Threading.Tasks.ParallelLoopResult For<TLocal>(int fromInclusive, int toExclusive, System.Threading.Tasks.ParallelOptions parallelOptions, System.Func<TLocal> localInit, System.Func<int, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
-        public static System.Threading.Tasks.ParallelLoopResult For<TLocal>(long fromInclusive, long toExclusive, System.Func<TLocal> localInit, System.Func<long, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
-        public static System.Threading.Tasks.ParallelLoopResult For<TLocal>(long fromInclusive, long toExclusive, System.Threading.Tasks.ParallelOptions parallelOptions, System.Func<TLocal> localInit, System.Func<long, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
         public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource>(System.Collections.Concurrent.OrderablePartitioner<TSource> source, System.Action<TSource, System.Threading.Tasks.ParallelLoopState, long> body) { throw null; }
         public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource>(System.Collections.Concurrent.OrderablePartitioner<TSource> source, System.Threading.Tasks.ParallelOptions parallelOptions, System.Action<TSource, System.Threading.Tasks.ParallelLoopState, long> body) { throw null; }
         public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource>(System.Collections.Concurrent.Partitioner<TSource> source, System.Action<TSource, System.Threading.Tasks.ParallelLoopState> body) { throw null; }
@@ -38,16 +33,20 @@ namespace System.Threading.Tasks
         public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource, TLocal>(System.Collections.Concurrent.OrderablePartitioner<TSource> source, System.Threading.Tasks.ParallelOptions parallelOptions, System.Func<TLocal> localInit, System.Func<TSource, System.Threading.Tasks.ParallelLoopState, long, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
         public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource, TLocal>(System.Collections.Concurrent.Partitioner<TSource> source, System.Func<TLocal> localInit, System.Func<TSource, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
         public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource, TLocal>(System.Collections.Concurrent.Partitioner<TSource> source, System.Threading.Tasks.ParallelOptions parallelOptions, System.Func<TLocal> localInit, System.Func<TSource, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
-        public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource, TLocal>(System.Collections.Generic.IEnumerable<TSource> source, System.Func<TLocal> localInit, System.Func<TSource, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
         public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource, TLocal>(System.Collections.Generic.IEnumerable<TSource> source, System.Func<TLocal> localInit, System.Func<TSource, System.Threading.Tasks.ParallelLoopState, long, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
-        public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource, TLocal>(System.Collections.Generic.IEnumerable<TSource> source, System.Threading.Tasks.ParallelOptions parallelOptions, System.Func<TLocal> localInit, System.Func<TSource, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
+        public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource, TLocal>(System.Collections.Generic.IEnumerable<TSource> source, System.Func<TLocal> localInit, System.Func<TSource, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
         public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource, TLocal>(System.Collections.Generic.IEnumerable<TSource> source, System.Threading.Tasks.ParallelOptions parallelOptions, System.Func<TLocal> localInit, System.Func<TSource, System.Threading.Tasks.ParallelLoopState, long, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
+        public static System.Threading.Tasks.ParallelLoopResult ForEach<TSource, TLocal>(System.Collections.Generic.IEnumerable<TSource> source, System.Threading.Tasks.ParallelOptions parallelOptions, System.Func<TLocal> localInit, System.Func<TSource, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
+        public static System.Threading.Tasks.ParallelLoopResult For<TLocal>(int fromInclusive, int toExclusive, System.Func<TLocal> localInit, System.Func<int, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
+        public static System.Threading.Tasks.ParallelLoopResult For<TLocal>(int fromInclusive, int toExclusive, System.Threading.Tasks.ParallelOptions parallelOptions, System.Func<TLocal> localInit, System.Func<int, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
+        public static System.Threading.Tasks.ParallelLoopResult For<TLocal>(long fromInclusive, long toExclusive, System.Func<TLocal> localInit, System.Func<long, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
+        public static System.Threading.Tasks.ParallelLoopResult For<TLocal>(long fromInclusive, long toExclusive, System.Threading.Tasks.ParallelOptions parallelOptions, System.Func<TLocal> localInit, System.Func<long, System.Threading.Tasks.ParallelLoopState, TLocal, TLocal> body, System.Action<TLocal> localFinally) { throw null; }
         public static void Invoke(params System.Action[] actions) { }
         public static void Invoke(System.Threading.Tasks.ParallelOptions parallelOptions, params System.Action[] actions) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ParallelLoopResult
     {
+        private int _dummy;
         public bool IsCompleted { get { throw null; } }
         public System.Nullable<long> LowestBreakIteration { get { throw null; } }
     }

--- a/src/System.Threading.Tasks/ref/System.Threading.Tasks.cs
+++ b/src/System.Threading.Tasks/ref/System.Threading.Tasks.cs
@@ -43,9 +43,9 @@ namespace System
 }
 namespace System.Runtime.CompilerServices
 {
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct AsyncTaskMethodBuilder
     {
+        private object _dummy;
         public System.Threading.Tasks.Task Task { get { throw null; } }
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.INotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
@@ -55,9 +55,9 @@ namespace System.Runtime.CompilerServices
         public void SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) { }
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct AsyncTaskMethodBuilder<TResult>
     {
+        private System.Threading.Tasks.Task<TResult> _dummy;
         public System.Threading.Tasks.Task<TResult> Task { get { throw null; } }
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.INotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
@@ -67,9 +67,9 @@ namespace System.Runtime.CompilerServices
         public void SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) { }
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct AsyncVoidMethodBuilder
     {
+        private object _dummy;
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.INotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
         public static System.Runtime.CompilerServices.AsyncVoidMethodBuilder Create() { throw null; }

--- a/src/System.Threading/ref/System.Threading.cs
+++ b/src/System.Threading/ref/System.Threading.cs
@@ -22,6 +22,7 @@ namespace System.Threading
     }
     public partial struct AsyncFlowControl : System.IDisposable
     {
+        private object _dummy;
         public void Dispose() { }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Threading.AsyncFlowControl obj) { throw null; }
@@ -36,9 +37,9 @@ namespace System.Threading
         public AsyncLocal(System.Action<System.Threading.AsyncLocalValueChangedArgs<T>> valueChangedHandler) { }
         public T Value { get { throw null; } set { } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct AsyncLocalValueChangedArgs<T>
     {
+        private T _dummy;
         public T CurrentValue { get { throw null; } }
         public T PreviousValue { get { throw null; } }
         public bool ThreadContextChanged { get { throw null; } }
@@ -179,6 +180,7 @@ namespace System.Threading
     }
     public partial struct LockCookie
     {
+        private int _dummy;
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Threading.LockCookie obj) { throw null; }
         public override int GetHashCode() { throw null; }
@@ -340,9 +342,9 @@ namespace System.Threading
         public System.Threading.Tasks.Task<bool> WaitAsync(System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public delegate void SendOrPostCallback(object state);
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SpinLock
     {
+        private int _dummy;
         public SpinLock(bool enableThreadOwnerTracking) { throw null; }
         public bool IsHeld { get { throw null; } }
         public bool IsHeldByCurrentThread { get { throw null; } }
@@ -354,9 +356,9 @@ namespace System.Threading
         public void TryEnter(int millisecondsTimeout, ref bool lockTaken) { }
         public void TryEnter(System.TimeSpan timeout, ref bool lockTaken) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SpinWait
     {
+        private int _dummy;
         public int Count { get { throw null; } }
         public bool NextSpinWillYield { get { throw null; } }
         public void Reset() { }

--- a/src/System.Transactions.Local/ref/System.Transactions.Local.cs
+++ b/src/System.Transactions.Local/ref/System.Transactions.Local.cs
@@ -200,9 +200,9 @@ namespace System.Transactions
         public TransactionManagerCommunicationException(string message) { }
         public TransactionManagerCommunicationException(string message, System.Exception innerException) { }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct TransactionOptions
     {
+        private int _dummy;
         public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } set { } }
         public System.TimeSpan Timeout { get { throw null; } set { } }
         public override bool Equals(object obj) { throw null; }

--- a/src/System.Transactions.Local/ref/System.Transactions.Local.csproj
+++ b/src/System.Transactions.Local/ref/System.Transactions.Local.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="System.Transactions.cs" />
+    <Compile Include="System.Transactions.Local.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />

--- a/src/System.Xml.XmlSerializer/ref/System.Xml.XmlSerializer.cs
+++ b/src/System.Xml.XmlSerializer/ref/System.Xml.XmlSerializer.cs
@@ -251,9 +251,9 @@ namespace System.Xml.Serialization
         public XmlChoiceIdentifierAttribute(string name) { }
         public string MemberName { get { throw null; } set { } }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct XmlDeserializationEvents
     {
+        private object _dummy;
         public System.Xml.Serialization.XmlAttributeEventHandler OnUnknownAttribute { get { throw null; } set { } }
         public System.Xml.Serialization.XmlElementEventHandler OnUnknownElement { get { throw null; } set { } }
         public System.Xml.Serialization.XmlNodeEventHandler OnUnknownNode { get { throw null; } set { } }

--- a/tools-local/DefaultGenApiDocIds.txt
+++ b/tools-local/DefaultGenApiDocIds.txt
@@ -6,6 +6,7 @@ T:System.ComponentModel.Design.Serialization.RootDesignerSerializerAttribute
 T:System.ComponentModel.EditorAttribute
 T:System.ComponentModel.TypeConverterAttribute
 T:System.Configuration.ConfigurationPropertyAttribute
+T:System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute
 T:System.Diagnostics.CodeAnalysis.SuppressMessageAttribute
 T:System.Diagnostics.DebuggerBrowsableAttribute
 T:System.Diagnostics.DebuggerDisplayAttribute


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/6185.

This is an update to the rest of the reference assemblies in corefx. I updated every reference assembly that as a struct with any private fields. Some of the refs that weren't easy to regenerate I did targeted fixes for and others I regenerated with the latest tools so there are some other normalization changes in some of the refs.

PTAL @jkotas @VSadov @jaredpar @gafter @tmat @nguerrera 