### PR TITLE
Test: ignore specific WinHttpException on old Windows versions

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1333,16 +1333,11 @@ namespace System.Net.Http
                     0,
                     state.ToIntPtr()))
                 {
-                    int lastError = Marshal.GetLastWin32Error();
-                    Debug.Assert((unchecked((int)lastError) != Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER &&
-                        unchecked((int)lastError) != unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
-                        $"Unexpected async error in WinHttpRequestCallback: {unchecked((int)lastError)}");
-
                     // Dispose (which will unpin) the state object. Since this failed, WinHTTP won't associate
                     // our context value (state object) to the request handle. And thus we won't get HANDLE_CLOSING
                     // notifications which would normally cause the state object to be unpinned and disposed.
                     state.Dispose();
-                    throw WinHttpException.CreateExceptionUsingError(lastError);
+                    WinHttpException.ThrowExceptionUsingLastError();
                 }
             }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -317,10 +317,6 @@ namespace System.Net.Http
             
             Debug.Assert(state != null, "OnRequestError: state is null");
 
-            Debug.Assert((unchecked((int)asyncResult.dwError) != Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER &&
-                unchecked((int)asyncResult.dwError) != unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
-                $"Unexpected async error in WinHttpRequestCallback: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}");
-
             Exception innerException = WinHttpException.CreateExceptionUsingError(unchecked((int)asyncResult.dwError));
 
             switch (unchecked((uint)asyncResult.dwResult.ToInt32()))

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -19,7 +19,6 @@ namespace System.Net.Http.Functional.Tests
     [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework throws PNSE for ServerCertificateCustomValidationCallback")]
     public partial class HttpClientHandler_ServerCertificates_Test : HttpClientTestBase
     {
-        // TODO: https://github.com/dotnet/corefx/issues/7812
         private static bool ClientSupportsDHECipherSuites => (!PlatformDetection.IsWindows || PlatformDetection.IsWindows10Version1607OrGreater);
         private bool BackendSupportsCustomCertificateHandlingAndClientSupportsDHECipherSuites =>
             (BackendSupportsCustomCertificateHandling && ClientSupportsDHECipherSuites);
@@ -337,29 +336,41 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(CertificateValidationServersAndExpectedPolicies))]
         public async Task UseCallback_BadCertificate_ExpectedPolicyErrors(string url, SslPolicyErrors expectedErrors)
         {
+            const int SEC_E_BUFFER_TOO_SMALL = unchecked((int)0x80090321);
+
             if (!BackendSupportsCustomCertificateHandlingAndClientSupportsDHECipherSuites)
             {
                 return;
             }
 
-            if (PlatformDetection.IsUap)
+            try
             {
-                // UAP HTTP stack caches connections per-process. This causes interference when these tests run in
-                // the same process as the other tests. Each test needs to be isolated to its own process.
-                // See dicussion: https://github.com/dotnet/corefx/issues/21945
-                RemoteInvoke((remoteUrl, remoteExpectedErrors, useManagedHandlerString) =>
+                if (PlatformDetection.IsUap)
                 {
-                    UseCallback_BadCertificate_ExpectedPolicyErrors_Helper(
-                        remoteUrl,
-                        bool.Parse(useManagedHandlerString),
-                        (SslPolicyErrors)Enum.Parse(typeof(SslPolicyErrors), remoteExpectedErrors)).Wait();
+                    // UAP HTTP stack caches connections per-process. This causes interference when these tests run in
+                    // the same process as the other tests. Each test needs to be isolated to its own process.
+                    // See dicussion: https://github.com/dotnet/corefx/issues/21945
+                    RemoteInvoke((remoteUrl, remoteExpectedErrors, useManagedHandlerString) =>
+                    {
+                        UseCallback_BadCertificate_ExpectedPolicyErrors_Helper(
+                            remoteUrl,
+                            bool.Parse(useManagedHandlerString),
+                            (SslPolicyErrors)Enum.Parse(typeof(SslPolicyErrors), remoteExpectedErrors)).Wait();
 
-                    return SuccessExitCode;
-                }, url, expectedErrors.ToString(), UseManagedHandler.ToString()).Dispose();
+                        return SuccessExitCode;
+                    }, url, expectedErrors.ToString(), UseManagedHandler.ToString()).Dispose();
+                }
+                else
+                {
+                    await UseCallback_BadCertificate_ExpectedPolicyErrors_Helper(url, UseManagedHandler, expectedErrors);
+                }
             }
-            else
+            catch (HttpRequestException e) when (e.InnerException?.GetType().Name == "WinHttpException" &&
+                e.InnerException.HResult == SEC_E_BUFFER_TOO_SMALL &&
+                !PlatformDetection.IsWindows10Version1607OrGreater)
             {
-                await UseCallback_BadCertificate_ExpectedPolicyErrors_Helper(url, UseManagedHandler, expectedErrors);
+                // Testing on old Windows versions can hit https://github.com/dotnet/corefx/issues/7812
+                // Ignore SEC_E_BUFFER_TOO_SMALL error on such cases.
             }
         }
 


### PR DESCRIPTION
The root cause issue was already fixed in Windows but old versions still hit this issue. This change makes the intermittently failing test to ignore the known issue on these old Windows versions.

Fixes #7812 (just so GH closes the issue at merge time, the actual issue was fixed in Windows).