### PR TITLE
Make XSL tests log unexpected output

### DIFF
--- a/src/Common/tests/System/Xml/ModuleCore/ctestexception.cs
+++ b/src/Common/tests/System/Xml/ModuleCore/ctestexception.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Text;
 
 namespace OLEDB.Test.ModuleCore
 {
@@ -76,6 +77,19 @@ namespace OLEDB.Test.ModuleCore
             Result = result;
             Actual = actual;
             Expected = expected;
+        }
+
+        public override string Message
+        {
+            get
+            {
+                StringBuilder text = new StringBuilder();
+                text.AppendLine(base.Message);
+                text.AppendLine($"Expected: `{Expected.ToString()}`");
+                text.AppendLine($"Actual: `{Actual.ToString()}`");
+                text.AppendLine($"Result: {Result}");
+                return text.ToString();
+            }
         }
     }
 }

--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCommon.cs
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCommon.cs
@@ -333,16 +333,22 @@ namespace XmlCoreTest.Common
 
         public static string SearchPath(String fileName)
         {
-            var tools64 = @"C:\program Files (x86)\Microsoft SDKs\Windows";
-            var tools32 = @"C:\program Files\Microsoft SDKs\Windows";
+            var locations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            // 32 bit if on 64 bit Windows
+            locations.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"Microsoft SDKs\Windows"));
+            // 32 bit if on 32 bit Windows, otherwise 64 bit
+            locations.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), @"Microsoft SDKs\Windows"));
+            // 64 bit if in 32 bit process on 64 bit Windows
+            locations.Add(Path.Combine(Environment.GetEnvironmentVariable("ProgramW6432"), @"Microsoft SDKs\Windows"));
 
             var files = new List<string>();
 
-            if (Directory.Exists(tools64))
-                files.AddRange(Directory.GetFiles(tools64, fileName, SearchOption.AllDirectories));
-
-            if (Directory.Exists(tools32))
-                files.AddRange(Directory.GetFiles(tools32, fileName, SearchOption.AllDirectories));
+            foreach (var location in locations)
+            {
+                if (Directory.Exists(location))
+                    files.AddRange(Directory.GetFiles(location, fileName, SearchOption.AllDirectories));
+            }
 
             if (files.Count == 0)
                 throw new FileNotFoundException(fileName);


### PR DESCRIPTION
Rather than just "Output not as expected" to help diagnose https://github.com/dotnet/corefx/issues/26424

Also help it find xsltc.exe on more machines. On my box, it's in 4.6.2 folder not 4.6.1.