### PR TITLE
Make AsnWriter IDisposable

### DIFF
--- a/src/Common/src/System/Security/Cryptography/AsnWriter.cs
+++ b/src/Common/src/System/Security/Cryptography/AsnWriter.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Security.Cryptography.Asn1
 {
-    internal class AsnWriter
+    internal sealed class AsnWriter : IDisposable
     {
         private byte[] _buffer;
         private int _offset;
@@ -33,6 +33,19 @@ namespace System.Security.Cryptography.Asn1
             }
 
             RuleSet = ruleSet;
+        }
+
+        public void Dispose()
+        {
+            _nestingStack = null;
+
+            if (_buffer != null)
+            {
+                Array.Clear(_buffer, 0, _offset);
+                ArrayPool<byte>.Shared.Return(_buffer);
+                _buffer = null;
+                _offset = 0;
+            }
         }
 
         private void EnsureWriteCapacity(int pendingCount)

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Serializer/SimpleSerialize.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Serializer/SimpleSerialize.cs
@@ -21,14 +21,16 @@ namespace System.Security.Cryptography.Tests.Asn1
                 Parameters = new byte[] { 5, 0 },
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(identifier, AsnEncodingRules.DER);
+            using (AsnWriter writer = AsnSerializer.Serialize(identifier, AsnEncodingRules.DER))
+            {
 
-            const string ExpectedHex =
-                "300D" +
-                    "0609608648016503040201" +
-                    "0500";
+                const string ExpectedHex =
+                    "300D" +
+                        "0609608648016503040201" +
+                        "0500";
 
-            Assert.Equal(ExpectedHex, writer.Encode().ByteArrayToHex());
+                Assert.Equal(ExpectedHex, writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -40,15 +42,16 @@ namespace System.Security.Cryptography.Tests.Asn1
                 Parameters = new byte[] { 5, 0 },
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(identifier, AsnEncodingRules.CER);
+            using (AsnWriter writer = AsnSerializer.Serialize(identifier, AsnEncodingRules.CER))
+            {
+                const string ExpectedHex =
+                    "3080" +
+                        "0609608648016503040201" +
+                        "0500" +
+                        "0000";
 
-            const string ExpectedHex =
-                "3080" +
-                    "0609608648016503040201" +
-                    "0500" +
-                    "0000";
-
-            Assert.Equal(ExpectedHex, writer.Encode().ByteArrayToHex());
+                Assert.Equal(ExpectedHex, writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -147,17 +150,21 @@ namespace System.Security.Cryptography.Tests.Asn1
                 BigInteger = BigInteger.Parse("0102030405060708090A0B0C0D0E0F", NumberStyles.HexNumber),
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(allTheThings, AsnEncodingRules.CER);
-            Assert.Equal(ExpectedHex, writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(allTheThings, AsnEncodingRules.CER))
+            {
+                Assert.Equal(ExpectedHex, writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
         public static void SerializeChoice_Null()
         {
             DirectoryStringClass directoryString = default;
-            AsnWriter writer = AsnSerializer.Serialize(directoryString, AsnEncodingRules.DER);
 
-            Assert.Equal("0500", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(directoryString, AsnEncodingRules.DER))
+            {
+                Assert.Equal("0500", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -168,8 +175,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 Utf8String = "UTF8",
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(directoryString, AsnEncodingRules.DER);
-            Assert.Equal("0C0455544638", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(directoryString, AsnEncodingRules.DER))
+            {
+                Assert.Equal("0C0455544638", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -180,8 +189,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 BmpString = "BMP",
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(directoryString, AsnEncodingRules.DER);
-            Assert.Equal("1E060042004D0050", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(directoryString, AsnEncodingRules.DER))
+            {
+                Assert.Equal("1E060042004D0050", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -192,8 +203,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 PrintableString = "Printable",
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(directoryString, AsnEncodingRules.DER);
-            Assert.Equal("13095072696E7461626C65", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(directoryString, AsnEncodingRules.DER))
+            {
+                Assert.Equal("13095072696E7461626C65", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -226,8 +239,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 Ascii = "IA5",
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER);
-            Assert.Equal("1603494135", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER))
+            {
+                Assert.Equal("1603494135", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -241,8 +256,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 },
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER);
-            Assert.Equal("0C054D6172636F", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER))
+            {
+                Assert.Equal("0C054D6172636F", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -256,8 +273,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 },
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER);
-            Assert.Equal("1E080050006F006C006F", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER))
+            {
+                Assert.Equal("1E080050006F006C006F", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -271,8 +290,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 },
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER);
-            Assert.Equal("1E080050006F006C006F", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER))
+            {
+                Assert.Equal("1E080050006F006C006F", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -286,8 +307,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 },
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER);
-            Assert.Equal("0C054D6172636F", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER))
+            {
+                Assert.Equal("0C054D6172636F", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -298,8 +321,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 Ascii = "IA5",
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER);
-            Assert.Equal("1603494135", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(hybrid, AsnEncodingRules.DER))
+            {
+                Assert.Equal("1603494135", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -310,8 +335,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 DefaultMode = SomeFlagsEnum.BitEleven | SomeFlagsEnum.BitTwo | SomeFlagsEnum.BitFourteen
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(flagsContainer, AsnEncodingRules.DER);
-            Assert.Equal("30050303012012", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(flagsContainer, AsnEncodingRules.DER))
+            {
+                Assert.Equal("30050303012012", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -324,8 +351,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 ExtnValue = new byte[] { 0x30, 0x00 },
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(extension, AsnEncodingRules.DER);
-            Assert.Equal("30090603551D1304023000", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(extension, AsnEncodingRules.DER))
+            {
+                Assert.Equal("30090603551D1304023000", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -338,8 +367,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 ExtnValue = new byte[] { 0x03, 0x02, 0x05, 0xA0 },
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(extension, AsnEncodingRules.DER);
-            Assert.Equal("300E0603551D0F0101FF0404030205A0", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(extension, AsnEncodingRules.DER))
+            {
+                Assert.Equal("300E0603551D0F0101FF0404030205A0", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -351,8 +382,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 ImplicitInt = 0x17,
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(data, AsnEncodingRules.DER);
-            Assert.Equal("3008A003020103020117", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(data, AsnEncodingRules.DER))
+            {
+                Assert.Equal("3008A003020103020117", writer.Encode().ByteArrayToHex());
+            }
         }
 
         [Fact]
@@ -366,8 +399,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 Data = anyValue,
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(data, AsnEncodingRules.DER);
-            Assert.Equal("30080601003003010100", writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(data, AsnEncodingRules.DER))
+            {
+                Assert.Equal("30080601003003010100", writer.Encode().ByteArrayToHex());
+            }
 
             anyValue[0] = 0xA0;
 
@@ -387,8 +422,10 @@ namespace System.Security.Cryptography.Tests.Asn1
                 IA5String = hasIa5 ? "IA5" : null,
             };
 
-            AsnWriter writer = AsnSerializer.Serialize(data, AsnEncodingRules.DER);
-            Assert.Equal(expectedHex, writer.Encode().ByteArrayToHex());
+            using (AsnWriter writer = AsnSerializer.Serialize(data, AsnEncodingRules.DER))
+            {
+                Assert.Equal(expectedHex, writer.Encode().ByteArrayToHex());
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/ComprehensiveWriteTest.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/ComprehensiveWriteTest.cs
@@ -16,247 +16,265 @@ namespace System.Security.Cryptography.Tests.Asn1
         [Fact]
         public static void WriteMicrosoftDotComCert()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            // Certificate
-            writer.PushSequence();
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                // Certificate
+                writer.PushSequence();
 
-            // tbsCertificate
-            writer.PushSequence();
+                // tbsCertificate
+                writer.PushSequence();
 
-            // version ([0] EXPLICIT INTEGER)
-            Asn1Tag context0 = new Asn1Tag(TagClass.ContextSpecific, 0, true);
-            writer.PushSequence(context0);
-            writer.WriteInteger(2);
-            writer.PopSequence(context0);
+                // version ([0] EXPLICIT INTEGER)
+                Asn1Tag context0 = new Asn1Tag(TagClass.ContextSpecific, 0, true);
+                writer.PushSequence(context0);
+                writer.WriteInteger(2);
+                writer.PopSequence(context0);
 
-            BigInteger serialValue = BigInteger.Parse("82365655871428336739211871484630851433");
-            writer.WriteInteger(serialValue);
+                BigInteger serialValue = BigInteger.Parse("82365655871428336739211871484630851433");
+                writer.WriteInteger(serialValue);
 
-            // signature (algorithm)
-            writer.PushSequence();
-            writer.WriteObjectIdentifier("1.2.840.113549.1.1.11");
-            writer.WriteNull();
-            writer.PopSequence();
+                // signature (algorithm)
+                writer.PushSequence();
+                writer.WriteObjectIdentifier("1.2.840.113549.1.1.11");
+                writer.WriteNull();
+                writer.PopSequence();
 
-            // issuer
-            writer.PushSequence();
-            WriteRdn(writer, "2.5.4.6", "US", UniversalTagNumber.PrintableString);
-            WriteRdn(writer, "2.5.4.10", "Symantec Corporation", UniversalTagNumber.PrintableString);
-            WriteRdn(writer, "2.5.4.11", "Symantec Trust Network", UniversalTagNumber.PrintableString);
-            WriteRdn(writer, "2.5.4.3", "Symantec Class 3 EV SSL CA - G3", UniversalTagNumber.PrintableString);
-            writer.PopSequence();
+                // issuer
+                writer.PushSequence();
+                WriteRdn(writer, "2.5.4.6", "US", UniversalTagNumber.PrintableString);
+                WriteRdn(writer, "2.5.4.10", "Symantec Corporation", UniversalTagNumber.PrintableString);
+                WriteRdn(writer, "2.5.4.11", "Symantec Trust Network", UniversalTagNumber.PrintableString);
+                WriteRdn(writer, "2.5.4.3", "Symantec Class 3 EV SSL CA - G3", UniversalTagNumber.PrintableString);
+                writer.PopSequence();
 
-            // validity
-            writer.PushSequence();
-            writer.WriteUtcTime(new DateTimeOffset(2014, 10, 15, 0, 0, 0, TimeSpan.Zero));
-            writer.WriteUtcTime(new DateTimeOffset(2016, 10, 15, 23, 59, 59, TimeSpan.Zero));
-            writer.PopSequence();
+                // validity
+                writer.PushSequence();
+                writer.WriteUtcTime(new DateTimeOffset(2014, 10, 15, 0, 0, 0, TimeSpan.Zero));
+                writer.WriteUtcTime(new DateTimeOffset(2016, 10, 15, 23, 59, 59, TimeSpan.Zero));
+                writer.PopSequence();
 
-            // subject
-            writer.PushSequence();
-            WriteRdn(writer, "1.3.6.1.4.1.311.60.2.1.3", "US", UniversalTagNumber.PrintableString);
-            WriteRdn(writer, "1.3.6.1.4.1.311.60.2.1.2", "Washington", UniversalTagNumber.UTF8String);
-            WriteRdn(writer, "2.5.4.15", "Private Organization", UniversalTagNumber.PrintableString);
-            WriteRdn(writer, "2.5.4.5", "600413485", UniversalTagNumber.PrintableString);
-            WriteRdn(writer, "2.5.4.6", "US", UniversalTagNumber.PrintableString);
-            WriteRdn(writer, "2.5.4.17", "98052", UniversalTagNumber.UTF8String);
-            WriteRdn(writer, "2.5.4.8", "Washington", UniversalTagNumber.UTF8String);
-            WriteRdn(writer, "2.5.4.7", "Redmond", UniversalTagNumber.UTF8String);
-            WriteRdn(writer, "2.5.4.9", "1 Microsoft Way", UniversalTagNumber.UTF8String);
-            WriteRdn(writer, "2.5.4.10", "Microsoft Corporation", UniversalTagNumber.UTF8String);
-            WriteRdn(writer, "2.5.4.11", "MSCOM", UniversalTagNumber.UTF8String);
-            WriteRdn(writer, "2.5.4.3", "www.microsoft.com", UniversalTagNumber.UTF8String);
-            writer.PopSequence();
+                // subject
+                writer.PushSequence();
+                WriteRdn(writer, "1.3.6.1.4.1.311.60.2.1.3", "US", UniversalTagNumber.PrintableString);
+                WriteRdn(writer, "1.3.6.1.4.1.311.60.2.1.2", "Washington", UniversalTagNumber.UTF8String);
+                WriteRdn(writer, "2.5.4.15", "Private Organization", UniversalTagNumber.PrintableString);
+                WriteRdn(writer, "2.5.4.5", "600413485", UniversalTagNumber.PrintableString);
+                WriteRdn(writer, "2.5.4.6", "US", UniversalTagNumber.PrintableString);
+                WriteRdn(writer, "2.5.4.17", "98052", UniversalTagNumber.UTF8String);
+                WriteRdn(writer, "2.5.4.8", "Washington", UniversalTagNumber.UTF8String);
+                WriteRdn(writer, "2.5.4.7", "Redmond", UniversalTagNumber.UTF8String);
+                WriteRdn(writer, "2.5.4.9", "1 Microsoft Way", UniversalTagNumber.UTF8String);
+                WriteRdn(writer, "2.5.4.10", "Microsoft Corporation", UniversalTagNumber.UTF8String);
+                WriteRdn(writer, "2.5.4.11", "MSCOM", UniversalTagNumber.UTF8String);
+                WriteRdn(writer, "2.5.4.3", "www.microsoft.com", UniversalTagNumber.UTF8String);
+                writer.PopSequence();
 
-            // subjectPublicKeyInfo
-            writer.PushSequence();
-            // subjectPublicKeyInfo.algorithm
-            writer.PushSequence();
-            writer.WriteObjectIdentifier("1.2.840.113549.1.1.1");
-            writer.WriteNull();
-            writer.PopSequence();
+                // subjectPublicKeyInfo
+                writer.PushSequence();
+                // subjectPublicKeyInfo.algorithm
+                writer.PushSequence();
+                writer.WriteObjectIdentifier("1.2.840.113549.1.1.1");
+                writer.WriteNull();
+                writer.PopSequence();
 
-            AsnWriter publicKeyWriter = new AsnWriter(AsnEncodingRules.DER);
-            publicKeyWriter.PushSequence();
-            BigInteger modulus = BigInteger.Parse(
-                "207545550571844404676608632512851454930111394466749205318948660756381" +
-                "523214360115124048083611193260260272384440199925180817531535965931647" +
-                "037093368608713442955529617501657176146245891571745113402870077189045" +
-                "116705181899983704226178882882602868159586789723579670915035003754974" +
-                "985730226756711782751711104985926458681071638525996766798322809764200" +
-                "941677343791419428587801897366593842552727222686457866144928124161967" +
-                "521735393182823375650694786333059783380738262856873316471830589717911" +
-                "537307419734834201104082715701367336140572971505716740825623220507359" +
-                "42929758463490933054115079473593821332264673455059897928082590541");
-            publicKeyWriter.WriteInteger(modulus);
-            publicKeyWriter.WriteInteger(65537);
-            publicKeyWriter.PopSequence();
+                using (AsnWriter publicKeyWriter = new AsnWriter(AsnEncodingRules.DER))
+                {
+                    publicKeyWriter.PushSequence();
+                    BigInteger modulus = BigInteger.Parse(
+                        "207545550571844404676608632512851454930111394466749205318948660756381" +
+                        "523214360115124048083611193260260272384440199925180817531535965931647" +
+                        "037093368608713442955529617501657176146245891571745113402870077189045" +
+                        "116705181899983704226178882882602868159586789723579670915035003754974" +
+                        "985730226756711782751711104985926458681071638525996766798322809764200" +
+                        "941677343791419428587801897366593842552727222686457866144928124161967" +
+                        "521735393182823375650694786333059783380738262856873316471830589717911" +
+                        "537307419734834201104082715701367336140572971505716740825623220507359" +
+                        "42929758463490933054115079473593821332264673455059897928082590541");
+                    publicKeyWriter.WriteInteger(modulus);
+                    publicKeyWriter.WriteInteger(65537);
+                    publicKeyWriter.PopSequence();
 
-            // subjectPublicKeyInfo.subjectPublicKey
-            writer.WriteBitString(publicKeyWriter.Encode());
-            writer.PopSequence();
-            
-            // extensions ([3] EXPLICIT Extensions)
-            Asn1Tag context3 = new Asn1Tag(TagClass.ContextSpecific, 3);
-            writer.PushSequence(context3);
-            writer.PushSequence();
+                    // subjectPublicKeyInfo.subjectPublicKey
+                    writer.WriteBitString(publicKeyWriter.Encode());
+                    writer.PopSequence();
+                }
 
-            Asn1Tag dnsName = new Asn1Tag(TagClass.ContextSpecific, 2);
-            AsnWriter extensionValueWriter = new AsnWriter(AsnEncodingRules.DER);
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.WriteCharacterString(dnsName, UniversalTagNumber.IA5String, "www.microsoft.com");
-            extensionValueWriter.WriteCharacterString(dnsName, UniversalTagNumber.IA5String, "wwwqa.microsoft.com");
-            extensionValueWriter.PopSequence();
+                // extensions ([3] EXPLICIT Extensions)
+                Asn1Tag context3 = new Asn1Tag(TagClass.ContextSpecific, 3);
+                writer.PushSequence(context3);
+                writer.PushSequence();
 
-            writer.PushSequence();
-            writer.WriteObjectIdentifier("2.5.29.17");
-            writer.WriteOctetString(extensionValueWriter.Encode());
-            writer.PopSequence();
+                Asn1Tag dnsName = new Asn1Tag(TagClass.ContextSpecific, 2);
 
-            writer.PushSequence();
-            writer.WriteObjectIdentifier("2.5.29.19");
-            // Empty sequence as the payload for a non-CA basic constraint.
-            writer.WriteOctetString(new byte[] { 0x30, 0x00 });
-            writer.PopSequence();
+                using (AsnWriter extensionValueWriter = new AsnWriter(AsnEncodingRules.DER))
+                {
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.WriteCharacterString(dnsName, UniversalTagNumber.IA5String, "www.microsoft.com");
+                    extensionValueWriter.WriteCharacterString(dnsName, UniversalTagNumber.IA5String, "wwwqa.microsoft.com");
+                    extensionValueWriter.PopSequence();
 
-            extensionValueWriter = new AsnWriter(AsnEncodingRules.DER);
-            // This extension doesn't use a sequence at all, just Named Bit List.
-            extensionValueWriter.WriteNamedBitList(
-                X509KeyUsageCSharpStyle.DigitalSignature | X509KeyUsageCSharpStyle.KeyEncipherment);
+                    writer.PushSequence();
+                    writer.WriteObjectIdentifier("2.5.29.17");
+                    writer.WriteOctetString(extensionValueWriter.Encode());
+                    writer.PopSequence();
+                }
 
-            writer.PushSequence();
-            writer.WriteObjectIdentifier("2.5.29.15");
-            // critical: true
-            writer.WriteBoolean(true);
-            writer.WriteOctetString(extensionValueWriter.Encode());
-            writer.PopSequence();
+                writer.PushSequence();
+                writer.WriteObjectIdentifier("2.5.29.19");
+                // Empty sequence as the payload for a non-CA basic constraint.
+                writer.WriteOctetString(new byte[] { 0x30, 0x00 });
+                writer.PopSequence();
 
-            extensionValueWriter = new AsnWriter(AsnEncodingRules.DER);
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.3.1");
-            extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.3.2");
-            extensionValueWriter.PopSequence();
+                using (AsnWriter extensionValueWriter = new AsnWriter(AsnEncodingRules.DER))
+                {
+                    // This extension doesn't use a sequence at all, just Named Bit List.
+                    extensionValueWriter.WriteNamedBitList(
+                        X509KeyUsageCSharpStyle.DigitalSignature | X509KeyUsageCSharpStyle.KeyEncipherment);
 
-            writer.PushSequence();
-            writer.WriteObjectIdentifier("2.5.29.37");
-            writer.WriteOctetString(extensionValueWriter.Encode());
-            writer.PopSequence();
+                    writer.PushSequence();
+                    writer.WriteObjectIdentifier("2.5.29.15");
+                    // critical: true
+                    writer.WriteBoolean(true);
+                    writer.WriteOctetString(extensionValueWriter.Encode());
+                    writer.PopSequence();
+                }
 
-            extensionValueWriter = new AsnWriter(AsnEncodingRules.DER);
+                using (AsnWriter extensionValueWriter = new AsnWriter(AsnEncodingRules.DER))
+                {
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.3.1");
+                    extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.3.2");
+                    extensionValueWriter.PopSequence();
 
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.WriteObjectIdentifier("2.16.840.1.113733.1.7.23.6");
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.2.1");
-            extensionValueWriter.WriteCharacterString(UniversalTagNumber.IA5String, "https://d.symcb.com/cps");
-            extensionValueWriter.PopSequence();
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.2.2");
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.WriteCharacterString(UniversalTagNumber.VisibleString, "https://d.symcb.com/rpa");
-            extensionValueWriter.PopSequence();
-            extensionValueWriter.PopSequence();
-            extensionValueWriter.PopSequence();
-            extensionValueWriter.PopSequence();
-            extensionValueWriter.PopSequence();
+                    writer.PushSequence();
+                    writer.WriteObjectIdentifier("2.5.29.37");
+                    writer.WriteOctetString(extensionValueWriter.Encode());
+                    writer.PopSequence();
+                }
 
-            writer.PushSequence();
-            writer.WriteObjectIdentifier("2.5.29.32");
-            writer.WriteOctetString(extensionValueWriter.Encode());
-            writer.PopSequence();
+                using (AsnWriter extensionValueWriter = new AsnWriter(AsnEncodingRules.DER))
+                {
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.WriteObjectIdentifier("2.16.840.1.113733.1.7.23.6");
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.2.1");
+                    extensionValueWriter.WriteCharacterString(UniversalTagNumber.IA5String, "https://d.symcb.com/cps");
+                    extensionValueWriter.PopSequence();
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.2.2");
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.WriteCharacterString(UniversalTagNumber.VisibleString, "https://d.symcb.com/rpa");
+                    extensionValueWriter.PopSequence();
+                    extensionValueWriter.PopSequence();
+                    extensionValueWriter.PopSequence();
+                    extensionValueWriter.PopSequence();
+                    extensionValueWriter.PopSequence();
 
-            byte[] authorityKeyIdentifier = "0159ABE7DD3A0B59A66463D6CF200757D591E76A".HexToByteArray();
-            Asn1Tag keyIdentifier = context0;
-            extensionValueWriter = new AsnWriter(AsnEncodingRules.DER);
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.WriteOctetString(keyIdentifier, authorityKeyIdentifier);
-            extensionValueWriter.PopSequence();
+                    writer.PushSequence();
+                    writer.WriteObjectIdentifier("2.5.29.32");
+                    writer.WriteOctetString(extensionValueWriter.Encode());
+                    writer.PopSequence();
+                }
 
-            writer.PushSequence();
-            writer.WriteObjectIdentifier("2.5.29.35");
-            writer.WriteOctetString(extensionValueWriter.Encode());
-            writer.PopSequence();
+                byte[] authorityKeyIdentifier = "0159ABE7DD3A0B59A66463D6CF200757D591E76A".HexToByteArray();
+                Asn1Tag keyIdentifier = context0;
+                using (AsnWriter extensionValueWriter = new AsnWriter(AsnEncodingRules.DER))
+                {
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.WriteOctetString(keyIdentifier, authorityKeyIdentifier);
+                    extensionValueWriter.PopSequence();
 
-            Asn1Tag distributionPointChoice = context0;
-            Asn1Tag fullNameChoice = context0;
-            Asn1Tag generalNameUriChoice = new Asn1Tag(TagClass.ContextSpecific, 6);
-            extensionValueWriter = new AsnWriter(AsnEncodingRules.DER);
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.PushSequence(distributionPointChoice);
-            extensionValueWriter.PushSequence(fullNameChoice);
-            extensionValueWriter.WriteCharacterString(
-                generalNameUriChoice,
-                UniversalTagNumber.IA5String,
-                "http://sr.symcb.com/sr.crl");
-            extensionValueWriter.PopSequence(fullNameChoice);
-            extensionValueWriter.PopSequence(distributionPointChoice);
-            extensionValueWriter.PopSequence();
-            extensionValueWriter.PopSequence();
+                    writer.PushSequence();
+                    writer.WriteObjectIdentifier("2.5.29.35");
+                    writer.WriteOctetString(extensionValueWriter.Encode());
+                    writer.PopSequence();
+                }
 
-            writer.PushSequence();
-            writer.WriteObjectIdentifier("2.5.29.31");
-            writer.WriteOctetString(extensionValueWriter.Encode());
-            writer.PopSequence();
+                Asn1Tag distributionPointChoice = context0;
+                Asn1Tag fullNameChoice = context0;
+                Asn1Tag generalNameUriChoice = new Asn1Tag(TagClass.ContextSpecific, 6);
+                using (AsnWriter extensionValueWriter = new AsnWriter(AsnEncodingRules.DER))
+                {
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.PushSequence(distributionPointChoice);
+                    extensionValueWriter.PushSequence(fullNameChoice);
+                    extensionValueWriter.WriteCharacterString(
+                        generalNameUriChoice,
+                        UniversalTagNumber.IA5String,
+                        "http://sr.symcb.com/sr.crl");
+                    extensionValueWriter.PopSequence(fullNameChoice);
+                    extensionValueWriter.PopSequence(distributionPointChoice);
+                    extensionValueWriter.PopSequence();
+                    extensionValueWriter.PopSequence();
 
-            extensionValueWriter = new AsnWriter(AsnEncodingRules.DER);
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.48.1");
-            extensionValueWriter.WriteCharacterString(
-                generalNameUriChoice,
-                UniversalTagNumber.IA5String,
-                "http://sr.symcd.com");
-            extensionValueWriter.PopSequence();
-            extensionValueWriter.PushSequence();
-            extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.48.2");
-            extensionValueWriter.WriteCharacterString(
-                generalNameUriChoice,
-                UniversalTagNumber.IA5String,
-                "http://sr.symcb.com/sr.crt");
-            extensionValueWriter.PopSequence();
-            extensionValueWriter.PopSequence();
+                    writer.PushSequence();
+                    writer.WriteObjectIdentifier("2.5.29.31");
+                    writer.WriteOctetString(extensionValueWriter.Encode());
+                    writer.PopSequence();
+                }
 
-            writer.PushSequence();
-            writer.WriteObjectIdentifier("1.3.6.1.5.5.7.1.1");
-            writer.WriteOctetString(extensionValueWriter.Encode());
-            writer.PopSequence();
+                using (AsnWriter extensionValueWriter = new AsnWriter(AsnEncodingRules.DER))
+                {
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.48.1");
+                    extensionValueWriter.WriteCharacterString(
+                        generalNameUriChoice,
+                        UniversalTagNumber.IA5String,
+                        "http://sr.symcd.com");
+                    extensionValueWriter.PopSequence();
+                    extensionValueWriter.PushSequence();
+                    extensionValueWriter.WriteObjectIdentifier("1.3.6.1.5.5.7.48.2");
+                    extensionValueWriter.WriteCharacterString(
+                        generalNameUriChoice,
+                        UniversalTagNumber.IA5String,
+                        "http://sr.symcb.com/sr.crt");
+                    extensionValueWriter.PopSequence();
+                    extensionValueWriter.PopSequence();
 
-            writer.PopSequence();
-            writer.PopSequence(context3);
+                    writer.PushSequence();
+                    writer.WriteObjectIdentifier("1.3.6.1.5.5.7.1.1");
+                    writer.WriteOctetString(extensionValueWriter.Encode());
+                    writer.PopSequence();
+                }
 
-            // tbsCertificate
-            writer.PopSequence();
+                writer.PopSequence();
+                writer.PopSequence(context3);
 
-            // signatureAlgorithm
-            writer.PushSequence();
-            writer.WriteObjectIdentifier("1.2.840.113549.1.1.11");
-            writer.WriteNull();
-            writer.PopSequence();
+                // tbsCertificate
+                writer.PopSequence();
 
-            // signature
-            byte[] containsSignature = (
-                "010203040506070809" +
-                "15F8505B627ED7F9F96707097E93A51E7A7E05A3D420A5C258EC7A1CFE1843EC" +
-                "20ACF728AAFA7A1A1BC222A7CDBF4AF90AA26DEEB3909C0B3FB5C78070DAE3D6" +
-                "45BFCF840A4A3FDD988C7B3308BFE4EB3FD66C45641E96CA3352DBE2AEB4488A" +
-                "64A9C5FB96932BA70059CE92BD278B41299FD213471BD8165F924285AE3ECD66" +
-                "6C703885DCA65D24DA66D3AFAE39968521995A4C398C7DF38DFA82A20372F13D" +
-                "4A56ADB21B5822549918015647B5F8AC131CC5EB24534D172BC60218A88B65BC" +
-                "F71C7F388CE3E0EF697B4203720483BB5794455B597D80D48CD3A1D73CBBC609" +
-                "C058767D1FF060A609D7E3D4317079AF0CD0A8A49251AB129157F9894A036487" +
-                "090807060504030201").HexToByteArray();
+                // signatureAlgorithm
+                writer.PushSequence();
+                writer.WriteObjectIdentifier("1.2.840.113549.1.1.11");
+                writer.WriteNull();
+                writer.PopSequence();
 
-            writer.WriteBitString(containsSignature.AsReadOnlySpan().Slice(9, 256));
+                // signature
+                byte[] containsSignature = (
+                    "010203040506070809" +
+                    "15F8505B627ED7F9F96707097E93A51E7A7E05A3D420A5C258EC7A1CFE1843EC" +
+                    "20ACF728AAFA7A1A1BC222A7CDBF4AF90AA26DEEB3909C0B3FB5C78070DAE3D6" +
+                    "45BFCF840A4A3FDD988C7B3308BFE4EB3FD66C45641E96CA3352DBE2AEB4488A" +
+                    "64A9C5FB96932BA70059CE92BD278B41299FD213471BD8165F924285AE3ECD66" +
+                    "6C703885DCA65D24DA66D3AFAE39968521995A4C398C7DF38DFA82A20372F13D" +
+                    "4A56ADB21B5822549918015647B5F8AC131CC5EB24534D172BC60218A88B65BC" +
+                    "F71C7F388CE3E0EF697B4203720483BB5794455B597D80D48CD3A1D73CBBC609" +
+                    "C058767D1FF060A609D7E3D4317079AF0CD0A8A49251AB129157F9894A036487" +
+                    "090807060504030201").HexToByteArray();
 
-            // certificate
-            writer.PopSequence();
+                writer.WriteBitString(containsSignature.AsReadOnlySpan().Slice(9, 256));
 
-            Assert.Equal(
-                ComprehensiveReadTests.MicrosoftDotComSslCertBytes.ByteArrayToHex(),
-                writer.Encode().ByteArrayToHex());
+                // certificate
+                writer.PopSequence();
+
+                Assert.Equal(
+                    ComprehensiveReadTests.MicrosoftDotComSslCertBytes.ByteArrayToHex(),
+                    writer.Encode().ByteArrayToHex());
+            }
         }
 
         private static void WriteRdn(AsnWriter writer, string oid, string value, UniversalTagNumber valueType)

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/PushPopSequence.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/PushPopSequence.cs
@@ -17,12 +17,13 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PopNewWriter(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            // Maybe ArgumentException isn't right for this, since no argument was provided.
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSequence());
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                // Maybe ArgumentException isn't right for this, since no argument was provided.
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSequence());
+            }
         }
 
         [Theory]
@@ -31,11 +32,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PopNewWriter_CustomTag(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+            }
         }
 
         [Theory]
@@ -44,14 +46,16 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PopBalancedWriter(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSequence();
-            writer.PopSequence();
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSequence();
+                writer.PopSequence();
 
-            // Maybe ArgumentException isn't right for this, since no argument was provided.
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSequence());
+                // Maybe ArgumentException isn't right for this, since no argument was provided.
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSequence());
+            }
         }
 
         [Theory]
@@ -60,13 +64,15 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PopBalancedWriter_CustomTag(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSequence();
-            writer.PopSequence();
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSequence();
+                writer.PopSequence();
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+            }
         }
 
         [Theory]
@@ -75,13 +81,15 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushCustom_PopStandard(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true));
 
-            // Maybe ArgumentException isn't right for this, since no argument was provided.
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSequence());
+                // Maybe ArgumentException isn't right for this, since no argument was provided.
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSequence());
+            }
         }
 
         [Theory]
@@ -90,12 +98,14 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushStandard_PopCustom(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSequence();
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSequence();
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+            }
         }
 
         [Theory]
@@ -104,17 +114,19 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushPrimitive_PopStandard(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSequence(new Asn1Tag(UniversalTagNumber.Sequence));
-            writer.PopSequence();
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSequence(new Asn1Tag(UniversalTagNumber.Sequence));
+                writer.PopSequence();
 
-            if (ruleSet == PublicEncodingRules.CER)
-            {
-                Verify(writer, "30800000");
-            }
-            else
-            {
-                Verify(writer, "3000");
+                if (ruleSet == PublicEncodingRules.CER)
+                {
+                    Verify(writer, "30800000");
+                }
+                else
+                {
+                    Verify(writer, "3000");
+                }
             }
         }
 
@@ -124,17 +136,19 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushCustomPrimitive_PopConstructed(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSequence(new Asn1Tag(TagClass.Private, 5));
-            writer.PopSequence(new Asn1Tag(TagClass.Private, 5, true));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSequence(new Asn1Tag(TagClass.Private, 5));
+                writer.PopSequence(new Asn1Tag(TagClass.Private, 5, true));
 
-            if (ruleSet == PublicEncodingRules.CER)
-            {
-                Verify(writer, "E5800000");
-            }
-            else
-            {
-                Verify(writer, "E500");
+                if (ruleSet == PublicEncodingRules.CER)
+                {
+                    Verify(writer, "E5800000");
+                }
+                else
+                {
+                    Verify(writer, "E500");
+                }
             }
         }
 
@@ -144,17 +158,19 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushStandard_PopPrimitive(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSequence();
-            writer.PopSequence(new Asn1Tag(UniversalTagNumber.Sequence, isConstructed: false));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSequence();
+                writer.PopSequence(new Asn1Tag(UniversalTagNumber.Sequence, isConstructed: false));
 
-            if (ruleSet == PublicEncodingRules.CER)
-            {
-                Verify(writer, "30800000");
-            }
-            else
-            {
-                Verify(writer, "3000");
+                if (ruleSet == PublicEncodingRules.CER)
+                {
+                    Verify(writer, "30800000");
+                }
+                else
+                {
+                    Verify(writer, "3000");
+                }
             }
         }
 
@@ -164,78 +180,92 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushCustomConstructed_PopPrimitive(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSequence(new Asn1Tag(TagClass.Private, (int)ruleSet, true));
-            writer.PopSequence(new Asn1Tag(TagClass.Private, (int)ruleSet));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSequence(new Asn1Tag(TagClass.Private, (int)ruleSet, true));
+                writer.PopSequence(new Asn1Tag(TagClass.Private, (int)ruleSet));
 
-            byte tag = (byte)((int)ruleSet | 0b1110_0000);
-            string tagHex = tag.ToString("X2");
-            string rest = ruleSet == PublicEncodingRules.CER ? "800000" : "00";
+                byte tag = (byte)((int)ruleSet | 0b1110_0000);
+                string tagHex = tag.ToString("X2");
+                string rest = ruleSet == PublicEncodingRules.CER ? "800000" : "00";
 
-            Verify(writer, tagHex + rest);
+                Verify(writer, tagHex + rest);
+            }
         }
 
         [Fact]
         public static void BER_WritesDefinite_Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            writer.PushSequence();
