### PR TITLE
Remove use of Unsafe in UTF-8 formatters, plus performance improvements

### DIFF
--- a/src/System.Memory/src/System/Buffers/Text/Utf8Constants.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Constants.cs
@@ -20,12 +20,7 @@ namespace System.Buffers.Text
         // Invariant formatting uses groups of 3 for each number group separated by commas.
         //   ex. 1,234,567,890
         public const int GroupSize = 3;
-
-        public static readonly byte[] s_capitalizedTrue = { (byte)'T', (byte)'r', (byte)'u', (byte)'e' };
-        public static readonly byte[] s_capitalizedFalse = { (byte)'F', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };
-        public static readonly byte[] s_true = { (byte)'t', (byte)'r', (byte)'u', (byte)'e' };
-        public static readonly byte[] s_false = { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };
-
+        
         public static readonly TimeSpan s_nullUtcOffset = TimeSpan.MinValue;  // Utc offsets must range from -14:00 to 14:00 so this is never a valid offset.
 
         public const int DateTimeMaxUtcOffsetHours = 14; // The UTC offset portion of a TimeSpan or DateTime can be no more than 14 hours and no less than -14 hours.

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
@@ -23,7 +23,9 @@ namespace System.Buffers.Text
         private const int FractionDigits = 7;
 
         // A simple lookup table for converting numbers to hex.
-        private const string HexTable = "0123456789abcdef";
+        internal const string HexTableLower = "0123456789abcdef";
+
+        internal const string HexTableUpper = "0123456789ABCDEF";
 
         // TODO: Where should the below method live? Ideally it should be publicly exposed
         // since having blittable access to structs would be convenient.
@@ -375,6 +377,35 @@ namespace System.Buffers.Text
             }
 
             return count + 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int CountHexDigits(ulong value)
+        {
+            // TODO: When x86 intrinsic support comes online, experiment with implementing this using lzcnt.
+            // return 16 - (int)((uint)Lzcnt.LeadingZeroCount(value | 1) >> 3);
+
+            int digits = 1;
+
+            if (value > 0xFFFFFFFF)
+            {
+                digits += 8;
+                value >>= 0x20;
+            }
+            if (value > 0xFFFF)
+            {
+                digits += 4;
+                value >>= 0x10;
+            }
+            if (value > 0xFF)
+            {
+                digits += 2;
+                value >>= 0x8;
+            }
+            if (value > 0xF)
+                digits++;
+
+            return digits;
         }
 
         #endregion Character counting helper methods

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
@@ -20,36 +20,7 @@ namespace System.Buffers.Text
         internal const string HexTableLower = "0123456789abcdef";
 
         internal const string HexTableUpper = "0123456789ABCDEF";
-
-        // TODO: Where should the below method live? Ideally it should be publicly exposed
-        // since having blittable access to structs would be convenient.
-        // Should it be on BinaryPrimitives?
-
-        /// <summary>
-        /// Given a reference to a blittable value type, returns a Span that allows
-        /// access to the binary representation of the value.
-        /// </summary>
-        /// <remarks>
-        /// No copy is performed as part of this method's logic.
-        /// This is intended to be a "safe" API even though it's implemented in terms of unsafe casts.
-        /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Span<byte> GetSpanForBlittable<T>(ref T value) where T : struct
-        {
-#if netstandard
-            if (SpanHelpers.IsReferenceOrContainsReferences<T>())
-            {
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
-            }
-#else
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-            {
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
-            }
-#endif
-            return Span<byte>.DangerousCreate(null, ref Unsafe.As<T, byte>(ref value), Unsafe.SizeOf<T>());
-        }
-
+        
         /// <summary>
         /// Returns the symbol contained within the standard format. If the standard format
         /// has not been initialized, returns the provided fallback symbol.

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
@@ -212,6 +212,46 @@ namespace System.Buffers.Text
             Debug.Assert(left == 0);
         }
 
+        /// <summary>
+        /// Writes a value [ 0000 .. 9999 ] to the buffer starting at the specified offset.
+        /// This method performs best when the starting index is a constant literal.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteFourDecimalDigits(uint value, Span<byte> buffer, int startingIndex = 0)
+        {
+            Debug.Assert(0 <= value && value <= 9999);
+
+            uint temp = '0' + value;
+            value /= 10;
+            buffer[startingIndex + 3] = (byte)(temp - (value * 10));
+
+            temp = '0' + value;
+            value /= 10;
+            buffer[startingIndex + 2] = (byte)(temp - (value * 10));
+
+            temp = '0' + value;
+            value /= 10;
+            buffer[startingIndex + 1] = (byte)(temp - (value * 10));
+
+            buffer[startingIndex] = (byte)('0' + value);
+        }
+
+        /// <summary>
+        /// Writes a value [ 00 .. 99 ] to the buffer starting at the specified offset.
+        /// This method performs best when the starting index is a constant literal.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteTwoDecimalDigits(uint value, Span<byte> buffer, int startingIndex = 0)
+        {
+            Debug.Assert(0 <= value && value <= 99);
+
+            uint temp = '0' + value;
+            value /= 10;
+            buffer[startingIndex + 1] = (byte)(temp - (value * 10));
+
+            buffer[startingIndex] = (byte)('0' + value);
+        }
+
         #endregion UTF-8 Helper methods
 
         #region Math Helper methods

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
@@ -20,7 +20,7 @@ namespace System.Buffers.Text
         internal const string HexTableLower = "0123456789abcdef";
 
         internal const string HexTableUpper = "0123456789ABCDEF";
-        
+
         /// <summary>
         /// Returns the symbol contained within the standard format. If the standard format
         /// has not been initialized, returns the provided fallback symbol.

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
@@ -25,15 +25,119 @@ namespace System.Buffers.Text
         // A simple lookup table for converting numbers to hex.
         private const string HexTable = "0123456789abcdef";
 
-        #region UTF-8 Helper methods
+        // TODO: Where should the below method live? Ideally it should be publicly exposed
+        // since having blittable access to structs would be convenient.
+        // Should it be on BinaryPrimitives?
 
+        /// <summary>
+        /// Given a reference to a blittable value type, returns a Span that allows
+        /// access to the binary representation of the value.
+        /// </summary>
+        /// <remarks>
+        /// No copy is performed as part of this method's logic.
+        /// This is intended to be a "safe" API even though it's implemented in terms of unsafe casts.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteHexByte(byte value, ref byte buffer, int index)
+        public static Span<byte> GetSpanForBlittable<T>(ref T value) where T : struct
         {
-            Unsafe.Add(ref buffer, index) = (byte)HexTable[value >> 4];
-            Unsafe.Add(ref buffer, index + 1) = (byte)HexTable[value & 0xF];
+#if netstandard
+            if (SpanHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+            }
+#else
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+            }
+#endif
+            return Span<byte>.DangerousCreate(null, ref Unsafe.As<T, byte>(ref value), Unsafe.SizeOf<T>());
         }
 
