### PR TITLE
Make Linux and macOS throw the same exception on unknown hash algorithms

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.OSX.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.OSX.cs
@@ -27,7 +27,7 @@ namespace Internal.Cryptography
                     return new AppleDigestProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Sha512);
             }
 
-            throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
+            throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
         }
 
         public static HashProvider CreateMacProvider(string hashAlgorithmId, byte[] key)
@@ -46,7 +46,7 @@ namespace Internal.Cryptography
                     return new AppleHmacProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Sha512, key);
             }
 
-            throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
+            throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
         }
 
         // -----------------------------

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
@@ -27,7 +27,7 @@ namespace Internal.Cryptography
                 case HashAlgorithmNames.MD5:
                     return new EvpHashProvider(Interop.Crypto.EvpMd5());
             }
-            throw new CryptographicException();
+            throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
         }
 
         public static unsafe HashProvider CreateMacProvider(string hashAlgorithmId, byte[] key)
@@ -45,7 +45,7 @@ namespace Internal.Cryptography
                 case HashAlgorithmNames.MD5:
                     return new HmacHashProvider(Interop.Crypto.EvpMd5(), key);
             }
-            throw new CryptographicException();
+            throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
         }
 
         // -----------------------------

--- a/src/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.cs
@@ -265,5 +265,19 @@ namespace System.Security.Cryptography.Algorithms.Tests
                 Assert.Throws<ObjectDisposedException>(() => hash.GetHashAndReset());
             }
         }
+
+        [Fact]
+        public static void UnknownDigestAlgorithm()
+        {
+            Assert.ThrowsAny<CryptographicException>(
+                () => IncrementalHash.CreateHash(new HashAlgorithmName("SHA0")));
+        }
+
+        [Fact]
+        public static void UnknownHmacAlgorithm()
+        {
+            Assert.ThrowsAny<CryptographicException>(
+                () => IncrementalHash.CreateHMAC(new HashAlgorithmName("SHA0"), Array.Empty<byte>()));
+        }
     }
 }


### PR DESCRIPTION
Currently Linux throws CryptographicException with a default message, and
macOS throws a PNSE with a message.

This normalizes them to throw CryptographicException with a message.
Windows NetFX throws CryptographicException(NTE_BAD_ALGID), and CoreFx
behaves similarly.

Fixes #24462.