-            writer.PopSequence();
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                writer.PushSequence();
+                writer.PopSequence();
 
-            Verify(writer, "3000");
+                Verify(writer, "3000");
+            }
         }
 
         [Fact]
         public static void CER_WritesIndefinite_Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            writer.PushSequence();
-            writer.PopSequence();
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                writer.PushSequence();
+                writer.PopSequence();
 
-            Verify(writer, "30800000");
+                Verify(writer, "30800000");
+            }
         }
 
         [Fact]
         public static void DER_WritesDefinite_CustomTag_Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            writer.PushSequence();
-            writer.PopSequence();
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                writer.PushSequence();
+                writer.PopSequence();
 
-            Verify(writer, "3000");
+                Verify(writer, "3000");
+            }
         }
 
         [Fact]
         public static void BER_WritesDefinite_CustomTag__Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Private, 15, true);
-            writer.PushSequence(tag);
-            writer.PopSequence(tag);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Private, 15, true);
+                writer.PushSequence(tag);
+                writer.PopSequence(tag);
 
-            Verify(writer, "EF00");
+                Verify(writer, "EF00");
+            }
         }
 
         [Fact]
         public static void CER_WritesIndefinite_CustomTag__Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Application, 91, true);
-            writer.PushSequence(tag);
-            writer.PopSequence(tag);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Application, 91, true);
+                writer.PushSequence(tag);
+                writer.PopSequence(tag);
 
