### PR TITLE
clean up request and response version handling in managed handler

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -378,6 +378,9 @@
   <data name="net_http_unsupported_chunking" xml:space="preserve">
     <value>HTTP 1.0 does not support chunking.</value>
   </data>
+  <data name="net_http_unsupported_version" xml:space="preserve">
+    <value>Request specified an unsupported HTTP version.</value>
+  </data>
   <data name="IO_SeekBeforeBegin" xml:space="preserve">
     <value>An attempt was made to move the position before the beginning of the stream.</value>
   </data>

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -379,7 +379,7 @@
     <value>HTTP 1.0 does not support chunking.</value>
   </data>
   <data name="net_http_unsupported_version" xml:space="preserve">
-    <value>Request specified an unsupported HTTP version.</value>
+    <value>Request HttpVersion 0.X is not supported.  Use 1.0 or above.</value>
   </data>
   <data name="IO_SeekBeforeBegin" xml:space="preserve">
     <value>An attempt was made to move the position before the beginning of the stream.</value>

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -533,14 +533,10 @@ namespace System.Net.Http
 
             // Set the response HttpVersion
             byte minorVersion = line[7];
-            if (!IsDigit(minorVersion))
-            {
-                ThrowInvalidHttpResponse();
-            }
-
             response.Version =
                 minorVersion == '1' ? HttpVersion.Version11 :
                 minorVersion == '0' ? HttpVersion.Version10 :
+                !IsDigit(minorVersion) ? throw new HttpRequestException(SR.net_http_invalid_response) :
                 new Version(1, minorVersion - '0');
 
             // Set the status code

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1949,6 +1949,12 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task SendAsync_RequestVersionNotSpecified_ServerReceivesVersion11Request()
         {
+            // Managed handler treats 0.0 as a bad version, and throws.
+            if (UseManagedHandler)
+            {
+                return;
+            }
+
             // The default value for HttpRequestMessage.Version is Version(1,1).
             // So, we need to set something different (0,0), to test the "unknown" version.
             Version receivedRequestVersion = await SendRequestAndGetRequestVersionAsync(new Version(0, 0));

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -15,8 +15,9 @@ namespace System.Net.Http.Functional.Tests
     {
         protected virtual Stream GetStream(Stream s) => s;
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // Uap does not support 1.0
         [Fact]
-        public async Task GetAsyncVersion10_SendsVersion10_Success()
+        public async Task GetAsync_RequestVersion10_Success()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
@@ -40,7 +41,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public async Task GetAsyncVersion11_SendsVersion11_Success()
+        public async Task GetAsync_RequestVersion11_Success()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
@@ -64,14 +65,19 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData(0, 0)]
-        [InlineData(0, 1)]
-        [InlineData(0, 9)]
-        public async Task GetAsync_BadVersion_Throws(int majorVersion, int minorVersion)
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(9)]
+        public async Task GetAsync_RequestVersion0X_ThrowsOr11(int minorVersion)
         {
-            if (!UseManagedHandler)
+            Type exceptionType = null;
+            if (UseManagedHandler)
             {
-                return;
+                exceptionType = typeof(NotSupportedException);
+            }
+            else if (PlatformDetection.IsFullFramework)
+            {
+                exceptionType = typeof(ArgumentException);
             }
 
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -79,9 +85,24 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient())
                 {
                     HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
-                    request.Version = new Version(majorVersion, minorVersion);
+                    request.Version = new Version(0, minorVersion);
 
-                    await Assert.ThrowsAsync<NotSupportedException>(async () => await client.SendAsync(request));
+                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
+                    Task<List<string>> serverTask =
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
+                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+
+                    if (exceptionType == null)
+                    {
+                        await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+                        var requestLines = await serverTask;
+                        Assert.Equal($"GET {url.PathAndQuery} HTTP/1.1", requestLines[0]);
+                    }
+                    else
+                    {
+                        await Assert.ThrowsAsync(exceptionType, (() => TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask)));
+                    }
                 }
             });
         }
@@ -89,16 +110,17 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(1, 2)]
         [InlineData(1, 6)]
-        [InlineData(2, 0)]
+        [InlineData(2, 0)]  // Note, this is plain HTTP (not HTTPS), so 2.0 is not supported and should degrade to 1.1
         [InlineData(2, 1)]
         [InlineData(2, 7)]
         [InlineData(3, 0)]
         [InlineData(4, 2)]
