### PR TITLE
Support System.Runtime.Caching on Linux

### DIFF
--- a/src/System.Runtime.Caching/src/Configurations.props
+++ b/src/System.Runtime.Caching/src/Configurations.props
@@ -1,9 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <PackageConfigurations>
+      netstandard;
+      netcoreapp2.0-Windows_NT;
+      netcoreapp2.0-Unix;
+    </PackageConfigurations>
     <BuildConfigurations>
-      netstandard-Windows_NT;
-      netstandard-Unix;
+      $(PackageConfigurations);
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
       _netfx;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Runtime.Caching/src/Configurations.props
+++ b/src/System.Runtime.Caching/src/Configurations.props
@@ -6,8 +6,8 @@
       netcoreapp2.0-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
-      $(PackageConfigurations);
-      netcoreapp-Windows_NT;
+      netstandard-Windows_NT;
+      netstandard-Unix;
       _netfx;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Runtime.Caching/src/Configurations.props
+++ b/src/System.Runtime.Caching/src/Configurations.props
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageConfigurations>
-      netstandard;
-      netcoreapp2.0-Windows_NT;
-    </PackageConfigurations>
     <BuildConfigurations>
       netstandard-Windows_NT;
       netstandard-Unix;

--- a/src/System.Runtime.Caching/src/Resources/Strings.resx
+++ b/src/System.Runtime.Caching/src/Resources/Strings.resx
@@ -183,4 +183,7 @@
   <data name="PlatformNotSupported_Caching" xml:space="preserve">
     <value>System.Runtime.Caching is not supported on this platform.</value>
   </data>
+  <data name="PlatformNotSupported_PhysicalMemoryLimitPercentage" xml:space="preserve">
+    <value>PhysicalMemoryLimitPercentage parameter is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/System.Runtime.Caching/src/Resources/Strings.resx
+++ b/src/System.Runtime.Caching/src/Resources/Strings.resx
@@ -184,6 +184,6 @@
     <value>System.Runtime.Caching is not supported on this platform.</value>
   </data>
   <data name="PlatformNotSupported_PhysicalMemoryLimitPercentage" xml:space="preserve">
-    <value>PhysicalMemoryLimitPercentage parameter is not supported on this platform.</value>
+    <value>The PhysicalMemoryLimitPercentage parameter is not supported on this platform.</value>
   </data>
 </root>

--- a/src/System.Runtime.Caching/src/System.Runtime.Caching.csproj
+++ b/src/System.Runtime.Caching/src/System.Runtime.Caching.csproj
@@ -90,6 +90,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
     <Reference Include="System.Security.Permissions" />
     <Reference Include="System.Security.Principal.Windows" />
     <Reference Include="System.Threading" />

--- a/src/System.Runtime.Caching/src/System.Runtime.Caching.csproj
+++ b/src/System.Runtime.Caching/src/System.Runtime.Caching.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Although we have a netstandard configuration, we know we are not currently UAP compatible-->
     <UWPCompatible>false</UWPCompatible>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard'">SR.PlatformNotSupported_Caching</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
@@ -14,7 +15,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp2.0-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
     <Compile Include="System\Runtime\Caching\_shims.cs" />
     <Compile Include="System\Runtime\Caching\CacheEntryChangeMonitor.cs" />
     <Compile Include="System\Runtime\Caching\CacheEntryRemovedArguments.cs" />

--- a/src/System.Runtime.Caching/src/System.Runtime.Caching.csproj
+++ b/src/System.Runtime.Caching/src/System.Runtime.Caching.csproj
@@ -7,7 +7,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Although we have a netstandard configuration, we know we are not currently UAP compatible-->
     <UWPCompatible>false</UWPCompatible>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_Caching</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
@@ -15,7 +14,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp2.0-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+  <ItemGroup>
     <Compile Include="System\Runtime\Caching\_shims.cs" />
     <Compile Include="System\Runtime\Caching\CacheEntryChangeMonitor.cs" />
     <Compile Include="System\Runtime\Caching\CacheEntryRemovedArguments.cs" />
@@ -59,6 +58,10 @@
     <Compile Include="System\Runtime\Caching\Hosting\IFileChangeNotificationSystem.cs" />
     <Compile Include="System\Runtime\Caching\Hosting\IMemoryCacheManager.cs" />
     <Compile Include="System\Runtime\Caching\Resources\RH.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="System\Runtime\Caching\MemoryMonitor.Windows.cs" />
+    <Compile Include="System\Runtime\Caching\PhysicalMemoryMonitor.Windows.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GlobalMemoryStatusEx.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.GlobalMemoryStatusEx.cs</Link>
     </Compile>
