### PR TITLE
Improving EnsureCapacity unit tests

### DIFF
--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
@@ -85,7 +85,19 @@ namespace System.Collections.Tests
         #endregion
 
         #region EnsureCapacity
-        
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void EnsureCapacity_RequestingLargerCapacity_DoesNotInvalidateEnumeration(int count)
+        {
+            Dictionary<TKey, TValue> dictionary = (Dictionary<TKey, TValue>)(GenericIDictionaryFactory(count));
+            var capacity = dictionary.EnsureCapacity(0);
+            ICollection<TValue> values = dictionary.Values;
+            IEnumerator<TValue> valuesEnum = values.GetEnumerator();
+            dictionary.EnsureCapacity(capacity + 1); // Verify EnsureCapacity does not invalidate enumeration
+            while (valuesEnum.MoveNext());
+        }
+
         [Fact]
         public void EnsureCapacity_NegativeCapacityRequested_Throws()
         {

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
@@ -127,11 +127,10 @@ namespace System.Collections.Tests
             }
         }
 
-        [Fact]
-        public void EnsureCapacity_ExistingCapacityRequested_SameValueReturned()
+        [Theory]
+        [InlineData(7)]
+        public void EnsureCapacity_ExistingCapacityRequested_SameValueReturned(int capacity)
         {
-            int capacity = 7;
-
             var dictionary = new Dictionary<int, int>(capacity);
             Assert.Equal(capacity, dictionary.EnsureCapacity(capacity));
 
@@ -156,7 +155,7 @@ namespace System.Collections.Tests
             int capacity = dictionary.EnsureCapacity(count * 2);
             Assert.Equal(capacity, dictionary.EnsureCapacity(count * 2));
         }
-        
+
         [Theory]
         [InlineData(1)]
         [InlineData(5)]
@@ -171,16 +170,17 @@ namespace System.Collections.Tests
             Assert.InRange(dictionary.EnsureCapacity(count - 1), count, int.MaxValue);
         }
 
-        [Fact]
-        public void EnsureCapacity_DictionaryNotEmpty_SetsToAtLeastTheRequested()
+        [Theory]
+        [InlineData(7)]
+        [InlineData(20)]
+        public void EnsureCapacity_DictionaryNotEmpty_SetsToAtLeastTheRequested(int count)
         {
-            int count = 20;
             var dictionary = new Dictionary<int, int>();
             for (int i = 0; i < count; i++)
             {
                 dictionary.Add(i, 0);
             }
-            
+
             // get current capacity
             int currentCapacity = dictionary.EnsureCapacity(0);
 


### PR DESCRIPTION
Marking test
```EnsureCapacity_DictionaryNotInitialized_RequestedZero_ReturnsZero``` as ActiveIssue, until corecl behavioral change PR 16076 gets merged.

cc: @danmosemsft 