### PR TITLE
Remove test for "wrong nested this" in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_AmbigBinaryOps = 34,
         ERR_AmbigUnaryOp = 35,
         ERR_ValueCantBeNull = 37,
-        ERR_WrongNestedThis = 38,
         ERR_NoSuchMember = 117,
         ERR_ObjectRequired = 120,
         ERR_AmbigCall = 121,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -44,9 +44,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case ErrorCode.ERR_ValueCantBeNull:
                     codeStr = SR.ValueCantBeNull;
                     break;
-                case ErrorCode.ERR_WrongNestedThis:
-                    codeStr = SR.WrongNestedThis;
-                    break;
                 case ErrorCode.ERR_NoSuchMember:
                     codeStr = SR.NoSuchMember;
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1135,8 +1135,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     pfConstrained = true;
                 }
 
-                Debug.Assert(tryConvert(pObject, swt.GetType(), CONVERTTYPE.NOUDC) != null);
-                return tryConvert(pObject, swt.GetType(), CONVERTTYPE.NOUDC);
+                pObject = tryConvert(pObject, swt.GetType(), CONVERTTYPE.NOUDC);
+                Debug.Assert(pObject != null);
             }
 
             return pObject;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1135,18 +1135,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     pfConstrained = true;
                 }
 
-                Expr objNew = tryConvert(pObject, swt.GetType(), CONVERTTYPE.NOUDC);
-
-                // This check ensures that we do not bind to methods in an outer class
-                // which are visible, but whose this pointer is of an incorrect type...
-                // ... also handles case of calling an pObject method on a RefAny value.
-                // WE don't give a great message for this, but it'll do.
-                if (objNew == null)
-                {
-                    throw ErrorContext.Error(ErrorCode.ERR_WrongNestedThis, swt.GetType(), pObject.Type);
-                }
-
-                pObject = objNew;
+                Debug.Assert(tryConvert(pObject, swt.GetType(), CONVERTTYPE.NOUDC) != null);
+                return tryConvert(pObject, swt.GetType(), CONVERTTYPE.NOUDC);
             }
 
             return pObject;

--- a/src/Microsoft.CSharp/src/Resources/Strings.de.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.de.resx
@@ -81,9 +81,6 @@
   <data name="ValueCantBeNull" xml:space="preserve">
     <value>NULL kann nicht in {0} konvertiert werden, da dieser Werttyp nicht auf NULL festgelegt werden kann.</value>
   </data>
-  <data name="WrongNestedThis" xml:space="preserve">
-    <value>Auf einen nicht statischen Member des äußeren {0}-Typs kann nicht über den geschachtelten {1}-Typ zugegriffen werden.</value>
-  </data>
   <data name="NoSuchMember" xml:space="preserve">
     <value>{0} enthält keine Definition für {1}.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.es.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.es.resx
@@ -81,9 +81,6 @@
   <data name="ValueCantBeNull" xml:space="preserve">
     <value>No se puede convertir NULL en '{0}' porque es un tipo de valor que no acepta valores NULL.</value>
   </data>
-  <data name="WrongNestedThis" xml:space="preserve">
-    <value>No se puede obtener acceso a un miembro no estático de tipo externo '{0}' mediante el tipo anidado '{1}'.</value>
-  </data>
   <data name="NoSuchMember" xml:space="preserve">
     <value>'{0}' no contiene una definición para '{1}'.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
@@ -81,9 +81,6 @@
   <data name="ValueCantBeNull" xml:space="preserve">
     <value>Impossible de convertir null en '{0}', car il s'agit d'un type valeur qui n'autorise pas les valeurs null</value>
   </data>
-  <data name="WrongNestedThis" xml:space="preserve">
-    <value>Impossible d'accéder à un membre non statique de type externe '{0}' par l'intermédiaire du type imbriqué '{1}'</value>
-  </data>
   <data name="NoSuchMember" xml:space="preserve">
     <value>'{0}' ne contient pas de définition pour '{1}'</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.it.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.it.resx