@@ -68,6 +71,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="System\Runtime\Caching\PhysicalMemoryMonitor.Unix.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/Dbg.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/Dbg.cs
@@ -530,7 +530,10 @@ namespace System.Runtime.Caching
             else {
                 if (s_includeThreadPrefix) {
                     idThread = Thread.CurrentThread.ManagedThreadId;
-                    idProcess = Process.GetCurrentProcess().Id;
+                    using(var process = Process.GetCurrentProcess())
+                    {
+                        idProcess = process.Id;
+                    }
                     traceFormat = "[0x{0:x}.{1:x} {2} {3}] {4}\n{5}";
                 }
                 else {
@@ -616,6 +619,11 @@ Stack trace:
 
 A=Exit process R=Debug I=Continue";
             }
+            int idProcess = 0;
+            using (var process = Process.GetCurrentProcess())
+            {
+                idProcess = process.Id;
+            }
 
             string dialogMessage = string.Format(
                 CultureInfo.InvariantCulture,
@@ -623,35 +631,9 @@ A=Exit process R=Debug I=Continue";
                 message,
                 fileName, lineNumber,
                 COMPONENT,
-                Process.GetCurrentProcess().Id, Thread.CurrentThread.ManagedThreadId,
+                idProcess, Thread.CurrentThread.ManagedThreadId,
                 trace.ToString());
 
-            //MBResult mbResult = new MBResult();
-
-            //Thread thread = new Thread(
-            //    delegate() {
-            //        for (int i = 0; i < 100; i++) {
-            //            NativeMethods.MSG msg = new NativeMethods.MSG();
-            //            NativeMethods.PeekMessage(ref msg, new HandleRef(mbResult, IntPtr.Zero), 0, 0, NativeMethods.PM_REMOVE);
-            //        }
-
-            //        mbResult.Result = NativeMethods.MessageBox(new HandleRef(mbResult, IntPtr.Zero), dialogMessage, PRODUCT + " Assertion",                
-            //            NativeMethods.MB_SERVICE_NOTIFICATION | 
-            //            NativeMethods.MB_TOPMOST |
-            //            NativeMethods.MB_ABORTRETRYIGNORE | 
-            //            NativeMethods.MB_ICONEXCLAMATION);
-            //    }
-            //);
-
-            //thread.Start();
-            //thread.Join();
-
-            //if (mbResult.Result == NativeMethods.IDABORT) {
-            //    IntPtr currentProcess = NativeMethods.GetCurrentProcess();
-            //    NativeMethods.TerminateProcess(new HandleRef(mbResult, currentProcess), 1);
-            //}
-
-            //return mbResult.Result == NativeMethods.IDRETRY;
             Debug.Fail(dialogMessage);
             return true;
         }
@@ -832,22 +814,15 @@ A=Exit process R=Debug I=Continue";
         internal static void Break()
         {
 #if DEBUG
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && NativeMethods.IsDebuggerPresent()) 
             {
-                if (NativeMethods.IsDebuggerPresent()) 
-                {
-                    NativeMethods.DebugBreak();
-                }
-                else if (!Debugger.IsAttached) 
-                {
-                    Debugger.Launch();
-                }
-                else 
-                {
-                    Debugger.Break();            
-                }
+                NativeMethods.DebugBreak();
             }
