### PR TITLE
add ability to enable managed handler via runtime config

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http
     {
         // This partial implementation contains members common to all HttpClientHandler implementations.
         private const string ManagedHandlerSettingName = "COMPlus_UseManagedHttpClientHandler";
-        private const string AppCtxManagedHandlerSettingName = "Switch.System.Net.Http.DefaultUseManagedHttp";
+        private const string AppCtxManagedHandlerSettingName = "Switch.System.Net.Http.DefaultHttpClientHandlerToManagedHandler";
 
         private static LocalDataStoreSlot s_useManagedHandlerSlot;
 

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -27,8 +27,7 @@ namespace System.Net.Http
                     return true;
                 }
 
-                bool managedEnabled;
-                if (AppContext.TryGetSwitch(AppCtxManagedHandlerSettingName, out managedEnabled) && managedEnabled)
+                if (AppContext.TryGetSwitch(AppCtxManagedHandlerSettingName, out bool isManagedEnabled) && isManagedEnabled)
                 {
                     return true;
                 }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http
     {
         // This partial implementation contains members common to all HttpClientHandler implementations.
         private const string ManagedHandlerSettingName = "COMPlus_UseManagedHttpClientHandler";
-        private const string AppCtxManagedHandlerSettingName = "Switch.System.Net.Http.DefaultHttpClientHandlerToManagedHandler";
+        private const string AppCtxManagedHandlerSettingName = "System.Net.Http.UseManagedHttpClientHandler";
 
         private static LocalDataStoreSlot s_useManagedHandlerSlot;
 

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http
                     return true;
                 }
 
-                bool managedEnabled=false;
+                bool managedEnabled;
                 if (AppContext.TryGetSwitch(AppCtxManagedHandlerSettingName, out managedEnabled) && managedEnabled)
                 {
                     return true;

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -13,6 +13,7 @@ namespace System.Net.Http
     {
         // This partial implementation contains members common to all HttpClientHandler implementations.
         private const string ManagedHandlerSettingName = "COMPlus_UseManagedHttpClientHandler";
+        private const string AppCtxManagedHandlerSettingName = "Switch.System.Net.Http.DefaultUseManagedHttp";
 
         private static LocalDataStoreSlot s_useManagedHandlerSlot;
 
@@ -22,6 +23,12 @@ namespace System.Net.Http
             {
                 // Check the environment variable to see if it's been set to true.  If it has, use the managed handler.
                 if (Environment.GetEnvironmentVariable(ManagedHandlerSettingName) == "true")
+                {
+                    return true;
+                }
+
+                bool managedEnabled=false;
+                if (AppContext.TryGetSwitch(AppCtxManagedHandlerSettingName, out managedEnabled) && managedEnabled)
                 {
                     return true;
                 }


### PR DESCRIPTION
add ability to enable managed handler via Switch.System.Net.Http.DefaultUseManagedHttp appContext setting

Testing: 
- create simple app using http handler/client.
-set all_proxy on Linux and  make request.
- verify that the variable is used.
-  add to proxy-test.runtimeconfig.json 
{
  "runtimeOptions": {
    "configProperties": {
        "Switch.System.Net.Http. DefaultHttpClientHandlerToManagedHandler": true
    },
}
- run test again. verify that all_proxy variable is ignored. That means managed handler is in use (as it does not yet support it) 
I also did some testing with adding debug messages and UseManagedHandler() returns true is set to true, and new block is skipped is missing or set to false. 