+        /// <summary>
+        /// Returns the symbol contained within the standard format. If the standard format
+        /// has not been initialized, returns the provided fallback symbol.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static char GetSymbolOrDefault(in StandardFormat format, char defaultSymbol)
+        {
+            // This is equivalent to the line below, but it is written in such a way
+            // that the JIT is able to perform more optimizations.
+            //
+            // return (format.IsDefault) ? defaultSymbol : format.Symbol;
+
+            var symbol = format.Symbol;
+            if (symbol == default && format.Precision == default)
+            {
+                symbol = defaultSymbol;
+            }
+            return symbol;
+        }
+
+        #region UTF-8 Helper methods
+
+        public enum HexCasing : uint
+        {
+            // Output [ '0' .. '9' ] and [ 'A' .. 'F' ].
+            Uppercase = 0,
+
+            // Output [ '0' .. '9' ] and [ 'a' .. 'f' ].
+            // This works because values in the range [ 0x30 .. 0x39 ] ([ '0' .. '9' ])
+            // already have the 0x20 bit set, so ORing them with 0x20 is a no-op,
+            // while outputs in the range [ 0x41 .. 0x46 ] ([ 'A' .. 'F' ])
+            // don't have the 0x20 bit set, so ORing them maps to
+            // [ 0x61 .. 0x66 ] ([ 'a' .. 'f' ]), which is what we want.
+            Lowercase = 0x2020U,
+        }
+
+        // The JIT can elide bounds checks if 'startingIndex' is constant and if the caller is
+        // writing to a span of known length (or the caller has already checked the bounds of the
+        // furthest access).
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteHexByte(byte value, Span<byte> buffer, int startingIndex = 0, HexCasing casing = HexCasing.Uppercase)
+        {
+            // We want to pack the incoming byte into a single integer [ 0000 HHHH 0000 LLLL ],
+            // where HHHH and LLLL are the high and low nibbles of the incoming byte. Then
+            // subtract this integer from a constant minuend as shown below.
+            //
+            //   [ 1000 1001 1000 1001 ]
+            // - [ 0000 HHHH 0000 LLLL ]
+            // =========================
+            //   [ *YYY **** *ZZZ **** ]
+            //
+            // The end result of this is that YYY is 0b000 if HHHH <= 9, and YYY is 0b111 if HHHH >= 10.
+            // Similarly, ZZZ is 0b000 if LLLL <= 9, and ZZZ is 0b111 if LLLL >= 10.
+            // (We don't care about the value of asterisked bits.)
+            //
+            // To turn a nibble in the range [ 0 .. 9 ] into hex, we calculate hex := nibble + 48 (ascii '0').
+            // To turn a nibble in the range [ 10 .. 15 ] into hex, we calculate hex := nibble - 10 + 65 (ascii 'A').
+            //                                                                => hex := nibble + 55.
+            // The difference in the starting ASCII offset is (55 - 48) = 7, depending on whether the nibble is <= 9 or >= 10.
+            // Since 7 is 0b111, this conveniently matches the YYY or ZZZ value computed during the earlier subtraction.
+
+            // The commented out code below is code that directly implements the logic described above.
+
+            //uint packedOriginalValues = (((uint)value & 0xF0U) << 4) + ((uint)value & 0x0FU);
+            //uint difference = 0x8989U - packedOriginalValues;
+            //uint add7Mask = (difference & 0x7070U) >> 4; // line YYY and ZZZ back up with the packed values
+            //uint packedResult = packedOriginalValues + add7Mask + 0x3030U /* ascii '0' */;
+
+            // The code below is equivalent to the commented out code above but has been tweaked
+            // to allow codegen to make some extra optimizations.
+
+            uint difference = (((uint)value & 0xF0U) << 4) + ((uint)value & 0x0FU) - 0x8989U;
+            uint packedResult = ((((uint)(-(int)difference) & 0x7070U) >> 4) + difference + 0xB9B9U) | (uint)casing;
+
+            // The low byte of the packed result contains the hex representation of the incoming byte's low nibble.
+            // The adjacent byte of the packed result contains the hex representation of the incoming byte's high nibble.
+
+            // Finally, write to the output buffer starting with the *highest* index so that codegen can
+            // elide all but the first bounds check. (This only works if 'startingIndex' is a compile-time constant.)
+
+            buffer[startingIndex + 1] = (byte)(packedResult);
+            buffer[startingIndex] = (byte)(packedResult >> 8);
+        }
+        
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteFractionDigits(long value, int digitCount, ref byte buffer, int index)
         {
@@ -229,11 +333,11 @@ namespace System.Buffers.Text
                 digits += 5;
             }
 
-            if (value < 10) 
-            { 
+            if (value < 10)
+            {
                 // no-op
             }
-            else if (value < 100) 
+            else if (value < 100)
             {
                 digits += 1;
             }

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.L.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.L.cs
@@ -2,13 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
-#if !netstandard
-using Internal.Runtime.CompilerServices;
-#endif
-
 namespace System.Buffers.Text
 {
     public static partial class Utf8Formatter
@@ -21,47 +14,52 @@ namespace System.Buffers.Text
         //
         private static bool TryFormatDateTimeL(DateTime value, Span<byte> buffer, out int bytesWritten)
         {
-            bytesWritten = 29;
-            if (buffer.Length < bytesWritten)
+            // Writing the check in this fashion elides all bounds checks on 'buffer'
+            // for the remainder of the method.
+            if ((uint)28 >= (uint)buffer.Length)
             {
                 bytesWritten = 0;
                 return false;
             }
 
-            ref byte utf8Bytes = ref MemoryMarshal.GetReference(buffer);
+            var dayAbbrev = DayAbbreviationsLowercase[(int)value.DayOfWeek];
 
-            byte[] dayAbbrev = DayAbbreviationsLowercase[(int)value.DayOfWeek];
-            Unsafe.Add(ref utf8Bytes, 0) = dayAbbrev[0];
-            Unsafe.Add(ref utf8Bytes, 1) = dayAbbrev[1];
-            Unsafe.Add(ref utf8Bytes, 2) = dayAbbrev[2];
-            Unsafe.Add(ref utf8Bytes, 3) = Utf8Constants.Comma;
-            Unsafe.Add(ref utf8Bytes, 4) = Utf8Constants.Space;
+            buffer[0] = (byte)dayAbbrev;
+            dayAbbrev >>= 8;
+            buffer[1] = (byte)dayAbbrev;
+            dayAbbrev >>= 8;
+            buffer[2] = (byte)dayAbbrev;
+            buffer[3] = Utf8Constants.Comma;
+            buffer[4] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 5);
-            Unsafe.Add(ref utf8Bytes, 7) = (byte)' ';
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Day, buffer, 5);
+            buffer[7] = Utf8Constants.Space;
 
-            byte[] monthAbbrev = MonthAbbreviationsLowercase[value.Month - 1];
-            Unsafe.Add(ref utf8Bytes, 8) = monthAbbrev[0];
-            Unsafe.Add(ref utf8Bytes, 9) = monthAbbrev[1];
-            Unsafe.Add(ref utf8Bytes, 10) = monthAbbrev[2];
-            Unsafe.Add(ref utf8Bytes, 11) = Utf8Constants.Space;
+            var monthAbbrev = MonthAbbreviationsLowercase[value.Month - 1];
+            buffer[8] = (byte)monthAbbrev;
+            monthAbbrev >>= 8;
+            buffer[9] = (byte)monthAbbrev;
+            monthAbbrev >>= 8;
+            buffer[10] = (byte)monthAbbrev;
+            buffer[11] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 12);
-            Unsafe.Add(ref utf8Bytes, 16) = Utf8Constants.Space;
+            FormattingHelpers.WriteFourDecimalDigits((uint)value.Year, buffer, 12);
+            buffer[16] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 17);
-            Unsafe.Add(ref utf8Bytes, 19) = Utf8Constants.Colon;
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Hour, buffer, 17);
+            buffer[19] = Utf8Constants.Colon;
 