-            Verify(writer, "7F5B800000");
+                Verify(writer, "7F5B800000");
+            }
         }
 
         [Fact]
         public static void DER_WritesDefinite_CustomTag__Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 30, true);
-            writer.PushSequence(tag);
-            writer.PopSequence(tag);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 30, true);
+                writer.PushSequence(tag);
+                writer.PopSequence(tag);
 
-            Verify(writer, "BE00");
+                Verify(writer, "BE00");
+            }
         }
 
         private static void TestNested(AsnWriter writer, Asn1Tag alt, string expectedHex)
@@ -267,28 +297,34 @@ namespace System.Security.Cryptography.Tests.Asn1
         [Fact]
         public static void BER_Nested()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag alt = new Asn1Tag(TagClass.Private, 127, true);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag alt = new Asn1Tag(TagClass.Private, 127, true);
 
-            TestNested(writer, alt, "300AFF7F003005FF7F023000");
+                TestNested(writer, alt, "300AFF7F003005FF7F023000");
+            }
         }
 
         [Fact]
         public static void CER_Nested()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            Asn1Tag alt = new Asn1Tag(TagClass.ContextSpecific, 12, true);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag alt = new Asn1Tag(TagClass.ContextSpecific, 12, true);
 
-            TestNested(writer, alt, "3080AC8000003080AC8030800000000000000000");
+                TestNested(writer, alt, "3080AC8000003080AC8030800000000000000000");
+            }
         }
 
         [Fact]
         public static void DER_Nested()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            Asn1Tag alt = new Asn1Tag(TagClass.Application, 5, true);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                Asn1Tag alt = new Asn1Tag(TagClass.Application, 5, true);
 
-            TestNested(writer, alt, "30086500300465023000");
+                TestNested(writer, alt, "30086500300465023000");
+            }
         }
 
         private static void SimpleContentShift(AsnWriter writer, string expectedHex)
@@ -315,8 +351,6 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void SimpleContentShift(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            
             const string ExpectedHex =
                 "308180" +
                     "047E" +
@@ -325,14 +359,15 @@ namespace System.Security.Cryptography.Tests.Asn1
                         "F00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00D" +
                         "F00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00D";
 
-            SimpleContentShift(writer, ExpectedHex);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                SimpleContentShift(writer, ExpectedHex);
+            }
         }
 
         [Fact]
         public static void SimpleContentShift_CER()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-
             const string ExpectedHex =
                 "3080" +
                     "047E" +
@@ -342,48 +377,54 @@ namespace System.Security.Cryptography.Tests.Asn1
                         "F00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00D" +
                     "0000";
 
-            SimpleContentShift(writer, ExpectedHex);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                SimpleContentShift(writer, ExpectedHex);
+            }
         }
 
         private static void WriteRSAPublicKey(AsnEncodingRules ruleSet, string expectedHex)
         {
-            AsnWriter innerWriter = new AsnWriter(ruleSet);
+            using (AsnWriter innerWriter = new AsnWriter(ruleSet))
+            {
+                byte[] paddedBigEndianN = (
+                    "00" +
+                    "AF81C1CBD8203F624A539ED6608175372393A2837D4890E48A19DED369731156" +
+                    "20968D6BE0D3DAA38AA777BE02EE0B6B93B724E8DCC12B632B4FA80BBC925BCE" +
+                    "624F4CA7CC606306B39403E28C932D24DD546FFE4EF6A37F10770B2215EA8CBB" +
+                    "5BF427E8C4D89B79EB338375100C5F83E55DE9B4466DDFBEEE42539AEF33EF18" +
+                    "7B7760C3B1A1B2103C2D8144564A0C1039A09C85CF6B5974EB516FC8D6623C94" +
+                    "AE3A5A0BB3B4C792957D432391566CF3E2A52AFB0C142B9E0681B8972671AF2B" +
+                    "82DD390A39B939CF719568687E4990A63050CA7768DCD6B378842F18FDB1F6D9" +
+                    "FF096BAF7BEB98DCF930D66FCFD503F58D41BFF46212E24E3AFC45EA42BD8847").HexToByteArray();
 
-            byte[] paddedBigEndianN = (
-                "00" +
-                "AF81C1CBD8203F624A539ED6608175372393A2837D4890E48A19DED369731156" +
-                "20968D6BE0D3DAA38AA777BE02EE0B6B93B724E8DCC12B632B4FA80BBC925BCE" +
-                "624F4CA7CC606306B39403E28C932D24DD546FFE4EF6A37F10770B2215EA8CBB" +
-                "5BF427E8C4D89B79EB338375100C5F83E55DE9B4466DDFBEEE42539AEF33EF18" +
-                "7B7760C3B1A1B2103C2D8144564A0C1039A09C85CF6B5974EB516FC8D6623C94" +
-                "AE3A5A0BB3B4C792957D432391566CF3E2A52AFB0C142B9E0681B8972671AF2B" +
-                "82DD390A39B939CF719568687E4990A63050CA7768DCD6B378842F18FDB1F6D9" +
-                "FF096BAF7BEB98DCF930D66FCFD503F58D41BFF46212E24E3AFC45EA42BD8847").HexToByteArray();
+                // Now it's padded little-endian.
+                Array.Reverse(paddedBigEndianN);
+                BigInteger n = new BigInteger(paddedBigEndianN);
+                const long e = 8589935681;
 
-            // Now it's padded little-endian.
-            Array.Reverse(paddedBigEndianN);
-            BigInteger n = new BigInteger(paddedBigEndianN);
-            const long e = 8589935681;
+                innerWriter.PushSequence();
+                innerWriter.WriteInteger(n);
+                innerWriter.WriteInteger(e);
+                innerWriter.PopSequence();
 
-            innerWriter.PushSequence();
-            innerWriter.WriteInteger(n);
-            innerWriter.WriteInteger(e);
-            innerWriter.PopSequence();
+                using (AsnWriter outerWriter = new AsnWriter(ruleSet))
+                {
+                    // RSAPublicKey
+                    outerWriter.PushSequence();
 
-            AsnWriter outerWriter = new AsnWriter(ruleSet);
-            // RSAPublicKey
-            outerWriter.PushSequence();
-            
-            // AlgorithmIdentifier
-            outerWriter.PushSequence();
-            outerWriter.WriteObjectIdentifier("1.2.840.113549.1.1.1");
-            outerWriter.WriteNull();
-            outerWriter.PopSequence();
+                    // AlgorithmIdentifier
+                    outerWriter.PushSequence();
+                    outerWriter.WriteObjectIdentifier("1.2.840.113549.1.1.1");
+                    outerWriter.WriteNull();
+                    outerWriter.PopSequence();
 
-            outerWriter.WriteBitString(innerWriter.Encode());
-            outerWriter.PopSequence();
+                    outerWriter.WriteBitString(innerWriter.Encode());
+                    outerWriter.PopSequence();
 
-            Verify(outerWriter, expectedHex);
+                    Verify(outerWriter, expectedHex);
+                }
+            }
         }
 
         [Theory]
@@ -476,26 +517,27 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER, true)]
         public static void CannotEncodeWhileUnbalanced(PublicEncodingRules ruleSet, bool customTag)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            if (customTag)
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true));
+                if (customTag)
+                {
+                    writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true));
+                }
+                else
+                {
+                    writer.PushSequence();
+                }
+
+                int written = -5;
+
+                Assert.Throws<InvalidOperationException>(() => writer.Encode());
+                Assert.Throws<InvalidOperationException>(() => writer.TryEncode(Span<byte>.Empty, out written));
+                Assert.Equal(-5, written);
+
+                byte[] buf = new byte[10];
+                Assert.Throws<InvalidOperationException>(() => writer.TryEncode(buf, out written));
+                Assert.Equal(-5, written);
             }
-            else
-            {
-                writer.PushSequence();
-            }
-
-            int written = -5;
-
-            Assert.Throws<InvalidOperationException>(() => writer.Encode());
-            Assert.Throws<InvalidOperationException>(() => writer.TryEncode(Span<byte>.Empty, out written));
-            Assert.Equal(-5, written);
-
-            byte[] buf = new byte[10];
-            Assert.Throws<InvalidOperationException>(() => writer.TryEncode(buf, out written));
-            Assert.Equal(-5, written);
         }
 
         [Theory]