-        public async Task GetAsync_UnknownVersion_DegradesTo11(int majorVersion, int minorVersion)
+        public async Task GetAsync_UnknownRequestVersion_ThrowsOrDegradesTo11(int majorVersion, int minorVersion)
         {
-            if (!UseManagedHandler)
+            Type exceptionType = null;
+            if (PlatformDetection.IsFullFramework)
             {
-                return;
+                exceptionType = typeof(ArgumentException);
             }
 
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -114,26 +136,25 @@ namespace System.Net.Http.Functional.Tests
                             $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
                             new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
 
-                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
-
-                    var requestLines = await serverTask;
-                    Assert.Equal($"GET {url.PathAndQuery} HTTP/1.1", requestLines[0]);
+                    if (exceptionType == null)
+                    {
+                        await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+                        var requestLines = await serverTask;
+                        Assert.Equal($"GET {url.PathAndQuery} HTTP/1.1", requestLines[0]);
+                    }
+                    else
+                    {
+                        await Assert.ThrowsAsync(exceptionType, (() => TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask)));
+                    }
                 }
             });
         }
 
         [Theory]
-        [InlineData(0, false)]
-        [InlineData(1, false)]
-        [InlineData(2, true)]
-        [InlineData(7, true)]
-        public async Task GetAsync_ResponseVersion1X_Success(int responseMinorVersion, bool managedHandlerOnly)
+        [InlineData(0)]
+        [InlineData(1)]
+        public async Task GetAsync_ResponseVersion10or11_Success(int responseMinorVersion)
         {
-            if (managedHandlerOnly && !UseManagedHandler)
-            {
-                return;
-            }
-
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
                 using (HttpClient client = CreateHttpClient())
@@ -159,14 +180,104 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData(0, 0)]
-        [InlineData(0, 1)]
+        [InlineData(2)]
+        [InlineData(7)]
+        public async Task GetAsync_ResponseUnknownVersion1X_Success(int responseMinorVersion)
+        {
+            bool reportAs11 = PlatformDetection.IsFullFramework;
+            bool reportAs00 = !UseManagedHandler;
+
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Version = HttpVersion.Version11;
+
+                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
+                    Task<List<string>> serverTask =
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                            $"HTTP/1.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
+                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    using (HttpResponseMessage response = await getResponseTask)
+                    {
+                        if (reportAs11)
+                        {
+                            Assert.Equal(1, response.Version.Major);
+                            Assert.Equal(1, response.Version.Minor);
+                        }
+                        else if (reportAs00)
+                        {
+                            Assert.Equal(0, response.Version.Major);
+                            Assert.Equal(0, response.Version.Minor);
+                        }
+                        else
+                        {
+                            Assert.Equal(1, response.Version.Major);
+                            Assert.Equal(responseMinorVersion, response.Version.Minor);
+                        }
+                    }
+                }
+            });
+        }
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // Uap ignores response version if not 1.0 or 1.1
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(9)]
+        public async Task GetAsync_ResponseVersion0X_ThrowsOr10(int responseMinorVersion)
+        {
+            bool reportAs10 = PlatformDetection.IsFullFramework;
+
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Version = HttpVersion.Version11;
+
+                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
+                    Task<List<string>> serverTask =
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                            $"HTTP/0.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
+                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+
+                    if (reportAs10)
+                    {
+                        await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                        using (HttpResponseMessage response = await getResponseTask)
+                        {
+                            Assert.Equal(1, response.Version.Major);
+                            Assert.Equal(0, response.Version.Minor);
+                        }
+                    }
+                    else
+                    {
+                        await Assert.ThrowsAsync<HttpRequestException>(async () => await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask));
+                    }
+                }
+            });
+        }
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // Uap ignores response version if not 1.0 or 1.1
+        [Theory]
         [InlineData(2, 0)]
         [InlineData(2, 1)]
         [InlineData(3, 0)]
         [InlineData(4, 2)]
-        public async Task GetAsyncVersion11_BadResponseVersion_Throws(int responseMajorVersion, int responseMinorVersion)
+        public async Task GetAsyncVersion11_BadResponseVersion_ThrowsOr00(int responseMajorVersion, int responseMinorVersion)
         {
+            // Full framework reports 1.0 or 1.1, depending on minor version, instead of throwing
+            bool reportAs1X = PlatformDetection.IsFullFramework;
+
+            // CurlHandler reports this as 0.0, instead of throwing.
+            bool reportAs00 = (!PlatformDetection.IsWindows && !UseManagedHandler);
+
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
                 using (HttpClient client = CreateHttpClient())
@@ -180,7 +291,30 @@ namespace System.Net.Http.Functional.Tests
                             $"HTTP/{responseMajorVersion}.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
                             new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
 
-                    await Assert.ThrowsAsync<HttpRequestException>(async () => await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask));
+                    if (reportAs00)
+                    {
+                        await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                        using (HttpResponseMessage response = await getResponseTask)
+                        {
+                            Assert.Equal(0, response.Version.Major);
+                            Assert.Equal(0, response.Version.Minor);
+                        }
+                    }
+                    else if (reportAs1X)
+                    {
+                        await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                        using (HttpResponseMessage response = await getResponseTask)
+                        {
+                            Assert.Equal(1, response.Version.Major);
+                            Assert.Equal(responseMinorVersion == 0 ? 0 : 1, response.Version.Minor);
+                        }
+                    }
+                    else
+                    {
+                        await Assert.ThrowsAsync<HttpRequestException>(async () => await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask));
+                    }
                 }
             });
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Test.Common;
 using System.Threading;