-            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 20);
-            Unsafe.Add(ref utf8Bytes, 22) = Utf8Constants.Colon;
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Minute, buffer, 20);
+            buffer[22] = Utf8Constants.Colon;
 
-            FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 23);
-            Unsafe.Add(ref utf8Bytes, 25) = Utf8Constants.Space;
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Second, buffer, 23);
+            buffer[25] = Utf8Constants.Space;
 
-            Unsafe.Add(ref utf8Bytes, 26) = GMT1Lowercase;
-            Unsafe.Add(ref utf8Bytes, 27) = GMT2Lowercase;
-            Unsafe.Add(ref utf8Bytes, 28) = GMT3Lowercase;
+            buffer[26] = GMT1Lowercase;
+            buffer[27] = GMT2Lowercase;
+            buffer[28] = GMT3Lowercase;
 
+            bytesWritten = 29;
             return true;
         }
     }

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.O.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.O.cs
@@ -2,13 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
-#if !netstandard
-using Internal.Runtime.CompilerServices;
-#endif
-
 namespace System.Buffers.Text
 {
     public static partial class Utf8Formatter
@@ -26,7 +19,7 @@ namespace System.Buffers.Text
         {
             const int MinimumBytesNeeded = 27;
 
-            bytesWritten = MinimumBytesNeeded;
+            int bytesRequired = MinimumBytesNeeded;
             DateTimeKind kind = DateTimeKind.Local;
 
             if (offset == Utf8Constants.s_nullUtcOffset)
@@ -35,67 +28,75 @@ namespace System.Buffers.Text
                 if (kind == DateTimeKind.Local)
                 {
                     offset = TimeZoneInfo.Local.GetUtcOffset(value);
-                    bytesWritten += 6;
+                    bytesRequired += 6;
                 }
                 else if (kind == DateTimeKind.Utc)
                 {
-                    bytesWritten += 1;
+                    bytesRequired += 1;
                 }
             }
             else
             {
-                bytesWritten += 6;
+                bytesRequired += 6;
             }
 
-            if (buffer.Length < bytesWritten)
+            if (buffer.Length < bytesRequired)
             {
                 bytesWritten = 0;
                 return false;
             }
 
-            ref byte utf8Bytes = ref MemoryMarshal.GetReference(buffer);
+            bytesWritten = bytesRequired;
 
-            FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 0);
-            Unsafe.Add(ref utf8Bytes, 4) = Utf8Constants.Minus;
+            // Hoist most of the bounds checks on buffer.
+            { var unused = buffer[MinimumBytesNeeded - 1]; }
 
-            FormattingHelpers.WriteDigits(value.Month, 2, ref utf8Bytes, 5);
-            Unsafe.Add(ref utf8Bytes, 7) = Utf8Constants.Minus;
+            FormattingHelpers.WriteFourDecimalDigits((uint)value.Year, buffer, 0);
+            buffer[4] = Utf8Constants.Minus;
 
-            FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 8);
-            Unsafe.Add(ref utf8Bytes, 10) = TimeMarker;
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Month, buffer, 5);
+            buffer[7] = Utf8Constants.Minus;
 
-            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 11);
-            Unsafe.Add(ref utf8Bytes, 13) = Utf8Constants.Colon;
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Day, buffer, 8);
+            buffer[10] = TimeMarker;
 
-            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 14);
-            Unsafe.Add(ref utf8Bytes, 16) = Utf8Constants.Colon;
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Hour, buffer, 11);
+            buffer[13] = Utf8Constants.Colon;
 
-            FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 17);
-            Unsafe.Add(ref utf8Bytes, 19) = Utf8Constants.Period;
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Minute, buffer, 14);
+            buffer[16] = Utf8Constants.Colon;
 
