### PR TITLE
Enable Span.ToString tests

### DIFF
--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Span\StartsWith.T.cs" />
     <Compile Include="Span\StartsWith.byte.cs" />
     <Compile Include="Span\ToArray.cs" />
+    <Compile Include="Span\ToString.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ReadOnlySpan\AsBytes.cs" />
@@ -109,6 +110,7 @@
     <Compile Include="ReadOnlySpan\StartsWith.T.cs" />
     <Compile Include="ReadOnlySpan\StartsWith.byte.cs" />
     <Compile Include="ReadOnlySpan\ToArray.cs" />
+    <Compile Include="ReadOnlySpan\ToString.cs" />
     <Compile Include="ReadOnlySpan\TrimAnyCharacter.cs" />
     <Compile Include="ReadOnlySpan\TrimManyCharacters.cs" />
     <Compile Include="ReadOnlySpan\TrimWhiteSpace.cs" />


### PR DESCRIPTION
With the update to the ToString output for the slow span in https://github.com/dotnet/corefx/pull/26467, we needed to reflect those changes in the fast span as well: https://github.com/dotnet/coreclr/pull/16087

After https://github.com/dotnet/coreclr/pull/16087 is merged and CoreFX is updated to use the new coreclr version, this PR should be merged to enable the simple ToString tests that were already reviewed and merged in https://github.com/dotnet/corefx/pull/26467 but not yet added to the csproj.

cc: @ahsonkhan 
related to https://github.com/dotnet/corefx/issues/26295