### PR TITLE
Add more tests for Span.CopyTo

### DIFF
--- a/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -193,27 +192,31 @@ namespace System.SpanTests
         [Fact]
         public static void CopyToVaryingSizes()
         {
-            var rng = new Random();
-            byte[] inputBuffer = new byte[2048];
-            byte[] outputBuffer = new byte[2048];
+            const int MaxLength = 2048;
 
-            // Test all inputs from size 0 .. 2048 (inclusive) to make sure we don't have
+            var rng = new Random();
+            byte[] inputArray = new byte[MaxLength];
+            ReadOnlySpan<byte> inputSpan = inputArray;
+            Span<byte> outputSpan = new byte[MaxLength];
+            Span<byte> allZerosSpan = new byte[MaxLength];
+
+            // Test all inputs from size 0 .. MaxLength (inclusive) to make sure we don't have
             // gaps in our Memmove logic.
-            for (int i = 0; i <= inputBuffer.Length; i++)
+            for (int i = 0; i <= MaxLength; i++)
             {
                 // Arrange
 
-                rng.NextBytes(inputBuffer);
-                Array.Clear(outputBuffer, 0, outputBuffer.Length);
+                rng.NextBytes(inputArray);
+                outputSpan.Clear();
 
                 // Act
 
-                new ReadOnlySpan<byte>(inputBuffer, 0, i).CopyTo(outputBuffer);
+                inputSpan.Slice(0, i).CopyTo(outputSpan);
 
                 // Assert
 
-                Assert.Equal(inputBuffer.Take(i), outputBuffer.Take(i)); // src successfully copied to dst
-                Assert.Equal(0, outputBuffer.Skip(i).Count(b => b != 0)); // no other part of dst was overwritten
+                Assert.True(inputSpan.Slice(0, i).SequenceEqual(outputSpan.Slice(0, i))); // src successfully copied to dst
+                Assert.True(outputSpan.Slice(i).SequenceEqual(allZerosSpan.Slice(i))); // no other part of dst was overwritten
             }
         }
     }

--- a/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -186,6 +187,33 @@ namespace System.SpanTests
                     if (allocatedSecond)
                         AllocationHelper.ReleaseNative(ref memBlockSecond);
                 }
+            }
+        }
+
+        [Fact]
+        public static void CopyToVaryingSizes()
+        {
+            var rng = new Random();
+            byte[] inputBuffer = new byte[2048];
+            byte[] outputBuffer = new byte[2048];
+
+            // Test all inputs from size 0 .. 2048 (inclusive) to make sure we don't have
+            // gaps in our Memmove logic.
+            for (int i = 0; i <= inputBuffer.Length; i++)
+            {
+                // Arrange
+
+                rng.NextBytes(inputBuffer);
+                Array.Clear(outputBuffer, 0, outputBuffer.Length);
+
+                // Act
+
+                new ReadOnlySpan<byte>(inputBuffer, 0, i).CopyTo(outputBuffer);
+
+                // Assert
+
+                Assert.Equal(inputBuffer.Take(i), outputBuffer.Take(i)); // src successfully copied to dst
+                Assert.Equal(0, outputBuffer.Skip(i).Count(b => b != 0)); // no other part of dst was overwritten
             }
         }
     }

--- a/src/System.Memory/tests/Span/CopyTo.cs
+++ b/src/System.Memory/tests/Span/CopyTo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -255,6 +256,33 @@ namespace System.SpanTests
                     if (allocatedSecond)
                         AllocationHelper.ReleaseNative(ref memBlockSecond);
                 }
+            }
+        }
+
+        [Fact]
+        public static void CopyToVaryingSizes()
+        {
+            var rng = new Random();
+            byte[] inputBuffer = new byte[2048];
+            byte[] outputBuffer = new byte[2048];
+
+            // Test all inputs from size 0 .. 2048 (inclusive) to make sure we don't have
+            // gaps in our Memmove logic.
+            for (int i = 0; i <= inputBuffer.Length; i++)
+            {
+                // Arrange
+
+                rng.NextBytes(inputBuffer);
+                Array.Clear(outputBuffer, 0, outputBuffer.Length);
+
+                // Act
+
+                new Span<byte>(inputBuffer, 0, i).CopyTo(outputBuffer);
+
+                // Assert
+
+                Assert.Equal(inputBuffer.Take(i), outputBuffer.Take(i)); // src successfully copied to dst
+                Assert.Equal(0, outputBuffer.Skip(i).Count(b => b != 0)); // no other part of dst was overwritten
             }
         }
     }

--- a/src/System.Memory/tests/Span/CopyTo.cs
+++ b/src/System.Memory/tests/Span/CopyTo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -262,27 +261,31 @@ namespace System.SpanTests
         [Fact]
         public static void CopyToVaryingSizes()
         {
-            var rng = new Random();
-            byte[] inputBuffer = new byte[2048];
-            byte[] outputBuffer = new byte[2048];
+            const int MaxLength = 2048;
 
-            // Test all inputs from size 0 .. 2048 (inclusive) to make sure we don't have
+            var rng = new Random();
+            byte[] inputArray = new byte[MaxLength];
+            Span<byte> inputSpan = inputArray;
+            Span<byte> outputSpan = new byte[MaxLength];
+            Span<byte> allZerosSpan = new byte[MaxLength];
+
+            // Test all inputs from size 0 .. MaxLength (inclusive) to make sure we don't have
             // gaps in our Memmove logic.
-            for (int i = 0; i <= inputBuffer.Length; i++)
+            for (int i = 0; i <= MaxLength; i++)
             {
                 // Arrange
 
-                rng.NextBytes(inputBuffer);
-                Array.Clear(outputBuffer, 0, outputBuffer.Length);
+                rng.NextBytes(inputArray);
+                outputSpan.Clear();
 
                 // Act
 
-                new Span<byte>(inputBuffer, 0, i).CopyTo(outputBuffer);
+                inputSpan.Slice(0, i).CopyTo(outputSpan);
 
                 // Assert
 
-                Assert.Equal(inputBuffer.Take(i), outputBuffer.Take(i)); // src successfully copied to dst
-                Assert.Equal(0, outputBuffer.Skip(i).Count(b => b != 0)); // no other part of dst was overwritten
+                Assert.True(inputSpan.Slice(0, i).SequenceEqual(outputSpan.Slice(0, i))); // src successfully copied to dst
+                Assert.True(outputSpan.Slice(i).SequenceEqual(allZerosSpan.Slice(i))); // no other part of dst was overwritten
             }
         }
     }


### PR DESCRIPTION
Since `Span<T>.CopyTo` has different implementations for fast span and slow span, it's worthwhile to add some extra unit tests exercising the complex logic of `Memmove`.

I've tested this against the coreclr PR https://github.com/dotnet/coreclr/pull/15947 to make sure we didn't accidentally break the _CopyTo_ routine.

/cc @ahsonkhan @jkotas