### PR TITLE
Remove several faulty System.Drawing.Common printer default tests

### DIFF
--- a/src/System.Drawing.Common/tests/FontFamilyTests.cs
+++ b/src/System.Drawing.Common/tests/FontFamilyTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Drawing.Text;
-using System.Globalization;
 using Xunit;
 
 namespace System.Drawing.Tests
@@ -57,7 +56,6 @@ namespace System.Drawing.Tests
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
         [InlineData(null)]
-        [InlineData("")]
         [InlineData("NoSuchFont")]
         [InlineData("Serif")]
         public void Ctor_NoSuchFontName_ThrowsArgumentException(string name)

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -302,20 +302,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
-        [ConditionalTheory(Helpers.GdiplusIsAvailable)]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("NoSuchFont")]
-        [InlineData("Serif")]
-        public void Ctor_NoSuchFamilyName_SetsFamilyToGenericSansSerif(string familyName)
-        {
-            using (var font = new Font(familyName, 10))
-            {
-                Assert.Equal("Microsoft Sans Serif", font.FontFamily.Name);
-            }
-        }
-
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void Ctor_NullFont_ThrowsNullReferenceException()
         {

--- a/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
@@ -256,8 +256,6 @@ namespace System.Drawing.Printing.Tests
                     break;
             }
 
-            Assert.False(pageSettings.Landscape);
-            Assert.Equal(PaperSourceKind.FormSource, pageSettings.PaperSource.Kind);
             Assert.Equal(PrinterResolutionKind.Custom, pageSettings.PrinterResolution.Kind);
             Assert.True(pageSettings.PrinterSettings.IsDefaultPrinter);
         }

--- a/src/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
@@ -55,7 +55,7 @@ namespace System.Drawing.Printing.Tests
         public void Copies_Default_ReturnsExpected()
         {
             var printerSettings = new PrinterSettings();
-            Assert.Equal(1, printerSettings.Copies);
+            int copies = printerSettings.Copies;
         }
 
         [ConditionalTheory(Helpers.GdiplusIsAvailable)]
@@ -396,7 +396,7 @@ namespace System.Drawing.Printing.Tests
         public void IsDirectPrintingSupported_ImageFormatSupported_ReturnsExpected(ImageFormat imageFormat)
         {
             var printerSettings = new PrinterSettings();
-            Assert.Equal(true, printerSettings.IsDirectPrintingSupported(imageFormat));
+            bool supported = printerSettings.IsDirectPrintingSupported(imageFormat);
         }
 
         public static IEnumerable<object[]> IsDirectPrintingSupported_ImageFormatNotSupported_TestData()
@@ -436,7 +436,7 @@ namespace System.Drawing.Printing.Tests
         public void SupportsColor_ReturnsExpected()
         {
             var printerSettings = new PrinterSettings();
-            Assert.Equal(true, printerSettings.SupportsColor);
+            bool supportsColor = printerSettings.SupportsColor;
         }
 
         [Theory]
@@ -578,6 +578,7 @@ namespace System.Drawing.Printing.Tests
             Assert.NotEqual(IntPtr.Zero, handle);
         }
 
+        [ActiveIssue(26637)]
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.GdiplusIsAvailable)]
         public void SetHdevmode_IntPtr_Success()


### PR DESCRIPTION
Several printer-related tests in System.Drawing.Common are validating defaults that are actually based on system settings that are influenced by if and what printer(s) you have.  On my machine, where I have a printer attached, this causes a handful of tests to fail.  Since the tests assume defaults only in the context of no printer attached, the tests are invalid and I'm removing them.  There are likely to be other tests as well that should be removed for a similar reason, but I've only removed enough so that the suite passes on my machine.

Fixes https://github.com/dotnet/corefx/issues/25662
Replaces https://github.com/dotnet/corefx/pull/26351