### PR TITLE
Fix bug with SslStream Read behavior.

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -282,7 +282,7 @@ namespace System.Net.Security
                             _sslState.ReplyOnReAuthentication(extraBuffer);
 
                             // Loop on read.
-                            return -1;
+                            continue;
                         }
 
                         if (message.CloseConnection)

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
@@ -52,11 +52,8 @@ namespace System.Net.Security.Tests
                 // Initiate Read operation, that results in starting renegotiation as per server response to the above request.
                 int bytesRead = await ssl.ReadAsync(message, 0, message.Length);
 
-                // SslStream.ReadAsync should return -1 bytes, indicating renegotiation operation is in progress.
-                Assert.Equal(-1, bytesRead);
-
-                // Do another Read, to get the HTTP response from the server, after successful renegotiation.
-                bytesRead = await ssl.ReadAsync(message, 0, message.Length);
+                // There's no good way to ensure renegotiation happened in the test.
+                // Under the debugger, we can see this test hits the renegotiation codepath.
                 Assert.InRange(bytesRead, 1, message.Length);
                 Assert.Contains("HTTP/1.1 200 OK", Encoding.UTF8.GetString(message));
             }

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -101,11 +101,8 @@ namespace System.Net.Security.Tests
                 // Initiate Read operation, that results in starting renegotiation as per server response to the above request.
                 int bytesRead = await ssl.ReadAsync(message, 0, message.Length);
 
-                // SslStream.ReadAsync should return -1 bytes, indicating renegotiation operation is in progress.
-                Assert.Equal(-1, bytesRead);
-
-                // Do another Read, to get the HTTP response from the server, after successful renegotiation.
-                bytesRead = await ssl.ReadAsync(message, 0, message.Length);
+                // There's no good way to ensure renegotiation happened in the test.
+                // Under the debugger, we can see this test hits the renegotiation codepath.
                 Assert.InRange(bytesRead, 1, message.Length);
                 Assert.Contains("HTTP/1.1 200 OK", Encoding.UTF8.GetString(message));
             }


### PR DESCRIPTION
Recent refactoring of Sslstream methods from apm to task introduced a bug with Read behavior. In full framework and previous code, we never returned -1 from SslStream.Read. If there was a renegotiation request from server, we just looped until we read 0 or some decrypted bytes. With the current refactoring, SslStream.Read returns -1 in case of renegotiation.

Fixing the code to match old behavior, but because of this there's no good way to test for renegotiation as now Read will only return 0 or the decrypted bytes count. Although under the debugger we can see that the renegotiation codepath is hit.

The negative test with AllowRenegotiation=false, should terminate the ssl connection, when the client receives a renegotiation request from server. This test works as expected, throwing IOException in Read, and is already part of the test project. This can be sufficient to prove that the renegotiation codepath is exercised, along with these positive tests, hitting the same server with similar request parameters.

fixes #26213 

cc @stephentoub @karelz @wfurt @Drawaes 