### PR TITLE
Added missing status code 429 Too Many Requests

### DIFF
--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -172,6 +172,10 @@ namespace System.Net
         Unused = 306,
         UpgradeRequired = 426,
         UseProxy = 305,
+        PreconditionRequired = 428,
+        TooManyRequests = 429,
+        RequestHeaderFieldsTooLarge = 431,
+        NetworkAuthenticationRequired = 511
     }
     public partial interface ICredentials
     {

--- a/src/System.Net.Primitives/src/System/Net/HttpStatusCode.cs
+++ b/src/System.Net.Primitives/src/System/Net/HttpStatusCode.cs
@@ -56,6 +56,7 @@ namespace System.Net
         ExpectationFailed = 417,
 
         UpgradeRequired = 426,
+        TooManyRequests = 429,
 
         // Server Error 5xx
         InternalServerError = 500,

--- a/src/System.Net.Primitives/src/System/Net/HttpStatusCode.cs
+++ b/src/System.Net.Primitives/src/System/Net/HttpStatusCode.cs
@@ -56,7 +56,9 @@ namespace System.Net
         ExpectationFailed = 417,
 
         UpgradeRequired = 426,
+        PreconditionRequired = 428,
         TooManyRequests = 429,
+        RequestHeaderFieldsTooLarge = 431,
 
         // Server Error 5xx
         InternalServerError = 500,
@@ -65,5 +67,6 @@ namespace System.Net
         ServiceUnavailable = 503,
         GatewayTimeout = 504,
         HttpVersionNotSupported = 505,
+        NetworkAuthenticationRequired = 511,
     }
 }


### PR DESCRIPTION
This enumeration is missing HTTP status code 429 Too Many Requests - this is used by many rate-limited services to indicate that the current allocation has been exceeded.

For example the British government's companies registry service does this: https://developer.companieshouse.gov.uk/api/docs/index/gettingStarted/rateLimiting.html

.NET should be able to handle and create responses with this status code.