### PR TITLE
Add arm64 build for uapaot

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -248,6 +248,20 @@
           }
         },
         {
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
+          "Parameters": {
+            "PB_Platform": "arm64",
+            "PB_BuildArguments": "-framework=uapaot -buildArch=arm64 -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=win10 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10 /p:TargetGroup=uapaot /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm64",
+            "SubType": "uapaot"
+          }
+        },
+        {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
             "PB_Platform": "x64",

--- a/pkg/Microsoft.Private.CoreFx.UAP/uap.rids.props
+++ b/pkg/Microsoft.Private.CoreFx.UAP/uap.rids.props
@@ -8,12 +8,18 @@
     <OfficialBuildRID Include="win10-arm">
       <Platform>arm</Platform>
     </OfficialBuildRID>
+    <OfficialBuildRID Include="win10-arm64">
+      <Platform>arm64</Platform>
+    </OfficialBuildRID>
     <OfficialBuildRID Include="win10-x86-aot">
       <Platform>x86</Platform>
     </OfficialBuildRID>
     <OfficialBuildRID Include="win10-x64-aot" />
     <OfficialBuildRID Include="win10-arm-aot">
       <Platform>arm</Platform>
+    </OfficialBuildRID>
+    <OfficialBuildRID Include="win10-arm64-aot">
+      <Platform>arm64</Platform>
     </OfficialBuildRID>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This add a build and adds win10-arm64 to the list of supported UWP rids

Fixes https://github.com/dotnet/corefx/issues/26308. 