-            FormattingHelpers.DivMod(value.Ticks, TimeSpan.TicksPerSecond, out long fraction);
-            FormattingHelpers.WriteDigits(fraction, Utf8Constants.DateTimeNumFractionDigits, ref utf8Bytes, 20);
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Second, buffer, 17);
+            buffer[19] = Utf8Constants.Period;
+
+            FormattingHelpers.WriteDigits((uint)((ulong)value.Ticks % (ulong)TimeSpan.TicksPerSecond), buffer.Slice(20, 7));
 
             if (kind == DateTimeKind.Local)
             {
-                int hours = offset.Hours;
-                byte sign = Utf8Constants.Plus;
+                byte sign;
 
-                if (offset.Hours < 0)
+                if (offset < default(TimeSpan) /* a "const" version of TimeSpan.Zero */)
                 {
-                    hours = -offset.Hours;
                     sign = Utf8Constants.Minus;
+                    offset = TimeSpan.FromTicks(-offset.Ticks);
+                }
+                else
+                {
+                    sign = Utf8Constants.Plus;
                 }
 
-                Unsafe.Add(ref utf8Bytes, 27) = sign;
-                FormattingHelpers.WriteDigits(hours, 2, ref utf8Bytes, 28);
-                Unsafe.Add(ref utf8Bytes, 30) = Utf8Constants.Colon;
-                int offsetMinutes = Math.Abs(offset.Minutes);
-                FormattingHelpers.WriteDigits(offsetMinutes, 2, ref utf8Bytes, 31);
+                // Writing the value backward allows the JIT to optimize by
+                // performing a single bounds check against buffer.
+
+                FormattingHelpers.WriteTwoDecimalDigits((uint)offset.Minutes, buffer, 31);
+                buffer[30] = Utf8Constants.Colon;
+                FormattingHelpers.WriteTwoDecimalDigits((uint)offset.Hours, buffer, 28);
+                buffer[27] = sign;
+
             }
             else if (kind == DateTimeKind.Utc)
             {
-                Unsafe.Add(ref utf8Bytes, 27) = UtcMarker;
+                buffer[27] = UtcMarker;
             }
 
             return true;

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.R.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.R.cs
@@ -2,14 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if !netstandard
-using Internal.Runtime.CompilerServices;
-#else
-using System.Runtime.CompilerServices;
-#endif
-
-using System.Runtime.InteropServices;
-
 namespace System.Buffers.Text
 {
     public static partial class Utf8Formatter
@@ -22,47 +14,52 @@ namespace System.Buffers.Text
         //
         private static bool TryFormatDateTimeR(DateTime value, Span<byte> buffer, out int bytesWritten)
         {
-            bytesWritten = 29;
-            if (buffer.Length < bytesWritten)
+            // Writing the check in this fashion elides all bounds checks on 'buffer'
+            // for the remainder of the method.
+            if ((uint)28 >= (uint)buffer.Length)
             {
                 bytesWritten = 0;
                 return false;
             }
 
-            ref byte utf8Bytes = ref MemoryMarshal.GetReference(buffer);
+            var dayAbbrev = DayAbbreviations[(int)value.DayOfWeek];
 
-            byte[] dayAbbrev = DayAbbreviations[(int)value.DayOfWeek];
-            Unsafe.Add(ref utf8Bytes, 0) = dayAbbrev[0];
-            Unsafe.Add(ref utf8Bytes, 1) = dayAbbrev[1];
-            Unsafe.Add(ref utf8Bytes, 2) = dayAbbrev[2];
-            Unsafe.Add(ref utf8Bytes, 3) = Utf8Constants.Comma;
-            Unsafe.Add(ref utf8Bytes, 4) = Utf8Constants.Space;
+            buffer[0] = (byte)dayAbbrev;
+            dayAbbrev >>= 8;
+            buffer[1] = (byte)dayAbbrev;
+            dayAbbrev >>= 8;
+            buffer[2] = (byte)dayAbbrev;
+            buffer[3] = Utf8Constants.Comma;
+            buffer[4] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 5);
-            Unsafe.Add(ref utf8Bytes, 7) = (byte)' ';
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Day, buffer, 5);
+            buffer[7] = Utf8Constants.Space;
 
-            byte[] monthAbbrev = MonthAbbreviations[value.Month - 1];
-            Unsafe.Add(ref utf8Bytes, 8) = monthAbbrev[0];
-            Unsafe.Add(ref utf8Bytes, 9) = monthAbbrev[1];
-            Unsafe.Add(ref utf8Bytes, 10) = monthAbbrev[2];
-            Unsafe.Add(ref utf8Bytes, 11) = Utf8Constants.Space;
+            var monthAbbrev = MonthAbbreviations[value.Month - 1];
+            buffer[8] = (byte)monthAbbrev;
+            monthAbbrev >>= 8;
+            buffer[9] = (byte)monthAbbrev;
+            monthAbbrev >>= 8;
+            buffer[10] = (byte)monthAbbrev;
+            buffer[11] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 12);
-            Unsafe.Add(ref utf8Bytes, 16) = Utf8Constants.Space;
+            FormattingHelpers.WriteFourDecimalDigits((uint)value.Year, buffer, 12);
+            buffer[16] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 17);
-            Unsafe.Add(ref utf8Bytes, 19) = Utf8Constants.Colon;
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Hour, buffer, 17);
+            buffer[19] = Utf8Constants.Colon;
 
-            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 20);
-            Unsafe.Add(ref utf8Bytes, 22) = Utf8Constants.Colon;
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Minute, buffer, 20);
+            buffer[22] = Utf8Constants.Colon;
 
-            FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 23);
-            Unsafe.Add(ref utf8Bytes, 25) = Utf8Constants.Space;
+            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Second, buffer, 23);
+            buffer[25] = Utf8Constants.Space;
 
-            Unsafe.Add(ref utf8Bytes, 26) = GMT1;
-            Unsafe.Add(ref utf8Bytes, 27) = GMT2;
-            Unsafe.Add(ref utf8Bytes, 28) = GMT3;
+            buffer[26] = GMT1;
+            buffer[27] = GMT2;
+            buffer[28] = GMT3;
 
+            bytesWritten = 29;
             return true;
         }
     }

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.cs
@@ -17,58 +17,60 @@ namespace System.Buffers.Text
         private const byte GMT2Lowercase = (byte)'m';
         private const byte GMT3Lowercase = (byte)'t';
 
-        private static readonly byte[][] DayAbbreviations = new byte[][]
+        // The three-letter abbreviation is packed into a 24-bit unsigned integer
+        // where the least significant byte represents the first letter.
+        private static readonly uint[] DayAbbreviations = new uint[]
         {
-            new byte[] { (byte)'S', (byte)'u', (byte)'n' },
-            new byte[] { (byte)'M', (byte)'o', (byte)'n' },
-            new byte[] { (byte)'T', (byte)'u', (byte)'e' },
-            new byte[] { (byte)'W', (byte)'e', (byte)'d' },
-            new byte[] { (byte)'T', (byte)'h', (byte)'u' },
-            new byte[] { (byte)'F', (byte)'r', (byte)'i' },
-            new byte[] { (byte)'S', (byte)'a', (byte)'t' },
+            'S' + ('u' << 8) + ('n' << 16),
+            'M' + ('o' << 8) + ('n' << 16),
+            'T' + ('u' << 8) + ('e' << 16),
+            'W' + ('e' << 8) + ('d' << 16),
+            'T' + ('h' << 8) + ('u' << 16),
+            'F' + ('r' << 8) + ('i' << 16),
+            'S' + ('a' << 8) + ('t' << 16),
         };
 
-        private static readonly byte[][] DayAbbreviationsLowercase = new byte[][]
+        private static readonly uint[] DayAbbreviationsLowercase = new uint[]
         {
-            new byte[] { (byte)'s', (byte)'u', (byte)'n' },
-            new byte[] { (byte)'m', (byte)'o', (byte)'n' },
-            new byte[] { (byte)'t', (byte)'u', (byte)'e' },
-            new byte[] { (byte)'w', (byte)'e', (byte)'d' },
-            new byte[] { (byte)'t', (byte)'h', (byte)'u' },
-            new byte[] { (byte)'f', (byte)'r', (byte)'i' },
-            new byte[] { (byte)'s', (byte)'a', (byte)'t' },
+            's' + ('u' << 8) + ('n' << 16),
+            'm' + ('o' << 8) + ('n' << 16),
+            't' + ('u' << 8) + ('e' << 16),
+            'w' + ('e' << 8) + ('d' << 16),
+            't' + ('h' << 8) + ('u' << 16),
+            'f' + ('r' << 8) + ('i' << 16),
+            's' + ('a' << 8) + ('t' << 16)
         };
 
