### PR TITLE
Refactor Microsoft.CSharp's SubstContext

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 return;
             }
 
-            if (pctx != null && !pctx.FNop() && parent is AggregateSymbol agg && 0 != agg.GetTypeVarsAll().Count)
+            if (pctx != null && !pctx.IsNop && parent is AggregateSymbol agg && 0 != agg.GetTypeVarsAll().Count)
             {
                 CType pType = GetTypeManager().SubstType(agg.getThisType(), pctx);
                 ErrAppendType(pType, null);
@@ -415,7 +415,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         {
             if (pctx != null)
             {
-                if (!pctx.FNop())
+                if (!pctx.IsNop)
                 {
                     pType = GetTypeManager().SubstType(pType, pctx);
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -406,21 +406,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             }
         }
 
-        private void ErrAppendType(CType pType, SubstContext pCtx)
+        private void ErrAppendType(CType pType, SubstContext pctx)
         {
-            ErrAppendType(pType, pCtx, true);
-        }
-
-        private void ErrAppendType(CType pType, SubstContext pctx, bool fArgs)
-        {
-            if (pctx != null)
+            if (pctx != null && !pctx.IsNop)
             {
-                if (!pctx.IsNop)
-                {
-                    pType = GetTypeManager().SubstType(pType, pctx);
-                }
-                // We shouldn't use the SubstContext again so set it to NULL.
-                pctx = null;
+                pType = GetTypeManager().SubstType(pType, pctx);
             }
 
             switch (pType.TypeKind)
@@ -441,19 +431,19 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                         {
                             if (pAggType.OuterType != null)
                             {
-                                ErrAppendType(pAggType.OuterType, pctx);
+                                ErrAppendType(pAggType.OuterType, null);
                                 ErrAppendChar('.');
                             }
                             else
                             {
                                 // In a namespace.
-                                ErrAppendParentSym(pAggType.OwningAggregate, pctx);
+                                ErrAppendParentSym(pAggType.OwningAggregate, null);
                             }
 
                             ErrAppendName(pAggType.OwningAggregate.name);
                         }
 
-                        ErrAppendTypeParameters(pAggType.TypeArgsThis, pctx, true);
+                        ErrAppendTypeParameters(pAggType.TypeArgsThis, null, true);
                         break;
                     }
 
@@ -494,13 +484,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     {
                         CType elementType = ((ArrayType)pType).BaseElementType;
 
-                        if (null == elementType)
-                        {
-                            Debug.Assert(false, "No element type");
-                            break;
-                        }
+                        Debug.Assert(elementType != null, "No element type");
 
-                        ErrAppendType(elementType, pctx);
+                        ErrAppendType(elementType, null);
 
                         for (elementType = pType;
                                 elementType is ArrayType arrType;
@@ -542,12 +528,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     ErrAppendString(mod.IsOut ? "out " : "ref ");
 
                     // add base type name
-                    ErrAppendType(mod.ParameterType, pctx);
+                    ErrAppendType(mod.ParameterType, null);
                     break;
 
                 case TypeKind.TK_PointerType:
                     // Generate the base type.
-                    ErrAppendType(((PointerType)pType).ReferentType, pctx);
+                    ErrAppendType(((PointerType)pType).ReferentType, null);
                     {
                         // add the trailing *
                         ErrAppendChar('*');
@@ -555,7 +541,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     break;
 
                 case TypeKind.TK_NullableType:
-                    ErrAppendType(((NullableType)pType).UnderlyingType, pctx);
+                    ErrAppendType(((NullableType)pType).UnderlyingType, null);
                     ErrAppendChar('?');
                     break;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -407,7 +407,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         methsym.isVirtual == isVirtual &&
                         methsym.typeVars.Count == cMethodTyVars &&
                         GetTypeManager().SubstEqualTypes(methsym.RetType, returnType, null, methsym.typeVars, true) &&
-                        GetTypeManager().SubstEqualTypeArrays(methsym.Params, argumentTypes, null, methsym.typeVars, true))
+                        GetTypeManager().SubstEqualTypeArrays(methsym.Params, argumentTypes, null, methsym.typeVars))
                     {
                         return methsym;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -406,9 +406,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         methsym.isStatic == isStatic &&
                         methsym.isVirtual == isVirtual &&
                         methsym.typeVars.Count == cMethodTyVars &&
-                        GetTypeManager().SubstEqualTypes(methsym.RetType, returnType, null, methsym.typeVars, SubstTypeFlags.DenormMeth) &&
-                        GetTypeManager().SubstEqualTypeArrays(methsym.Params, argumentTypes, (TypeArray)null,
-                            methsym.typeVars, SubstTypeFlags.DenormMeth))
+                        GetTypeManager().SubstEqualTypes(methsym.RetType, returnType, null, methsym.typeVars, true) &&
+                        GetTypeManager().SubstEqualTypeArrays(methsym.Params, argumentTypes, null, methsym.typeVars, true))
                     {
                         return methsym;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
@@ -44,9 +44,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
         }
 
-        public bool FNop()
-        {
-            return prgtypeCls.Length == 0 & prgtypeMeth.Length == 0;
-        }
+        public bool IsNop => prgtypeCls.Length == 0 & prgtypeMeth.Length == 0;
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
@@ -6,41 +6,33 @@ using System;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    // Used to specify whether and which type variables should be normalized.
-    [Flags]
-    internal enum SubstTypeFlags
-    {
-        NormNone = 0x00,
-        DenormMeth = 0x08,   // Replace normalized (standard) method type variables with the given method type args.
-    }
-
     internal sealed class SubstContext
     {
         public readonly CType[] ClassTypes;
         public readonly CType[] MethodTypes;
-        public readonly SubstTypeFlags grfst;
+        public readonly bool DenormMeth;
 
-        public SubstContext(TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
+        public SubstContext(TypeArray typeArgsCls, TypeArray typeArgsMeth, bool denormMeth)
         {
             typeArgsCls?.AssertValid();
             ClassTypes = typeArgsCls?.Items ?? Array.Empty<CType>();
             typeArgsMeth?.AssertValid();
             MethodTypes = typeArgsMeth?.Items ?? Array.Empty<CType>();
-            this.grfst = grfst;
+            DenormMeth = denormMeth;
         }
 
         public SubstContext(AggregateType type)
-            : this(type, null, SubstTypeFlags.NormNone)
+            : this(type, null, false)
         {
         }
 
         public SubstContext(AggregateType type, TypeArray typeArgsMeth)
-            : this(type, typeArgsMeth, SubstTypeFlags.NormNone)
+            : this(type, typeArgsMeth, false)
         {
         }
 
-        private SubstContext(AggregateType type, TypeArray typeArgsMeth, SubstTypeFlags grfst)
-            : this(type?.TypeArgsAll, typeArgsMeth, grfst)
+        private SubstContext(AggregateType type, TypeArray typeArgsMeth, bool denormMeth)
+            : this(type?.TypeArgsAll, typeArgsMeth, denormMeth)
         {
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
@@ -11,9 +11,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     internal enum SubstTypeFlags
     {
         NormNone = 0x00,
-        NormClass = 0x01,  // Replace class type variables with the normalized (standard) ones.
-        NormMeth = 0x02,   // Replace method type variables with the normalized (standard) ones.
-        NormAll = NormClass | NormMeth,
         DenormMeth = 0x08,   // Replace normalized (standard) method type variables with the given method type args.
     }
 
@@ -61,7 +58,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool FNop()
         {
-            return 0 == ctypeCls && 0 == ctypeMeth && 0 == (grfst & SubstTypeFlags.NormAll);
+            return 0 == ctypeCls && 0 == ctypeMeth;
         }
 
         // Initializes a substitution context. Returns false iff no substitutions will ever be performed.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
@@ -16,53 +16,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
     internal sealed class SubstContext
     {
-        public CType[] prgtypeCls;
-        public int ctypeCls;
-        public CType[] prgtypeMeth;
-        public int ctypeMeth;
-        public SubstTypeFlags grfst;
+        public readonly CType[] prgtypeCls;
+        public readonly int ctypeCls;
+        public readonly CType[] prgtypeMeth;
+        public readonly int ctypeMeth;
+        public readonly SubstTypeFlags grfst;
 
         public SubstContext(TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
-        {
-            Init(typeArgsCls, typeArgsMeth, grfst);
-        }
-
-        public SubstContext(AggregateType type)
-            : this(type, null, SubstTypeFlags.NormNone)
-        {
-        }
-
-        public SubstContext(AggregateType type, TypeArray typeArgsMeth)
-            : this(type, typeArgsMeth, SubstTypeFlags.NormNone)
-        {
-        }
-
-        private SubstContext(AggregateType type, TypeArray typeArgsMeth, SubstTypeFlags grfst)
-        {
-            Init(type?.TypeArgsAll, typeArgsMeth, grfst);
-        }
-
-        public SubstContext(CType[] prgtypeCls, int ctypeCls, CType[] prgtypeMeth, int ctypeMeth)
-            : this(prgtypeCls, ctypeCls, prgtypeMeth, ctypeMeth, SubstTypeFlags.NormNone)
-        {
-        }
-
-        private SubstContext(CType[] prgtypeCls, int ctypeCls, CType[] prgtypeMeth, int ctypeMeth, SubstTypeFlags grfst)
-        {
-            this.prgtypeCls = prgtypeCls;
-            this.ctypeCls = ctypeCls;
-            this.prgtypeMeth = prgtypeMeth;
-            this.ctypeMeth = ctypeMeth;
-            this.grfst = grfst;
-        }
-
-        public bool FNop()
-        {
-            return 0 == ctypeCls && 0 == ctypeMeth;
-        }
-
-        // Initializes a substitution context. Returns false iff no substitutions will ever be performed.
-        private void Init(TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
         {
             if (typeArgsCls != null)
             {
@@ -89,6 +49,40 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             this.grfst = grfst;
+        }
+
+        public SubstContext(AggregateType type)
+            : this(type, null, SubstTypeFlags.NormNone)
+        {
+        }
+
+        public SubstContext(AggregateType type, TypeArray typeArgsMeth)
+            : this(type, typeArgsMeth, SubstTypeFlags.NormNone)
+        {
+        }
+
+        private SubstContext(AggregateType type, TypeArray typeArgsMeth, SubstTypeFlags grfst)
+            : this(type?.TypeArgsAll, typeArgsMeth, grfst)
+        {
+        }
+
+        public SubstContext(CType[] prgtypeCls, int ctypeCls, CType[] prgtypeMeth, int ctypeMeth)
+            : this(prgtypeCls, ctypeCls, prgtypeMeth, ctypeMeth, SubstTypeFlags.NormNone)
+        {
+        }
+
+        private SubstContext(CType[] prgtypeCls, int ctypeCls, CType[] prgtypeMeth, int ctypeMeth, SubstTypeFlags grfst)
+        {
+            this.prgtypeCls = prgtypeCls;
+            this.ctypeCls = ctypeCls;
+            this.prgtypeMeth = prgtypeMeth;
+            this.ctypeMeth = ctypeMeth;
+            this.grfst = grfst;
+        }
+
+        public bool FNop()
+        {
+            return 0 == ctypeCls && 0 == ctypeMeth;
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
@@ -17,37 +17,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     internal sealed class SubstContext
     {
         public readonly CType[] prgtypeCls;
-        public readonly int ctypeCls;
         public readonly CType[] prgtypeMeth;
-        public readonly int ctypeMeth;
         public readonly SubstTypeFlags grfst;
 
         public SubstContext(TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
         {
-            if (typeArgsCls != null)
-            {
-                typeArgsCls.AssertValid();
-                ctypeCls = typeArgsCls.Count;
-                prgtypeCls = typeArgsCls.Items;
-            }
-            else
-            {
-                ctypeCls = 0;
-                prgtypeCls = null;
-            }
-
-            if (typeArgsMeth != null)
-            {
-                typeArgsMeth.AssertValid();
-                ctypeMeth = typeArgsMeth.Count;
-                prgtypeMeth = typeArgsMeth.Items;
-            }
-            else
-            {
-                ctypeMeth = 0;
-                prgtypeMeth = null;
-            }
-
+            typeArgsCls?.AssertValid();
+            prgtypeCls = typeArgsCls?.Items ?? Array.Empty<CType>();
+            typeArgsMeth?.AssertValid();
+            prgtypeMeth = typeArgsMeth?.Items ?? Array.Empty<CType>();
             this.grfst = grfst;
         }
 
@@ -68,7 +46,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool FNop()
         {
-            return 0 == ctypeCls && 0 == ctypeMeth;
+            return prgtypeCls.Length == 0 & prgtypeMeth.Length == 0;
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
@@ -66,20 +66,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
         }
 
-        public SubstContext(CType[] prgtypeCls, int ctypeCls, CType[] prgtypeMeth, int ctypeMeth)
-            : this(prgtypeCls, ctypeCls, prgtypeMeth, ctypeMeth, SubstTypeFlags.NormNone)
-        {
-        }
-
-        private SubstContext(CType[] prgtypeCls, int ctypeCls, CType[] prgtypeMeth, int ctypeMeth, SubstTypeFlags grfst)
-        {
-            this.prgtypeCls = prgtypeCls;
-            this.ctypeCls = ctypeCls;
-            this.prgtypeMeth = prgtypeMeth;
-            this.ctypeMeth = ctypeMeth;
-            this.grfst = grfst;
-        }
-
         public bool FNop()
         {
             return 0 == ctypeCls && 0 == ctypeMeth;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
@@ -14,10 +14,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         NormClass = 0x01,  // Replace class type variables with the normalized (standard) ones.
         NormMeth = 0x02,   // Replace method type variables with the normalized (standard) ones.
         NormAll = NormClass | NormMeth,
-        DenormClass = 0x04,  // Replace normalized (standard) class type variables with the given class type args.
         DenormMeth = 0x08,   // Replace normalized (standard) method type variables with the given method type args.
-        DenormAll = DenormClass | DenormMeth,
-        NoRefOutDifference = 0x10
     }
 
     internal sealed class SubstContext

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
@@ -16,16 +16,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
     internal sealed class SubstContext
     {
-        public readonly CType[] prgtypeCls;
-        public readonly CType[] prgtypeMeth;
+        public readonly CType[] ClassTypes;
+        public readonly CType[] MethodTypes;
         public readonly SubstTypeFlags grfst;
 
         public SubstContext(TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
         {
             typeArgsCls?.AssertValid();
-            prgtypeCls = typeArgsCls?.Items ?? Array.Empty<CType>();
+            ClassTypes = typeArgsCls?.Items ?? Array.Empty<CType>();
             typeArgsMeth?.AssertValid();
-            prgtypeMeth = typeArgsMeth?.Items ?? Array.Empty<CType>();
+            MethodTypes = typeArgsMeth?.Items ?? Array.Empty<CType>();
             this.grfst = grfst;
         }
 
@@ -44,6 +44,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
         }
 
-        public bool IsNop => prgtypeCls.Length == 0 & prgtypeMeth.Length == 0;
+        public bool IsNop => ClassTypes.Length == 0 & MethodTypes.Length == 0;
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -202,25 +202,17 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private CType SubstType(CType typeSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth, bool denormMeth)
         {
-            if (typeSrc == null)
-                return null;
-
-            var ctx = new SubstContext(typeArgsCls, typeArgsMeth, denormMeth);
+            Debug.Assert(typeSrc != null);
+            SubstContext ctx = new SubstContext(typeArgsCls, typeArgsMeth, denormMeth);
             return ctx.IsNop ? typeSrc : SubstTypeCore(typeSrc, ctx);
         }
 
         public AggregateType SubstType(AggregateType typeSrc, TypeArray typeArgsCls)
         {
-            if (typeSrc != null)
-            {
-                SubstContext ctx = new SubstContext(typeArgsCls, null, false);
-                if (!ctx.IsNop)
-                {
-                    return SubstTypeCore(typeSrc, ctx);
-                }
-            }
+            Debug.Assert(typeSrc != null);
 
-            return typeSrc;
+            SubstContext ctx = new SubstContext(typeArgsCls, null, false);
+            return ctx.IsNop ? typeSrc : SubstTypeCore(typeSrc, ctx);
         }
 
         private CType SubstType(CType typeSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth) =>

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -417,10 +417,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     goto LCheckBases;
 
                 case TypeKind.TK_ParameterModifierType:
-                    if (!(typeDst is ParameterModifierType modDest) ||
-                        ((pctx.grfst & SubstTypeFlags.NoRefOutDifference) == 0 &&
-                         modDest.IsOut != ((ParameterModifierType)typeSrc).IsOut))
+                    if (!(typeDst is ParameterModifierType modDest) || modDest.IsOut != ((ParameterModifierType)typeSrc).IsOut)
+                    {
                         return false;
+                    }
+
                     goto LCheckBases;
 
                 case TypeKind.TK_PointerType:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -352,7 +352,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return !ctx.IsNop && SubstEqualTypesCore(typeDst, typeSrc, ctx);
         }
 
-        public bool SubstEqualTypeArrays(TypeArray taDst, TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth, bool denormMeth)
+        public bool SubstEqualTypeArrays(TypeArray taDst, TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth)
         {
             // Handle the simple common cases first.
             if (taDst == taSrc || (taDst != null && taDst.Equals(taSrc)))
@@ -370,7 +370,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (taDst.Count == 0)
                 return true;
 
-            var ctx = new SubstContext(typeArgsCls, typeArgsMeth, denormMeth);
+            var ctx = new SubstContext(typeArgsCls, typeArgsMeth, true);
 
             if (ctx.IsNop)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -206,7 +206,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return null;
 
             var ctx = new SubstContext(typeArgsCls, typeArgsMeth, grfst);
-            return ctx.FNop() ? typeSrc : SubstTypeCore(typeSrc, ctx);
+            return ctx.IsNop ? typeSrc : SubstTypeCore(typeSrc, ctx);
         }
 
         public AggregateType SubstType(AggregateType typeSrc, TypeArray typeArgsCls)
@@ -214,7 +214,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (typeSrc != null)
             {
                 SubstContext ctx = new SubstContext(typeArgsCls, null, SubstTypeFlags.NormNone);
-                if (!ctx.FNop())
+                if (!ctx.IsNop)
                 {
                     return SubstTypeCore(typeSrc, ctx);
                 }
@@ -230,7 +230,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public TypeArray SubstTypeArray(TypeArray taSrc, SubstContext ctx)
         {
-            if (taSrc != null && taSrc.Count != 0 && ctx != null && !ctx.FNop())
+            if (taSrc != null && taSrc.Count != 0 && ctx != null && !ctx.IsNop)
             {
                 CType[] srcs = taSrc.Items;
                 for (int i = 0; i < srcs.Length; i++)
@@ -348,7 +348,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             var ctx = new SubstContext(typeArgsCls, typeArgsMeth, grfst);
 
-            return !ctx.FNop() && SubstEqualTypesCore(typeDst, typeSrc, ctx);
+            return !ctx.IsNop && SubstEqualTypesCore(typeDst, typeSrc, ctx);
         }
 
         public bool SubstEqualTypeArrays(TypeArray taDst, TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
@@ -371,8 +371,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             var ctx = new SubstContext(typeArgsCls, typeArgsMeth, grfst);
 
-            if (ctx.FNop())
+            if (ctx.IsNop)
+            {
                 return false;
+            }
 
             for (int i = 0; i < taDst.Count; i++)
             {
@@ -603,12 +605,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         public AggregateType SubstType(AggregateType typeSrc, SubstContext ctx) =>
-            ctx == null || ctx.FNop() ? typeSrc : SubstTypeCore(typeSrc, ctx);
+            ctx == null || ctx.IsNop ? typeSrc : SubstTypeCore(typeSrc, ctx);
 
-        public CType SubstType(CType typeSrc, SubstContext pctx)
-        {
-            return (pctx == null || pctx.FNop()) ? typeSrc : SubstTypeCore(typeSrc, pctx);
-        }
+        public CType SubstType(CType typeSrc, SubstContext pctx) =>
+            pctx == null || pctx.IsNop ? typeSrc : SubstTypeCore(typeSrc, pctx);
 
         public CType SubstType(CType typeSrc, AggregateType atsCls)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -21,14 +21,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private SymbolTable _symbolTable;
 
         private readonly StdTypeVarColl _stvcMethod;
-        private readonly StdTypeVarColl _stvcClass;
 
         public TypeManager(BSYMMGR bsymmgr, PredefinedTypes predefTypes)
         {
             _typeTable = new TypeTable();
 
             _stvcMethod = new StdTypeVarColl();
-            _stvcClass = new StdTypeVarColl();
             _BSymmgr = bsymmgr;
             _predefTypes = predefTypes;
         }
@@ -653,11 +651,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public TypeParameterType GetStdMethTypeVar(int iv)
         {
             return _stvcMethod.GetTypeVarSym(iv, this, true);
-        }
-
-        private TypeParameterType GetStdClsTypeVar(int iv)
-        {
-            return _stvcClass.GetTypeVarSym(iv, this, false);
         }
 
         // These are singletons for each.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -324,16 +324,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             if ((pctx.grfst & SubstTypeFlags.DenormMeth) != 0 && tvs.parent != null)
                                 return type;
                             Debug.Assert(tvs.GetIndexInOwnParameters() == tvs.GetIndexInTotalParameters());
-                            if (index < pctx.prgtypeMeth.Length)
+                            if (index < pctx.MethodTypes.Length)
                             {
-                                Debug.Assert(pctx.prgtypeMeth != null);
-                                return pctx.prgtypeMeth[index];
+                                Debug.Assert(pctx.MethodTypes != null);
+                                return pctx.MethodTypes[index];
                             }
 
                             return type;
                         }
 
-                        return index < pctx.prgtypeCls.Length ? pctx.prgtypeCls[index] : type;
+                        return index < pctx.ClassTypes.Length ? pctx.ClassTypes[index] : type;
                     }
             }
         }
@@ -463,18 +463,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                 return false;
                             }
                             Debug.Assert(tvs.GetIndexInOwnParameters() == index);
-                            Debug.Assert(tvs.GetIndexInTotalParameters() < pctx.prgtypeMeth.Length);
-                            if (index < pctx.prgtypeMeth.Length)
+                            Debug.Assert(tvs.GetIndexInTotalParameters() < pctx.MethodTypes.Length);
+                            if (index < pctx.MethodTypes.Length)
                             {
-                                return typeDst == pctx.prgtypeMeth[index];
+                                return typeDst == pctx.MethodTypes[index];
                             }
                         }
                         else
                         {
-                            Debug.Assert(index < pctx.prgtypeCls.Length);
-                            if (index < pctx.prgtypeCls.Length)
+                            Debug.Assert(index < pctx.ClassTypes.Length);
+                            if (index < pctx.ClassTypes.Length)
                             {
-                                return typeDst == pctx.prgtypeCls[index];
+                                return typeDst == pctx.ClassTypes[index];
                             }
                         }
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -331,15 +331,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                 Debug.Assert(pctx.prgtypeMeth != null);
                                 return pctx.prgtypeMeth[index];
                             }
-                            else
-                            {
-                                return ((pctx.grfst & SubstTypeFlags.NormMeth) != 0 ? GetStdMethTypeVar(index) : type);
-                            }
-                        }
-                        if ((pctx.grfst & SubstTypeFlags.DenormClass) != 0 && tvs.parent != null)
+
                             return type;
-                        return index < pctx.ctypeCls ? pctx.prgtypeCls[index] :
-                               ((pctx.grfst & SubstTypeFlags.NormClass) != 0 ? GetStdClsTypeVar(index) : type);
+                        }
+
+                        return index < pctx.ctypeCls ? pctx.prgtypeCls[index] : type;
                     }
             }
         }
@@ -472,24 +468,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             {
                                 return typeDst == pctx.prgtypeMeth[index];
                             }
-                            if ((pctx.grfst & SubstTypeFlags.NormMeth) != 0)
-                            {
-                                return typeDst == GetStdMethTypeVar(index);
-                            }
                         }
                         else
                         {
-                            if ((pctx.grfst & SubstTypeFlags.DenormClass) != 0 && tvs.parent != null)
-                            {
-                                // typeDst == typeSrc was handled above.
-                                Debug.Assert(typeDst != typeSrc);
-                                return false;
-                            }
                             Debug.Assert(pctx.prgtypeCls == null || tvs.GetIndexInTotalParameters() < pctx.ctypeCls);
                             if (index < pctx.ctypeCls)
                                 return typeDst == pctx.prgtypeCls[index];
-                            if ((pctx.grfst & SubstTypeFlags.NormClass) != 0)
-                                return typeDst == GetStdClsTypeVar(index);
                         }
                     }
                     return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -324,7 +324,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             if ((pctx.grfst & SubstTypeFlags.DenormMeth) != 0 && tvs.parent != null)
                                 return type;
                             Debug.Assert(tvs.GetIndexInOwnParameters() == tvs.GetIndexInTotalParameters());
-                            if (index < pctx.ctypeMeth)
+                            if (index < pctx.prgtypeMeth.Length)
                             {
                                 Debug.Assert(pctx.prgtypeMeth != null);
                                 return pctx.prgtypeMeth[index];
@@ -333,7 +333,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             return type;
                         }
 
-                        return index < pctx.ctypeCls ? pctx.prgtypeCls[index] : type;
+                        return index < pctx.prgtypeCls.Length ? pctx.prgtypeCls[index] : type;
                     }
             }
         }
