### PR TITLE
Merge #26514 into release/2.1 branch

### DIFF
--- a/src/Common/src/CoreLib/System/Memory.cs
+++ b/src/Common/src/CoreLib/System/Memory.cs
@@ -106,7 +106,7 @@ namespace System
         /// <summary>
         /// Defines an implicit conversion of an array to a <see cref="Memory{T}"/>
         /// </summary>
-        public static implicit operator Memory<T>(T[] array) => new Memory<T>(array);
+        public static implicit operator Memory<T>(T[] array) => (array != null) ? new Memory<T>(array) : default;
 
         /// <summary>
         /// Defines an implicit conversion of a <see cref="ArraySegment{T}"/> to a <see cref="Memory{T}"/>

--- a/src/Common/src/CoreLib/System/ReadOnlyMemory.cs
+++ b/src/Common/src/CoreLib/System/ReadOnlyMemory.cs
@@ -97,7 +97,7 @@ namespace System
         /// <summary>
         /// Defines an implicit conversion of an array to a <see cref="ReadOnlyMemory{T}"/>
         /// </summary>
-        public static implicit operator ReadOnlyMemory<T>(T[] array) => new ReadOnlyMemory<T>(array);
+        public static implicit operator ReadOnlyMemory<T>(T[] array) => (array != null) ? new ReadOnlyMemory<T>(array) : default;
 
         /// <summary>
         /// Defines an implicit conversion of a <see cref="ArraySegment{T}"/> to a <see cref="ReadOnlyMemory{T}"/>

--- a/src/System.Memory/tests/Memory/ImplicitConversion.cs
+++ b/src/System.Memory/tests/Memory/ImplicitConversion.cs
@@ -113,6 +113,14 @@ namespace System.MemoryTests
             CastReadOnly<int>(memoryEmptyInt);
         }
 
+        [Fact]
+        public static void NullImplicitCast()
+        {
+            int[] dst = null;
+            Memory<int> srcMemory = dst;
+            Assert.True(Memory<int>.Empty.Span == srcMemory.Span);
+        }
+
         private static void Cast<T>(Memory<T> memory, params T[] expected) where T : struct, IEquatable<T>
         {
             memory.Validate(expected);

--- a/src/System.Memory/tests/ReadOnlyMemory/ImplicitConversion.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/ImplicitConversion.cs
@@ -67,6 +67,14 @@ namespace System.MemoryTests
             CastReadOnly<int>(segmentInt);
         }
 
+        [Fact]
+        public static void NullImplicitCast()
+        {
+            int[] dst = null;
+            ReadOnlyMemory<int> srcMemory = dst;
+            Assert.True(ReadOnlyMemory<int>.Empty.Span == srcMemory.Span);
+        }
+
         private static void CastReadOnly<T>(ReadOnlyMemory<T> memory, params T[] expected) where T : struct, IEquatable<T>
         {
             memory.Validate(expected);


### PR DESCRIPTION
These changes were already in coreclr before the 2.1-preview1 snap, but they didn't make it to corefx in time. We should bring these in to corefx's 2.1-preview1 release for behavioral parity with coreclr's 2.1-preview1 release.