### PR TITLE
Refactor and tests for MS.CSharp's GetBestAccessibleType()

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -274,15 +274,13 @@ namespace Microsoft.CSharp.RuntimeBinder
 
                 // This ensures that the type we pick is something that the user could have written.
 
-                CType actualType = _symbolTable.GetCTypeFromType(t);
-                bool res = _semanticChecker.GetTypeManager().GetBestAccessibleType(_semanticChecker, _bindingContext.ContextForMemberLookup, actualType, out CType bestType);
-
                 // Since the actual type of these arguments are never going to be pointer
                 // types or ref/out types (they are in fact boxed into an object), we have
                 // a guarantee that we will always be able to find a best accessible type
                 // (which, in the worst case, may be object).
-                Debug.Assert(res, "Unexpected failure of GetBestAccessibleType in construction of argument array");
 
+                CType actualType = _symbolTable.GetCTypeFromType(t);
+                CType bestType = _semanticChecker.GetTypeManager().GetBestAccessibleType(_semanticChecker, _bindingContext.ContextForMemberLookup, actualType);
                 t = bestType.AssociatedSystemType;
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -275,9 +275,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 // This ensures that the type we pick is something that the user could have written.
 
                 CType actualType = _symbolTable.GetCTypeFromType(t);
-                CType bestType;
-
-                bool res = _semanticChecker.GetTypeManager().GetBestAccessibleType(_semanticChecker, _bindingContext, actualType, out bestType);
+                bool res = _semanticChecker.GetTypeManager().GetBestAccessibleType(_semanticChecker, _bindingContext.ContextForMemberLookup, actualType, out CType bestType);
 
                 // Since the actual type of these arguments are never going to be pointer
                 // types or ref/out types (they are in fact boxed into an object), we have

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -1704,30 +1704,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // used to alter the types at the beginning of binding. that
             // way we get an accessible type, and if it so happens that
             // the selected type is inappropriate (for conversions) then
-            // we let overload resolution sort it out. 
+            // we let overload resolution sort it out.
             //
             // since we can never infer ref/out or pointer types here, we
-            // are more or less guaranteed a best accessible type. However,
-            // in the interest of safety, if it becomes impossible to
-            // choose a "best accessible" type, then we will fail type
-            // inference so we do not try to pass the inaccessible type
-            // back to overload resolution.
+            // are guaranteed a best accessible type.
 
-            if (GetTypeManager().GetBestAccessibleType(_binder.GetSemanticChecker(), _binder.GetContext().ContextForMemberLookup, pBest, out CType pBestAccessible))
-            {
-                pBest = pBestAccessible;
-            }
-            else
-            {
-                Debug.Assert(false, "Method type inference could not find an accessible type over the best candidate in fixed");
-                return false;
-            }
-
+            _pFixedResults[iParam] = GetTypeManager().GetBestAccessibleType(_binder.GetSemanticChecker(), _binder.GetContext().ContextForMemberLookup, pBest);
             // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             // END RUNTIME BINDER ONLY CHANGE
             // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-            _pFixedResults[iParam] = pBest;
             UpdateDependenciesAfterFix(iParam);
             return true;
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -1713,8 +1713,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // inference so we do not try to pass the inaccessible type
             // back to overload resolution.
 
-            CType pBestAccessible;
-            if (GetTypeManager().GetBestAccessibleType(_binder.GetSemanticChecker(), _binder.GetContext(), pBest, out pBestAccessible))
+            if (GetTypeManager().GetBestAccessibleType(_binder.GetSemanticChecker(), _binder.GetContext().ContextForMemberLookup, pBest, out CType pBestAccessible))
             {
                 pBest = pBestAccessible;
             }