-        private static readonly byte[][] MonthAbbreviations = new byte[][]
+        private static readonly uint[] MonthAbbreviations = new uint[]
         {
-            new byte[] { (byte)'J', (byte)'a', (byte)'n' },
-            new byte[] { (byte)'F', (byte)'e', (byte)'b' },
-            new byte[] { (byte)'M', (byte)'a', (byte)'r' },
-            new byte[] { (byte)'A', (byte)'p', (byte)'r' },
-            new byte[] { (byte)'M', (byte)'a', (byte)'y' },
-            new byte[] { (byte)'J', (byte)'u', (byte)'n' },
-            new byte[] { (byte)'J', (byte)'u', (byte)'l' },
-            new byte[] { (byte)'A', (byte)'u', (byte)'g' },
-            new byte[] { (byte)'S', (byte)'e', (byte)'p' },
-            new byte[] { (byte)'O', (byte)'c', (byte)'t' },
-            new byte[] { (byte)'N', (byte)'o', (byte)'v' },
-            new byte[] { (byte)'D', (byte)'e', (byte)'c' },
+            'J' + ('a' << 8) + ('n' << 16),
+            'F' + ('e' << 8) + ('b' << 16),
+            'M' + ('a' << 8) + ('r' << 16),
+            'A' + ('p' << 8) + ('r' << 16),
+            'M' + ('a' << 8) + ('y' << 16),
+            'J' + ('u' << 8) + ('n' << 16),
+            'J' + ('u' << 8) + ('l' << 16),
+            'A' + ('u' << 8) + ('g' << 16),
+            'S' + ('e' << 8) + ('p' << 16),
+            'O' + ('c' << 8) + ('t' << 16),
+            'N' + ('o' << 8) + ('v' << 16),
+            'D' + ('e' << 8) + ('c' << 16),
         };
 
-        private static readonly byte[][] MonthAbbreviationsLowercase = new byte[][]
+        private static readonly uint[] MonthAbbreviationsLowercase = new uint[]
         {
-            new byte[] { (byte)'j', (byte)'a', (byte)'n' },
-            new byte[] { (byte)'f', (byte)'e', (byte)'b' },
-            new byte[] { (byte)'m', (byte)'a', (byte)'r' },
-            new byte[] { (byte)'a', (byte)'p', (byte)'r' },
-            new byte[] { (byte)'m', (byte)'a', (byte)'y' },
-            new byte[] { (byte)'j', (byte)'u', (byte)'n' },
-            new byte[] { (byte)'j', (byte)'u', (byte)'l' },
-            new byte[] { (byte)'a', (byte)'u', (byte)'g' },
-            new byte[] { (byte)'s', (byte)'e', (byte)'p' },
-            new byte[] { (byte)'o', (byte)'c', (byte)'t' },
-            new byte[] { (byte)'n', (byte)'o', (byte)'v' },
-            new byte[] { (byte)'d', (byte)'e', (byte)'c' },
+            'j' + ('a' << 8) + ('n' << 16),
+            'f' + ('e' << 8) + ('b' << 16),
+            'm' + ('a' << 8) + ('r' << 16),
+            'a' + ('p' << 8) + ('r' << 16),
+            'm' + ('a' << 8) + ('y' << 16),
+            'j' + ('u' << 8) + ('n' << 16),
+            'j' + ('u' << 8) + ('l' << 16),
+            'a' + ('u' << 8) + ('g' << 16),
+            's' + ('e' << 8) + ('p' << 16),
+            'o' + ('c' << 8) + ('t' << 16),
+            'n' + ('o' << 8) + ('v' << 16),
+            'd' + ('e' << 8) + ('c' << 16),
         };
 
         /// <summary>
