### PR TITLE
Disable Msec test on macOS

### DIFF
--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -68,6 +68,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ActiveIssue(26349, TestPlatforms.OSX)]
         public void TimesIncludeMillisecondPart()
         {
             T item = GetExistingItem();


### PR DESCRIPTION
Relates to #26349

CI showed green, despite the failure.: https://github.com/dotnet/core-eng/issues/2411