### PR TITLE
Regression test for AM/PMDesignator handling

### DIFF
--- a/src/System.Runtime/tests/System/DateTimeTests.cs
+++ b/src/System.Runtime/tests/System/DateTimeTests.cs
@@ -816,6 +816,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Needs desktop port: https://github.com/dotnet/coreclr/issues/15896")]
         // Regression test for https://github.com/dotnet/coreclr/issues/15896
         public static void TryParseExact_EmptyAMPMDesignator()
         {

--- a/src/System.Runtime/tests/System/DateTimeTests.cs
+++ b/src/System.Runtime/tests/System/DateTimeTests.cs
@@ -815,6 +815,16 @@ namespace System.Tests
             Assert.Equal(expectedString, result.ToString("g"));
         }
 
+        [Fact]
+        // Regression test for https://github.com/dotnet/coreclr/issues/15896
+        public static void TryParseExact_EmptyAMPMDesignator()
+        {
+            var englishCulture = new CultureInfo("en-US");
+            englishCulture.DateTimeFormat.AMDesignator = "";
+            englishCulture.DateTimeFormat.PMDesignator = "";
+            Assert.False(DateTime.TryParseExact(" ", "%t", englishCulture, DateTimeStyles.None, out _));
+        }
+
         public static void ParseExact_EscapedSingleQuotes()
         {
             var formatInfo = DateTimeFormatInfo.GetInstance(new CultureInfo("mt-MT"));


### PR DESCRIPTION
Regression test for https://github.com/dotnet/coreclr/issues/15896

This PR will fail until corefx pulls coreclr which has this merged: https://github.com/dotnet/coreclr/pull/15904 (https://github.com/dotnet/coreclr/commit/734a8d7612237b4fab066957318345b5b7b157fe)

cc: @wstaelens
