### PR TITLE
Support Process.Start as a different user on Unix.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
@@ -15,6 +15,7 @@ internal static partial class Interop
         internal static unsafe void ForkAndExecProcess(
             string filename, string[] argv, string[] envp, string cwd,
             bool redirectStdin, bool redirectStdout, bool redirectStderr,
+            bool setUser, uint userId, uint groupId,
             out int lpChildPid, out int stdinFd, out int stdoutFd, out int stderrFd, bool shouldThrow = true)
         {
             byte** argvPtr = null, envpPtr = null;
@@ -26,6 +27,7 @@ internal static partial class Interop
                 result = ForkAndExecProcess(
                     filename, argvPtr, envpPtr, cwd,
                     redirectStdin ? 1 : 0, redirectStdout ? 1 : 0, redirectStderr ? 1 :0,
+                    setUser ? 1 : 0, userId, groupId,
                     out lpChildPid, out stdinFd, out stdoutFd, out stderrFd);
                 if (result != 0)
                 {
@@ -53,6 +55,7 @@ internal static partial class Interop
         private static extern unsafe int ForkAndExecProcess(
             string filename, byte** argv, byte** envp, string cwd,
             int redirectStdin, int redirectStdout, int redirectStderr,
+            int setUser, uint userId, uint groupId,
             out int lpChildPid, out int stdinFd, out int stdoutFd, out int stderrFd);
 
         private static unsafe void AllocNullTerminatedArray(string[] arr, ref byte** arrPtr)

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
@@ -22,5 +22,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPwUidR", SetLastError = false)]
         internal static extern unsafe int GetPwUidR(uint uid, out Passwd pwd, byte* buf, int bufLen);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPwNamR", SetLastError = false)]
+        internal static extern unsafe int GetPwNamR(string name, out Passwd pwd, byte* buf, int bufLen);
     }
 }

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -149,6 +149,7 @@ namespace System.Diagnostics
         public string ExceptionFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public int ExpectedExitCode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool Start { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool RunAsSudo { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Diagnostics.ProcessStartInfo StartInfo { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public int TimeOut { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
@@ -58,8 +58,16 @@ namespace System.Diagnostics
             if (!File.Exists(HostRunner))
                 throw new IOException($"{HostRunner} test app isn't present in the test runtime directory.");
 
-            psi.FileName = HostRunner;
-            psi.Arguments = testConsoleAppArgs;
+            if (options.RunAsSudo)
+            {
+                psi.FileName = "sudo";
+                psi.Arguments = HostRunner + " " + testConsoleAppArgs;
+            }
+            else
+            {
+                psi.FileName = HostRunner;
+                psi.Arguments = testConsoleAppArgs;
+            }
 
             // Return the handle to the process, which may or not be started
             return new RemoteInvokeHandle(options.Start ?

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -233,6 +233,7 @@ namespace System.Diagnostics
     public sealed class RemoteInvokeOptions
     {
         public bool Start { get; set; } = true;
+        public bool RunAsSudo { get; set; } = false;
         public ProcessStartInfo StartInfo { get; set; } = new ProcessStartInfo();
         public bool EnableProfiling { get; set; } = true;
         public bool CheckExitCode { get; set; } = true;

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -40,7 +40,7 @@ namespace System.Diagnostics
         /// <param name="method">The method to invoke.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle RemoteInvoke(
-            Func<int> method, 
+            Func<int> method,
             RemoteInvokeOptions options = null)
         {
             return RemoteInvoke(GetMethodInfo(method), Array.Empty<string>(), options);
@@ -72,8 +72,8 @@ namespace System.Diagnostics
         /// <param name="arg1">The first argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle RemoteInvoke(
-            Func<string, int> method, 
-            string arg, 
+            Func<string, int> method,
+            string arg,
             RemoteInvokeOptions options = null)
         {
             return RemoteInvoke(GetMethodInfo(method), new[] { arg }, options);
@@ -85,8 +85,8 @@ namespace System.Diagnostics
         /// <param name="arg2">The second argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle RemoteInvoke(
-            Func<string, string, int> method, 
-            string arg1, string arg2, 
+            Func<string, string, int> method,
+            string arg1, string arg2,
             RemoteInvokeOptions options = null)
         {
             return RemoteInvoke(GetMethodInfo(method), new[] { arg1, arg2 }, options);
@@ -99,8 +99,8 @@ namespace System.Diagnostics
         /// <param name="arg3">The third argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle RemoteInvoke(
-            Func<string, string, string, int> method, 
-            string arg1, string arg2, string arg3, 
+            Func<string, string, string, int> method,
+            string arg1, string arg2, string arg3,
             RemoteInvokeOptions options = null)
         {
             return RemoteInvoke(GetMethodInfo(method), new[] { arg1, arg2, arg3 }, options);
@@ -114,8 +114,8 @@ namespace System.Diagnostics
         /// <param name="arg4">The fourth argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle RemoteInvoke(
-            Func<string, string, string, string, int> method, 
-            string arg1, string arg2, string arg3, string arg4, 
+            Func<string, string, string, string, int> method,
+            string arg1, string arg2, string arg3, string arg4,
             RemoteInvokeOptions options = null)
         {
             return RemoteInvoke(GetMethodInfo(method), new[] { arg1, arg2, arg3, arg4 }, options);
@@ -130,8 +130,8 @@ namespace System.Diagnostics
         /// <param name="arg5">The fifth argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle RemoteInvoke(
-            Func<string, string, string, string, string, int> method, 
-            string arg1, string arg2, string arg3, string arg4, string arg5, 
+            Func<string, string, string, string, string, int> method,
+            string arg1, string arg2, string arg3, string arg4, string arg5,
             RemoteInvokeOptions options = null)
         {
             return RemoteInvoke(GetMethodInfo(method), new[] { arg1, arg2, arg3, arg4, arg5 }, options);
@@ -232,8 +232,9 @@ namespace System.Diagnostics
     /// <summary>Options used with RemoteInvoke.</summary>
     public sealed class RemoteInvokeOptions
     {
+        private bool _runAsSudo;
+
         public bool Start { get; set; } = true;
-        public bool RunAsSudo { get; set; } = false;
         public ProcessStartInfo StartInfo { get; set; } = new ProcessStartInfo();
         public bool EnableProfiling { get; set; } = true;
         public bool CheckExitCode { get; set; } = true;
@@ -241,5 +242,22 @@ namespace System.Diagnostics
         public int TimeOut {get; set; } = RemoteExecutorTestBase.FailWaitTimeoutMilliseconds;
         public int ExpectedExitCode { get; set; } = RemoteExecutorTestBase.SuccessExitCode;
         public string ExceptionFile { get; } = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        public bool RunAsSudo
+        {
+            get
+            {
+                return _runAsSudo;
+            }
+            set
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    throw new PlatformNotSupportedException();
+                }
+
+                _runAsSudo = value;
+            }
+        }
     }
 }

--- a/src/Native/Unix/System.Native/pal_process.h
+++ b/src/Native/Unix/System.Native/pal_process.h
@@ -26,6 +26,9 @@ SystemNative_ForkAndExecProcess(const char* filename,   // filename argument to 
                    int32_t redirectStdin,  // whether to redirect standard input from the parent
                    int32_t redirectStdout, // whether to redirect standard output to the parent
                    int32_t redirectStderr, // whether to redirect standard error to the parent
+                   int32_t setCredentials, // whether to set the userId and groupId for the child process
+                   uint32_t userId,        // the user id under which the child process should run
+                   uint32_t groupId,       // the group id under which the child process should run
                    int32_t* childPid,      // [out] the child process' id
                    int32_t* stdinFd,       // [out] if redirectStdin, the parent's fd for the child's stdin
                    int32_t* stdoutFd,      // [out] if redirectStdout, the parent's fd for the child's stdout

--- a/src/Native/Unix/System.Native/pal_uid.cpp
+++ b/src/Native/Unix/System.Native/pal_uid.cpp
@@ -13,20 +13,8 @@
 #include <sys/types.h>
 #include <pwd.h>
 
-extern "C" int32_t SystemNative_GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t buflen)
+static int32_t ConvertNativePasswdToPalPasswd(int error, struct passwd* nativePwd, struct passwd* result, Passwd* pwd)
 {
-    assert(pwd != nullptr);
-    assert(buf != nullptr);
-    assert(buflen >= 0);
-
-    if (buflen < 0)
-        return EINVAL;
-
-    struct passwd nativePwd;
-    struct passwd* result;
-    int error;
-    while ((error = getpwuid_r(uid, &nativePwd, buf, UnsignedCast(buflen), &result)) == EINTR);
-
     // positive error number returned -> failure other than entry-not-found
     if (error != 0)
     {
@@ -43,15 +31,49 @@ extern "C" int32_t SystemNative_GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, 
     }
 
     // 0 returned with non-null result (guaranteed to be set to pwd arg) -> success
-    assert(result == &nativePwd);
-    pwd->Name = nativePwd.pw_name;
-    pwd->Password = nativePwd.pw_passwd;
-    pwd->UserId = nativePwd.pw_uid;
-    pwd->GroupId = nativePwd.pw_gid;
-    pwd->UserInfo = nativePwd.pw_gecos;
-    pwd->HomeDirectory = nativePwd.pw_dir;
-    pwd->Shell = nativePwd.pw_shell;
+    assert(result == nativePwd);
+    pwd->Name = nativePwd->pw_name;
+    pwd->Password = nativePwd->pw_passwd;
+    pwd->UserId = nativePwd->pw_uid;
+    pwd->GroupId = nativePwd->pw_gid;
+    pwd->UserInfo = nativePwd->pw_gecos;
+    pwd->HomeDirectory = nativePwd->pw_dir;
+    pwd->Shell = nativePwd->pw_shell;
     return 0;
+}
+
+extern "C" int32_t SystemNative_GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t buflen)
+{
+    assert(pwd != nullptr);
+    assert(buf != nullptr);
+    assert(buflen >= 0);
+
+    if (buflen < 0)
+        return EINVAL;
+
+    struct passwd nativePwd;
+    struct passwd* result;
+    int error;
+    while ((error = getpwuid_r(uid, &nativePwd, buf, UnsignedCast(buflen), &result)) == EINTR);
+
+    return ConvertNativePasswdToPalPasswd(error, &nativePwd, result, pwd);
+}
+
+extern "C" int32_t SystemNative_GetPwNamR(const char* name, Passwd* pwd, char* buf, int32_t buflen)
+{
+    assert(pwd != nullptr);
+    assert(buf != nullptr);
+    assert(buflen >= 0);
+
+    if (buflen < 0)
+        return EINVAL;
+
+    struct passwd nativePwd;
+    struct passwd* result;
+    int error;
+    while ((error = getpwnam_r(name, &nativePwd, buf, UnsignedCast(buflen), &result)) == EINTR);
+
+    return ConvertNativePasswdToPalPasswd(error, &nativePwd, result, pwd);
 }
 
 extern "C" uint32_t SystemNative_GetEUid()

--- a/src/Native/Unix/System.Native/pal_uid.h
+++ b/src/Native/Unix/System.Native/pal_uid.h
@@ -32,6 +32,15 @@ struct Passwd
 extern "C" int32_t SystemNative_GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t buflen);
 
 /**
+* Gets a password structure for the given user name.
+* Implemented as shim to getpwnam_r(3).
+*
+* Returns 0 for success, -1 if no entry found, positive error
+* number for any other failure.
+*/
+extern "C" int32_t SystemNative_GetPwNamR(const char* name, Passwd* pwd, char* buf, int32_t buflen);
+
+/**
 * Gets and returns the effective user's identity.
 * Implemented as shim to geteuid(2).
 *

--- a/src/System.Diagnostics.Process/System.Diagnostics.Process.sln
+++ b/src/System.Diagnostics.Process/System.Diagnostics.Process.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27309.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Process.Tests", "tests\System.Diagnostics.Process.Tests.csproj", "{E1114510-844C-4BB2-BBAD-8595BD16E24B}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -56,5 +56,8 @@ Global
 		{4E05E43A-1DC9-47C7-8280-13CF4EF741EA} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{F55047F8-E47B-46E3-B221-C23595AFE168} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{98B33275-39D8-4997-867D-04C69C69885E} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C8916A08-4E92-4222-8398-B0A8BBF3F952}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -312,4 +312,7 @@
   <data name="StandardInputEncodingNotAllowed" xml:space="preserve">
     <value>StandardInputEncoding is only supported when standard input is redirected.</value>
   </data>
+  <data name="UserDoesNotExist" xml:space="preserve">
+    <value>User with name '{0}' was not found.</value>
+  </data>
 </root>

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -318,6 +318,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPid.cs">
       <Link>Common\Interop\Unix\Interop.GetPid.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPwUid.cs">
+      <Link>Common\Interop\Unix\Interop.GetPwUid.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetSetPriority.cs">
       <Link>Common\Interop\Unix\Interop.GetSetPriority.cs</Link>
     </Compile>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
@@ -14,12 +14,6 @@ namespace System.Diagnostics
     {
         private const bool CaseSensitiveEnvironmentVariables = true;
 
-        public string UserName
-        {
-            get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported); }
-            set { throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported); }
-        }
-
         public string PasswordInClearText
         {
             get { throw new PlatformNotSupportedException(SR.ProcessStartIdentityNotSupported); }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Windows.cs
@@ -8,16 +8,9 @@ namespace System.Diagnostics
 {
     public sealed partial class ProcessStartInfo
     {
-        private string _userName;
         private string _domain;
 
         private const bool CaseSensitiveEnvironmentVariables = false;
-
-        public string UserName
-        {
-            get => _userName ?? string.Empty;
-            set => _userName = value;
-        }
 
         public string PasswordInClearText { get; set; }
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -20,6 +20,7 @@ namespace System.Diagnostics
         private string _fileName;
         private string _arguments;
         private string _directory;
+        private string _userName;
         private string _verb;
         private ProcessWindowStyle _windowStyle;
 
@@ -124,6 +125,12 @@ namespace System.Diagnostics
 
         public bool ErrorDialog { get; set; }
         public IntPtr ErrorDialogParentHandle { get; set; }
+
+        public string UserName
+        {
+            get => _userName ?? string.Empty;
+            set => _userName = value;
+        }
 
         [DefaultValue("")]
         public string Verb 

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -887,20 +887,10 @@ namespace System.Diagnostics.Tests
         [InlineData(null)]
         [InlineData("")]
         [InlineData("domain")]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public void UserName_SetWindows_GetReturnsExpected(string userName)
+        public void UserName_Set_GetReturnsExpected(string userName)
         {
             var info = new ProcessStartInfo { UserName = userName };
             Assert.Equal(userName ?? string.Empty, info.UserName);
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public void UserName_GetSetUnix_ThrowsPlatformNotSupportedException()
-        {
-            var info = new ProcessStartInfo();
-            Assert.Throws<PlatformNotSupportedException>(() => info.UserName);
-            Assert.Throws<PlatformNotSupportedException>(() => info.UserName = "username");
         }
 
         [Theory]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -304,8 +304,92 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Fact]
+        public void TestStartWithNonExistingUserThrows()
+        {
+            Process p = CreateProcessPortable(RemotelyInvokable.Dummy);
+            p.StartInfo.UserName = "DoesNotExist";
+            Assert.Throws<Win32Exception>(() => p.Start());
+        }
+
+        /// <summary>
+        /// Tests when running as a normal user and starting a new process as the same user
+        /// works as expected.
+        /// </summary>
+        [Fact]
+        public void TestStartWithNormalUser()
+        {
+            TestStartWithUserName();
+        }
+
+        /// <summary>
+        /// Tests when running as root and starting a new process as a normal user,
+        /// the new process doesn't have elevated privileges.
+        /// </summary>
+        [Fact]
+        [OuterLoop("Needs sudo access")]
+        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
+        public void TestStartWithRootUser()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions()
+            {
+                Start = false,
+                RunAsSudo = true
+            };
+            Process p = RemoteInvoke((Func<int>)TestStartWithUserName, options).Process;
+            AddProcessForDispose(p);
+
+            p.Start();
+            p.WaitForExit();
+
+            Assert.Equal(0, p.ExitCode);
+        }
+
+        public static int TestStartWithUserName()
+        {
+            using (ProcessTests testObject = new ProcessTests())
+            {
+                string realUserName;
+                if (geteuid() == 0)
+                {
+                    realUserName = Environment.GetEnvironmentVariable("SUDO_USER");
+                }
+                else
+                {
+                    realUserName = Environment.UserName;
+                }
+
+                Assert.NotNull(realUserName);
+                Assert.NotEqual("root", realUserName);
+
+                using (Process p = testObject.CreateProcessPortable(TestStartWithUserName_ChildProcess))
+                {
+                    p.StartInfo.UserName = realUserName;
+                    Assert.True(p.Start());
+
+                    p.WaitForExit();
+
+                    // since the process was started with the current real user, even if this test
+                    // was run with 'sudo', the child process will be run as the normal real user.
+                    // Assert that the effective user of the child process was never 'root'
+                    // and was the real user of this process.
+                    Assert.NotEqual(0, p.ExitCode);
+                }
+
+                return 0;
+            }
+        }
+
+        public static int TestStartWithUserName_ChildProcess()
+        {
+            return (int)geteuid();
+        }
+
         [DllImport("libc")]
         private static extern int chmod(string path, int mode);
+
+        [DllImport("libc")]
+        private static extern uint geteuid();
 
         private readonly string[] s_allowedProgramsToRun = new string[] { "xdg-open", "gnome-open", "kfmclient" };
     }


### PR DESCRIPTION
The most common use case is to de-escalate privileges from a privileged process to a normal process.

Part of #26268 

@safern and @tarekgh - I'm not sure who owns the RemoteExecution stuff, but could you guys give it a look?

/cc @arunjvs