-            else
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Debugger.IsAttached) 
+            {
+                Debugger.Launch();
+            }
+            else 
             {
                 Debugger.Break();            
             }

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheStatistics.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheStatistics.cs
@@ -147,6 +147,10 @@ namespace System.Runtime.Caching
                 _configCacheMemoryLimitMegabytes = ConfigUtil.GetIntValue(config, ConfigUtil.CacheMemoryLimitMegabytes, _configCacheMemoryLimitMegabytes, true, Int32.MaxValue);
                 _configPhysicalMemoryLimitPercentage = ConfigUtil.GetIntValue(config, ConfigUtil.PhysicalMemoryLimitPercentage, _configPhysicalMemoryLimitPercentage, true, 100);
             }
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && _configPhysicalMemoryLimitPercentage > 0)
+            {
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_PhysicalMemoryLimitPercentage);
+            }
         }
 
         private void InitDisposableMembers()

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.Windows.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.Windows.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Specialized;
+using System.Security;
+using System.Runtime.InteropServices;
+
+
+namespace System.Runtime.Caching
+{
+    internal abstract partial class MemoryMonitor
+    {
+        static MemoryMonitor()
+        {
+            Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx = default;
+            memoryStatusEx.dwLength = (uint)Marshal.SizeOf<Interop.Kernel32.MEMORYSTATUSEX>();
+            if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) != 0)
+            {
+                s_totalPhysical = (long)memoryStatusEx.ullTotalPhys;
+                s_totalVirtual = (long)memoryStatusEx.ullTotalVirtual;
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.cs
@@ -16,7 +16,7 @@ namespace System.Runtime.Caching
     // drop cache entries to avoid paging.  The second monitors the amount of memory used by
     // the cache itself, and helps determine when we should drop cache entries to avoid 
     // exceeding the cache's memory limit.  Both are configurable (see ConfigUtil.cs).
-    internal abstract class MemoryMonitor
+    internal abstract partial class MemoryMonitor
     {
         protected const int TERABYTE_SHIFT = 40;
         protected const long TERABYTE = 1L << TERABYTE_SHIFT;
@@ -39,25 +39,11 @@ namespace System.Runtime.Caching
         protected int[] _pressureHist;
         protected int _pressureTotal;
 
-        private static long s_totalPhysical;
-        private static long s_totalVirtual;
+        private static long s_totalPhysical = 0;
+        private static long s_totalVirtual = 0;
 
-        static MemoryMonitor()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx = default;
-                memoryStatusEx.dwLength = (uint)Marshal.SizeOf<Interop.Kernel32.MEMORYSTATUSEX>();
-                if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) != 0)
-                {
-                    s_totalPhysical = (long)memoryStatusEx.ullTotalPhys;
-                    s_totalVirtual = (long)memoryStatusEx.ullTotalVirtual;
-                }
-            }
-        }
-
-        internal static long TotalPhysical { get { return s_totalPhysical; } }
-        internal static long TotalVirtual { get { return s_totalVirtual; } }
+        internal static long TotalPhysical => s_totalPhysical;
+        internal static long TotalVirtual => s_totalVirtual;
 
         internal int PressureLast { get { return _pressureHist[_i0]; } }
         internal int PressureHigh { get { return _pressureHigh; } }

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.cs
@@ -44,12 +44,15 @@ namespace System.Runtime.Caching
 
         static MemoryMonitor()
         {
-            Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx;
-            memoryStatusEx.dwLength = (uint)Marshal.SizeOf(typeof(Interop.Kernel32.MEMORYSTATUSEX));
-            if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) != 0)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                s_totalPhysical = (long)memoryStatusEx.ullTotalPhys;
-                s_totalVirtual = (long)memoryStatusEx.ullTotalVirtual;
+                Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx = default;
+                memoryStatusEx.dwLength = (uint)Marshal.SizeOf(typeof(Interop.Kernel32.MEMORYSTATUSEX));
+                if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) != 0)
+                {
+                    s_totalPhysical = (long)memoryStatusEx.ullTotalPhys;
+                    s_totalVirtual = (long)memoryStatusEx.ullTotalVirtual;
+                }
             }
         }
 

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.cs
@@ -47,7 +47,7 @@ namespace System.Runtime.Caching
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx = default;
-                memoryStatusEx.dwLength = (uint)Marshal.SizeOf(typeof(Interop.Kernel32.MEMORYSTATUSEX));
+                memoryStatusEx.dwLength = (uint)Marshal.SizeOf<Interop.Kernel32.MEMORYSTATUSEX>();
                 if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) != 0)
                 {
                     s_totalPhysical = (long)memoryStatusEx.ullTotalPhys;

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Unix.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Unix.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Runtime.Caching
+{
+    internal sealed partial class PhysicalMemoryMonitor : MemoryMonitor
+    {
+        protected override int GetCurrentPressure()
+        {
+            return 0;
+        }
+    }
+}

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Windows.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Windows.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.Caching.Configuration;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace System.Runtime.Caching
+{
+    internal sealed partial class PhysicalMemoryMonitor : MemoryMonitor
+    {
+        protected override int GetCurrentPressure()
+        {
+            Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx = default;
+            memoryStatusEx.dwLength = (uint)Marshal.SizeOf<Interop.Kernel32.MEMORYSTATUSEX>();
+            if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) == 0)
+            {
+                return 0;
+            }
+
+            int memoryLoad = (int)memoryStatusEx.dwMemoryLoad;
+            return memoryLoad;
+        }
+    }
+}

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
@@ -12,7 +12,7 @@ namespace System.Runtime.Caching
     // PhysicalMemoryMonitor monitors the amound of physical memory used on the machine
     // and helps us determine when to drop entries to avoid paging and GC thrashing.
     // The limit is configurable (see ConfigUtil.cs).