@@ -145,7 +147,7 @@ namespace System.Buffers.Text
         /// </exceptions>
         public static bool TryFormat(DateTime value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default)
         {
-            char symbol = format.IsDefault ? 'G' : format.Symbol;
+            char symbol = FormattingHelpers.GetSymbolOrDefault(format, 'G');
 
             switch (symbol)
             {

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Guid.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Guid.cs
@@ -2,21 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if !netstandard
-using Internal.Runtime.CompilerServices;
-#else
-using System.Runtime.CompilerServices;
-#endif
-
-using System.Runtime.InteropServices;
-
 namespace System.Buffers.Text
 {
     public static partial class Utf8Formatter
     {
         #region Constants
-
-        private const int GuidChars = 32;
 
         private const byte OpenBrace = (byte)'{';
         private const byte CloseBrace = (byte)'}';
@@ -49,102 +39,153 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
-        public static unsafe bool TryFormat(Guid value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default)
+        public static bool TryFormat(Guid value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default)
         {
-            char formatSymbol = format.IsDefault ? 'D' : format.Symbol;
+            const int INSERT_DASHES = unchecked((int)0x80000000);
+            const int NO_DASHES = 0;
+            const int INSERT_CURLY_BRACES = (CloseBrace << 16) | (OpenBrace << 8);
+            const int INSERT_ROUND_BRACES = (CloseParen << 16) | (OpenParen << 8);
+            const int NO_BRACES = 0;
+            const int LEN_GUID_BASE = 32;
+            const int LEN_ADD_DASHES = 4;
+            const int LEN_ADD_BRACES = 2;
 
-            bool dash;
-            bool bookEnds;
-            switch (formatSymbol)
+            // This is a 32-bit value whose contents (where 0 is the low byte) are:
+            // 0th byte: minimum required length of the output buffer,
+            // 1st byte: the ASCII byte to insert for the opening brace position (or 0 if no braces),
+            // 2nd byte: the ASCII byte to insert for the closing brace position (or 0 if no braces),
+            // 3rd byte: high bit set if dashes are to be inserted.
+            // 
+            // The reason for keeping a single flag instead of separate vars is that we can avoid register spillage
+            // as we build up the output value.
+            int flags;
+
+            switch (FormattingHelpers.GetSymbolOrDefault(format, 'D'))
             {
                 case 'D': // nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn
-                    dash = true;
-                    bookEnds = false;
+                    flags = INSERT_DASHES + NO_BRACES + LEN_GUID_BASE + LEN_ADD_DASHES;
                     break;
 
                 case 'B': // {nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn}
-                    dash = true;
-                    bookEnds = true;
+                    flags = INSERT_DASHES + INSERT_CURLY_BRACES + LEN_GUID_BASE + LEN_ADD_DASHES + LEN_ADD_BRACES;
                     break;
 
                 case 'P': // (nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn)
-                    dash = true;
-                    bookEnds = true;
+                    flags = INSERT_DASHES + INSERT_ROUND_BRACES + LEN_GUID_BASE + LEN_ADD_DASHES + LEN_ADD_BRACES;
                     break;
 
                 case 'N': // nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
-                    dash = false;
-                    bookEnds = false;
+                    flags = NO_BRACES + NO_DASHES + LEN_GUID_BASE;
                     break;
 
                 default:
                     return ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
             }
 
-            bytesWritten = GuidChars + (dash ? 4 : 0) + (bookEnds ? 2 : 0);
-            if (buffer.Length < bytesWritten)
+            // At this point, the low byte of flags contains the minimum required length
+
+            if ((byte)flags > buffer.Length)
             {
                 bytesWritten = 0;
                 return false;
             }
 
-            ref byte utf8Bytes = ref MemoryMarshal.GetReference(buffer);
-            byte* bytes = (byte*)&value;
-            int idx = 0;
+            bytesWritten = (byte)flags;
+            flags >>= 8;
 
-            if (bookEnds && format.Symbol == 'B')
-                Unsafe.Add(ref utf8Bytes, idx++) = OpenBrace;
-            else if (bookEnds && format.Symbol == (byte)'P')
-                Unsafe.Add(ref utf8Bytes, idx++) = OpenParen;
+            // At this point, the low byte of flags contains the opening brace char (if any)
 
-            FormattingHelpers.WriteHexByte(bytes[3], ref utf8Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[2], ref utf8Bytes, idx + 2);
-            FormattingHelpers.WriteHexByte(bytes[1], ref utf8Bytes, idx + 4);
-            FormattingHelpers.WriteHexByte(bytes[0], ref utf8Bytes, idx + 6);
-            idx += 8;
-
-            if (dash)
-                Unsafe.Add(ref utf8Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[5], ref utf8Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[4], ref utf8Bytes, idx + 2);
-            idx += 4;
-
-            if (dash)
-                Unsafe.Add(ref utf8Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[7], ref utf8Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[6], ref utf8Bytes, idx + 2);
-            idx += 4;
-
-            if (dash)
-                Unsafe.Add(ref utf8Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[8], ref utf8Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[9], ref utf8Bytes, idx + 2);
-            idx += 4;
-
-            if (dash)
-                Unsafe.Add(ref utf8Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[10], ref utf8Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[11], ref utf8Bytes, idx + 2);
-            FormattingHelpers.WriteHexByte(bytes[12], ref utf8Bytes, idx + 4);
-            FormattingHelpers.WriteHexByte(bytes[13], ref utf8Bytes, idx + 6);
-            FormattingHelpers.WriteHexByte(bytes[14], ref utf8Bytes, idx + 8);
-            FormattingHelpers.WriteHexByte(bytes[15], ref utf8Bytes, idx + 10);
-            idx += 12;
-
-            if (bookEnds)
+            if ((byte)flags != 0)
             {
-                if (format.Symbol == 'B')
-                {
-                    Unsafe.Add(ref utf8Bytes, idx++) = CloseBrace;
-                }
-                else if (format.Symbol == 'P')
-                {
-                    Unsafe.Add(ref utf8Bytes, idx++) = CloseParen;
-                }
+                buffer[0] = (byte)flags;
+                buffer = buffer.Slice(1);
+            }
+            flags >>= 8;
+
+            // At this point, the low byte of flags contains the closing brace char (if any)
+            // And since we're performing arithmetic shifting the high bit of flags is set (flags is negative) if dashes are required
+
+            // The JIT is smart enough to elide bounds checking on accesses to guidAsBytes[00 .. 15]
+            // since the Span returned by GetSpanForBlittable is known to have length 16 [= sizeof(Guid)].
+
+            var guidAsBytes = FormattingHelpers.GetSpanForBlittable(ref value);
+
+            // When a GUID is blitted, the first three components are little-endian, and the last component is big-endian.
+
+            // The line below forces the JIT to hoist the bounds check for the following segment.
+            // The JIT will optimize away the read, but it cannot optimize away the bounds check
+            // because it may have an observeable side effect (throwing).
+            // We use 8 instead of 7 so that we also capture the dash if we're asked to insert one.
+
+            { var unused = buffer[8]; }
+            FormattingHelpers.WriteHexByte(guidAsBytes[3], buffer, 0, FormattingHelpers.HexCasing.Lowercase);
+            FormattingHelpers.WriteHexByte(guidAsBytes[2], buffer, 2, FormattingHelpers.HexCasing.Lowercase);
+            FormattingHelpers.WriteHexByte(guidAsBytes[1], buffer, 4, FormattingHelpers.HexCasing.Lowercase);
+            FormattingHelpers.WriteHexByte(guidAsBytes[0], buffer, 6, FormattingHelpers.HexCasing.Lowercase);
+
+            if (flags < 0 /* use dash? */)
+            {
+                buffer[8] = Dash;
+                buffer = buffer.Slice(9);
+            }
+            else
+            {
+                buffer = buffer.Slice(8);
+            }
+
+            { var unused = buffer[4]; }
+            FormattingHelpers.WriteHexByte(guidAsBytes[5], buffer, 0, FormattingHelpers.HexCasing.Lowercase);
+            FormattingHelpers.WriteHexByte(guidAsBytes[4], buffer, 2, FormattingHelpers.HexCasing.Lowercase);
+
+            if (flags < 0 /* use dash? */)
+            {
+                buffer[4] = Dash;
+                buffer = buffer.Slice(5);
+            }
+            else
+            {
+                buffer = buffer.Slice(4);
+            }
+
+            { var unused = buffer[4]; }
+            FormattingHelpers.WriteHexByte(guidAsBytes[7], buffer, 0, FormattingHelpers.HexCasing.Lowercase);
+            FormattingHelpers.WriteHexByte(guidAsBytes[6], buffer, 2, FormattingHelpers.HexCasing.Lowercase);
+
+            if (flags < 0 /* use dash? */)
+            {
+                buffer[4] = Dash;
+                buffer = buffer.Slice(5);
+            }
+            else
+            {
+                buffer = buffer.Slice(4);
+            }
+
+            { var unused = buffer[4]; }
+            FormattingHelpers.WriteHexByte(guidAsBytes[8], buffer, 0, FormattingHelpers.HexCasing.Lowercase);
+            FormattingHelpers.WriteHexByte(guidAsBytes[9], buffer, 2, FormattingHelpers.HexCasing.Lowercase);
+
+            if (flags < 0 /* use dash? */)
+            {
+                buffer[4] = Dash;
+                buffer = buffer.Slice(5);
+            }
+            else
+            {
+                buffer = buffer.Slice(4);
+            }
+
+            { var unused = buffer[11]; } // can't hoist bounds check on the final brace (if exists)
+            FormattingHelpers.WriteHexByte(guidAsBytes[10], buffer, 0, FormattingHelpers.HexCasing.Lowercase);
+            FormattingHelpers.WriteHexByte(guidAsBytes[11], buffer, 2, FormattingHelpers.HexCasing.Lowercase);
+            FormattingHelpers.WriteHexByte(guidAsBytes[12], buffer, 4, FormattingHelpers.HexCasing.Lowercase);
+            FormattingHelpers.WriteHexByte(guidAsBytes[13], buffer, 6, FormattingHelpers.HexCasing.Lowercase);
+            FormattingHelpers.WriteHexByte(guidAsBytes[14], buffer, 8, FormattingHelpers.HexCasing.Lowercase);
+            FormattingHelpers.WriteHexByte(guidAsBytes[15], buffer, 10, FormattingHelpers.HexCasing.Lowercase);
+
+            if ((byte)flags != 0)
+            {
+                buffer[12] = (byte)flags;
             }
 
             return true;

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.D.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.D.cs
@@ -42,7 +42,7 @@ namespace System.Buffers.Text
             // Int64.MinValue = -9,223,372,036,854,775,808
             // Int64.MaxValue =  9,223,372,036,854,775,807
 
-            bool retVal = TryFormatUInt64D((ulong)Int64.MaxValue, precision, buffer, true /* insertNegationSign */, out int tempBytesWritten);
+            bool retVal = TryFormatUInt64D((ulong)Int64.MaxValue, precision, buffer, insertNegationSign: true, out int tempBytesWritten);
             if (retVal)
             {
                 buffer[tempBytesWritten - 1]++; // bump the last ASCII '7' to an '8'

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.D.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.D.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
 #if !netstandard
 using Internal.Runtime.CompilerServices;
-#else
-using System.Runtime.CompilerServices;
 #endif
-
-using System.Runtime.InteropServices;
 
 namespace System.Buffers.Text
 {
@@ -17,59 +16,40 @@ namespace System.Buffers.Text
     /// </summary>
     public static partial class Utf8Formatter
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool TryFormatInt64D(long value, byte precision, Span<byte> buffer, out int bytesWritten)
         {
-            int digitCount = FormattingHelpers.CountDigits(value);
-            int bytesNeeded = digitCount + (int)((value >> 63) & 1);
-            if (precision != StandardFormat.NoPrecision && precision > digitCount)
-            {
-                bytesNeeded += (precision - digitCount);
-            }
-
-            if (buffer.Length < bytesNeeded)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            ref byte utf8Bytes = ref MemoryMarshal.GetReference(buffer);
-            int idx = 0;
-
+            bool insertNegationSign = false;
             if (value < 0)
             {
-                Unsafe.Add(ref utf8Bytes, idx++) = Utf8Constants.Minus;
-
-                // Abs(long.MinValue) == long.MaxValue + 1, so we need to handle this specially.
-                if (value == long.MinValue)
-                {
-                    if (precision != StandardFormat.NoPrecision)
-                    {
-                        int leadingZeros = (int)precision - 19;
-                        while (leadingZeros-- > 0)
-                            Unsafe.Add(ref utf8Bytes, idx++) = (byte)'0';
-                    }
-
-                    Unsafe.Add(ref utf8Bytes, idx++) = (byte)'9';
-                    FormattingHelpers.WriteDigits(223372036854775808L, 18, ref utf8Bytes, idx);
-
-                    bytesWritten = idx + 18;
-                    return true;
-                }
-
+                insertNegationSign = true;
                 value = -value;
+                if (value < 0)
+                {
+                    Debug.Assert(value == Int64.MinValue);
+                    return TryFormatInt64D_MinValue(precision, buffer, out bytesWritten);
+                }
             }
 
-            if (precision != StandardFormat.NoPrecision)
+            return TryFormatUInt64D((ulong)value, precision, buffer, insertNegationSign, out bytesWritten);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool TryFormatInt64D_MinValue(byte precision, Span<byte> buffer, out int bytesWritten)
+        {
+            // Int64.MinValue must be treated specially since its two's complement negation doesn't fit into 64 bits.
+            // Instead, we'll perform one's complement negation and fix up the +1 later (-x := ~x + 1).
+            // Int64.MinValue = -9,223,372,036,854,775,808
+            // Int64.MaxValue =  9,223,372,036,854,775,807
+
+            bool retVal = TryFormatUInt64D((ulong)Int64.MaxValue, precision, buffer, true /* insertNegationSign */, out int tempBytesWritten);
+            if (retVal)
             {
-                int leadingZeros = (int)precision - digitCount;
-                while (leadingZeros-- > 0)
-                    Unsafe.Add(ref utf8Bytes, idx++) = (byte)'0';
+                buffer[tempBytesWritten - 1]++; // bump the last ASCII '7' to an '8'
             }
 
-            FormattingHelpers.WriteDigits(value, digitCount, ref utf8Bytes, idx);
-
-            bytesWritten = digitCount + idx;
-            return true;
+            bytesWritten = tempBytesWritten;
+            return retVal;
         }
     }
 }

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.N.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.N.cs
@@ -42,7 +42,7 @@ namespace System.Buffers.Text
             // Int64.MinValue = -9,223,372,036,854,775,808 (26 digits, including minus and commas)
             // Int64.MaxValue =  9,223,372,036,854,775,807
 
-            bool retVal = TryFormatUInt64N((ulong)Int64.MaxValue, precision, buffer, true /* insertNegationSign */, out int tempBytesWritten);
+            bool retVal = TryFormatUInt64N((ulong)Int64.MaxValue, precision, buffer, insertNegationSign: true, out int tempBytesWritten);
             if (retVal)
             {
                 buffer[25]++; // bump the last ASCII '7' to an '8'

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.N.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.N.cs
@@ -3,14 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 #if !netstandard
 using Internal.Runtime.CompilerServices;
-#else
-using System.Runtime.CompilerServices;
 #endif
-
-using System.Runtime.InteropServices;
 
 namespace System.Buffers.Text
 {
@@ -19,70 +16,40 @@ namespace System.Buffers.Text
     /// </summary>
     public static partial class Utf8Formatter
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool TryFormatInt64N(long value, byte precision, Span<byte> buffer, out int bytesWritten)
         {
-            int digitCount = FormattingHelpers.CountDigits(value);
-            int groupSeparators = (int)FormattingHelpers.DivMod(digitCount, Utf8Constants.GroupSize, out long firstGroup);
-            if (firstGroup == 0)
+            bool insertNegationSign = false;
+            if (value < 0)
             {
-                firstGroup = 3;
-                groupSeparators--;
-            }
-
-            int trailingZeros = (precision == StandardFormat.NoPrecision) ? 2 : precision;
-            int idx = (int)((value >> 63) & 1) + digitCount + groupSeparators;
-
-            bytesWritten = idx;
-            if (trailingZeros > 0)
-                bytesWritten += trailingZeros + 1; // +1 for period.
-
-            if (buffer.Length < bytesWritten)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            ref byte utf8Bytes = ref MemoryMarshal.GetReference(buffer);
-            long v = value;
-
-            if (v < 0)
-            {
-                Unsafe.Add(ref utf8Bytes, 0) = Utf8Constants.Minus;
-
-                // Abs(long.MinValue) == long.MaxValue + 1, so we need to re-route to unsigned to handle value
-                if (v == long.MinValue)
+                insertNegationSign = true;
+                value = -value;
+                if (value < 0)
                 {
-                    bool success = TryFormatUInt64N((ulong)long.MaxValue + 1, precision, buffer.Slice(1), out bytesWritten);
-                    Debug.Assert(success, "TryFormatInt64N already did a full buffer length check so this subcall should never have failed.");
-
-                    bytesWritten += 1; // Add the minus sign
-                    return true;
+                    Debug.Assert(value == Int64.MinValue);
+                    return TryFormatInt64N_MinValue(precision, buffer, out bytesWritten);
                 }
-
-                v = -v;
             }
 
-            // Write out the trailing zeros
-            if (trailingZeros > 0)
+            return TryFormatUInt64N((ulong)value, precision, buffer, insertNegationSign, out bytesWritten);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool TryFormatInt64N_MinValue(byte precision, Span<byte> buffer, out int bytesWritten)
+        {
+            // Int64.MinValue must be treated specially since its two's complement negation doesn't fit into 64 bits.
+            // Instead, we'll perform one's complement negation and fix up the +1 later (-x := ~x + 1).
+            // Int64.MinValue = -9,223,372,036,854,775,808 (26 digits, including minus and commas)
+            // Int64.MaxValue =  9,223,372,036,854,775,807
+
+            bool retVal = TryFormatUInt64N((ulong)Int64.MaxValue, precision, buffer, true /* insertNegationSign */, out int tempBytesWritten);
+            if (retVal)
             {
-                Unsafe.Add(ref utf8Bytes, idx) = Utf8Constants.Period;
-                FormattingHelpers.WriteDigits(0, trailingZeros, ref utf8Bytes, idx + 1);
+                buffer[25]++; // bump the last ASCII '7' to an '8'
             }
 
-            // Starting from the back, write each group of digits except the first group
-            while (digitCount > 3)
-            {
-                digitCount -= 3;
-                idx -= 3;
-                v = FormattingHelpers.DivMod(v, 1000, out long groupValue);
-                FormattingHelpers.WriteDigits(groupValue, 3, ref utf8Bytes, idx);
-                Unsafe.Add(ref utf8Bytes, --idx) = Utf8Constants.Separator;
-            }
-
-            // Write the first group of digits.
-            FormattingHelpers.WriteDigits(v, (int)firstGroup, ref utf8Bytes, idx - (int)firstGroup);
-
-            return true;
+            bytesWritten = tempBytesWritten;
+            return retVal;
         }
     }
 }

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.cs
@@ -28,15 +28,15 @@ namespace System.Buffers.Text
                 case 'g':
                     if (format.HasPrecision)
                         throw new NotSupportedException(SR.Argument_GWithPrecisionNotSupported); // With a precision, 'G' can produce exponential format, even for integers.
-                    return TryFormatUInt64D(value, format.Precision, buffer, false /* insertNegationSign */, out bytesWritten);
+                    return TryFormatUInt64D(value, format.Precision, buffer, insertNegationSign: false, out bytesWritten);
 
                 case 'd':
                 case 'D':
-                    return TryFormatUInt64D(value, format.Precision, buffer, false /* insertNegationSign */, out bytesWritten);
+                    return TryFormatUInt64D(value, format.Precision, buffer, insertNegationSign: false, out bytesWritten);
 
                 case 'n':
                 case 'N':
-                    return TryFormatUInt64N(value, format.Precision, buffer, false /* insertNegationSign */, out bytesWritten);
+                    return TryFormatUInt64N(value, format.Precision, buffer, insertNegationSign: false, out bytesWritten);
 
                 case 'x':
                     return TryFormatUInt64X(value, format.Precision, true /* useLower */, buffer, out bytesWritten);

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.cs
@@ -28,21 +28,21 @@ namespace System.Buffers.Text
                 case 'g':
                     if (format.HasPrecision)
                         throw new NotSupportedException(SR.Argument_GWithPrecisionNotSupported); // With a precision, 'G' can produce exponential format, even for integers.
-                    return TryFormatUInt64D(value, format.Precision, buffer, out bytesWritten);
+                    return TryFormatUInt64D(value, format.Precision, buffer, false /* insertNegationSign */, out bytesWritten);
 
                 case 'd':
                 case 'D':
-                    return TryFormatUInt64D(value, format.Precision, buffer, out bytesWritten);
+                    return TryFormatUInt64D(value, format.Precision, buffer, false /* insertNegationSign */, out bytesWritten);
 
                 case 'n':
                 case 'N':
-                    return TryFormatUInt64N(value, format.Precision, buffer, out bytesWritten);
+                    return TryFormatUInt64N(value, format.Precision, buffer, false /* insertNegationSign */, out bytesWritten);
 
                 case 'x':
-                    return TryFormatUInt64X(value, format.Precision, true, buffer, out bytesWritten);
+                    return TryFormatUInt64X(value, format.Precision, true /* useLower */, buffer, out bytesWritten);
 
                 case 'X':
-                    return TryFormatUInt64X(value, format.Precision, false, buffer, out bytesWritten);
+                    return TryFormatUInt64X(value, format.Precision, false /* useLower */, buffer, out bytesWritten);
 
                 default:
                     return ThrowHelper.TryFormatThrowFormatException(out bytesWritten);

--- a/src/System.Memory/tests/ParsersAndFormatters/TestData.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/TestData.cs
@@ -322,6 +322,8 @@ namespace System.Buffers.Text.Tests
             {
                 yield return DateTimeOffset.MinValue;
                 yield return DateTimeOffset.MaxValue;
+                yield return new DateTimeOffset(year: 2017, month: 1, day: 13, hour: 3, minute: 45, second: 32, new TimeSpan(hours: 0, minutes: 30, seconds: 0));
+                yield return new DateTimeOffset(year: 2017, month: 1, day: 13, hour: 3, minute: 45, second: 32, new TimeSpan(hours: 0, minutes: -30, seconds: 0));
                 yield return new DateTimeOffset(year: 2017, month: 1, day: 13, hour: 3, minute: 45, second: 32, new TimeSpan(hours: 8, minutes: 0, seconds: 0));
                 yield return new DateTimeOffset(year: 2017, month: 1, day: 13, hour: 3, minute: 45, second: 32, new TimeSpan(hours: -8, minutes: 0, seconds: 0));
                 yield return new DateTimeOffset(year: 2017, month: 12, day: 31, hour: 23, minute: 59, second: 58, new TimeSpan(hours: 14, minutes: 0, seconds: 0));


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/25648.

My first attempt to switch the implementations from unsafe code to safe buffer-based code was a bit naive and resulted in considerable performance degradation (double-digit percentage loss of throughput across many APIs). I've spent time reworking the implementations to to work around the performance loss, and in many cases the new implementations are faster than the originals.

For reviewers: I recommend looking at each commit in isolation, as each commit deals with a very specific formatter. It'll also be easier to see which helper routines in `FormatterHelpers` correlate with which implementations. This also allows individual commits to be backed out without affecting the rest of the PR if reviewers deem a particular commit as unwanted.