@@ -13,6 +14,176 @@ namespace System.Net.Http.Functional.Tests
     public class HttpProtocolTests : HttpClientTestBase
     {
         protected virtual Stream GetStream(Stream s) => s;
+
+        [Fact]
+        public async Task GetAsyncVersion10_SendsVersion10_Success()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Version = HttpVersion.Version10;
+
+                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
+                    Task<List<string>> serverTask =
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
+                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    var requestLines = await serverTask;
+                    Assert.Equal($"GET {url.PathAndQuery} HTTP/1.0", requestLines[0]);
+                }
+            });
+        }
+
+        [Fact]
+        public async Task GetAsyncVersion11_SendsVersion11_Success()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Version = HttpVersion.Version11;
+
+                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
+                    Task<List<string>> serverTask =
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
+                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    var requestLines = await serverTask;
+                    Assert.Equal($"GET {url.PathAndQuery} HTTP/1.1", requestLines[0]);
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(0, 1)]
+        [InlineData(0, 9)]
+        public async Task GetAsync_BadVersion_Throws(int majorVersion, int minorVersion)
+        {
+            if (!UseManagedHandler)
+            {
+                return;
+            }
+
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Version = new Version(majorVersion, minorVersion);
+
+                    await Assert.ThrowsAsync<NotSupportedException>(async () => await client.SendAsync(request));
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData(1, 2)]
+        [InlineData(1, 6)]
+        [InlineData(2, 0)]
+        [InlineData(2, 1)]
+        [InlineData(2, 7)]
+        [InlineData(3, 0)]
+        [InlineData(4, 2)]
+        public async Task GetAsync_UnknownVersion_DegradesTo11(int majorVersion, int minorVersion)
+        {
+            if (!UseManagedHandler)
+            {
+                return;
+            }
+
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Version = new Version(majorVersion, minorVersion);
+
+                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
+                    Task<List<string>> serverTask =
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                            $"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
+                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    var requestLines = await serverTask;
+                    Assert.Equal($"GET {url.PathAndQuery} HTTP/1.1", requestLines[0]);
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData(0, false)]
+        [InlineData(1, false)]
+        [InlineData(2, true)]
+        [InlineData(7, true)]
+        public async Task GetAsync_ResponseVersion1X_Success(int responseMinorVersion, bool managedHandlerOnly)
+        {
+            if (managedHandlerOnly && !UseManagedHandler)
+            {
+                return;
+            }
+
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Version = HttpVersion.Version11;
+
+                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
+                    Task<List<string>> serverTask =
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                            $"HTTP/1.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
+                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    using (HttpResponseMessage response = await getResponseTask)
+                    {
+                        Assert.Equal(1, response.Version.Major);
+                        Assert.Equal(responseMinorVersion, response.Version.Minor);
+                    }
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(0, 1)]
+        [InlineData(2, 0)]
+        [InlineData(2, 1)]
+        [InlineData(3, 0)]
+        [InlineData(4, 2)]
+        public async Task GetAsyncVersion11_BadResponseVersion_Throws(int responseMajorVersion, int responseMinorVersion)
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Version = HttpVersion.Version11;
+
+                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
+                    Task<List<string>> serverTask =
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                            $"HTTP/{responseMajorVersion}.{responseMinorVersion} 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n",
+                            new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+
+                    await Assert.ThrowsAsync<HttpRequestException>(async () => await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask));
+                }
+            });
+        }
 
         [Theory]
         // The following disabled by ActiveIssue: 26540


### PR DESCRIPTION
For request version: treat < 1.0 as an error, and > 1.1 should degrade to 1.1.
For response version: 1.x should return version as received; anything else should be treated as a bad response.

Add tests.

@stephentoub @davidsh @Priya91 @wfurt