### PR TITLE
Improve performance of ReverseEndianness

### DIFF
--- a/src/System.Memory/src/System/Buffers/Binary/Reader.cs
+++ b/src/System.Memory/src/System/Buffers/Binary/Reader.cs
@@ -71,7 +71,14 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ReverseEndianness(ushort value)
         {
-            return (ushort)((value & 0x00FFU) << 8 | (value & 0xFF00U) >> 8);
+            // Don't need to AND with 0xFF00 or 0x00FF since the final
+            // cast back to ushort will clear out all bits above [ 15 .. 00 ].
+            // This is normally implemented via "movzx eax, ax" on the return.
+            // Alternatively, the compiler could elide the movzx instruction
+            // entirely if it knows the caller is only going to access "ax"
+            // instead of "eax" / "rax" when the function returns.
+
+            return (ushort)((value >> 8) + (value << 8));
         }
 
         /// <summary>
@@ -81,9 +88,30 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ReverseEndianness(uint value)
         {
-            value = (value << 16) | (value >> 16);
-            value = (value & 0x00FF00FF) << 8 | (value & 0xFF00FF00) >> 8;
-            return value;
+            // This takes advantage of the fact that the JIT can detect
+            // ROL32 / ROR32 patterns and output the correct intrinsic.
+            //
+            // Input: value = [ ww xx yy zz ]
+            //
+            // First line generates : [ ww xx yy zz ]
+            //                      & [ 00 FF 00 FF ]
+            //                      = [ 00 xx 00 zz ]
+            //             ROR32(8) = [ zz 00 xx 00 ]
+            //
+            // Second line generates: [ ww xx yy zz ]
+            //                      & [ FF 00 FF 00 ]
+            //                      = [ ww 00 yy 00 ]
+            //             ROL32(8) = [ 00 yy 00 ww ]
+            //
+            //                (sum) = [ zz yy xx ww ]
+            //
+            // Testing shows that throughput increases if the AND
+            // is performed before the ROL / ROR.
+
+            uint mask_xx_zz = (value & 0x00FF00FFU);
+            uint mask_ww_yy = (value & 0xFF00FF00U);
+            return ((mask_xx_zz >> 8) | (mask_xx_zz << 24))
+                + ((mask_ww_yy << 8) | (mask_ww_yy >> 24));
         }
 
         /// <summary>
@@ -93,10 +121,11 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ReverseEndianness(ulong value)
         {
-            value = (value << 32) | (value >> 32);
-            value = (value & 0x0000FFFF0000FFFF) << 16 | (value & 0xFFFF0000FFFF0000) >> 16;
-            value = (value & 0x00FF00FF00FF00FF) << 8 | (value & 0xFF00FF00FF00FF00) >> 8;
-            return value;
+            // Operations on 32-bit values have higher throughput than
+            // operations on 64-bit values, so decompose.
+
+            return ((ulong)ReverseEndianness((uint)value) << 32)
+                + ReverseEndianness((uint)(value >> 32));
         }
 
         /// <summary>


### PR DESCRIPTION
This PR further improves the performance of `BinaryPrimitives.ReverseEndianness`.

Performance testing was accomplished by calling the methods 1 billion times in a loop, plus forcing a memory access between each iteration to prevent codegen from collapsing the iterations together. The performance testbed application can be found at https://gist.github.com/GrabYourPitchforks/2551846942913e81b0972c5860470f96. Results are laid out in the table below. All tests were performed on a Win10 FCU amd64 machine with runtime framework 2.1.0-preview1-26111-03 in a 64-bit process unless otherwise specified.

| Test | Average time taken (ms) | StdDev (ms) |
|------|-------------------------|-------------|
| `IPAddress.HostToNetworkOrder(uint32)` | 3950.95 | 49.88 |
| `BinaryPrimitives.ReverseEndianness(uint32)` (Original) | 2295.63 | 24.67 |
| `BinaryPrimitives.ReverseEndianness(uint32)` (New) | 1729.21 | 19.62 | -25% |
| `IPAddress.HostToNetworkOrder(uint16)` | 1808.44 | 23.67 |
| `BinaryPrimitives.ReverseEndianness(uint16)` (Original) | 2036.60 | 53.54 |
| `BinaryPrimitives.ReverseEndianness(uint16)` (New) | 1508.71 | 16.00 |
| `IPAddress.HostToNetworkOrder(uint64)` | 6908.92 | 59.79 |
| `BinaryPrimitives.ReverseEndianness(uint64)` (Original) | 3110.94 | 39.78 |
| `BinaryPrimitives.ReverseEndianness(uint64)` (New) | 2712.44 | 24.76 |
| `IPAddress.HostToNetworkOrder(uint64)` (32-bit proc) | 5726.56 | 33.08 |
| `BinaryPrimitives.ReverseEndianness(uint64)` (Original, 32-bit proc) | 4404.27 | 15.10 |
| `BinaryPrimitives.ReverseEndianness(uint64)` (New, 32-bit proc) | 2595.94 | 12.07 |

/cc @jkotas @ahsonkhan @benaadams 
