### PR TITLE
Update private fields for structs in refs

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -65,6 +65,7 @@ namespace System
     }
     public readonly partial struct Memory<T>
     {
+        private readonly object _dummy;
         public Memory(T[] array) { throw null; }
         public Memory(T[] array, int start, int length) { throw null; }
         public static System.Memory<T> Empty { get { throw null; } }
@@ -89,6 +90,7 @@ namespace System
     }
     public readonly partial struct ReadOnlyMemory<T>
     {
+        private readonly object _dummy;
         public ReadOnlyMemory(T[] array) { throw null; }
         public ReadOnlyMemory(T[] array, int start, int length) { throw null; }
         public static System.ReadOnlyMemory<T> Empty { get { throw null; } }
@@ -111,6 +113,7 @@ namespace System
     }
     public readonly ref partial struct ReadOnlySpan<T>
     {
+        private readonly object _dummy;
         [System.CLSCompliantAttribute(false)]
         public unsafe ReadOnlySpan(void* pointer, int length) { throw null; }
         public ReadOnlySpan(T[] array) { throw null; }
@@ -139,12 +142,14 @@ namespace System
         public bool TryCopyTo(System.Span<T> destination) { throw null; }
         public ref partial struct Enumerator
         {
+            private object _dummy;
             public ref readonly T Current { get { throw null; } }
             public bool MoveNext() { throw null; }
         }
     }
     public readonly ref partial struct Span<T>
     {
+        private readonly object _dummy;
         [System.CLSCompliantAttribute(false)]
         public unsafe Span(void* pointer, int length) { throw null; }
         public Span(T[] array) { throw null; }
@@ -176,6 +181,7 @@ namespace System
         public bool TryCopyTo(System.Span<T> destination) { throw null; }
         public ref partial struct Enumerator
         {
+            private object _dummy;
             public ref T Current { get { throw null; } }
             public bool MoveNext() { throw null; }
         }
@@ -190,8 +196,9 @@ namespace System.Buffers
     }
     public partial struct MemoryHandle : System.IDisposable
     {
+        private object _dummy;
         [System.CLSCompliantAttribute(false)]
-        public unsafe MemoryHandle(System.Buffers.IRetainable owner, void* pointer=null, System.Runtime.InteropServices.GCHandle handle=default(System.Runtime.InteropServices.GCHandle)) { throw null; }
+        public unsafe MemoryHandle(System.Buffers.IRetainable retainable, void* pointer=null, System.Runtime.InteropServices.GCHandle handle=default(System.Runtime.InteropServices.GCHandle)) { throw null; }
         public bool HasPointer { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
         public unsafe void* Pointer { get { throw null; } }
@@ -221,6 +228,7 @@ namespace System.Buffers
     }
     public readonly partial struct StandardFormat : System.IEquatable<System.Buffers.StandardFormat>
     {
+        private readonly int _dummy;
         public const byte MaxPrecision = (byte)99;
         public const byte NoPrecision = (byte)255;
         public StandardFormat(char symbol, byte precision=(byte)255) { throw null; }
@@ -236,6 +244,7 @@ namespace System.Buffers
         public static bool operator !=(System.Buffers.StandardFormat left, System.Buffers.StandardFormat right) { throw null; }
         public static System.Buffers.StandardFormat Parse(System.ReadOnlySpan<char> format) { throw null; }
         public static System.Buffers.StandardFormat Parse(string format) { throw null; }
+        public override string ToString() { throw null; }
     }
 }
 namespace System.Buffers.Binary

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -5,454 +5,398 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-using System.Collections.Generic;
-
 namespace System
 {
-    public readonly ref struct ReadOnlySpan<T>
+    public static partial class MemoryExtensions
     {
-        public static ReadOnlySpan<T> Empty { get { throw null; } }
+        public static System.ReadOnlySpan<byte> AsBytes<T>(this System.ReadOnlySpan<T> source) where T : struct { throw null; }
+        public static System.Span<byte> AsBytes<T>(this System.Span<T> source) where T : struct { throw null; }
+        public static System.ReadOnlyMemory<char> AsReadOnlyMemory(this string text) { throw null; }
+        public static System.ReadOnlyMemory<T> AsReadOnlyMemory<T>(this System.Memory<T> memory) { throw null; }
+        public static System.ReadOnlySpan<char> AsReadOnlySpan(this string text) { throw null; }
+        public static System.ReadOnlySpan<T> AsReadOnlySpan<T>(this System.ArraySegment<T> arraySegment) { throw null; }
+        public static System.ReadOnlySpan<T> AsReadOnlySpan<T>(this System.Span<T> span) { throw null; }
+        public static System.ReadOnlySpan<T> AsReadOnlySpan<T>(this T[] array) { throw null; }
+        public static System.Span<T> AsSpan<T>(this System.ArraySegment<T> arraySegment) { throw null; }
+        public static System.Span<T> AsSpan<T>(this T[] array) { throw null; }
+        public static int BinarySearch<T>(this System.ReadOnlySpan<T> span, System.IComparable<T> comparable) { throw null; }
+        public static int BinarySearch<T>(this System.Span<T> span, System.IComparable<T> comparable) { throw null; }
+        public static int BinarySearch<T, TComparer>(this System.ReadOnlySpan<T> span, T value, TComparer comparer) where TComparer : System.Collections.Generic.IComparer<T> { throw null; }
+        public static int BinarySearch<T, TComparable>(this System.ReadOnlySpan<T> span, TComparable comparable) where TComparable : System.IComparable<T> { throw null; }
+        public static int BinarySearch<T, TComparer>(this System.Span<T> span, T value, TComparer comparer) where TComparer : System.Collections.Generic.IComparer<T> { throw null; }
+        public static int BinarySearch<T, TComparable>(this System.Span<T> span, TComparable comparable) where TComparable : System.IComparable<T> { throw null; }
+        public static void CopyTo<T>(this T[] array, System.Memory<T> destination) { }
+        public static void CopyTo<T>(this T[] array, System.Span<T> destination) { }
+        public static bool EndsWith<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> value) where T : System.IEquatable<T> { throw null; }
+        public static bool EndsWith<T>(this System.Span<T> span, System.ReadOnlySpan<T> value) where T : System.IEquatable<T> { throw null; }
+        public static int IndexOfAny<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> values) where T : System.IEquatable<T> { throw null; }
+        public static int IndexOfAny<T>(this System.ReadOnlySpan<T> span, T value0, T value1) where T : System.IEquatable<T> { throw null; }
+        public static int IndexOfAny<T>(this System.ReadOnlySpan<T> span, T value0, T value1, T value2) where T : System.IEquatable<T> { throw null; }
+        public static int IndexOfAny<T>(this System.Span<T> span, System.ReadOnlySpan<T> values) where T : System.IEquatable<T> { throw null; }
+        public static int IndexOfAny<T>(this System.Span<T> span, T value0, T value1) where T : System.IEquatable<T> { throw null; }
+        public static int IndexOfAny<T>(this System.Span<T> span, T value0, T value1, T value2) where T : System.IEquatable<T> { throw null; }
+        public static int IndexOf<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> value) where T : System.IEquatable<T> { throw null; }
+        public static int IndexOf<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T> { throw null; }
+        public static int IndexOf<T>(this System.Span<T> span, System.ReadOnlySpan<T> value) where T : System.IEquatable<T> { throw null; }
+        public static int IndexOf<T>(this System.Span<T> span, T value) where T : System.IEquatable<T> { throw null; }
+        public static int LastIndexOfAny<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> values) where T : System.IEquatable<T> { throw null; }
+        public static int LastIndexOfAny<T>(this System.ReadOnlySpan<T> span, T value0, T value1) where T : System.IEquatable<T> { throw null; }
+        public static int LastIndexOfAny<T>(this System.ReadOnlySpan<T> span, T value0, T value1, T value2) where T : System.IEquatable<T> { throw null; }
+        public static int LastIndexOfAny<T>(this System.Span<T> span, System.ReadOnlySpan<T> values) where T : System.IEquatable<T> { throw null; }
+        public static int LastIndexOfAny<T>(this System.Span<T> span, T value0, T value1) where T : System.IEquatable<T> { throw null; }
+        public static int LastIndexOfAny<T>(this System.Span<T> span, T value0, T value1, T value2) where T : System.IEquatable<T> { throw null; }
+        public static int LastIndexOf<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> value) where T : System.IEquatable<T> { throw null; }
+        public static int LastIndexOf<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T> { throw null; }
+        public static int LastIndexOf<T>(this System.Span<T> span, System.ReadOnlySpan<T> value) where T : System.IEquatable<T> { throw null; }
+        public static int LastIndexOf<T>(this System.Span<T> span, T value) where T : System.IEquatable<T> { throw null; }
+        public static System.ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this System.ReadOnlySpan<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
+        public static System.Span<TTo> NonPortableCast<TFrom, TTo>(this System.Span<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
+        public static bool Overlaps<T>(this System.ReadOnlySpan<T> first, System.ReadOnlySpan<T> second) { throw null; }
+        public static bool Overlaps<T>(this System.ReadOnlySpan<T> first, System.ReadOnlySpan<T> second, out int elementOffset) { throw null; }
+        public static bool Overlaps<T>(this System.Span<T> first, System.ReadOnlySpan<T> second) { throw null; }
+        public static bool Overlaps<T>(this System.Span<T> first, System.ReadOnlySpan<T> second, out int elementOffset) { throw null; }
+        public static int SequenceCompareTo<T>(this System.ReadOnlySpan<T> first, System.ReadOnlySpan<T> second) where T : System.IComparable<T> { throw null; }
+        public static int SequenceCompareTo<T>(this System.Span<T> first, System.ReadOnlySpan<T> second) where T : System.IComparable<T> { throw null; }
+        public static bool SequenceEqual<T>(this System.ReadOnlySpan<T> first, System.ReadOnlySpan<T> second) where T : System.IEquatable<T> { throw null; }
+        public static bool SequenceEqual<T>(this System.Span<T> first, System.ReadOnlySpan<T> second) where T : System.IEquatable<T> { throw null; }
+        public static bool StartsWith<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> value) where T : System.IEquatable<T> { throw null; }
+        public static bool StartsWith<T>(this System.Span<T> span, System.ReadOnlySpan<T> value) where T : System.IEquatable<T> { throw null; }
+        public static bool TryGetString(this System.ReadOnlyMemory<char> readOnlyMemory, out string text, out int start, out int length) { throw null; }
+    }
+    public readonly partial struct Memory<T>
+    {
+        public Memory(T[] array) { throw null; }
+        public Memory(T[] array, int start, int length) { throw null; }
+        public static System.Memory<T> Empty { get { throw null; } }
+        public bool IsEmpty { get { throw null; } }
+        public int Length { get { throw null; } }
+        public System.Span<T> Span { get { throw null; } }
+        public void CopyTo(System.Memory<T> destination) { }
+        public bool Equals(System.Memory<T> other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public override int GetHashCode() { throw null; }
+        public static implicit operator System.Memory<T> (System.ArraySegment<T> arraySegment) { throw null; }
+        public static implicit operator System.ReadOnlyMemory<T> (System.Memory<T> memory) { throw null; }
+        public static implicit operator System.Memory<T> (T[] array) { throw null; }
+        public System.Buffers.MemoryHandle Retain(bool pin=false) { throw null; }
+        public System.Memory<T> Slice(int start) { throw null; }
+        public System.Memory<T> Slice(int start, int length) { throw null; }
+        public T[] ToArray() { throw null; }
+        public bool TryCopyTo(System.Memory<T> destination) { throw null; }
+        public bool TryGetArray(out System.ArraySegment<T> arraySegment) { throw null; }
+    }
+    public readonly partial struct ReadOnlyMemory<T>
+    {
+        public ReadOnlyMemory(T[] array) { throw null; }
+        public ReadOnlyMemory(T[] array, int start, int length) { throw null; }
+        public static System.ReadOnlyMemory<T> Empty { get { throw null; } }
+        public bool IsEmpty { get { throw null; } }
+        public int Length { get { throw null; } }
+        public System.ReadOnlySpan<T> Span { get { throw null; } }
+        public void CopyTo(System.Memory<T> destination) { }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.ReadOnlyMemory<T> other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public override int GetHashCode() { throw null; }
+        public static implicit operator System.ReadOnlyMemory<T> (System.ArraySegment<T> arraySegment) { throw null; }
+        public static implicit operator System.ReadOnlyMemory<T> (T[] array) { throw null; }
+        public System.Buffers.MemoryHandle Retain(bool pin=false) { throw null; }
+        public System.ReadOnlyMemory<T> Slice(int start) { throw null; }
+        public System.ReadOnlyMemory<T> Slice(int start, int length) { throw null; }
+        public T[] ToArray() { throw null; }
+        public bool TryCopyTo(System.Memory<T> destination) { throw null; }
+    }
+    public readonly ref partial struct ReadOnlySpan<T>
+    {
+        [System.CLSCompliantAttribute(false)]
+        public unsafe ReadOnlySpan(void* pointer, int length) { throw null; }
         public ReadOnlySpan(T[] array) { throw null; }
         public ReadOnlySpan(T[] array, int start, int length) { throw null; }
-        [CLSCompliant(false)]
-        public unsafe ReadOnlySpan(void* pointer, int length) { throw null; }
+        public static System.ReadOnlySpan<T> Empty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
-        public ref readonly T this[int index] { get { throw null; }}
+        public ref readonly T this[int index] { get { throw null; } }
         public int Length { get { throw null; } }
-        public void CopyTo(Span<T> destination) { }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public static ReadOnlySpan<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
-#pragma warning disable 0809  //warning CS0809: Obsolete member 'Span<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
+        public void CopyTo(System.Span<T> destination) { }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public static System.ReadOnlySpan<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("Equals() on ReadOnlySpan will always throw an exception. Use == instead.")]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
-        public Enumerator GetEnumerator() { throw null; }
+        public System.ReadOnlySpan<T>.Enumerator GetEnumerator() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("GetHashCode() on ReadOnlySpan will always throw an exception.")]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-#pragma warning restore 0809
-        public static bool operator ==(ReadOnlySpan<T> left, ReadOnlySpan<T> right) { throw null; }
-        public static implicit operator ReadOnlySpan<T>(T[] array) { throw null; }
-        public static implicit operator ReadOnlySpan<T>(ArraySegment<T> arraySegment) { throw null; }
-        public static bool operator !=(ReadOnlySpan<T> left, ReadOnlySpan<T> right) { throw null; }
-        public ReadOnlySpan<T> Slice(int start) { throw null; }
-        public ReadOnlySpan<T> Slice(int start, int length) { throw null; }
+        public static bool operator ==(System.ReadOnlySpan<T> left, System.ReadOnlySpan<T> right) { throw null; }
+        public static implicit operator System.ReadOnlySpan<T> (System.ArraySegment<T> arraySegment) { throw null; }
+        public static implicit operator System.ReadOnlySpan<T> (T[] array) { throw null; }
+        public static bool operator !=(System.ReadOnlySpan<T> left, System.ReadOnlySpan<T> right) { throw null; }
+        public System.ReadOnlySpan<T> Slice(int start) { throw null; }
+        public System.ReadOnlySpan<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
-        public bool TryCopyTo(Span<T> destination) { throw null; }
-        public ref struct Enumerator
+        public bool TryCopyTo(System.Span<T> destination) { throw null; }
+        public ref partial struct Enumerator
         {
-            public bool MoveNext() { throw null; }
             public ref readonly T Current { get { throw null; } }
+            public bool MoveNext() { throw null; }
         }
     }
