### PR TITLE
Fix OOM in regex for large regex quantifier

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
@@ -91,7 +91,11 @@ namespace System.Text.RegularExpressions
 
                     case RegexNode.Oneloop:
                     case RegexNode.Onelazy:
-                        if (curNode.M > 0)
+#if DEBUG
+                        if (curNode._m > 0 && curNode._m < 50) // In debug, exercise the cutoff path
+#else // DEBUG
+                        if (curNode._m > 0 && curNode._m < 1_000_000) // In release, cutoff at a length to which we can reasonably construct a string
+#endif // DEBUG
                         {
                             string pref = string.Empty.PadRight(curNode.M, curNode.Ch);
                             return new RegexPrefix(pref, 0 != (curNode.Options & RegexOptions.IgnoreCase));

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
@@ -92,11 +92,16 @@ namespace System.Text.RegularExpressions
                     case RegexNode.Oneloop:
                     case RegexNode.Onelazy:
 
-                        int cutoff = 1_000_000; // In release, cutoff at a length to which we can reasonably construct a string
-#if DEBUG
-                        cutoff = 50; // In debug, use a smaller cutoff to exercise the cutoff path
-#endif // DEBUG
-                        if (curNode._m > 0 && curNode._m < cutoff)
+                        // In release, cutoff at a length to which we can still reasonably construct a string
+                        // In debug, use a smaller cutoff to exercise the cutoff path in tests
+                        const int Cutoff =
+                        #if DEBUG
+                            50;
+                        #else
+                            1_000_000;
+                        #endif
+
+                        if (curNode._m > 0 && curNode._m < Cutoff)
                         {
                             string pref = string.Empty.PadRight(curNode.M, curNode.Ch);
                             return new RegexPrefix(pref, 0 != (curNode.Options & RegexOptions.IgnoreCase));

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
@@ -91,11 +91,12 @@ namespace System.Text.RegularExpressions
 
                     case RegexNode.Oneloop:
                     case RegexNode.Onelazy:
+
+                        int cutoff = 1_000_000; // In release, cutoff at a length to which we can reasonably construct a string
 #if DEBUG
-                        if (curNode._m > 0 && curNode._m < 50) // In debug, exercise the cutoff path
-#else // DEBUG
-                        if (curNode._m > 0 && curNode._m < 1_000_000) // In release, cutoff at a length to which we can reasonably construct a string
+                        cutoff = 50; // In debug, use a smaller cutoff to exercise the cutoff path
 #endif // DEBUG
+                        if (curNode._m > 0 && curNode._m < cutoff)
                         {
                             string pref = string.Empty.PadRight(curNode.M, curNode.Ch);
                             return new RegexPrefix(pref, 0 != (curNode.Options & RegexOptions.IgnoreCase));

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
@@ -101,7 +101,7 @@ namespace System.Text.RegularExpressions
                             1_000_000;
                         #endif
 
-                        if (curNode._m > 0 && curNode._m < Cutoff)
+                        if (curNode.M > 0 && curNode.M < Cutoff)
                         {
                             string pref = string.Empty.PadRight(curNode.M, curNode.Ch);
                             return new RegexPrefix(pref, 0 != (curNode.Options & RegexOptions.IgnoreCase));

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -40,6 +40,18 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"a{11}b", new string('a', 10) + "bc", RegexOptions.None, 0, 12, false, string.Empty };
             yield return new object[] { @"a{101}b", new string('a', 100) + "bc", RegexOptions.None, 0, 102, false, string.Empty };
 
+            yield return new object[] { @"a{1,3}b", "bc", RegexOptions.None, 0, 2, false, string.Empty };
+            yield return new object[] { @"a{1,3}b", "abc", RegexOptions.None, 0, 3, true, "ab" };
+            yield return new object[] { @"a{1,3}b", "aaabc", RegexOptions.None, 0, 5, true, "aaab" };
+            yield return new object[] { @"a{1,3}b", "aaaabc", RegexOptions.None, 0, 6, true, "aaab" };
+
+            yield return new object[] { @"a{2,}b", "abc", RegexOptions.None, 0, 3, false, string.Empty };
+            yield return new object[] { @"a{2,}b", "aabc", RegexOptions.None, 0, 4, true, "aab" };
+
+            yield return new object[] { @"a{,3}b", "aaaabc", RegexOptions.None, 0, 6, false, string.Empty };
+            yield return new object[] { @"a{,3}b", "aaabc", RegexOptions.None, 0, 5, true, "aaab" };
+            yield return new object[] { @"a{,3}b", "bc", RegexOptions.None, 0, 2, true, "b" };
+
             // Using [a-z], \s, \w: Actual - "([a-zA-Z]+)\\s(\\w+)"
             yield return new object[] { @"([a-zA-Z]+)\s(\w+)", "David Bau", RegexOptions.None, 0, 9, true, "David Bau" };
 

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -769,9 +769,11 @@ namespace System.Text.RegularExpressions.Tests
         {
             RemoteInvoke(() =>
             {
-                  // Should not throw out of memory
-                  Assert.False(Regex.IsMatch("a", @"a{2147483647,}"));
-                  Assert.False(Regex.IsMatch("a", @"a{999999}"));
+                // Should not throw out of memory
+                Assert.False(Regex.IsMatch("a", @"a{2147483647,}"));
+                Assert.False(Regex.IsMatch("a", @"a{1000001,}")); // 1 over the cutoff for Boyer-Moore prefix
+
+                Assert.False(Regex.IsMatch("a", @"a{50000}")); // creates string for Boyer-Moore but not so large that tests fail and start paging
             });
         }
 

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -758,7 +758,7 @@ namespace System.Text.RegularExpressions.Tests
             {
                   // Should not throw out of memory
                   Assert.False(Regex.IsMatch("a", @"a{2147483647,}"));
-                  Assert.False(Regex.IsMatch("a", @"a{2_000_000,}"));
+                  Assert.False(Regex.IsMatch("a", @"a{999999}"));
             });
         }
 

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -774,7 +774,7 @@ namespace System.Text.RegularExpressions.Tests
                 Assert.False(Regex.IsMatch("a", @"a{1000001,}")); // 1 over the cutoff for Boyer-Moore prefix
 
                 Assert.False(Regex.IsMatch("a", @"a{50000}")); // creates string for Boyer-Moore but not so large that tests fail and start paging
-            });
+            }).Dispose();
         }
 
         [Fact]

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -764,6 +764,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework needs fix for #26484")]
         public void Match_ExcessPrefix()
         {
             RemoteInvoke(() =>

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -48,9 +48,9 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"a{2,}b", "abc", RegexOptions.None, 0, 3, false, string.Empty };
             yield return new object[] { @"a{2,}b", "aabc", RegexOptions.None, 0, 4, true, "aab" };
 
-            yield return new object[] { @"a{,3}b", "aaaabc", RegexOptions.None, 0, 6, false, string.Empty };
-            yield return new object[] { @"a{,3}b", "aaabc", RegexOptions.None, 0, 5, true, "aaab" };
-            yield return new object[] { @"a{,3}b", "bc", RegexOptions.None, 0, 2, true, "b" };
+            // {,n} is treated as a literal rather than {0,n} as it should be
+            yield return new object[] { @"a{,3}b", "a{,3}bc", RegexOptions.None, 0, 6, true, "a{,3}b" };
+            yield return new object[] { @"a{,3}b", "aaabc", RegexOptions.None, 0, 5, false, String.Empty };
 
             // Using [a-z], \s, \w: Actual - "([a-zA-Z]+)\\s(\\w+)"
             yield return new object[] { @"([a-zA-Z]+)\s(\w+)", "David Bau", RegexOptions.None, 0, 9, true, "David Bau" };

--- a/src/System.Text.RegularExpressions/tests/RegexCompilationHelper.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexCompilationHelper.cs
@@ -33,7 +33,7 @@ namespace System.Text.RegularExpressions.Tests
                     return result;
                 }
             }
