### PR TITLE
Several small ManagedHandler fixes

### DIFF
--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -153,6 +153,7 @@ namespace System.Net.Test.Common
         {
             options = options ?? new Options();
             Socket s = await server.AcceptAsync().ConfigureAwait(false);
+            s.NoDelay = true;
             try
             {
                 Stream stream = new NetworkStream(s, ownsSocket: false);

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -519,7 +519,6 @@ namespace System.Net.Http
             response.Version =
                 (majorVersion == '1' && minorVersion == '1') ? HttpVersionInternal.Version11 :
                 (majorVersion == '1' && minorVersion == '0') ? HttpVersionInternal.Version10 :
-                (majorVersion == '2' && minorVersion == '0') ? HttpVersionInternal.Version20 :
                 HttpVersionInternal.Unknown;
             response.StatusCode =
                 (HttpStatusCode)(100 * (status1 - '0') + 10 * (status2 - '0') + (status3 - '0'));

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -74,7 +74,6 @@ namespace System.Net.Http
             {
                 foreach (AuthenticationHeaderValue h in response.Headers.ProxyAuthenticate)
                 {
-                    // We only support Basic auth, ignore others
                     if (h.Scheme == AuthenticationHelper.Basic)
                     {
                         NetworkCredential credential =
@@ -111,7 +110,7 @@ namespace System.Net.Http
                                 response = await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
                                 // Retry in case of nonce timeout in server.
-                                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                                if (response.StatusCode == HttpStatusCode.ProxyAuthenticationRequired)
                                 {
                                     foreach (AuthenticationHeaderValue ahv in response.Headers.ProxyAuthenticate)
                                     {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public class HttpProtocolTests : HttpClientTest
+    public class HttpProtocolTests : HttpClientTestBase
     {
         protected virtual Stream GetStream(Stream s) => s;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -108,7 +108,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    public class HttpProtocolTests_Dribble : HttpProtocolTests, IDisposable
+    public class HttpProtocolTests_Dribble : HttpProtocolTests
     {
         protected override Stream GetStream(Stream s) => new DribbleStream(s);
 
@@ -123,7 +123,7 @@ namespace System.Net.Http.Functional.Tests
                 for (int i = 0; i < count; i++)
                 {
                     await _wrapped.WriteAsync(buffer, offset + i, 1);
-                    await Task.Yield(); // introduce short delays, enough to send packets individually but so long as to extend test duration significantly
+                    await Task.Delay(3); // introduce short delays, enough to send packets individually but not so long as to extend test duration significantly
                 }
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
@@ -134,7 +134,7 @@ namespace System.Net.Http.Functional.Tests
     public sealed class HttpClientHandler_IdnaProtocolTests : IdnaProtocolTests
     {
         // WinHttp on Win7 does not support IDNA
-        protected override bool SupportsIdna => !PlatformDetection.IsWindows7;
+        protected override bool SupportsIdna => !PlatformDetection.IsWindows7 && !PlatformDetection.IsFullFramework;
     }
 
     public sealed class ManagedHandler_IdnaProtocolTests : IdnaProtocolTests

--- a/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
@@ -136,10 +136,4 @@ namespace System.Net.Http.Functional.Tests
         // WinHttp on Win7 does not support IDNA
         protected override bool SupportsIdna => !PlatformDetection.IsWindows7 && !PlatformDetection.IsFullFramework;
     }
-
-    public sealed class ManagedHandler_IdnaProtocolTests : IdnaProtocolTests
-    {
-        protected override bool UseManagedHandler => true;
-        protected override bool SupportsIdna => true;
-    }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
@@ -11,10 +11,18 @@ namespace System.Net.Http.Functional.Tests
 {
     public abstract class IdnaProtocolTests : HttpClientTestBase
     {
+        protected abstract bool SupportsIdna { get; }
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP does not support custom proxies.")]
         [Theory]
         [MemberData(nameof(InternationalHostNames))]
         public async Task InternationalUrl_UsesIdnaEncoding_Success(string hostname)
         {
+            if (!SupportsIdna)
+            {
+                return;
+            }
+
             Uri uri = new Uri($"http://{hostname}/");
 
             await LoopbackServer.CreateServerAsync(async (server, serverUrl) =>
@@ -46,6 +54,11 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(InternationalHostNames))]
         public async Task InternationalRequestHeaderValues_UsesIdnaEncoding_Success(string hostname)
         {
+            if (!SupportsIdna)
+            {
+                return;
+            }
+
             Uri uri = new Uri($"http://{hostname}/");
 
             await LoopbackServer.CreateServerAsync(async (server, serverUrl) =>
@@ -73,6 +86,11 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(InternationalHostNames))]
         public async Task InternationalResponseHeaderValues_UsesIdnaDecoding_Success(string hostname)
         {
+            if (!SupportsIdna)
+            {
+                return;
+            }
+
             Uri uri = new Uri($"http://{hostname}/");
 
             await LoopbackServer.CreateServerAsync(async (server, serverUrl) =>
@@ -115,10 +133,13 @@ namespace System.Net.Http.Functional.Tests
 
     public sealed class HttpClientHandler_IdnaProtocolTests : IdnaProtocolTests
     {
+        // WinHttp on Win7 does not support IDNA
+        protected override bool SupportsIdna => !PlatformDetection.IsWindows7;
     }
 
     public sealed class ManagedHandler_IdnaProtocolTests : IdnaProtocolTests
     {
         protected override bool UseManagedHandler => true;
+        protected override bool SupportsIdna => true;
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Net.Test.Common;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public abstract class IdnaProtocolTests : HttpClientTestBase
+    {
+        private const string s_IdnaHost = "âbçdë.com";
+        private static Uri s_IdnaUri = new Uri($"http://{s_IdnaHost}/");
+        private static string s_EncodedHostName = s_IdnaUri.IdnHost;
+        private static string s_EncodedUri = $"http://{s_EncodedHostName}/";
+
+        [Fact]
+        public async Task InternationalUrl_UsesIdnaEncoding_Success()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                // We don't actually want to do DNS lookup on the IDNA host name in the URL.
+                // So instead, configure the loopback server as a proxy so we will send to it.
+                HttpClientHandler handler = CreateHttpClientHandler();
+                handler.UseProxy = true;
+                handler.Proxy = new SimpleWebProxy(url);
+
+                using (HttpClient client = new HttpClient(handler))
+                {
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(s_IdnaUri);
+                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server, LoopbackServer.DefaultHttpResponse);
+
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    List<string> requestLines = await serverTask;
+
+                    // Note since we're using a proxy, host name is included in the request line
+                    Assert.Equal($"GET http://{s_EncodedHostName}/ HTTP/1.1", requestLines[0]);
+                    Assert.Contains($"Host: {s_EncodedHostName}", requestLines);
+                }
+            });
+        }
+
+        [ActiveIssue(26355)] // We aren't doing IDNA encoding properly
+        [Fact]
+        public async Task InternationalRequestHeaderValues_UsesIdnaEncoding_Success()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = new HttpClient(CreateHttpClientHandler()))
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Headers.Host = s_IdnaHost;
+                    request.Headers.Referrer = s_IdnaUri;
+                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
+                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server, LoopbackServer.DefaultHttpResponse);
+
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    List<string> requestLines = await serverTask;
+
+                    Assert.Contains($"Host: {s_EncodedHostName}", requestLines);
+                    Assert.Contains($"Referer: {s_EncodedUri}", requestLines);
+                }
+            });
+        }
+
+        [ActiveIssue(26355)] // We aren't doing IDNA decoding properly
+        [Fact]
+        public async Task InternationalResponseHeaderValues_UsesIdnaDecoding_Success()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                HttpClientHandler handler = CreateHttpClientHandler();
+                handler.AllowAutoRedirect = false;
+
+                using (HttpClient client = new HttpClient(handler))
+                {
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
+                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server, 
+                        $"HTTP/1.1 302 Redirect\r\nLocation: {s_EncodedUri}\r\n\r\n");
+
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    HttpResponseMessage response = await getResponseTask;
+                    Console.WriteLine($"Location header={response.Headers.Location}");
+                    Console.WriteLine($"Location header.Host={response.Headers.Location.Host}");
+                    Console.WriteLine($"Location header.IdnHost={response.Headers.Location.IdnHost}");
+                }
+            });
+        }
+
+        sealed class SimpleWebProxy : IWebProxy
+        {
+            private Uri _proxyUri;
+
+            public SimpleWebProxy(Uri proxyUri)
+            {
+                _proxyUri = proxyUri;
+            }
+
+            public ICredentials Credentials { get => null; set => throw new NotImplementedException(); }
+            public Uri GetProxy(Uri destination) => _proxyUri;
+            public bool IsBypassed(Uri host) => false;
+        }
+    }
+
+    public sealed class DefaultHandler_IdnaProtocolTests : IdnaProtocolTests
+    {
+    }
+
+    public sealed class ManagedHandler_IdnaProtocolTests : IdnaProtocolTests
+    {
+        protected override bool UseManagedHandler => true;
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -104,6 +104,13 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseManagedHandler => true;
     }
 
+    public sealed class ManagedHandler_IdnaProtocolTests : IdnaProtocolTests
+    {
+        protected override bool UseManagedHandler => true;
+        protected override bool SupportsIdna => true;
+    }
+
+
     // TODO #23141: Socket's don't support canceling individual operations, so ReadStream on NetworkStream
     // isn't cancelable once the operation has started.  We either need to wrap the operation with one that's
     // "cancelable", meaning that the underlying operation will still be running even though we've returned "canceled",

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpMessageInvokerTest.cs" />
     <Compile Include="HttpMethodTest.cs" />
+    <Compile Include="IdnaProtocolTests.cs" />
     <Compile Include="HttpProtocolTests.cs" />
     <Compile Include="HttpRequestMessageTest.cs" />
     <Compile Include="HttpResponseMessageTest.cs" />


### PR DESCRIPTION
(1) Don't check for HTTP 2.0 on response, since we should never see this
(2) Remove IP parsing logic and just let ConnectAsync handle this
(3) Fix proxy auth retry handling
(4) Fix IDNA host name handling in proxy case
(5) Various test additions/fixes

@stephentoub @Priya91 @wfurt @davidsh