@@ -504,11 +546,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushSequence_EndOfContents(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PushSequence(Asn1Tag.EndOfContents));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PushSequence(Asn1Tag.EndOfContents));
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/PushPopSetOf.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/PushPopSetOf.cs
@@ -17,12 +17,13 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PopNewWriter(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            // Maybe ArgumentException isn't right for this, since no argument was provided.
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSetOf());
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                // Maybe ArgumentException isn't right for this, since no argument was provided.
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSetOf());
+            }
         }
 
         [Theory]
@@ -31,11 +32,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PopNewWriter_CustomTag(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSetOf(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSetOf(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+            }
         }
 
         [Theory]
@@ -44,14 +46,16 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PopBalancedWriter(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSetOf();
-            writer.PopSetOf();
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSetOf();
+                writer.PopSetOf();
 
-            // Maybe ArgumentException isn't right for this, since no argument was provided.
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSetOf());
+                // Maybe ArgumentException isn't right for this, since no argument was provided.
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSetOf());
+            }
         }
 
         [Theory]
@@ -60,13 +64,15 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PopBalancedWriter_CustomTag(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSetOf();
-            writer.PopSetOf();
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSetOf();
+                writer.PopSetOf();
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSetOf(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSetOf(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+            }
         }
 
         [Theory]
@@ -75,13 +81,15 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushCustom_PopStandard(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSetOf(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSetOf(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true));
 
-            // Maybe ArgumentException isn't right for this, since no argument was provided.
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSetOf());
+                // Maybe ArgumentException isn't right for this, since no argument was provided.
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSetOf());
+            }
         }
 
         [Theory]
@@ -90,12 +98,14 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushStandard_PopCustom(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSetOf();
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSetOf();
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PopSetOf(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PopSetOf(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true)));
+            }
         }
 
         [Theory]
@@ -104,17 +114,19 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushPrimitive_PopStandard(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSetOf(new Asn1Tag(UniversalTagNumber.SetOf));
-            writer.PopSetOf();
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSetOf(new Asn1Tag(UniversalTagNumber.SetOf));
+                writer.PopSetOf();
 
-            if (ruleSet == PublicEncodingRules.CER)
-            {
-                Verify(writer, "31800000");
-            }
-            else
-            {
-                Verify(writer, "3100");
+                if (ruleSet == PublicEncodingRules.CER)
+                {
+                    Verify(writer, "31800000");
+                }
+                else
+                {
+                    Verify(writer, "3100");
+                }
             }
         }
 
@@ -124,17 +136,19 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushCustomPrimitive_PopConstructed(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSetOf(new Asn1Tag(TagClass.Private, 5));
-            writer.PopSetOf(new Asn1Tag(TagClass.Private, 5, true));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSetOf(new Asn1Tag(TagClass.Private, 5));
+                writer.PopSetOf(new Asn1Tag(TagClass.Private, 5, true));
 
-            if (ruleSet == PublicEncodingRules.CER)
-            {
-                Verify(writer, "E5800000");
-            }
-            else
-            {
-                Verify(writer, "E500");
+                if (ruleSet == PublicEncodingRules.CER)
+                {
+                    Verify(writer, "E5800000");
+                }
+                else
+                {
+                    Verify(writer, "E500");
+                }
             }
         }
 
@@ -144,17 +158,19 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushStandard_PopPrimitive(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSetOf();
-            writer.PopSetOf(new Asn1Tag(UniversalTagNumber.SetOf));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSetOf();
+                writer.PopSetOf(new Asn1Tag(UniversalTagNumber.SetOf));
 
-            if (ruleSet == PublicEncodingRules.CER)
-            {
-                Verify(writer, "31800000");
-            }
-            else
-            {
-                Verify(writer, "3100");
+                if (ruleSet == PublicEncodingRules.CER)
+                {
+                    Verify(writer, "31800000");
+                }
+                else
+                {
+                    Verify(writer, "3100");
+                }
             }
         }
 
@@ -164,78 +180,92 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushCustomConstructed_PopPrimitive(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.PushSetOf(new Asn1Tag(TagClass.Private, (int)ruleSet, true));
-            writer.PopSetOf(new Asn1Tag(TagClass.Private, (int)ruleSet));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.PushSetOf(new Asn1Tag(TagClass.Private, (int)ruleSet, true));
+                writer.PopSetOf(new Asn1Tag(TagClass.Private, (int)ruleSet));
 
-            byte tag = (byte)((int)ruleSet | 0b1110_0000);
-            string tagHex = tag.ToString("X2");
-            string rest = ruleSet == PublicEncodingRules.CER ? "800000" : "00";
+                byte tag = (byte)((int)ruleSet | 0b1110_0000);
+                string tagHex = tag.ToString("X2");
+                string rest = ruleSet == PublicEncodingRules.CER ? "800000" : "00";
 
-            Verify(writer, tagHex + rest);
+                Verify(writer, tagHex + rest);
+            }
         }
 
         [Fact]
         public static void BER_WritesDefinite_Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            writer.PushSetOf();
-            writer.PopSetOf();
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                writer.PushSetOf();
+                writer.PopSetOf();
 
-            Verify(writer, "3100");
+                Verify(writer, "3100");
+            }
         }
 
         [Fact]
         public static void CER_WritesIndefinite_Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            writer.PushSetOf();
-            writer.PopSetOf();
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                writer.PushSetOf();
+                writer.PopSetOf();
 
-            Verify(writer, "31800000");
+                Verify(writer, "31800000");
+            }
         }
 
         [Fact]
         public static void DER_WritesDefinite_CustomTag_Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            writer.PushSetOf();
-            writer.PopSetOf();
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                writer.PushSetOf();
+                writer.PopSetOf();
 
-            Verify(writer, "3100");
+                Verify(writer, "3100");
+            }
         }
 
         [Fact]
         public static void BER_WritesDefinite_CustomTag__Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Private, 15, true);
-            writer.PushSetOf(tag);
-            writer.PopSetOf(tag);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Private, 15, true);
+                writer.PushSetOf(tag);
+                writer.PopSetOf(tag);
 
-            Verify(writer, "EF00");
+                Verify(writer, "EF00");
+            }
         }
 
         [Fact]
         public static void CER_WritesIndefinite_CustomTag__Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Application, 91, true);
-            writer.PushSetOf(tag);
-            writer.PopSetOf(tag);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Application, 91, true);
+                writer.PushSetOf(tag);
+                writer.PopSetOf(tag);
 
-            Verify(writer, "7F5B800000");
+                Verify(writer, "7F5B800000");
+            }
         }
 
         [Fact]
         public static void DER_WritesDefinite_CustomTag__Empty()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 30, true);
-            writer.PushSetOf(tag);
-            writer.PopSetOf(tag);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 30, true);
+                writer.PushSetOf(tag);
+                writer.PopSetOf(tag);
 
-            Verify(writer, "BE00");
+                Verify(writer, "BE00");
+            }
         }
 
         private static void TestNested(AsnWriter writer, Asn1Tag alt, string expectedHex)
@@ -268,28 +298,34 @@ namespace System.Security.Cryptography.Tests.Asn1
         [Fact]
         public static void BER_Nested()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag alt = new Asn1Tag(TagClass.Private, 127, true);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag alt = new Asn1Tag(TagClass.Private, 127, true);
 
-            TestNested(writer, alt, "310A3105FF7F023100FF7F00");
+                TestNested(writer, alt, "310A3105FF7F023100FF7F00");
+            }
         }
 
         [Fact]
         public static void CER_Nested()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            Asn1Tag alt = new Asn1Tag(TagClass.ContextSpecific, 12, true);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag alt = new Asn1Tag(TagClass.ContextSpecific, 12, true);
 
-            TestNested(writer, alt, "31803180AC803180000000000000AC8000000000");
+                TestNested(writer, alt, "31803180AC803180000000000000AC8000000000");
+            }
         }
 
         [Fact]
         public static void DER_Nested()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            Asn1Tag alt = new Asn1Tag(TagClass.Application, 5, true);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                Asn1Tag alt = new Asn1Tag(TagClass.Application, 5, true);
 
-            TestNested(writer, alt, "31083104650231006500");
+                TestNested(writer, alt, "31083104650231006500");
+            }
         }
 
         private static void SimpleContentShift(AsnWriter writer, string expectedHex)
@@ -316,8 +352,6 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void SimpleContentShift(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
             const string ExpectedHex =
                 "318180" +
                     "047E" +
@@ -326,14 +360,15 @@ namespace System.Security.Cryptography.Tests.Asn1
                         "F00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00D" +
                         "F00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00D";
 
-            SimpleContentShift(writer, ExpectedHex);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                SimpleContentShift(writer, ExpectedHex);
+            }
         }
 
         [Fact]
         public static void SimpleContentShift_CER()
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-
             const string ExpectedHex =
                 "3180" +
                     "047E" +
@@ -343,56 +378,62 @@ namespace System.Security.Cryptography.Tests.Asn1
                         "F00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00DF00D" +
                     "0000";
 
-            SimpleContentShift(writer, ExpectedHex);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                SimpleContentShift(writer, ExpectedHex);
+            }
         }
 
-        private static void ValidateDataSorting(AsnWriter writer, string expectedHex)
+        private static void ValidateDataSorting(AsnEncodingRules ruleSet, string expectedHex)
         {
-            writer.PushSetOf();
+            using (AsnWriter writer = new AsnWriter(ruleSet))
+            {
+                writer.PushSetOf();
 
-            // 02 01 FF
-            writer.WriteInteger(-1);
-            // 02 01 00
-            writer.WriteInteger(0);
-            // 02 02 00 FF
-            writer.WriteInteger(255);
-            // 01 01 FF
-            writer.WriteBoolean(true);
-            // 45 01 00
-            writer.WriteBoolean(new Asn1Tag(TagClass.Application, 5), false);
-            // 02 01 7F
-            writer.WriteInteger(127);
-            // 02 01 80
-            writer.WriteInteger(sbyte.MinValue);
-            // 02 02 00 FE
-            writer.WriteInteger(254);
-            // 02 01 00
-            writer.WriteInteger(0);
+                // 02 01 FF
+                writer.WriteInteger(-1);
+                // 02 01 00
+                writer.WriteInteger(0);
+                // 02 02 00 FF
+                writer.WriteInteger(255);
+                // 01 01 FF
+                writer.WriteBoolean(true);
+                // 45 01 00
+                writer.WriteBoolean(new Asn1Tag(TagClass.Application, 5), false);
+                // 02 01 7F
+                writer.WriteInteger(127);
+                // 02 01 80
+                writer.WriteInteger(sbyte.MinValue);
+                // 02 02 00 FE
+                writer.WriteInteger(254);
+                // 02 01 00
+                writer.WriteInteger(0);
 
-            writer.PopSetOf();
+                writer.PopSetOf();
 
-            // The correct sort order (CER, DER) is
-            // Universal Boolean: true
-            // Universal Integer: 0
-            // Universal Integer: 0
-            // Universal Integer: 127
-            // Universal Integer: -128
-            // Universal Integer: -1
-            // Universal Integer: 254
-            // Universal Integer: 255
-            // Application 5 (Boolean): false
+                // The correct sort order (CER, DER) is
+                // Universal Boolean: true
+                // Universal Integer: 0
+                // Universal Integer: 0
+                // Universal Integer: 127
+                // Universal Integer: -128
+                // Universal Integer: -1
+                // Universal Integer: 254
+                // Universal Integer: 255
+                // Application 5 (Boolean): false
 
-            // This test would be
-            //
-            // GrabBag ::= SET OF GrabBagItem
-            //
-            // GrabBagItem ::= CHOICE (
-            //    value INTEGER
-            //    bool BOOLEAN
-            //    grr [APPLICATION 5] IMPLICIT BOOLEAN
-            // )
+                // This test would be
+                //
+                // GrabBag ::= SET OF GrabBagItem
+                //
+                // GrabBagItem ::= CHOICE (
+                //    value INTEGER
+                //    bool BOOLEAN
+                //    grr [APPLICATION 5] IMPLICIT BOOLEAN
+                // )
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Fact]
@@ -410,7 +451,7 @@ namespace System.Security.Cryptography.Tests.Asn1
                     "020200FE" +
                     "020100";
 
-            ValidateDataSorting(new AsnWriter(AsnEncodingRules.BER), ExpectedHex);
+            ValidateDataSorting(AsnEncodingRules.BER, ExpectedHex);
         }
 
         [Fact]
@@ -429,7 +470,7 @@ namespace System.Security.Cryptography.Tests.Asn1
                     "450100" +
                     "0000";
 
-            ValidateDataSorting(new AsnWriter(AsnEncodingRules.CER), ExpectedHex);
+            ValidateDataSorting(AsnEncodingRules.CER, ExpectedHex);
         }
 
         [Fact]
@@ -447,7 +488,7 @@ namespace System.Security.Cryptography.Tests.Asn1
                     "020200FF" +
                     "450100";
 
-            ValidateDataSorting(new AsnWriter(AsnEncodingRules.DER), ExpectedHex);
+            ValidateDataSorting(AsnEncodingRules.DER, ExpectedHex);
         }
         
         [Theory]
@@ -459,26 +500,27 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER, true)]
         public static void CannotEncodeWhileUnbalanced(PublicEncodingRules ruleSet, bool customTag)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            if (customTag)
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.PushSetOf(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true));
+                if (customTag)
+                {
+                    writer.PushSetOf(new Asn1Tag(TagClass.ContextSpecific, (int)ruleSet, true));
+                }
+                else
+                {
+                    writer.PushSetOf();
+                }
+
+                int written = -5;
+
+                Assert.Throws<InvalidOperationException>(() => writer.Encode());
+                Assert.Throws<InvalidOperationException>(() => writer.TryEncode(Span<byte>.Empty, out written));
+                Assert.Equal(-5, written);
+
+                byte[] buf = new byte[10];
+                Assert.Throws<InvalidOperationException>(() => writer.TryEncode(buf, out written));
+                Assert.Equal(-5, written);
             }
-            else
-            {
-                writer.PushSetOf();
-            }
-
-            int written = -5;
-
-            Assert.Throws<InvalidOperationException>(() => writer.Encode());
-            Assert.Throws<InvalidOperationException>(() => writer.TryEncode(Span<byte>.Empty, out written));
-            Assert.Equal(-5, written);
-
-            byte[] buf = new byte[10];
-            Assert.Throws<InvalidOperationException>(() => writer.TryEncode(buf, out written));
-            Assert.Equal(-5, written);
         }
 
         [Theory]
