### PR TITLE
Disable the default interface methods feature (release/2.1)

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -25,7 +25,7 @@
 
   <!-- Indicates this is not an officially supported release. Release branches should set this to false. -->
   <PropertyGroup>
-    <IsPrerelease>true</IsPrerelease>
+    <IsPrerelease>false</IsPrerelease>
   </PropertyGroup>
 
   <!-- Common repo directories -->


### PR DESCRIPTION
This feature is not shipping in 2.1.

Related: dotnet/coreclr#15994.