-    internal sealed class PhysicalMemoryMonitor : MemoryMonitor
+    internal sealed partial class PhysicalMemoryMonitor : MemoryMonitor
     {
         private const int MIN_TOTAL_MEMORY_TRIM_PERCENT = 10;
         private static readonly long s_TARGET_TOTAL_MEMORY_TRIM_INTERVAL_TICKS = 5 * TimeSpan.TicksPerMinute;
@@ -48,7 +48,6 @@ namespace System.Runtime.Caching
             */
 
             long memory = TotalPhysical;
-            Dbg.Assert(memory != 0, "memory != 0");
             if (memory >= 0x100000000)
             {
                 _pressureHigh = 99;
@@ -74,26 +73,6 @@ namespace System.Runtime.Caching
 
             SetLimit(physicalMemoryLimitPercentage);
             InitHistory();
-        }
-
-        protected override int GetCurrentPressure()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx = default;
-                memoryStatusEx.dwLength = (uint)Marshal.SizeOf<Interop.Kernel32.MEMORYSTATUSEX>();
-                if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) == 0)
-                {
-                    return 0;
-                }
-
-                int memoryLoad = (int)memoryStatusEx.dwMemoryLoad;
-                return memoryLoad;
-            }
-            else
-            {
-                return 0;
-            }
         }
 
         internal override int GetPercentToTrim(DateTime lastTrimTime, int lastTrimPercent)

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
@@ -78,15 +78,22 @@ namespace System.Runtime.Caching
 
         protected override int GetCurrentPressure()
         {
-            Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx = default;
-            memoryStatusEx.dwLength = (uint)Marshal.SizeOf(typeof(Interop.Kernel32.MEMORYSTATUSEX));
-            if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) == 0)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx = default;
+                memoryStatusEx.dwLength = (uint)Marshal.SizeOf(typeof(Interop.Kernel32.MEMORYSTATUSEX));
+                if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) == 0)
+                {
+                    return 0;
+                }
+
+                int memoryLoad = (int)memoryStatusEx.dwMemoryLoad;
+                return memoryLoad;
+            }
+            else
             {
                 return 0;
             }
-
-            int memoryLoad = (int)memoryStatusEx.dwMemoryLoad;
-            return memoryLoad;
         }
 
         internal override int GetPercentToTrim(DateTime lastTrimTime, int lastTrimPercent)

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
@@ -81,7 +81,7 @@ namespace System.Runtime.Caching
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Interop.Kernel32.MEMORYSTATUSEX memoryStatusEx = default;
-                memoryStatusEx.dwLength = (uint)Marshal.SizeOf(typeof(Interop.Kernel32.MEMORYSTATUSEX));
+                memoryStatusEx.dwLength = (uint)Marshal.SizeOf<Interop.Kernel32.MEMORYSTATUSEX>();
                 if (Interop.Kernel32.GlobalMemoryStatusEx(out memoryStatusEx) == 0)
                 {
                     return 0;

--- a/src/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -145,6 +145,18 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Negative case for "physicalMemoryLimitPercentage" on non Windows
+        public void PhysicalMemoryLimitNotSupported()
+        {
+            var config = new NameValueCollection();
+            config.Add("PhysicalMemoryLimitPercentage", "99");
+            Assert.Throws<PlatformNotSupportedException>(() =>
+            {
+                new MemoryCache("MyCache", config);
+            });
+        }
+
+        [Fact]
         public void Defaults()
         {
             var mc = new MemoryCache("MyCache");
@@ -177,6 +189,7 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]  // Uses "physicalMemoryLimitPercentage" not supported on other platforms
         public void ConstructorValues()
         {
             var config = new NameValueCollection();
@@ -992,6 +1005,7 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]  // Uses "physicalMemoryLimitPercentage" not supported on other platforms
         public void TestExpiredGetValues()
         {
             var config = new NameValueCollection();
@@ -1025,6 +1039,7 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]  // Uses "physicalMemoryLimitPercentage" not supported on other platforms
         [OuterLoop] // makes long wait
         public void TestCacheSliding()
         {
@@ -1332,6 +1347,7 @@ namespace MonoTests.System.Runtime.Caching
     public class MemoryCacheTestExpires4
     {
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]  // Uses "physicalMemoryLimitPercentage" not supported on other platforms
         public async Task TestCacheShrink()
         {
             const int HEAP_RESIZE_THRESHOLD = 8192 + 2;
@@ -1389,6 +1405,7 @@ namespace MonoTests.System.Runtime.Caching
     public class MemoryCacheTestExpires5
     {
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]  // Uses "physicalMemoryLimitPercentage" not supported on other platforms
         public async Task TestCacheExpiryOrdering()
         {
             var config = new NameValueCollection();


### PR DESCRIPTION
The only significant difference with Windows is that an attempt to set PhysicalMemoryLimitPercentage config parameter will result in PNSE on Linux as we don't support a notion of memory pressure on Linux yet.