### PR TITLE
Remove old stat struct

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.Stat.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Stat.Pipe.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat2", SetLastError = true)]
         internal static extern int FStat(SafePipeHandle fd, out FileStatus output);
     }
 }

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -171,6 +171,8 @@ static void ConvertFileStatus(const struct stat_* src, struct FileStatus* dst)
 #endif
 }
 
+// CoreCLR expects the "2" suffixes on these: they should be cleaned up in our
+// next coordinated System.Native changes
 int32_t SystemNative_Stat2(const char* path, struct FileStatus* output)
 {
     struct stat_ result;

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -151,27 +151,6 @@ static void ConvertFileStatus(const struct stat_* src, struct FileStatus* dst)
     dst->Uid = src->st_uid;
     dst->Gid = src->st_gid;
     dst->Size = src->st_size;
-    dst->ATime = src->st_atime;
-    dst->MTime = src->st_mtime;
-    dst->CTime = src->st_ctime;
-
-#if HAVE_STAT_BIRTHTIME
-    dst->BirthTime = src->st_birthtime;
-    dst->Flags |= FILESTATUS_FLAGS_HAS_BIRTHTIME;
-#else
-    dst->BirthTime = 0;
-#endif
-}
-
-static void ConvertFileStatus2(const struct stat_* src, struct FileStatus2* dst)
-{
-    dst->Dev = (int64_t)src->st_dev;
-    dst->Ino = (int64_t)src->st_ino;
-    dst->Flags = FILESTATUS_FLAGS_NONE;
-    dst->Mode = (int32_t)src->st_mode;
-    dst->Uid = src->st_uid;
-    dst->Gid = src->st_gid;
-    dst->Size = src->st_size;
 
     dst->ATime = src->st_atime;
     dst->MTime = src->st_mtime;
@@ -192,7 +171,7 @@ static void ConvertFileStatus2(const struct stat_* src, struct FileStatus2* dst)
 #endif
 }
 
-int32_t SystemNative_Stat(const char* path, struct FileStatus* output)
+int32_t SystemNative_Stat2(const char* path, struct FileStatus* output)
 {
     struct stat_ result;
     int ret;
@@ -206,7 +185,7 @@ int32_t SystemNative_Stat(const char* path, struct FileStatus* output)
     return ret;
 }
 
-int32_t SystemNative_FStat(intptr_t fd, struct FileStatus* output)
+int32_t SystemNative_FStat2(intptr_t fd, struct FileStatus* output)
 {
     struct stat_ result;
     int ret;
@@ -220,7 +199,7 @@ int32_t SystemNative_FStat(intptr_t fd, struct FileStatus* output)
     return ret;
 }
 
-int32_t SystemNative_LStat(const char* path, struct FileStatus* output)
+int32_t SystemNative_LStat2(const char* path, struct FileStatus* output)
 {
     struct stat_ result;
     int ret = lstat_(path, &result);
@@ -228,47 +207,6 @@ int32_t SystemNative_LStat(const char* path, struct FileStatus* output)
     if (ret == 0)
     {
         ConvertFileStatus(&result, output);
-    }
-
-    return ret;
-}
-
-int32_t SystemNative_Stat2(const char* path, struct FileStatus2* output)
-{
-    struct stat_ result;
-    int ret;
-    while ((ret = stat_(path, &result)) < 0 && errno == EINTR);
-
-    if (ret == 0)
-    {
-        ConvertFileStatus2(&result, output);
-    }
-
-    return ret;
-}
-
-int32_t SystemNative_FStat2(intptr_t fd, struct FileStatus2* output)
-{
-    struct stat_ result;
-    int ret;
-    while ((ret = fstat_(ToFileDescriptor(fd), &result)) < 0 && errno == EINTR);
-
-    if (ret == 0)
-    {
-        ConvertFileStatus2(&result, output);
-    }
-
-    return ret;
-}
-
-int32_t SystemNative_LStat2(const char* path, struct FileStatus2* output)
-{
-    struct stat_ result;
-    int ret = lstat_(path, &result);
-
-    if (ret == 0)
-    {
-        ConvertFileStatus2(&result, output);
     }
 
     return ret;

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -26,24 +26,6 @@ struct FileStatus
     uint32_t Gid;      // group ID of owner
     int64_t Size;      // total size, in bytes
     int64_t ATime;     // time of last access
-    int64_t MTime;     // time of last modification
-    int64_t CTime;     // time of last status change
-    int64_t BirthTime; // time the file was created
-    int64_t Dev;       // ID of the device containing the file
-    int64_t Ino;       // inode number of the file
-};
-
-/**
- * File status returned by Stat or FStat.
- */
-struct FileStatus2
-{
-    int32_t Flags;     // flags for testing if some members are present (see FileStatusFlags)
-    int32_t Mode;      // file mode (see S_I* constants above for bit values)
-    uint32_t Uid;      // user ID of owner
-    uint32_t Gid;      // group ID of owner
-    int64_t Size;      // total size, in bytes
-    int64_t ATime;     // time of last access
     int64_t ATimeNsec; //     nanosecond part
     int64_t MTime;     // time of last modification
     int64_t MTimeNsec; //     nanosecond part


### PR DESCRIPTION
Depends on ingesting https://github.com/dotnet/coreclr/pull/15872

Remove "2" suffix from stat struct and private function.
Retain "2" suffix for public functions since CoreCLR calls that.

@jkotas I do not plan to do 4th and 5th commits to get rid of this "2" suffix as it does not seem very important. I imagine we can continue this scheme (@JeremyKuhne has some similar edits to do) and do a "suffix cleanup" pass later. LMK if you would rather I continue with the commits.