### PR TITLE
preserve spaces in arguments when passing among scripts on Unix

### DIFF
--- a/build-managed.sh
+++ b/build-managed.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$working_tree_root/run.sh build-managed $*
+$working_tree_root/run.sh build-managed "$@"
 exit $?

--- a/build-native.sh
+++ b/build-native.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #The Run Command Tool is calling src/Native/build-native.sh
-$working_tree_root/run.sh build-native $*
+$working_tree_root/run.sh build-native "$@"
 exit $?

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$working_tree_root/run.sh build-managed -packages $*
+$working_tree_root/run.sh build-managed -packages "$@"
 exit $?

--- a/build.sh
+++ b/build.sh
@@ -38,10 +38,10 @@ if [ "$1" != "" ] && [[ "$1" != -* ]]; then
     fi
 fi
 
-"$__scriptpath/build-native.sh" $*
+"$__scriptpath/build-native.sh" "$@"
 if [ $? -ne 0 ];then
    exit 1
 fi
 
-"$__scriptpath/build-managed.sh" -BuildPackages=true $*
+"$__scriptpath/build-managed.sh" -BuildPackages=true "$@"
 exit $?

--- a/clean.sh
+++ b/clean.sh
@@ -33,5 +33,5 @@ if [ $# == 0 ]; then
     __args=-b
 fi
 
-$__working_tree_root/run.sh clean $__args $*
+$__working_tree_root/run.sh clean $__args "$@"
 exit $?

--- a/publish-packages.sh
+++ b/publish-packages.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$working_tree_root/run.sh publish-packages $*
+$working_tree_root/run.sh publish-packages "$@"
 exit $?

--- a/run.sh
+++ b/run.sh
@@ -14,5 +14,5 @@ __toolRuntime=$__scriptpath/Tools
 __dotnet=$__toolRuntime/dotnetcli/dotnet
 
 cd $__scriptpath
-$__dotnet $__toolRuntime/run.exe $__scriptpath/config.json $*
+$__dotnet $__toolRuntime/run.exe $__scriptpath/config.json "$@"
 exit $?

--- a/sync.sh
+++ b/sync.sh
@@ -6,5 +6,5 @@ fi
 
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-$working_tree_root/run.sh sync $__args $*
+$working_tree_root/run.sh sync $__args "$@"
 exit $?


### PR DESCRIPTION
partial fix for #23360

replace $* with "$@" to properly preserve spaces in shell arguments
With $*, passing "aa bb" will be transformed to "aa" "bb" on Next level. 
"$@" will preserve arguments with spaces as they were passed in. 
(like the "-showprogress -parallel none") 

To fully fix the issue we will also need to update msbuild.sh it self. 
 
I've been using this for quite a while in my local build trees. 
The open question is if anything in CI infrastructure depends on existing (broken) behavior. 
There was one earlier failed attempt because it did uncovered unbalanced quotes in some other scripts. 
