### PR TITLE
Improve Span/ReadOnlySpan test coverage

### DIFF
--- a/src/System.Memory/tests/Memory/Span.cs
+++ b/src/System.Memory/tests/Memory/Span.cs
@@ -66,10 +66,10 @@ namespace System.MemoryTests
             Memory<int> memory;
 
             memory = new Memory<int>(empty);
-            memory.Span.Validate();
+            memory.Span.ValidateNonNullEmpty();
 
             memory = new Memory<int>(empty, 0, empty.Length);
-            memory.Span.Validate();
+            memory.Span.ValidateNonNullEmpty();
 
             OwnedMemory<int> owner = new CustomMemoryForTest<int>(empty);
             owner.Memory.Span.Validate();

--- a/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
+++ b/src/System.Memory/tests/Performance/System.Memory.Performance.Tests.csproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <IncludePerformanceTests>true</IncludePerformanceTests>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{18482C55-6B57-41E8-BBC4-383B9E2C7AA2}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />

--- a/src/System.Memory/tests/ReadOnlyMemory/Span.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Span.cs
@@ -66,10 +66,10 @@ namespace System.MemoryTests
             ReadOnlyMemory<int> memory;
 
             memory = new ReadOnlyMemory<int>(empty);
-            memory.Span.Validate();
+            memory.Span.ValidateNonNullEmpty();
 
             memory = new ReadOnlyMemory<int>(empty, 0, empty.Length);
-            memory.Span.Validate();
+            memory.Span.ValidateNonNullEmpty();
 
             OwnedMemory<int> owner = new CustomMemoryForTest<int>(empty);
             ((ReadOnlyMemory<int>)owner.Memory).Span.Validate();

--- a/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
@@ -46,7 +46,7 @@ namespace System.SpanTests
         {
             int[] empty = Array.Empty<int>();
             ReadOnlySpan<int> span = empty.AsReadOnlySpan();
-            span.Validate();
+            span.ValidateNonNullEmpty();
         }
 
         [Fact]
@@ -86,12 +86,12 @@ namespace System.SpanTests
             int[] empty = Array.Empty<int>();
             ArraySegment<int> emptySegment = new ArraySegment<int>(empty);
             ReadOnlySpan<int> span = emptySegment.AsReadOnlySpan();
-            span.Validate();
+            span.ValidateNonNullEmpty();
 
             int[] a = { 19, -17 };
             ArraySegment<int> segmentInt = new ArraySegment<int>(a, 1, 0);
             ReadOnlySpan<int> spanInt = segmentInt.AsReadOnlySpan();
-            spanInt.Validate();
+            spanInt.ValidateNonNullEmpty();
         }
 
         [Fact]
@@ -108,8 +108,7 @@ namespace System.SpanTests
         {
             string s = "";
             ReadOnlySpan<char> span = s.AsReadOnlySpan();
-            char[] expected = s.ToCharArray();
-            span.Validate(expected);
+            span.ValidateNonNullEmpty();
         }
 
         [Fact]

--- a/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
@@ -63,10 +63,10 @@ namespace System.SpanTests
             ReadOnlySpan<int> span;
 
             span = new ReadOnlySpan<int>(empty);
-            span.Validate();
+            span.ValidateNonNullEmpty();
 
             span = new ReadOnlySpan<int>(empty, 0, empty.Length);
-            span.Validate();
+            span.ValidateNonNullEmpty();
         }
 
         [Fact]

--- a/src/System.Memory/tests/ReadOnlySpan/CtorArrayIntInt.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CtorArrayIntInt.cs
@@ -73,7 +73,7 @@ namespace System.SpanTests
             // Valid for start to equal the array length. This returns an empty span that starts "just past the array."
             int[] a = { 91, 92, 93 };
             ReadOnlySpan<int> span = new ReadOnlySpan<int>(a, 3, 0);
-            span.Validate();
+            span.ValidateNonNullEmpty();
         }
     }
 }

--- a/src/System.Memory/tests/Span/AsSpan.cs
+++ b/src/System.Memory/tests/Span/AsSpan.cs
@@ -39,7 +39,7 @@ namespace System.SpanTests
         {
             int[] empty = Array.Empty<int>();
             Span<int> span = empty.AsSpan();
-            span.Validate();
+            span.ValidateNonNullEmpty();
         }
 
         [Fact]
