### PR TITLE
Replace TryCopyTo with CopyTo

### DIFF
--- a/src/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -1455,8 +1455,7 @@ namespace System.Globalization
                             if (thousandsSepCtr >= thousandsSepPos.Length)
                             {
                                 var newThousandsSepPos = new int[thousandsSepPos.Length * 2];
-                                bool copied = thousandsSepPos.TryCopyTo(newThousandsSepPos);
-                                Debug.Assert(copied, "Expect copy to succeed, as the new array is larger than the original");
+                                thousandsSepPos.CopyTo(newThousandsSepPos);
                                 thousandsSepPos = newThousandsSepPos;
                             }
 

--- a/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
@@ -440,8 +440,7 @@ namespace System.IO
             Debug.Assert(readbytes >= 0);
             if (readbytes > 0)
             {
-                bool copied = new Span<byte>(_buffer, _readPos, readbytes).TryCopyTo(destination);
-                Debug.Assert(copied);
+                new ReadOnlySpan<byte>(_buffer, _readPos, readbytes).CopyTo(destination);
                 _readPos += readbytes;
             }
             return readbytes;


### PR DESCRIPTION
While doing various Span-related work involving copying, in a few places, I previously used a pattern of calling TryCopyTo and then asserting its result, in places where I knew the destination was long enough. This was because CopyTo was implemented as a wrapper around TryCopyTo and thus involved an extra unnecessary branch. Now that that's no longer the case, I'm simplifying the call sites.

cc: @GrabYourPitchforks 

(corefx version of https://github.com/dotnet/coreclr/pull/16078)