### PR TITLE
Fix IO error handling for adding certs to X509Store on Linux

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -163,11 +163,7 @@ namespace Internal.Cryptography.Pal
                     {
                         userIntermediate.Add(cert);
                     }
-                    catch (CryptographicException)
-                    {
-                        // Saving is opportunistic, just ignore failures
-                    }
-                    catch (IOException)
+                    catch
                     {
                         // Saving is opportunistic, just ignore failures
                     }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -116,6 +116,22 @@ namespace Internal.Cryptography.Pal
                 throw new CryptographicException(SR.Cryptography_X509_StoreReadOnly);
             }
 
+            try
+            {
+                AddCertToStore(certPal);
+            }
+            catch (CryptographicException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new CryptographicException(SR.Cryptography_X509_StoreAddFailure, e);
+            }
+        }
+
+        private void AddCertToStore(ICertificatePal certPal)
+        {
             // This may well be the first time that we've added something to this store.
             Directory.CreateDirectory(_storePath);
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -235,6 +235,9 @@
   <data name="Cryptography_X509_PKCS7_NoSigner" xml:space="preserve">
     <value>Cannot find the original signer.</value>
   </data>
+  <data name="Cryptography_X509_StoreAddFailure" xml:space="preserve">
+    <value>The X509 certificate could not be added to the store.</value>
+  </data>
   <data name="Cryptography_X509_StoreNoFileAvailable" xml:space="preserve">
     <value>The X509 certificate could not be added to the store because all candidate file names were in use.</value>
   </data>


### PR DESCRIPTION
If a directory was readonly then UnauthorizedAccessException was being thrown
and not handled by opportunistic caching, so caching now won't fail on that
exception.

Other tests being run after

mv ~/.dotnet{,-sav}
chmod u-w ~

showed that the exception model wasn't very tight, so now all rogue
exceptions from X509Store.Add will be wrapped in CryptographicException.
This better matches Windows and macOS where a CryptographicException
is raised to interpret a failed NTSTATUS/HRESULT/OSStatus.

Fixes #23549.