-
-    public readonly ref struct Span<T>
+    public readonly ref partial struct Span<T>
     {
-        public static Span<T> Empty { get { throw null; } }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe Span(void* pointer, int length) { throw null; }
         public Span(T[] array) { throw null; }
         public Span(T[] array, int start, int length) { throw null; }
-        [CLSCompliant(false)]
-        public unsafe Span(void* pointer, int length) { throw null; }
+        public static System.Span<T> Empty { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
         public ref T this[int index] { get { throw null; } }
         public int Length { get { throw null; } }
         public void Clear() { }
-        public void Fill(T value) { }
-        public void CopyTo(Span<T> destination) { }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public static Span<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
-#pragma warning disable 0809  //warning CS0809: Obsolete member 'Span<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
+        public void CopyTo(System.Span<T> destination) { }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public static System.Span<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("Equals() on Span will always throw an exception. Use == instead.")]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
-        public Enumerator GetEnumerator() { throw null; }
+        public void Fill(T value) { }
+        public System.Span<T>.Enumerator GetEnumerator() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         [System.ObsoleteAttribute("GetHashCode() on Span will always throw an exception.")]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-#pragma warning restore 0809
-        public static bool operator ==(Span<T> left, Span<T> right) { throw null; }
-        public static implicit operator Span<T>(T[] array) { throw null; }
-        public static implicit operator Span<T>(ArraySegment<T> arraySegment) { throw null; }
-        public static implicit operator ReadOnlySpan<T>(Span<T> span) { throw null; }
-        public static bool operator !=(Span<T> left, Span<T> right) { throw null; }
-        public Span<T> Slice(int start) { throw null; }
-        public Span<T> Slice(int start, int length) { throw null; }
+        public static bool operator ==(System.Span<T> left, System.Span<T> right) { throw null; }
+        public static implicit operator System.Span<T> (System.ArraySegment<T> arraySegment) { throw null; }
+        public static implicit operator System.ReadOnlySpan<T> (System.Span<T> span) { throw null; }
+        public static implicit operator System.Span<T> (T[] array) { throw null; }
+        public static bool operator !=(System.Span<T> left, System.Span<T> right) { throw null; }
+        public System.Span<T> Slice(int start) { throw null; }
+        public System.Span<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
-        public bool TryCopyTo(Span<T> destination) { throw null; }
-        public ref struct Enumerator
+        public bool TryCopyTo(System.Span<T> destination) { throw null; }
+        public ref partial struct Enumerator
         {
-            public bool MoveNext() { throw null; }
             public ref T Current { get { throw null; } }
+            public bool MoveNext() { throw null; }
         }
     }