--- a/src/Microsoft.CSharp/tests/AccessTests.cs
+++ b/src/Microsoft.CSharp/tests/AccessTests.cs
@@ -1,0 +1,188 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public partial class AccessTests
+    {
+        public abstract class PublicReferenceType
+        {
+            public abstract int IntValueProperty { get; }
+        }
+
+        public interface ITestIFace
+        {
+        }
+
+        public interface ITestIFaceCons<out T> where T : ITestIFace
+        {
+        }
+
+        private static class Container
+        {
+            private abstract class ReferenceTypeIntermediary : PublicReferenceType
+            {
+            }
+
+            private class ReferenceType : ReferenceTypeIntermediary, ITestIFace
+            {
+                public override int IntValueProperty => 23;
+            }
+
+            private struct PrivateValueType
+            {
+            }
+
+            private interface IPrivateInterface
+            {
+            }
+
+            public static dynamic GetReferenceType() => new ReferenceType();
+
+            public static dynamic TenReferenceTypesArray() => new ReferenceType[10];
+
+            public static dynamic TenReferenceTypesRepeat() => Enumerable.Repeat(new ReferenceType(), 10);
+
+            public static dynamic ReferenceTypeDelegate() =>
+                (Func<int, IEnumerable<ReferenceType>>)(i => Enumerable.Repeat(new ReferenceType(), i));
+
+            public static dynamic ValueTypeArray() => new PrivateValueType[2];
+
+            private delegate int PrivateFunc<T>(T arg);
+
+            public static dynamic PrivateDelegateType() => (PrivateFunc<ReferenceType>)(r => r.IntValueProperty);
+
+            public static dynamic ValueTypeDelegate() => (Func<PrivateValueType>)(() => new PrivateValueType());
+
+            public unsafe static dynamic PointerArray() => new PrivateValueType*[4];
+
+            public static dynamic PrivateInterfaceDelegate() => (Func<IPrivateInterface>)(() => null);
+
+            public static dynamic PrivateConstraintInterfaceDelegate() => (Func<ITestIFaceCons<ReferenceType>>)(() => null);
+        }
+
+        [Fact]
+        public void CanGetAccessibleBaseOfInaccessibleType() => Assert.Equal(23, Container.GetReferenceType().IntValueProperty);
+
+        [Fact]
+        public void AccessibleArray() => Assert.Equal(10, Enumerable.Count(Container.TenReferenceTypesArray()));
+
+        [Fact]
+        public void AccessibleInterface() => Assert.Equal(10, Enumerable.Count(Container.TenReferenceTypesRepeat()));
+
+        [Fact]
+        public void AccessCovariantDelegate()
+        {
+            IEnumerable<PublicReferenceType> prts = Container.ReferenceTypeDelegate()(4);
+            Assert.Equal(4, prts.Count());
+            foreach (PublicReferenceType prt in prts)
+            {
+                Assert.Equal(23, prt.IntValueProperty);
+            }
+        }
+
+        [Fact]
+        public void NonCovariantArrayToArrayType() => Assert.Equal(2, Container.ValueTypeArray().Length);
+
+        [Fact]
+        public void NonCovariantArrayNotCastToIndexableType()
+        {
+            dynamic array = Container.ValueTypeArray();
+            Assert.Throws<RuntimeBinderException>(() => array[0]);
+        }
+
+        [Fact]
+        public void PointerArrayToArrayType() => Assert.Equal(4, Container.PointerArray().Length);
+
+        [Fact]
+        public void PointerArrayNotCastToIndexableType()
+        {
+            dynamic array = Container.PointerArray();
+            Assert.Throws<RuntimeBinderException>(() => array[0]);
+        }
+
+        [Fact]
+        public void PrivateDelegateType()
+        {
+            dynamic d = Container.PrivateDelegateType();
+            dynamic a = Container.GetReferenceType();
+            Assert.Throws<RuntimeBinderException>(() => d(a));
+            d.DynamicInvoke(a); // Can use as MulticastDelegate.
+        }
+
+        [Fact]
+        public void PrivateValueTypeDelegateType()
+        {
+            dynamic d = Container.ValueTypeDelegate();
+            Assert.Throws<RuntimeBinderException>(() => d());
+            ValueType result = d.DynamicInvoke(); // Can use as MulticastDelegate.
+        }
+
+        [Fact]
+        public void PrivateIFaceDelegateType()
+        {
+            dynamic d = Container.PrivateInterfaceDelegate();
+            Assert.Null(d());
+        }
+
+        [Fact]
+        public void PrivateInterfaceConstraint()
+        {
+            // Casting Func<ITestIFaceCons<ReferenceType>> to Func<ITestIFaceCons<PublicReferenceType>>
+            // would be illegal because ITestIFaceCons<PublicReferenceType> violates the ITestIFaceCons
+            // constraints, so the binder has to detect that, and cast to Func<object>.
+            dynamic d = Container.PrivateConstraintInterfaceDelegate();
+            Assert.Null(d());
+        }
+
+        private struct SomeValueType
+        {
+            public override string ToString() => "test";
+        }
+
+        [Fact]
+        public void NullableOfInaccessible()
+        {
+            // ValueType members work without access to the type.
+            CallSite<Func<CallSite, SomeValueType?, object>> site =
+                CallSite<Func<CallSite, SomeValueType?, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, "ToString", null, null,
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                        }));
+            Func<CallSite, SomeValueType?, object> target = site.Target;
+            Assert.Equal("test", target(site, new SomeValueType()));
+
+            // Nullable<T> members work with access to the type.
+            site = CallSite<Func<CallSite, SomeValueType?, object>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.None, "GetValueOrDefault", null, GetType(),
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                    }));
+            target = site.Target;
+            Assert.Equal(new SomeValueType(), target(site, new SomeValueType()));
+
+            // Nullable<T> members don't work without access to the type.
+            site = CallSite<Func<CallSite, SomeValueType?, object>>.Create(
+                Binder.InvokeMember(
+                    CSharpBinderFlags.None, "GetValueOrDefault", null, null,
+                    new[]
+                    {
+                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                    }));
+            target = site.Target;
+            Assert.Throws<RuntimeBinderException>(() => target(site, new SomeValueType()));
+        }
+    }
+}

--- a/src/Microsoft.CSharp/tests/AccessTests.netcoreapp.cs
+++ b/src/Microsoft.CSharp/tests/AccessTests.netcoreapp.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Microsoft.CSharp.RuntimeBinder.Tests
 {
-    public class AccessTests
+    public partial class AccessTests
     {
         private readonly Type _baseType;
         private readonly Type _siblingType;

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -3,12 +3,14 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="AccessTests.cs" />
     <Compile Include="ArrayHandling.cs" />
     <Compile Include="AssignmentTests.cs" />
     <Compile Include="BindingErrors.cs" />


### PR DESCRIPTION
* Rearrange `GetBestAccessibleType` to avoid repeated tests & recursion.

Keep all code for `AggregateType` in the first branch for `AggregateType`, etc.

* Use `ContextForMemberLookup` instead of `BindingContext` for best accessible

The `BindingContext` is only used for this property, which it hits repeatedly, so just pass it in instead.

* Don't use intermediate variables for `out` parameters.

If just going to assign it to something anyway.

* Return type directly from `GetBestAccessibleType()`

The type passed in can never be `ParameterModifierType` or `PointerType` so the case where false is returned can never be hit. Change to returning the accessible type directly, and remove branches for false returns.

* Add tests for getting best accessible type.