### PR TITLE
WebClient progress monitoring uses ContentLength header

### DIFF
--- a/src/System.Net.WebClient/src/System/Net/WebClient.cs
+++ b/src/System.Net.WebClient/src/System/Net/WebClient.cs
@@ -875,6 +875,11 @@ namespace System.Net
                     }
                     writeStream.SetLength(copyBuffer.Length);
                 }
+                
+                if (contentLength > 0)
+                {
+                    _progress.TotalBytesToReceive = contentLength;
+                }
 
                 using (writeStream)
                 using (Stream readStream = response.GetResponseStream())

--- a/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
+++ b/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
@@ -20,6 +20,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.cs">
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
     </Compile>
+	<Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/System.Net.WebClient/tests/WebClientTest.cs
@@ -560,6 +560,7 @@ namespace System.Net.Tests
                 string largeText = GetRandomText(1024 * 1024);
 
                 var downloadProgressInvokedWithContentLength = new TaskCompletionSource<bool>();
+                var wc = new WebClient();
                 wc.DownloadProgressChanged += (s, e) =>
                 {
                     if (e.TotalBytesToReceive == largeText.Length && e.BytesReceived < e.TotalBytesToReceive)
@@ -568,7 +569,6 @@ namespace System.Net.Tests
                     }
                 };
 
-                var wc = new WebClient();
                 Task<byte[]> download = DownloadDataAsync(wc, url.ToString());
                 await LoopbackServer.ReadRequestAndSendResponseAsync(server,
                         "HTTP/1.1 200 OK\r\n" +

--- a/src/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/System.Net.WebClient/tests/WebClientTest.cs
@@ -476,6 +476,8 @@ namespace System.Net.Tests
 
     public abstract class WebClientTestBase
     {
+        public const int TimeoutMilliseconds = 30 * 1000;
+
         public static readonly object[][] EchoServers = System.Net.Test.Common.Configuration.Http.EchoServers;
         const string ExpectedText =
             "To be, or not to be, that is the question:" +
@@ -548,7 +550,11 @@ namespace System.Net.Tests
                         "\r\n" +
                         $"{ExpectedText}");
                 Assert.Equal(ExpectedText, Encoding.ASCII.GetString(await download));
-                Assert.True(!IsAsync || await downloadProgressInvoked.Task, "Expected download progress callback to be invoked");
+
+                if (IsAsync)
+                {
+                    await downloadProgressInvoked.Task.TimeoutAfter(TimeoutMilliseconds);
+                }
             });
         }
 
@@ -577,7 +583,11 @@ namespace System.Net.Tests
                         "\r\n" +
                         $"{largeText}");
                 Assert.Equal(largeText, Encoding.ASCII.GetString(await download));
-                Assert.True(!IsAsync || await downloadProgressInvokedWithContentLength.Task, "Expected download progress callback to be invoked with Content-Length");
+
+                if (IsAsync)
+                {
+                    await downloadProgressInvokedWithContentLength.Task.TimeoutAfter(TimeoutMilliseconds);
+                }
             });
         }
 
@@ -654,7 +664,10 @@ namespace System.Net.Tests
 
             byte[] result = await UploadDataAsync(wc, echoServer.ToString(), Encoding.UTF8.GetBytes(ExpectedText));
             Assert.Contains(ExpectedText, Encoding.UTF8.GetString(result));
-            Assert.True(!IsAsync || await uploadProgressInvoked.Task, "Expected upload progress callback to be invoked");
+            if(IsAsync)
+            {
+                await uploadProgressInvoked.Task.TimeoutAfter(TimeoutMilliseconds);
+            }
         }
 
         [OuterLoop("Networking test talking to remote server: issue #11345")]


### PR DESCRIPTION
This avoids divide by zero situations and fixes progress monitoring for WebClient's binary async methods.
Fixes #26454 