### PR TITLE
Make sure HttpListenerContext will not deallocate twice

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -1335,11 +1335,11 @@ namespace System.Net
         
         private static void FreeContext(ref HttpListenerContext httpContext, RequestContextBase memoryBlob)
         {
-            if (httpContext != null)
+            HttpListenerContext context = Interlocked.Exchange(ref httpContext, null);
+            if (context != null)
             {
-                httpContext.Request.DetachBlob(memoryBlob);
-                httpContext.Close();
-                httpContext = null;
+                context.Request.DetachBlob(memoryBlob);
+                context.Close();
             }
         }
 

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -1335,11 +1335,11 @@ namespace System.Net
         
         private static void FreeContext(ref HttpListenerContext httpContext, RequestContextBase memoryBlob)
         {
-            HttpListenerContext context = Interlocked.Exchange(ref httpContext, null);
-            if (context != null)
+            if (httpContext != null)
             {
-                context.Request.DetachBlob(memoryBlob);
-                context.Close();
+                httpContext.Request.DetachBlob(memoryBlob);
+                httpContext.Close();
+                httpContext = null;
             }
         }
 


### PR DESCRIPTION
Under certain stress conditions, HttpListener.EndGetContext (GetContextAsync) will throw NullReferenceException
as it tries to deallocate an internal HttpListenerContext object twice while processing authentication.
This fix ensures that the code will not deallocate twice.

I have verified that the issue will repro on .NET Core 2.0, but I didn't ported the .NET Framework stress test, 
because the test may regress networking CI runs. It is ignored on .NET Framework test run as well
`[Ignore] // TODO: Failed with System.TimeoutException when running on dev machine.`

This issue was reported in internal bug 200343.