### PR TITLE
Add Span/ReadOnlySpan TryCast

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -75,6 +75,8 @@ namespace System
         public static System.ReadOnlySpan<char> TrimStart(this System.ReadOnlySpan<char> span, char trimChar) { throw null; }
         public static System.ReadOnlySpan<char> TrimStart(this System.ReadOnlySpan<char> span, System.ReadOnlySpan<char> trimChars) { throw null; }
         public static bool TryGetString(this System.ReadOnlyMemory<char> readOnlyMemory, out string text, out int start, out int length) { throw null; }
+        public static bool TryCast<TFrom, TTo>(this ReadOnlySpan<TFrom> source, out ReadOnlySpan<TTo> output) where TFrom : struct where TTo : struct { throw null; }
+        public static bool TryCast<TFrom, TTo>(this Span<TFrom> source, out Span<TTo> output) where TFrom : struct where TTo : struct { throw null; }
     }
     public readonly partial struct Memory<T>
     {

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -143,6 +143,7 @@
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <ReferenceFromRuntime Include="System.Private.CoreLib" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.InteropServices.RuntimeInformation\src\System.Runtime.InteropServices.RuntimeInformation.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
     <ProjectReference Include="..\..\System.Numerics.Vectors\src\System.Numerics.Vectors.csproj" />
   </ItemGroup>

--- a/src/System.Memory/src/System/MemoryExtensions.Fast.cs
+++ b/src/System.Memory/src/System/MemoryExtensions.Fast.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Internal.Runtime.CompilerServices;
 
 namespace System
 {
@@ -101,5 +103,120 @@ namespace System
         /// <returns></returns>
         public static bool TryGetString(this ReadOnlyMemory<char> readOnlyMemory, out string text, out int start, out int length) =>
             Span.TryGetString(readOnlyMemory, out text, out start, out length);
+
+        /// <summary>
+        /// Attempts to cast a ReadOnlySpan of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
+        /// </summary>
+        /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
+        /// <param name="output">The destination of type <typeparamref name="TTo"/>.</param>
+        /// <remarks>If <typeparamref name="TTo"/> is 8-byte aligned and <paramref name="source"/> points to a valid aligned <typeparamref name="TTo"/> address,
+        /// this will always return true. This is because all C# primitives are aligned against at most 8 bytes, so a pointer that is 8 byte aligned 
+        /// will be aligned to all primitives.</remarks>
+        /// <remarks>If <paramref name="source"/> doesn't point to an address that follows the os-specific alignment rules of <typeparamref name="TFrom"/>, then 
+        /// this will always return false</remarks>
+        /// <remarks>Does not require the memory being spanned over to be fixed.</remarks>
+        /// <returns>True if successful; else False</returns>
+        public static bool TryCast<TFrom, TTo>(this ReadOnlySpan<TFrom> source, out ReadOnlySpan<TTo> output) where TFrom : struct where TTo : struct
+        {
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<TFrom>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<TTo>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
+
+            if (RuntimeInformation.OSArchitecture == Architecture.X64 ||
+                RuntimeInformation.OSArchitecture == Architecture.X86)
+            {
+                output = MemoryMarshal.Cast<TFrom, TTo>(source);
+                return true;
+            }
+            else
+            {
+                unsafe
+                {
+                    // Test that the source pointer is aligned to either the size of the type or the max alignment size (8), whichever is smaller.
+
+                    // This check will return false in the case where TTo is a struct that is 8 bytes long but only 1/2/4-byte aligned and the source pointer
+                    // is 1/2/4 byte-aligned but not also 8-byte aligned. Unfortunately, to catch that case we would have to walk the 
+                    // struct element sizes to determine the actual struct alignment.
+
+                    // This check also returns false if it's coincidentally aligned to TTo in the case where sizeof(TFrom)<sizeof(TTo). This is
+                    // because the source location can move such that it no longer adheres to the alignment requirement of TTo while still
+                    // following the alignment rules for it's declared/constructed type, TFrom.
+                    void* pointer = Unsafe.AsPointer(ref MemoryMarshal.GetReference(source));
+
+                    // First we have to make sure the given pointer follows the alignment rules of its TFrom type. Since the TFrom alignment will
+                    // be preserved even if the memory is moved, we can safely make assumptions about the alignment of TTo without the need for pinning.
+                    int sizeOfTFrom = Math.Min(8, Unsafe.SizeOf<TFrom>());
+                    if (new IntPtr(pointer).ToInt64() % sizeOfTFrom == 0)
+                    {
+                        if (sizeOfTFrom == 8 || Math.Min(8, Unsafe.SizeOf<TTo>()) <= sizeOfTFrom)
+                        {
+                            output = MemoryMarshal.Cast<TFrom, TTo>(source);
+                            return true;
+                        }
+                    }
+                    output = null;
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Attempts to cast a Span of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
+        /// </summary>
+        /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
+        /// <param name="output">The destination  of type <typeparamref name="TTo"/>.</param>
+        /// <remarks>If <typeparamref name="TTo"/> is 8-byte aligned and <paramref name="source"/> points to a valid aligned <typeparamref name="TTo"/> address,
+        /// this will always return true. This is because all C# primitives are aligned against at most 8 bytes, so a pointer that is 8 byte aligned 
+        /// will be aligned to all primitives.</remarks>
+        /// <remarks>If <paramref name="source"/> doesn't point to an address that follows the os-specific alignment rules of <typeparamref name="TFrom"/>, then 
+        /// this will always return false</remarks>
+        /// <remarks>Does not require the memory being spanned over to be fixed.</remarks>
+        /// <returns>True if successful; else False</returns>
+        public static bool TryCast<TFrom, TTo>(this Span<TFrom> source, out Span<TTo> output) where TFrom : struct where TTo : struct
+        {
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<TFrom>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<TTo>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
+
+            output = null;
+            if (RuntimeInformation.OSArchitecture == Architecture.X64 ||
+                RuntimeInformation.OSArchitecture == Architecture.X86)
+            {
+                output = MemoryMarshal.Cast<TFrom, TTo>(source);
+                return true;
+            }
+            else
+            {
+                unsafe
+                {
+                    // Test that the source pointer is aligned to either the size of TTo or the max alignment size (8), whichever is smaller.
+
+                    // This check will return false in the case where TTo is a struct that is 8 bytes long but only 1/2/4-byte aligned and the source pointer
+                    // is 1/2/4 byte-aligned but not also 8-byte aligned. Unfortunately, to catch that case we would have to walk the 
+                    // struct element sizes to determine the actual struct alignment.
+
+                    // This check also returns false if it's coincidentally aligned to TTo in the case where sizeof(TFrom)<sizeof(TTo). This is
+                    // because the source location can move such that it no longer adheres to the alignment requirement of TTo while still
+                    // following the alignment rules for it's declared/constructed type, TFrom.
+                    void* pointer = Unsafe.AsPointer(ref MemoryMarshal.GetReference(source));
+
+                    // First we have to make sure the given pointer follows the alignment rules of its TFrom type. Since the TFrom alignment will
+                    // be preserved even if the memory is moved, we can safely make assumptions about the alignment of TTo without the need for pinning.
+                    int sizeOfTFrom = Math.Min(8, Unsafe.SizeOf<TFrom>());
+                    if (new IntPtr(pointer).ToInt64() % sizeOfTFrom == 0)
+                    {
+                        if (sizeOfTFrom == 8 || Math.Min(8, Unsafe.SizeOf<TTo>()) <= sizeOfTFrom)
+                        {
+                            output = MemoryMarshal.Cast<TFrom, TTo>(source);
+                            return true;
+                        }
+                    }
+                    output = null;
+                    return false;
+                }
+            }
+        }
     }
 }

--- a/src/System.Memory/src/System/MemoryExtensions.Portable.cs
+++ b/src/System.Memory/src/System/MemoryExtensions.Portable.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System
 {
@@ -191,6 +192,120 @@ namespace System
                 fixed (char* pSampleString = sampleString)
                 {
                     return Unsafe.ByteOffset<char>(ref Unsafe.As<Pinnable<char>>(sampleString).Data, ref Unsafe.AsRef<char>(pSampleString));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Attempts to cast a ReadOnlySpan of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
+        /// </summary>
+        /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
+        /// <param name="output">The destination of type <typeparamref name="TTo"/>.</param>
+        /// <remarks>If <typeparamref name="TTo"/> is 8-byte aligned and <paramref name="source"/> points to a valid aligned <typeparamref name="TTo"/> address,
+        /// this will always return true. This is because all C# primitives are aligned against at most 8 bytes, so a pointer that is 8 byte aligned 
+        /// will be aligned to all primitives.</remarks>
+        /// <remarks>If <paramref name="source"/> doesn't point to an address that follows the os-specific alignment rules of <typeparamref name="TFrom"/>, then 
+        /// this will always return false</remarks>
+        /// <remarks>Does not require the memory being spanned over to be fixed.</remarks>
+        /// <returns>True if successful; else False</returns>
+        public static bool TryCast<TFrom, TTo>(this ReadOnlySpan<TFrom> source, out ReadOnlySpan<TTo> output) where TFrom : struct where TTo : struct
+        {
+            if (SpanHelpers.IsReferenceOrContainsReferences<TFrom>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
+            if (SpanHelpers.IsReferenceOrContainsReferences<TTo>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
+
+            if (RuntimeInformation.OSArchitecture == Architecture.X64 ||
+                RuntimeInformation.OSArchitecture == Architecture.X86)
+            {
+                output = MemoryMarshal.Cast<TFrom, TTo>(source);
+                return true;
+            }
+            else
+            {
+                unsafe
+                {
+                    // Test that the source pointer is aligned to either the size of the type or the max alignment size (8), whichever is smaller.
+
+                    // This check will return false in the case where TTo is a struct that is 8 bytes long but only 1/2/4-byte aligned and the source pointer
+                    // is 1/2/4 byte-aligned but not also 8-byte aligned. Unfortunately, to catch that case we would have to walk the 
+                    // struct element sizes to determine the actual struct alignment.
+
+                    // This check also returns false if it's coincidentally aligned to TTo in the case where sizeof(TFrom)<sizeof(TTo). This is
+                    // because the source location can move such that it no longer adheres to the alignment requirement of TTo while still
+                    // following the alignment rules for it's declared/constructed type, TFrom.
+                    void* pointer = Unsafe.AsPointer(ref MemoryMarshal.GetReference(source));
+
+                    // First we have to make sure the given pointer follows the alignment rules of its TFrom type. Since the TFrom alignment will
+                    // be preserved even if the memory is moved, we can safely make assumptions about the alignment of TTo without the need for pinning.
+                    int sizeOfTFrom = Math.Min(8, Unsafe.SizeOf<TFrom>());
+                    if (new IntPtr(pointer).ToInt64() % sizeOfTFrom == 0)
+                    {
+                        if (sizeOfTFrom == 8 || Math.Min(8, Unsafe.SizeOf<TTo>()) <= sizeOfTFrom)
+                        {
+                            output = MemoryMarshal.Cast<TFrom, TTo>(source);
+                            return true;
+                        }
+                    }
+                    output = null;
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Attempts to cast a Span of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
+        /// </summary>
+        /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
+        /// <param name="output">The destination  of type <typeparamref name="TTo"/>.</param>
+        /// <remarks>If <typeparamref name="TTo"/> is 8-byte aligned and <paramref name="source"/> points to a valid aligned <typeparamref name="TTo"/> address,
+        /// this will always return true. This is because all C# primitives are aligned against at most 8 bytes, so a pointer that is 8 byte aligned 
+        /// will be aligned to all primitives.</remarks>
+        /// <remarks>If <paramref name="source"/> doesn't point to an address that follows the os-specific alignment rules of <typeparamref name="TFrom"/>, then 
+        /// this will always return false</remarks>
+        /// <remarks>Does not require the memory being spanned over to be fixed.</remarks>
+        /// <returns>True if successful; else False</returns>
+        public static bool TryCast<TFrom, TTo>(this Span<TFrom> source, out Span<TTo> output) where TFrom : struct where TTo : struct
+        {
+            if (SpanHelpers.IsReferenceOrContainsReferences<TFrom>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
+            if (SpanHelpers.IsReferenceOrContainsReferences<TTo>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
+
+            if (RuntimeInformation.OSArchitecture == Architecture.X64 ||
+                RuntimeInformation.OSArchitecture == Architecture.X86)
+            {
+                output = MemoryMarshal.Cast<TFrom, TTo>(source);
+                return true;
+            }
+            else
+            {
+                unsafe
+                {
+                    // Test that the source pointer is aligned to either the size of TTo or the max alignment size (8), whichever is smaller.
+
+                    // This check will return false in the case where TTo is a struct that is 8 bytes long but only 1/2/4-byte aligned and the source pointer
+                    // is 1/2/4 byte-aligned but not also 8-byte aligned. Unfortunately, to catch that case we would have to walk the 
+                    // struct element sizes to determine the actual struct alignment.
+
+                    // This check also returns false if it's coincidentally aligned to TTo in the case where sizeof(TFrom)<sizeof(TTo). This is
+                    // because the source location can move such that it no longer adheres to the alignment requirement of TTo while still
+                    // following the alignment rules for it's declared/constructed type, TFrom.
+                    void* pointer = Unsafe.AsPointer(ref MemoryMarshal.GetReference(source));
+
+                    // First we have to make sure the given pointer follows the alignment rules of its TFrom type. Since the TFrom alignment will
+                    // be preserved even if the memory is moved, we can safely make assumptions about the alignment of TTo without the need for pinning.
+                    int sizeOfTFrom = Math.Min(8, Unsafe.SizeOf<TFrom>());
+                    if (new IntPtr(pointer).ToInt64() % sizeOfTFrom == 0)
+                    {
+                        if (sizeOfTFrom == 8 || Math.Min(8, Unsafe.SizeOf<TTo>()) <= sizeOfTFrom)
+                        {
+                            output = MemoryMarshal.Cast<TFrom, TTo>(source);
+                            return true;
+                        }
+                    }
+                    output = null;
+                    return false;
                 }
             }
         }

--- a/src/System.Memory/tests/ReadOnlySpan/TryCast.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/TryCast.cs
@@ -1,0 +1,180 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using static System.TestHelpers;
+
+namespace System.SpanTests
+{
+    public static partial class MemoryMarshalTests
+    {
+        /// <summary>
+        /// Tests an attempted cast from a 4-byte aligned type to a 4-byte aligned struct that is >4 total bytes in length.
+        /// </summary>
+        [Fact]
+        public static unsafe void TryCastReadOnlySpan_TToStructLengthIsGreaterThanAlignment()
+        {
+            int[] a = { 100, 222 };
+            ReadOnlySpan<int> span = new ReadOnlySpan<int>(a);
+            ReadOnlySpan<PaddedStruct> asPaddedStruct;
+            if (RuntimeInformation.OSArchitecture == Architecture.X64 ||
+                RuntimeInformation.OSArchitecture == Architecture.X86)
+            {
+                Assert.True(span.TryCast(out asPaddedStruct));
+                Assert.Equal(span[1], asPaddedStruct[0].a2);
+            }
+            else
+            {
+                Assert.False(span.TryCast(out asPaddedStruct));
+            }
+        }
+
+        /// <summary>
+        /// Check that a TryCast from a 4-byte type to a struct with inserted padding up to a total length of 4 bytes
+        /// will always succeed.
+        /// </summary>
+        [Fact]
+        public static unsafe void TryCastReadOnlySpan_TToStructIsPadded()
+        {
+            int[] a = { 1, 2 };
+            ReadOnlySpan<int> span = new ReadOnlySpan<int>(a);
+            ReadOnlySpan<PaddedStruct4> asPaddedStruct;
+            Assert.True(span.TryCast(out asPaddedStruct));
+        }
+
+        /// <summary>
+        /// Test that a byte-aligned type can always be casted to another byte-aligned type.
+        /// </summary>
+        [Fact]
+        public static unsafe void TryCastReadOnlySpan_TFrom3ByteStruct()
+        {
+            ThreeByteStruct[] a = { new ThreeByteStruct { a1 = (byte)'7', a2 = (byte)'1', a3 = (byte)'2' }, new ThreeByteStruct { a1 = (byte)'0', a2 = (byte)'1', a3 = (byte)'2' } };
+            ReadOnlySpan<ThreeByteStruct> span = new ReadOnlySpan<ThreeByteStruct>(a);
+            ReadOnlySpan<byte> asByte;
+            Assert.True(span.TryCast(out asByte));
+            Assert.Equal(a[0].a1, asByte[0]);
+        }
+
+        /// <summary>
+        /// A 3-byte struct should be byte aligned, so any address is aligned
+        /// </summary>
+        [Fact]
+        public static unsafe void TryCastReadOnlySpan_TTo3ByteStruct()
+        {
+            int[] a = { 1, 2};
+            ReadOnlySpan<int> span = new ReadOnlySpan<int>(a);
+            ReadOnlySpan<ThreeByteStruct> asThreeByteStruct;
+            Assert.True(span.TryCast(out asThreeByteStruct));
+            Assert.Equal(a[0], asThreeByteStruct[0].a1);
+        }
+
+        [Fact]
+        public static unsafe void TryCastReadOnlySpan_TToSameSizeAsTFrom()
+        {
+            Length24_2[] a = { new Length24_2 { a1 = 0, a2 = 1, a3 = 2 }, new Length24_2 { a1 = 0, a2 = 1, a3 = 2 } };
+            ReadOnlySpan<Length24_2> span = new ReadOnlySpan<Length24_2>(a);
+            ReadOnlySpan<Length24> asLength24;
+            Assert.True(span.TryCast(out asLength24));
+            Assert.Equal(a[0].a1, (long)asLength24[0].a1);
+        }
+
+        [Fact]
+        public static unsafe void TryCastReadOnlySpan_TToSameAsTFrom()
+        {
+            Length24[] a = { new Length24 { a1 = 0, a2 = 1, a3 = 2 }, new Length24 { a1 = 0, a2 = 1, a3 = 2 } };
+            ReadOnlySpan<Length24> span = new ReadOnlySpan<Length24>(a);
+            ReadOnlySpan<Length24> asLength24;
+            Assert.True(span.TryCast(out asLength24));
+            Assert.Equal(a[0].a1, asLength24[0].a1);
+        }
+
+        [Fact]
+        public static unsafe void TryCastReadOnlySpan_ToLargeStruct()
+        {
+            long[] a = { 0x44332211, 0x88776655 };
+            ReadOnlySpan<long> span = new ReadOnlySpan<long>(a);
+            ReadOnlySpan<Length24> asLength24;
+            Assert.True(span.TryCast(out asLength24));
+        }
+
+        [Fact]
+        public static unsafe void TryCastReadOnlySpan_ToEmptyStruct()
+        {
+            long[] a = { 0x44332211, 0x88776655 };
+            Span<long> span = new Span<long>(a);
+            Span<EmptyStruct> asEmpty;
+            Assert.True(span.TryCast(out asEmpty));
+        }
+
+        [Fact]
+        public static unsafe void TryCastReadOnlySpan_FromUnalignedAddress()
+        {
+            // Create a span, get a pointer to it, add 1 to that pointer, then dangerously construct a new span at that unaligned pointer location
+            uint[] a = { 0x44332211, 0x88776655 };
+            ReadOnlySpan<uint> span = new ReadOnlySpan<uint>(a);
+            void* pointerSpan = Unsafe.AsPointer(ref MemoryMarshal.GetReference(span)); // this can be moved, but we're not dereferencing the pointer from here on out anyways so it doesn't matter what actually lives there
+            ReadOnlySpan<uint> offsetSpan = new ReadOnlySpan<uint>(new IntPtr(new IntPtr(pointerSpan).ToInt64() + 1).ToPointer(), span.Length);
+            ReadOnlySpan<ushort> asUShort;
+            if (RuntimeInformation.OSArchitecture == Architecture.X64 || RuntimeInformation.OSArchitecture == Architecture.X86)
+                Assert.True(offsetSpan.TryCast(out asUShort));
+            else
+                Assert.False(offsetSpan.TryCast(out asUShort));
+        }
+
+        [Fact]
+        public static void TryCastReadOnlySpan_UIntToUShort()
+        {
+            uint[] a = { 0x44332211, 0x88776655 };
+            ReadOnlySpan<uint> span = new ReadOnlySpan<uint>(a);
+            ReadOnlySpan<ushort> asUShort;
+            Assert.True(span.TryCast(out asUShort));
+
+            Assert.True(Unsafe.AreSame<ushort>(ref Unsafe.As<uint, ushort>(ref Unsafe.AsRef(in MemoryMarshal.GetReference(span))), ref Unsafe.AsRef(in MemoryMarshal.GetReference(asUShort))));
+            asUShort.Validate<ushort>(0x2211, 0x4433, 0x6655, 0x8877);
+        }
+
+        [Fact]
+        public static void TryCastReadOnlySpan_ShortToLong()
+        {
+            short[] a = { 0x1234, 0x2345, 0x3456, 0x4567, 0x5678 };
+            ReadOnlySpan<short> span = new ReadOnlySpan<short>(a);
+            ReadOnlySpan<long> asLong;
+            if (RuntimeInformation.OSArchitecture == Architecture.X64 || RuntimeInformation.OSArchitecture == Architecture.X86)
+            {
+                Assert.True(span.TryCast(out asLong));
+                Assert.True(Unsafe.AreSame<long>(ref Unsafe.As<short, long>(ref MemoryMarshal.GetReference(span)), ref MemoryMarshal.GetReference(asLong)));
+                asLong.Validate<long>(0x4567345623451234);
+            }
+            else
+            {
+                Assert.False(span.TryCast(out asLong));
+            }
+        }
+
+        [Fact]
+        public static unsafe void TryCastReadOnlySpan_Overflow()
+        {
+            ReadOnlySpan<TestStructExplicit> span = new ReadOnlySpan<TestStructExplicit>(null, Int32.MaxValue);
+
+            AssertThrows<OverflowException, TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<TestStructExplicit, byte>(_span).DontBox());
+            AssertThrows<OverflowException, TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<TestStructExplicit, ulong>(_span).DontBox());
+        }
+
+        [Fact]
+        public static void TryCastReadOnlySpan_ToTypeContainsReferences()
+        {
+            ReadOnlySpan<uint> span = new ReadOnlySpan<uint>(Array.Empty<uint>());
+            AssertThrows<ArgumentException, uint>(span, (_span) => MemoryMarshal.Cast<uint, SpanTests.StructWithReferences>(_span).DontBox());
+        }
+
+        [Fact]
+        public static void TryCastReadOnlySpan_FromTypeContainsReferences()
+        {
+            ReadOnlySpan<SpanTests.StructWithReferences> span = new ReadOnlySpan<SpanTests.StructWithReferences>(Array.Empty<SpanTests.StructWithReferences>());
+            AssertThrows<ArgumentException, SpanTests.StructWithReferences>(span, (_span) => MemoryMarshal.Cast<SpanTests.StructWithReferences, uint>(_span).DontBox());
+        }
+    }
+}

--- a/src/System.Memory/tests/Span/TryCast.cs
+++ b/src/System.Memory/tests/Span/TryCast.cs
@@ -1,0 +1,180 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using static System.TestHelpers;
+
+namespace System.SpanTests
+{
+    public static partial class MemoryMarshalTests
+    {
+        /// <summary>
+        /// Tests an attempted cast from a 4-byte aligned type to a 4-byte aligned struct that is >4 total bytes in length.
+        /// </summary>
+        [Fact]
+        public static unsafe void TryCastSpan_TToStructLengthIsGreaterThanAlignment()
+        {
+            int[] a = { 100, 222 };
+            Span<int> span = new Span<int>(a);
+            Span<PaddedStruct> asPaddedStruct;
+            if (RuntimeInformation.OSArchitecture == Architecture.X64 ||
+                RuntimeInformation.OSArchitecture == Architecture.X86)
+            {
+                Assert.True(span.TryCast(out asPaddedStruct));
+                Assert.Equal(span[1], asPaddedStruct[0].a2);
+            }
+            else
+            {
+                Assert.False(span.TryCast(out asPaddedStruct));
+            }
+        }
+
+        /// <summary>
+        /// Check that a TryCast from a 4-byte type to a struct with inserted padding up to a total length of 4 bytes
+        /// will always succeed.
+        /// </summary>
+        [Fact]
+        public static unsafe void TryCastSpan_TToStructIsPadded()
+        {
+            int[] a = { 1, 2 };
+            Span<int> span = new Span<int>(a);
+            Span<PaddedStruct4> asPaddedStruct;
+            Assert.True(span.TryCast(out asPaddedStruct));
+        }
+
+        /// <summary>
+        /// Test that a byte-aligned type can always be casted to another byte-aligned type.
+        /// </summary>
+        [Fact]
+        public static unsafe void TryCastSpan_TFrom3ByteStruct()
+        {
+            ThreeByteStruct[] a = { new ThreeByteStruct { a1 = (byte)'7', a2 = (byte)'1', a3 = (byte)'2' }, new ThreeByteStruct { a1 = (byte)'0', a2 = (byte)'1', a3 = (byte)'2' } };
+            Span<ThreeByteStruct> span = new Span<ThreeByteStruct>(a);
+            Span<byte> asByte;
+            Assert.True(span.TryCast(out asByte));
+            Assert.Equal(a[0].a1, asByte[0]);
+        }
+
+        /// <summary>
+        /// A 3-byte struct should be byte aligned, so any address is aligned
+        /// </summary>
+        [Fact]
+        public static unsafe void TryCastSpan_TTo3ByteStruct()
+        {
+            int[] a = { 1, 2 };
+            Span<int> span = new Span<int>(a);
+            Span<ThreeByteStruct> asThreeByteStruct;
+            Assert.True(span.TryCast(out asThreeByteStruct));
+            Assert.Equal(a[0], asThreeByteStruct[0].a1);
+        }
+
+        [Fact]
+        public static unsafe void TryCastSpan_TToSameSizeAsTFrom()
+        {
+            Length24_2[] a = { new Length24_2 { a1 = 0, a2 = 1, a3 = 2 }, new Length24_2 { a1 = 0, a2 = 1, a3 = 2 } };
+            Span<Length24_2> span = new Span<Length24_2>(a);
+            Span<Length24> asLength24;
+            Assert.True(span.TryCast(out asLength24));
+            Assert.Equal(a[0].a1, (long)asLength24[0].a1);
+        }
+
+        [Fact]
+        public static unsafe void TryCastSpan_TToSameAsTFrom()
+        {
+            Length24[] a = { new Length24 { a1 = 0, a2 = 1, a3 = 2 }, new Length24 { a1 = 0, a2 = 1, a3 = 2 } };
+            Span<Length24> span = new Span<Length24>(a);
+            Span<Length24> asLength24;
+            Assert.True(span.TryCast(out asLength24));
+            Assert.Equal(a[0].a1, asLength24[0].a1);
+        }
+
+        [Fact]
+        public static unsafe void TryCastSpan_ToLargeStruct()
+        {
+            long[] a = { 0x44332211, 0x88776655 };
+            Span<long> span = new Span<long>(a);
+            Span<Length24> asLength24;
+            Assert.True(span.TryCast(out asLength24));
+        }
+
+        [Fact]
+        public static unsafe void TryCastSpan_ToEmptyStruct()
+        {
+            long[] a = { 0x44332211, 0x88776655 };
+            Span<long> span = new Span<long>(a);
+            Span<EmptyStruct> asEmpty;
+            Assert.True(span.TryCast(out asEmpty));
+        }
+
+        [Fact]
+        public static unsafe void TryCastSpan_FromUnalignedAddress()
+        {
+            // Create a span, get a pointer to it, add 1 to that pointer, then dangerously construct a new span at that unaligned pointer location
+            uint[] a = { 0x44332211, 0x88776655 };
+            Span<uint> span = new Span<uint>(a);
+            void* pointerSpan = Unsafe.AsPointer(ref MemoryMarshal.GetReference(span)); // this can be moved, but we're not dereferencing the pointer from here on out anyways so it doesn't matter what actually lives there
+            Span<uint> offsetSpan = new Span<uint>(new IntPtr(new IntPtr(pointerSpan).ToInt64() + 1).ToPointer(), span.Length);
+            Span<ushort> asUShort;
+            if (RuntimeInformation.OSArchitecture == Architecture.X64 || RuntimeInformation.OSArchitecture == Architecture.X86)
+                Assert.True(offsetSpan.TryCast(out asUShort));
+            else
+                Assert.False(offsetSpan.TryCast(out asUShort));
+        }
+
+        [Fact]
+        public static void TryCastSpan_UIntToUShort()
+        {
+            uint[] a = { 0x44332211, 0x88776655 };
+            Span<uint> span = new Span<uint>(a);
+            Span<ushort> asUShort;
+            Assert.True(span.TryCast(out asUShort));
+
+            Assert.True(Unsafe.AreSame<ushort>(ref Unsafe.As<uint, ushort>(ref Unsafe.AsRef(in MemoryMarshal.GetReference(span))), ref Unsafe.AsRef(in MemoryMarshal.GetReference(asUShort))));
+            asUShort.Validate<ushort>(0x2211, 0x4433, 0x6655, 0x8877);
+        }
+
+        [Fact]
+        public static void TryCastSpan_ShortToLong()
+        {
+            short[] a = { 0x1234, 0x2345, 0x3456, 0x4567, 0x5678 };
+            Span<short> span = new Span<short>(a);
+            Span<long> asLong;
+            if (RuntimeInformation.OSArchitecture == Architecture.X64 || RuntimeInformation.OSArchitecture == Architecture.X86)
+            {
+                Assert.True(span.TryCast(out asLong));
+                Assert.True(Unsafe.AreSame<long>(ref Unsafe.As<short, long>(ref MemoryMarshal.GetReference(span)), ref MemoryMarshal.GetReference(asLong)));
+                asLong.Validate<long>(0x4567345623451234);
+            }
+            else
+            {
+                Assert.False(span.TryCast(out asLong));
+            }
+        }
+
+        [Fact]
+        public static unsafe void TryCastSpan_Overflow()
+        {
+            Span<TestStructExplicit> span = new Span<TestStructExplicit>(null, Int32.MaxValue);
+
+            AssertThrows<OverflowException, TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<TestStructExplicit, byte>(_span).DontBox());
+            AssertThrows<OverflowException, TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<TestStructExplicit, ulong>(_span).DontBox());
+        }
+
+        [Fact]
+        public static void TryCastSpan_ToTypeContainsReferences()
+        {
+            Span<uint> span = new Span<uint>(Array.Empty<uint>());
+            AssertThrows<ArgumentException, uint>(span, (_span) => MemoryMarshal.Cast<uint, SpanTests.StructWithReferences>(_span).DontBox());
+        }
+
+        [Fact]
+        public static void TryCastSpan_FromTypeContainsReferences()
+        {
+            Span<SpanTests.StructWithReferences> span = new Span<SpanTests.StructWithReferences>(Array.Empty<SpanTests.StructWithReferences>());
+            AssertThrows<ArgumentException, SpanTests.StructWithReferences>(span, (_span) => MemoryMarshal.Cast<SpanTests.StructWithReferences, uint>(_span).DontBox());
+        }
+    }
+}

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Span\StartsWith.T.cs" />
     <Compile Include="Span\StartsWith.byte.cs" />
     <Compile Include="Span\ToArray.cs" />
+    <Compile Include="Span\TryCast.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ReadOnlySpan\AsBytes.cs" />
@@ -112,6 +113,7 @@
     <Compile Include="ReadOnlySpan\TrimAnyCharacter.cs" />
     <Compile Include="ReadOnlySpan\TrimManyCharacters.cs" />
     <Compile Include="ReadOnlySpan\TrimWhiteSpace.cs" />
+    <Compile Include="ReadOnlySpan\TryCast.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Memory\AsReadOnlyMemory.cs" />

--- a/src/System.Memory/tests/TestHelpers.cs
+++ b/src/System.Memory/tests/TestHelpers.cs
@@ -294,6 +294,53 @@ namespace System
             e4,
         }
 
+        public struct Length24
+        {
+            public ulong a1;
+            public ulong a2;
+            public ulong a3;
+        }
+
+        public struct Length24_2
+        {
+            public long a1;
+            public long a2;
+            public long a3;
+        }
+
+        public struct ThreeByteStruct
+        {
+            public byte a1;
+            public byte a2;
+            public byte a3;
+        }
+
+        public struct PaddedStruct4
+        {
+            public byte a1;  // 1 bytes
+                             // 1 bytes padding
+            public char a2;  // 2 bytes
+
+            public PaddedStruct4(byte a11, char a22)
+            {
+                a1 = a11;
+                a2 = a22;
+            }
+        }
+
+        public struct PaddedStruct
+        {
+            public char a1; // 2 bytes
+                            // 2 bytes padding
+            public int a2;  // 4 bytes
+
+            public PaddedStruct(char a11, int a22)
+            {
+                a1 = a11;
+                a2 = a22;
+            }
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void DoNotIgnore<T>(T value, int consumed)
         {


### PR DESCRIPTION
- Exposes Span.TryCast and ReadOnlySpan.TryCast as extension methods in MemoryExtensions.
- Implemented for both the fast and portable implementations in equivalent ways, though eventually [the fast implementation should be moved to corelib with the other MemoryExtensions.Fast methods](https://github.com/dotnet/corefx/issues/25182) and implemented using compiler directives (e.g. #IF intelProcessorCompiled) or maybe an intrinsic for the else case.
- I decided that requiring a fixed memory location for the source span would be too restrictive, so I implemented the functions in a way that works even if the memory pointed to by the span gets moved mid-operation or post-operation. The downside to this is that we can't handle the "accidentally aligned" case as well, but this is a worthy tradeoff in my opinion. More details in the doc comments for TryCast.
- Added a bunch of tests for TryCast that assert the behavior for param types of various sizes and alignment.
- This code is based around two large assumptions:
  - The alignment rules for TFrom will be followed if sourceSpan<TFrom> is moved.
  - The maximum alignment size of any data item is 8 bytes. For C# this is true for all primitives, including decimal.


resolves https://github.com/dotnet/corefx/issues/26465

cc: @stephentoub @ahsonkhan @KrzysztofCwalina  @GrabYourPitchforks 