### PR TITLE
Enable ClientAndServer_OneOrBothUseDefault_Ok test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -14,7 +14,6 @@ namespace System.Net.Http.Functional.Tests
 
     public class HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test : HttpClientTestBase
     {
-        // TODO: https://github.com/dotnet/corefx/issues/7812
         private static bool ClientSupportsDHECipherSuites => (!PlatformDetection.IsWindows || PlatformDetection.IsWindows10Version1607OrGreater);
 
         [Fact]

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Net.Http;
 using System.Net.Test.Common;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Authentication;
@@ -31,7 +32,6 @@ namespace System.Net.Security.Tests
         protected abstract Task AuthenticateClientAsync(string targetHost, X509CertificateCollection clientCertificates, bool checkCertificateRevocation, SslProtocols? protocols = null);
         protected abstract Task AuthenticateServerAsync(X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation, SslProtocols? protocols = null);
 
-        [ActiveIssue(7812, TestPlatforms.Windows)]
         [Theory]
         [InlineData(null, null)]
         [InlineData(SslProtocols.None, null)]
@@ -45,6 +45,8 @@ namespace System.Net.Security.Tests
         [InlineData(null, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12)]
         public async Task ClientAndServer_OneOrBothUseDefault_Ok(SslProtocols? clientProtocols, SslProtocols? serverProtocols)
         {
+            const int SEC_E_BUFFER_TOO_SMALL = unchecked((int)0x80090321);
+
             X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate();
             string serverHost = serverCertificate.GetNameInfo(X509NameType.SimpleName, false);
             var clientCertificates = new X509CertificateCollection();
@@ -53,14 +55,25 @@ namespace System.Net.Security.Tests
             var tasks = new Task[2];
             tasks[0] = AuthenticateClientAsync(serverHost, clientCertificates, checkCertificateRevocation: false, protocols: clientProtocols);
             tasks[1] = AuthenticateServerAsync(serverCertificate, clientCertificateRequired: true, checkCertificateRevocation: false, protocols: serverProtocols);
-            await await Task.WhenAny(tasks);
-            await Task.WhenAll(tasks);
 
-            if (PlatformDetection.IsWindows && PlatformDetection.WindowsVersion >= 10)
+            try
             {
-                Assert.True(_clientStream.HashAlgorithm == HashAlgorithmType.Sha256 ||
-                            _clientStream.HashAlgorithm == HashAlgorithmType.Sha384 ||
-                            _clientStream.HashAlgorithm == HashAlgorithmType.Sha512);
+                await Task.WhenAll(tasks);
+                if (PlatformDetection.IsWindows && PlatformDetection.WindowsVersion >= 10)
+                {
+                    Assert.True(
+                        (_clientStream.SslProtocol == SslProtocols.Tls11 && _clientStream.HashAlgorithm == HashAlgorithmType.Sha1) ||
+                        _clientStream.HashAlgorithm == HashAlgorithmType.Sha256 ||
+                        _clientStream.HashAlgorithm == HashAlgorithmType.Sha384 ||
+                        _clientStream.HashAlgorithm == HashAlgorithmType.Sha512);
+                }
+            }
+            catch (HttpRequestException e) when (e.InnerException?.GetType().Name == "WinHttpException" &&
+                e.InnerException.HResult == SEC_E_BUFFER_TOO_SMALL &&
+                !PlatformDetection.IsWindows10Version1607OrGreater)
+            {
+                // Testing on old Windows versions can hit https://github.com/dotnet/corefx/issues/7812
+                // Ignore SEC_E_BUFFER_TOO_SMALL error on such cases.
             }
         }
 

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -29,10 +29,12 @@ namespace System.Net.Security.Tests
             _serverStream = new SslStream(serverNet, false, ServerCertCallback);
         }
 
+        public static bool IsNotWindows7 => !PlatformDetection.IsWindows7;
+
         protected abstract Task AuthenticateClientAsync(string targetHost, X509CertificateCollection clientCertificates, bool checkCertificateRevocation, SslProtocols? protocols = null);
         protected abstract Task AuthenticateServerAsync(X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation, SslProtocols? protocols = null);
 
-        [Theory]
+        [ConditionalTheory(nameof(IsNotWindows7))]
         [InlineData(null, null)]
         [InlineData(SslProtocols.None, null)]
         [InlineData(null, SslProtocols.None)]

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -58,7 +58,7 @@ namespace System.Net.Security.Tests
 
             try
             {
-                await Task.WhenAll(tasks);
+                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(tasks);
                 if (PlatformDetection.IsWindows && PlatformDetection.WindowsVersion >= 10)
                 {
                     Assert.True(


### PR DESCRIPTION
Protected against error in old versions of Windows and updated assert to
include the case when hash algorithm can be Sha1.

Fixes #7812 (actual fix done on Windows, just re-enabling affected tests
with proper guard)