### PR TITLE
Removing uapvNext assets where there shouldn't be

### DIFF
--- a/external/dir.proj
+++ b/external/dir.proj
@@ -8,6 +8,7 @@
   <!-- Build for all configurations -->
   <ItemGroup>
     <Project Condition="'$(BuildAllConfigurations)' == 'true'" Include="netcoreapp/netcoreapp.depproj" />
+    <Project Condition="'$(BuildAllConfigurations)' == 'true'" Include="uap/uap.depproj" />
     <Project Include="netstandard/netstandard.depproj" />
     <Project Include="netfx/netfx.depproj" />
     <Project Include="runtime/runtime.depproj" />

--- a/external/uap/Configurations.props
+++ b/external/uap/Configurations.props
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard;
-      netstandard1.1;
       uap10.0.15138;
     </BuildConfigurations>
   </PropertyGroup>

--- a/external/uap/uap.depproj
+++ b/external/uap/uap.depproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <!-- This project restores and publishes the targeting pack for specific versions of UAP.
+       With this, we are able to compile assemblies against shipped, stable versions of UAP. -->
+  <PropertyGroup>
+    <BinPlaceRef>true</BinPlaceRef>
+    <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
+    <UAPPackageVersion>6.0.6</UAPPackageVersion>
+    <TargetFramework>uap10.0.15138</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+      <Version>$(UAPPackageVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- for all configurations this project provides refs for that configuration -->
+    <BinPlaceConfiguration Include="$(Configuration)">
+      <RefPath>$(RefPath)</RefPath>
+    </BinPlaceConfiguration>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Buffers/ref/Configurations.props
+++ b/src/System.Buffers/ref/Configurations.props
@@ -5,6 +5,7 @@
       netstandard;
       netstandard1.1;
       uap10.0.15138;
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Buffers/ref/Configurations.props
+++ b/src/System.Buffers/ref/Configurations.props
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
       netstandard1.1;
       uap10.0.15138;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
       uap;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Buffers/ref/System.Buffers.csproj
+++ b/src/System.Buffers/ref/System.Buffers.csproj
@@ -10,11 +10,16 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Buffers.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.1' Or '$(TargetGroup)' == 'uap10.0.15138'">
     <Reference Include="System.Runtime" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+    <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Buffers/ref/System.Buffers.csproj
+++ b/src/System.Buffers/ref/System.Buffers.csproj
@@ -8,10 +8,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Buffers.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.1'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.1' Or '$(TargetGroup)' == 'uap10.0.15138'">
     <Reference Include="System.Runtime" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Buffers/src/Configurations.props
+++ b/src/System.Buffers/src/Configurations.props
@@ -6,6 +6,7 @@
       netstandard;
       netcoreapp2.0-Windows_NT;
       netcoreapp2.0-Unix;
+      uap10.0.15138-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Buffers/src/Configurations.props
+++ b/src/System.Buffers/src/Configurations.props
@@ -6,13 +6,13 @@
       netstandard;
       netcoreapp2.0-Windows_NT;
       netcoreapp2.0-Unix;
-      uap-Windows_NT;
-      uapaot-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
+      uap-Windows_NT;
+      uapaot-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netstandard' and '$(TargetGroup)' != 'netstandard1.1'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netstandard' and '$(TargetGroup)' != 'netstandard1.1' and '$(TargetGroup)' != 'uap10.0.15138'">true</IsPartialFacadeAssembly>
     <ExcludeResourcesImport Condition="'$(IsPartialFacadeAssembly)'=='true'">true</ExcludeResourcesImport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
@@ -24,6 +24,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Windows_NT-Release|AnyCPU'" />
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Buffers\ArrayPool.cs" />
     <Compile Include="System\Buffers\ArrayPoolEventSource.cs" />

--- a/src/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.csproj
+++ b/src/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.csproj
@@ -3,8 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{FD6AA2B9-56DB-4BCC-85E0-7727506562B0}</ProjectGuid>
-    <!-- UAPvNext is not yet mapped to netstandard2.0, manually duplicate this ref -->
-    <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard'">netstandard2.0;$(UAPvNextTFM)</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />

--- a/src/System.IO.Packaging/src/System.IO.Packaging.csproj
+++ b/src/System.IO.Packaging/src/System.IO.Packaging.csproj
@@ -7,8 +7,6 @@
     <AssemblyName>System.IO.Packaging</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='netfx' OR '$(TargetGroup)'=='net46'">true</IsPartialFacadeAssembly>
-    <!-- UAPvNext is not yet mapped to netstandard2.0, manually duplicate this ref -->
-    <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard'">netstandard2.0;$(UAPvNextTFM)</PackageTargetFramework>
     <DefineConstants Condition="'$(TargetGroup)' != 'netstandard1.3'">$(DefineConstants);FEATURE_SERIALIZATION</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46-Debug|AnyCPU'" />

--- a/src/System.Memory/ref/Configurations.props
+++ b/src/System.Memory/ref/Configurations.props
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard1.1;
       netstandard;
       netcoreapp;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
       uap;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Memory/ref/Configurations.props
+++ b/src/System.Memory/ref/Configurations.props
@@ -5,6 +5,7 @@
       netstandard1.1;
       netstandard;
       netcoreapp;
+      uap10.0.15138;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Memory/ref/System.Memory.csproj
+++ b/src/System.Memory/ref/System.Memory.csproj
@@ -19,11 +19,11 @@
   <ItemGroup>
     <Compile Include="System.Memory.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true' and '$(TargetGroup)' != 'uap10.0.15138'">
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Runtime.InteropServices\ref\System.Runtime.InteropServices.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.1'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.1' Or '$(TargetGroup)' == 'uap10.0.15138'">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices" />
   </ItemGroup>

--- a/src/System.Memory/src/Configurations.props
+++ b/src/System.Memory/src/Configurations.props
@@ -6,6 +6,7 @@
       netstandard;
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
+      uap10.0.15138-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Memory/src/Configurations.props
+++ b/src/System.Memory/src/Configurations.props
@@ -1,11 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard1.1;
       netstandard;
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Reflection.DispatchProxy/ref/Configurations.props
+++ b/src/System.Reflection.DispatchProxy/ref/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      uap10.0.15138;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.DispatchProxy/ref/Configurations.props
+++ b/src/System.Reflection.DispatchProxy/ref/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netstandard;
       uap10.0.15138;
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.DispatchProxy/ref/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/ref/System.Reflection.DispatchProxy.csproj
@@ -8,11 +8,16 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Reflection.DispatchProxy.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uap10.0.15138'">
     <Reference Include="System.Runtime" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+    <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.DispatchProxy/ref/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/ref/System.Reflection.DispatchProxy.csproj
@@ -6,8 +6,13 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Reflection.DispatchProxy.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap10.0.15138'">
+    <Reference Include="System.Runtime" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.DispatchProxy/src/Configurations.props
+++ b/src/System.Reflection.DispatchProxy/src/Configurations.props
@@ -6,6 +6,7 @@
       netstandard;
       netcoreapp2.0;
       uap10.0.15138;
+      uap10.0.15138aot;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Reflection.DispatchProxy/src/Configurations.props
+++ b/src/System.Reflection.DispatchProxy/src/Configurations.props
@@ -5,12 +5,12 @@
       netfx;
       netstandard;
       netcoreapp2.0;
-      uapaot-Windows_NT;
-      uap-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
       netcoreapp;
+      uap-Windows_NT;
+      uapaot-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.DispatchProxy/src/Configurations.props
+++ b/src/System.Reflection.DispatchProxy/src/Configurations.props
@@ -5,6 +5,7 @@
       netfx;
       netstandard;
       netcoreapp2.0;
+      uap10.0.15138;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
@@ -7,7 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'uapaot'">true</IsPartialFacadeAssembly>
     <!-- this library depends on Ref.Emit which is not available for netstandard -->
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard' Or '$(TargetGroup)' == 'uap10.0.15138'">SR.PlatformNotSupported_ReflectionDispatchProxy</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard' Or '$(TargetGroup)' == 'uap10.0.15138' Or '$(TargetGroup)' == 'uap10.0.15138aot'">SR.PlatformNotSupported_ReflectionDispatchProxy</GeneratePlatformNotSupportedAssemblyMessage>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'uapaot'">None</ResourcesSourceOutputDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
@@ -22,9 +22,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138aot-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138aot-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(TargetGroup)' != 'netstandard' And '$(TargetGroup)' != 'uap10.0.15138'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(TargetGroup)' != 'netstandard' And '$(TargetGroup)' != 'uap10.0.15138' And '$(TargetGroup)' != 'uap10.0.15138aot'">
     <Compile Include="System\Reflection\DispatchProxy.cs" />
     <Compile Include="System\Reflection\DispatchProxyGenerator.cs" />
   </ItemGroup>
@@ -42,8 +44,8 @@
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Linq" />
     <Reference Include="System.Reflection" />
-    <Reference Include="System.Reflection.Emit" Condition="'$(TargetGroup)' != 'uap10.0.15138'" />
-    <Reference Include="System.Reflection.Emit.ILGeneration" Condition="'$(TargetGroup)' != 'uap10.0.15138'" />
+    <Reference Include="System.Reflection.Emit" Condition="'$(TargetGroup)' != 'uap10.0.15138' And '$(TargetGroup)' != 'uap10.0.15138aot'" />
+    <Reference Include="System.Reflection.Emit.ILGeneration" Condition="'$(TargetGroup)' != 'uap10.0.15138' And '$(TargetGroup)' != 'uap10.0.15138aot'" />
     <Reference Include="System.Reflection.Extensions" />
     <Reference Include="System.Reflection.Primitives" />
     <Reference Include="System.Resources.ResourceManager" />

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
@@ -7,7 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'uapaot'">true</IsPartialFacadeAssembly>
     <!-- this library depends on Ref.Emit which is not available for netstandard -->
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard'">SR.PlatformNotSupported_ReflectionDispatchProxy</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard' Or '$(TargetGroup)' == 'uap10.0.15138'">SR.PlatformNotSupported_ReflectionDispatchProxy</GeneratePlatformNotSupportedAssemblyMessage>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'uapaot'">None</ResourcesSourceOutputDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
@@ -20,9 +20,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap10.0.15138-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(TargetGroup)' != 'netstandard'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(TargetGroup)' != 'netstandard' And '$(TargetGroup)' != 'uap10.0.15138'">
     <Compile Include="System\Reflection\DispatchProxy.cs" />
     <Compile Include="System\Reflection\DispatchProxyGenerator.cs" />
   </ItemGroup>
@@ -40,8 +42,8 @@
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Linq" />
     <Reference Include="System.Reflection" />
-    <Reference Include="System.Reflection.Emit" />
-    <Reference Include="System.Reflection.Emit.ILGeneration" />
+    <Reference Include="System.Reflection.Emit" Condition="'$(TargetGroup)' != 'uap10.0.15138'" />
+    <Reference Include="System.Reflection.Emit.ILGeneration" Condition="'$(TargetGroup)' != 'uap10.0.15138'" />
     <Reference Include="System.Reflection.Extensions" />
     <Reference Include="System.Reflection.Primitives" />
     <Reference Include="System.Resources.ResourceManager" />

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -3,8 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{07CAF142-B259-418E-86EF-C4BD8B50253E}</ProjectGuid>
-    <!-- UAPvNext is not yet mapped to netstandard2.0, manually duplicate this ref -->
-    <PackageTargetFramework>netstandard2.0;$(UAPvNextTFM)</PackageTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />

--- a/tools-local/targetgroups.props
+++ b/tools-local/targetgroups.props
@@ -17,7 +17,7 @@
       <Imports>netcore50</Imports>
       <CompatibleWith>netstandard1.4</CompatibleWith>
     </TargetGroups>
-    <TargetGroups Include="uapaot10.0.15138">
+    <TargetGroups Include="uap10.0.15138aot">
       <PackageTargetRuntimeSuffix>aot</PackageTargetRuntimeSuffix>
       <NuGetTargetMoniker>UAP,Version=v10.0.15138</NuGetTargetMoniker>
       <NuGetTargetMonikerShort>uap10.0.15138</NuGetTargetMonikerShort>
@@ -37,7 +37,7 @@
       <NuGetTargetMoniker>$(UAPvNextTFMFull)</NuGetTargetMoniker>
       <NuGetTargetMonikerShort>$(UAPvNextTFM)</NuGetTargetMonikerShort>
       <UWPCompatible>true</UWPCompatible>
-      <Imports>uapaot10.0.15138</Imports>
+      <Imports>uap10.0.15138aot</Imports>
       <CompatibleWith>uapvnext;netstandard2.0</CompatibleWith>
     </TargetGroups>
     <TargetGroups Include="uapvnext">

--- a/tools-local/targetgroups.props
+++ b/tools-local/targetgroups.props
@@ -17,19 +17,34 @@
       <Imports>netcore50</Imports>
       <CompatibleWith>netstandard1.4</CompatibleWith>
     </TargetGroups>
+    <TargetGroups Include="uapaot10.0.15138">
+      <PackageTargetRuntimeSuffix>aot</PackageTargetRuntimeSuffix>
+      <NuGetTargetMoniker>UAP,Version=v10.0.15138</NuGetTargetMoniker>
+      <NuGetTargetMonikerShort>uap10.0.15138</NuGetTargetMonikerShort>
+      <UWPCompatible>true</UWPCompatible>
+      <Imports>netcore50aot</Imports>
+      <CompatibleWith>uap10.0.15138;netstandard2.0</CompatibleWith>
+    </TargetGroups>
+    <TargetGroups Include="uap10.0.15138">
+      <NuGetTargetMoniker>UAP,Version=v10.0.15138</NuGetTargetMoniker>
+      <NuGetTargetMonikerShort>uap10.0.15138</NuGetTargetMonikerShort>
+      <UWPCompatible>true</UWPCompatible>
+      <Imports>netcore50</Imports>
+      <CompatibleWith>netstandard2.0</CompatibleWith>
+    </TargetGroups>
     <TargetGroups Include="uapvnextaot">
       <PackageTargetRuntimeSuffix>aot</PackageTargetRuntimeSuffix>
       <NuGetTargetMoniker>$(UAPvNextTFMFull)</NuGetTargetMoniker>
       <NuGetTargetMonikerShort>$(UAPvNextTFM)</NuGetTargetMonikerShort>
       <UWPCompatible>true</UWPCompatible>
-      <Imports>netcore50aot</Imports>
+      <Imports>uapaot10.0.15138</Imports>
       <CompatibleWith>uapvnext;netstandard2.0</CompatibleWith>
     </TargetGroups>
     <TargetGroups Include="uapvnext">
       <NuGetTargetMoniker>$(UAPvNextTFMFull)</NuGetTargetMoniker>
       <NuGetTargetMonikerShort>$(UAPvNextTFM)</NuGetTargetMonikerShort>
       <UWPCompatible>true</UWPCompatible>
-      <Imports>netcore50</Imports>
+      <Imports>uap10.0.15138</Imports>
       <CompatibleWith>netstandard2.0</CompatibleWith>
     </TargetGroups>
     <!-- uap is an alias for uapvNext any/coreclr runtime -->


### PR DESCRIPTION
cc: @ericstj @weshaggard 

There are OOB packages that have uap vnext assets which already ship inbox, so by removing them we are now able to change the API surface using the netstandard asset if needed after a UAP release.