### PR TITLE
Fix various issues with System.Json.JsonValue.Save

### DIFF
--- a/src/System.Json/src/System.Json.csproj
+++ b/src/System.Json/src/System.Json.csproj
@@ -31,6 +31,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Text.Encoding" />
+    <Reference Include="System.Text.Encoding.Extensions" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Json/src/System/Json/JsonObject.cs
+++ b/src/System.Json/src/System/Json/JsonObject.cs
@@ -114,35 +114,7 @@ namespace System.Json
 
         public override void Save(Stream stream)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            stream.WriteByte((byte)'{');
-
-            foreach (JsonPair pair in _map)
-            {
-                stream.WriteByte((byte)'"');
-                byte[] bytes = Encoding.UTF8.GetBytes(EscapeString(pair.Key));
-                stream.Write(bytes, 0, bytes.Length);
-                stream.WriteByte((byte)'"');
-                stream.WriteByte((byte)',');
-                stream.WriteByte((byte)' ');
-                if (pair.Value == null)
-                {
-                    stream.WriteByte((byte)'n');
-                    stream.WriteByte((byte)'u');
-                    stream.WriteByte((byte)'l');
-                    stream.WriteByte((byte)'l');
-                }
-                else
-                {
-                    pair.Value.Save(stream);
-                }
-            }
-
-            stream.WriteByte((byte)'}');
+            base.Save(stream);
         }
 
         public bool TryGetValue(string key, out JsonValue value) => _map.TryGetValue(key, out value);

--- a/src/System.Json/src/System/Json/JsonValue.cs
+++ b/src/System.Json/src/System/Json/JsonValue.cs
@@ -15,6 +15,8 @@ namespace System.Json
 {
     public abstract class JsonValue : IEnumerable
     {
+        private static readonly UTF8Encoding s_encoding = new UTF8Encoding(false, true);
+
         public static JsonValue Load(Stream stream)
         {
             if (stream == null)
@@ -122,7 +124,7 @@ namespace System.Json
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (StreamWriter writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, true))
+            using (StreamWriter writer = new StreamWriter(stream, s_encoding, 1024, true))
             {
                 Save(writer);
             }

--- a/src/System.Json/src/System/Json/JsonValue.cs
+++ b/src/System.Json/src/System/Json/JsonValue.cs
@@ -122,7 +122,10 @@ namespace System.Json
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            Save(new StreamWriter(stream));
+            using (StreamWriter writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, true))
+            {
+                Save(writer);
+            }
         }
 
         public virtual void Save(TextWriter textWriter)

--- a/src/System.Json/tests/JsonObjectTests.cs
+++ b/src/System.Json/tests/JsonObjectTests.cs
@@ -270,7 +270,7 @@ namespace System.Json.Tests
             {
                 obj.Save(stream);
                 string result = Encoding.UTF8.GetString(stream.ToArray());
-                Assert.Equal("{\"key\", true\"key2\", null}", result);
+                Assert.Equal("{\"key\": true, \"key2\": null}", result);
             }
         }
 

--- a/src/System.Json/tests/JsonValueTests.cs
+++ b/src/System.Json/tests/JsonValueTests.cs
@@ -432,7 +432,22 @@ namespace System.Json.Tests
             using (MemoryStream stream = new MemoryStream())
             {
                 value.Save(stream);
-                Assert.Empty(stream.ToArray());
+                string json = Encoding.UTF8.GetString(stream.ToArray());
+                Assert.True(stream.CanWrite);
+                Assert.Equal("Hello", json);
+            }
+        }
+
+        [Fact]
+        public void Save_TextWriter()
+        {
+            JsonSubValue value = new JsonSubValue();
+
+            using (StringWriter writer = new StringWriter())
+            {
+                value.Save(writer);
+                string json = writer.ToString();
+                Assert.Equal("Hello", json);
             }
         }
 


### PR DESCRIPTION
The `JsonObject` class overrides `JsonValue.Save(Stream)`, but was
implemented incorrectly: it would produce output resembling
`{"key1","value1""key2","value2"}`, instead of the more reasonable
`{"key1": "value1", "key2": "value2"}`. Because `JsonValue` already
contains code that can properly serialize a `JsonObject`, the override
now simply calls the base method.

In addition, it turns out that the `JsonValue.Save(Stream)` method was
also implemented incorrectly. This method would invoke
`JsonValue.Save(TetxtWriter)`, but the `StreamWriter` it created was never
flushed or disposed, so output could go missing. In addition, it would
encode json as utf-8, but would include a BOM, while none of the methods
that override `JsonValue.Save(Stream)` would write a BOM. Both these
issues have been resolved.

The tests have also been modified to test for the new and correct
behavior.

Fixes #26486