@@ -487,11 +529,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void PushSetOf_EndOfContents(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.PushSetOf(Asn1Tag.EndOfContents));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.PushSetOf(Asn1Tag.EndOfContents));
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteBoolean.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteBoolean.cs
@@ -18,10 +18,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER, true, "0101FF")]
         public void VerifyWriteBoolean(PublicEncodingRules ruleSet, bool value, string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteBoolean(value);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteBoolean(value);
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -33,10 +35,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER, true, "8301FF")]
         public void VerifyWriteBoolean_Context3(PublicEncodingRules ruleSet, bool value, string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteBoolean(new Asn1Tag(TagClass.ContextSpecific, 3), value);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteBoolean(new Asn1Tag(TagClass.ContextSpecific, 3), value);
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -48,11 +52,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER, true)]
         public void VerifyWriteBoolean_EndOfContents(PublicEncodingRules ruleSet, bool value)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteBoolean(Asn1Tag.EndOfContents, value));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteBoolean(Asn1Tag.EndOfContents, value));
+            }
         }
 
         [Theory]
@@ -64,17 +69,19 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER, true)]
         public void VerifyWriteBoolean_ConstructedIgnored(PublicEncodingRules ruleSet, bool value)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteBoolean(new Asn1Tag(TagClass.ContextSpecific, 7, true), value);
-            writer.WriteBoolean(new Asn1Tag(UniversalTagNumber.Boolean, true), value);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteBoolean(new Asn1Tag(TagClass.ContextSpecific, 7, true), value);
+                writer.WriteBoolean(new Asn1Tag(UniversalTagNumber.Boolean, true), value);
 
-            if (value)
-            {
-                Verify(writer, "8701FF0101FF");
-            }
-            else
-            {
-                Verify(writer, "870100010100");
+                if (value)
+                {
+                    Verify(writer, "8701FF0101FF");
+                }
+                else
+                {
+                    Verify(writer, "870100010100");
+                }
             }
         }
     }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteCharacterString.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteCharacterString.cs
@@ -42,261 +42,312 @@ namespace System.Security.Cryptography.Tests.Asn1
 
         protected void VerifyWrite_BER_String(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            WriteString(writer, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                WriteString(writer, input);
 
-            Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+                Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_BER_String_CustomTag(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 14);
-            WriteString(writer, tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 14);
+                WriteString(writer, tag, input);
 
-            Verify(writer, Stringify(tag) + expectedPayloadHex);
+                Verify(writer, Stringify(tag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_CER_String(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            WriteString(writer, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                WriteString(writer, input);
 
-            Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+                Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_CER_String_CustomTag(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Private, 19);
-            WriteString(writer, tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Private, 19);
+                WriteString(writer, tag, input);
 
-            Verify(writer, Stringify(tag) + expectedPayloadHex);
+                Verify(writer, Stringify(tag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_DER_String(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            WriteString(writer, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                WriteString(writer, input);
 
-            Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+                Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_DER_String_CustomTag(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Application, 2);
-            WriteString(writer, tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Application, 2);
+                WriteString(writer, tag, input);
 
-            Verify(writer, Stringify(tag) + expectedPayloadHex);
+                Verify(writer, Stringify(tag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_BER_Span(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            WriteSpan(writer, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                WriteSpan(writer, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+                Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_BER_Span_CustomTag(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Private, int.MaxValue >> 1);
-            WriteSpan(writer, tag, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Private, int.MaxValue >> 1);
+                WriteSpan(writer, tag, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(tag) + expectedPayloadHex);
+                Verify(writer, Stringify(tag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_CER_Span(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            WriteSpan(writer, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                WriteSpan(writer, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+                Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_CER_Span_CustomTag(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Application, 30);
-            WriteSpan(writer, tag, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Application, 30);
+                WriteSpan(writer, tag, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(tag) + expectedPayloadHex);
+                Verify(writer, Stringify(tag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_DER_Span(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            WriteSpan(writer, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                WriteSpan(writer, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+                Verify(writer, Stringify(StandardTag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_DER_Span_CustomTag(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 31);
-            WriteSpan(writer, tag, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 31);
+                WriteSpan(writer, tag, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(tag) + expectedPayloadHex);
+                Verify(writer, Stringify(tag) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_BER_String_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag standard = StandardTag;
-            Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
-            WriteString(writer, tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag standard = StandardTag;
+                Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
+                WriteString(writer, tag, input);
 
-            Verify(writer, Stringify(standard) + expectedPayloadHex);
+                Verify(writer, Stringify(standard) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_BER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Application, 19, isConstructed: true);
-            Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
-            WriteString(writer, tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Application, 19, isConstructed: true);
+                Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
+                WriteString(writer, tag, input);
 
-            Verify(writer, Stringify(expected) + expectedPayloadHex);
+                Verify(writer, Stringify(expected) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_BER_Span_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag standard = StandardTag;
-            Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
-            WriteSpan(writer, tag, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag standard = StandardTag;
+                Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
+                WriteSpan(writer, tag, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(standard) + expectedPayloadHex);
+                Verify(writer, Stringify(standard) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_BER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Private, 24601, isConstructed: true);
-            Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
-            WriteSpan(writer, tag, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Private, 24601, isConstructed: true);
+                Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
+                WriteSpan(writer, tag, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(expected) + expectedPayloadHex);
+                Verify(writer, Stringify(expected) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_CER_String_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            Asn1Tag standard = StandardTag;
-            Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
-            WriteString(writer, tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag standard = StandardTag;
+                Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
+                WriteString(writer, tag, input);
 
-            Verify(writer, Stringify(standard) + expectedPayloadHex);
+                Verify(writer, Stringify(standard) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_CER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 1701, isConstructed: true);
-            Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
-            WriteString(writer, tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 1701, isConstructed: true);
+                Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
+                WriteString(writer, tag, input);
 
-            Verify(writer, Stringify(expected) + expectedPayloadHex);
+                Verify(writer, Stringify(expected) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_CER_Span_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            Asn1Tag standard = StandardTag;
-            Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
-            WriteSpan(writer, tag, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag standard = StandardTag;
+                Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
+                WriteSpan(writer, tag, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(standard) + expectedPayloadHex);
+                Verify(writer, Stringify(standard) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_CER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Application, 11, isConstructed: true);
-            Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
-            WriteSpan(writer, tag, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Application, 11, isConstructed: true);
+                Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
+                WriteSpan(writer, tag, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(expected) + expectedPayloadHex);
+                Verify(writer, Stringify(expected) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_DER_String_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            Asn1Tag standard = StandardTag;
-            Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
-            WriteString(writer, tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                Asn1Tag standard = StandardTag;
+                Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
+                WriteString(writer, tag, input);
 
-            Verify(writer, Stringify(standard) + expectedPayloadHex);
+                Verify(writer, Stringify(standard) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_DER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Application, 19, isConstructed: true);
-            Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
-            WriteString(writer, tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Application, 19, isConstructed: true);
+                Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
+                WriteString(writer, tag, input);
 
-            Verify(writer, Stringify(expected) + expectedPayloadHex);
+                Verify(writer, Stringify(expected) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_DER_Span_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            Asn1Tag standard = StandardTag;
-            Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
-            WriteSpan(writer, tag, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                Asn1Tag standard = StandardTag;
+                Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, isConstructed: true);
+                WriteSpan(writer, tag, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(standard) + expectedPayloadHex);
+                Verify(writer, Stringify(standard) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_DER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Private, 24601, isConstructed: true);
-            Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
-            WriteSpan(writer, tag, input.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Private, 24601, isConstructed: true);
+                Asn1Tag expected = new Asn1Tag(tag.TagClass, tag.TagValue);
+                WriteSpan(writer, tag, input.AsReadOnlySpan());
 
-            Verify(writer, Stringify(expected) + expectedPayloadHex);
+                Verify(writer, Stringify(expected) + expectedPayloadHex);
+            }
         }
 
         protected void VerifyWrite_String_Null(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentNullException>(
-                "str",
-                () => WriteString(writer, null));
-
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentNullException>(
+                    "str",
+                    () => WriteString(writer, null));
+            }
         }
 
         protected void VerifyWrite_String_Null_CustomTag(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentNullException>(
-                "str",
-                () => WriteString(writer, new Asn1Tag(TagClass.ContextSpecific, 3), null));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentNullException>(
+                    "str",
+                    () => WriteString(writer, new Asn1Tag(TagClass.ContextSpecific, 3), null));
+            }
         }
 
         protected void VerifyWrite_EndOfContents_String(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => WriteString(writer, Asn1Tag.EndOfContents, "hi"));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => WriteString(writer, Asn1Tag.EndOfContents, "hi"));
+            }
         }
 
         protected void VerifyWrite_EndOfContents_Span(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => WriteSpan(writer, Asn1Tag.EndOfContents, "hi".AsReadOnlySpan()));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => WriteSpan(writer, Asn1Tag.EndOfContents, "hi".AsReadOnlySpan()));
+            }
         }
 
         private void VerifyWrite_CERSegmented(AsnWriter writer, string tagHex, int contentByteCount)
@@ -328,110 +379,120 @@ namespace System.Security.Cryptography.Tests.Asn1
 
         protected void VerifyWrite_CERSegmented_String(string input, int contentByteCount)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag standard = StandardTag;
+                Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, true);
+                string tagHex = Stringify(tag);
 
-            Asn1Tag standard = StandardTag;
-            Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, true);
-            string tagHex = Stringify(tag);
-
-            WriteString(writer, input);
-            VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+                WriteString(writer, input);
+                VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+            }
         }
 
         protected void VerifyWrite_CERSegmented_String_CustomTag(string input, int contentByteCount)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Private, 7, true);
+                string tagHex = Stringify(tag);
 
-            Asn1Tag tag = new Asn1Tag(TagClass.Private, 7, true);
-            string tagHex = Stringify(tag);
-
-            WriteString(writer, tag, input);
-            VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+                WriteString(writer, tag, input);
+                VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+            }
         }
 
         protected void VerifyWrite_CERSegmented_String_ConstructedTag(string input, int contentByteCount)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag standard = StandardTag;
+                Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, true);
+                string tagHex = Stringify(tag);
 
-            Asn1Tag standard = StandardTag;
-            Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, true);
-            string tagHex = Stringify(tag);
-
-            WriteString(writer, tag, input);
-            VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+                WriteString(writer, tag, input);
+                VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+            }
         }
 
         protected void VerifyWrite_CERSegmented_String_CustomPrimitiveTag(string input, int contentByteCount)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag prim = new Asn1Tag(TagClass.Application, 42);
+                Asn1Tag constr = new Asn1Tag(prim.TagClass, prim.TagValue, true);
+                string tagHex = Stringify(constr);
 
-            Asn1Tag prim = new Asn1Tag(TagClass.Application, 42);
-            Asn1Tag constr = new Asn1Tag(prim.TagClass, prim.TagValue, true);
-            string tagHex = Stringify(constr);
-
-            WriteString(writer, prim, input);
-            VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+                WriteString(writer, prim, input);
+                VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+            }
         }
 
         protected void VerifyWrite_CERSegmented_Span(string input, int contentByteCount)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag standard = StandardTag;
+                Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, true);
+                string tagHex = Stringify(tag);
 
-            Asn1Tag standard = StandardTag;
-            Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, true);
-            string tagHex = Stringify(tag);
-
-            WriteSpan(writer, input.AsReadOnlySpan());
-            VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+                WriteSpan(writer, input.AsReadOnlySpan());
+                VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+            }
         }
 
         protected void VerifyWrite_CERSegmented_Span_CustomTag(string input, int contentByteCount)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Private, 7, true);
+                string tagHex = Stringify(tag);
 
-            Asn1Tag tag = new Asn1Tag(TagClass.Private, 7, true);
-            string tagHex = Stringify(tag);
-
-            WriteSpan(writer, tag, input.AsReadOnlySpan());
-            VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+            }
         }
 
         protected void VerifyWrite_CERSegmented_Span_ConstructedTag(string input, int contentByteCount)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag standard = StandardTag;
+                Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, true);
+                string tagHex = Stringify(tag);
 
-            Asn1Tag standard = StandardTag;
-            Asn1Tag tag = new Asn1Tag(standard.TagClass, standard.TagValue, true);
-            string tagHex = Stringify(tag);
-
-            WriteSpan(writer, tag, input.AsReadOnlySpan());
-            VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+                WriteSpan(writer, tag, input.AsReadOnlySpan());
+                VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+            }
         }
 
         protected void VerifyWrite_CERSegmented_Span_CustomPrimitiveTag(string input, int contentByteCount)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag prim = new Asn1Tag(TagClass.Application, 42);
+                Asn1Tag constr = new Asn1Tag(prim.TagClass, prim.TagValue, true);
+                string tagHex = Stringify(constr);
 
-            Asn1Tag prim = new Asn1Tag(TagClass.Application, 42);
-            Asn1Tag constr = new Asn1Tag(prim.TagClass, prim.TagValue, true);
-            string tagHex = Stringify(constr);
-
-            WriteSpan(writer, prim, input.AsReadOnlySpan());
-            VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+                WriteSpan(writer, prim, input.AsReadOnlySpan());
+                VerifyWrite_CERSegmented(writer, tagHex, contentByteCount);
+            }
         }
 
         protected void VerifyWrite_String_NonEncodable(string input)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-
-            Assert.Throws<EncoderFallbackException>(() => WriteString(writer, input));
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Assert.Throws<EncoderFallbackException>(() => WriteString(writer, input));
+            }
         }
 
         protected void VerifyWrite_Span_NonEncodable(string input)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-
-            Assert.Throws<EncoderFallbackException>(() => WriteSpan(writer, input.AsReadOnlySpan()));
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Assert.Throws<EncoderFallbackException>(() => WriteSpan(writer, input.AsReadOnlySpan()));
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteEnumerated.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteEnumerated.cs
@@ -24,18 +24,19 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool customTag,
             string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            if (customTag)
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 30), value);
-            }
-            else
-            {
-                writer.WriteEnumeratedValue(value);
-            }
+                if (customTag)
+                {
+                    writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 30), value);
+                }
+                else
+                {
+                    writer.WriteEnumeratedValue(value);
+                }
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -50,18 +51,19 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool customTag,
             string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            if (customTag)
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 26), value);
-            }
-            else
-            {
-                writer.WriteEnumeratedValue(value);
-            }
+                if (customTag)
+                {
+                    writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 26), value);
+                }
+                else
+                {
+                    writer.WriteEnumeratedValue(value);
+                }
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -78,18 +80,19 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool customTag,
             string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            if (customTag)
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.WriteEnumeratedValue(new Asn1Tag(TagClass.Private, 212), value);
-            }
-            else
-            {
-                writer.WriteEnumeratedValue(value);
-            }
+                if (customTag)
+                {
+                    writer.WriteEnumeratedValue(new Asn1Tag(TagClass.Private, 212), value);
+                }
+                else
+                {
+                    writer.WriteEnumeratedValue(value);
+                }
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -106,18 +109,19 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool customTag,
             string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            if (customTag)
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.WriteEnumeratedValue(new Asn1Tag(TagClass.Application, 13), value);
-            }
-            else
-            {
-                writer.WriteEnumeratedValue(value);
-            }
+                if (customTag)
+                {
+                    writer.WriteEnumeratedValue(new Asn1Tag(TagClass.Application, 13), value);
+                }
+                else
+                {
+                    writer.WriteEnumeratedValue(value);
+                }
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -136,18 +140,19 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool customTag,
             string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            if (customTag)
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.WriteEnumeratedValue(new Asn1Tag(TagClass.Application, short.MaxValue), value);
-            }
-            else
-            {
-                writer.WriteEnumeratedValue(value);
-            }
+                if (customTag)
+                {
+                    writer.WriteEnumeratedValue(new Asn1Tag(TagClass.Application, short.MaxValue), value);
+                }
+                else
+                {
+                    writer.WriteEnumeratedValue(value);
+                }
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -164,18 +169,19 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool customTag,
             string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            if (customTag)
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 97), value);
-            }
-            else
-            {
-                writer.WriteEnumeratedValue(value);
-            }
+                if (customTag)
+                {
+                    writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 97), value);
+                }
+                else
+                {
+                    writer.WriteEnumeratedValue(value);
+                }
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -196,18 +202,19 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool customTag,
             string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            if (customTag)
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 0), value);
-            }
-            else
-            {
-                writer.WriteEnumeratedValue(value);
-            }
+                if (customTag)
+                {
+                    writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 0), value);
+                }
+                else
+                {
+                    writer.WriteEnumeratedValue(value);
+                }
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -226,18 +233,19 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool customTag,
             string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            if (customTag)
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
-                writer.WriteEnumeratedValue(new Asn1Tag(TagClass.Private, 1), value);
-            }
-            else
-            {
-                writer.WriteEnumeratedValue(value);
-            }
+                if (customTag)
+                {
+                    writer.WriteEnumeratedValue(new Asn1Tag(TagClass.Private, 1), value);
+                }
+                else
+                {
+                    writer.WriteEnumeratedValue(value);
+                }
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -246,27 +254,28 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyFlagsBased(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tEnum",
+                    () => writer.WriteEnumeratedValue(OpenFlags.IncludeArchived));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tEnum",
-                () => writer.WriteEnumeratedValue(OpenFlags.IncludeArchived));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tEnum",
+                    () => writer.WriteEnumeratedValue(
+                        new Asn1Tag(TagClass.ContextSpecific, 13),
+                        OpenFlags.IncludeArchived));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tEnum",
-                () => writer.WriteEnumeratedValue(
-                    new Asn1Tag(TagClass.ContextSpecific, 13),
-                    OpenFlags.IncludeArchived));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tEnum",
+                    () => writer.WriteEnumeratedValue((object)OpenFlags.IncludeArchived));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tEnum",
-                () => writer.WriteEnumeratedValue((object)OpenFlags.IncludeArchived));
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tEnum",
-                () => writer.WriteEnumeratedValue(
-                    new Asn1Tag(TagClass.ContextSpecific, 13),
-                    (object)OpenFlags.IncludeArchived));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tEnum",
+                    () => writer.WriteEnumeratedValue(
+                        new Asn1Tag(TagClass.ContextSpecific, 13),
+                        (object)OpenFlags.IncludeArchived));
+            }
         }
 
         [Theory]