-
-    public static class MemoryExtensions
-    {
-        public static int IndexOf<T>(this Span<T> span, T value) where T : IEquatable<T> { throw null; }
-        public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
-
-        public static int IndexOfAny<T>(this Span<T> span, T value0, T value1) where T : IEquatable<T> { throw null; }
-        public static int IndexOfAny<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T> { throw null; }
-        public static int IndexOfAny<T>(this Span<T> span, ReadOnlySpan<T> values) where T : IEquatable<T> { throw null; }
-
-        public static int LastIndexOf<T>(this Span<T> span, T value) where T : IEquatable<T> { throw null; }
-        public static int LastIndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
-
-        public static int LastIndexOfAny<T>(this Span<T> span, T value0, T value1) where T : IEquatable<T> { throw null; }
-        public static int LastIndexOfAny<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T> { throw null; }
-        public static int LastIndexOfAny<T>(this Span<T> span, ReadOnlySpan<T> values) where T : IEquatable<T> { throw null; }
-
-        public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second) where T : IEquatable<T> { throw null; }
-
-        public static bool StartsWith<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
-
-        public static bool EndsWith<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
-        public static bool EndsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
-
-        public static Span<byte> AsBytes<T>(this Span<T> source) where T : struct { throw null; }
-
-        public static Span<TTo> NonPortableCast<TFrom, TTo>(this Span<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
-
-        public static ReadOnlySpan<char> AsReadOnlySpan(this string text) { throw null; }
-        public static ReadOnlyMemory<char> AsReadOnlyMemory(this string text) { throw null; }
-
-        public static Span<T> AsSpan<T>(this T[] array) { throw null; }
-        public static Span<T> AsSpan<T>(this ArraySegment<T> arraySegment) { throw null; }
-        public static ReadOnlySpan<T> AsReadOnlySpan<T>(this T[] array) { throw null; }
-        public static ReadOnlySpan<T> AsReadOnlySpan<T>(this Span<T> span) { throw null; }
-        public static ReadOnlySpan<T> AsReadOnlySpan<T>(this ArraySegment<T> arraySegment) { throw null; }
-        public static ReadOnlyMemory<T> AsReadOnlyMemory<T>(this Memory<T> memory) { throw null; }
-
-        public static void CopyTo<T>(this T[] array, Span<T> destination) { throw null; }
-        public static void CopyTo<T>(this T[] array, Memory<T> destination) { throw null; }
-
-        public static int IndexOf<T>(this ReadOnlySpan<T> span, T value) where T : IEquatable<T> { throw null; }
-        public static int IndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
-
-        public static int IndexOfAny<T>(this ReadOnlySpan<T> span, T value0, T value1) where T : IEquatable<T> { throw null; }
-        public static int IndexOfAny<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2) where T : IEquatable<T> { throw null; }
-        public static int IndexOfAny<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values) where T : IEquatable<T> { throw null; }
-
-        public static int LastIndexOf<T>(this ReadOnlySpan<T> span, T value) where T : IEquatable<T> { throw null; }
-        public static int LastIndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
-
-        public static int LastIndexOfAny<T>(this ReadOnlySpan<T> span, T value0, T value1) where T : IEquatable<T> { throw null; }
-        public static int LastIndexOfAny<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2) where T : IEquatable<T> { throw null; }
-        public static int LastIndexOfAny<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values) where T : IEquatable<T> { throw null; }
-
-        public static bool SequenceEqual<T>(this ReadOnlySpan<T> first, ReadOnlySpan<T> second) where T : IEquatable<T> { throw null; }
-
-        public static bool StartsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value) where T : IEquatable<T> { throw null; }
-
-        public static ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source) where T : struct { throw null; }
-
-        public static ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this ReadOnlySpan<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
-
-        public static bool TryGetString(this ReadOnlyMemory<char> readOnlyMemory, out string text, out int start, out int length) { throw null; }
-
-        public static bool Overlaps<T>(this Span<T> first, ReadOnlySpan<T> second) { throw null; }
-        public static bool Overlaps<T>(this Span<T> first, ReadOnlySpan<T> second, out int elementOffset) { throw null; }
-        public static bool Overlaps<T>(this ReadOnlySpan<T> first, ReadOnlySpan<T> second) { throw null; }
-        public static bool Overlaps<T>(this ReadOnlySpan<T> first, ReadOnlySpan<T> second, out int elementOffset) { throw null; }
-
-        public static int SequenceCompareTo<T>(this Span<T> first, ReadOnlySpan<T> second) where T : IComparable<T> { throw null; }
-        public static int SequenceCompareTo<T>(this ReadOnlySpan<T> first, ReadOnlySpan<T> second) where T : IComparable<T> { throw null; }
-        
-        public static int BinarySearch<T>(this ReadOnlySpan<T> span, IComparable<T> comparable) { throw null; }
-        public static int BinarySearch<T, TComparable>(this ReadOnlySpan<T> span, TComparable comparable) where TComparable : IComparable<T> { throw null; }
-        public static int BinarySearch<T, TComparer>(this ReadOnlySpan<T> span, T value, TComparer comparer) where TComparer : IComparer<T> { throw null; }
-        public static int BinarySearch<T>(this Span<T> span, IComparable<T> comparable) { throw null; }
-        public static int BinarySearch<T, TComparable>(this Span<T> span, TComparable comparable) where TComparable : IComparable<T> { throw null; }
-        public static int BinarySearch<T, TComparer>(this Span<T> span, T value, TComparer comparer) where TComparer : IComparer<T> { throw null; }
-    }
-
-    public readonly struct ReadOnlyMemory<T>
-    {
-        public static ReadOnlyMemory<T> Empty { get { throw null; } }
-        public ReadOnlyMemory(T[] array) { throw null; }
-        public ReadOnlyMemory(T[] array, int start, int length) { throw null; }
-        public bool IsEmpty { get { throw null; } }
-        public int Length { get { throw null; } }
-        public void CopyTo(Memory<T> destination) { }
-        public bool TryCopyTo(Memory<T> destination) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public override bool Equals(object obj) { throw null; }
-        public bool Equals(ReadOnlyMemory<T> other) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public override int GetHashCode() { throw null; }
-        public static implicit operator ReadOnlyMemory<T>(T[] array) { throw null; }
-        public static implicit operator ReadOnlyMemory<T>(ArraySegment<T> arraySegment) { throw null; }
-        public ReadOnlyMemory<T> Slice(int start) { throw null; }
-        public ReadOnlyMemory<T> Slice(int start, int length) { throw null; }
-        public ReadOnlySpan<T> Span { get { throw null; } }
-        public unsafe Buffers.MemoryHandle Retain(bool pin = false) { throw null; }
-        public T[] ToArray() { throw null; }
-    }
-
-    public readonly struct Memory<T>
-    {
-        public static Memory<T> Empty { get { throw null; } }
-        public Memory(T[] array) { throw null; }
-        public Memory(T[] array, int start, int length) { throw null; }
-        public bool IsEmpty { get { throw null; } }
-        public int Length { get { throw null; } }
-        public void CopyTo(Memory<T> destination) { }
-        public bool TryCopyTo(Memory<T> destination) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public override bool Equals(object obj) { throw null; }
-        public bool Equals(Memory<T> other) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public override int GetHashCode() { throw null; }
-        public static implicit operator Memory<T>(T[] array) { throw null; }
-        public static implicit operator Memory<T>(ArraySegment<T> arraySegment) { throw null; }
-        public static implicit operator ReadOnlyMemory<T>(Memory<T> memory) { throw null; }
-        public Memory<T> Slice(int start) { throw null; }
-        public Memory<T> Slice(int start, int length) { throw null; }
-        public Span<T> Span { get { throw null; } }
-        public unsafe Buffers.MemoryHandle Retain(bool pin = false) { throw null; }
-        public T[] ToArray() { throw null; }
-        public bool TryGetArray(out ArraySegment<T> arraySegment) { throw null; }
-    }
 }
