### PR TITLE
Make ProtectedData function on empty input

### DIFF
--- a/src/System.Security.Cryptography.ProtectedData/tests/ProtectedDataTests.cs
+++ b/src/System.Security.Cryptography.ProtectedData/tests/ProtectedDataTests.cs
@@ -33,6 +33,24 @@ namespace System.Security.Cryptography.ProtectedDataTests
             }
         }
 
+        [Theory]
+        [InlineData(DataProtectionScope.CurrentUser, false)]
+        [InlineData(DataProtectionScope.CurrentUser, true)]
+        [InlineData(DataProtectionScope.LocalMachine, false)]
+        [InlineData(DataProtectionScope.LocalMachine, true)]
+        public static void ProtectEmptyData(DataProtectionScope scope, bool useEntropy)
+        {
+            // Use new byte[0] instead of Array.Empty<byte> to prove the implementation
+            // isn't using reference equality
+            byte[] data = new byte[0];
+            byte[] entropy = useEntropy ? new byte[] { 68, 65, 72, 72, 75 } : null;
+            byte[] encrypted = ProtectedData.Protect(data, entropy, scope);
+
+            Assert.NotEqual(data, encrypted);
+            byte[] recovered = ProtectedData.Unprotect(encrypted, entropy, scope);
+            Assert.Equal(data, recovered);
+        }
+
         [Fact]
         public static void NullEntropyEquivalence()
         {


### PR DESCRIPTION
In .NET Framework the implementation used GCHandle.Alloc, which does not
normalize an empty array to null.  In .NET Core the implementation uses fixed,
which does normalize empty to null.  Since the Win32 API rejects null inputs,
map empty to some other array for the duration of the call.

Fixes  #26273.