@@ -275,25 +284,26 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyNonEnum(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                Assert.Throws<ArgumentException>(
+                    () => writer.WriteEnumeratedValue(5));
 
-            Assert.Throws<ArgumentException>(
-                () => writer.WriteEnumeratedValue(5));
+                Assert.Throws<ArgumentException>(
+                    () => writer.WriteEnumeratedValue((object)"hi"));
 
-            Assert.Throws<ArgumentException>(
-                () => writer.WriteEnumeratedValue((object)"hi"));
+                Assert.Throws<ArgumentException>(
+                    () => writer.WriteEnumeratedValue((object)5));
 
-            Assert.Throws<ArgumentException>(
-                () => writer.WriteEnumeratedValue((object)5));
+                Assert.Throws<ArgumentException>(
+                    () => writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 3), 5));
 
-            Assert.Throws<ArgumentException>(
-                () => writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 3), 5));
+                Assert.Throws<ArgumentException>(
+                    () => writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 3), (object)"hi"));
 
-            Assert.Throws<ArgumentException>(
-                () => writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 3), (object)"hi"));
-
-            Assert.Throws<ArgumentException>(
-                () => writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 3), (object)5));
+                Assert.Throws<ArgumentException>(
+                    () => writer.WriteEnumeratedValue(new Asn1Tag(TagClass.ContextSpecific, 3), (object)5));
+            }
         }
 
         [Theory]
@@ -302,15 +312,16 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyEndOfContents(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteEnumeratedValue(Asn1Tag.EndOfContents, ReadEnumerated.IntBacked.Pillow));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteEnumeratedValue(Asn1Tag.EndOfContents, ReadEnumerated.IntBacked.Pillow));
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteEnumeratedValue(Asn1Tag.EndOfContents, (object)ReadEnumerated.IntBacked.Pillow));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteEnumeratedValue(Asn1Tag.EndOfContents, (object)ReadEnumerated.IntBacked.Pillow));
+            }
         }
 
         [Theory]
@@ -319,17 +330,18 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void VerifyWriteEnumeratedValue_NonNull(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentNullException>(
+                    "enumValue",
+                    () => writer.WriteEnumeratedValue(null));
 
-            AssertExtensions.Throws<ArgumentNullException>(
-                "enumValue",
-                () => writer.WriteEnumeratedValue(null));
-
-            AssertExtensions.Throws<ArgumentNullException>(
-                "enumValue",
-                () => writer.WriteEnumeratedValue(
-                    new Asn1Tag(TagClass.ContextSpecific, 1),
-                    null));
+                AssertExtensions.Throws<ArgumentNullException>(
+                    "enumValue",
+                    () => writer.WriteEnumeratedValue(
+                        new Asn1Tag(TagClass.ContextSpecific, 1),
+                        null));
+            }
         }
 
         [Theory]
@@ -338,19 +350,20 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void VerifyWriteEnumeratedValue_Object(PublicEncodingRules ruleSet)
         {
-            AsnWriter objWriter = new AsnWriter((AsnEncodingRules)ruleSet);
-            AsnWriter genWriter = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter objWriter = new AsnWriter((AsnEncodingRules)ruleSet))
+            using (AsnWriter genWriter = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                genWriter.WriteEnumeratedValue(ReadEnumerated.UIntBacked.Fluff);
+                objWriter.WriteEnumeratedValue((object)ReadEnumerated.UIntBacked.Fluff);
 
-            genWriter.WriteEnumeratedValue(ReadEnumerated.UIntBacked.Fluff);
-            objWriter.WriteEnumeratedValue((object)ReadEnumerated.UIntBacked.Fluff);
+                genWriter.WriteEnumeratedValue(ReadEnumerated.SByteBacked.Fluff);
+                objWriter.WriteEnumeratedValue((object)ReadEnumerated.SByteBacked.Fluff);
 
-            genWriter.WriteEnumeratedValue(ReadEnumerated.SByteBacked.Fluff);
-            objWriter.WriteEnumeratedValue((object)ReadEnumerated.SByteBacked.Fluff);
+                genWriter.WriteEnumeratedValue(ReadEnumerated.ULongBacked.Fluff);
+                objWriter.WriteEnumeratedValue((object)ReadEnumerated.ULongBacked.Fluff);
 
-            genWriter.WriteEnumeratedValue(ReadEnumerated.ULongBacked.Fluff);
-            objWriter.WriteEnumeratedValue((object)ReadEnumerated.ULongBacked.Fluff);
-
-            Verify(objWriter, genWriter.Encode().ByteArrayToHex());
+                Verify(objWriter, genWriter.Encode().ByteArrayToHex());
+            }
         }
 
         [Theory]
@@ -359,25 +372,26 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void VerifyWriteEnumeratedValue_Object_WithTag(PublicEncodingRules ruleSet)
         {
-            AsnWriter objWriter = new AsnWriter((AsnEncodingRules)ruleSet);
-            AsnWriter genWriter = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter objWriter = new AsnWriter((AsnEncodingRules)ruleSet))
+            using (AsnWriter genWriter = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 52);
 
-            Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 52);
+                genWriter.WriteEnumeratedValue(tag, ReadEnumerated.UIntBacked.Fluff);
+                objWriter.WriteEnumeratedValue(tag, (object)ReadEnumerated.UIntBacked.Fluff);
 
-            genWriter.WriteEnumeratedValue(tag, ReadEnumerated.UIntBacked.Fluff);
-            objWriter.WriteEnumeratedValue(tag, (object)ReadEnumerated.UIntBacked.Fluff);
+                tag = new Asn1Tag(TagClass.Private, 4);
 
-            tag = new Asn1Tag(TagClass.Private, 4);
+                genWriter.WriteEnumeratedValue(tag, ReadEnumerated.SByteBacked.Fluff);
+                objWriter.WriteEnumeratedValue(tag, (object)ReadEnumerated.SByteBacked.Fluff);
 
-            genWriter.WriteEnumeratedValue(tag, ReadEnumerated.SByteBacked.Fluff);
-            objWriter.WriteEnumeratedValue(tag, (object)ReadEnumerated.SByteBacked.Fluff);
+                tag = new Asn1Tag(TagClass.Application, 75);
 
-            tag = new Asn1Tag(TagClass.Application, 75);
+                genWriter.WriteEnumeratedValue(tag, ReadEnumerated.ULongBacked.Fluff);
+                objWriter.WriteEnumeratedValue(tag, (object)ReadEnumerated.ULongBacked.Fluff);
 
-            genWriter.WriteEnumeratedValue(tag, ReadEnumerated.ULongBacked.Fluff);
-            objWriter.WriteEnumeratedValue(tag, (object)ReadEnumerated.ULongBacked.Fluff);
-
-            Verify(objWriter, genWriter.Encode().ByteArrayToHex());
+                Verify(objWriter, genWriter.Encode().ByteArrayToHex());
+            }
         }
 
         [Theory]
@@ -386,17 +400,18 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyWriteEnumeratedValue_ConstructedIgnored(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteEnumeratedValue(
+                    new Asn1Tag(UniversalTagNumber.Enumerated, isConstructed: true),
+                    ReadEnumerated.ULongBacked.Fluff);
 
-            writer.WriteEnumeratedValue(
-                new Asn1Tag(UniversalTagNumber.Enumerated, isConstructed: true),
-                ReadEnumerated.ULongBacked.Fluff);
+                writer.WriteEnumeratedValue(
+                    new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true),
+                    (object)ReadEnumerated.SByteBacked.Fluff);
 
-            writer.WriteEnumeratedValue(
-                new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true),
-                (object)ReadEnumerated.SByteBacked.Fluff);
-
-            Verify(writer, "0A0900FACEF00DCAFEBEEF" + "800153");
+                Verify(writer, "0A0900FACEF00DCAFEBEEF" + "800153");
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteGeneralizedTime.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteGeneralizedTime.cs
@@ -135,10 +135,12 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool omitFractionalSeconds,
             string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            writer.WriteGeneralizedTime(input, omitFractionalSeconds);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                writer.WriteGeneralizedTime(input, omitFractionalSeconds);
 
-            Verify(writer, "18" + expectedHexPayload);
+                Verify(writer, "18" + expectedHexPayload);
+            }
         }
 
         [Theory]
@@ -148,11 +150,13 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool omitFractionalSeconds,
             string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Application, 11);
-            writer.WriteGeneralizedTime(tag, input, omitFractionalSeconds);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Application, 11);
+                writer.WriteGeneralizedTime(tag, input, omitFractionalSeconds);
 
-            Verify(writer, Stringify(tag) + expectedHexPayload);
+                Verify(writer, Stringify(tag) + expectedHexPayload);
+            }
         }
 
         [Theory]
@@ -162,10 +166,12 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool omitFractionalSeconds,
             string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            writer.WriteGeneralizedTime(input, omitFractionalSeconds);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                writer.WriteGeneralizedTime(input, omitFractionalSeconds);
 
-            Verify(writer, "18" + expectedHexPayload);
+                Verify(writer, "18" + expectedHexPayload);
+            }
         }
 
         [Theory]
@@ -175,11 +181,13 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool omitFractionalSeconds,
             string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Private, 95);
-            writer.WriteGeneralizedTime(tag, input, omitFractionalSeconds);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Private, 95);
+                writer.WriteGeneralizedTime(tag, input, omitFractionalSeconds);
 
-            Verify(writer, Stringify(tag) + expectedHexPayload);
+                Verify(writer, Stringify(tag) + expectedHexPayload);
+            }
         }
 
         [Theory]
@@ -189,10 +197,12 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool omitFractionalSeconds,
             string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            writer.WriteGeneralizedTime(input, omitFractionalSeconds);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                writer.WriteGeneralizedTime(input, omitFractionalSeconds);
 
-            Verify(writer, "18" + expectedHexPayload);
+                Verify(writer, "18" + expectedHexPayload);
+            }
         }
 
         [Theory]
@@ -202,11 +212,13 @@ namespace System.Security.Cryptography.Tests.Asn1
             bool omitFractionalSeconds,
             string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 3);
-            writer.WriteGeneralizedTime(tag, input, omitFractionalSeconds);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 3);
+                writer.WriteGeneralizedTime(tag, input, omitFractionalSeconds);
 
-            Verify(writer, Stringify(tag) + expectedHexPayload);
+                Verify(writer, Stringify(tag) + expectedHexPayload);
+            }
         }
 
         [Theory]
@@ -220,11 +232,12 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             bool omitFractionalSeconds)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteGeneralizedTime(Asn1Tag.EndOfContents, DateTimeOffset.Now, omitFractionalSeconds));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteGeneralizedTime(Asn1Tag.EndOfContents, DateTimeOffset.Now, omitFractionalSeconds));
+            }
         }
 
         [Theory]
@@ -233,12 +246,14 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyWriteGeneralizedTime_IgnoresConstructed(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            DateTimeOffset value = new DateTimeOffset(2017, 11, 16, 17, 35, 1, TimeSpan.Zero);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                DateTimeOffset value = new DateTimeOffset(2017, 11, 16, 17, 35, 1, TimeSpan.Zero);
 
-            writer.WriteGeneralizedTime(new Asn1Tag(UniversalTagNumber.GeneralizedTime, true), value);
-            writer.WriteGeneralizedTime(new Asn1Tag(TagClass.ContextSpecific, 3, true), value);
-            Verify(writer, "180F32303137313131363137333530315A" + "830F32303137313131363137333530315A");
+                writer.WriteGeneralizedTime(new Asn1Tag(UniversalTagNumber.GeneralizedTime, true), value);
+                writer.WriteGeneralizedTime(new Asn1Tag(TagClass.ContextSpecific, 3, true), value);
+                Verify(writer, "180F32303137313131363137333530315A" + "830F32303137313131363137333530315A");
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteInteger.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteInteger.cs
@@ -122,10 +122,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER, 9223372036854775806, "02087FFFFFFFFFFFFFFE")]
         public void VerifyWriteInteger_Long(PublicEncodingRules ruleSet, long value, string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteInteger(value);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteInteger(value);
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -196,10 +198,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.BER, ulong.MaxValue-1, "020900FFFFFFFFFFFFFFFE")]
         public void VerifyWriteInteger_ULong(PublicEncodingRules ruleSet, ulong value, string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteInteger(value);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteInteger(value);
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -218,10 +222,13 @@ namespace System.Security.Cryptography.Tests.Asn1
         public void VerifyWriteInteger_BigInteger(PublicEncodingRules ruleSet, string decimalValue, string expectedHex)
         {
             BigInteger value = BigInteger.Parse(decimalValue);
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteInteger(value);
 
-            Verify(writer, expectedHex);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteInteger(value);
+
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -230,10 +237,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER, 9223372036854775806, "47087FFFFFFFFFFFFFFE")]
         public void VerifyWriteInteger_Application7_Long(PublicEncodingRules ruleSet, long value, string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteInteger(new Asn1Tag(TagClass.Application, 7), value);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteInteger(new Asn1Tag(TagClass.Application, 7), value);
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -242,10 +251,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER, 9223372036854775806, "89087FFFFFFFFFFFFFFE")]
         public void VerifyWriteInteger_Context9_ULong(PublicEncodingRules ruleSet, ulong value, string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteInteger(new Asn1Tag(TagClass.ContextSpecific, 9), value);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteInteger(new Asn1Tag(TagClass.ContextSpecific, 9), value);
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -259,10 +270,13 @@ namespace System.Security.Cryptography.Tests.Asn1
             string expectedHex)
         {
             BigInteger value = BigInteger.Parse(decimalValue);
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteInteger(new Asn1Tag(TagClass.Private, 16), value);
 
-            Verify(writer, expectedHex);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteInteger(new Asn1Tag(TagClass.Private, 16), value);
+
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -271,19 +285,20 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyWriteInteger_EndOfContents(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteInteger(Asn1Tag.EndOfContents, 0L));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteInteger(Asn1Tag.EndOfContents, 0L));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteInteger(Asn1Tag.EndOfContents, 0UL));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteInteger(Asn1Tag.EndOfContents, 0UL));
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteInteger(Asn1Tag.EndOfContents, BigInteger.Zero));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteInteger(Asn1Tag.EndOfContents, BigInteger.Zero));
+            }
         }
 
         [Theory]