-
 namespace System.Buffers
 {
-    public unsafe struct MemoryHandle : IDisposable
-    {
-        [CLSCompliant(false)]
-        public MemoryHandle(IRetainable owner, void* pointer = null, System.Runtime.InteropServices.GCHandle handle = default) { throw null; }
-        [CLSCompliant(false)]
-        public void* Pointer { get { throw null; } }
-        public bool HasPointer { get { throw null; } }
-        public void Dispose() { throw null; }
-    }
-
-    public interface IRetainable
+    public partial interface IRetainable
     {
         bool Release();
         void Retain();
     }
-
-    public abstract class OwnedMemory<T> : IDisposable, IRetainable
+    public partial struct MemoryHandle : System.IDisposable
     {
-        public Memory<T> Memory { get { throw null; } }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe MemoryHandle(System.Buffers.IRetainable owner, void* pointer=null, System.Runtime.InteropServices.GCHandle handle=default(System.Runtime.InteropServices.GCHandle)) { throw null; }
+        public bool HasPointer { get { throw null; } }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe void* Pointer { get { throw null; } }
+        public void Dispose() { }
+    }
+    public enum OperationStatus
+    {
+        DestinationTooSmall = 1,
+        Done = 0,
+        InvalidData = 3,
+        NeedMoreData = 2,
+    }
+    public abstract partial class OwnedMemory<T> : System.Buffers.IRetainable, System.IDisposable
+    {
+        protected OwnedMemory() { }
         public abstract bool IsDisposed { get; }
         protected abstract bool IsRetained { get; }
         public abstract int Length { get; }
-        public abstract Span<T> Span { get; }
-        public void Dispose() { throw null; }
+        public System.Memory<T> Memory { get { throw null; } }
+        public abstract System.Span<T> Span { get; }
+        public void Dispose() { }
         protected abstract void Dispose(bool disposing);
-        public abstract MemoryHandle Pin();
+        public abstract System.Buffers.MemoryHandle Pin();
         public abstract bool Release();
         public abstract void Retain();
-        protected internal abstract bool TryGetArray(out ArraySegment<T> arraySegment);
+        protected internal abstract bool TryGetArray(out System.ArraySegment<T> arraySegment);
     }
-
-    public enum OperationStatus
+    public readonly partial struct StandardFormat : System.IEquatable<System.Buffers.StandardFormat>
     {
-        Done,
-        DestinationTooSmall,
-        NeedMoreData,
-        InvalidData,
+        public const byte MaxPrecision = (byte)99;
+        public const byte NoPrecision = (byte)255;
+        public StandardFormat(char symbol, byte precision=(byte)255) { throw null; }
+        public bool HasPrecision { get { throw null; } }
+        public bool IsDefault { get { throw null; } }
+        public byte Precision { get { throw null; } }
+        public char Symbol { get { throw null; } }
+        public bool Equals(System.Buffers.StandardFormat other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Buffers.StandardFormat left, System.Buffers.StandardFormat right) { throw null; }
+        public static implicit operator System.Buffers.StandardFormat (char symbol) { throw null; }
+        public static bool operator !=(System.Buffers.StandardFormat left, System.Buffers.StandardFormat right) { throw null; }
+        public static System.Buffers.StandardFormat Parse(System.ReadOnlySpan<char> format) { throw null; }
+        public static System.Buffers.StandardFormat Parse(string format) { throw null; }
     }
 }
