### PR TITLE
Utf8Parsing for Int32 'N' format

### DIFF
--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.N.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.N.cs
@@ -18,7 +18,97 @@ namespace System.Buffers.Text
 
         private static bool TryParseInt32N(ReadOnlySpan<byte> text, out int value, out int bytesConsumed)
         {
-            throw NotImplemented.ActiveIssue("https://github.com/dotnet/corefx/issues/24986");
+            if (text.Length < 1)
+                goto FalseExit;
+
+            int sign = 1;
+            int index = 0;
+            int c = text[index];
+            if (c == '-')
+            {
+                sign = -1;
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+            else if (c == '+')
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+
+            int answer;
+
+            // Handle the first digit (or period) as a special case. This ensures some compatible edge-case behavior with the classic parse routines
+            // (at least one digit must precede any commas, and a string without any digits prior to the decimal point must have at least 
+            // one digit after the decimal point.)
+            if (c == Utf8Constants.Period)
+                goto FractionalPartWithoutLeadingDigits;
+            if (!ParserHelpers.IsDigit(c))
+                goto FalseExit;
+            answer = c - '0';
+
+            for (; ; )
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+
+                c = text[index];
+                if (c == Utf8Constants.Comma)
+                    continue;
+
+                if (c == Utf8Constants.Period)
+                    goto FractionalDigits;
+
+                if (!ParserHelpers.IsDigit(c))
+                    goto Done;
+
+                if (((uint)answer) > int.MaxValue / 10)
+                    goto FalseExit;
+
+                answer = answer * 10 + c - '0';
+
+                // if sign < 0, (-1 * sign + 1) / 2 = 1
+                // else, (-1 * sign + 1) / 2 = 0
+                if ((uint)answer > (uint)int.MaxValue + (-1 * sign + 1) / 2)
+                    goto FalseExit; // Overflow
+            }
+
+FractionalPartWithoutLeadingDigits: // If we got here, we found a decimal point before we found any digits. This is legal as long as there's at least one zero after the decimal point.
+            answer = 0;
+            index++;
+            if ((uint)index >= (uint)text.Length)
+                goto FalseExit;
+            if (text[index] != '0')
+                goto FalseExit;
+
+FractionalDigits: // "N" format allows a fractional portion despite being an integer format but only if the post-fraction digits are all 0.
+            do
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                c = text[index];
+            }
+            while (c == '0');
+
+            if (ParserHelpers.IsDigit(c))
+                goto FalseExit; // The fractional portion contained a non-zero digit. Treat this as an error, not an early termination.
+            goto Done;
+
+FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
+
+Done:
+            bytesConsumed = index;
+            value = answer * sign;
+            return true;
         }
 
         private static bool TryParseInt64N(ReadOnlySpan<byte> text, out long value, out int bytesConsumed)

--- a/src/System.Memory/tests/ParsersAndFormatters/Parser/ParserTests.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/Parser/ParserTests.cs
@@ -147,6 +147,9 @@ namespace System.Buffers.Text.Tests
             //
             try
             {
+                if (integerType == typeof(int))
+                    return;
+
                 TryParseUtf8(integerType, Array.Empty<byte>(), out _, out _, 'N');
                 Assert.False(true,
                     $"Thank you for implementing the TryParse 'N' format. You can now disable this test and change {nameof(TestData.IsParsingImplemented)}() so it no longer suppresses 'N' testing.");

--- a/src/System.Memory/tests/ParsersAndFormatters/SupportedFormats.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/SupportedFormats.cs
@@ -33,7 +33,7 @@ namespace System.Buffers.Text.Tests
         //
         public static bool IsParsingImplemented(this SupportedFormat f, Type t)
         {
-            if (IntegerTypes.Contains(t) && (f.Symbol == 'N' || f.Symbol == 'n'))
+            if (IntegerTypes.Contains(t) && t != typeof(int) && (f.Symbol == 'N' || f.Symbol == 'n'))
                 return false;
 
             return true;


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/24986

This is a piece of the Utf8Parser that was punted for time
last year.

There are 8 overloads for each of the 8 integer types.
This PR only covers Int32. I'm putting this through
by itself for this PR so I don't have to apply every PR
feedback in octuplicate.

The "N" format prints out integers like this:

  `"N2" => 12,345.00`

This parser mimics the behavior of

 `int.TryParse(v, NumberStyles.Integer | AllowThousands | AllowDecimalPoint)`

The thing that may look strange is that the parser
allows commas anywhere, not just on the 10^3 digits.
This mimics the desktop api behavior. Comma placement is
culture-dependent and this is an api that is culture-agnostic.

The test data was confirmed on a control implementation
that calls the classic int.TryParse().