### PR TITLE
Make AsnSerializer resiliant to ILC reflection rules

### DIFF
--- a/src/Common/src/System/Security/Cryptography/Asn1V2.Serializer.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1V2.Serializer.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace System.Security.Cryptography.Asn1
 {
@@ -115,7 +116,8 @@ namespace System.Security.Cryptography.Asn1
                         return fieldInfos;
                     }
 
-                    return fieldInfos.OrderBy(fi => fi.MetadataToken).ToArray();
+                    Array.Sort(fieldInfos, (x, y) => x.MetadataToken.CompareTo(y.MetadataToken));
+                    return fieldInfos;
                 });
         }
 


### PR DESCRIPTION
AsnSerializer had two different paths which checked for ordered fields, one
which used the MetadataToken and one which didn't.  The MetadataToken
method is more reliable, but is not available on ILC.

With this change

* MetadataToken is used when available, and we hope for the best otherwise.
* The two paths now use the same resolution, so future algorithms apply evenly
* The results are cached, so we only sort once per type

Fixes #26123.