-            
+
             throw new Exception($"Test method '{testDataMethodName}' not found");
         }
 

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -6,7 +6,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
   </PropertyGroup>
  <PropertyGroup>
-    <!-- Temporary property to diagnose flaky crashing tests in Unix -->
+    <!-- Temporary property to diagnose hanging test -->
     <XunitShowProgress>true</XunitShowProgress>
     <XunitMaxThreads>1</XunitMaxThreads>
   </PropertyGroup>  

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -5,6 +5,11 @@
     <ProjectGuid>{94B106C2-D574-4392-80AB-3EE308A078DF}</ProjectGuid>
     <AppDesignerFolder>Properties</AppDesignerFolder>
   </PropertyGroup>
+ <PropertyGroup>
+    <!-- Temporary property to diagnose flaky crashing tests in Unix -->
+    <XunitShowProgress>true</XunitShowProgress>
+    <XunitMaxThreads>1</XunitMaxThreads>
+  </PropertyGroup>  
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -5,11 +5,12 @@
     <ProjectGuid>{94B106C2-D574-4392-80AB-3EE308A078DF}</ProjectGuid>
     <AppDesignerFolder>Properties</AppDesignerFolder>
   </PropertyGroup>
- <PropertyGroup>
-    <!-- Temporary property to diagnose hanging test -->
+  <PropertyGroup>
+    <!-- Temporary property to diagnose hanging test
     <XunitShowProgress>true</XunitShowProgress>
     <XunitMaxThreads>1</XunitMaxThreads>
-  </PropertyGroup>  
+    -->
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />


### PR DESCRIPTION
Fix #26484

As an optimization, the regex engine tries to establish a definite prefix that matches must have, if it can. For example "a{5,10}bcd" indicates all matches must begin with "aaaaa". If there is such a prefix, the engine can use Boyer-Moore to skip more quickly to the next plausible match. It is optional though (as far as I can tell).

As implemented the code constructs a string with the prefix. So if the quantifier is very large, it will run out of memory. This could be avoided with a larger change, but I'm making a minimal change to not make prefix strings larger than 10^6 characters, an arbitrarily large number that can still be formed into a string.