@@ -79,12 +79,12 @@ namespace System.SpanTests
             int[] empty = Array.Empty<int>();
             ArraySegment<int> segmentEmpty = new ArraySegment<int>(empty);
             Span<int> spanEmpty = segmentEmpty.AsSpan();
-            spanEmpty.Validate();
+            spanEmpty.ValidateNonNullEmpty();
 
             int[] a = { 91, 92, -93, 94 };
             ArraySegment<int> segmentInt = new ArraySegment<int>(a, 0, 0);
             Span<int> spanInt = segmentInt.AsSpan();
-            spanInt.Validate();
+            spanInt.ValidateNonNullEmpty();
         }
     }
 }

--- a/src/System.Memory/tests/Span/CtorArray.cs
+++ b/src/System.Memory/tests/Span/CtorArray.cs
@@ -62,10 +62,10 @@ namespace System.SpanTests
             Span<int> span;
 
             span = new Span<int>(empty);
-            span.Validate();
+            span.ValidateNonNullEmpty();
 
             span = new Span<int>(empty, 0, empty.Length);
-            span.Validate();
+            span.ValidateNonNullEmpty();
         }
 
         [Fact]

--- a/src/System.Memory/tests/Span/CtorArrayIntInt.cs
+++ b/src/System.Memory/tests/Span/CtorArrayIntInt.cs
@@ -73,7 +73,7 @@ namespace System.SpanTests
             // Valid for start to equal the array length. This returns an empty span that starts "just past the array."
             int[] a = { 91, 92, 93 };
             Span<int> span = new Span<int>(a, 3, 0);
-            span.Validate();
+            span.ValidateNonNullEmpty();
         }
     }
 }

--- a/src/System.Memory/tests/TestHelpers.cs
+++ b/src/System.Memory/tests/TestHelpers.cs
@@ -33,6 +33,8 @@ namespace System
         public static unsafe void ValidateNonNullEmpty<T>(this Span<T> span)
         {
             Assert.True(span.IsEmpty);
+
+            // Validate that empty Span is not normalized to null
             Assert.True(Unsafe.AsPointer(ref MemoryMarshal.GetReference(span)) != null);
         }
 
@@ -95,6 +97,8 @@ namespace System
         public static unsafe void ValidateNonNullEmpty<T>(this ReadOnlySpan<T> span)
         {
             Assert.True(span.IsEmpty);
+
+            // Validate that empty Span is not normalized to null
             Assert.True(Unsafe.AsPointer(ref MemoryMarshal.GetReference(span)) != null);
         }
 

--- a/src/System.Memory/tests/TestHelpers.cs
+++ b/src/System.Memory/tests/TestHelpers.cs
@@ -30,6 +30,12 @@ namespace System
             AssertThrows<IndexOutOfRangeException, T>(span, (_span) => ignore = _span[expected.Length]);
         }
 
+        public static unsafe void ValidateNonNullEmpty<T>(this Span<T> span)
+        {
+            Assert.True(span.IsEmpty);
+            Assert.True(Unsafe.AsPointer(ref MemoryMarshal.GetReference(span)) != null);
+        }
+
         public delegate void AssertThrowsAction<T>(Span<T> span);
 
         // Cannot use standard Assert.Throws() when testing Span - Span and closures don't get along.
@@ -84,6 +90,12 @@ namespace System
 
             T ignore;
             AssertThrows<IndexOutOfRangeException, T>(span, (_span) => ignore = _span[expected.Length]);
+        }
+
+        public static unsafe void ValidateNonNullEmpty<T>(this ReadOnlySpan<T> span)
+        {
+            Assert.True(span.IsEmpty);
+            Assert.True(Unsafe.AsPointer(ref MemoryMarshal.GetReference(span)) != null);
         }
 
         public delegate void AssertThrowsActionReadOnly<T>(ReadOnlySpan<T> span);


### PR DESCRIPTION
Add missing tests from https://github.com/dotnet/coreclr/blob/master/tests/src/CoreMangLib/system/span/BasicSpanTest.cs.

BasicSpanTest.cs was a temporary test when we have started the `Span<T>` feature. It is redundant with the CoreFX Span tests. I am going to delete it.