@@ -292,15 +307,17 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyWriteInteger_ConstructedIgnored(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteInteger(new Asn1Tag(UniversalTagNumber.Integer, isConstructed: true), 0L);
-            writer.WriteInteger(new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true), 0L);
-            writer.WriteInteger(new Asn1Tag(UniversalTagNumber.Integer, isConstructed: true), 0UL);
-            writer.WriteInteger(new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true), 0UL);
-            writer.WriteInteger(new Asn1Tag(UniversalTagNumber.Integer, isConstructed: true), BigInteger.Zero);
-            writer.WriteInteger(new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true), BigInteger.Zero);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteInteger(new Asn1Tag(UniversalTagNumber.Integer, isConstructed: true), 0L);
+                writer.WriteInteger(new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true), 0L);
+                writer.WriteInteger(new Asn1Tag(UniversalTagNumber.Integer, isConstructed: true), 0UL);
+                writer.WriteInteger(new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true), 0UL);
+                writer.WriteInteger(new Asn1Tag(UniversalTagNumber.Integer, isConstructed: true), BigInteger.Zero);
+                writer.WriteInteger(new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true), BigInteger.Zero);
 
-            Verify(writer, "020100800100020100800100020100800100");
+                Verify(writer, "020100800100020100800100020100800100");
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteNamedBitList.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteNamedBitList.cs
@@ -42,10 +42,12 @@ namespace System.Security.Cryptography.Tests.Asn1
             string expectedHex,
             object value)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteNamedBitList(value);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteNamedBitList(value);
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -88,10 +90,12 @@ namespace System.Security.Cryptography.Tests.Asn1
 
             Asn1Tag tag = new Asn1Tag(tagClass, ruleSetVal);
 
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteNamedBitList(tag, value);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteNamedBitList(tag, value);
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -100,18 +104,19 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void VerifyWriteNamedBitList_Generic(PublicEncodingRules ruleSet)
         {
-            AsnWriter objWriter = new AsnWriter((AsnEncodingRules)ruleSet);
-            AsnWriter genWriter = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter objWriter = new AsnWriter((AsnEncodingRules)ruleSet))
+            using (AsnWriter genWriter = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                var flagsValue =
+                    ReadNamedBitList.X509KeyUsageCSharpStyle.DigitalSignature |
+                    ReadNamedBitList.X509KeyUsageCSharpStyle.KeyEncipherment |
+                    ReadNamedBitList.X509KeyUsageCSharpStyle.DataEncipherment;
 
-            var flagsValue =
-                ReadNamedBitList.X509KeyUsageCSharpStyle.DigitalSignature |
-                ReadNamedBitList.X509KeyUsageCSharpStyle.KeyEncipherment |
-                ReadNamedBitList.X509KeyUsageCSharpStyle.DataEncipherment;
+                genWriter.WriteNamedBitList(flagsValue);
+                objWriter.WriteNamedBitList((object)flagsValue);
 
-            genWriter.WriteNamedBitList(flagsValue);
-            objWriter.WriteNamedBitList((object)flagsValue);
-
-            Verify(genWriter, objWriter.Encode().ByteArrayToHex());
+                Verify(genWriter, objWriter.Encode().ByteArrayToHex());
+            }
         }
 
         [Theory]
@@ -120,20 +125,21 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void VerifyWriteNamedBitList_Generic_WithTag(PublicEncodingRules ruleSet)
         {
-            AsnWriter objWriter = new AsnWriter((AsnEncodingRules)ruleSet);
-            AsnWriter genWriter = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter objWriter = new AsnWriter((AsnEncodingRules)ruleSet))
+            using (AsnWriter genWriter = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 52);
 
-            Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 52);
-           
-            var flagsValue =
-                ReadNamedBitList.X509KeyUsageCSharpStyle.DigitalSignature |
-                ReadNamedBitList.X509KeyUsageCSharpStyle.KeyEncipherment |
-                ReadNamedBitList.X509KeyUsageCSharpStyle.DataEncipherment;
+                var flagsValue =
+                    ReadNamedBitList.X509KeyUsageCSharpStyle.DigitalSignature |
+                    ReadNamedBitList.X509KeyUsageCSharpStyle.KeyEncipherment |
+                    ReadNamedBitList.X509KeyUsageCSharpStyle.DataEncipherment;
 
-            genWriter.WriteNamedBitList(tag, flagsValue);
-            objWriter.WriteNamedBitList(tag, (object)flagsValue);
+                genWriter.WriteNamedBitList(tag, flagsValue);
+                objWriter.WriteNamedBitList(tag, (object)flagsValue);
 
-            Verify(genWriter, objWriter.Encode().ByteArrayToHex());
+                Verify(genWriter, objWriter.Encode().ByteArrayToHex());
+            }
         }
 
         [Theory]
@@ -142,15 +148,16 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void VerifyWriteNamedBitList_NonNull(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentNullException>(
+                    "enumValue",
+                    () => writer.WriteNamedBitList(null));
 
-            AssertExtensions.Throws<ArgumentNullException>(
-                "enumValue",
-                () => writer.WriteNamedBitList(null));
-
-            AssertExtensions.Throws<ArgumentNullException>(
-                "enumValue",
-                () => writer.WriteNamedBitList(new Asn1Tag(TagClass.ContextSpecific, 1), null));
+                AssertExtensions.Throws<ArgumentNullException>(
+                    "enumValue",
+                    () => writer.WriteNamedBitList(new Asn1Tag(TagClass.ContextSpecific, 1), null));
+            }
         }
 
         [Theory]
@@ -159,19 +166,20 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void VerifyWriteNamedBitList_EnumRequired(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                Assert.Throws<ArgumentException>(
+                    () => writer.WriteNamedBitList(3));
 
-            Assert.Throws<ArgumentException>(
-                () => writer.WriteNamedBitList(3));
+                Assert.Throws<ArgumentException>(
+                    () => writer.WriteNamedBitList(new Asn1Tag(TagClass.ContextSpecific, 1), 3));
 
-            Assert.Throws<ArgumentException>(
-                () => writer.WriteNamedBitList(new Asn1Tag(TagClass.ContextSpecific, 1), 3));
+                Assert.Throws<ArgumentException>(
+                    () => writer.WriteNamedBitList((object)3));
 
-            Assert.Throws<ArgumentException>(
-                () => writer.WriteNamedBitList((object)3));
-
-            Assert.Throws<ArgumentException>(
-                () => writer.WriteNamedBitList(new Asn1Tag(TagClass.ContextSpecific, 1), (object)3));
+                Assert.Throws<ArgumentException>(
+                    () => writer.WriteNamedBitList(new Asn1Tag(TagClass.ContextSpecific, 1), (object)3));
+            }
         }
 
         [Theory]
@@ -180,27 +188,28 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void VerifyWriteNamedBitList_FlagsEnumRequired(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tEnum",
+                    () => writer.WriteNamedBitList(AsnEncodingRules.BER));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tEnum",
-                () => writer.WriteNamedBitList(AsnEncodingRules.BER));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tEnum",
+                    () => writer.WriteNamedBitList(
+                        new Asn1Tag(TagClass.ContextSpecific, 1),
+                        AsnEncodingRules.BER));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tEnum",
-                () => writer.WriteNamedBitList(
-                    new Asn1Tag(TagClass.ContextSpecific, 1),
-                    AsnEncodingRules.BER));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tEnum",
+                    () => writer.WriteNamedBitList((object)AsnEncodingRules.BER));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tEnum",
-                () => writer.WriteNamedBitList((object)AsnEncodingRules.BER));
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tEnum",
-                () => writer.WriteNamedBitList(
-                    new Asn1Tag(TagClass.ContextSpecific, 1),
-                    (object)AsnEncodingRules.BER));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tEnum",
+                    () => writer.WriteNamedBitList(
+                        new Asn1Tag(TagClass.ContextSpecific, 1),
+                        (object)AsnEncodingRules.BER));
+            }
         }
 
         [Theory]
@@ -209,19 +218,20 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public static void VerifyWriteNamedBitList_EndOfContents(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteNamedBitList(
+                        Asn1Tag.EndOfContents,
+                        StringSplitOptions.RemoveEmptyEntries));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteNamedBitList(
-                    Asn1Tag.EndOfContents,
-                    StringSplitOptions.RemoveEmptyEntries));
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteNamedBitList(
-                    Asn1Tag.EndOfContents,
-                    (object)StringSplitOptions.RemoveEmptyEntries));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteNamedBitList(
+                        Asn1Tag.EndOfContents,
+                        (object)StringSplitOptions.RemoveEmptyEntries));
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteNull.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteNull.cs
@@ -15,10 +15,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.CER)]
         public void VerifyWriteNull(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteNull();
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteNull();
 
-            Verify(writer, "0500");
+                Verify(writer, "0500");
+            }
         }
 
         [Theory]
@@ -27,11 +29,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.CER)]
         public void VerifyWriteNull_EndOfContents(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteNull(Asn1Tag.EndOfContents));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteNull(Asn1Tag.EndOfContents));
+            }
         }
 
         [Theory]
@@ -40,11 +43,13 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.CER)]
         public void VerifyWriteNull_ConstructedIgnored(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteNull(new Asn1Tag(TagClass.ContextSpecific, 7, true));
-            writer.WriteNull(new Asn1Tag(UniversalTagNumber.Null, true));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteNull(new Asn1Tag(TagClass.ContextSpecific, 7, true));
+                writer.WriteNull(new Asn1Tag(UniversalTagNumber.Null, true));
 
-            Verify(writer, "87000500");
+                Verify(writer, "87000500");
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteObjectIdentifier.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteObjectIdentifier.cs
@@ -17,10 +17,12 @@ namespace System.Security.Cryptography.Tests.Asn1
             string oidValue,
             string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteObjectIdentifier(oidValue);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteObjectIdentifier(oidValue);
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -30,10 +32,12 @@ namespace System.Security.Cryptography.Tests.Asn1
             string oidValue,
             string expectedHex)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteObjectIdentifier(oidValue.AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteObjectIdentifier(oidValue.AsReadOnlySpan());
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -44,10 +48,13 @@ namespace System.Security.Cryptography.Tests.Asn1
             string expectedHex)
         {
             Oid oidObj = new Oid(oidValue, "FriendlyName does not matter");
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteObjectIdentifier(oidObj);
 
-            Verify(writer, expectedHex);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteObjectIdentifier(oidObj);
+
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -57,10 +64,11 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string nonOidValue)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            Assert.Throws<CryptographicException>(
-                () => writer.WriteObjectIdentifier(nonOidValue));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                Assert.Throws<CryptographicException>(
+                    () => writer.WriteObjectIdentifier(nonOidValue));
+            }
         }
 
         [Theory]
@@ -70,10 +78,11 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string nonOidValue)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            Assert.Throws<CryptographicException>(
-                () => writer.WriteObjectIdentifier(nonOidValue.AsReadOnlySpan()));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                Assert.Throws<CryptographicException>(
+                    () => writer.WriteObjectIdentifier(nonOidValue.AsReadOnlySpan()));
+            }
         }
 
         [Theory]
@@ -83,11 +92,13 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string nonOidValue)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            Oid nonOidObj = new Oid(nonOidValue, "FriendlyName does not matter");
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                Oid nonOidObj = new Oid(nonOidValue, "FriendlyName does not matter");
 
-            Assert.Throws<CryptographicException>(
-                () => writer.WriteObjectIdentifier(nonOidObj));
+                Assert.Throws<CryptographicException>(
+                    () => writer.WriteObjectIdentifier(nonOidObj));
+            }
         }
 
         [Theory]
@@ -96,10 +107,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void WriteObjectIdentifier_CustomTag_String(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteObjectIdentifier(new Asn1Tag(TagClass.ContextSpecific, 3), "1.3.14.3.2.26");
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteObjectIdentifier(new Asn1Tag(TagClass.ContextSpecific, 3), "1.3.14.3.2.26");
 
-            Verify(writer, "83052B0E03021A");
+                Verify(writer, "83052B0E03021A");
+            }
         }
 
         [Theory]
@@ -108,10 +121,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void WriteObjectIdentifier_CustomTag_Span(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteObjectIdentifier(new Asn1Tag(TagClass.Application, 2), "1.3.14.3.2.26".AsReadOnlySpan());
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteObjectIdentifier(new Asn1Tag(TagClass.Application, 2), "1.3.14.3.2.26".AsReadOnlySpan());
 
-            Verify(writer, "42052B0E03021A");
+                Verify(writer, "42052B0E03021A");
+            }
         }
 
         [Theory]
@@ -120,10 +135,14 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void WriteObjectIdentifier_CustomTag_Oid(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteObjectIdentifier(new Asn1Tag(TagClass.Private, 36), Oid.FromFriendlyName("SHA1", OidGroup.HashAlgorithm));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteObjectIdentifier(
+                    new Asn1Tag(TagClass.Private, 36),
+                    Oid.FromFriendlyName("SHA1", OidGroup.HashAlgorithm));
 
-            Verify(writer, "DF24052B0E03021A");
+                Verify(writer, "DF24052B0E03021A");
+            }
         }
 
         [Theory]
@@ -131,21 +150,22 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(true)]
         public void WriteObjectIdentifier_NullString(bool defaultTag)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-
