### PR TITLE
Rename Pin offset to byteOffset and clean up Retain test

### DIFF
--- a/src/Common/src/CoreLib/System/Buffers/OwnedMemory.cs
+++ b/src/Common/src/CoreLib/System/Buffers/OwnedMemory.cs
@@ -43,7 +43,7 @@ namespace System.Buffers
         /// <summary>
         /// Returns a handle for the array that has been pinned and hence its address can be taken
         /// </summary>
-        public abstract MemoryHandle Pin(int offset = 0);
+        public abstract MemoryHandle Pin(int byteOffset = 0);
 
         /// <summary>
         /// Returns an array segment.

--- a/src/Common/tests/System/Buffers/NativeOwnedMemory.cs
+++ b/src/Common/tests/System/Buffers/NativeOwnedMemory.cs
@@ -53,10 +53,10 @@ namespace System.Buffers
 
         public override unsafe Span<byte> Span => new Span<byte>((void*)_ptr, _length);
 
-        public override unsafe MemoryHandle Pin(int offset = 0)
+        public override unsafe MemoryHandle Pin(int byteOffset = 0)
         {
-            if (offset < 0 || offset > _length) throw new ArgumentOutOfRangeException(nameof(offset));
-            void* pointer = (void*)((byte*)_ptr + offset);
+            if (byteOffset < 0 || byteOffset > _length) throw new ArgumentOutOfRangeException(nameof(byteOffset));
+            void* pointer = (void*)((byte*)_ptr + byteOffset);
             return new MemoryHandle(this, pointer);
         }
 

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -226,7 +226,7 @@ namespace System.Buffers
         public abstract System.Span<T> Span { get; }
         public void Dispose() { }
         protected abstract void Dispose(bool disposing);
-        public abstract System.Buffers.MemoryHandle Pin(int offset=0);
+        public abstract System.Buffers.MemoryHandle Pin(int byteOffset=0);
         public abstract bool Release();
         public abstract void Retain();
         protected internal abstract bool TryGetArray(out System.ArraySegment<T> arraySegment);

--- a/src/System.Memory/tests/Memory/CustomMemoryForTest.cs
+++ b/src/System.Memory/tests/Memory/CustomMemoryForTest.cs
@@ -39,14 +39,14 @@ namespace System.MemoryTests
             }
         }
 
-        public override MemoryHandle Pin(int offset = 0)
+        public override MemoryHandle Pin(int byteOffset = 0)
         {
             unsafe
             {
                 Retain();
-                if (offset < 0 || offset > _array.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+                if (byteOffset < 0 || (byteOffset/Unsafe.SizeOf<T>()) > _array.Length) throw new ArgumentOutOfRangeException(nameof(byteOffset));
                 var handle = GCHandle.Alloc(_array, GCHandleType.Pinned);
-                return new MemoryHandle(this, Unsafe.Add<byte>((void*)handle.AddrOfPinnedObject(), offset), handle);
+                return new MemoryHandle(this, Unsafe.Add<byte>((void*)handle.AddrOfPinnedObject(), byteOffset), handle);
             }
         }
 

--- a/src/System.Memory/tests/Memory/Retain.cs
+++ b/src/System.Memory/tests/Memory/Retain.cs
@@ -116,14 +116,6 @@ namespace System.MemoryTests
             Memory<int> memory = new int[0];
             MemoryHandle handle = memory.Retain(pin: true);
             Assert.True(handle.HasPointer);
-            unsafe
-            {
-                int* pointer = (int*)handle.Pointer;
-
-                GC.Collect();
-
-                Assert.True(pointer != null);
-            }
             handle.Dispose();
         }
 

--- a/src/System.Memory/tests/ReadOnlyMemory/Retain.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Retain.cs
@@ -51,14 +51,6 @@ namespace System.MemoryTests
             ReadOnlyMemory<int> memory = new int[0];
             MemoryHandle handle = memory.Retain(pin: true);
             Assert.True(handle.HasPointer);
-            unsafe
-            {
-                int* pointer = (int*)handle.Pointer;
-
-                GC.Collect();
-
-                Assert.True(pointer != null);
-            }
             handle.Dispose();
         }
 

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -3728,7 +3728,7 @@ namespace System.Buffers
         public abstract System.Span<T> Span { get; }
         public void Dispose() { }
         protected abstract void Dispose(bool disposing);
-        public abstract MemoryHandle Pin(int offset=0);
+        public abstract MemoryHandle Pin(int byteOffset=0);
         public abstract bool Release();
         public abstract void Retain();
         protected internal abstract bool TryGetArray(out System.ArraySegment<T> arraySegment);


### PR DESCRIPTION
- Leftover test clean up from https://github.com/dotnet/corefx/pull/25770#discussion_r162998101
- Renaming offset to byteOffset: https://github.com/dotnet/corefx/issues/25229#issuecomment-359541147


cc @AtsushiKan, @jkotas, @KrzysztofCwalina