### PR TITLE
Avoid cast of Microsoft.CSharp's binder types.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         private static MethodInfo s_SingleIsNaN;
 
         internal static DynamicMetaObject Bind(
-                DynamicMetaObjectBinder action,
+                ICSharpBinder action,
                 RuntimeBinder binder,
                 DynamicMetaObject[] args,
                 IEnumerable<CSharpArgumentInfo> arginfos,
@@ -89,8 +89,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             // Get the bound expression.
             try
             {
-                DynamicMetaObject deferredBinding;
-                Expression expression = binder.Bind(action, parameters, args, out deferredBinding);
+                Expression expression = binder.Bind(action, parameters, args, out DynamicMetaObject deferredBinding);
 
                 if (deferredBinding != null)
                 {
@@ -282,7 +281,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        private static Expression ConvertResult(Expression binding, DynamicMetaObjectBinder action)
+        private static Expression ConvertResult(Expression binding, ICSharpBinder action)
         {
             // Need to handle the following cases:
             //   (1) Call to a constructor: no conversions.
@@ -292,25 +291,21 @@ namespace Microsoft.CSharp.RuntimeBinder
             // In all other cases, binding.Type should be equivalent or
             // reference assignable to resultType.
 
-            var invokeConstructor = action as CSharpInvokeConstructorBinder;
-            if (invokeConstructor != null)
+            // No conversions needed for , the call site has the correct type.
+            if (action is CSharpInvokeConstructorBinder)
             {
-                // No conversions needed, the call site has the correct type.
                 return binding;
             }
 
             if (binding.Type == typeof(void))
             {
-                var invoke = action as ICSharpInvokeOrInvokeMemberBinder;
-                if (invoke != null && invoke.ResultDiscarded)
+                if (action is ICSharpInvokeOrInvokeMemberBinder invoke && invoke.ResultDiscarded)
                 {
                     Debug.Assert(action.ReturnType == typeof(object));
                     return Expression.Block(binding, Expression.Default(action.ReturnType));
                 }
-                else
-                {
-                    throw Error.BindToVoidMethodButExpectResult();
-                }
+
+                throw Error.BindToVoidMethodButExpectResult();
             }
 
             if (binding.Type.IsValueType && !action.ReturnType.IsValueType)
@@ -324,7 +319,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        private static Type GetTypeForErrorMetaObject(DynamicMetaObjectBinder action, DynamicMetaObject[] args)
+        private static Type GetTypeForErrorMetaObject(ICSharpBinder action, DynamicMetaObject[] args)
         {
             // This is similar to ConvertResult but has fewer things to worry about.
 
@@ -341,13 +336,9 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        private static bool IsIncrementOrDecrementActionOnLocal(DynamicMetaObjectBinder action)
-        {
-            CSharpUnaryOperationBinder operatorPayload = action as CSharpUnaryOperationBinder;
-
-            return operatorPayload != null &&
-                (operatorPayload.Operation == ExpressionType.Increment || operatorPayload.Operation == ExpressionType.Decrement);
-        }
+        private static bool IsIncrementOrDecrementActionOnLocal(ICSharpBinder action) =>
+            action is CSharpUnaryOperationBinder operatorPayload
+            && (operatorPayload.Operation == ExpressionType.Increment || operatorPayload.Operation == ExpressionType.Decrement);
 
         /////////////////////////////////////////////////////////////////////////////////
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ICSharpBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ICSharpBinder.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         Type CallingContext { get; }
         bool IsChecked { get; }
 
-        // This is true for any binder that is eligible to take value type receiver 
+        // This is true for any binder that is eligible to take value type receiver
         // objects as a ref (for mutable operations). Such as calls ("v.M(d)"),
         // and indexers ("v[d] = v[d]"). Note that properties are not here because they
         // are only dispatched dynamically when the receiver is dynamic, and hence boxed.
@@ -24,5 +24,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         Expr DispatchPayload(RuntimeBinder runtimeBinder, ArgumentObject[] arguments, LocalVariableSymbol[] locals);
         BindingFlag BindingFlags { get; }
         string Name { get; }
+
+        Type ReturnType { get; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -75,11 +75,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        public Expression Bind(
-            DynamicMetaObjectBinder payload,
-            Expression[] parameters,
-            DynamicMetaObject[] args,
-            out DynamicMetaObject deferredBinding)
+        public Expression Bind(ICSharpBinder payload, Expression[] parameters, DynamicMetaObject[] args, out DynamicMetaObject deferredBinding)
         {
             // The lock is here to protect this instance of the binder from itself
             // when called on multiple threads. The cost in time of a single lock
@@ -98,12 +94,9 @@ namespace Microsoft.CSharp.RuntimeBinder
             // ...subsequent calls that were cache hits, i.e., already bound, took less
             // than 1/1000 sec for the whole 4000 of them.
 
-            ICSharpBinder binder = payload as ICSharpBinder;
-            Debug.Assert(binder != null);
-
             lock (_bindLock)
             {
-                return BindCore(binder, parameters, args, out deferredBinding);
+                return BindCore(payload, parameters, args, out deferredBinding);
             }
         }
 


### PR DESCRIPTION
Bind casts from `DynamicMetaObjectBinder` (base of all the C# binders) to `ICSharpBinder` (implemented by all C# binders), but adding `ReturnType` to `ICSharpBinder` allows that type to be used throughout.

Since `ReturnType` is virtual anyway there's no extra cost on the call, and the type safety can now be statically confirmed rather than just asserted.