-
 namespace System.Buffers.Binary
 {
-    public static class BinaryPrimitives
+    public static partial class BinaryPrimitives
     {
-        [CLSCompliant(false)]
-        public static sbyte ReverseEndianness(sbyte value) { throw null; }
+        public static short ReadInt16BigEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
+        public static short ReadInt16LittleEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
+        public static int ReadInt32BigEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
+        public static int ReadInt32LittleEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
+        public static long ReadInt64BigEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
+        public static long ReadInt64LittleEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
+        public static T ReadMachineEndian<T>(System.ReadOnlySpan<byte> buffer) where T : struct { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static ushort ReadUInt16BigEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static ushort ReadUInt16LittleEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static uint ReadUInt32BigEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static uint ReadUInt32LittleEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static ulong ReadUInt64BigEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static ulong ReadUInt64LittleEndian(System.ReadOnlySpan<byte> buffer) { throw null; }
         public static byte ReverseEndianness(byte value) { throw null; }
         public static short ReverseEndianness(short value) { throw null; }
-        [CLSCompliant(false)]
-        public static ushort ReverseEndianness(ushort value) { throw null; }
         public static int ReverseEndianness(int value) { throw null; }
-        [CLSCompliant(false)]
-        public static uint ReverseEndianness(uint value) { throw null; }
         public static long ReverseEndianness(long value) { throw null; }
-        [CLSCompliant(false)]
+        [System.CLSCompliantAttribute(false)]
+        public static sbyte ReverseEndianness(sbyte value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static ushort ReverseEndianness(ushort value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static uint ReverseEndianness(uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
         public static ulong ReverseEndianness(ulong value) { throw null; }
-
-        public static T ReadMachineEndian<T>(ReadOnlySpan<byte> buffer) where T : struct { throw null; }
-        public static bool TryReadMachineEndian<T>(ReadOnlySpan<byte> buffer, out T value) where T : struct { throw null; }
-
-        public static short ReadInt16LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
-        public static int ReadInt32LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
-        public static long ReadInt64LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
-        [CLSCompliant(false)]
-        public static ushort ReadUInt16LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
-        [CLSCompliant(false)]
-        public static uint ReadUInt32LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
-        [CLSCompliant(false)]
-        public static ulong ReadUInt64LittleEndian(ReadOnlySpan<byte> buffer) { throw null; }
-
-        public static bool TryReadInt16LittleEndian(ReadOnlySpan<byte> buffer, out short value) { throw null; }
-        public static bool TryReadInt32LittleEndian(ReadOnlySpan<byte> buffer, out int value) { throw null; }
-        public static bool TryReadInt64LittleEndian(ReadOnlySpan<byte> buffer, out long value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryReadUInt16LittleEndian(ReadOnlySpan<byte> buffer, out ushort value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryReadUInt32LittleEndian(ReadOnlySpan<byte> buffer, out uint value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryReadUInt64LittleEndian(ReadOnlySpan<byte> buffer, out ulong value) { throw null; }
-
-        public static short ReadInt16BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
-        public static int ReadInt32BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
-        public static long ReadInt64BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
-        [CLSCompliant(false)]
-        public static ushort ReadUInt16BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
-        [CLSCompliant(false)]
-        public static uint ReadUInt32BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
-        [CLSCompliant(false)]
-        public static ulong ReadUInt64BigEndian(ReadOnlySpan<byte> buffer) { throw null; }
-
-        public static bool TryReadInt16BigEndian(ReadOnlySpan<byte> buffer, out short value) { throw null; }
-        public static bool TryReadInt32BigEndian(ReadOnlySpan<byte> buffer, out int value) { throw null; }
-        public static bool TryReadInt64BigEndian(ReadOnlySpan<byte> buffer, out long value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryReadUInt16BigEndian(ReadOnlySpan<byte> buffer, out ushort value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryReadUInt32BigEndian(ReadOnlySpan<byte> buffer, out uint value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryReadUInt64BigEndian(ReadOnlySpan<byte> buffer, out ulong value) { throw null; }
-
-        public static void WriteMachineEndian<T>(Span<byte> buffer, ref T value) where T : struct { throw null; }
-        public static bool TryWriteMachineEndian<T>(Span<byte> buffer, ref T value) where T : struct { throw null; }
-
-        public static void WriteInt16LittleEndian(Span<byte> buffer, short value) { throw null; }
-        public static void WriteInt32LittleEndian(Span<byte> buffer, int value) { throw null; }
-        public static void WriteInt64LittleEndian(Span<byte> buffer, long value) { throw null; }
-        [CLSCompliant(false)]
-        public static void WriteUInt16LittleEndian(Span<byte> buffer, ushort value) { throw null; }
-        [CLSCompliant(false)]
-        public static void WriteUInt32LittleEndian(Span<byte> buffer, uint value) { throw null; }
-        [CLSCompliant(false)]
-        public static void WriteUInt64LittleEndian(Span<byte> buffer, ulong value) { throw null; }
-
-        public static bool TryWriteInt16LittleEndian(Span<byte> buffer, short value) { throw null; }
-        public static bool TryWriteInt32LittleEndian(Span<byte> buffer, int value) { throw null; }
-        public static bool TryWriteInt64LittleEndian(Span<byte> buffer, long value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryWriteUInt16LittleEndian(Span<byte> buffer, ushort value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryWriteUInt32LittleEndian(Span<byte> buffer, uint value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryWriteUInt64LittleEndian(Span<byte> buffer, ulong value) { throw null; }
-
-        public static void WriteInt16BigEndian(Span<byte> buffer, short value) { throw null; }
-        public static void WriteInt32BigEndian(Span<byte> buffer, int value) { throw null; }
-        public static void WriteInt64BigEndian(Span<byte> buffer, long value) { throw null; }
-        [CLSCompliant(false)]
-        public static void WriteUInt16BigEndian(Span<byte> buffer, ushort value) { throw null; }
-        [CLSCompliant(false)]
-        public static void WriteUInt32BigEndian(Span<byte> buffer, uint value) { throw null; }
-        [CLSCompliant(false)]
-        public static void WriteUInt64BigEndian(Span<byte> buffer, ulong value) { throw null; }
-
-        public static bool TryWriteInt16BigEndian(Span<byte> buffer, short value) { throw null; }
-        public static bool TryWriteInt32BigEndian(Span<byte> buffer, int value) { throw null; }
-        public static bool TryWriteInt64BigEndian(Span<byte> buffer, long value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryWriteUInt16BigEndian(Span<byte> buffer, ushort value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryWriteUInt32BigEndian(Span<byte> buffer, uint value) { throw null; }
-        [CLSCompliant(false)]
-        public static bool TryWriteUInt64BigEndian(Span<byte> buffer, ulong value) { throw null; }
+        public static bool TryReadInt16BigEndian(System.ReadOnlySpan<byte> buffer, out short value) { throw null; }
+        public static bool TryReadInt16LittleEndian(System.ReadOnlySpan<byte> buffer, out short value) { throw null; }
+        public static bool TryReadInt32BigEndian(System.ReadOnlySpan<byte> buffer, out int value) { throw null; }
+        public static bool TryReadInt32LittleEndian(System.ReadOnlySpan<byte> buffer, out int value) { throw null; }
+        public static bool TryReadInt64BigEndian(System.ReadOnlySpan<byte> buffer, out long value) { throw null; }
+        public static bool TryReadInt64LittleEndian(System.ReadOnlySpan<byte> buffer, out long value) { throw null; }
+        public static bool TryReadMachineEndian<T>(System.ReadOnlySpan<byte> buffer, out T value) where T : struct { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryReadUInt16BigEndian(System.ReadOnlySpan<byte> buffer, out ushort value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryReadUInt16LittleEndian(System.ReadOnlySpan<byte> buffer, out ushort value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryReadUInt32BigEndian(System.ReadOnlySpan<byte> buffer, out uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryReadUInt32LittleEndian(System.ReadOnlySpan<byte> buffer, out uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryReadUInt64BigEndian(System.ReadOnlySpan<byte> buffer, out ulong value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryReadUInt64LittleEndian(System.ReadOnlySpan<byte> buffer, out ulong value) { throw null; }
+        public static bool TryWriteInt16BigEndian(System.Span<byte> buffer, short value) { throw null; }
+        public static bool TryWriteInt16LittleEndian(System.Span<byte> buffer, short value) { throw null; }
+        public static bool TryWriteInt32BigEndian(System.Span<byte> buffer, int value) { throw null; }
+        public static bool TryWriteInt32LittleEndian(System.Span<byte> buffer, int value) { throw null; }
+        public static bool TryWriteInt64BigEndian(System.Span<byte> buffer, long value) { throw null; }
+        public static bool TryWriteInt64LittleEndian(System.Span<byte> buffer, long value) { throw null; }
+        public static bool TryWriteMachineEndian<T>(System.Span<byte> buffer, ref T value) where T : struct { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteUInt16BigEndian(System.Span<byte> buffer, ushort value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteUInt16LittleEndian(System.Span<byte> buffer, ushort value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteUInt32BigEndian(System.Span<byte> buffer, uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteUInt32LittleEndian(System.Span<byte> buffer, uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteUInt64BigEndian(System.Span<byte> buffer, ulong value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryWriteUInt64LittleEndian(System.Span<byte> buffer, ulong value) { throw null; }
+        public static void WriteInt16BigEndian(System.Span<byte> buffer, short value) { }
+        public static void WriteInt16LittleEndian(System.Span<byte> buffer, short value) { }
+        public static void WriteInt32BigEndian(System.Span<byte> buffer, int value) { }
+        public static void WriteInt32LittleEndian(System.Span<byte> buffer, int value) { }
+        public static void WriteInt64BigEndian(System.Span<byte> buffer, long value) { }
+        public static void WriteInt64LittleEndian(System.Span<byte> buffer, long value) { }
+        public static void WriteMachineEndian<T>(System.Span<byte> buffer, ref T value) where T : struct { }
+        [System.CLSCompliantAttribute(false)]
+        public static void WriteUInt16BigEndian(System.Span<byte> buffer, ushort value) { }
+        [System.CLSCompliantAttribute(false)]
+        public static void WriteUInt16LittleEndian(System.Span<byte> buffer, ushort value) { }
+        [System.CLSCompliantAttribute(false)]
+        public static void WriteUInt32BigEndian(System.Span<byte> buffer, uint value) { }
+        [System.CLSCompliantAttribute(false)]
+        public static void WriteUInt32LittleEndian(System.Span<byte> buffer, uint value) { }
+        [System.CLSCompliantAttribute(false)]
+        public static void WriteUInt64BigEndian(System.Span<byte> buffer, ulong value) { }
+        [System.CLSCompliantAttribute(false)]
+        public static void WriteUInt64LittleEndian(System.Span<byte> buffer, ulong value) { }
     }
 }
-
-namespace System.Buffers
-{
-    public readonly struct StandardFormat : IEquatable<StandardFormat>
-    {
-        public const byte MaxPrecision = 99;
-        public const byte NoPrecision = 255;
-        public StandardFormat(char symbol, byte precision = 255) => throw null;
-        public bool HasPrecision => throw null;
-        public bool IsDefault => throw null;
-        public byte Precision => throw null;
-        public char Symbol => throw null;
-        public static implicit operator StandardFormat(char symbol) => throw null;
-        public static StandardFormat Parse(ReadOnlySpan<char> format) => throw null;
-        public static StandardFormat Parse(string format) => throw null;
-        public override bool Equals(object obj) => throw null;
-        public override int GetHashCode() => throw null;
-        public bool Equals(StandardFormat other) => throw null;
-        public static bool operator ==(StandardFormat left, StandardFormat right) => throw null;
-        public static bool operator !=(StandardFormat left, StandardFormat right) => throw null;
-    }
-}
-
 namespace System.Buffers.Text
 {
-    public static class Base64
+    public static partial class Base64
     {
-        public static OperationStatus EncodeToUtf8(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int consumed, out int written, bool isFinalBlock = true) { throw null; }
-        public static OperationStatus EncodeToUtf8InPlace(Span<byte> buffer, int dataLength, out int written) { throw null; }
-        public static int GetMaxEncodedToUtf8Length(int length) { throw null; }
-        public static OperationStatus DecodeFromUtf8(ReadOnlySpan<byte> utf8, Span<byte> bytes, out int consumed, out int written, bool isFinalBlock = true) { throw null; }
-        public static OperationStatus DecodeFromUtf8InPlace(Span<byte> buffer, out int written) { throw null; }
+        public static System.Buffers.OperationStatus DecodeFromUtf8(System.ReadOnlySpan<byte> utf8, System.Span<byte> bytes, out int consumed, out int written, bool isFinalBlock=true) { throw null; }
+        public static System.Buffers.OperationStatus DecodeFromUtf8InPlace(System.Span<byte> buffer, out int written) { throw null; }
+        public static System.Buffers.OperationStatus EncodeToUtf8(System.ReadOnlySpan<byte> bytes, System.Span<byte> utf8, out int consumed, out int written, bool isFinalBlock=true) { throw null; }
+        public static System.Buffers.OperationStatus EncodeToUtf8InPlace(System.Span<byte> buffer, int dataLength, out int written) { throw null; }
         public static int GetMaxDecodedFromUtf8Length(int length) { throw null; }
+        public static int GetMaxEncodedToUtf8Length(int length) { throw null; }
     }
-
-    public static class Utf8Formatter
+    public static partial class Utf8Formatter
     {
-        public static bool TryFormat(bool value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        public static bool TryFormat(byte value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        public static bool TryFormat(DateTime value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        public static bool TryFormat(DateTimeOffset value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        public static bool TryFormat(decimal value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        public static bool TryFormat(double value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        public static bool TryFormat(Guid value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        public static bool TryFormat(short value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        public static bool TryFormat(int value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        public static bool TryFormat(long value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        [CLSCompliant(false)]
-        public static bool TryFormat(sbyte value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        public static bool TryFormat(float value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        public static bool TryFormat(TimeSpan value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        [CLSCompliant(false)]
-        public static bool TryFormat(ushort value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        [CLSCompliant(false)]
-        public static bool TryFormat(uint value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
-        [CLSCompliant(false)]
-        public static bool TryFormat(ulong value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default) => throw null;
+        public static bool TryFormat(bool value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(byte value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(System.DateTime value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(System.DateTimeOffset value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(decimal value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(double value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(System.Guid value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(short value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(int value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(long value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryFormat(sbyte value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(float value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(System.TimeSpan value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryFormat(ushort value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryFormat(uint value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryFormat(ulong value, System.Span<byte> buffer, out int bytesWritten, System.Buffers.StandardFormat format=default(System.Buffers.StandardFormat)) { throw null; }
     }
-    public static class Utf8Parser
+    public static partial class Utf8Parser
     {
-        public static bool TryParse(ReadOnlySpan<byte> text, out bool value, out int bytesConsumed, char standardFormat = default) => throw null;
-        public static bool TryParse(ReadOnlySpan<byte> text, out byte value, out int bytesConsumed, char standardFormat = default) => throw null;
-        public static bool TryParse(ReadOnlySpan<byte> text, out DateTime value, out int bytesConsumed, char standardFormat = default) => throw null;
-        public static bool TryParse(ReadOnlySpan<byte> text, out DateTimeOffset value, out int bytesConsumed, char standardFormat = default) => throw null;
-        public static bool TryParse(ReadOnlySpan<byte> text, out decimal value, out int bytesConsumed, char standardFormat = default) => throw null;
-        public static bool TryParse(ReadOnlySpan<byte> text, out double value, out int bytesConsumed, char standardFormat = default) => throw null;
-        public static bool TryParse(ReadOnlySpan<byte> text, out Guid value, out int bytesConsumed, char standardFormat = default) => throw null;
-        public static bool TryParse(ReadOnlySpan<byte> text, out short value, out int bytesConsumed, char standardFormat = default) => throw null;
-        public static bool TryParse(ReadOnlySpan<byte> text, out int value, out int bytesConsumed, char standardFormat = default) => throw null;
-        public static bool TryParse(ReadOnlySpan<byte> text, out long value, out int bytesConsumed, char standardFormat = default) => throw null;
-        [CLSCompliant(false)]
-        public static bool TryParse(ReadOnlySpan<byte> text, out sbyte value, out int bytesConsumed, char standardFormat = default) => throw null;
-        public static bool TryParse(ReadOnlySpan<byte> text, out float value, out int bytesConsumed, char standardFormat = default) => throw null;
-        public static bool TryParse(ReadOnlySpan<byte> text, out TimeSpan value, out int bytesConsumed, char standardFormat = default) => throw null;
-        [CLSCompliant(false)]
-        public static bool TryParse(ReadOnlySpan<byte> text, out ushort value, out int bytesConsumed, char standardFormat = default) => throw null;
-        [CLSCompliant(false)]
-        public static bool TryParse(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed, char standardFormat = default) => throw null;
-        [CLSCompliant(false)]
-        public static bool TryParse(ReadOnlySpan<byte> text, out ulong value, out int bytesConsumed, char standardFormat = default) => throw null;
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out bool value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out byte value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out System.DateTime value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out System.DateTimeOffset value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out decimal value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out double value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out System.Guid value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out short value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out int value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out long value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out sbyte value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out float value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out System.TimeSpan value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out ushort value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out uint value, out int bytesConsumed, char standardFormat='\0') { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryParse(System.ReadOnlySpan<byte> text, out ulong value, out int bytesConsumed, char standardFormat='\0') { throw null; }
     }
 }
-
 namespace System.Runtime.InteropServices
 {
-    public static class MemoryMarshal
+    public static partial class MemoryMarshal
     {
-        public static Memory<T> AsMemory<T>(ReadOnlyMemory<T> readOnlyMemory) { throw null; }
-
-        public static ref T GetReference<T>(Span<T> span) { throw null; }
-        public static ref T GetReference<T>(ReadOnlySpan<T> span) { throw null; }
-
-        public static bool TryGetArray<T>(ReadOnlyMemory<T> readOnlyMemory, out ArraySegment<T> arraySegment) { throw null; }
+        public static System.Memory<T> AsMemory<T>(System.ReadOnlyMemory<T> readOnlyMemory) { throw null; }
+        public static ref T GetReference<T>(System.ReadOnlySpan<T> span) { throw null; }
+        public static ref T GetReference<T>(System.Span<T> span) { throw null; }
+        public static bool TryGetArray<T>(System.ReadOnlyMemory<T> readOnlyMemory, out System.ArraySegment<T> arraySegment) { throw null; }
     }
 }

--- a/src/System.Memory/ref/System.Memory.csproj
+++ b/src/System.Memory/ref/System.Memory.csproj
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{E883935B-D8FD-4FC9-A189-9D9E7F7EF550}</ProjectGuid>
+    <!-- disable warnings about obsolete APIs -->
+    <NoWarn>$(NoWarn);0809</NoWarn>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' Or '$(TargetGroup)' == 'uap'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />

--- a/src/System.Memory/src/System/ReadOnlySpan.cs
+++ b/src/System.Memory/src/System/ReadOnlySpan.cs
@@ -219,7 +219,7 @@ namespace System
         /// Always thrown by this method.
         /// </exception>
         /// </summary>
-        [Obsolete("Equals() on Span will always throw an exception. Use == instead.")]
+        [Obsolete("Equals() on ReadOnlySpan will always throw an exception. Use == instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj)
         {
@@ -232,7 +232,7 @@ namespace System
         /// Always thrown by this method.
         /// </exception>
         /// </summary>
-        [Obsolete("GetHashCode() on Span will always throw an exception.")]
+        [Obsolete("GetHashCode() on ReadOnlySpan will always throw an exception.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {


### PR DESCRIPTION
PTAL @jkotas @ahsonkhan 

This updates System.Memory ref to correctly have the private struct fields.

@ahsonkhan I've normalized the ref based on the netstandard OOB implementation so you can not regenerate the ref by running the following in the src/System.Memory/src dir:
```
msbuild /p:TargetGroup=netstandard /t:GenerateReferenceSource
```
This should make update the ref much easier going forward.