### PR TITLE
Http protocol dribble tests taking too long

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -167,7 +167,7 @@ namespace System.Net.Http.Functional.Tests
                 for (int i = 0; i < count; i++)
                 {
                     await _wrapped.WriteAsync(buffer, offset + i, 1);
-                    await Task.Delay(3); // introduce short delays, enough to send packets individually but not so long as to extend test duration significantly
+                    await Task.Yield(); // introduce short delays, enough to send packets individually but not so long as to extend test duration significantly
                 }
             }
 


### PR DESCRIPTION
The time of inner loop is dominated by the http protocol dribble tests.

Returning the Task.Delay to Task.Yield reduces it from ~19 seconds to less than a second on a Windows 10 RS3 box.

Single run for comparison (times in seconds):

| Test | Task.Delay(3) | Task.Yield |
| ---- | -------------- | ----------- |
ManagedHandler_HttpProtocolTests_Dribble | 19.308 | 0.569 |
HttpProtocolTests_Dribble | 17.920 | 0.872 |