@@ -460,18 +460,20 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                 Debug.Assert(typeDst != typeSrc);
                                 return false;
                             }
-                            Debug.Assert(tvs.GetIndexInOwnParameters() == tvs.GetIndexInTotalParameters());
-                            Debug.Assert(pctx.prgtypeMeth == null || tvs.GetIndexInTotalParameters() < pctx.ctypeMeth);
-                            if (index < pctx.ctypeMeth && pctx.prgtypeMeth != null)
+                            Debug.Assert(tvs.GetIndexInOwnParameters() == index);
+                            Debug.Assert(tvs.GetIndexInTotalParameters() < pctx.prgtypeMeth.Length);
+                            if (index < pctx.prgtypeMeth.Length)
                             {
                                 return typeDst == pctx.prgtypeMeth[index];
                             }
                         }
                         else
                         {
-                            Debug.Assert(pctx.prgtypeCls == null || tvs.GetIndexInTotalParameters() < pctx.ctypeCls);
-                            if (index < pctx.ctypeCls)
+                            Debug.Assert(index < pctx.prgtypeCls.Length);
+                            if (index < pctx.prgtypeCls.Length)
+                            {
                                 return typeDst == pctx.prgtypeCls[index];
+                            }
                         }
                     }
                     return false;


### PR DESCRIPTION
* Remove `SubstTypeFlags.NoRefOutDifference`

Looked for, but never set.

* Remove `SubstTypeFlags.DenormClass`

Looked for, but never set.

* Remove `SubstTypeFlags.Norm*`

Looked for, but never set.

* Remove `_stvcClass`

No longer used.

* Move init into ctor and make fields readonly

* Remove unused ctors

* Remove counts from `SubsContext`

Just get them from the arrays.

* `FNop()` method to `IsNop` property

* Rename context's arrays

Non-Hungarian based.

* Remove `SubstTypeFlags`

Only two values in use, so use boolean.

* Remove `denormMeth` argument to `SubstEqualTypeArrays`

Always true

* Remove most uses of context in `ErrAppendType`

Instead of setting to null, just use null.
