### PR TITLE
LargeArrayBuilder<T> optimization of Add and AddRange

### DIFF
--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -124,13 +124,29 @@ namespace System.Collections.Generic
         {
             Debug.Assert(_maxCapacity > _count);
 
-            if (_index == _current.Length)
+            int index = _index;
+            T[] current = _current;
+            
+            // Must be >= and not == to enable range check elimination
+            if ((uint)index >= (uint)current.Length)
             {
-                AllocateBuffer();
+                AddWithBufferAllocation(item);
             }
-
-            _current[_index++] = item;
+            else
+            {
+                current[index] = item;
+                _index = index + 1;
+            }
+            
             _count++;
+        }
+        
+        // Non-inline to improve code quality as uncommon path
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void AddWithBufferAllocation(T item)
+        {
+            AllocateBuffer();
+            _current[_index++] = item;
         }
 
         /// <summary>

--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -171,23 +171,36 @@ namespace System.Collections.Generic
 
                 while (enumerator.MoveNext())
                 {
-                    if (index == destination.Length)
+                    T item = enumerator.Current;
+                    
+                    if ((uint)index >= (uint)destination.Length)
                     {
-                        // No more space in this buffer. Resize.
-                        _count += index - _index;
-                        _index = index;
-                        AllocateBuffer();
-                        destination = _current;
-                        index = _index; // May have been reset to 0
+                        AddWithBufferAllocation(item, ref destination, ref index);
                     }
-
-                    destination[index++] = enumerator.Current;
+                    else
+                    {
+                        destination[index] = item;
+                    }
+                    
+                    index++;
                 }
 
                 // Final update to _count and _index.
                 _count += index - _index;
                 _index = index;
             }
+        }
+
+        // Non-inline to improve code quality as uncommon path
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void AddWithBufferAllocation(T item, ref T[] destination, ref int index)
+        {
+            _count += index - _index;
+            _index = index;
+            AllocateBuffer();
+            destination = _current;
+            index = _index;
+            _current[index] = item;
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Enabled range check elimination on array-access, and split the uncommon path to a separate non-inlining method, to make the hot path compacter.

This PR is a kind of extension to #17318

# Benchmarks

## Add

Code for benchmark is [here](https://github.com/gfoidl/Benchmarks/blob/master/corefx/System/Collections/Generic/LargeArrayBuilder/source/LargeArrayBuilderBenchmarks/Benchmarks/AddBenchmarks.cs) and in the parent directory (two levels up).

``` ini

BenchmarkDotNet=v0.10.12, OS=ubuntu 16.04
Intel Xeon CPU 2.60GHz, 1 CPU, 4 logical cores and 2 physical cores
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT


```
|  Method |     Mean |    Error |   StdDev | Scaled | ScaledSD |
|-------- |---------:|---------:|---------:|-------:|---------:|
| Default | 432.3 us | 8.485 us | 19.67 us |   1.00 |     0.00 |
|    New1 | 390.7 us | 7.880 us | 19.77 us |   0.91 |     0.06 |

## AddRange

Code for benchmark is [here](https://github.com/gfoidl/Benchmarks/blob/master/corefx/System/Collections/Generic/LargeArrayBuilder/source/LargeArrayBuilderBenchmarks/Benchmarks/AddRangeBenchmarks.cs) and in the parent directory (two levels up).

``` ini

BenchmarkDotNet=v0.10.12, OS=ubuntu 16.04
Intel Xeon CPU 2.60GHz, 1 CPU, 4 logical cores and 2 physical cores
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT


```
|  Method |     Mean |    Error |   StdDev | Scaled | ScaledSD |
|-------- |---------:|---------:|---------:|-------:|---------:|
| Default | 973.0 us | 19.21 us | 21.36 us |   1.00 |     0.00 |
|    New1 | 842.1 us | 13.26 us | 12.41 us |   0.87 |     0.02 |
|    New2 | 900.3 us | 16.75 us | 15.67 us |   0.93 |     0.03 |

Note: `New1` is used in this PR. `New2` was a try, that didn't satisfy but for the record it is in the results.