@@ -81,9 +81,6 @@
   <data name="ValueCantBeNull" xml:space="preserve">
     <value>Impossibile convertire Null in '{0}' perché è un tipo di valore non nullable</value>
   </data>
-  <data name="WrongNestedThis" xml:space="preserve">
-    <value>Impossibile accedere a un membro non statico di tipo outer '{0}' tramite il tipo annidato '{1}'</value>
-  </data>
   <data name="NoSuchMember" xml:space="preserve">
     <value>'{0}' non contiene una definizione per '{1}'</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
@@ -81,9 +81,6 @@
   <data name="ValueCantBeNull" xml:space="preserve">
     <value>Null 非許容の値型であるため、Null を '{0}' に変換できません</value>
   </data>
-  <data name="WrongNestedThis" xml:space="preserve">
-    <value>入れ子にされた型 '{1}' を経由して、外の型 '{0}' の静的でないメンバーにアクセスすることはできません</value>
-  </data>
   <data name="NoSuchMember" xml:space="preserve">
     <value>'{0}' に '{1}' の定義がありません</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
@@ -81,9 +81,6 @@
   <data name="ValueCantBeNull" xml:space="preserve">
     <value>'{0}'은(는) null을 허용하지 않는 값 형식이므로 null을 이 형식으로 변환할 수 없습니다.</value>
   </data>
-  <data name="WrongNestedThis" xml:space="preserve">
-    <value>중첩 형식 '{1}'을(를) 통해 외부 형식 '{0}'의 static이 아닌 멤버에 액세스할 수 없습니다.</value>
-  </data>
   <data name="NoSuchMember" xml:space="preserve">
     <value>'{0}'에 '{1}'에 대한 정의가 없습니다.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -109,9 +109,6 @@
   <data name="ValueCantBeNull" xml:space="preserve">
     <value>Cannot convert null to '{0}' because it is a non-nullable value type</value>
   </data>
-  <data name="WrongNestedThis" xml:space="preserve">
-    <value>Cannot access a non-static member of outer type '{0}' via nested type '{1}'</value>
-  </data>
   <data name="NoSuchMember" xml:space="preserve">
     <value>'{0}' does not contain a definition for '{1}'</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
@@ -81,9 +81,6 @@
   <data name="ValueCantBeNull" xml:space="preserve">
     <value>Cannot convert null to "{0}" because it is a non-nullable value type</value>
   </data>
-  <data name="WrongNestedThis" xml:space="preserve">
-    <value>Невозможно получить доступ к нестатическому члену внешнего типа "{0}" через вложенный тип "{1}"</value>
-  </data>
   <data name="NoSuchMember" xml:space="preserve">
     <value>"{0}" не содержит определения для "{1}"</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
@@ -81,9 +81,6 @@
   <data name="ValueCantBeNull" xml:space="preserve">
     <value>无法将 null 转换为“{0}”，因为后者是不可以为 null 的值类型</value>
   </data>
-  <data name="WrongNestedThis" xml:space="preserve">
-    <value>无法通过嵌套类型“{1}”来访问外部类型“{0}”的非静态成员</value>
-  </data>
   <data name="NoSuchMember" xml:space="preserve">
     <value>“{0}”未包含“{1}”的定义</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
@@ -81,9 +81,6 @@
   <data name="ValueCantBeNull" xml:space="preserve">
     <value>無法將 null 轉換成 '{0}'，因為它是不可為 null 的實值型別</value>
   </data>
-  <data name="WrongNestedThis" xml:space="preserve">
-    <value>無法透過巢狀型別 '{1}' 存取外部型別 '{0}' 的非靜態成員</value>
-  </data>
   <data name="NoSuchMember" xml:space="preserve">
     <value>'{0}' 不包含 '{1}' 的定義</value>
   </data>


### PR DESCRIPTION
Since we have dynamically found a member by examining a type or the type of an object, it can never not be nor be derived from the type the member was found on, unlike in the static binding when where lookup can include outer classes, (with CS0038 resulting if the member found isn't static).

Remove the test, which involves removing `ERR_WrongNestedThis`, contributing to #22470