### PR TITLE
Restore temporarily removed assertion in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1819,16 +1819,10 @@ namespace Microsoft.CSharp.RuntimeBinder
 
                 AggregateSymbol aggregate = GetCTypeFromType(baseMethodInfo.DeclaringType).getAggregate();
                 MethodSymbol baseMethod = FindMethodFromMemberInfo(baseMethodInfo);
-
-                // This assert is temporarily disabled to improve testability of the area on .NetNative
-                //Debug.Assert(baseMethod != null);
-                if ((object)baseMethod == null)
-                {
-                    throw Error.InternalCompilerError();
-                }
-
+                Debug.Assert(baseMethod != null);
                 return new SymWithType(baseMethod, aggregate.getThisType());
             }
+
             return null;
         }
 


### PR DESCRIPTION
Assert was replaced by a runtime check "temporarily" to help for testing purposes in 7de4fc3a (2015-06-11)

Restore to original.