### PR TITLE
Update runtime.json to include missing RIDs

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -1,935 +1,1647 @@
 {
-    "runtimes": {
-        "base": {
-        },
-
-        "any": {
-            "#import": [ "base" ]
-        },
-
-        "android": {
-            "#import": [ "any" ]
-        },
-        "android-arm": {
-            "#import": [ "any" ]
-        },
-        "android-arm64": {
-            "#import": [ "any" ]
-        },
-
-        "android.21": {
-            "#import": [ "android" ]
-        },
-        "android.21-arm": {
-            "#import": [ "android.21", "android-arm" ]
-        },
-        "android.21-arm64": {
-            "#import": [ "android.21", "android-arm64" ]
-        },
-
-        "win": {
-            "#import": [ "any" ]
-        },
-        "win-x86": {
-            "#import": [ "win" ]
-        },
-        "win-x64": {
-            "#import": [ "win" ]
-        },
-        "win-arm": {
-            "#import": [ "win" ]
-        },
-        "win-arm64": {
-            "#import": [ "win" ]
-        },
-
-        "win7": {
-            "#import": [ "win" ]
-        },
-        "win7-x86": {
-            "#import": [ "win7", "win-x86" ]
-        },
-        "win7-x64": {
-            "#import": [ "win7", "win-x64" ]
-        },
-
-        "win8": {
-            "#import": [ "win7" ]
-        },
-        "win8-x86": {
-            "#import": [ "win8", "win7-x86" ]
-        },
-        "win8-x64": {
-            "#import": [ "win8", "win7-x64" ]
-        },
-        "win8-arm": {
-            "#import": [ "win8", "win-arm" ]
-        },
-
-        "win81": {
-            "#import": [ "win8" ]
-        },
-        "win81-x86": {
-            "#import": [ "win81", "win8-x86" ]
-        },
-        "win81-x64": {
-            "#import": [ "win81", "win8-x64" ]
-        },
-        "win81-arm": {
-            "#import": [ "win81", "win8-arm" ]
-        },
-
-        "win10": {
-            "#import": [ "win81" ]
-        },
-        "win10-x86": {
-            "#import": [ "win10", "win81-x86" ]
-        },
-        "win10-x64": {
-            "#import": [ "win10", "win81-x64" ]
-        },
-        "win10-arm": {
-            "#import": [ "win10", "win81-arm" ]
-        },
-        "win10-arm64": {
-            "#import": [ "win10", "win-arm64" ]
-        },
-
-        "aot": {
-            "#import": [ "any" ]
-        },
-
-        "win-aot": {
-            "#import": [ "win", "aot" ]
-        },
-        "win-x86-aot": {
-            "#import": [ "win-aot", "win-x86" ]
-        },
-        "win-x64-aot": {
-            "#import": [ "win-aot", "win-x64" ]
-        },
-
-        "win7-aot": {
-            "#import": [ "win-aot", "win7" ]
-        },
-        "win7-x86-aot": {
-            "#import": [ "win7-aot", "win7-x86" ]
-        },
-        "win7-x64-aot": {
-            "#import": [ "win7-aot", "win7-x64" ]
-        },
-
-        "win8-aot": {
-            "#import": [ "win8", "win7-aot" ]
-        },
-        "win8-x86-aot": {
-            "#import": [ "win8-aot", "win8-x86", "win7-x86-aot" ]
-        },
-        "win8-x64-aot": {
-            "#import": [ "win8-aot", "win8-x64", "win7-x64-aot" ]
-        },
-        "win8-arm-aot": {
-            "#import": [ "win8-aot", "win8-arm" ]
-        },
-
-        "win81-aot": {
-            "#import": [ "win81", "win8-aot" ]
-        },
-        "win81-x86-aot": {
-            "#import": [ "win81-aot", "win81-x86", "win8-x86-aot" ]
-        },
-        "win81-x64-aot": {
-            "#import": [ "win81-aot", "win81-x64", "win8-x64-aot" ]
-        },
-        "win81-arm-aot": {
-            "#import": [ "win81-aot", "win81-arm", "win8-arm-aot" ]
-        },
-
-        "win10-aot": {
-            "#import": [ "win10", "win81-aot" ]
-        },
-        "win10-x86-aot": {
-            "#import": [ "win10-aot", "win10-x86", "win81-x86-aot" ]
-        },
-        "win10-x64-aot": {
-            "#import": [ "win10-aot", "win10-x64", "win81-x64-aot" ]
-        },
-        "win10-arm-aot": {
-            "#import": [ "win10-aot", "win10-arm", "win81-arm-aot" ]
-        },
-        "win10-arm64-aot": {
-            "#import": [ "win10-aot", "win10-arm64" ]
-        },
-
-        "unix": {
-            "#import": [ "any" ]
-        },
-        "unix-x64": {
-            "#import": [ "unix" ]
-        },
-        "unix-x86": {
-            "#import": [ "unix" ]
-        },
-        "unix-arm": {
-            "#import": [ "unix" ]
-        },
-        "unix-armel": {
-            "#import": [ "unix" ]
-        },
-        "unix-arm64": {
-            "#import": [ "unix" ]
-        },
-
-        "osx": {
-            "#import": [ "unix" ]
-        },
-        "osx-x64": {
-            "#import": [ "osx", "unix-x64" ]
-        },
-
-        "osx.10.10": {
-            "#import": [ "osx" ]
-        },
-        "osx.10.10-x64": {
-            "#import": [ "osx.10.10", "osx-x64" ]
-        },
-
-        "osx.10.11": {
-            "#import": [ "osx.10.10" ]
-        },
-        "osx.10.11-x64": {
-            "#import": [ "osx.10.11", "osx.10.10-x64" ]
-        },
-
-        "osx.10.12": {
-            "#import": [ "osx.10.11" ]
-        },
-        "osx.10.12-x64": {
-            "#import": [ "osx.10.12", "osx.10.11-x64" ]
-        },
-
-        "linux": {
-            "#import": [ "unix" ]
-        },
-        "linux-x64": {
-            "#import": [ "linux", "unix-x64" ]
-        },
-        "linux-x86": {
-            "#import": [ "linux", "unix-x86" ]
-        },
-        "linux-arm": {
-            "#import": [ "linux", "unix-arm" ]
-        },
-        "linux-armel": {
-            "#import": [ "linux", "unix-armel" ]
-        },
-        "linux-arm64": {
-            "#import": [ "linux", "unix-arm64" ]
-        },
-
-        "rhel": {
-            "#import": [ "linux" ]
-        },
-        "rhel-x64": {
-            "#import": [ "rhel", "linux-x64" ]
-        },
-
-        "rhel.6": {
-            "#import": [ "rhel" ]
-        },
-        "rhel.6-x64": {
-            "#import": [ "rhel.6", "rhel-x64" ]
-        },
-
-        "rhel.7": {
-            "#import": [ "rhel" ]
-        },
-        "rhel.7-x64": {
-            "#import": [ "rhel.7", "rhel-x64" ]
-        },
-
-        "rhel.7.0": {
-            "#import": [ "rhel.7" ]
-        },
-        "rhel.7.0-x64": {
-            "#import": [ "rhel.7.0", "rhel.7-x64" ]
-        },
-
-        "rhel.7.1": {
-            "#import": [ "rhel.7.0" ]
-        },
-        "rhel.7.1-x64": {
-            "#import": [ "rhel.7.1", "rhel.7.0-x64" ]
-        },
-
-        "rhel.7.2": {
-            "#import": [ "rhel.7.1" ]
-        },
-        "rhel.7.2-x64": {
-            "#import": [ "rhel.7.2", "rhel.7.1-x64" ]
-        },
-
-        "rhel.7.3": {
-            "#import": [ "rhel.7.2" ]
-        },
-        "rhel.7.3-x64": {
-            "#import": [ "rhel.7.3", "rhel.7.2-x64" ]
-        },
-
-        "rhel.7.4": {
-            "#import": [ "rhel.7.3" ]
-        },
-        "rhel.7.4-x64": {
-            "#import": [ "rhel.7.4", "rhel.7.3-x64" ]
-        },
-
-        "ol": {
-            "#import": [ "rhel" ]
-        },
-        "ol-x64": {
-            "#import": [ "ol", "rhel-x64" ]
-        },
-
-        "ol.7": {
-            "#import": [ "ol", "rhel.7" ]
-        },
-        "ol.7-x64": {
-            "#import": [ "ol.7", "ol-x64", "rhel.7-x64" ]
-        },
-
-        "ol.7.0": {
-            "#import": [ "ol.7", "rhel.7.0" ]
-        },
-        "ol.7.0-x64": {
-            "#import": [ "ol.7.0", "ol.7-x64", "rhel.7.0-x64" ]
-        },
-
-        "ol.7.1": {
-            "#import": [ "ol.7.0", "rhel.7.1" ]
-        },
-        "ol.7.1-x64": {
-            "#import": [ "ol.7.1", "ol.7.0-x64", "rhel.7.1-x64" ]
-        },
-
-        "ol.7.2": {
-            "#import": [ "ol.7.1", "rhel.7.2" ]
-        },
-        "ol.7.2-x64": {
-            "#import": [ "ol.7.2", "ol.7.1-x64", "rhel.7.2-x64" ]
-        },
-
-        "centos": {
-            "#import": [ "rhel" ]
-        },
-        "centos-x64": {
-            "#import": [ "centos", "rhel-x64" ]
-        },
-
-        "centos.7": {
-            "#import": [ "centos", "rhel.7" ]
-        },
-        "centos.7-x64": {
-            "#import": [ "centos.7", "centos-x64", "rhel.7-x64" ]
-        },
-
-        "debian": {
-            "#import": [ "linux" ]
-        },
-        "debian-x64": {
-            "#import": [ "debian", "linux-x64" ]
-        },
-        "debian-x86": {
-            "#import": [ "debian", "linux-x86" ]
-        },
-        "debian-arm": {
-            "#import": [ "debian", "linux-arm" ]
-        },
-        "debian-armel": {
-            "#import": [ "debian", "linux-armel" ]
-        },
-        "debian-arm64": {
-            "#import": [ "debian", "linux-arm64" ]
-        },
-
-        "debian.8": {
-            "#import": [ "debian" ]
-        },
-        "debian.8-x64": {
-            "#import": [ "debian.8", "debian-x64" ]
-        },
-        "debian.8-x86": {
-            "#import": [ "debian.8", "debian-x86" ]
-        },
-        "debian.8-arm": {
-            "#import": [ "debian.8", "debian-arm" ]
-        },
-        "debian.8-armel": {
-            "#import": [ "debian.8", "debian-armel" ]
-        },
-        "debian.8-arm64": {
-            "#import": [ "debian.8", "debian-arm64" ]
-        },
-
-        "tizen": {
-            "#import": [ "linux" ]
-        },
-        "tizen-armel": {
-            "#import": [ "tizen", "linux-armel" ]
-        },
-        "tizen.4.0.0-armel": {
-            "#import": [ "tizen.4.0.0", "tizen-armel" ]
-        },
-
-        "ubuntu": {
-            "#import": [ "debian" ]
-        },
-
-        "ubuntu-x64": {
-            "#import": [ "ubuntu", "debian-x64" ]
-        },
-
-        "ubuntu-x86": {
-            "#import": [ "ubuntu", "debian-x86" ]
-        },
-
-        "ubuntu-arm": {
-            "#import": [ "ubuntu", "debian-arm" ]
-        },
-
-        "ubuntu-arm64": {
-            "#import": [ "ubuntu", "debian-arm64" ]
-        },
-
-        "ubuntu.14.04": {
-            "#import": [ "ubuntu" ]
-        },
-        "ubuntu.14.04-x64": {
-            "#import": [ "ubuntu.14.04", "ubuntu-x64" ]
-        },
-        "ubuntu.14.04-x86": {
-            "#import": [ "ubuntu.14.04", "ubuntu-x86" ]
-        },
-        "ubuntu.14.04-arm": {
-            "#import": [ "ubuntu.14.04", "ubuntu-arm" ]
-        },
-
-        "ubuntu.14.10": {
-            "#import": [ "ubuntu" ]
-        },
-        "ubuntu.14.10-x64": {
-            "#import": [ "ubuntu.14.10", "ubuntu-x64" ]
-        },
-        "ubuntu.14.10-x86": {
-            "#import": [ "ubuntu.14.10", "ubuntu-x86" ]
-        },
-        "ubuntu.14.10-arm": {
-            "#import": [ "ubuntu.14.10", "ubuntu-arm" ]
-        },
-
-        "ubuntu.15.04": {
-            "#import": [ "ubuntu" ]
-        },
-        "ubuntu.15.04-x64": {
-            "#import": [ "ubuntu.15.04", "ubuntu-x64" ]
-        },
-        "ubuntu.15.04-x86": {
-            "#import": [ "ubuntu.15.04", "ubuntu-x86" ]
-        },
-        "ubuntu.15.04-arm": {
-            "#import": [ "ubuntu.15.04", "ubuntu-arm" ]
-        },
-
-        "ubuntu.15.10": {
-            "#import": [ "ubuntu" ]
-        },
-        "ubuntu.15.10-x64": {
-            "#import": [ "ubuntu.15.10", "ubuntu-x64" ]
-        },
-        "ubuntu.15.10-x86": {
-            "#import": [ "ubuntu.15.10", "ubuntu-x86" ]
-        },
-        "ubuntu.15.10-arm": {
-            "#import": [ "ubuntu.15.10", "ubuntu-arm" ]
-        },
-
-        "ubuntu.16.04": {
-            "#import": [ "ubuntu" ]
-        },
-        "ubuntu.16.04-x64": {
-            "#import": [ "ubuntu.16.04", "ubuntu-x64" ]
-        },
-        "ubuntu.16.04-x86": {
-            "#import": [ "ubuntu.16.04", "ubuntu-x86" ]
-        },
-        "ubuntu.16.04-arm": {
-            "#import": [ "ubuntu.16.04", "ubuntu-arm" ]
-        },
-        "ubuntu.16.04-arm64": {
-            "#import": [ "ubuntu.16.04", "ubuntu-arm64" ]
-        },
-
-        "ubuntu.16.10": {
-            "#import": [ "ubuntu" ]
-        },
-        "ubuntu.16.10-x64": {
-            "#import": [ "ubuntu.16.10", "ubuntu-x64" ]
-        },
-        "ubuntu.16.10-x86": {
-            "#import": [ "ubuntu.16.10", "ubuntu-x86" ]
-        },
-        "ubuntu.16.10-arm": {
-            "#import": [ "ubuntu.16.10", "ubuntu-arm" ]
-        },
-        "ubuntu.16.10-arm64": {
-            "#import": [ "ubuntu.16.10", "ubuntu-arm64" ]
-        },
-
-        "linuxmint.17": {
-            "#import": [ "ubuntu.14.04" ]
-        },
-        "linuxmint.17-x64": {
-            "#import": [ "linuxmint.17", "ubuntu.14.04-x64" ]
-        },
-
-        "linuxmint.17.1": {
-            "#import": [ "linuxmint.17" ]
-        },
-        "linuxmint.17.1-x64": {
-            "#import": [ "linuxmint.17.1", "linuxmint.17-x64" ]
-        },
-
-        "linuxmint.17.2": {
-            "#import": [ "linuxmint.17.1" ]
-        },
-        "linuxmint.17.2-x64": {
-            "#import": [ "linuxmint.17.2", "linuxmint.17.1-x64" ]
-        },
-
-        "linuxmint.17.3": {
-            "#import": [ "linuxmint.17.2" ]
-        },
-        "linuxmint.17.3-x64": {
-            "#import": [ "linuxmint.17.3", "linuxmint.17.2-x64" ]
-        },
-
-        "linuxmint.18": {
-            "#import": [ "ubuntu.16.04" ]
-        },
-        "linuxmint.18-x64": {
-            "#import": [ "linuxmint.18", "ubuntu.16.04-x64" ]
-        },
-        "linuxmint.18.1": {
-            "#import": [ "linuxmint.18" ]
-        },
-        "linuxmint.18.1-x64": {
-            "#import": [ "linuxmint.18.1", "linuxmint.18-x64" ]
-        },
-
-        "fedora": {
-            "#import": [ "linux" ]
-        },
-        "fedora-x64": {
-            "#import": [ "fedora", "linux-x64" ]
-        },
-
-        "fedora.23": {
-            "#import": [ "fedora" ]
-        },
-        "fedora.23-x64": {
-            "#import": [ "fedora.23", "fedora-x64" ]
-        },
-
-        "fedora.24": {
-            "#import": [ "fedora" ]
-        },
-        "fedora.24-x64": {
-            "#import": [ "fedora.24", "fedora-x64" ]
-        },
-
-        "fedora.25": {
-            "#import": [ "fedora" ]
-        },
-        "fedora.25-x64": {
-            "#import": [ "fedora.25", "fedora-x64" ]
-        },
-
-        "fedora.26": {
-            "#import": [ "fedora" ]
-        },
-        "fedora.26-x64": {
-            "#import": [ "fedora.26", "fedora-x64" ]
-        },
-
-        "opensuse": {
-            "#import": [ "linux" ]
-        },
-        "opensuse-x64": {
-            "#import": [ "opensuse", "linux-x64" ]
-        },
-
-        "opensuse.13.2": {
-            "#import": [ "opensuse" ]
-        },
-        "opensuse.13.2-x64": {
-            "#import": [ "opensuse.13.2", "opensuse-x64" ]
-        },
-
-        "opensuse.42.1": {
-            "#import": [ "opensuse" ]
-        },
-        "opensuse.42.1-x64": {
-            "#import": [ "opensuse.42.1", "opensuse-x64" ]
-        },
-
-        "corert": {
-            "#import": [ "any" ]
-        },
-
-        "win-corert": {
-            "#import": [ "corert", "win" ]
-        },
-        "win-x86-corert": {
-            "#import": [ "win-corert", "win-x86" ]
-        },
-        "win-x64-corert": {
-            "#import": [ "win-corert", "win-x64" ]
-        },
-
-        "win7-corert": {
-            "#import": [ "win-corert", "win7" ]
-        },
-        "win7-x86-corert": {
-            "#import": [ "win7-corert", "win7-x86" ]
-        },
-        "win7-x64-corert": {
-            "#import": [ "win7-corert", "win7-x64" ]
-        },
-
-        "win8-corert": {
-            "#import": [ "win7-corert", "win8" ]
-        },
-        "win8-x86-corert": {
-            "#import": [ "win8-corert", "win7-x86-corert", "win8-x86" ]
-        },
-        "win8-x64-corert": {
-            "#import": [ "win8-corert", "win7-x64-corert", "win8-x64" ]
-        },
-        "win8-arm-corert": {
-            "#import": [ "win8-corert", "win8-arm" ]
-        },
-
-        "win81-corert": {
-            "#import": [ "win8-corert", "win81" ]
-        },
-        "win81-x86-corert": {
-            "#import": [ "win81-corert", "win8-x86-corert", "win81-x86" ]
-        },
-        "win81-x64-corert": {
-            "#import": [ "win81-corert", "win8-x64-corert", "win81-x64" ]
-        },
-        "win81-arm-corert": {
-            "#import": [ "win81-corert", "win8-arm-corert", "win81-arm" ]
-        },
-
-        "win10-corert": {
-            "#import": [ "win81-corert", "win10" ]
-        },
-        "win10-x86-corert": {
-            "#import": [ "win10-corert", "win81-x86-corert", "win10-x86" ]
-        },
-        "win10-x64-corert": {
-            "#import": [ "win10-corert", "win81-x64-corert", "win10-x64" ]
-        },
-        "win10-arm-corert": {
-            "#import": [ "win10-corert", "win81-arm-corert", "win10-arm" ]
-        },
-        "win10-arm64-corert": {
-            "#import": [ "win10-corert", "win10-arm64" ]
-        },
-
-        "unix-corert": {
-            "#import": [ "corert", "unix" ]
-        },
-        "unix-x64-corert": {
-            "#import": [ "unix-corert", "unix-x64" ]
-        },
-        "unix-arm-corert": {
-            "#import": [ "unix-corert", "unix-arm" ]
-        },
-        "unix-arm64-corert": {
-            "#import": [ "unix-corert", "unix-arm64" ]
-        },
-
-        "osx-corert": {
-            "#import": [ "unix-corert", "osx" ]
-        },
-        "osx-x64-corert": {
-            "#import": [ "osx-corert", "unix-x64-corert", "osx-x64" ]
-        },
-
-        "osx.10.10-corert": {
-            "#import": [ "osx-corert", "osx.10.10" ]
-        },
-        "osx.10.10-x64-corert": {
-            "#import": [ "osx.10.10-corert", "osx-x64-corert", "osx.10.10-x64" ]
-        },
-
-        "osx.10.11-corert": {
-            "#import": [ "osx.10.10-corert", "osx.10.11" ]
-        },
-        "osx.10.11-x64-corert": {
-            "#import": [ "osx.10.11-corert", "osx.10.10-x64-corert", "osx.10.11-x64" ]
-        },
-
-        "osx.10.12-corert": {
-            "#import": [ "osx.10.11-corert", "osx.10.12" ]
-        },
-        "osx.10.12-x64-corert": {
-            "#import": [ "osx.10.12-corert", "osx.10.11-x64-corert", "osx.10.12-x64" ]
-        },
-
-        "linux-corert": {
-            "#import": [ "corert", "linux", "unix-corert" ]
-        },
-        "linux-x64-corert": {
-            "#import": [ "linux-corert", "linux-x64" ]
-        },
-        "linux-arm-corert": {
-            "#import": [ "linux-corert", "linux-arm" ]
-        },
-        "linux-arm64-corert": {
-            "#import": [ "linux-corert", "linux-arm64" ]
-        },
-
-        "rhel-corert": {
-            "#import": [ "corert", "rhel" ]
-        },
-        "rhel-x64-corert": {
-            "#import": [ "rhel-corert", "linux-x64-corert", "rhel-x64" ]
-        },
-
-        "rhel.7-corert": {
-            "#import": [ "rhel-corert", "rhel.7" ]
-        },
-        "rhel.7-x64-corert": {
-            "#import": [ "rhel.7-corert", "rhel-x64-corert", "rhel.7-x64" ]
-        },
-
-        "rhel.7.0-corert": {
-            "#import": [ "rhel.7-corert", "rhel.7.0" ]
-        },
-        "rhel.7.0-x64-corert": {
-            "#import": [ "rhel.7.0-corert", "rhel.7-x64-corert", "rhel.7.0-x64" ]
-        },
-
-        "rhel.7.1-corert": {
-            "#import": [ "rhel.7.0-corert", "rhel.7.1" ]
-        },
-        "rhel.7.1-x64-corert": {
-            "#import": [ "rhel.7.1-corert", "rhel.7.0-x64-corert", "rhel.7.1-x64" ]
-        },
-
-        "rhel.7.2-corert": {
-            "#import": [ "rhel.7.1-corert", "rhel.7.2" ]
-        },
-        "rhel.7.2-x64-corert": {
-            "#import": [ "rhel.7.2-corert", "rhel.7.1-x64-corert", "rhel.7.2-x64" ]
-        },
-
-        "ol-corert": {
-            "#import": [ "rhel-corert", "ol" ]
-        },
-        "ol-x64-corert": {
-            "#import": [ "ol-corert", "rhel-x64-corert", "ol-x64" ]
-        },
-
-        "ol.7-corert": {
-            "#import": [ "ol-corert", "ol.7" ]
-        },
-        "ol.7-x64-corert": {
-            "#import": [ "ol.7-corert", "rhel.7-x64-corert", "ol.7-x64" ]
-        },
-
-        "ol.7.0-corert": {
-            "#import": [ "ol.7-corert", "ol.7.0" ]
-        },
-        "ol.7.0-x64-corert": {
-            "#import": [ "ol.7.0-corert", "rhel.7.0-corert", "ol.7.0-x64" ]
-        },
-
-        "ol.7.1-corert": {
-            "#import": [ "ol.7.0-corert", "ol.7.1" ]
-        },
-        "ol.7.1-x64-corert": {
-            "#import": [ "ol.7.1-corert", "rhel.7.1-x64-corert", "ol.7.1-x64" ]
-        },
-
-        "centos-corert": {
-            "#import": [ "rel-corert", "centos" ]
-        },
-        "centos-x64-corert": {
-            "#import": [ "centos-corert", "rhel-x64-corert", "centos-x64" ]
-        },
-
-        "centos.7-corert": {
-            "#import": [ "centos-corert", "centos.7" ]
-        },
-        "centos.7-x64-corert": {
-            "#import": [ "centos.7-corert", "centos-x64-corert", "centos.7-x64" ]
-        },
-
-        "debian-corert": {
-            "#import": [ "linux-corert", "debian" ]
-        },
-        "debian-x64-corert": {
-            "#import": [ "debian-corert", "linux-x64-corert", "debian-x64" ]
-        },
-        "debian-arm-corert": {
-            "#import": [ "debian-corert", "debian-arm" ]
-        },
-        "debian-arm64-corert": {
-            "#import": [ "debian-corert", "debian-arm64" ]
-        },
-
-        "debian.8-corert": {
-            "#import": [ "debian-corert", "debian.8" ]
-        },
-        "debian.8-x64-corert": {
-            "#import": [ "debian.8-corert", "debian-x64-corert", "debian.8-x64" ]
-        },
-        "debian.8-arm-corert": {
-            "#import": [ "debian.8-corert", "debian-arm-corert", "debian.8-arm" ]
-        },
-        "debian.8-arm64-corert": {
-            "#import": [ "debian.8-corert", "debian-arm64-corert", "debian.8-arm64" ]
-        },
-
-        "ubuntu-corert": {
-            "#import": [ "debian-corert", "ubuntu" ]
-        },
-
-        "ubuntu-x64-corert": {
-            "#import": [ "ubuntu-corert", "debian-x64-corert", "ubuntu-x64" ]
-        },
-
-        "ubuntu.14.04-corert": {
-            "#import": [ "ubuntu-corert", "ubuntu.14.06" ]
-        },
-        "ubuntu.14.04-x64-corert": {
-            "#import": [ "ubuntu.14.04-corert", "ubuntu-x64-corert", "ubuntu-14.04-x64" ]
-        },
-
-        "ubuntu.14.10-corert": {
-            "#import": [ "ubuntu.14.04-corert", "ubuntu-14.10" ]
-        },
-        "ubuntu.14.10-x64-corert": {
-            "#import": [ "ubuntu.14.10-corert", "ubuntu.14.04-x64-corert", "ubuntu.14.10-x64" ]
-        },
-
-        "ubuntu.15.04-corert": {
-            "#import": [ "ubuntu.14.10-corert", "ubuntu-15.04" ]
-        },
-        "ubuntu.15.04-x64-corert": {
-            "#import": [ "ubuntu.15.04-corert", "ubuntu.14.10-x64-corert", "ubuntu.15.04-x64" ]
-        },
-
-        "ubuntu.15.10-corert": {
-            "#import": [ "ubuntu.15.04-corert", "ubuntu-15.10" ]
-        },
-        "ubuntu.15.10-x64-corert": {
-            "#import": [ "ubuntu.15.10-corert", "ubuntu.15.04-x64-corert", "ubuntu.15.10-x64" ]
-        },
-
-        "ubuntu.16.04-corert": {
-            "#import": [ "ubuntu.15.10-corert", "ubuntu-16.04" ]
-        },
-        "ubuntu.16.04-x64-corert": {
-            "#import": [ "ubuntu.16.04-corert", "ubuntu.15.10-x64-corert", "ubuntu.16.04-x64" ]
-        },
-
-        "ubuntu.16.10-corert": {
-            "#import": [ "ubuntu.16.04-corert", "ubuntu.16.10" ]
-        },
-        "ubuntu.16.10-x64-corert": {
-            "#import": [ "ubuntu.16.10-corert", "ubuntu.16.04-x64-corert", "ubuntu.16.10-x64" ]
-        },
-
-        "linuxmint.17-corert": {
-            "#import": [ "ubuntu.14.04-corert", "linuxmint.17" ]
-        },
-        "linuxmint.17-x64-corert": {
-            "#import": [ "linuxmint.17-corert", "ubuntu.14.04-x64-corert", "linuxmint.17-x64" ]
-        },
-
-        "linuxmint.17.1-corert": {
-            "#import": [ "linuxmint.17-corert", "linuxmint.17.1" ]
-        },
-        "linuxmint.17.1-x64-corert": {
-            "#import": [ "linuxmint.17.1-corert", "linuxmint.17-x64-corert", "linuxmint.17.1-x64" ]
-        },
-
-        "linuxmint.17.2-corert": {
-            "#import": [ "linuxmint.17.1-corert", "linuxmint.17.2" ]
-        },
-        "linuxmint.17.2-x64-corert": {
-            "#import": [ "linuxmint.17.2-corert", "linuxmint.17.1-x64-corert", "linuxmint.17.2-x64" ]
-        },
-
-        "linuxmint.17.3-corert": {
-            "#import": [ "linuxmint.17.2-corert", "linuxmint.17.3" ]
-        },
-        "linuxmint.17.3-x64-corert": {
-            "#import": [ "linuxmint.17.3-corert", "linuxmint.17.2-x64-corert", "linuxmint.17.3-x64" ]
-        },
-
-        "linuxmint.18-corert": {
-            "#import": [ "ubuntu.16.04-corert", "linuxmint.18" ]
-        },
-        "linuxmint.18-x64-corert": {
-            "#import": [ "linuxmint.18-corert", "ubuntu.16.04-x64-corert", "linuxmint.18-x64" ]
-        },
-
-        "fedora-corert": {
-            "#import": [ "linux-corert", "fedora" ]
-        },
-        "fedora-x64-corert": {
-            "#import": [ "fedora-corert", "linux-x64-corert", "fedora-x64" ]
-        },
-
-        "fedora.23-corert": {
-            "#import": [ "fedora-corert", "fedora.23" ]
-        },
-        "fedora.23-x64-corert": {
-            "#import": [ "fedora.23-corert", "fedora-x64-corert", "fedora.23-x64" ]
-        },
-
-        "fedora.24-corert": {
-            "#import": [ "fedora.23-corert", "fedora.24" ]
-        },
-        "fedora.24-x64-corert": {
-            "#import": [ "fedora.24-corert", "fedora.23-x64-corert", "fedora.24-x64" ]
-        },
-
-        "opensuse-corert": {
-            "#import": [ "linux-corert", "opensuse" ]
-        },
-        "opensuse-x64-corert": {
-            "#import": [ "opensuse-corert", "linux-x64-corert", "opensuste-x64" ]
-        },
-
-        "opensuse.13.2-corert": {
-            "#import": [ "opensuse-corert", "opensuse.13.2" ]
-        },
-        "opensuse.13.2-x64-corert": {
-            "#import": [ "opensuse.13.2-corert", "opensuse-x64-corert", "opensuse.13.2-x64" ]
-        },
-
-        "opensuse.42.1-corert": {
-            "#import": [ "opensuse.13.2-corert", "opensuse.42.1" ]
-        },
-        "opensuse.42.1-x64-corert": {
-            "#import": [ "opensuse.42.1-corert", "opensuse.13.2-x64-corert", "opensuse.42.1-x64" ]
-        },
-
-    }
+  "runtimes": {
+    "base": {},
+    "any": {
+      "#import": [
+        "base"
+      ]
+    },
+    "android": {
+      "#import": [
+        "any"
+      ]
+    },
+    "android-arm": {
+      "#import": [
+        "any"
+      ]
+    },
+    "android-arm64": {
+      "#import": [
+        "any"
+      ]
+    },
+    "android.21": {
+      "#import": [
+        "android"
+      ]
+    },
+    "android.21-arm": {
+      "#import": [
+        "android.21",
+        "android-arm"
+      ]
+    },
+    "android.21-arm64": {
+      "#import": [
+        "android.21",
+        "android-arm64"
+      ]
+    },
+    "win": {
+      "#import": [
+        "any"
+      ]
+    },
+    "win-x86": {
+      "#import": [
+        "win"
+      ]
+    },
+    "win-x64": {
+      "#import": [
+        "win"
+      ]
+    },
+    "win-arm": {
+      "#import": [
+        "win"
+      ]
+    },
+    "win-arm64": {
+      "#import": [
+        "win"
+      ]
+    },
+    "win7": {
+      "#import": [
+        "win"
+      ]
+    },
+    "win7-x86": {
+      "#import": [
+        "win7",
+        "win-x86"
+      ]
+    },
+    "win7-x64": {
+      "#import": [
+        "win7",
+        "win-x64"
+      ]
+    },
+    "win8": {
+      "#import": [
+        "win7"
+      ]
+    },
+    "win8-x86": {
+      "#import": [
+        "win8",
+        "win7-x86"
+      ]
+    },
+    "win8-x64": {
+      "#import": [
+        "win8",
+        "win7-x64"
+      ]
+    },
+    "win8-arm": {
+      "#import": [
+        "win8",
+        "win-arm"
+      ]
+    },
+    "win81": {
+      "#import": [
+        "win8"
+      ]
+    },
+    "win81-x86": {
+      "#import": [
+        "win81",
+        "win8-x86"
+      ]
+    },
+    "win81-x64": {
+      "#import": [
+        "win81",
+        "win8-x64"
+      ]
+    },
+    "win81-arm": {
+      "#import": [
+        "win81",
+        "win8-arm"
+      ]
+    },
+    "win10": {
+      "#import": [
+        "win81"
+      ]
+    },
+    "win10-x86": {
+      "#import": [
+        "win10",
+        "win81-x86"
+      ]
+    },
+    "win10-x64": {
+      "#import": [
+        "win10",
+        "win81-x64"
+      ]
+    },
+    "win10-arm": {
+      "#import": [
+        "win10",
+        "win81-arm"
+      ]
+    },
+    "win10-arm64": {
+      "#import": [
+        "win10",
+        "win-arm64"
+      ]
+    },
+    "aot": {
+      "#import": [
+        "any"
+      ]
+    },
+    "win-aot": {
+      "#import": [
+        "win",
+        "aot"
+      ]
+    },
+    "win-x86-aot": {
+      "#import": [
+        "win-aot",
+        "win-x86"
+      ]
+    },
+    "win-x64-aot": {
+      "#import": [
+        "win-aot",
+        "win-x64"
+      ]
+    },
+    "win7-aot": {
+      "#import": [
+        "win-aot",
+        "win7"
+      ]
+    },
+    "win7-x86-aot": {
+      "#import": [
+        "win7-aot",
+        "win7-x86"
+      ]
+    },
+    "win7-x64-aot": {
+      "#import": [
+        "win7-aot",
+        "win7-x64"
+      ]
+    },
+    "win8-aot": {
+      "#import": [
+        "win8",
+        "win7-aot"
+      ]
+    },
+    "win8-x86-aot": {
+      "#import": [
+        "win8-aot",
+        "win8-x86",
+        "win7-x86-aot"
+      ]
+    },
+    "win8-x64-aot": {
+      "#import": [
+        "win8-aot",
+        "win8-x64",
+        "win7-x64-aot"
+      ]
+    },
+    "win8-arm-aot": {
+      "#import": [
+        "win8-aot",
+        "win8-arm"
+      ]
+    },
+    "win81-aot": {
+      "#import": [
+        "win81",
+        "win8-aot"
+      ]
+    },
+    "win81-x86-aot": {
+      "#import": [
+        "win81-aot",
+        "win81-x86",
+        "win8-x86-aot"
+      ]
+    },
+    "win81-x64-aot": {
+      "#import": [
+        "win81-aot",
+        "win81-x64",
+        "win8-x64-aot"
+      ]
+    },
+    "win81-arm-aot": {
+      "#import": [
+        "win81-aot",
+        "win81-arm",
+        "win8-arm-aot"
+      ]
+    },
+    "win10-aot": {
+      "#import": [
+        "win10",
+        "win81-aot"
+      ]
+    },
+    "win10-x86-aot": {
+      "#import": [
+        "win10-aot",
+        "win10-x86",
+        "win81-x86-aot"
+      ]
+    },
+    "win10-x64-aot": {
+      "#import": [
+        "win10-aot",
+        "win10-x64",
+        "win81-x64-aot"
+      ]
+    },
+    "win10-arm-aot": {
+      "#import": [
+        "win10-aot",
+        "win10-arm",
+        "win81-arm-aot"
+      ]
+    },
+    "win10-arm64-aot": {
+      "#import": [
+        "win10-aot",
+        "win10-arm64"
+      ]
+    },
+    "unix": {
+      "#import": [
+        "any"
+      ]
+    },
+    "unix-x64": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-x86": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-arm": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-armel": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-arm64": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "osx": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "osx-x64": {
+      "#import": [
+        "osx",
+        "unix-x64"
+      ]
+    },
+    "osx.10.10": {
+      "#import": [
+        "osx"
+      ]
+    },
+    "osx.10.10-x64": {
+      "#import": [
+        "osx.10.10",
+        "osx-x64"
+      ]
+    },
+    "osx.10.11": {
+      "#import": [
+        "osx.10.10"
+      ]
+    },
+    "osx.10.11-x64": {
+      "#import": [
+        "osx.10.11",
+        "osx.10.10-x64"
+      ]
+    },
+    "osx.10.12": {
+      "#import": [
+        "osx.10.11"
+      ]
+    },
+    "osx.10.12-x64": {
+      "#import": [
+        "osx.10.12",
+        "osx.10.11-x64"
+      ]
+    },
+    "linux": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "linux-x64": {
+      "#import": [
+        "linux",
+        "unix-x64"
+      ]
+    },
+    "linux-x86": {
+      "#import": [
+        "linux",
+        "unix-x86"
+      ]
+    },
+    "linux-arm": {
+      "#import": [
+        "linux",
+        "unix-arm"
+      ]
+    },
+    "linux-armel": {
+      "#import": [
+        "linux",
+        "unix-armel"
+      ]
+    },
+    "linux-arm64": {
+      "#import": [
+        "linux",
+        "unix-arm64"
+      ]
+    },
+    "rhel": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "rhel-x64": {
+      "#import": [
+        "rhel",
+        "linux-x64"
+      ]
+    },
+    "rhel.6": {
+      "#import": [
+        "rhel"
+      ]
+    },
+    "rhel.6-x64": {
+      "#import": [
+        "rhel.6",
+        "rhel-x64"
+      ]
+    },
+    "rhel.7": {
+      "#import": [
+        "rhel"
+      ]
+    },
+    "rhel.7-x64": {
+      "#import": [
+        "rhel.7",
+        "rhel-x64"
+      ]
+    },
+    "rhel.7.0": {
+      "#import": [
+        "rhel.7"
+      ]
+    },
+    "rhel.7.0-x64": {
+      "#import": [
+        "rhel.7.0",
+        "rhel.7-x64"
+      ]
+    },
+    "rhel.7.1": {
+      "#import": [
+        "rhel.7.0"
+      ]
+    },
+    "rhel.7.1-x64": {
+      "#import": [
+        "rhel.7.1",
+        "rhel.7.0-x64"
+      ]
+    },
+    "rhel.7.2": {
+      "#import": [
+        "rhel.7.1"
+      ]
+    },
+    "rhel.7.2-x64": {
+      "#import": [
+        "rhel.7.2",
+        "rhel.7.1-x64"
+      ]
+    },
+    "rhel.7.3": {
+      "#import": [
+        "rhel.7.2"
+      ]
+    },
+    "rhel.7.3-x64": {
+      "#import": [
+        "rhel.7.3",
+        "rhel.7.2-x64"
+      ]
+    },
+    "rhel.7.4": {
+      "#import": [
+        "rhel.7.3"
+      ]
+    },
+    "rhel.7.4-x64": {
+      "#import": [
+        "rhel.7.4",
+        "rhel.7.3-x64"
+      ]
+    },
+    "ol": {
+      "#import": [
+        "rhel"
+      ]
+    },
+    "ol-x64": {
+      "#import": [
+        "ol",
+        "rhel-x64"
+      ]
+    },
+    "ol.7": {
+      "#import": [
+        "ol",
+        "rhel.7"
+      ]
+    },
+    "ol.7-x64": {
+      "#import": [
+        "ol.7",
+        "ol-x64",
+        "rhel.7-x64"
+      ]
+    },
+    "ol.7.0": {
+      "#import": [
+        "ol.7",
+        "rhel.7.0"
+      ]
+    },
+    "ol.7.0-x64": {
+      "#import": [
+        "ol.7.0",
+        "ol.7-x64",
+        "rhel.7.0-x64"
+      ]
+    },
+    "ol.7.1": {
+      "#import": [
+        "ol.7.0",
+        "rhel.7.1"
+      ]
+    },
+    "ol.7.1-x64": {
+      "#import": [
+        "ol.7.1",
+        "ol.7.0-x64",
+        "rhel.7.1-x64"
+      ]
+    },
+    "ol.7.2": {
+      "#import": [
+        "ol.7.1",
+        "rhel.7.2"
+      ]
+    },
+    "ol.7.2-x64": {
+      "#import": [
+        "ol.7.2",
+        "ol.7.1-x64",
+        "rhel.7.2-x64"
+      ]
+    },
+    "centos": {
+      "#import": [
+        "rhel"
+      ]
+    },
+    "centos-x64": {
+      "#import": [
+        "centos",
+        "rhel-x64"
+      ]
+    },
+    "centos.7": {
+      "#import": [
+        "centos",
+        "rhel.7"
+      ]
+    },
+    "centos.7-x64": {
+      "#import": [
+        "centos.7",
+        "centos-x64",
+        "rhel.7-x64"
+      ]
+    },
+    "debian": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "debian-x64": {
+      "#import": [
+        "debian",
+        "linux-x64"
+      ]
+    },
+    "debian-x86": {
+      "#import": [
+        "debian",
+        "linux-x86"
+      ]
+    },
+    "debian-arm": {
+      "#import": [
+        "debian",
+        "linux-arm"
+      ]
+    },
+    "debian-armel": {
+      "#import": [
+        "debian",
+        "linux-armel"
+      ]
+    },
+    "debian-arm64": {
+      "#import": [
+        "debian",
+        "linux-arm64"
+      ]
+    },
+    "debian.8": {
+      "#import": [
+        "debian"
+      ]
+    },
+    "debian.8-x64": {
+      "#import": [
+        "debian.8",
+        "debian-x64"
+      ]
+    },
+    "debian.8-x86": {
+      "#import": [
+        "debian.8",
+        "debian-x86"
+      ]
+    },
+    "debian.8-arm": {
+      "#import": [
+        "debian.8",
+        "debian-arm"
+      ]
+    },
+    "debian.8-armel": {
+      "#import": [
+        "debian.8",
+        "debian-armel"
+      ]
+    },
+    "debian.8-arm64": {
+      "#import": [
+        "debian.8",
+        "debian-arm64"
+      ]
+    },
+    "tizen": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "tizen-armel": {
+      "#import": [
+        "tizen",
+        "linux-armel"
+      ]
+    },
+    "tizen.4.0.0-armel": {
+      "#import": [
+        "tizen.4.0.0",
+        "tizen-armel"
+      ]
+    },
+    "ubuntu": {
+      "#import": [
+        "debian"
+      ]
+    },
+    "ubuntu-x64": {
+      "#import": [
+        "ubuntu",
+        "debian-x64"
+      ]
+    },
+    "ubuntu-x86": {
+      "#import": [
+        "ubuntu",
+        "debian-x86"
+      ]
+    },
+    "ubuntu-arm": {
+      "#import": [
+        "ubuntu",
+        "debian-arm"
+      ]
+    },
+    "ubuntu-arm64": {
+      "#import": [
+        "ubuntu",
+        "debian-arm64"
+      ]
+    },
+    "ubuntu.14.04": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.14.04-x64": {
+      "#import": [
+        "ubuntu.14.04",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.14.04-x86": {
+      "#import": [
+        "ubuntu.14.04",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.14.04-arm": {
+      "#import": [
+        "ubuntu.14.04",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.14.10": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.14.10-x64": {
+      "#import": [
+        "ubuntu.14.10",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.14.10-x86": {
+      "#import": [
+        "ubuntu.14.10",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.14.10-arm": {
+      "#import": [
+        "ubuntu.14.10",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.15.04": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.15.04-x64": {
+      "#import": [
+        "ubuntu.15.04",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.15.04-x86": {
+      "#import": [
+        "ubuntu.15.04",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.15.04-arm": {
+      "#import": [
+        "ubuntu.15.04",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.15.10": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.15.10-x64": {
+      "#import": [
+        "ubuntu.15.10",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.15.10-x86": {
+      "#import": [
+        "ubuntu.15.10",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.15.10-arm": {
+      "#import": [
+        "ubuntu.15.10",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.16.04": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.16.04-x64": {
+      "#import": [
+        "ubuntu.16.04",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.16.04-x86": {
+      "#import": [
+        "ubuntu.16.04",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.16.04-arm": {
+      "#import": [
+        "ubuntu.16.04",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.16.04-arm64": {
+      "#import": [
+        "ubuntu.16.04",
+        "ubuntu-arm64"
+      ]
+    },
+    "ubuntu.16.10": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.16.10-x64": {
+      "#import": [
+        "ubuntu.16.10",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.16.10-x86": {
+      "#import": [
+        "ubuntu.16.10",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.16.10-arm": {
+      "#import": [
+        "ubuntu.16.10",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.16.10-arm64": {
+      "#import": [
+        "ubuntu.16.10",
+        "ubuntu-arm64"
+      ]
+    },
+    "linuxmint.17": {
+      "#import": [
+        "ubuntu.14.04"
+      ]
+    },
+    "linuxmint.17-x64": {
+      "#import": [
+        "linuxmint.17",
+        "ubuntu.14.04-x64"
+      ]
+    },
+    "linuxmint.17.1": {
+      "#import": [
+        "linuxmint.17"
+      ]
+    },
+    "linuxmint.17.1-x64": {
+      "#import": [
+        "linuxmint.17.1",
+        "linuxmint.17-x64"
+      ]
+    },
+    "linuxmint.17.2": {
+      "#import": [
+        "linuxmint.17.1"
+      ]
+    },
+    "linuxmint.17.2-x64": {
+      "#import": [
+        "linuxmint.17.2",
+        "linuxmint.17.1-x64"
+      ]
+    },
+    "linuxmint.17.3": {
+      "#import": [
+        "linuxmint.17.2"
+      ]
+    },
+    "linuxmint.17.3-x64": {
+      "#import": [
+        "linuxmint.17.3",
+        "linuxmint.17.2-x64"
+      ]
+    },
+    "linuxmint.18": {
+      "#import": [
+        "ubuntu.16.04"
+      ]
+    },
+    "linuxmint.18-x64": {
+      "#import": [
+        "linuxmint.18",
+        "ubuntu.16.04-x64"
+      ]
+    },
+    "linuxmint.18.1": {
+      "#import": [
+        "linuxmint.18"
+      ]
+    },
+    "linuxmint.18.1-x64": {
+      "#import": [
+        "linuxmint.18.1",
+        "linuxmint.18-x64"
+      ]
+    },
+    "fedora": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "fedora-x64": {
+      "#import": [
+        "fedora",
+        "linux-x64"
+      ]
+    },
+    "fedora.23": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.23-x64": {
+      "#import": [
+        "fedora.23",
+        "fedora-x64"
+      ]
+    },
+    "fedora.24": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.24-x64": {
+      "#import": [
+        "fedora.24",
+        "fedora-x64"
+      ]
+    },
+    "fedora.25": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.25-x64": {
+      "#import": [
+        "fedora.25",
+        "fedora-x64"
+      ]
+    },
+    "fedora.26": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.26-x64": {
+      "#import": [
+        "fedora.26",
+        "fedora-x64"
+      ]
+    },
+    "opensuse": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "opensuse-x64": {
+      "#import": [
+        "opensuse",
+        "linux-x64"
+      ]
+    },
+    "opensuse.13.2": {
+      "#import": [
+        "opensuse"
+      ]
+    },
+    "opensuse.13.2-x64": {
+      "#import": [
+        "opensuse.13.2",
+        "opensuse-x64"
+      ]
+    },
+    "opensuse.42.1": {
+      "#import": [
+        "opensuse"
+      ]
+    },
+    "opensuse.42.1-x64": {
+      "#import": [
+        "opensuse.42.1",
+        "opensuse-x64"
+      ]
+    },
+    "corert": {
+      "#import": [
+        "any"
+      ]
+    },
+    "win-corert": {
+      "#import": [
+        "corert",
+        "win"
+      ]
+    },
+    "win-x86-corert": {
+      "#import": [
+        "win-corert",
+        "win-x86"
+      ]
+    },
+    "win-x64-corert": {
+      "#import": [
+        "win-corert",
+        "win-x64"
+      ]
+    },
+    "win7-corert": {
+      "#import": [
+        "win-corert",
+        "win7"
+      ]
+    },
+    "win7-x86-corert": {
+      "#import": [
+        "win7-corert",
+        "win7-x86"
+      ]
+    },
+    "win7-x64-corert": {
+      "#import": [
+        "win7-corert",
+        "win7-x64"
+      ]
+    },
+    "win8-corert": {
+      "#import": [
+        "win7-corert",
+        "win8"
+      ]
+    },
+    "win8-x86-corert": {
+      "#import": [
+        "win8-corert",
+        "win7-x86-corert",
+        "win8-x86"
+      ]
+    },
+    "win8-x64-corert": {
+      "#import": [
+        "win8-corert",
+        "win7-x64-corert",
+        "win8-x64"
+      ]
+    },
+    "win8-arm-corert": {
+      "#import": [
+        "win8-corert",
+        "win8-arm"
+      ]
+    },
+    "win81-corert": {
+      "#import": [
+        "win8-corert",
+        "win81"
+      ]
+    },
+    "win81-x86-corert": {
+      "#import": [
+        "win81-corert",
+        "win8-x86-corert",
+        "win81-x86"
+      ]
+    },
+    "win81-x64-corert": {
+      "#import": [
+        "win81-corert",
+        "win8-x64-corert",
+        "win81-x64"
+      ]
+    },
+    "win81-arm-corert": {
+      "#import": [
+        "win81-corert",
+        "win8-arm-corert",
+        "win81-arm"
+      ]
+    },
+    "win10-corert": {
+      "#import": [
+        "win81-corert",
+        "win10"
+      ]
+    },
+    "win10-x86-corert": {
+      "#import": [
+        "win10-corert",
+        "win81-x86-corert",
+        "win10-x86"
+      ]
+    },
+    "win10-x64-corert": {
+      "#import": [
+        "win10-corert",
+        "win81-x64-corert",
+        "win10-x64"
+      ]
+    },
+    "win10-arm-corert": {
+      "#import": [
+        "win10-corert",
+        "win81-arm-corert",
+        "win10-arm"
+      ]
+    },
+    "win10-arm64-corert": {
+      "#import": [
+        "win10-corert",
+        "win10-arm64"
+      ]
+    },
+    "unix-corert": {
+      "#import": [
+        "corert",
+        "unix"
+      ]
+    },
+    "unix-x64-corert": {
+      "#import": [
+        "unix-corert",
+        "unix-x64"
+      ]
+    },
+    "unix-arm-corert": {
+      "#import": [
+        "unix-corert",
+        "unix-arm"
+      ]
+    },
+    "unix-arm64-corert": {
+      "#import": [
+        "unix-corert",
+        "unix-arm64"
+      ]
+    },
+    "osx-corert": {
+      "#import": [
+        "unix-corert",
+        "osx"
+      ]
+    },
+    "osx-x64-corert": {
+      "#import": [
+        "osx-corert",
+        "unix-x64-corert",
+        "osx-x64"
+      ]
+    },
+    "osx.10.10-corert": {
+      "#import": [
+        "osx-corert",
+        "osx.10.10"
+      ]
+    },
+    "osx.10.10-x64-corert": {
+      "#import": [
+        "osx.10.10-corert",
+        "osx-x64-corert",
+        "osx.10.10-x64"
+      ]
+    },
+    "osx.10.11-corert": {
+      "#import": [
+        "osx.10.10-corert",
+        "osx.10.11"
+      ]
+    },
+    "osx.10.11-x64-corert": {
+      "#import": [
+        "osx.10.11-corert",
+        "osx.10.10-x64-corert",
+        "osx.10.11-x64"
+      ]
+    },
+    "osx.10.12-corert": {
+      "#import": [
+        "osx.10.11-corert",
+        "osx.10.12"
+      ]
+    },
+    "osx.10.12-x64-corert": {
+      "#import": [
+        "osx.10.12-corert",
+        "osx.10.11-x64-corert",
+        "osx.10.12-x64"
+      ]
+    },
+    "linux-corert": {
+      "#import": [
+        "corert",
+        "linux",
+        "unix-corert"
+      ]
+    },
+    "linux-x64-corert": {
+      "#import": [
+        "linux-corert",
+        "linux-x64"
+      ]
+    },
+    "linux-arm-corert": {
+      "#import": [
+        "linux-corert",
+        "linux-arm"
+      ]
+    },
+    "linux-arm64-corert": {
+      "#import": [
+        "linux-corert",
+        "linux-arm64"
+      ]
+    },
+    "rhel-corert": {
+      "#import": [
+        "corert",
+        "rhel"
+      ]
+    },
+    "rhel-x64-corert": {
+      "#import": [
+        "rhel-corert",
+        "linux-x64-corert",
+        "rhel-x64"
+      ]
+    },
+    "rhel.7-corert": {
+      "#import": [
+        "rhel-corert",
+        "rhel.7"
+      ]
+    },
+    "rhel.7-x64-corert": {
+      "#import": [
+        "rhel.7-corert",
+        "rhel-x64-corert",
+        "rhel.7-x64"
+      ]
+    },
+    "rhel.7.0-corert": {
+      "#import": [
+        "rhel.7-corert",
+        "rhel.7.0"
+      ]
+    },
+    "rhel.7.0-x64-corert": {
+      "#import": [
+        "rhel.7.0-corert",
+        "rhel.7-x64-corert",
+        "rhel.7.0-x64"
+      ]
+    },
+    "rhel.7.1-corert": {
+      "#import": [
+        "rhel.7.0-corert",
+        "rhel.7.1"
+      ]
+    },
+    "rhel.7.1-x64-corert": {
+      "#import": [
+        "rhel.7.1-corert",
+        "rhel.7.0-x64-corert",
+        "rhel.7.1-x64"
+      ]
+    },
+    "rhel.7.2-corert": {
+      "#import": [
+        "rhel.7.1-corert",
+        "rhel.7.2"
+      ]
+    },
+    "rhel.7.2-x64-corert": {
+      "#import": [
+        "rhel.7.2-corert",
+        "rhel.7.1-x64-corert",
+        "rhel.7.2-x64"
+      ]
+    },
+    "ol-corert": {
+      "#import": [
+        "rhel-corert",
+        "ol"
+      ]
+    },
+    "ol-x64-corert": {
+      "#import": [
+        "ol-corert",
+        "rhel-x64-corert",
+        "ol-x64"
+      ]
+    },
+    "ol.7-corert": {
+      "#import": [
+        "ol-corert",
+        "ol.7"
+      ]
+    },
+    "ol.7-x64-corert": {
+      "#import": [
+        "ol.7-corert",
+        "rhel.7-x64-corert",
+        "ol.7-x64"
+      ]
+    },
+    "ol.7.0-corert": {
+      "#import": [
+        "ol.7-corert",
+        "ol.7.0"
+      ]
+    },
+    "ol.7.0-x64-corert": {
+      "#import": [
+        "ol.7.0-corert",
+        "rhel.7.0-corert",
+        "ol.7.0-x64"
+      ]
+    },
+    "ol.7.1-corert": {
+      "#import": [
+        "ol.7.0-corert",
+        "ol.7.1"
+      ]
+    },
+    "ol.7.1-x64-corert": {
+      "#import": [
+        "ol.7.1-corert",
+        "rhel.7.1-x64-corert",
+        "ol.7.1-x64"
+      ]
+    },
+    "centos-corert": {
+      "#import": [
+        "rel-corert",
+        "centos"
+      ]
+    },
+    "centos-x64-corert": {
+      "#import": [
+        "centos-corert",
+        "rhel-x64-corert",
+        "centos-x64"
+      ]
+    },
+    "centos.7-corert": {
+      "#import": [
+        "centos-corert",
+        "centos.7"
+      ]
+    },
+    "centos.7-x64-corert": {
+      "#import": [
+        "centos.7-corert",
+        "centos-x64-corert",
+        "centos.7-x64"
+      ]
+    },
+    "debian-corert": {
+      "#import": [
+        "linux-corert",
+        "debian"
+      ]
+    },
+    "debian-x64-corert": {
+      "#import": [
+        "debian-corert",
+        "linux-x64-corert",
+        "debian-x64"
+      ]
+    },
+    "debian-arm-corert": {
+      "#import": [
+        "debian-corert",
+        "debian-arm"
+      ]
+    },
+    "debian-arm64-corert": {
+      "#import": [
+        "debian-corert",
+        "debian-arm64"
+      ]
+    },
+    "debian.8-corert": {
+      "#import": [
+        "debian-corert",
+        "debian.8"
+      ]
+    },
+    "debian.8-x64-corert": {
+      "#import": [
+        "debian.8-corert",
+        "debian-x64-corert",
+        "debian.8-x64"
+      ]
+    },
+    "debian.8-arm-corert": {
+      "#import": [
+        "debian.8-corert",
+        "debian-arm-corert",
+        "debian.8-arm"
+      ]
+    },
+    "debian.8-arm64-corert": {
+      "#import": [
+        "debian.8-corert",
+        "debian-arm64-corert",
+        "debian.8-arm64"
+      ]
+    },
+    "ubuntu-corert": {
+      "#import": [
+        "debian-corert",
+        "ubuntu"
+      ]
+    },
+    "ubuntu-x64-corert": {
+      "#import": [
+        "ubuntu-corert",
+        "debian-x64-corert",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.14.04-corert": {
+      "#import": [
+        "ubuntu-corert",
+        "ubuntu.14.06"
+      ]
+    },
+    "ubuntu.14.04-x64-corert": {
+      "#import": [
+        "ubuntu.14.04-corert",
+        "ubuntu-x64-corert",
+        "ubuntu-14.04-x64"
+      ]
+    },
+    "ubuntu.14.10-corert": {
+      "#import": [
+        "ubuntu.14.04-corert",
+        "ubuntu-14.10"
+      ]
+    },
+    "ubuntu.14.10-x64-corert": {
+      "#import": [
+        "ubuntu.14.10-corert",
+        "ubuntu.14.04-x64-corert",
+        "ubuntu.14.10-x64"
+      ]
+    },
+    "ubuntu.15.04-corert": {
+      "#import": [
+        "ubuntu.14.10-corert",
+        "ubuntu-15.04"
+      ]
+    },
+    "ubuntu.15.04-x64-corert": {
+      "#import": [
+        "ubuntu.15.04-corert",
+        "ubuntu.14.10-x64-corert",
+        "ubuntu.15.04-x64"
+      ]
+    },
+    "ubuntu.15.10-corert": {
+      "#import": [
+        "ubuntu.15.04-corert",
+        "ubuntu-15.10"
+      ]
+    },
+    "ubuntu.15.10-x64-corert": {
+      "#import": [
+        "ubuntu.15.10-corert",
+        "ubuntu.15.04-x64-corert",
+        "ubuntu.15.10-x64"
+      ]
+    },
+    "ubuntu.16.04-corert": {
+      "#import": [
+        "ubuntu.15.10-corert",
+        "ubuntu-16.04"
+      ]
+    },
+    "ubuntu.16.04-x64-corert": {
+      "#import": [
+        "ubuntu.16.04-corert",
+        "ubuntu.15.10-x64-corert",
+        "ubuntu.16.04-x64"
+      ]
+    },
+    "ubuntu.16.10-corert": {
+      "#import": [
+        "ubuntu.16.04-corert",
+        "ubuntu.16.10"
+      ]
+    },
+    "ubuntu.16.10-x64-corert": {
+      "#import": [
+        "ubuntu.16.10-corert",
+        "ubuntu.16.04-x64-corert",
+        "ubuntu.16.10-x64"
+      ]
+    },
+    "linuxmint.17-corert": {
+      "#import": [
+        "ubuntu.14.04-corert",
+        "linuxmint.17"
+      ]
+    },
+    "linuxmint.17-x64-corert": {
+      "#import": [
+        "linuxmint.17-corert",
+        "ubuntu.14.04-x64-corert",
+        "linuxmint.17-x64"
+      ]
+    },
+    "linuxmint.17.1-corert": {
+      "#import": [
+        "linuxmint.17-corert",
+        "linuxmint.17.1"
+      ]
+    },
+    "linuxmint.17.1-x64-corert": {
+      "#import": [
+        "linuxmint.17.1-corert",
+        "linuxmint.17-x64-corert",
+        "linuxmint.17.1-x64"
+      ]
+    },
+    "linuxmint.17.2-corert": {
+      "#import": [
+        "linuxmint.17.1-corert",
+        "linuxmint.17.2"
+      ]
+    },
+    "linuxmint.17.2-x64-corert": {
+      "#import": [
+        "linuxmint.17.2-corert",
+        "linuxmint.17.1-x64-corert",
+        "linuxmint.17.2-x64"
+      ]
+    },
+    "linuxmint.17.3-corert": {
+      "#import": [
+        "linuxmint.17.2-corert",
+        "linuxmint.17.3"
+      ]
+    },
+    "linuxmint.17.3-x64-corert": {
+      "#import": [
+        "linuxmint.17.3-corert",
+        "linuxmint.17.2-x64-corert",
+        "linuxmint.17.3-x64"
+      ]
+    },
+    "linuxmint.18-corert": {
+      "#import": [
+        "ubuntu.16.04-corert",
+        "linuxmint.18"
+      ]
+    },
+    "linuxmint.18-x64-corert": {
+      "#import": [
+        "linuxmint.18-corert",
+        "ubuntu.16.04-x64-corert",
+        "linuxmint.18-x64"
+      ]
+    },
+    "fedora-corert": {
+      "#import": [
+        "linux-corert",
+        "fedora"
+      ]
+    },
+    "fedora-x64-corert": {
+      "#import": [
+        "fedora-corert",
+        "linux-x64-corert",
+        "fedora-x64"
+      ]
+    },
+    "fedora.23-corert": {
+      "#import": [
+        "fedora-corert",
+        "fedora.23"
+      ]
+    },
+    "fedora.23-x64-corert": {
+      "#import": [
+        "fedora.23-corert",
+        "fedora-x64-corert",
+        "fedora.23-x64"
+      ]
+    },
+    "fedora.24-corert": {
+      "#import": [
+        "fedora.23-corert",
+        "fedora.24"
+      ]
+    },
+    "fedora.24-x64-corert": {
+      "#import": [
+        "fedora.24-corert",
+        "fedora.23-x64-corert",
+        "fedora.24-x64"
+      ]
+    },
+    "opensuse-corert": {
+      "#import": [
+        "linux-corert",
+        "opensuse"
+      ]
+    },
+    "opensuse-x64-corert": {
+      "#import": [
+        "opensuse-corert",
+        "linux-x64-corert",
+        "opensuste-x64"
+      ]
+    },
+    "opensuse.13.2-corert": {
+      "#import": [
+        "opensuse-corert",
+        "opensuse.13.2"
+      ]
+    },
+    "opensuse.13.2-x64-corert": {
+      "#import": [
+        "opensuse.13.2-corert",
+        "opensuse-x64-corert",
+        "opensuse.13.2-x64"
+      ]
+    },
+    "opensuse.42.1-corert": {
+      "#import": [
+        "opensuse.13.2-corert",
+        "opensuse.42.1"
+      ]
+    },
+    "opensuse.42.1-x64-corert": {
+      "#import": [
+        "opensuse.42.1-corert",
+        "opensuse.13.2-x64-corert",
+        "opensuse.42.1-x64"
+      ]
+    },
+  }
 }

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -1,11 +1,5 @@
 {
   "runtimes": {
-    "base": {},
-    "any": {
-      "#import": [
-        "base"
-      ]
-    },
     "android": {
       "#import": [
         "any"
@@ -38,121 +32,9 @@
         "android-arm64"
       ]
     },
-    "win": {
+    "any": {
       "#import": [
-        "any"
-      ]
-    },
-    "win-x86": {
-      "#import": [
-        "win"
-      ]
-    },
-    "win-x64": {
-      "#import": [
-        "win"
-      ]
-    },
-    "win-arm": {
-      "#import": [
-        "win"
-      ]
-    },
-    "win-arm64": {
-      "#import": [
-        "win"
-      ]
-    },
-    "win7": {
-      "#import": [
-        "win"
-      ]
-    },
-    "win7-x86": {
-      "#import": [
-        "win7",
-        "win-x86"
-      ]
-    },
-    "win7-x64": {
-      "#import": [
-        "win7",
-        "win-x64"
-      ]
-    },
-    "win8": {
-      "#import": [
-        "win7"
-      ]
-    },
-    "win8-x86": {
-      "#import": [
-        "win8",
-        "win7-x86"
-      ]
-    },
-    "win8-x64": {
-      "#import": [
-        "win8",
-        "win7-x64"
-      ]
-    },
-    "win8-arm": {
-      "#import": [
-        "win8",
-        "win-arm"
-      ]
-    },
-    "win81": {
-      "#import": [
-        "win8"
-      ]
-    },
-    "win81-x86": {
-      "#import": [
-        "win81",
-        "win8-x86"
-      ]
-    },
-    "win81-x64": {
-      "#import": [
-        "win81",
-        "win8-x64"
-      ]
-    },
-    "win81-arm": {
-      "#import": [
-        "win81",
-        "win8-arm"
-      ]
-    },
-    "win10": {
-      "#import": [
-        "win81"
-      ]
-    },
-    "win10-x86": {
-      "#import": [
-        "win10",
-        "win81-x86"
-      ]
-    },
-    "win10-x64": {
-      "#import": [
-        "win10",
-        "win81-x64"
-      ]
-    },
-    "win10-arm": {
-      "#import": [
-        "win10",
-        "win81-arm"
-      ]
-    },
-    "win10-arm64": {
-      "#import": [
-        "win10",
-        "win-arm64"
+        "base"
       ]
     },
     "aot": {
@@ -160,391 +42,16 @@
         "any"
       ]
     },
-    "win-aot": {
-      "#import": [
-        "win",
-        "aot"
-      ]
-    },
-    "win-x86-aot": {
-      "#import": [
-        "win-aot",
-        "win-x86"
-      ]
-    },
-    "win-x64-aot": {
-      "#import": [
-        "win-aot",
-        "win-x64"
-      ]
-    },
-    "win7-aot": {
-      "#import": [
-        "win-aot",
-        "win7"
-      ]
-    },
-    "win7-x86-aot": {
-      "#import": [
-        "win7-aot",
-        "win7-x86"
-      ]
-    },
-    "win7-x64-aot": {
-      "#import": [
-        "win7-aot",
-        "win7-x64"
-      ]
-    },
-    "win8-aot": {
-      "#import": [
-        "win8",
-        "win7-aot"
-      ]
-    },
-    "win8-x86-aot": {
-      "#import": [
-        "win8-aot",
-        "win8-x86",
-        "win7-x86-aot"
-      ]
-    },
-    "win8-x64-aot": {
-      "#import": [
-        "win8-aot",
-        "win8-x64",
-        "win7-x64-aot"
-      ]
-    },
-    "win8-arm-aot": {
-      "#import": [
-        "win8-aot",
-        "win8-arm"
-      ]
-    },
-    "win81-aot": {
-      "#import": [
-        "win81",
-        "win8-aot"
-      ]
-    },
-    "win81-x86-aot": {
-      "#import": [
-        "win81-aot",
-        "win81-x86",
-        "win8-x86-aot"
-      ]
-    },
-    "win81-x64-aot": {
-      "#import": [
-        "win81-aot",
-        "win81-x64",
-        "win8-x64-aot"
-      ]
-    },
-    "win81-arm-aot": {
-      "#import": [
-        "win81-aot",
-        "win81-arm",
-        "win8-arm-aot"
-      ]
-    },
-    "win10-aot": {
-      "#import": [
-        "win10",
-        "win81-aot"
-      ]
-    },
-    "win10-x86-aot": {
-      "#import": [
-        "win10-aot",
-        "win10-x86",
-        "win81-x86-aot"
-      ]
-    },
-    "win10-x64-aot": {
-      "#import": [
-        "win10-aot",
-        "win10-x64",
-        "win81-x64-aot"
-      ]
-    },
-    "win10-arm-aot": {
-      "#import": [
-        "win10-aot",
-        "win10-arm",
-        "win81-arm-aot"
-      ]
-    },
-    "win10-arm64-aot": {
-      "#import": [
-        "win10-aot",
-        "win10-arm64"
-      ]
-    },
-    "unix": {
-      "#import": [
-        "any"
-      ]
-    },
-    "unix-x64": {
-      "#import": [
-        "unix"
-      ]
-    },
-    "unix-x86": {
-      "#import": [
-        "unix"
-      ]
-    },
-    "unix-arm": {
-      "#import": [
-        "unix"
-      ]
-    },
-    "unix-armel": {
-      "#import": [
-        "unix"
-      ]
-    },
-    "unix-arm64": {
-      "#import": [
-        "unix"
-      ]
-    },
-    "osx": {
-      "#import": [
-        "unix"
-      ]
-    },
-    "osx-x64": {
-      "#import": [
-        "osx",
-        "unix-x64"
-      ]
-    },
-    "osx.10.10": {
-      "#import": [
-        "osx"
-      ]
-    },
-    "osx.10.10-x64": {
-      "#import": [
-        "osx.10.10",
-        "osx-x64"
-      ]
-    },
-    "osx.10.11": {
-      "#import": [
-        "osx.10.10"
-      ]
-    },
-    "osx.10.11-x64": {
-      "#import": [
-        "osx.10.11",
-        "osx.10.10-x64"
-      ]
-    },
-    "osx.10.12": {
-      "#import": [
-        "osx.10.11"
-      ]
-    },
-    "osx.10.12-x64": {
-      "#import": [
-        "osx.10.12",
-        "osx.10.11-x64"
-      ]
-    },
-    "linux": {
-      "#import": [
-        "unix"
-      ]
-    },
-    "linux-x64": {
-      "#import": [
-        "linux",
-        "unix-x64"
-      ]
-    },
-    "linux-x86": {
-      "#import": [
-        "linux",
-        "unix-x86"
-      ]
-    },
-    "linux-arm": {
-      "#import": [
-        "linux",
-        "unix-arm"
-      ]
-    },
-    "linux-armel": {
-      "#import": [
-        "linux",
-        "unix-armel"
-      ]
-    },
-    "linux-arm64": {
-      "#import": [
-        "linux",
-        "unix-arm64"
-      ]
-    },
-    "rhel": {
-      "#import": [
-        "linux"
-      ]
-    },
-    "rhel-x64": {
-      "#import": [
-        "rhel",
-        "linux-x64"
-      ]
-    },
-    "rhel.6": {
-      "#import": [
-        "rhel"
-      ]
-    },
-    "rhel.6-x64": {
-      "#import": [
-        "rhel.6",
-        "rhel-x64"
-      ]
-    },
-    "rhel.7": {
-      "#import": [
-        "rhel"
-      ]
-    },
-    "rhel.7-x64": {
-      "#import": [
-        "rhel.7",
-        "rhel-x64"
-      ]
-    },
-    "rhel.7.0": {
-      "#import": [
-        "rhel.7"
-      ]
-    },
-    "rhel.7.0-x64": {
-      "#import": [
-        "rhel.7.0",
-        "rhel.7-x64"
-      ]
-    },
-    "rhel.7.1": {
-      "#import": [
-        "rhel.7.0"
-      ]
-    },
-    "rhel.7.1-x64": {
-      "#import": [
-        "rhel.7.1",
-        "rhel.7.0-x64"
-      ]
-    },
-    "rhel.7.2": {
-      "#import": [
-        "rhel.7.1"
-      ]
-    },
-    "rhel.7.2-x64": {
-      "#import": [
-        "rhel.7.2",
-        "rhel.7.1-x64"
-      ]
-    },
-    "rhel.7.3": {
-      "#import": [
-        "rhel.7.2"
-      ]
-    },
-    "rhel.7.3-x64": {
-      "#import": [
-        "rhel.7.3",
-        "rhel.7.2-x64"
-      ]
-    },
-    "rhel.7.4": {
-      "#import": [
-        "rhel.7.3"
-      ]
-    },
-    "rhel.7.4-x64": {
-      "#import": [
-        "rhel.7.4",
-        "rhel.7.3-x64"
-      ]
-    },
-    "ol": {
-      "#import": [
-        "rhel"
-      ]
-    },
-    "ol-x64": {
-      "#import": [
-        "ol",
-        "rhel-x64"
-      ]
-    },
-    "ol.7": {
-      "#import": [
-        "ol",
-        "rhel.7"
-      ]
-    },
-    "ol.7-x64": {
-      "#import": [
-        "ol.7",
-        "ol-x64",
-        "rhel.7-x64"
-      ]
-    },
-    "ol.7.0": {
-      "#import": [
-        "ol.7",
-        "rhel.7.0"
-      ]
-    },
-    "ol.7.0-x64": {
-      "#import": [
-        "ol.7.0",
-        "ol.7-x64",
-        "rhel.7.0-x64"
-      ]
-    },
-    "ol.7.1": {
-      "#import": [
-        "ol.7.0",
-        "rhel.7.1"
-      ]
-    },
-    "ol.7.1-x64": {
-      "#import": [
-        "ol.7.1",
-        "ol.7.0-x64",
-        "rhel.7.1-x64"
-      ]
-    },
-    "ol.7.2": {
-      "#import": [
-        "ol.7.1",
-        "rhel.7.2"
-      ]
-    },
-    "ol.7.2-x64": {
-      "#import": [
-        "ol.7.2",
-        "ol.7.1-x64",
-        "rhel.7.2-x64"
-      ]
-    },
+    "base": {},
     "centos": {
       "#import": [
         "rhel"
+      ]
+    },
+    "centos-corert": {
+      "#import": [
+        "rel-corert",
+        "centos"
       ]
     },
     "centos-x64": {
@@ -553,10 +60,23 @@
         "rhel-x64"
       ]
     },
+    "centos-x64-corert": {
+      "#import": [
+        "centos-corert",
+        "rhel-x64-corert",
+        "centos-x64"
+      ]
+    },
     "centos.7": {
       "#import": [
         "centos",
         "rhel.7"
+      ]
+    },
+    "centos.7-corert": {
+      "#import": [
+        "centos-corert",
+        "centos.7"
       ]
     },
     "centos.7-x64": {
@@ -566,21 +86,21 @@
         "rhel.7-x64"
       ]
     },
+    "centos.7-x64-corert": {
+      "#import": [
+        "centos.7-corert",
+        "centos-x64-corert",
+        "centos.7-x64"
+      ]
+    },
+    "corert": {
+      "#import": [
+        "any"
+      ]
+    },
     "debian": {
       "#import": [
         "linux"
-      ]
-    },
-    "debian-x64": {
-      "#import": [
-        "debian",
-        "linux-x64"
-      ]
-    },
-    "debian-x86": {
-      "#import": [
-        "debian",
-        "linux-x86"
       ]
     },
     "debian-arm": {
@@ -589,10 +109,10 @@
         "linux-arm"
       ]
     },
-    "debian-armel": {
+    "debian-arm-corert": {
       "#import": [
-        "debian",
-        "linux-armel"
+        "debian-corert",
+        "debian-arm"
       ]
     },
     "debian-arm64": {
@@ -601,21 +121,46 @@
         "linux-arm64"
       ]
     },
-    "debian.8": {
+    "debian-arm64-corert": {
       "#import": [
+        "debian-corert",
+        "debian-arm64"
+      ]
+    },
+    "debian-armel": {
+      "#import": [
+        "debian",
+        "linux-armel"
+      ]
+    },
+    "debian-corert": {
+      "#import": [
+        "linux-corert",
         "debian"
       ]
     },
-    "debian.8-x64": {
+    "debian-x64": {
       "#import": [
-        "debian.8",
+        "debian",
+        "linux-x64"
+      ]
+    },
+    "debian-x64-corert": {
+      "#import": [
+        "debian-corert",
+        "linux-x64-corert",
         "debian-x64"
       ]
     },
-    "debian.8-x86": {
+    "debian-x86": {
       "#import": [
-        "debian.8",
-        "debian-x86"
+        "debian",
+        "linux-x86"
+      ]
+    },
+    "debian.8": {
+      "#import": [
+        "debian"
       ]
     },
     "debian.8-arm": {
@@ -624,10 +169,11 @@
         "debian-arm"
       ]
     },
-    "debian.8-armel": {
+    "debian.8-arm-corert": {
       "#import": [
-        "debian.8",
-        "debian-armel"
+        "debian.8-corert",
+        "debian-arm-corert",
+        "debian.8-arm"
       ]
     },
     "debian.8-arm64": {
@@ -636,271 +182,53 @@
         "debian-arm64"
       ]
     },
-    "tizen": {
+    "debian.8-arm64-corert": {
       "#import": [
-        "linux"
+        "debian.8-corert",
+        "debian-arm64-corert",
+        "debian.8-arm64"
       ]
     },
-    "tizen-armel": {
+    "debian.8-armel": {
       "#import": [
-        "tizen",
-        "linux-armel"
+        "debian.8",
+        "debian-armel"
       ]
     },
-    "tizen.4.0.0-armel": {
+    "debian.8-corert": {
       "#import": [
-        "tizen.4.0.0",
-        "tizen-armel"
+        "debian-corert",
+        "debian.8"
       ]
     },
-    "ubuntu": {
+    "debian.8-x64": {
       "#import": [
-        "debian"
-      ]
-    },
-    "ubuntu-x64": {
-      "#import": [
-        "ubuntu",
+        "debian.8",
         "debian-x64"
       ]
     },
-    "ubuntu-x86": {
+    "debian.8-x64-corert": {
       "#import": [
-        "ubuntu",
+        "debian.8-corert",
+        "debian-x64-corert",
+        "debian.8-x64"
+      ]
+    },
+    "debian.8-x86": {
+      "#import": [
+        "debian.8",
         "debian-x86"
-      ]
-    },
-    "ubuntu-arm": {
-      "#import": [
-        "ubuntu",
-        "debian-arm"
-      ]
-    },
-    "ubuntu-arm64": {
-      "#import": [
-        "ubuntu",
-        "debian-arm64"
-      ]
-    },
-    "ubuntu.14.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.14.04-x64": {
-      "#import": [
-        "ubuntu.14.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.14.04-x86": {
-      "#import": [
-        "ubuntu.14.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.14.04-arm": {
-      "#import": [
-        "ubuntu.14.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.14.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.14.10-x64": {
-      "#import": [
-        "ubuntu.14.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.14.10-x86": {
-      "#import": [
-        "ubuntu.14.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.14.10-arm": {
-      "#import": [
-        "ubuntu.14.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.15.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.15.04-x64": {
-      "#import": [
-        "ubuntu.15.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.15.04-x86": {
-      "#import": [
-        "ubuntu.15.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.15.04-arm": {
-      "#import": [
-        "ubuntu.15.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.15.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.15.10-x64": {
-      "#import": [
-        "ubuntu.15.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.15.10-x86": {
-      "#import": [
-        "ubuntu.15.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.15.10-arm": {
-      "#import": [
-        "ubuntu.15.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.16.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.16.04-x64": {
-      "#import": [
-        "ubuntu.16.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.16.04-x86": {
-      "#import": [
-        "ubuntu.16.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.16.04-arm": {
-      "#import": [
-        "ubuntu.16.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.16.04-arm64": {
-      "#import": [
-        "ubuntu.16.04",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.16.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.16.10-x64": {
-      "#import": [
-        "ubuntu.16.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.16.10-x86": {
-      "#import": [
-        "ubuntu.16.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.16.10-arm": {
-      "#import": [
-        "ubuntu.16.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.16.10-arm64": {
-      "#import": [
-        "ubuntu.16.10",
-        "ubuntu-arm64"
-      ]
-    },
-    "linuxmint.17": {
-      "#import": [
-        "ubuntu.14.04"
-      ]
-    },
-    "linuxmint.17-x64": {
-      "#import": [
-        "linuxmint.17",
-        "ubuntu.14.04-x64"
-      ]
-    },
-    "linuxmint.17.1": {
-      "#import": [
-        "linuxmint.17"
-      ]
-    },
-    "linuxmint.17.1-x64": {
-      "#import": [
-        "linuxmint.17.1",
-        "linuxmint.17-x64"
-      ]
-    },
-    "linuxmint.17.2": {
-      "#import": [
-        "linuxmint.17.1"
-      ]
-    },
-    "linuxmint.17.2-x64": {
-      "#import": [
-        "linuxmint.17.2",
-        "linuxmint.17.1-x64"
-      ]
-    },
-    "linuxmint.17.3": {
-      "#import": [
-        "linuxmint.17.2"
-      ]
-    },
-    "linuxmint.17.3-x64": {
-      "#import": [
-        "linuxmint.17.3",
-        "linuxmint.17.2-x64"
-      ]
-    },
-    "linuxmint.18": {
-      "#import": [
-        "ubuntu.16.04"
-      ]
-    },
-    "linuxmint.18-x64": {
-      "#import": [
-        "linuxmint.18",
-        "ubuntu.16.04-x64"
-      ]
-    },
-    "linuxmint.18.1": {
-      "#import": [
-        "linuxmint.18"
-      ]
-    },
-    "linuxmint.18.1-x64": {
-      "#import": [
-        "linuxmint.18.1",
-        "linuxmint.18-x64"
       ]
     },
     "fedora": {
       "#import": [
         "linux"
+      ]
+    },
+    "fedora-corert": {
+      "#import": [
+        "linux-corert",
+        "fedora"
       ]
     },
     "fedora-x64": {
@@ -909,9 +237,22 @@
         "linux-x64"
       ]
     },
+    "fedora-x64-corert": {
+      "#import": [
+        "fedora-corert",
+        "linux-x64-corert",
+        "fedora-x64"
+      ]
+    },
     "fedora.23": {
       "#import": [
         "fedora"
+      ]
+    },
+    "fedora.23-corert": {
+      "#import": [
+        "fedora-corert",
+        "fedora.23"
       ]
     },
     "fedora.23-x64": {
@@ -920,15 +261,35 @@
         "fedora-x64"
       ]
     },
+    "fedora.23-x64-corert": {
+      "#import": [
+        "fedora.23-corert",
+        "fedora-x64-corert",
+        "fedora.23-x64"
+      ]
+    },
     "fedora.24": {
       "#import": [
         "fedora"
+      ]
+    },
+    "fedora.24-corert": {
+      "#import": [
+        "fedora.23-corert",
+        "fedora.24"
       ]
     },
     "fedora.24-x64": {
       "#import": [
         "fedora.24",
         "fedora-x64"
+      ]
+    },
+    "fedora.24-x64-corert": {
+      "#import": [
+        "fedora.24-corert",
+        "fedora.23-x64-corert",
+        "fedora.24-x64"
       ]
     },
     "fedora.25": {
@@ -953,240 +314,39 @@
         "fedora-x64"
       ]
     },
-    "opensuse": {
+    "linux": {
       "#import": [
-        "linux"
-      ]
-    },
-    "opensuse-x64": {
-      "#import": [
-        "opensuse",
-        "linux-x64"
-      ]
-    },
-    "opensuse.13.2": {
-      "#import": [
-        "opensuse"
-      ]
-    },
-    "opensuse.13.2-x64": {
-      "#import": [
-        "opensuse.13.2",
-        "opensuse-x64"
-      ]
-    },
-    "opensuse.42.1": {
-      "#import": [
-        "opensuse"
-      ]
-    },
-    "opensuse.42.1-x64": {
-      "#import": [
-        "opensuse.42.1",
-        "opensuse-x64"
-      ]
-    },
-    "corert": {
-      "#import": [
-        "any"
-      ]
-    },
-    "win-corert": {
-      "#import": [
-        "corert",
-        "win"
-      ]
-    },
-    "win-x86-corert": {
-      "#import": [
-        "win-corert",
-        "win-x86"
-      ]
-    },
-    "win-x64-corert": {
-      "#import": [
-        "win-corert",
-        "win-x64"
-      ]
-    },
-    "win7-corert": {
-      "#import": [
-        "win-corert",
-        "win7"
-      ]
-    },
-    "win7-x86-corert": {
-      "#import": [
-        "win7-corert",
-        "win7-x86"
-      ]
-    },
-    "win7-x64-corert": {
-      "#import": [
-        "win7-corert",
-        "win7-x64"
-      ]
-    },
-    "win8-corert": {
-      "#import": [
-        "win7-corert",
-        "win8"
-      ]
-    },
-    "win8-x86-corert": {
-      "#import": [
-        "win8-corert",
-        "win7-x86-corert",
-        "win8-x86"
-      ]
-    },
-    "win8-x64-corert": {
-      "#import": [
-        "win8-corert",
-        "win7-x64-corert",
-        "win8-x64"
-      ]
-    },
-    "win8-arm-corert": {
-      "#import": [
-        "win8-corert",
-        "win8-arm"
-      ]
-    },
-    "win81-corert": {
-      "#import": [
-        "win8-corert",
-        "win81"
-      ]
-    },
-    "win81-x86-corert": {
-      "#import": [
-        "win81-corert",
-        "win8-x86-corert",
-        "win81-x86"
-      ]
-    },
-    "win81-x64-corert": {
-      "#import": [
-        "win81-corert",
-        "win8-x64-corert",
-        "win81-x64"
-      ]
-    },
-    "win81-arm-corert": {
-      "#import": [
-        "win81-corert",
-        "win8-arm-corert",
-        "win81-arm"
-      ]
-    },
-    "win10-corert": {
-      "#import": [
-        "win81-corert",
-        "win10"
-      ]
-    },
-    "win10-x86-corert": {
-      "#import": [
-        "win10-corert",
-        "win81-x86-corert",
-        "win10-x86"
-      ]
-    },
-    "win10-x64-corert": {
-      "#import": [
-        "win10-corert",
-        "win81-x64-corert",
-        "win10-x64"
-      ]
-    },
-    "win10-arm-corert": {
-      "#import": [
-        "win10-corert",
-        "win81-arm-corert",
-        "win10-arm"
-      ]
-    },
-    "win10-arm64-corert": {
-      "#import": [
-        "win10-corert",
-        "win10-arm64"
-      ]
-    },
-    "unix-corert": {
-      "#import": [
-        "corert",
         "unix"
       ]
     },
-    "unix-x64-corert": {
+    "linux-arm": {
       "#import": [
-        "unix-corert",
-        "unix-x64"
-      ]
-    },
-    "unix-arm-corert": {
-      "#import": [
-        "unix-corert",
+        "linux",
         "unix-arm"
       ]
     },
-    "unix-arm64-corert": {
+    "linux-arm-corert": {
       "#import": [
-        "unix-corert",
+        "linux-corert",
+        "linux-arm"
+      ]
+    },
+    "linux-arm64": {
+      "#import": [
+        "linux",
         "unix-arm64"
       ]
     },
-    "osx-corert": {
+    "linux-arm64-corert": {
       "#import": [
-        "unix-corert",
-        "osx"
+        "linux-corert",
+        "linux-arm64"
       ]
     },
-    "osx-x64-corert": {
+    "linux-armel": {
       "#import": [
-        "osx-corert",
-        "unix-x64-corert",
-        "osx-x64"
-      ]
-    },
-    "osx.10.10-corert": {
-      "#import": [
-        "osx-corert",
-        "osx.10.10"
-      ]
-    },
-    "osx.10.10-x64-corert": {
-      "#import": [
-        "osx.10.10-corert",
-        "osx-x64-corert",
-        "osx.10.10-x64"
-      ]
-    },
-    "osx.10.11-corert": {
-      "#import": [
-        "osx.10.10-corert",
-        "osx.10.11"
-      ]
-    },
-    "osx.10.11-x64-corert": {
-      "#import": [
-        "osx.10.11-corert",
-        "osx.10.10-x64-corert",
-        "osx.10.11-x64"
-      ]
-    },
-    "osx.10.12-corert": {
-      "#import": [
-        "osx.10.11-corert",
-        "osx.10.12"
-      ]
-    },
-    "osx.10.12-x64-corert": {
-      "#import": [
-        "osx.10.12-corert",
-        "osx.10.11-x64-corert",
-        "osx.10.12-x64"
+        "linux",
+        "unix-armel"
       ]
     },
     "linux-corert": {
@@ -1196,314 +356,39 @@
         "unix-corert"
       ]
     },
+    "linux-x64": {
+      "#import": [
+        "linux",
+        "unix-x64"
+      ]
+    },
     "linux-x64-corert": {
       "#import": [
         "linux-corert",
         "linux-x64"
       ]
     },
-    "linux-arm-corert": {
+    "linux-x86": {
       "#import": [
-        "linux-corert",
-        "linux-arm"
+        "linux",
+        "unix-x86"
       ]
     },
-    "linux-arm64-corert": {
+    "linuxmint.17": {
       "#import": [
-        "linux-corert",
-        "linux-arm64"
-      ]
-    },
-    "rhel-corert": {
-      "#import": [
-        "corert",
-        "rhel"
-      ]
-    },
-    "rhel-x64-corert": {
-      "#import": [
-        "rhel-corert",
-        "linux-x64-corert",
-        "rhel-x64"
-      ]
-    },
-    "rhel.7-corert": {
-      "#import": [
-        "rhel-corert",
-        "rhel.7"
-      ]
-    },
-    "rhel.7-x64-corert": {
-      "#import": [
-        "rhel.7-corert",
-        "rhel-x64-corert",
-        "rhel.7-x64"
-      ]
-    },
-    "rhel.7.0-corert": {
-      "#import": [
-        "rhel.7-corert",
-        "rhel.7.0"
-      ]
-    },
-    "rhel.7.0-x64-corert": {
-      "#import": [
-        "rhel.7.0-corert",
-        "rhel.7-x64-corert",
-        "rhel.7.0-x64"
-      ]
-    },
-    "rhel.7.1-corert": {
-      "#import": [
-        "rhel.7.0-corert",
-        "rhel.7.1"
-      ]
-    },
-    "rhel.7.1-x64-corert": {
-      "#import": [
-        "rhel.7.1-corert",
-        "rhel.7.0-x64-corert",
-        "rhel.7.1-x64"
-      ]
-    },
-    "rhel.7.2-corert": {
-      "#import": [
-        "rhel.7.1-corert",
-        "rhel.7.2"
-      ]
-    },
-    "rhel.7.2-x64-corert": {
-      "#import": [
-        "rhel.7.2-corert",
-        "rhel.7.1-x64-corert",
-        "rhel.7.2-x64"
-      ]
-    },
-    "ol-corert": {
-      "#import": [
-        "rhel-corert",
-        "ol"
-      ]
-    },
-    "ol-x64-corert": {
-      "#import": [
-        "ol-corert",
-        "rhel-x64-corert",
-        "ol-x64"
-      ]
-    },
-    "ol.7-corert": {
-      "#import": [
-        "ol-corert",
-        "ol.7"
-      ]
-    },
-    "ol.7-x64-corert": {
-      "#import": [
-        "ol.7-corert",
-        "rhel.7-x64-corert",
-        "ol.7-x64"
-      ]
-    },
-    "ol.7.0-corert": {
-      "#import": [
-        "ol.7-corert",
-        "ol.7.0"
-      ]
-    },
-    "ol.7.0-x64-corert": {
-      "#import": [
-        "ol.7.0-corert",
-        "rhel.7.0-corert",
-        "ol.7.0-x64"
-      ]
-    },
-    "ol.7.1-corert": {
-      "#import": [
-        "ol.7.0-corert",
-        "ol.7.1"
-      ]
-    },
-    "ol.7.1-x64-corert": {
-      "#import": [
-        "ol.7.1-corert",
-        "rhel.7.1-x64-corert",
-        "ol.7.1-x64"
-      ]
-    },
-    "centos-corert": {
-      "#import": [
-        "rel-corert",
-        "centos"
-      ]
-    },
-    "centos-x64-corert": {
-      "#import": [
-        "centos-corert",
-        "rhel-x64-corert",
-        "centos-x64"
-      ]
-    },
-    "centos.7-corert": {
-      "#import": [
-        "centos-corert",
-        "centos.7"
-      ]
-    },
-    "centos.7-x64-corert": {
-      "#import": [
-        "centos.7-corert",
-        "centos-x64-corert",
-        "centos.7-x64"
-      ]
-    },
-    "debian-corert": {
-      "#import": [
-        "linux-corert",
-        "debian"
-      ]
-    },
-    "debian-x64-corert": {
-      "#import": [
-        "debian-corert",
-        "linux-x64-corert",
-        "debian-x64"
-      ]
-    },
-    "debian-arm-corert": {
-      "#import": [
-        "debian-corert",
-        "debian-arm"
-      ]
-    },
-    "debian-arm64-corert": {
-      "#import": [
-        "debian-corert",
-        "debian-arm64"
-      ]
-    },
-    "debian.8-corert": {
-      "#import": [
-        "debian-corert",
-        "debian.8"
-      ]
-    },
-    "debian.8-x64-corert": {
-      "#import": [
-        "debian.8-corert",
-        "debian-x64-corert",
-        "debian.8-x64"
-      ]
-    },
-    "debian.8-arm-corert": {
-      "#import": [
-        "debian.8-corert",
-        "debian-arm-corert",
-        "debian.8-arm"
-      ]
-    },
-    "debian.8-arm64-corert": {
-      "#import": [
-        "debian.8-corert",
-        "debian-arm64-corert",
-        "debian.8-arm64"
-      ]
-    },
-    "ubuntu-corert": {
-      "#import": [
-        "debian-corert",
-        "ubuntu"
-      ]
-    },
-    "ubuntu-x64-corert": {
-      "#import": [
-        "ubuntu-corert",
-        "debian-x64-corert",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.14.04-corert": {
-      "#import": [
-        "ubuntu-corert",
-        "ubuntu.14.06"
-      ]
-    },
-    "ubuntu.14.04-x64-corert": {
-      "#import": [
-        "ubuntu.14.04-corert",
-        "ubuntu-x64-corert",
-        "ubuntu-14.04-x64"
-      ]
-    },
-    "ubuntu.14.10-corert": {
-      "#import": [
-        "ubuntu.14.04-corert",
-        "ubuntu-14.10"
-      ]
-    },
-    "ubuntu.14.10-x64-corert": {
-      "#import": [
-        "ubuntu.14.10-corert",
-        "ubuntu.14.04-x64-corert",
-        "ubuntu.14.10-x64"
-      ]
-    },
-    "ubuntu.15.04-corert": {
-      "#import": [
-        "ubuntu.14.10-corert",
-        "ubuntu-15.04"
-      ]
-    },
-    "ubuntu.15.04-x64-corert": {
-      "#import": [
-        "ubuntu.15.04-corert",
-        "ubuntu.14.10-x64-corert",
-        "ubuntu.15.04-x64"
-      ]
-    },
-    "ubuntu.15.10-corert": {
-      "#import": [
-        "ubuntu.15.04-corert",
-        "ubuntu-15.10"
-      ]
-    },
-    "ubuntu.15.10-x64-corert": {
-      "#import": [
-        "ubuntu.15.10-corert",
-        "ubuntu.15.04-x64-corert",
-        "ubuntu.15.10-x64"
-      ]
-    },
-    "ubuntu.16.04-corert": {
-      "#import": [
-        "ubuntu.15.10-corert",
-        "ubuntu-16.04"
-      ]
-    },
-    "ubuntu.16.04-x64-corert": {
-      "#import": [
-        "ubuntu.16.04-corert",
-        "ubuntu.15.10-x64-corert",
-        "ubuntu.16.04-x64"
-      ]
-    },
-    "ubuntu.16.10-corert": {
-      "#import": [
-        "ubuntu.16.04-corert",
-        "ubuntu.16.10"
-      ]
-    },
-    "ubuntu.16.10-x64-corert": {
-      "#import": [
-        "ubuntu.16.10-corert",
-        "ubuntu.16.04-x64-corert",
-        "ubuntu.16.10-x64"
+        "ubuntu.14.04"
       ]
     },
     "linuxmint.17-corert": {
       "#import": [
         "ubuntu.14.04-corert",
         "linuxmint.17"
+      ]
+    },
+    "linuxmint.17-x64": {
+      "#import": [
+        "linuxmint.17",
+        "ubuntu.14.04-x64"
       ]
     },
     "linuxmint.17-x64-corert": {
@@ -1513,10 +398,21 @@
         "linuxmint.17-x64"
       ]
     },
+    "linuxmint.17.1": {
+      "#import": [
+        "linuxmint.17"
+      ]
+    },
     "linuxmint.17.1-corert": {
       "#import": [
         "linuxmint.17-corert",
         "linuxmint.17.1"
+      ]
+    },
+    "linuxmint.17.1-x64": {
+      "#import": [
+        "linuxmint.17.1",
+        "linuxmint.17-x64"
       ]
     },
     "linuxmint.17.1-x64-corert": {
@@ -1526,10 +422,21 @@
         "linuxmint.17.1-x64"
       ]
     },
+    "linuxmint.17.2": {
+      "#import": [
+        "linuxmint.17.1"
+      ]
+    },
     "linuxmint.17.2-corert": {
       "#import": [
         "linuxmint.17.1-corert",
         "linuxmint.17.2"
+      ]
+    },
+    "linuxmint.17.2-x64": {
+      "#import": [
+        "linuxmint.17.2",
+        "linuxmint.17.1-x64"
       ]
     },
     "linuxmint.17.2-x64-corert": {
@@ -1539,10 +446,21 @@
         "linuxmint.17.2-x64"
       ]
     },
+    "linuxmint.17.3": {
+      "#import": [
+        "linuxmint.17.2"
+      ]
+    },
     "linuxmint.17.3-corert": {
       "#import": [
         "linuxmint.17.2-corert",
         "linuxmint.17.3"
+      ]
+    },
+    "linuxmint.17.3-x64": {
+      "#import": [
+        "linuxmint.17.3",
+        "linuxmint.17.2-x64"
       ]
     },
     "linuxmint.17.3-x64-corert": {
@@ -1552,10 +470,21 @@
         "linuxmint.17.3-x64"
       ]
     },
+    "linuxmint.18": {
+      "#import": [
+        "ubuntu.16.04"
+      ]
+    },
     "linuxmint.18-corert": {
       "#import": [
         "ubuntu.16.04-corert",
         "linuxmint.18"
+      ]
+    },
+    "linuxmint.18-x64": {
+      "#import": [
+        "linuxmint.18",
+        "ubuntu.16.04-x64"
       ]
     },
     "linuxmint.18-x64-corert": {
@@ -1565,49 +494,147 @@
         "linuxmint.18-x64"
       ]
     },
-    "fedora-corert": {
+    "linuxmint.18.1": {
       "#import": [
-        "linux-corert",
-        "fedora"
+        "linuxmint.18"
       ]
     },
-    "fedora-x64-corert": {
+    "linuxmint.18.1-x64": {
       "#import": [
-        "fedora-corert",
-        "linux-x64-corert",
-        "fedora-x64"
+        "linuxmint.18.1",
+        "linuxmint.18-x64"
       ]
     },
-    "fedora.23-corert": {
+    "ol": {
       "#import": [
-        "fedora-corert",
-        "fedora.23"
+        "rhel"
       ]
     },
-    "fedora.23-x64-corert": {
+    "ol-corert": {
       "#import": [
-        "fedora.23-corert",
-        "fedora-x64-corert",
-        "fedora.23-x64"
+        "rhel-corert",
+        "ol"
       ]
     },
-    "fedora.24-corert": {
+    "ol-x64": {
       "#import": [
-        "fedora.23-corert",
-        "fedora.24"
+        "ol",
+        "rhel-x64"
       ]
     },
-    "fedora.24-x64-corert": {
+    "ol-x64-corert": {
       "#import": [
-        "fedora.24-corert",
-        "fedora.23-x64-corert",
-        "fedora.24-x64"
+        "ol-corert",
+        "rhel-x64-corert",
+        "ol-x64"
+      ]
+    },
+    "ol.7": {
+      "#import": [
+        "ol",
+        "rhel.7"
+      ]
+    },
+    "ol.7-corert": {
+      "#import": [
+        "ol-corert",
+        "ol.7"
+      ]
+    },
+    "ol.7-x64": {
+      "#import": [
+        "ol.7",
+        "ol-x64",
+        "rhel.7-x64"
+      ]
+    },
+    "ol.7-x64-corert": {
+      "#import": [
+        "ol.7-corert",
+        "rhel.7-x64-corert",
+        "ol.7-x64"
+      ]
+    },
+    "ol.7.0": {
+      "#import": [
+        "ol.7",
+        "rhel.7.0"
+      ]
+    },
+    "ol.7.0-corert": {
+      "#import": [
+        "ol.7-corert",
+        "ol.7.0"
+      ]
+    },
+    "ol.7.0-x64": {
+      "#import": [
+        "ol.7.0",
+        "ol.7-x64",
+        "rhel.7.0-x64"
+      ]
+    },
+    "ol.7.0-x64-corert": {
+      "#import": [
+        "ol.7.0-corert",
+        "rhel.7.0-corert",
+        "ol.7.0-x64"
+      ]
+    },
+    "ol.7.1": {
+      "#import": [
+        "ol.7.0",
+        "rhel.7.1"
+      ]
+    },
+    "ol.7.1-corert": {
+      "#import": [
+        "ol.7.0-corert",
+        "ol.7.1"
+      ]
+    },
+    "ol.7.1-x64": {
+      "#import": [
+        "ol.7.1",
+        "ol.7.0-x64",
+        "rhel.7.1-x64"
+      ]
+    },
+    "ol.7.1-x64-corert": {
+      "#import": [
+        "ol.7.1-corert",
+        "rhel.7.1-x64-corert",
+        "ol.7.1-x64"
+      ]
+    },
+    "ol.7.2": {
+      "#import": [
+        "ol.7.1",
+        "rhel.7.2"
+      ]
+    },
+    "ol.7.2-x64": {
+      "#import": [
+        "ol.7.2",
+        "ol.7.1-x64",
+        "rhel.7.2-x64"
+      ]
+    },
+    "opensuse": {
+      "#import": [
+        "linux"
       ]
     },
     "opensuse-corert": {
       "#import": [
         "linux-corert",
         "opensuse"
+      ]
+    },
+    "opensuse-x64": {
+      "#import": [
+        "opensuse",
+        "linux-x64"
       ]
     },
     "opensuse-x64-corert": {
@@ -1617,10 +644,21 @@
         "opensuste-x64"
       ]
     },
+    "opensuse.13.2": {
+      "#import": [
+        "opensuse"
+      ]
+    },
     "opensuse.13.2-corert": {
       "#import": [
         "opensuse-corert",
         "opensuse.13.2"
+      ]
+    },
+    "opensuse.13.2-x64": {
+      "#import": [
+        "opensuse.13.2",
+        "opensuse-x64"
       ]
     },
     "opensuse.13.2-x64-corert": {
@@ -1630,10 +668,21 @@
         "opensuse.13.2-x64"
       ]
     },
+    "opensuse.42.1": {
+      "#import": [
+        "opensuse"
+      ]
+    },
     "opensuse.42.1-corert": {
       "#import": [
         "opensuse.13.2-corert",
         "opensuse.42.1"
+      ]
+    },
+    "opensuse.42.1-x64": {
+      "#import": [
+        "opensuse.42.1",
+        "opensuse-x64"
       ]
     },
     "opensuse.42.1-x64-corert": {
@@ -1641,6 +690,957 @@
         "opensuse.42.1-corert",
         "opensuse.13.2-x64-corert",
         "opensuse.42.1-x64"
+      ]
+    },
+    "osx": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "osx-corert": {
+      "#import": [
+        "unix-corert",
+        "osx"
+      ]
+    },
+    "osx-x64": {
+      "#import": [
+        "osx",
+        "unix-x64"
+      ]
+    },
+    "osx-x64-corert": {
+      "#import": [
+        "osx-corert",
+        "unix-x64-corert",
+        "osx-x64"
+      ]
+    },
+    "osx.10.10": {
+      "#import": [
+        "osx"
+      ]
+    },
+    "osx.10.10-corert": {
+      "#import": [
+        "osx-corert",
+        "osx.10.10"
+      ]
+    },
+    "osx.10.10-x64": {
+      "#import": [
+        "osx.10.10",
+        "osx-x64"
+      ]
+    },
+    "osx.10.10-x64-corert": {
+      "#import": [
+        "osx.10.10-corert",
+        "osx-x64-corert",
+        "osx.10.10-x64"
+      ]
+    },
+    "osx.10.11": {
+      "#import": [
+        "osx.10.10"
+      ]
+    },
+    "osx.10.11-corert": {
+      "#import": [
+        "osx.10.10-corert",
+        "osx.10.11"
+      ]
+    },
+    "osx.10.11-x64": {
+      "#import": [
+        "osx.10.11",
+        "osx.10.10-x64"
+      ]
+    },
+    "osx.10.11-x64-corert": {
+      "#import": [
+        "osx.10.11-corert",
+        "osx.10.10-x64-corert",
+        "osx.10.11-x64"
+      ]
+    },
+    "osx.10.12": {
+      "#import": [
+        "osx.10.11"
+      ]
+    },
+    "osx.10.12-corert": {
+      "#import": [
+        "osx.10.11-corert",
+        "osx.10.12"
+      ]
+    },
+    "osx.10.12-x64": {
+      "#import": [
+        "osx.10.12",
+        "osx.10.11-x64"
+      ]
+    },
+    "osx.10.12-x64-corert": {
+      "#import": [
+        "osx.10.12-corert",
+        "osx.10.11-x64-corert",
+        "osx.10.12-x64"
+      ]
+    },
+    "rhel": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "rhel-corert": {
+      "#import": [
+        "corert",
+        "rhel"
+      ]
+    },
+    "rhel-x64": {
+      "#import": [
+        "rhel",
+        "linux-x64"
+      ]
+    },
+    "rhel-x64-corert": {
+      "#import": [
+        "rhel-corert",
+        "linux-x64-corert",
+        "rhel-x64"
+      ]
+    },
+    "rhel.6": {
+      "#import": [
+        "rhel"
+      ]
+    },
+    "rhel.6-x64": {
+      "#import": [
+        "rhel.6",
+        "rhel-x64"
+      ]
+    },
+    "rhel.7": {
+      "#import": [
+        "rhel"
+      ]
+    },
+    "rhel.7-corert": {
+      "#import": [
+        "rhel-corert",
+        "rhel.7"
+      ]
+    },
+    "rhel.7-x64": {
+      "#import": [
+        "rhel.7",
+        "rhel-x64"
+      ]
+    },
+    "rhel.7-x64-corert": {
+      "#import": [
+        "rhel.7-corert",
+        "rhel-x64-corert",
+        "rhel.7-x64"
+      ]
+    },
+    "rhel.7.0": {
+      "#import": [
+        "rhel.7"
+      ]
+    },
+    "rhel.7.0-corert": {
+      "#import": [
+        "rhel.7-corert",
+        "rhel.7.0"
+      ]
+    },
+    "rhel.7.0-x64": {
+      "#import": [
+        "rhel.7.0",
+        "rhel.7-x64"
+      ]
+    },
+    "rhel.7.0-x64-corert": {
+      "#import": [
+        "rhel.7.0-corert",
+        "rhel.7-x64-corert",
+        "rhel.7.0-x64"
+      ]
+    },
+    "rhel.7.1": {
+      "#import": [
+        "rhel.7.0"
+      ]
+    },
+    "rhel.7.1-corert": {
+      "#import": [
+        "rhel.7.0-corert",
+        "rhel.7.1"
+      ]
+    },
+    "rhel.7.1-x64": {
+      "#import": [
+        "rhel.7.1",
+        "rhel.7.0-x64"
+      ]
+    },
+    "rhel.7.1-x64-corert": {
+      "#import": [
+        "rhel.7.1-corert",
+        "rhel.7.0-x64-corert",
+        "rhel.7.1-x64"
+      ]
+    },
+    "rhel.7.2": {
+      "#import": [
+        "rhel.7.1"
+      ]
+    },
+    "rhel.7.2-corert": {
+      "#import": [
+        "rhel.7.1-corert",
+        "rhel.7.2"
+      ]
+    },
+    "rhel.7.2-x64": {
+      "#import": [
+        "rhel.7.2",
+        "rhel.7.1-x64"
+      ]
+    },
+    "rhel.7.2-x64-corert": {
+      "#import": [
+        "rhel.7.2-corert",
+        "rhel.7.1-x64-corert",
+        "rhel.7.2-x64"
+      ]
+    },
+    "rhel.7.3": {
+      "#import": [
+        "rhel.7.2"
+      ]
+    },
+    "rhel.7.3-x64": {
+      "#import": [
+        "rhel.7.3",
+        "rhel.7.2-x64"
+      ]
+    },
+    "rhel.7.4": {
+      "#import": [
+        "rhel.7.3"
+      ]
+    },
+    "rhel.7.4-x64": {
+      "#import": [
+        "rhel.7.4",
+        "rhel.7.3-x64"
+      ]
+    },
+    "tizen": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "tizen-armel": {
+      "#import": [
+        "tizen",
+        "linux-armel"
+      ]
+    },
+    "tizen.4.0.0-armel": {
+      "#import": [
+        "tizen.4.0.0",
+        "tizen-armel"
+      ]
+    },
+    "ubuntu": {
+      "#import": [
+        "debian"
+      ]
+    },
+    "ubuntu-arm": {
+      "#import": [
+        "ubuntu",
+        "debian-arm"
+      ]
+    },
+    "ubuntu-arm64": {
+      "#import": [
+        "ubuntu",
+        "debian-arm64"
+      ]
+    },
+    "ubuntu-corert": {
+      "#import": [
+        "debian-corert",
+        "ubuntu"
+      ]
+    },
+    "ubuntu-x64": {
+      "#import": [
+        "ubuntu",
+        "debian-x64"
+      ]
+    },
+    "ubuntu-x64-corert": {
+      "#import": [
+        "ubuntu-corert",
+        "debian-x64-corert",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu-x86": {
+      "#import": [
+        "ubuntu",
+        "debian-x86"
+      ]
+    },
+    "ubuntu.14.04": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.14.04-arm": {
+      "#import": [
+        "ubuntu.14.04",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.14.04-corert": {
+      "#import": [
+        "ubuntu-corert",
+        "ubuntu.14.06"
+      ]
+    },
+    "ubuntu.14.04-x64": {
+      "#import": [
+        "ubuntu.14.04",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.14.04-x64-corert": {
+      "#import": [
+        "ubuntu.14.04-corert",
+        "ubuntu-x64-corert",
+        "ubuntu-14.04-x64"
+      ]
+    },
+    "ubuntu.14.04-x86": {
+      "#import": [
+        "ubuntu.14.04",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.14.10": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.14.10-arm": {
+      "#import": [
+        "ubuntu.14.10",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.14.10-corert": {
+      "#import": [
+        "ubuntu.14.04-corert",
+        "ubuntu-14.10"
+      ]
+    },
+    "ubuntu.14.10-x64": {
+      "#import": [
+        "ubuntu.14.10",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.14.10-x64-corert": {
+      "#import": [
+        "ubuntu.14.10-corert",
+        "ubuntu.14.04-x64-corert",
+        "ubuntu.14.10-x64"
+      ]
+    },
+    "ubuntu.14.10-x86": {
+      "#import": [
+        "ubuntu.14.10",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.15.04": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.15.04-arm": {
+      "#import": [
+        "ubuntu.15.04",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.15.04-corert": {
+      "#import": [
+        "ubuntu.14.10-corert",
+        "ubuntu-15.04"
+      ]
+    },
+    "ubuntu.15.04-x64": {
+      "#import": [
+        "ubuntu.15.04",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.15.04-x64-corert": {
+      "#import": [
+        "ubuntu.15.04-corert",
+        "ubuntu.14.10-x64-corert",
+        "ubuntu.15.04-x64"
+      ]
+    },
+    "ubuntu.15.04-x86": {
+      "#import": [
+        "ubuntu.15.04",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.15.10": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.15.10-arm": {
+      "#import": [
+        "ubuntu.15.10",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.15.10-corert": {
+      "#import": [
+        "ubuntu.15.04-corert",
+        "ubuntu-15.10"
+      ]
+    },
+    "ubuntu.15.10-x64": {
+      "#import": [
+        "ubuntu.15.10",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.15.10-x64-corert": {
+      "#import": [
+        "ubuntu.15.10-corert",
+        "ubuntu.15.04-x64-corert",
+        "ubuntu.15.10-x64"
+      ]
+    },
+    "ubuntu.15.10-x86": {
+      "#import": [
+        "ubuntu.15.10",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.16.04": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.16.04-arm": {
+      "#import": [
+        "ubuntu.16.04",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.16.04-arm64": {
+      "#import": [
+        "ubuntu.16.04",
+        "ubuntu-arm64"
+      ]
+    },
+    "ubuntu.16.04-corert": {
+      "#import": [
+        "ubuntu.15.10-corert",
+        "ubuntu-16.04"
+      ]
+    },
+    "ubuntu.16.04-x64": {
+      "#import": [
+        "ubuntu.16.04",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.16.04-x64-corert": {
+      "#import": [
+        "ubuntu.16.04-corert",
+        "ubuntu.15.10-x64-corert",
+        "ubuntu.16.04-x64"
+      ]
+    },
+    "ubuntu.16.04-x86": {
+      "#import": [
+        "ubuntu.16.04",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.16.10": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.16.10-arm": {
+      "#import": [
+        "ubuntu.16.10",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.16.10-arm64": {
+      "#import": [
+        "ubuntu.16.10",
+        "ubuntu-arm64"
+      ]
+    },
+    "ubuntu.16.10-corert": {
+      "#import": [
+        "ubuntu.16.04-corert",
+        "ubuntu.16.10"
+      ]
+    },
+    "ubuntu.16.10-x64": {
+      "#import": [
+        "ubuntu.16.10",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.16.10-x64-corert": {
+      "#import": [
+        "ubuntu.16.10-corert",
+        "ubuntu.16.04-x64-corert",
+        "ubuntu.16.10-x64"
+      ]
+    },
+    "ubuntu.16.10-x86": {
+      "#import": [
+        "ubuntu.16.10",
+        "ubuntu-x86"
+      ]
+    },
+    "unix": {
+      "#import": [
+        "any"
+      ]
+    },
+    "unix-arm": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-arm-corert": {
+      "#import": [
+        "unix-corert",
+        "unix-arm"
+      ]
+    },
+    "unix-arm64": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-arm64-corert": {
+      "#import": [
+        "unix-corert",
+        "unix-arm64"
+      ]
+    },
+    "unix-armel": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-corert": {
+      "#import": [
+        "corert",
+        "unix"
+      ]
+    },
+    "unix-x64": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-x64-corert": {
+      "#import": [
+        "unix-corert",
+        "unix-x64"
+      ]
+    },
+    "unix-x86": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "win": {
+      "#import": [
+        "any"
+      ]
+    },
+    "win-aot": {
+      "#import": [
+        "win",
+        "aot"
+      ]
+    },
+    "win-arm": {
+      "#import": [
+        "win"
+      ]
+    },
+    "win-arm64": {
+      "#import": [
+        "win"
+      ]
+    },
+    "win-corert": {
+      "#import": [
+        "corert",
+        "win"
+      ]
+    },
+    "win-x64": {
+      "#import": [
+        "win"
+      ]
+    },
+    "win-x64-aot": {
+      "#import": [
+        "win-aot",
+        "win-x64"
+      ]
+    },
+    "win-x64-corert": {
+      "#import": [
+        "win-corert",
+        "win-x64"
+      ]
+    },
+    "win-x86": {
+      "#import": [
+        "win"
+      ]
+    },
+    "win-x86-aot": {
+      "#import": [
+        "win-aot",
+        "win-x86"
+      ]
+    },
+    "win-x86-corert": {
+      "#import": [
+        "win-corert",
+        "win-x86"
+      ]
+    },
+    "win10": {
+      "#import": [
+        "win81"
+      ]
+    },
+    "win10-aot": {
+      "#import": [
+        "win10",
+        "win81-aot"
+      ]
+    },
+    "win10-arm": {
+      "#import": [
+        "win10",
+        "win81-arm"
+      ]
+    },
+    "win10-arm-aot": {
+      "#import": [
+        "win10-aot",
+        "win10-arm",
+        "win81-arm-aot"
+      ]
+    },
+    "win10-arm-corert": {
+      "#import": [
+        "win10-corert",
+        "win81-arm-corert",
+        "win10-arm"
+      ]
+    },
+    "win10-arm64": {
+      "#import": [
+        "win10",
+        "win-arm64"
+      ]
+    },
+    "win10-arm64-aot": {
+      "#import": [
+        "win10-aot",
+        "win10-arm64"
+      ]
+    },
+    "win10-arm64-corert": {
+      "#import": [
+        "win10-corert",
+        "win10-arm64"
+      ]
+    },
+    "win10-corert": {
+      "#import": [
+        "win81-corert",
+        "win10"
+      ]
+    },
+    "win10-x64": {
+      "#import": [
+        "win10",
+        "win81-x64"
+      ]
+    },
+    "win10-x64-aot": {
+      "#import": [
+        "win10-aot",
+        "win10-x64",
+        "win81-x64-aot"
+      ]
+    },
+    "win10-x64-corert": {
+      "#import": [
+        "win10-corert",
+        "win81-x64-corert",
+        "win10-x64"
+      ]
+    },
+    "win10-x86": {
+      "#import": [
+        "win10",
+        "win81-x86"
+      ]
+    },
+    "win10-x86-aot": {
+      "#import": [
+        "win10-aot",
+        "win10-x86",
+        "win81-x86-aot"
+      ]
+    },
+    "win10-x86-corert": {
+      "#import": [
+        "win10-corert",
+        "win81-x86-corert",
+        "win10-x86"
+      ]
+    },
+    "win7": {
+      "#import": [
+        "win"
+      ]
+    },
+    "win7-aot": {
+      "#import": [
+        "win-aot",
+        "win7"
+      ]
+    },
+    "win7-corert": {
+      "#import": [
+        "win-corert",
+        "win7"
+      ]
+    },
+    "win7-x64": {
+      "#import": [
+        "win7",
+        "win-x64"
+      ]
+    },
+    "win7-x64-aot": {
+      "#import": [
+        "win7-aot",
+        "win7-x64"
+      ]
+    },
+    "win7-x64-corert": {
+      "#import": [
+        "win7-corert",
+        "win7-x64"
+      ]
+    },
+    "win7-x86": {
+      "#import": [
+        "win7",
+        "win-x86"
+      ]
+    },
+    "win7-x86-aot": {
+      "#import": [
+        "win7-aot",
+        "win7-x86"
+      ]
+    },
+    "win7-x86-corert": {
+      "#import": [
+        "win7-corert",
+        "win7-x86"
+      ]
+    },
+    "win8": {
+      "#import": [
+        "win7"
+      ]
+    },
+    "win8-aot": {
+      "#import": [
+        "win8",
+        "win7-aot"
+      ]
+    },
+    "win8-arm": {
+      "#import": [
+        "win8",
+        "win-arm"
+      ]
+    },
+    "win8-arm-aot": {
+      "#import": [
+        "win8-aot",
+        "win8-arm"
+      ]
+    },
+    "win8-arm-corert": {
+      "#import": [
+        "win8-corert",
+        "win8-arm"
+      ]
+    },
+    "win8-corert": {
+      "#import": [
+        "win7-corert",
+        "win8"
+      ]
+    },
+    "win8-x64": {
+      "#import": [
+        "win8",
+        "win7-x64"
+      ]
+    },
+    "win8-x64-aot": {
+      "#import": [
+        "win8-aot",
+        "win8-x64",
+        "win7-x64-aot"
+      ]
+    },
+    "win8-x64-corert": {
+      "#import": [
+        "win8-corert",
+        "win7-x64-corert",
+        "win8-x64"
+      ]
+    },
+    "win8-x86": {
+      "#import": [
+        "win8",
+        "win7-x86"
+      ]
+    },
+    "win8-x86-aot": {
+      "#import": [
+        "win8-aot",
+        "win8-x86",
+        "win7-x86-aot"
+      ]
+    },
+    "win8-x86-corert": {
+      "#import": [
+        "win8-corert",
+        "win7-x86-corert",
+        "win8-x86"
+      ]
+    },
+    "win81": {
+      "#import": [
+        "win8"
+      ]
+    },
+    "win81-aot": {
+      "#import": [
+        "win81",
+        "win8-aot"
+      ]
+    },
+    "win81-arm": {
+      "#import": [
+        "win81",
+        "win8-arm"
+      ]
+    },
+    "win81-arm-aot": {
+      "#import": [
+        "win81-aot",
+        "win81-arm",
+        "win8-arm-aot"
+      ]
+    },
+    "win81-arm-corert": {
+      "#import": [
+        "win81-corert",
+        "win8-arm-corert",
+        "win81-arm"
+      ]
+    },
+    "win81-corert": {
+      "#import": [
+        "win8-corert",
+        "win81"
+      ]
+    },
+    "win81-x64": {
+      "#import": [
+        "win81",
+        "win8-x64"
+      ]
+    },
+    "win81-x64-aot": {
+      "#import": [
+        "win81-aot",
+        "win81-x64",
+        "win8-x64-aot"
+      ]
+    },
+    "win81-x64-corert": {
+      "#import": [
+        "win81-corert",
+        "win8-x64-corert",
+        "win81-x64"
+      ]
+    },
+    "win81-x86": {
+      "#import": [
+        "win81",
+        "win8-x86"
+      ]
+    },
+    "win81-x86-aot": {
+      "#import": [
+        "win81-aot",
+        "win81-x86",
+        "win8-x86-aot"
+      ]
+    },
+    "win81-x86-corert": {
+      "#import": [
+        "win81-corert",
+        "win8-x86-corert",
+        "win81-x86"
       ]
     }
   }

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -1642,6 +1642,6 @@
         "opensuse.13.2-x64-corert",
         "opensuse.42.1-x64"
       ]
-    },
+    }
   }
 }

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -1,5 +1,54 @@
 {
   "runtimes": {
+    "alpine": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "alpine-corert": {
+      "#import": [
+        "alpine",
+        "unix-corert"
+      ]
+    },
+    "alpine-x64": {
+      "#import": [
+        "alpine",
+        "unix-x64"
+      ]
+    },
+    "alpine-x64-corert": {
+      "#import": [
+        "alpine-corert",
+        "alpine-x64",
+        "unix-x64-corert"
+      ]
+    },
+    "alpine.3.6": {
+      "#import": [
+        "alpine"
+      ]
+    },
+    "alpine.3.6-corert": {
+      "#import": [
+        "alpine.3.6",
+        "alpine-corert"
+      ]
+    },
+    "alpine.3.6-x64": {
+      "#import": [
+        "alpine.3.6",
+        "alpine-x64"
+      ]
+    },
+    "alpine.3.6-x64-corert": {
+      "#import": [
+        "alpine.3.6-corert",
+        "alpine.3.6-x64",
+        "alpine.3.6",
+        "alpine-x64-corert"
+      ]
+    },
     "android": {
       "#import": [
         "any"
@@ -7,12 +56,30 @@
     },
     "android-arm": {
       "#import": [
-        "any"
+        "android"
+      ]
+    },
+    "android-arm-corert": {
+      "#import": [
+        "android-corert",
+        "android-arm"
       ]
     },
     "android-arm64": {
       "#import": [
-        "any"
+        "android"
+      ]
+    },
+    "android-arm64-corert": {
+      "#import": [
+        "android-corert",
+        "android-arm64"
+      ]
+    },
+    "android-corert": {
+      "#import": [
+        "android",
+        "corert"
       ]
     },
     "android.21": {
@@ -26,10 +93,32 @@
         "android-arm"
       ]
     },
+    "android.21-arm-corert": {
+      "#import": [
+        "android.21-corert",
+        "android.21-arm",
+        "android.21",
+        "android-arm-corert"
+      ]
+    },
     "android.21-arm64": {
       "#import": [
         "android.21",
         "android-arm64"
+      ]
+    },
+    "android.21-arm64-corert": {
+      "#import": [
+        "android.21-corert",
+        "android.21-arm64",
+        "android.21",
+        "android-arm64-corert"
+      ]
+    },
+    "android.21-corert": {
+      "#import": [
+        "android.21",
+        "android-corert"
       ]
     },
     "any": {
@@ -42,7 +131,9 @@
         "any"
       ]
     },
-    "base": {},
+    "base": {
+      "#import": []
+    },
     "centos": {
       "#import": [
         "rhel"
@@ -50,8 +141,8 @@
     },
     "centos-corert": {
       "#import": [
-        "rel-corert",
-        "centos"
+        "centos",
+        "rhel-corert"
       ]
     },
     "centos-x64": {
@@ -63,8 +154,8 @@
     "centos-x64-corert": {
       "#import": [
         "centos-corert",
-        "rhel-x64-corert",
-        "centos-x64"
+        "centos-x64",
+        "rhel-x64-corert"
       ]
     },
     "centos.7": {
@@ -75,8 +166,9 @@
     },
     "centos.7-corert": {
       "#import": [
+        "centos.7",
         "centos-corert",
-        "centos.7"
+        "rhel.7-corert"
       ]
     },
     "centos.7-x64": {
@@ -89,8 +181,9 @@
     "centos.7-x64-corert": {
       "#import": [
         "centos.7-corert",
-        "centos-x64-corert",
-        "centos.7-x64"
+        "centos.7-x64",
+        "centos.7",
+        "centos-x64-corert"
       ]
     },
     "corert": {
@@ -112,7 +205,8 @@
     "debian-arm-corert": {
       "#import": [
         "debian-corert",
-        "debian-arm"
+        "debian-arm",
+        "linux-arm-corert"
       ]
     },
     "debian-arm64": {
@@ -124,7 +218,8 @@
     "debian-arm64-corert": {
       "#import": [
         "debian-corert",
-        "debian-arm64"
+        "debian-arm64",
+        "linux-arm64-corert"
       ]
     },
     "debian-armel": {
@@ -133,10 +228,17 @@
         "linux-armel"
       ]
     },
+    "debian-armel-corert": {
+      "#import": [
+        "debian-corert",
+        "debian-armel",
+        "linux-armel-corert"
+      ]
+    },
     "debian-corert": {
       "#import": [
-        "linux-corert",
-        "debian"
+        "debian",
+        "linux-corert"
       ]
     },
     "debian-x64": {
@@ -148,14 +250,21 @@
     "debian-x64-corert": {
       "#import": [
         "debian-corert",
-        "linux-x64-corert",
-        "debian-x64"
+        "debian-x64",
+        "linux-x64-corert"
       ]
     },
     "debian-x86": {
       "#import": [
         "debian",
         "linux-x86"
+      ]
+    },
+    "debian-x86-corert": {
+      "#import": [
+        "debian-corert",
+        "debian-x86",
+        "linux-x86-corert"
       ]
     },
     "debian.8": {
@@ -172,8 +281,9 @@
     "debian.8-arm-corert": {
       "#import": [
         "debian.8-corert",
-        "debian-arm-corert",
-        "debian.8-arm"
+        "debian.8-arm",
+        "debian.8",
+        "debian-arm-corert"
       ]
     },
     "debian.8-arm64": {
@@ -185,8 +295,9 @@
     "debian.8-arm64-corert": {
       "#import": [
         "debian.8-corert",
-        "debian-arm64-corert",
-        "debian.8-arm64"
+        "debian.8-arm64",
+        "debian.8",
+        "debian-arm64-corert"
       ]
     },
     "debian.8-armel": {
@@ -195,10 +306,18 @@
         "debian-armel"
       ]
     },
+    "debian.8-armel-corert": {
+      "#import": [
+        "debian.8-corert",
+        "debian.8-armel",
+        "debian.8",
+        "debian-armel-corert"
+      ]
+    },
     "debian.8-corert": {
       "#import": [
-        "debian-corert",
-        "debian.8"
+        "debian.8",
+        "debian-corert"
       ]
     },
     "debian.8-x64": {
@@ -210,14 +329,104 @@
     "debian.8-x64-corert": {
       "#import": [
         "debian.8-corert",
-        "debian-x64-corert",
-        "debian.8-x64"
+        "debian.8-x64",
+        "debian.8",
+        "debian-x64-corert"
       ]
     },
     "debian.8-x86": {
       "#import": [
         "debian.8",
         "debian-x86"
+      ]
+    },
+    "debian.8-x86-corert": {
+      "#import": [
+        "debian.8-corert",
+        "debian.8-x86",
+        "debian.8",
+        "debian-x86-corert"
+      ]
+    },
+    "debian.9": {
+      "#import": [
+        "debian"
+      ]
+    },
+    "debian.9-arm": {
+      "#import": [
+        "debian.9",
+        "debian-arm"
+      ]
+    },
+    "debian.9-arm-corert": {
+      "#import": [
+        "debian.9-corert",
+        "debian.9-arm",
+        "debian.9",
+        "debian-arm-corert"
+      ]
+    },
+    "debian.9-arm64": {
+      "#import": [
+        "debian.9",
+        "debian-arm64"
+      ]
+    },
+    "debian.9-arm64-corert": {
+      "#import": [
+        "debian.9-corert",
+        "debian.9-arm64",
+        "debian.9",
+        "debian-arm64-corert"
+      ]
+    },
+    "debian.9-armel": {
+      "#import": [
+        "debian.9",
+        "debian-armel"
+      ]
+    },
+    "debian.9-armel-corert": {
+      "#import": [
+        "debian.9-corert",
+        "debian.9-armel",
+        "debian.9",
+        "debian-armel-corert"
+      ]
+    },
+    "debian.9-corert": {
+      "#import": [
+        "debian.9",
+        "debian-corert"
+      ]
+    },
+    "debian.9-x64": {
+      "#import": [
+        "debian.9",
+        "debian-x64"
+      ]
+    },
+    "debian.9-x64-corert": {
+      "#import": [
+        "debian.9-corert",
+        "debian.9-x64",
+        "debian.9",
+        "debian-x64-corert"
+      ]
+    },
+    "debian.9-x86": {
+      "#import": [
+        "debian.9",
+        "debian-x86"
+      ]
+    },
+    "debian.9-x86-corert": {
+      "#import": [
+        "debian.9-corert",
+        "debian.9-x86",
+        "debian.9",
+        "debian-x86-corert"
       ]
     },
     "fedora": {
@@ -227,8 +436,8 @@
     },
     "fedora-corert": {
       "#import": [
-        "linux-corert",
-        "fedora"
+        "fedora",
+        "linux-corert"
       ]
     },
     "fedora-x64": {
@@ -240,8 +449,8 @@
     "fedora-x64-corert": {
       "#import": [
         "fedora-corert",
-        "linux-x64-corert",
-        "fedora-x64"
+        "fedora-x64",
+        "linux-x64-corert"
       ]
     },
     "fedora.23": {
@@ -251,8 +460,8 @@
     },
     "fedora.23-corert": {
       "#import": [
-        "fedora-corert",
-        "fedora.23"
+        "fedora.23",
+        "fedora-corert"
       ]
     },
     "fedora.23-x64": {
@@ -264,8 +473,9 @@
     "fedora.23-x64-corert": {
       "#import": [
         "fedora.23-corert",
-        "fedora-x64-corert",
-        "fedora.23-x64"
+        "fedora.23-x64",
+        "fedora.23",
+        "fedora-x64-corert"
       ]
     },
     "fedora.24": {
@@ -275,8 +485,8 @@
     },
     "fedora.24-corert": {
       "#import": [
-        "fedora.23-corert",
-        "fedora.24"
+        "fedora.24",
+        "fedora-corert"
       ]
     },
     "fedora.24-x64": {
@@ -288,13 +498,20 @@
     "fedora.24-x64-corert": {
       "#import": [
         "fedora.24-corert",
-        "fedora.23-x64-corert",
-        "fedora.24-x64"
+        "fedora.24-x64",
+        "fedora.24",
+        "fedora-x64-corert"
       ]
     },
     "fedora.25": {
       "#import": [
         "fedora"
+      ]
+    },
+    "fedora.25-corert": {
+      "#import": [
+        "fedora.25",
+        "fedora-corert"
       ]
     },
     "fedora.25-x64": {
@@ -303,15 +520,111 @@
         "fedora-x64"
       ]
     },
+    "fedora.25-x64-corert": {
+      "#import": [
+        "fedora.25-corert",
+        "fedora.25-x64",
+        "fedora.25",
+        "fedora-x64-corert"
+      ]
+    },
     "fedora.26": {
       "#import": [
         "fedora"
+      ]
+    },
+    "fedora.26-corert": {
+      "#import": [
+        "fedora.26",
+        "fedora-corert"
       ]
     },
     "fedora.26-x64": {
       "#import": [
         "fedora.26",
         "fedora-x64"
+      ]
+    },
+    "fedora.26-x64-corert": {
+      "#import": [
+        "fedora.26-corert",
+        "fedora.26-x64",
+        "fedora.26",
+        "fedora-x64-corert"
+      ]
+    },
+    "fedora.27": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.27-corert": {
+      "#import": [
+        "fedora.27",
+        "fedora-corert"
+      ]
+    },
+    "fedora.27-x64": {
+      "#import": [
+        "fedora.27",
+        "fedora-x64"
+      ]
+    },
+    "fedora.27-x64-corert": {
+      "#import": [
+        "fedora.27-corert",
+        "fedora.27-x64",
+        "fedora.27",
+        "fedora-x64-corert"
+      ]
+    },
+    "fedora.28": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.28-corert": {
+      "#import": [
+        "fedora.28",
+        "fedora-corert"
+      ]
+    },
+    "fedora.28-x64": {
+      "#import": [
+        "fedora.28",
+        "fedora-x64"
+      ]
+    },
+    "fedora.28-x64-corert": {
+      "#import": [
+        "fedora.28-corert",
+        "fedora.28-x64",
+        "fedora.28",
+        "fedora-x64-corert"
+      ]
+    },
+    "gentoo": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "gentoo-corert": {
+      "#import": [
+        "gentoo",
+        "linux-corert"
+      ]
+    },
+    "gentoo-x64": {
+      "#import": [
+        "gentoo",
+        "linux-x64"
+      ]
+    },
+    "gentoo-x64-corert": {
+      "#import": [
+        "gentoo-corert",
+        "gentoo-x64",
+        "linux-x64-corert"
       ]
     },
     "linux": {
@@ -328,7 +641,8 @@
     "linux-arm-corert": {
       "#import": [
         "linux-corert",
-        "linux-arm"
+        "linux-arm",
+        "unix-arm-corert"
       ]
     },
     "linux-arm64": {
@@ -340,7 +654,8 @@
     "linux-arm64-corert": {
       "#import": [
         "linux-corert",
-        "linux-arm64"
+        "linux-arm64",
+        "unix-arm64-corert"
       ]
     },
     "linux-armel": {
@@ -349,9 +664,15 @@
         "unix-armel"
       ]
     },
+    "linux-armel-corert": {
+      "#import": [
+        "linux-corert",
+        "linux-armel",
+        "unix-armel-corert"
+      ]
+    },
     "linux-corert": {
       "#import": [
-        "corert",
         "linux",
         "unix-corert"
       ]
@@ -365,13 +686,21 @@
     "linux-x64-corert": {
       "#import": [
         "linux-corert",
-        "linux-x64"
+        "linux-x64",
+        "unix-x64-corert"
       ]
     },
     "linux-x86": {
       "#import": [
         "linux",
         "unix-x86"
+      ]
+    },
+    "linux-x86-corert": {
+      "#import": [
+        "linux-corert",
+        "linux-x86",
+        "unix-x86-corert"
       ]
     },
     "linuxmint.17": {
@@ -381,8 +710,8 @@
     },
     "linuxmint.17-corert": {
       "#import": [
-        "ubuntu.14.04-corert",
-        "linuxmint.17"
+        "linuxmint.17",
+        "ubuntu.14.04-corert"
       ]
     },
     "linuxmint.17-x64": {
@@ -394,8 +723,8 @@
     "linuxmint.17-x64-corert": {
       "#import": [
         "linuxmint.17-corert",
-        "ubuntu.14.04-x64-corert",
-        "linuxmint.17-x64"
+        "linuxmint.17-x64",
+        "ubuntu.14.04-x64-corert"
       ]
     },
     "linuxmint.17.1": {
@@ -405,8 +734,8 @@
     },
     "linuxmint.17.1-corert": {
       "#import": [
-        "linuxmint.17-corert",
-        "linuxmint.17.1"
+        "linuxmint.17.1",
+        "linuxmint.17-corert"
       ]
     },
     "linuxmint.17.1-x64": {
@@ -418,8 +747,9 @@
     "linuxmint.17.1-x64-corert": {
       "#import": [
         "linuxmint.17.1-corert",
-        "linuxmint.17-x64-corert",
-        "linuxmint.17.1-x64"
+        "linuxmint.17.1-x64",
+        "linuxmint.17.1",
+        "linuxmint.17-x64-corert"
       ]
     },
     "linuxmint.17.2": {
@@ -429,8 +759,8 @@
     },
     "linuxmint.17.2-corert": {
       "#import": [
-        "linuxmint.17.1-corert",
-        "linuxmint.17.2"
+        "linuxmint.17.2",
+        "linuxmint.17.1-corert"
       ]
     },
     "linuxmint.17.2-x64": {
@@ -442,8 +772,9 @@
     "linuxmint.17.2-x64-corert": {
       "#import": [
         "linuxmint.17.2-corert",
-        "linuxmint.17.1-x64-corert",
-        "linuxmint.17.2-x64"
+        "linuxmint.17.2-x64",
+        "linuxmint.17.2",
+        "linuxmint.17.1-x64-corert"
       ]
     },
     "linuxmint.17.3": {
@@ -453,8 +784,8 @@
     },
     "linuxmint.17.3-corert": {
       "#import": [
-        "linuxmint.17.2-corert",
-        "linuxmint.17.3"
+        "linuxmint.17.3",
+        "linuxmint.17.2-corert"
       ]
     },
     "linuxmint.17.3-x64": {
@@ -466,8 +797,9 @@
     "linuxmint.17.3-x64-corert": {
       "#import": [
         "linuxmint.17.3-corert",
-        "linuxmint.17.2-x64-corert",
-        "linuxmint.17.3-x64"
+        "linuxmint.17.3-x64",
+        "linuxmint.17.3",
+        "linuxmint.17.2-x64-corert"
       ]
     },
     "linuxmint.18": {
@@ -477,8 +809,8 @@
     },
     "linuxmint.18-corert": {
       "#import": [
-        "ubuntu.16.04-corert",
-        "linuxmint.18"
+        "linuxmint.18",
+        "ubuntu.16.04-corert"
       ]
     },
     "linuxmint.18-x64": {
@@ -490,8 +822,8 @@
     "linuxmint.18-x64-corert": {
       "#import": [
         "linuxmint.18-corert",
-        "ubuntu.16.04-x64-corert",
-        "linuxmint.18-x64"
+        "linuxmint.18-x64",
+        "ubuntu.16.04-x64-corert"
       ]
     },
     "linuxmint.18.1": {
@@ -499,10 +831,98 @@
         "linuxmint.18"
       ]
     },
+    "linuxmint.18.1-corert": {
+      "#import": [
+        "linuxmint.18.1",
+        "linuxmint.18-corert"
+      ]
+    },
     "linuxmint.18.1-x64": {
       "#import": [
         "linuxmint.18.1",
         "linuxmint.18-x64"
+      ]
+    },
+    "linuxmint.18.1-x64-corert": {
+      "#import": [
+        "linuxmint.18.1-corert",
+        "linuxmint.18.1-x64",
+        "linuxmint.18.1",
+        "linuxmint.18-x64-corert"
+      ]
+    },
+    "linuxmint.18.2": {
+      "#import": [
+        "linuxmint.18.1"
+      ]
+    },
+    "linuxmint.18.2-corert": {
+      "#import": [
+        "linuxmint.18.2",
+        "linuxmint.18.1-corert"
+      ]
+    },
+    "linuxmint.18.2-x64": {
+      "#import": [
+        "linuxmint.18.2",
+        "linuxmint.18.1-x64"
+      ]
+    },
+    "linuxmint.18.2-x64-corert": {
+      "#import": [
+        "linuxmint.18.2-corert",
+        "linuxmint.18.2-x64",
+        "linuxmint.18.2",
+        "linuxmint.18.1-x64-corert"
+      ]
+    },
+    "linuxmint.18.3": {
+      "#import": [
+        "linuxmint.18.2"
+      ]
+    },
+    "linuxmint.18.3-corert": {
+      "#import": [
+        "linuxmint.18.3",
+        "linuxmint.18.2-corert"
+      ]
+    },
+    "linuxmint.18.3-x64": {
+      "#import": [
+        "linuxmint.18.3",
+        "linuxmint.18.2-x64"
+      ]
+    },
+    "linuxmint.18.3-x64-corert": {
+      "#import": [
+        "linuxmint.18.3-corert",
+        "linuxmint.18.3-x64",
+        "linuxmint.18.3",
+        "linuxmint.18.2-x64-corert"
+      ]
+    },
+    "linuxmint.19": {
+      "#import": [
+        "ubuntu.18.04"
+      ]
+    },
+    "linuxmint.19-corert": {
+      "#import": [
+        "linuxmint.19",
+        "ubuntu.18.04-corert"
+      ]
+    },
+    "linuxmint.19-x64": {
+      "#import": [
+        "linuxmint.19",
+        "ubuntu.18.04-x64"
+      ]
+    },
+    "linuxmint.19-x64-corert": {
+      "#import": [
+        "linuxmint.19-corert",
+        "linuxmint.19-x64",
+        "ubuntu.18.04-x64-corert"
       ]
     },
     "ol": {
@@ -512,8 +932,8 @@
     },
     "ol-corert": {
       "#import": [
-        "rhel-corert",
-        "ol"
+        "ol",
+        "rhel-corert"
       ]
     },
     "ol-x64": {
@@ -525,8 +945,8 @@
     "ol-x64-corert": {
       "#import": [
         "ol-corert",
-        "rhel-x64-corert",
-        "ol-x64"
+        "ol-x64",
+        "rhel-x64-corert"
       ]
     },
     "ol.7": {
@@ -537,8 +957,9 @@
     },
     "ol.7-corert": {
       "#import": [
+        "ol.7",
         "ol-corert",
-        "ol.7"
+        "rhel.7-corert"
       ]
     },
     "ol.7-x64": {
@@ -551,8 +972,9 @@
     "ol.7-x64-corert": {
       "#import": [
         "ol.7-corert",
-        "rhel.7-x64-corert",
-        "ol.7-x64"
+        "ol.7-x64",
+        "ol.7",
+        "ol-x64-corert"
       ]
     },
     "ol.7.0": {
@@ -563,8 +985,9 @@
     },
     "ol.7.0-corert": {
       "#import": [
+        "ol.7.0",
         "ol.7-corert",
-        "ol.7.0"
+        "rhel.7.0-corert"
       ]
     },
     "ol.7.0-x64": {
@@ -577,8 +1000,9 @@
     "ol.7.0-x64-corert": {
       "#import": [
         "ol.7.0-corert",
-        "rhel.7.0-corert",
-        "ol.7.0-x64"
+        "ol.7.0-x64",
+        "ol.7.0",
+        "ol.7-x64-corert"
       ]
     },
     "ol.7.1": {
@@ -589,8 +1013,9 @@
     },
     "ol.7.1-corert": {
       "#import": [
+        "ol.7.1",
         "ol.7.0-corert",
-        "ol.7.1"
+        "rhel.7.1-corert"
       ]
     },
     "ol.7.1-x64": {
@@ -603,14 +1028,22 @@
     "ol.7.1-x64-corert": {
       "#import": [
         "ol.7.1-corert",
-        "rhel.7.1-x64-corert",
-        "ol.7.1-x64"
+        "ol.7.1-x64",
+        "ol.7.1",
+        "ol.7.0-x64-corert"
       ]
     },
     "ol.7.2": {
       "#import": [
         "ol.7.1",
         "rhel.7.2"
+      ]
+    },
+    "ol.7.2-corert": {
+      "#import": [
+        "ol.7.2",
+        "ol.7.1-corert",
+        "rhel.7.2-corert"
       ]
     },
     "ol.7.2-x64": {
@@ -620,6 +1053,70 @@
         "rhel.7.2-x64"
       ]
     },
+    "ol.7.2-x64-corert": {
+      "#import": [
+        "ol.7.2-corert",
+        "ol.7.2-x64",
+        "ol.7.2",
+        "ol.7.1-x64-corert"
+      ]
+    },
+    "ol.7.3": {
+      "#import": [
+        "ol.7.2",
+        "rhel.7.3"
+      ]
+    },
+    "ol.7.3-corert": {
+      "#import": [
+        "ol.7.3",
+        "ol.7.2-corert",
+        "rhel.7.3-corert"
+      ]
+    },
+    "ol.7.3-x64": {
+      "#import": [
+        "ol.7.3",
+        "ol.7.2-x64",
+        "rhel.7.3-x64"
+      ]
+    },
+    "ol.7.3-x64-corert": {
+      "#import": [
+        "ol.7.3-corert",
+        "ol.7.3-x64",
+        "ol.7.3",
+        "ol.7.2-x64-corert"
+      ]
+    },
+    "ol.7.4": {
+      "#import": [
+        "ol.7.3",
+        "rhel.7.4"
+      ]
+    },
+    "ol.7.4-corert": {
+      "#import": [
+        "ol.7.4",
+        "ol.7.3-corert",
+        "rhel.7.4-corert"
+      ]
+    },
+    "ol.7.4-x64": {
+      "#import": [
+        "ol.7.4",
+        "ol.7.3-x64",
+        "rhel.7.4-x64"
+      ]
+    },
+    "ol.7.4-x64-corert": {
+      "#import": [
+        "ol.7.4-corert",
+        "ol.7.4-x64",
+        "ol.7.4",
+        "ol.7.3-x64-corert"
+      ]
+    },
     "opensuse": {
       "#import": [
         "linux"
@@ -627,8 +1124,8 @@
     },
     "opensuse-corert": {
       "#import": [
-        "linux-corert",
-        "opensuse"
+        "opensuse",
+        "linux-corert"
       ]
     },
     "opensuse-x64": {
@@ -640,8 +1137,8 @@
     "opensuse-x64-corert": {
       "#import": [
         "opensuse-corert",
-        "linux-x64-corert",
-        "opensuste-x64"
+        "opensuse-x64",
+        "linux-x64-corert"
       ]
     },
     "opensuse.13.2": {
@@ -651,8 +1148,8 @@
     },
     "opensuse.13.2-corert": {
       "#import": [
-        "opensuse-corert",
-        "opensuse.13.2"
+        "opensuse.13.2",
+        "opensuse-corert"
       ]
     },
     "opensuse.13.2-x64": {
@@ -664,8 +1161,9 @@
     "opensuse.13.2-x64-corert": {
       "#import": [
         "opensuse.13.2-corert",
-        "opensuse-x64-corert",
-        "opensuse.13.2-x64"
+        "opensuse.13.2-x64",
+        "opensuse.13.2",
+        "opensuse-x64-corert"
       ]
     },
     "opensuse.42.1": {
@@ -675,8 +1173,8 @@
     },
     "opensuse.42.1-corert": {
       "#import": [
-        "opensuse.13.2-corert",
-        "opensuse.42.1"
+        "opensuse.42.1",
+        "opensuse-corert"
       ]
     },
     "opensuse.42.1-x64": {
@@ -688,8 +1186,59 @@
     "opensuse.42.1-x64-corert": {
       "#import": [
         "opensuse.42.1-corert",
-        "opensuse.13.2-x64-corert",
-        "opensuse.42.1-x64"
+        "opensuse.42.1-x64",
+        "opensuse.42.1",
+        "opensuse-x64-corert"
+      ]
+    },
+    "opensuse.42.2": {
+      "#import": [
+        "opensuse"
+      ]
+    },
+    "opensuse.42.2-corert": {
+      "#import": [
+        "opensuse.42.2",
+        "opensuse-corert"
+      ]
+    },
+    "opensuse.42.2-x64": {
+      "#import": [
+        "opensuse.42.2",
+        "opensuse-x64"
+      ]
+    },
+    "opensuse.42.2-x64-corert": {
+      "#import": [
+        "opensuse.42.2-corert",
+        "opensuse.42.2-x64",
+        "opensuse.42.2",
+        "opensuse-x64-corert"
+      ]
+    },
+    "opensuse.42.3": {
+      "#import": [
+        "opensuse"
+      ]
+    },
+    "opensuse.42.3-corert": {
+      "#import": [
+        "opensuse.42.3",
+        "opensuse-corert"
+      ]
+    },
+    "opensuse.42.3-x64": {
+      "#import": [
+        "opensuse.42.3",
+        "opensuse-x64"
+      ]
+    },
+    "opensuse.42.3-x64-corert": {
+      "#import": [
+        "opensuse.42.3-corert",
+        "opensuse.42.3-x64",
+        "opensuse.42.3",
+        "opensuse-x64-corert"
       ]
     },
     "osx": {
@@ -699,8 +1248,8 @@
     },
     "osx-corert": {
       "#import": [
-        "unix-corert",
-        "osx"
+        "osx",
+        "unix-corert"
       ]
     },
     "osx-x64": {
@@ -712,8 +1261,8 @@
     "osx-x64-corert": {
       "#import": [
         "osx-corert",
-        "unix-x64-corert",
-        "osx-x64"
+        "osx-x64",
+        "unix-x64-corert"
       ]
     },
     "osx.10.10": {
@@ -723,8 +1272,8 @@
     },
     "osx.10.10-corert": {
       "#import": [
-        "osx-corert",
-        "osx.10.10"
+        "osx.10.10",
+        "osx-corert"
       ]
     },
     "osx.10.10-x64": {
@@ -736,8 +1285,9 @@
     "osx.10.10-x64-corert": {
       "#import": [
         "osx.10.10-corert",
-        "osx-x64-corert",
-        "osx.10.10-x64"
+        "osx.10.10-x64",
+        "osx.10.10",
+        "osx-x64-corert"
       ]
     },
     "osx.10.11": {
@@ -747,8 +1297,8 @@
     },
     "osx.10.11-corert": {
       "#import": [
-        "osx.10.10-corert",
-        "osx.10.11"
+        "osx.10.11",
+        "osx.10.10-corert"
       ]
     },
     "osx.10.11-x64": {
@@ -760,8 +1310,9 @@
     "osx.10.11-x64-corert": {
       "#import": [
         "osx.10.11-corert",
-        "osx.10.10-x64-corert",
-        "osx.10.11-x64"
+        "osx.10.11-x64",
+        "osx.10.11",
+        "osx.10.10-x64-corert"
       ]
     },
     "osx.10.12": {
@@ -771,8 +1322,8 @@
     },
     "osx.10.12-corert": {
       "#import": [
-        "osx.10.11-corert",
-        "osx.10.12"
+        "osx.10.12",
+        "osx.10.11-corert"
       ]
     },
     "osx.10.12-x64": {
@@ -784,8 +1335,34 @@
     "osx.10.12-x64-corert": {
       "#import": [
         "osx.10.12-corert",
-        "osx.10.11-x64-corert",
+        "osx.10.12-x64",
+        "osx.10.12",
+        "osx.10.11-x64-corert"
+      ]
+    },
+    "osx.10.13": {
+      "#import": [
+        "osx.10.12"
+      ]
+    },
+    "osx.10.13-corert": {
+      "#import": [
+        "osx.10.13",
+        "osx.10.12-corert"
+      ]
+    },
+    "osx.10.13-x64": {
+      "#import": [
+        "osx.10.13",
         "osx.10.12-x64"
+      ]
+    },
+    "osx.10.13-x64-corert": {
+      "#import": [
+        "osx.10.13-corert",
+        "osx.10.13-x64",
+        "osx.10.13",
+        "osx.10.12-x64-corert"
       ]
     },
     "rhel": {
@@ -795,8 +1372,8 @@
     },
     "rhel-corert": {
       "#import": [
-        "corert",
-        "rhel"
+        "rhel",
+        "linux-corert"
       ]
     },
     "rhel-x64": {
@@ -808,8 +1385,8 @@
     "rhel-x64-corert": {
       "#import": [
         "rhel-corert",
-        "linux-x64-corert",
-        "rhel-x64"
+        "rhel-x64",
+        "linux-x64-corert"
       ]
     },
     "rhel.6": {
@@ -817,10 +1394,24 @@
         "rhel"
       ]
     },
+    "rhel.6-corert": {
+      "#import": [
+        "rhel.6",
+        "rhel-corert"
+      ]
+    },
     "rhel.6-x64": {
       "#import": [
         "rhel.6",
         "rhel-x64"
+      ]
+    },
+    "rhel.6-x64-corert": {
+      "#import": [
+        "rhel.6-corert",
+        "rhel.6-x64",
+        "rhel.6",
+        "rhel-x64-corert"
       ]
     },
     "rhel.7": {
@@ -830,8 +1421,8 @@
     },
     "rhel.7-corert": {
       "#import": [
-        "rhel-corert",
-        "rhel.7"
+        "rhel.7",
+        "rhel-corert"
       ]
     },
     "rhel.7-x64": {
@@ -843,8 +1434,9 @@
     "rhel.7-x64-corert": {
       "#import": [
         "rhel.7-corert",
-        "rhel-x64-corert",
-        "rhel.7-x64"
+        "rhel.7-x64",
+        "rhel.7",
+        "rhel-x64-corert"
       ]
     },
     "rhel.7.0": {
@@ -854,8 +1446,8 @@
     },
     "rhel.7.0-corert": {
       "#import": [
-        "rhel.7-corert",
-        "rhel.7.0"
+        "rhel.7.0",
+        "rhel.7-corert"
       ]
     },
     "rhel.7.0-x64": {
@@ -867,8 +1459,9 @@
     "rhel.7.0-x64-corert": {
       "#import": [
         "rhel.7.0-corert",
-        "rhel.7-x64-corert",
-        "rhel.7.0-x64"
+        "rhel.7.0-x64",
+        "rhel.7.0",
+        "rhel.7-x64-corert"
       ]
     },
     "rhel.7.1": {
@@ -878,8 +1471,8 @@
     },
     "rhel.7.1-corert": {
       "#import": [
-        "rhel.7.0-corert",
-        "rhel.7.1"
+        "rhel.7.1",
+        "rhel.7.0-corert"
       ]
     },
     "rhel.7.1-x64": {
@@ -891,8 +1484,9 @@
     "rhel.7.1-x64-corert": {
       "#import": [
         "rhel.7.1-corert",
-        "rhel.7.0-x64-corert",
-        "rhel.7.1-x64"
+        "rhel.7.1-x64",
+        "rhel.7.1",
+        "rhel.7.0-x64-corert"
       ]
     },
     "rhel.7.2": {
@@ -902,8 +1496,8 @@
     },
     "rhel.7.2-corert": {
       "#import": [
-        "rhel.7.1-corert",
-        "rhel.7.2"
+        "rhel.7.2",
+        "rhel.7.1-corert"
       ]
     },
     "rhel.7.2-x64": {
@@ -915,13 +1509,20 @@
     "rhel.7.2-x64-corert": {
       "#import": [
         "rhel.7.2-corert",
-        "rhel.7.1-x64-corert",
-        "rhel.7.2-x64"
+        "rhel.7.2-x64",
+        "rhel.7.2",
+        "rhel.7.1-x64-corert"
       ]
     },
     "rhel.7.3": {
       "#import": [
         "rhel.7.2"
+      ]
+    },
+    "rhel.7.3-corert": {
+      "#import": [
+        "rhel.7.3",
+        "rhel.7.2-corert"
       ]
     },
     "rhel.7.3-x64": {
@@ -930,15 +1531,161 @@
         "rhel.7.2-x64"
       ]
     },
+    "rhel.7.3-x64-corert": {
+      "#import": [
+        "rhel.7.3-corert",
+        "rhel.7.3-x64",
+        "rhel.7.3",
+        "rhel.7.2-x64-corert"
+      ]
+    },
     "rhel.7.4": {
       "#import": [
         "rhel.7.3"
+      ]
+    },
+    "rhel.7.4-corert": {
+      "#import": [
+        "rhel.7.4",
+        "rhel.7.3-corert"
       ]
     },
     "rhel.7.4-x64": {
       "#import": [
         "rhel.7.4",
         "rhel.7.3-x64"
+      ]
+    },
+    "rhel.7.4-x64-corert": {
+      "#import": [
+        "rhel.7.4-corert",
+        "rhel.7.4-x64",
+        "rhel.7.4",
+        "rhel.7.3-x64-corert"
+      ]
+    },
+    "sles": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "sles-corert": {
+      "#import": [
+        "sles",
+        "linux-corert"
+      ]
+    },
+    "sles-x64": {
+      "#import": [
+        "sles",
+        "linux-x64"
+      ]
+    },
+    "sles-x64-corert": {
+      "#import": [
+        "sles-corert",
+        "sles-x64",
+        "linux-x64-corert"
+      ]
+    },
+    "sles.12": {
+      "#import": [
+        "sles"
+      ]
+    },
+    "sles.12-corert": {
+      "#import": [
+        "sles.12",
+        "sles-corert"
+      ]
+    },
+    "sles.12-x64": {
+      "#import": [
+        "sles.12",
+        "sles-x64"
+      ]
+    },
+    "sles.12-x64-corert": {
+      "#import": [
+        "sles.12-corert",
+        "sles.12-x64",
+        "sles.12",
+        "sles-x64-corert"
+      ]
+    },
+    "sles.12.1": {
+      "#import": [
+        "sles.12"
+      ]
+    },
+    "sles.12.1-corert": {
+      "#import": [
+        "sles.12.1",
+        "sles.12-corert"
+      ]
+    },
+    "sles.12.1-x64": {
+      "#import": [
+        "sles.12.1",
+        "sles.12-x64"
+      ]
+    },
+    "sles.12.1-x64-corert": {
+      "#import": [
+        "sles.12.1-corert",
+        "sles.12.1-x64",
+        "sles.12.1",
+        "sles.12-x64-corert"
+      ]
+    },
+    "sles.12.2": {
+      "#import": [
+        "sles.12.1"
+      ]
+    },
+    "sles.12.2-corert": {
+      "#import": [
+        "sles.12.2",
+        "sles.12.1-corert"
+      ]
+    },
+    "sles.12.2-x64": {
+      "#import": [
+        "sles.12.2",
+        "sles.12.1-x64"
+      ]
+    },
+    "sles.12.2-x64-corert": {
+      "#import": [
+        "sles.12.2-corert",
+        "sles.12.2-x64",
+        "sles.12.2",
+        "sles.12.1-x64-corert"
+      ]
+    },
+    "sles.12.3": {
+      "#import": [
+        "sles.12.2"
+      ]
+    },
+    "sles.12.3-corert": {
+      "#import": [
+        "sles.12.3",
+        "sles.12.2-corert"
+      ]
+    },
+    "sles.12.3-x64": {
+      "#import": [
+        "sles.12.3",
+        "sles.12.2-x64"
+      ]
+    },
+    "sles.12.3-x64-corert": {
+      "#import": [
+        "sles.12.3-corert",
+        "sles.12.3-x64",
+        "sles.12.3",
+        "sles.12.2-x64-corert"
       ]
     },
     "tizen": {
@@ -952,10 +1699,42 @@
         "linux-armel"
       ]
     },
+    "tizen-armel-corert": {
+      "#import": [
+        "tizen-corert",
+        "tizen-armel",
+        "linux-armel-corert"
+      ]
+    },
+    "tizen-corert": {
+      "#import": [
+        "tizen",
+        "linux-corert"
+      ]
+    },
+    "tizen.4.0.0": {
+      "#import": [
+        "tizen"
+      ]
+    },
     "tizen.4.0.0-armel": {
       "#import": [
         "tizen.4.0.0",
         "tizen-armel"
+      ]
+    },
+    "tizen.4.0.0-armel-corert": {
+      "#import": [
+        "tizen.4.0.0-corert",
+        "tizen.4.0.0-armel",
+        "tizen.4.0.0",
+        "tizen-armel-corert"
+      ]
+    },
+    "tizen.4.0.0-corert": {
+      "#import": [
+        "tizen.4.0.0",
+        "tizen-corert"
       ]
     },
     "ubuntu": {
@@ -969,16 +1748,30 @@
         "debian-arm"
       ]
     },
+    "ubuntu-arm-corert": {
+      "#import": [
+        "ubuntu-corert",
+        "ubuntu-arm",
+        "debian-arm-corert"
+      ]
+    },
     "ubuntu-arm64": {
       "#import": [
         "ubuntu",
         "debian-arm64"
       ]
     },
+    "ubuntu-arm64-corert": {
+      "#import": [
+        "ubuntu-corert",
+        "ubuntu-arm64",
+        "debian-arm64-corert"
+      ]
+    },
     "ubuntu-corert": {
       "#import": [
-        "debian-corert",
-        "ubuntu"
+        "ubuntu",
+        "debian-corert"
       ]
     },
     "ubuntu-x64": {
@@ -990,14 +1783,21 @@
     "ubuntu-x64-corert": {
       "#import": [
         "ubuntu-corert",
-        "debian-x64-corert",
-        "ubuntu-x64"
+        "ubuntu-x64",
+        "debian-x64-corert"
       ]
     },
     "ubuntu-x86": {
       "#import": [
         "ubuntu",
         "debian-x86"
+      ]
+    },
+    "ubuntu-x86-corert": {
+      "#import": [
+        "ubuntu-corert",
+        "ubuntu-x86",
+        "debian-x86-corert"
       ]
     },
     "ubuntu.14.04": {
@@ -1011,10 +1811,18 @@
         "ubuntu-arm"
       ]
     },
+    "ubuntu.14.04-arm-corert": {
+      "#import": [
+        "ubuntu.14.04-corert",
+        "ubuntu.14.04-arm",
+        "ubuntu.14.04",
+        "ubuntu-arm-corert"
+      ]
+    },
     "ubuntu.14.04-corert": {
       "#import": [
-        "ubuntu-corert",
-        "ubuntu.14.06"
+        "ubuntu.14.04",
+        "ubuntu-corert"
       ]
     },
     "ubuntu.14.04-x64": {
@@ -1026,14 +1834,23 @@
     "ubuntu.14.04-x64-corert": {
       "#import": [
         "ubuntu.14.04-corert",
-        "ubuntu-x64-corert",
-        "ubuntu-14.04-x64"
+        "ubuntu.14.04-x64",
+        "ubuntu.14.04",
+        "ubuntu-x64-corert"
       ]
     },
     "ubuntu.14.04-x86": {
       "#import": [
         "ubuntu.14.04",
         "ubuntu-x86"
+      ]
+    },
+    "ubuntu.14.04-x86-corert": {
+      "#import": [
+        "ubuntu.14.04-corert",
+        "ubuntu.14.04-x86",
+        "ubuntu.14.04",
+        "ubuntu-x86-corert"
       ]
     },
     "ubuntu.14.10": {
@@ -1047,10 +1864,18 @@
         "ubuntu-arm"
       ]
     },
+    "ubuntu.14.10-arm-corert": {
+      "#import": [
+        "ubuntu.14.10-corert",
+        "ubuntu.14.10-arm",
+        "ubuntu.14.10",
+        "ubuntu-arm-corert"
+      ]
+    },
     "ubuntu.14.10-corert": {
       "#import": [
-        "ubuntu.14.04-corert",
-        "ubuntu-14.10"
+        "ubuntu.14.10",
+        "ubuntu-corert"
       ]
     },
     "ubuntu.14.10-x64": {
@@ -1062,14 +1887,23 @@
     "ubuntu.14.10-x64-corert": {
       "#import": [
         "ubuntu.14.10-corert",
-        "ubuntu.14.04-x64-corert",
-        "ubuntu.14.10-x64"
+        "ubuntu.14.10-x64",
+        "ubuntu.14.10",
+        "ubuntu-x64-corert"
       ]
     },
     "ubuntu.14.10-x86": {
       "#import": [
         "ubuntu.14.10",
         "ubuntu-x86"
+      ]
+    },
+    "ubuntu.14.10-x86-corert": {
+      "#import": [
+        "ubuntu.14.10-corert",
+        "ubuntu.14.10-x86",
+        "ubuntu.14.10",
+        "ubuntu-x86-corert"
       ]
     },
     "ubuntu.15.04": {
@@ -1083,10 +1917,18 @@
         "ubuntu-arm"
       ]
     },
+    "ubuntu.15.04-arm-corert": {
+      "#import": [
+        "ubuntu.15.04-corert",
+        "ubuntu.15.04-arm",
+        "ubuntu.15.04",
+        "ubuntu-arm-corert"
+      ]
+    },
     "ubuntu.15.04-corert": {
       "#import": [
-        "ubuntu.14.10-corert",
-        "ubuntu-15.04"
+        "ubuntu.15.04",
+        "ubuntu-corert"
       ]
     },
     "ubuntu.15.04-x64": {
@@ -1098,14 +1940,23 @@
     "ubuntu.15.04-x64-corert": {
       "#import": [
         "ubuntu.15.04-corert",
-        "ubuntu.14.10-x64-corert",
-        "ubuntu.15.04-x64"
+        "ubuntu.15.04-x64",
+        "ubuntu.15.04",
+        "ubuntu-x64-corert"
       ]
     },
     "ubuntu.15.04-x86": {
       "#import": [
         "ubuntu.15.04",
         "ubuntu-x86"
+      ]
+    },
+    "ubuntu.15.04-x86-corert": {
+      "#import": [
+        "ubuntu.15.04-corert",
+        "ubuntu.15.04-x86",
+        "ubuntu.15.04",
+        "ubuntu-x86-corert"
       ]
     },
     "ubuntu.15.10": {
@@ -1119,10 +1970,18 @@
         "ubuntu-arm"
       ]
     },
+    "ubuntu.15.10-arm-corert": {
+      "#import": [
+        "ubuntu.15.10-corert",
+        "ubuntu.15.10-arm",
+        "ubuntu.15.10",
+        "ubuntu-arm-corert"
+      ]
+    },
     "ubuntu.15.10-corert": {
       "#import": [
-        "ubuntu.15.04-corert",
-        "ubuntu-15.10"
+        "ubuntu.15.10",
+        "ubuntu-corert"
       ]
     },
     "ubuntu.15.10-x64": {
@@ -1134,14 +1993,23 @@
     "ubuntu.15.10-x64-corert": {
       "#import": [
         "ubuntu.15.10-corert",
-        "ubuntu.15.04-x64-corert",
-        "ubuntu.15.10-x64"
+        "ubuntu.15.10-x64",
+        "ubuntu.15.10",
+        "ubuntu-x64-corert"
       ]
     },
     "ubuntu.15.10-x86": {
       "#import": [
         "ubuntu.15.10",
         "ubuntu-x86"
+      ]
+    },
+    "ubuntu.15.10-x86-corert": {
+      "#import": [
+        "ubuntu.15.10-corert",
+        "ubuntu.15.10-x86",
+        "ubuntu.15.10",
+        "ubuntu-x86-corert"
       ]
     },
     "ubuntu.16.04": {
@@ -1155,16 +2023,32 @@
         "ubuntu-arm"
       ]
     },
+    "ubuntu.16.04-arm-corert": {
+      "#import": [
+        "ubuntu.16.04-corert",
+        "ubuntu.16.04-arm",
+        "ubuntu.16.04",
+        "ubuntu-arm-corert"
+      ]
+    },
     "ubuntu.16.04-arm64": {
       "#import": [
         "ubuntu.16.04",
         "ubuntu-arm64"
       ]
     },
+    "ubuntu.16.04-arm64-corert": {
+      "#import": [
+        "ubuntu.16.04-corert",
+        "ubuntu.16.04-arm64",
+        "ubuntu.16.04",
+        "ubuntu-arm64-corert"
+      ]
+    },
     "ubuntu.16.04-corert": {
       "#import": [
-        "ubuntu.15.10-corert",
-        "ubuntu-16.04"
+        "ubuntu.16.04",
+        "ubuntu-corert"
       ]
     },
     "ubuntu.16.04-x64": {
@@ -1176,14 +2060,23 @@
     "ubuntu.16.04-x64-corert": {
       "#import": [
         "ubuntu.16.04-corert",
-        "ubuntu.15.10-x64-corert",
-        "ubuntu.16.04-x64"
+        "ubuntu.16.04-x64",
+        "ubuntu.16.04",
+        "ubuntu-x64-corert"
       ]
     },
     "ubuntu.16.04-x86": {
       "#import": [
         "ubuntu.16.04",
         "ubuntu-x86"
+      ]
+    },
+    "ubuntu.16.04-x86-corert": {
+      "#import": [
+        "ubuntu.16.04-corert",
+        "ubuntu.16.04-x86",
+        "ubuntu.16.04",
+        "ubuntu-x86-corert"
       ]
     },
     "ubuntu.16.10": {
@@ -1197,16 +2090,32 @@
         "ubuntu-arm"
       ]
     },
+    "ubuntu.16.10-arm-corert": {
+      "#import": [
+        "ubuntu.16.10-corert",
+        "ubuntu.16.10-arm",
+        "ubuntu.16.10",
+        "ubuntu-arm-corert"
+      ]
+    },
     "ubuntu.16.10-arm64": {
       "#import": [
         "ubuntu.16.10",
         "ubuntu-arm64"
       ]
     },
+    "ubuntu.16.10-arm64-corert": {
+      "#import": [
+        "ubuntu.16.10-corert",
+        "ubuntu.16.10-arm64",
+        "ubuntu.16.10",
+        "ubuntu-arm64-corert"
+      ]
+    },
     "ubuntu.16.10-corert": {
       "#import": [
-        "ubuntu.16.04-corert",
-        "ubuntu.16.10"
+        "ubuntu.16.10",
+        "ubuntu-corert"
       ]
     },
     "ubuntu.16.10-x64": {
@@ -1218,14 +2127,224 @@
     "ubuntu.16.10-x64-corert": {
       "#import": [
         "ubuntu.16.10-corert",
-        "ubuntu.16.04-x64-corert",
-        "ubuntu.16.10-x64"
+        "ubuntu.16.10-x64",
+        "ubuntu.16.10",
+        "ubuntu-x64-corert"
       ]
     },
     "ubuntu.16.10-x86": {
       "#import": [
         "ubuntu.16.10",
         "ubuntu-x86"
+      ]
+    },
+    "ubuntu.16.10-x86-corert": {
+      "#import": [
+        "ubuntu.16.10-corert",
+        "ubuntu.16.10-x86",
+        "ubuntu.16.10",
+        "ubuntu-x86-corert"
+      ]
+    },
+    "ubuntu.17.04": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.17.04-arm": {
+      "#import": [
+        "ubuntu.17.04",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.17.04-arm-corert": {
+      "#import": [
+        "ubuntu.17.04-corert",
+        "ubuntu.17.04-arm",
+        "ubuntu.17.04",
+        "ubuntu-arm-corert"
+      ]
+    },
+    "ubuntu.17.04-arm64": {
+      "#import": [
+        "ubuntu.17.04",
+        "ubuntu-arm64"
+      ]
+    },
+    "ubuntu.17.04-arm64-corert": {
+      "#import": [
+        "ubuntu.17.04-corert",
+        "ubuntu.17.04-arm64",
+        "ubuntu.17.04",
+        "ubuntu-arm64-corert"
+      ]
+    },
+    "ubuntu.17.04-corert": {
+      "#import": [
+        "ubuntu.17.04",
+        "ubuntu-corert"
+      ]
+    },
+    "ubuntu.17.04-x64": {
+      "#import": [
+        "ubuntu.17.04",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.17.04-x64-corert": {
+      "#import": [
+        "ubuntu.17.04-corert",
+        "ubuntu.17.04-x64",
+        "ubuntu.17.04",
+        "ubuntu-x64-corert"
+      ]
+    },
+    "ubuntu.17.04-x86": {
+      "#import": [
+        "ubuntu.17.04",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.17.04-x86-corert": {
+      "#import": [
+        "ubuntu.17.04-corert",
+        "ubuntu.17.04-x86",
+        "ubuntu.17.04",
+        "ubuntu-x86-corert"
+      ]
+    },
+    "ubuntu.17.10": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.17.10-arm": {
+      "#import": [
+        "ubuntu.17.10",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.17.10-arm-corert": {
+      "#import": [
+        "ubuntu.17.10-corert",
+        "ubuntu.17.10-arm",
+        "ubuntu.17.10",
+        "ubuntu-arm-corert"
+      ]
+    },
+    "ubuntu.17.10-arm64": {
+      "#import": [
+        "ubuntu.17.10",
+        "ubuntu-arm64"
+      ]
+    },
+    "ubuntu.17.10-arm64-corert": {
+      "#import": [
+        "ubuntu.17.10-corert",
+        "ubuntu.17.10-arm64",
+        "ubuntu.17.10",
+        "ubuntu-arm64-corert"
+      ]
+    },
+    "ubuntu.17.10-corert": {
+      "#import": [
+        "ubuntu.17.10",
+        "ubuntu-corert"
+      ]
+    },
+    "ubuntu.17.10-x64": {
+      "#import": [
+        "ubuntu.17.10",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.17.10-x64-corert": {
+      "#import": [
+        "ubuntu.17.10-corert",
+        "ubuntu.17.10-x64",
+        "ubuntu.17.10",
+        "ubuntu-x64-corert"
+      ]
+    },
+    "ubuntu.17.10-x86": {
+      "#import": [
+        "ubuntu.17.10",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.17.10-x86-corert": {
+      "#import": [
+        "ubuntu.17.10-corert",
+        "ubuntu.17.10-x86",
+        "ubuntu.17.10",
+        "ubuntu-x86-corert"
+      ]
+    },
+    "ubuntu.18.04": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.18.04-arm": {
+      "#import": [
+        "ubuntu.18.04",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.18.04-arm-corert": {
+      "#import": [
+        "ubuntu.18.04-corert",
+        "ubuntu.18.04-arm",
+        "ubuntu.18.04",
+        "ubuntu-arm-corert"
+      ]
+    },
+    "ubuntu.18.04-arm64": {
+      "#import": [
+        "ubuntu.18.04",
+        "ubuntu-arm64"
+      ]
+    },
+    "ubuntu.18.04-arm64-corert": {
+      "#import": [
+        "ubuntu.18.04-corert",
+        "ubuntu.18.04-arm64",
+        "ubuntu.18.04",
+        "ubuntu-arm64-corert"
+      ]
+    },
+    "ubuntu.18.04-corert": {
+      "#import": [
+        "ubuntu.18.04",
+        "ubuntu-corert"
+      ]
+    },
+    "ubuntu.18.04-x64": {
+      "#import": [
+        "ubuntu.18.04",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.18.04-x64-corert": {
+      "#import": [
+        "ubuntu.18.04-corert",
+        "ubuntu.18.04-x64",
+        "ubuntu.18.04",
+        "ubuntu-x64-corert"
+      ]
+    },
+    "ubuntu.18.04-x86": {
+      "#import": [
+        "ubuntu.18.04",
+        "ubuntu-x86"
+      ]
+    },
+    "ubuntu.18.04-x86-corert": {
+      "#import": [
+        "ubuntu.18.04-corert",
+        "ubuntu.18.04-x86",
+        "ubuntu.18.04",
+        "ubuntu-x86-corert"
       ]
     },
     "unix": {
@@ -1260,10 +2379,16 @@
         "unix"
       ]
     },
+    "unix-armel-corert": {
+      "#import": [
+        "unix-corert",
+        "unix-armel"
+      ]
+    },
     "unix-corert": {
       "#import": [
-        "corert",
-        "unix"
+        "unix",
+        "corert"
       ]
     },
     "unix-x64": {
@@ -1282,6 +2407,12 @@
         "unix"
       ]
     },
+    "unix-x86-corert": {
+      "#import": [
+        "unix-corert",
+        "unix-x86"
+      ]
+    },
     "win": {
       "#import": [
         "any"
@@ -1298,15 +2429,39 @@
         "win"
       ]
     },
+    "win-arm-aot": {
+      "#import": [
+        "win-aot",
+        "win-arm"
+      ]
+    },
+    "win-arm-corert": {
+      "#import": [
+        "win-corert",
+        "win-arm"
+      ]
+    },
     "win-arm64": {
       "#import": [
         "win"
       ]
     },
+    "win-arm64-aot": {
+      "#import": [
+        "win-aot",
+        "win-arm64"
+      ]
+    },
+    "win-arm64-corert": {
+      "#import": [
+        "win-corert",
+        "win-arm64"
+      ]
+    },
     "win-corert": {
       "#import": [
-        "corert",
-        "win"
+        "win",
+        "corert"
       ]
     },
     "win-x64": {
@@ -1364,38 +2519,44 @@
       "#import": [
         "win10-aot",
         "win10-arm",
+        "win10",
         "win81-arm-aot"
       ]
     },
     "win10-arm-corert": {
       "#import": [
         "win10-corert",
-        "win81-arm-corert",
-        "win10-arm"
+        "win10-arm",
+        "win10",
+        "win81-arm-corert"
       ]
     },
     "win10-arm64": {
       "#import": [
         "win10",
-        "win-arm64"
+        "win81-arm64"
       ]
     },
     "win10-arm64-aot": {
       "#import": [
         "win10-aot",
-        "win10-arm64"
+        "win10-arm64",
+        "win10",
+        "win81-arm64-aot"
       ]
     },
     "win10-arm64-corert": {
       "#import": [
         "win10-corert",
-        "win10-arm64"
+        "win10-arm64",
+        "win10",
+        "win81-arm64-corert"
       ]
     },
     "win10-corert": {
       "#import": [
-        "win81-corert",
-        "win10"
+        "win10",
+        "win81-corert"
       ]
     },
     "win10-x64": {
@@ -1408,14 +2569,16 @@
       "#import": [
         "win10-aot",
         "win10-x64",
+        "win10",
         "win81-x64-aot"
       ]
     },
     "win10-x64-corert": {
       "#import": [
         "win10-corert",
-        "win81-x64-corert",
-        "win10-x64"
+        "win10-x64",
+        "win10",
+        "win81-x64-corert"
       ]
     },
     "win10-x86": {
@@ -1428,14 +2591,16 @@
       "#import": [
         "win10-aot",
         "win10-x86",
+        "win10",
         "win81-x86-aot"
       ]
     },
     "win10-x86-corert": {
       "#import": [
         "win10-corert",
-        "win81-x86-corert",
-        "win10-x86"
+        "win10-x86",
+        "win10",
+        "win81-x86-corert"
       ]
     },
     "win7": {
@@ -1445,14 +2610,58 @@
     },
     "win7-aot": {
       "#import": [
-        "win-aot",
-        "win7"
+        "win7",
+        "win-aot"
+      ]
+    },
+    "win7-arm": {
+      "#import": [
+        "win7",
+        "win-arm"
+      ]
+    },
+    "win7-arm-aot": {
+      "#import": [
+        "win7-aot",
+        "win7-arm",
+        "win7",
+        "win-arm-aot"
+      ]
+    },
+    "win7-arm-corert": {
+      "#import": [
+        "win7-corert",
+        "win7-arm",
+        "win7",
+        "win-arm-corert"
+      ]
+    },
+    "win7-arm64": {
+      "#import": [
+        "win7",
+        "win-arm64"
+      ]
+    },
+    "win7-arm64-aot": {
+      "#import": [
+        "win7-aot",
+        "win7-arm64",
+        "win7",
+        "win-arm64-aot"
+      ]
+    },
+    "win7-arm64-corert": {
+      "#import": [
+        "win7-corert",
+        "win7-arm64",
+        "win7",
+        "win-arm64-corert"
       ]
     },
     "win7-corert": {
       "#import": [
-        "win-corert",
-        "win7"
+        "win7",
+        "win-corert"
       ]
     },
     "win7-x64": {
@@ -1464,13 +2673,17 @@
     "win7-x64-aot": {
       "#import": [
         "win7-aot",
-        "win7-x64"
+        "win7-x64",
+        "win7",
+        "win-x64-aot"
       ]
     },
     "win7-x64-corert": {
       "#import": [
         "win7-corert",
-        "win7-x64"
+        "win7-x64",
+        "win7",
+        "win-x64-corert"
       ]
     },
     "win7-x86": {
@@ -1482,13 +2695,17 @@
     "win7-x86-aot": {
       "#import": [
         "win7-aot",
-        "win7-x86"
+        "win7-x86",
+        "win7",
+        "win-x86-aot"
       ]
     },
     "win7-x86-corert": {
       "#import": [
         "win7-corert",
-        "win7-x86"
+        "win7-x86",
+        "win7",
+        "win-x86-corert"
       ]
     },
     "win8": {
@@ -1505,25 +2722,51 @@
     "win8-arm": {
       "#import": [
         "win8",
-        "win-arm"
+        "win7-arm"
       ]
     },
     "win8-arm-aot": {
       "#import": [
         "win8-aot",
-        "win8-arm"
+        "win8-arm",
+        "win8",
+        "win7-arm-aot"
       ]
     },
     "win8-arm-corert": {
       "#import": [
         "win8-corert",
-        "win8-arm"
+        "win8-arm",
+        "win8",
+        "win7-arm-corert"
+      ]
+    },
+    "win8-arm64": {
+      "#import": [
+        "win8",
+        "win7-arm64"
+      ]
+    },
+    "win8-arm64-aot": {
+      "#import": [
+        "win8-aot",
+        "win8-arm64",
+        "win8",
+        "win7-arm64-aot"
+      ]
+    },
+    "win8-arm64-corert": {
+      "#import": [
+        "win8-corert",
+        "win8-arm64",
+        "win8",
+        "win7-arm64-corert"
       ]
     },
     "win8-corert": {
       "#import": [
-        "win7-corert",
-        "win8"
+        "win8",
+        "win7-corert"
       ]
     },
     "win8-x64": {
@@ -1536,14 +2779,16 @@
       "#import": [
         "win8-aot",
         "win8-x64",
+        "win8",
         "win7-x64-aot"
       ]
     },
     "win8-x64-corert": {
       "#import": [
         "win8-corert",
-        "win7-x64-corert",
-        "win8-x64"
+        "win8-x64",
+        "win8",
+        "win7-x64-corert"
       ]
     },
     "win8-x86": {
@@ -1556,14 +2801,16 @@
       "#import": [
         "win8-aot",
         "win8-x86",
+        "win8",
         "win7-x86-aot"
       ]
     },
     "win8-x86-corert": {
       "#import": [
         "win8-corert",
-        "win7-x86-corert",
-        "win8-x86"
+        "win8-x86",
+        "win8",
+        "win7-x86-corert"
       ]
     },
     "win81": {
@@ -1587,20 +2834,44 @@
       "#import": [
         "win81-aot",
         "win81-arm",
+        "win81",
         "win8-arm-aot"
       ]
     },
     "win81-arm-corert": {
       "#import": [
         "win81-corert",
-        "win8-arm-corert",
-        "win81-arm"
+        "win81-arm",
+        "win81",
+        "win8-arm-corert"
+      ]
+    },
+    "win81-arm64": {
+      "#import": [
+        "win81",
+        "win8-arm64"
+      ]
+    },
+    "win81-arm64-aot": {
+      "#import": [
+        "win81-aot",
+        "win81-arm64",
+        "win81",
+        "win8-arm64-aot"
+      ]
+    },
+    "win81-arm64-corert": {
+      "#import": [
+        "win81-corert",
+        "win81-arm64",
+        "win81",
+        "win8-arm64-corert"
       ]
     },
     "win81-corert": {
       "#import": [
-        "win8-corert",
-        "win81"
+        "win81",
+        "win8-corert"
       ]
     },
     "win81-x64": {
@@ -1613,14 +2884,16 @@
       "#import": [
         "win81-aot",
         "win81-x64",
+        "win81",
         "win8-x64-aot"
       ]
     },
     "win81-x64-corert": {
       "#import": [
         "win81-corert",
-        "win8-x64-corert",
-        "win81-x64"
+        "win81-x64",
+        "win81",
+        "win8-x64-corert"
       ]
     },
     "win81-x86": {
@@ -1633,14 +2906,16 @@
       "#import": [
         "win81-aot",
         "win81-x86",
+        "win81",
         "win8-x86-aot"
       ]
     },
     "win81-x86-corert": {
       "#import": [
         "win81-corert",
-        "win8-x86-corert",
-        "win81-x86"
+        "win81-x86",
+        "win81",
+        "win8-x86-corert"
       ]
     }
   }


### PR DESCRIPTION
This brings the runtime.json changes introduced in #26439 to the release/2.0.0 branch as requested.

It looks like the overall shape of the file has diverged a bit between master and release/2.0.0, so the diff is showing the file as completely changed. As far as I can tell this doesn't remove any RIDs, just adding them and rearranging the ones that are already in the file.

cc: @joshfree @ianhays 