-            AssertExtensions.Throws<ArgumentNullException>(
-                "oidValue",
-                () =>
-                {
-                    if (defaultTag)
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                AssertExtensions.Throws<ArgumentNullException>(
+                    "oidValue",
+                    () =>
                     {
-                        writer.WriteObjectIdentifier((string)null);
-                    }
-                    else
-                    {
-                        writer.WriteObjectIdentifier(new Asn1Tag(TagClass.ContextSpecific, 6), (string)null);
-                    }
-                });
+                        if (defaultTag)
+                        {
+                            writer.WriteObjectIdentifier((string)null);
+                        }
+                        else
+                        {
+                            writer.WriteObjectIdentifier(new Asn1Tag(TagClass.ContextSpecific, 6), (string)null);
+                        }
+                    });
+            }
         }
 
         [Theory]
@@ -153,21 +173,22 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(true)]
         public void WriteObjectIdentifier_NullOid(bool defaultTag)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-
-            AssertExtensions.Throws<ArgumentNullException>(
-                "oid",
-                () =>
-                {
-                    if (defaultTag)
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                AssertExtensions.Throws<ArgumentNullException>(
+                    "oid",
+                    () =>
                     {
-                        writer.WriteObjectIdentifier((Oid)null);
-                    }
-                    else
-                    {
-                        writer.WriteObjectIdentifier(new Asn1Tag(TagClass.Application, 2), (Oid)null);
-                    }
-                });
+                        if (defaultTag)
+                        {
+                            writer.WriteObjectIdentifier((Oid)null);
+                        }
+                        else
+                        {
+                            writer.WriteObjectIdentifier(new Asn1Tag(TagClass.Application, 2), (Oid)null);
+                        }
+                    });
+            }
         }
 
 
@@ -177,19 +198,20 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyWriteObjectIdentifier_EndOfContents(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteObjectIdentifier(Asn1Tag.EndOfContents, "1.1"));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteObjectIdentifier(Asn1Tag.EndOfContents, "1.1"));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteObjectIdentifier(Asn1Tag.EndOfContents, "1.1".AsReadOnlySpan()));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteObjectIdentifier(Asn1Tag.EndOfContents, "1.1".AsReadOnlySpan()));
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteObjectIdentifier(Asn1Tag.EndOfContents, new Oid("1.1", "1.1")));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteObjectIdentifier(Asn1Tag.EndOfContents, new Oid("1.1", "1.1")));
+            }
         }
 
         [Theory]
@@ -198,19 +220,21 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyWriteObjectIdentifier_ConstructedIgnored(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            const string OidValue = "1.1";
-            Asn1Tag constructedOid = new Asn1Tag(UniversalTagNumber.ObjectIdentifier, isConstructed: true);
-            Asn1Tag constructedContext0 = new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                const string OidValue = "1.1";
+                Asn1Tag constructedOid = new Asn1Tag(UniversalTagNumber.ObjectIdentifier, isConstructed: true);
+                Asn1Tag constructedContext0 = new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true);
 
-            writer.WriteObjectIdentifier(constructedOid, OidValue);
-            writer.WriteObjectIdentifier(constructedContext0, OidValue);
-            writer.WriteObjectIdentifier(constructedOid, OidValue.AsReadOnlySpan());
-            writer.WriteObjectIdentifier(constructedContext0, OidValue.AsReadOnlySpan());
-            writer.WriteObjectIdentifier(constructedOid, new Oid(OidValue, OidValue));
-            writer.WriteObjectIdentifier(constructedContext0, new Oid(OidValue, OidValue));
+                writer.WriteObjectIdentifier(constructedOid, OidValue);
+                writer.WriteObjectIdentifier(constructedContext0, OidValue);
+                writer.WriteObjectIdentifier(constructedOid, OidValue.AsReadOnlySpan());
+                writer.WriteObjectIdentifier(constructedContext0, OidValue.AsReadOnlySpan());
+                writer.WriteObjectIdentifier(constructedOid, new Oid(OidValue, OidValue));
+                writer.WriteObjectIdentifier(constructedContext0, new Oid(OidValue, OidValue));
 
-            Verify(writer, "060129800129060129800129060129800129");
+                Verify(writer, "060129800129060129800129060129800129");
+            }
         }
 
         public static IEnumerable<object[]> ValidOidData { get; } =

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteOctetString.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteOctetString.cs
@@ -15,10 +15,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void WriteEmpty(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteOctetString(ReadOnlySpan<byte>.Empty);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteOctetString(ReadOnlySpan<byte>.Empty);
 
-            Verify(writer, "0400");
+                Verify(writer, "0400");
+            }
         }
 
         [Theory]
@@ -41,10 +43,12 @@ namespace System.Security.Cryptography.Tests.Asn1
             string expectedHex = hexStart + payloadHex;
             byte[] data = new byte[length];
 
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            writer.WriteOctetString(data);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                writer.WriteOctetString(data);
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
         
         [Theory]
@@ -63,10 +67,12 @@ namespace System.Security.Cryptography.Tests.Asn1
                 data[i] = 0x88;
             }
 
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            writer.WriteOctetString(data);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                writer.WriteOctetString(data);
 
-            Verify(writer, expectedHex);
+                Verify(writer, expectedHex);
+            }
         }
 
         [Theory]
@@ -116,10 +122,12 @@ namespace System.Security.Cryptography.Tests.Asn1
 
             foreach (Asn1Tag toTry in tagsToTry)
             {
-                AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-                writer.WriteOctetString(toTry, data);
+                using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+                {
+                    writer.WriteOctetString(toTry, data);
 
-                Assert.True(writer.TryEncode(answerBuf, out _));
+                    Assert.True(writer.TryEncode(answerBuf, out _));
+                }
                 Assert.True(Asn1Tag.TryParse(answerBuf, out Asn1Tag writtenTag, out _));
 
                 if (expectConstructed)
@@ -142,15 +150,16 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyWriteOctetString_EndOfContents(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteOctetString(Asn1Tag.EndOfContents, ReadOnlySpan<byte>.Empty));
 
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteOctetString(Asn1Tag.EndOfContents, ReadOnlySpan<byte>.Empty));
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteOctetString(Asn1Tag.EndOfContents, new byte[1]));
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteOctetString(Asn1Tag.EndOfContents, new byte[1]));
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteUtcTime.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteUtcTime.cs
@@ -33,63 +33,75 @@ namespace System.Security.Cryptography.Tests.Asn1
         [MemberData(nameof(TestCases))]
         public void VerifyWriteUtcTime_BER(DateTimeOffset input, string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            writer.WriteUtcTime(input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                writer.WriteUtcTime(input);
 
-            Verify(writer, "17" + expectedHexPayload);
+                Verify(writer, "17" + expectedHexPayload);
+            }
         }
 
         [Theory]
         [MemberData(nameof(TestCases))]
         public void VerifyWriteUtcTime_BER_CustomTag(DateTimeOffset input, string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.BER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Application, 11);
-            writer.WriteUtcTime(tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Application, 11);
+                writer.WriteUtcTime(tag, input);
 
-            Verify(writer, Stringify(tag) + expectedHexPayload);
+                Verify(writer, Stringify(tag) + expectedHexPayload);
+            }
         }
 
         [Theory]
         [MemberData(nameof(TestCases))]
         public void VerifyWriteUtcTime_CER(DateTimeOffset input, string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            writer.WriteUtcTime(input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                writer.WriteUtcTime(input);
 
-            Verify(writer, "17" + expectedHexPayload);
+                Verify(writer, "17" + expectedHexPayload);
+            }
         }
 
         [Theory]
         [MemberData(nameof(TestCases))]
         public void VerifyWriteUtcTime_CER_CustomTag(DateTimeOffset input, string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.CER);
-            Asn1Tag tag = new Asn1Tag(TagClass.Private, 95);
-            writer.WriteUtcTime(tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.Private, 95);
+                writer.WriteUtcTime(tag, input);
 
-            Verify(writer, Stringify(tag) + expectedHexPayload);
+                Verify(writer, Stringify(tag) + expectedHexPayload);
+            }
         }
 
         [Theory]
         [MemberData(nameof(TestCases))]
         public void VerifyWriteUtcTime_DER(DateTimeOffset input, string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            writer.WriteUtcTime(input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                writer.WriteUtcTime(input);
 
-            Verify(writer, "17" + expectedHexPayload);
+                Verify(writer, "17" + expectedHexPayload);
+            }
         }
 
         [Theory]
         [MemberData(nameof(TestCases))]
         public void VerifyWriteUtcTime_DER_CustomTag(DateTimeOffset input, string expectedHexPayload)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 3);
-            writer.WriteUtcTime(tag, input);
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 3);
+                writer.WriteUtcTime(tag, input);
 
-            Verify(writer, Stringify(tag) + expectedHexPayload);
+                Verify(writer, Stringify(tag) + expectedHexPayload);
+            }
         }
 
         [Theory]
@@ -98,11 +110,12 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyWriteUtcTime_EndOfContents(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-
-            AssertExtensions.Throws<ArgumentException>(
-                "tag",
-                () => writer.WriteUtcTime(Asn1Tag.EndOfContents, DateTimeOffset.Now));
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "tag",
+                    () => writer.WriteUtcTime(Asn1Tag.EndOfContents, DateTimeOffset.Now));
+            }
         }
 
         [Theory]
@@ -111,12 +124,14 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData(PublicEncodingRules.DER)]
         public void VerifyWriteUtcTime_IgnoresConstructed(PublicEncodingRules ruleSet)
         {
-            AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet);
-            DateTimeOffset value = new DateTimeOffset(2017, 11, 16, 17, 35, 1, TimeSpan.Zero);
+            using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
+            {
+                DateTimeOffset value = new DateTimeOffset(2017, 11, 16, 17, 35, 1, TimeSpan.Zero);
 
-            writer.WriteUtcTime(new Asn1Tag(UniversalTagNumber.UtcTime, true), value);
-            writer.WriteUtcTime(new Asn1Tag(TagClass.ContextSpecific, 3, true), value);
-            Verify(writer, "170D3137313131363137333530315A" + "830D3137313131363137333530315A");
+                writer.WriteUtcTime(new Asn1Tag(UniversalTagNumber.UtcTime, true), value);
+                writer.WriteUtcTime(new Asn1Tag(TagClass.ContextSpecific, 3, true), value);
+                Verify(writer, "170D3137313131363137333530315A" + "830D3137313131363137333530315A");
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/PkcsPal.AnyOS.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/PkcsPal.AnyOS.cs
@@ -42,9 +42,11 @@ namespace Internal.Cryptography
             public override byte[] EncodeOctetString(byte[] octets)
             {
                 // Write using DER to support the most readers.
-                AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-                writer.WriteOctetString(octets);
-                return writer.Encode();
+                using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+                {
+                    writer.WriteOctetString(octets);
+                    return writer.Encode();
+                }
             }
 
             public override byte[] DecodeOctetString(byte[] encodedOctets)
@@ -104,16 +106,17 @@ namespace Internal.Cryptography
             public override byte[] EncodeUtcTime(DateTime utcTime)
             {
                 // Write using DER to support the most readers.
-                AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-
-                // Sending the DateTime through ToLocalTime here will cause the right normalization
-                // of DateTimeKind.Unknown.
-                //
-                // Local => Local (noop) => UTC (in WriteUtcTime) (adjust, correct)
-                // UTC => Local (adjust) => UTC (adjust back, correct)
-                // Unknown => Local (adjust) => UTC (adjust "back", add Z marker; matches Windows)
-                writer.WriteUtcTime(utcTime.ToLocalTime());
-                return writer.Encode();
+                using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+                {
+                    // Sending the DateTime through ToLocalTime here will cause the right normalization
+                    // of DateTimeKind.Unknown.
+                    //
+                    // Local => Local (noop) => UTC (in WriteUtcTime) (adjust, correct)
+                    // UTC => Local (adjust) => UTC (adjust back, correct)
+                    // Unknown => Local (adjust) => UTC (adjust "back", add Z marker; matches Windows)
+                    writer.WriteUtcTime(utcTime.ToLocalTime());
+                    return writer.Encode();
+                }
             }
 
             public override DateTime DecodeUtcTime(byte[] encodedUtcTime)

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSignature.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSignature.cs
@@ -153,44 +153,46 @@ namespace System.Security.Cryptography.Pkcs
                 fieldSize * 2 == ieeeSignature.Length,
                 $"ieeeSignature.Length ({ieeeSignature.Length}) must be even");
 
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            writer.PushSequence();
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                writer.PushSequence();
 
 #if netcoreapp
-            // r
-            BigInteger val = new BigInteger(
-                ieeeSignature.Slice(0, fieldSize),
-                isUnsigned: true,
-                isBigEndian: true);
+                // r
+                BigInteger val = new BigInteger(
+                    ieeeSignature.Slice(0, fieldSize),
+                    isUnsigned: true,
+                    isBigEndian: true);
 
-            writer.WriteInteger(val);
+                writer.WriteInteger(val);
 
-            // s
-            val = new BigInteger(
-                ieeeSignature.Slice(fieldSize, fieldSize),
-                isUnsigned: true,
-                isBigEndian: true);
+                // s
+                val = new BigInteger(
+                    ieeeSignature.Slice(fieldSize, fieldSize),
+                    isUnsigned: true,
+                    isBigEndian: true);
 
-            writer.WriteInteger(val);
+                writer.WriteInteger(val);
 #else
-            byte[] buf = new byte[fieldSize + 1];
-            Span<byte> bufWriter = new Span<byte>(buf, 1, fieldSize);
+                byte[] buf = new byte[fieldSize + 1];
+                Span<byte> bufWriter = new Span<byte>(buf, 1, fieldSize);
 
-            ieeeSignature.Slice(0, fieldSize).CopyTo(bufWriter);
-            Array.Reverse(buf);
-            BigInteger val = new BigInteger(buf);
-            writer.WriteInteger(val);
+                ieeeSignature.Slice(0, fieldSize).CopyTo(bufWriter);
+                Array.Reverse(buf);
+                BigInteger val = new BigInteger(buf);
+                writer.WriteInteger(val);
 
-            buf[0] = 0;
-            ieeeSignature.Slice(fieldSize, fieldSize).CopyTo(bufWriter);
-            Array.Reverse(buf);
-            val = new BigInteger(buf);
-            writer.WriteInteger(val);
+                buf[0] = 0;
+                ieeeSignature.Slice(fieldSize, fieldSize).CopyTo(bufWriter);
+                Array.Reverse(buf);
+                val = new BigInteger(buf);
+                writer.WriteInteger(val);
 #endif
 
-            writer.PopSequence();
+                writer.PopSequence();
 
-            return writer.Encode();
+                return writer.Encode();
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9MessageDigest.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9MessageDigest.cs
@@ -22,9 +22,11 @@ namespace System.Security.Cryptography.Pkcs
 
         internal Pkcs9MessageDigest(ReadOnlySpan<byte> signatureDigest)
         {
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            writer.WriteOctetString(signatureDigest);
-            RawData = writer.Encode();
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                writer.WriteOctetString(signatureDigest);
+                RawData = writer.Encode();
+            }
         }
 
         //


### PR DESCRIPTION
Without this change the AsnWriter class always sends the last "rented" array to
the garbage collector.  Since arrays from the array pool are expected to be
gen-2 highly reused objects this has unfortunate consequences for both
the induced trickle allocation and Gen2 pressure.

Now it's IDisposable, and the Dispose implementation will return the rented array.