### PR TITLE
Improve IRI tests for unknown schemes and unicode/reserved characters

### DIFF
--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -83,6 +83,7 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Requires fix shipping in .NET 4.7.2")]
         public void Iri_UnknownSchemeWithoutAuthority_DoesNormalize()
         {
             string[] paths = { "\u00E8", "%C3%A8" };

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -64,15 +64,15 @@ namespace System.PrivateUri.Tests
         public void Iri_Uri_SchemaParsing_ShouldNotThrowArgumentOutOfRange()
         {
             string root = "viewcode://./codeschema_class?";
-            string uriDataFra = root + Uri.EscapeDataString("Type=\u00E9");
+            string uriDataFra = root + "Type=" + Uri.EscapeDataString("\u00E9");
 
             Uri u1 = new Uri(uriDataFra);
 
-            Assert.NotEqual(root + "Type=%C3%A9", u1.AbsoluteUri);
+            Assert.Equal(root + "Type=%C3%A9", u1.AbsoluteUri);
         }
 
         [Fact]
-        public void Iri_IncorrectNormalization()
+        public void Iri_ReservedCharacters_NotNormalized()
         {
             Uri u1 = new Uri(@"http://test.com/%2c");
             Uri u2 = new Uri(@"http://test.com/,");

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -68,9 +68,6 @@ namespace System.PrivateUri.Tests
 
             Uri u1 = new Uri(uriDataFra);
 
-            // TODO #8330 : Normalization should produce the same result for escaped/unescaped URIs.
-            // Assert.Equal(root + "Type=%C3%A9", u1.AbsoluteUri);
-
             Assert.NotEqual(root + "Type=%C3%A9", u1.AbsoluteUri);
         }
 
@@ -79,11 +76,6 @@ namespace System.PrivateUri.Tests
         {
             Uri u1 = new Uri(@"http://test.com/%2c");
             Uri u2 = new Uri(@"http://test.com/,");
-
-            // TODO #8330 : Normalization should produce the same result for escaped/unescaped URIs.
-            //Assert.Equal(
-            //    u1.ToString(),
-            //    u2.ToString());
 
             Assert.NotEqual(
                 u1.ToString(),

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -83,6 +83,17 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        public void Iri_UnknownSchemeWithoutAuthority_DoesNormalize()
+        {
+            string[] paths = { "\u00E8", "%C3%A8" };
+            foreach (string path in paths)
+            {
+                Uri noAuthority = new Uri("scheme:" + path);
+                Assert.Equal("scheme:\u00E8", noAuthority.ToString());
+            }
+        }
+
+        [Fact]
         public void Iri_804110_TryCreateUri_ShouldNotThrowIndexOutOfRange()
         {
             string u1 = "http://b.contos.oc.om/entry/d.contos.oc.om/AbcDefg/21234567/1234567890";


### PR DESCRIPTION
This adds a test for a regression we recently saw in .NET Framework. It also makes minor improvements to other IRI tests.

The change removes two TODO comments that were not correct. They were based off of the reserved character set from RFC 2396 rather than the more up to date RFC 3986. Normalization definitely shouldn't produce the same result for escaped and unescaped URIs when those URIs contain reserved chars.