### PR TITLE
Remove orphaned methods from Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
@@ -50,7 +50,5 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         internal static Exception DynamicArgumentNeedsValue(string paramName) =>
             new ArgumentException(SR.DynamicArgumentNeedsValue, paramName);
-
-        internal static Exception BindingNameCollision() => new RuntimeBinderException(SR.BindingNameCollision);
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -765,11 +765,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                         // The conversion is applicable so it affects the best types.
 
-                        prguci.Add(new UdConvInfo());
-                        prguci[prguci.Count - 1].mwt = new MethWithType();
-                        prguci[prguci.Count - 1].mwt.Set(convCur, atsCur);
-                        prguci[prguci.Count - 1].fSrcImplicit = fFromImplicit;
-                        prguci[prguci.Count - 1].fDstImplicit = fToImplicit;
+                        prguci.Add(new UdConvInfo
+                        {
+                            mwt = new MethWithType(convCur, atsCur),
+                            fSrcImplicit = fFromImplicit,
+                            fDstImplicit = fToImplicit
+                        });
 
                         if (!fBestSrcExact)
                         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -765,12 +765,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                         // The conversion is applicable so it affects the best types.
 
-                        prguci.Add(new UdConvInfo
-                        {
-                            mwt = new MethWithType(convCur, atsCur),
-                            fSrcImplicit = fFromImplicit,
-                            fDstImplicit = fToImplicit
-                        });
+                        prguci.Add(new UdConvInfo(new MethWithType(convCur, atsCur), fFromImplicit, fToImplicit));
 
                         if (!fBestSrcExact)
                         {
@@ -791,7 +786,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             else if (typeBestSrc != typeFrom)
                             {
                                 Debug.Assert(0 <= iuciBestSrc && iuciBestSrc < prguci.Count - 1);
-                                int n = CompareSrcTypesBased(typeBestSrc, prguci[iuciBestSrc].fSrcImplicit, typeFrom, fFromImplicit);
+                                int n = CompareSrcTypesBased(typeBestSrc, prguci[iuciBestSrc].SrcImplicit, typeFrom, fFromImplicit);
                                 if (n > 0)
                                 {
                                     typeBestSrc = typeFrom;
@@ -818,7 +813,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             else if (typeBestDst != typeTo)
                             {
                                 Debug.Assert(0 <= iuciBestDst && iuciBestDst < prguci.Count - 1);
-                                int n = CompareDstTypesBased(typeBestDst, prguci[iuciBestDst].fDstImplicit, typeTo, fToImplicit);
+                                int n = CompareDstTypesBased(typeBestDst, prguci[iuciBestDst].DstImplicit, typeTo, fToImplicit);
                                 if (n > 0)
                                 {
                                     typeBestDst = typeTo;
@@ -850,8 +845,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 UdConvInfo uci = prguci[iuci];
 
                 // Get the substituted src and dst types.
-                typeFrom = GetTypes().SubstType(uci.mwt.Meth().Params[0], uci.mwt.GetType());
-                typeTo = GetTypes().SubstType(uci.mwt.Meth().RetType, uci.mwt.GetType());
+                typeFrom = GetTypes().SubstType(uci.Meth.Meth().Params[0], uci.Meth.GetType());
+                typeTo = GetTypes().SubstType(uci.Meth.Meth().RetType, uci.Meth.GetType());
 
                 int ctypeLift = 0;
 
@@ -907,7 +902,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // convertible to each other (eg, int? and int??) and hence not distinguishable by CompareXxxTypesBase.
                 if (!fBestSrcExact && typeFrom != typeBestSrc)
                 {
-                    int n = CompareSrcTypesBased(typeBestSrc, prguci[iuciBestSrc].fSrcImplicit, typeFrom, uci.fSrcImplicit);
+                    int n = CompareSrcTypesBased(typeBestSrc, prguci[iuciBestSrc].SrcImplicit, typeFrom, uci.SrcImplicit);
                     Debug.Assert(n <= 0);
                     if (n >= 0)
                     {
@@ -921,7 +916,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 if (!fBestDstExact && typeTo != typeBestDst)
                 {
-                    int n = CompareDstTypesBased(typeBestDst, prguci[iuciBestDst].fDstImplicit, typeTo, uci.fDstImplicit);
+                    int n = CompareDstTypesBased(typeBestDst, prguci[iuciBestDst].DstImplicit, typeTo, uci.DstImplicit);
                     Debug.Assert(n <= 0);
                     if (n >= 0)
                     {
@@ -947,7 +942,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 throw HandleAmbiguity(typeSrc, typeDst, prguci, iuciBest, iuciAmbig);
             }
 
-            MethWithInst mwiBest = new MethWithInst(prguci[iuciBest].mwt.Meth(), prguci[iuciBest].mwt.GetType(), null);
+            MethWithInst mwiBest = new MethWithInst(prguci[iuciBest].Meth.Meth(), prguci[iuciBest].Meth.GetType(), null);
 
             Debug.Assert(ctypeLiftBest <= 2);
 
@@ -1026,7 +1021,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(0 <= iuciBestSrc && iuciBestSrc < prguci.Count);
             Debug.Assert(0 <= iuciBestDst && iuciBestDst < prguci.Count);
-            return ErrorContext.Error(ErrorCode.ERR_AmbigUDConv, prguci[iuciBestSrc].mwt, prguci[iuciBestDst].mwt, typeSrc, typeDst);
+            return ErrorContext.Error(ErrorCode.ERR_AmbigUDConv, prguci[iuciBestSrc].Meth, prguci[iuciBestDst].Meth, typeSrc, typeDst);
         }
 
         private void MarkAsIntermediateConversion(Expr pExpr)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -762,11 +762,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return _binder.GetSymbolLoader();
             }
-
-            private ExprFactory GetExprFactory()
-            {
-                return _binder.GetExprFactory();
-            }
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -12,11 +12,18 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     // Used by bindUserDefinedConversion
-    internal sealed class UdConvInfo
+    internal readonly struct UdConvInfo
     {
-        public MethWithType mwt;
-        public bool fSrcImplicit;
-        public bool fDstImplicit;
+        public readonly MethWithType Meth;
+        public readonly bool SrcImplicit;
+        public readonly bool DstImplicit;
+
+        public UdConvInfo(MethWithType mwt, bool srcImplicit, bool dstImplicit)
+        {
+            Meth = mwt;
+            SrcImplicit = srcImplicit;
+            DstImplicit = dstImplicit;
+        }
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////
@@ -1555,10 +1562,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             foreach (UdConvInfo conv in convTable)
             {
-                if (conv.mwt.Meth() == meth &&
-                    conv.mwt.GetType() == ats &&
-                    conv.fSrcImplicit == fSrc &&
-                    conv.fDstImplicit == fDst)
+                if (conv.Meth.Meth() == meth &&
+                    conv.Meth.GetType() == ats &&
+                    conv.SrcImplicit == fSrc &&
+                    conv.DstImplicit == fDst)
                 {
                     return true;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1052,30 +1052,19 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private void PostBindProperty(PropWithType pwt, Expr pObject, out MethWithType pmwtGet, out MethWithType pmwtSet)
         {
-            pmwtGet = new MethWithType();
-            pmwtSet = new MethWithType();
+            PropertySymbol prop = pwt.Prop();
+            Debug.Assert(prop != null);
             // Get the accessors.
-            if (pwt.Prop().GetterMethod != null)
-            {
-                pmwtGet.Set(pwt.Prop().GetterMethod, pwt.GetType());
-            }
-            else
-            {
-                pmwtGet.Clear();
-            }
+            pmwtGet = prop.GetterMethod != null
+                ? new MethWithType(prop.GetterMethod, pwt.GetType())
+                : new MethWithType();
+            pmwtSet = prop.SetterMethod != null
+                ? new MethWithType(prop.SetterMethod, pwt.GetType())
+                : new MethWithType();
 
-            if (pwt.Prop().SetterMethod != null)
+            if (prop.RetType != null)
             {
-                pmwtSet.Set(pwt.Prop().SetterMethod, pwt.GetType());
-            }
-            else
-            {
-                pmwtSet.Clear();
-            }
-
-            if (pwt.Prop().RetType != null)
-            {
-                checkUnsafe(pwt.Prop().RetType);
+                checkUnsafe(prop.RetType);
             }
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -1223,8 +1223,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     Debug.Assert(_results.UninferableResult.Sym is MethodSymbol);
 
-                    MethWithType mwtCantInfer = new MethWithType();
-                    mwtCantInfer.Set(_results.UninferableResult.Meth(), _results.UninferableResult.GetType());
+                    MethWithType mwtCantInfer = new MethWithType(_results.UninferableResult.Meth(), _results.UninferableResult.GetType());
                     return GetErrorContext().Error(ErrorCode.ERR_CantInferMethTypeArgs, mwtCantInfer);
                 }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -41,7 +41,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private CSemanticChecker _pSemanticChecker;
         private SymbolLoader _pSymbolLoader;
         private CType _typeSrc;
-        private Expr _obj;
         private CType _typeQual;
         private ParentSymbol _symWhere;
         private Name _name;
@@ -556,7 +555,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _pSemanticChecker = checker;
             _pSymbolLoader = checker.SymbolLoader;
             _typeSrc = typeSrc;
-            _obj = obj is ExprClass ? null : obj;
             _symWhere = symWhere;
             _name = name;
             _arity = arity;
@@ -613,34 +611,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         // The first symbol found.
-        public Symbol SymFirst()
-        {
-            return _swtFirst.Sym;
-        }
         public SymWithType SwtFirst()
         {
             return _swtFirst;
-        }
-
-        public Expr GetObject()
-        {
-            return _obj;
-        }
-
-        public CType GetSourceType()
-        {
-            return _typeSrc;
-        }
-
-        public MemLookFlags GetFlags()
-        {
-            return _flags;
-        }
-
-        // Put all the types in a type array.
-        private TypeArray GetAllTypes()
-        {
-            return GetSymbolLoader().getBSymmgr().AllocParams(_prgtype.Count, _prgtype.ToArray());
         }
 
         /******************************************************************************

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
@@ -21,10 +21,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             return _exprFactory;
         }
-        private ErrorHandling GetErrorContext()
-        {
-            return _pErrorContext;
-        }
 
         private static bool IsNullableConstructor(Expr expr, out ExprCall call)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -247,10 +247,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             return _loader;
         }
-        private ErrorHandling GetErrorContext()
-        {
-            return GetSymbolLoader().GetErrorContext();
-        }
+
         private TypeManager GetTypeManager()
         {
             return GetSymbolLoader().GetTypeManager();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
@@ -92,11 +92,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return _methKind == MethodKindEnum.EventAccessor;
         }
 
-        private bool isExplicit()          // is user defined explicit conversion operator
-        {
-            return _methKind == MethodKindEnum.ExplicitConv;
-        }
-
         public bool isImplicit()          // is user defined implicit conversion operator
         {
             return _methKind == MethodKindEnum.ImplicitConv;
@@ -114,14 +109,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public MethodSymbol ConvNext()
         {
-            Debug.Assert(isImplicit() || isExplicit());
+            AssertIsConversionOperator();
             return _convNext;
         }
 
         public void SetConvNext(MethodSymbol conv)
         {
-            Debug.Assert(isImplicit() || isExplicit());
-            Debug.Assert(conv == null || conv.isImplicit() || conv.isExplicit());
+            AssertIsConversionOperator();
+            conv?.AssertIsConversionOperator();
             _convNext = conv;
         }
 
@@ -149,9 +144,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _evt = evt;
         }
 
-        public bool isConversionOperator()
+        [Conditional("DEBUG")]
+        private void AssertIsConversionOperator()
         {
-            return (isExplicit() || isImplicit());
+            Debug.Assert(MethKind == MethodKindEnum.ExplicitConv || MethKind == MethodKindEnum.ImplicitConv);
         }
 
         public new bool isUserCallable()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
@@ -77,11 +77,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 IsConstructor();
         }
 
-        public bool IsDestructor()              // Is a destructor
-        {
-            return _methKind == MethodKindEnum.Destructor;
-        }
-
         public bool isPropertyAccessor()  // true if this method is a property set or get method
         {
             return _methKind == MethodKindEnum.PropAccessor;
@@ -95,11 +90,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public bool isImplicit()          // is user defined implicit conversion operator
         {
             return _methKind == MethodKindEnum.ImplicitConv;
-        }
-
-        public bool isInvoke()            // Invoke method on a delegate - isn't user callable
-        {
-            return _methKind == MethodKindEnum.Invoke;
         }
 
         public void SetMethKind(MethodKindEnum mk)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
@@ -62,10 +62,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return false;
         }
 
-        public MethodKindEnum MethKind()
-        {
-            return _methKind;
-        }
+        public MethodKindEnum MethKind => _methKind;
 
         public bool IsConstructor()
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -34,21 +34,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return GlobalSymbolContext;
         }
 
-        public MethodSymbol LookupInvokeMeth(AggregateSymbol pAggDel)
-        {
-            Debug.Assert(pAggDel.AggKind() == AggKindEnum.Delegate);
-            for (Symbol pSym = LookupAggMember(NameManager.GetPredefinedName(PredefinedName.PN_INVOKE), pAggDel, symbmask_t.MASK_ALL);
-                 pSym != null;
-                 pSym = LookupNextSym(pSym, pAggDel, symbmask_t.MASK_ALL))
-            {
-                if (pSym is MethodSymbol meth && meth.isInvoke())
-                {
-                    return meth;
-                }
-            }
-            return null;
-        }
-
         public PredefinedTypes GetPredefindTypes()
         {
             return GlobalSymbolContext.GetPredefTypes();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PredefinedTypes.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PredefinedTypes.cs
@@ -59,8 +59,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public static string GetNiceName(AggregateSymbol type) =>
             type.IsPredefined() ? GetNiceName(type.GetPredefType()) : null;
-
-        public static string GetFullName(PredefinedType pt) => PredefinedTypeFacts.GetName(pt);
     }
 
     internal static class PredefinedTypeFacts

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -583,38 +583,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        public static bool ParametersContainTyVar(TypeArray @params, TypeParameterType typeFind)
-        {
-            Debug.Assert(@params != null);
-            Debug.Assert(typeFind != null);
-            for (int p = 0; p < @params.Count; p++)
-            {
-                CType sym = @params[p];
-                if (TypeContainsType(sym, typeFind))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
         public AggregateSymbol GetPredefAgg(PredefinedType pt) => _predefTypes.GetPredefinedAggregate(pt);
 
         public TypeArray ConcatenateTypeArrays(TypeArray pTypeArray1, TypeArray pTypeArray2)
         {
             return _BSymmgr.ConcatParams(pTypeArray1, pTypeArray2);
-        }
-
-        public TypeArray GetStdMethTyVarArray(int cTyVars)
-        {
-            TypeParameterType[] prgvar = new TypeParameterType[cTyVars];
-
-            for (int ivar = 0; ivar < cTyVars; ivar++)
-            {
-                prgvar[ivar] = GetStdMethTypeVar(ivar);
-            }
-
-            return _BSymmgr.AllocParams(cTyVars, (CType[])prgvar);
         }
 
         public AggregateType SubstType(AggregateType typeSrc, SubstContext ctx) =>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -268,9 +268,6 @@
   <data name="DynamicArgumentNeedsValue" xml:space="preserve">
     <value>The runtime binder cannot bind a metaobject without a value</value>
   </data>
-  <data name="BindingNameCollision" xml:space="preserve">
-    <value>More than one type in the binding has the same full name.</value>
-  </data>
   <data name="BadNonTrailingNamedArgument" xml:space="preserve">
     <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
   </data>


### PR DESCRIPTION
Remove some methods that are unused due to their call sites being removed by other dead-code removal. The sort of completely-dead code that would be identified in #17905 if the reports for that were run again.

The first couple of commits here make use of methods that aren't being used, but were using them makes an improvement, and a further refactoring that doing that suggested, the last is just simple removal of methods that are never called.

* Switch on `MethodSymbol.MethKind` instead of repeated tests.

And make it a property.

* Make `isConversionOperator` an assertion and remove `isExplicit`

`isExplicit` is only used to assert the symbol is a conversion, so make the method itself an assertion property.

* Use binary `MethWithType` ctor

Rather than the nullary, only to set properties.

* Make `UdConvInfo` a readonly struct

* Remove orphaned methods.