### PR TITLE
Add netfx placeholder configurations for inbox projects and enable netfx tests

### DIFF
--- a/src/System.DirectoryServices.AccountManagement/src/Configurations.props
+++ b/src/System.DirectoryServices.AccountManagement/src/Configurations.props
@@ -8,6 +8,7 @@
     <BuildConfigurations>
       $(PackageConfigurations);
       netcoreapp-Windows_NT;
+      _netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices.AccountManagement/tests/Configurations.props
+++ b/src/System.DirectoryServices.AccountManagement/tests/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp-Windows_NT;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices.Protocols/src/Configurations.props
+++ b/src/System.DirectoryServices.Protocols/src/Configurations.props
@@ -8,6 +8,7 @@
     <BuildConfigurations>
       $(PackageConfigurations);
       netcoreapp-Windows_NT;
+      _netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices.Protocols/tests/Configurations.props
+++ b/src/System.DirectoryServices.Protocols/tests/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
         netcoreapp-Windows_NT;
+        netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices/src/Configurations.props
+++ b/src/System.DirectoryServices/src/Configurations.props
@@ -8,6 +8,7 @@
     <BuildConfigurations>
       $(PackageConfigurations);
       netcoreapp-Windows_NT;
+      _netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices/tests/Configurations.props
+++ b/src/System.DirectoryServices/tests/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
         netcoreapp-Windows_NT;
+        netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Management/src/Configurations.props
+++ b/src/System.Management/src/Configurations.props
@@ -8,6 +8,7 @@
     <BuildConfigurations>
       $(PackageConfigurations);
       netcoreapp-Windows_NT;
+      _netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Management/tests/Configurations.props
+++ b/src/System.Management/tests/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
         netcoreapp-Windows_NT;
+        netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is part of the projects that need to be ignored. 

Missing: System.ComponentModel.Composition and https://github.com/dotnet/corefx/issues/24517

cc: @weshaggard @danmosemsft 

FYI: @tarekgh @pjanotti 