### PR TITLE
set null value with indexer for concurrent dictionary

### DIFF
--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
@@ -309,6 +309,19 @@ namespace System.Collections.Tests
             Assert.Equal(count + 1, dictionary.Count);
             Assert.Equal(newValue, dictionary[existingKey]);
         }
+		
+		 [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void IDictionary_NonGeneric_ItemSet_NullValue(int count)
+        {
+            if (!IsReadOnly)
+            {
+                IDictionary dictionary = NonGenericIDictionaryFactory(count);
+                object key = GetNewKey(dictionary);
+                dictionary[key] = null;
+                Assert.Null(dictionary[key]);
+            }
+        }
 
         #endregion
 

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1577,7 +1577,7 @@ namespace System.Collections.Concurrent
                 if (key == null) ThrowKeyNullException();
 
                 if (!(key is TKey)) throw new ArgumentException(SR.ConcurrentDictionary_TypeOfKeyIncorrect);
-                if (!(value is TValue)) throw new ArgumentException(SR.ConcurrentDictionary_TypeOfValueIncorrect);
+                if (!(value is TValue) && value != null) throw new ArgumentException(SR.ConcurrentDictionary_TypeOfValueIncorrect);
 
                 ((ConcurrentDictionary<TKey, TValue>)this)[(TKey)key] = (TValue)value;
             }


### PR DESCRIPTION
Fix #26447