### PR TITLE
Utf8Parsing - the remaining 'N' format overloads

### DIFF
--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.N.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.N.cs
@@ -8,12 +8,186 @@ namespace System.Buffers.Text
     {
         private static bool TryParseSByteN(ReadOnlySpan<byte> text, out sbyte value, out int bytesConsumed)
         {
-            throw NotImplemented.ActiveIssue("https://github.com/dotnet/corefx/issues/24986");
+            if (text.Length < 1)
+                goto FalseExit;
+
+            int sign = 1;
+            int index = 0;
+            int c = text[index];
+            if (c == '-')
+            {
+                sign = -1;
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+            else if (c == '+')
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+
+            int answer;
+
+            // Handle the first digit (or period) as a special case. This ensures some compatible edge-case behavior with the classic parse routines
+            // (at least one digit must precede any commas, and a string without any digits prior to the decimal point must have at least 
+            // one digit after the decimal point.)
+            if (c == Utf8Constants.Period)
+                goto FractionalPartWithoutLeadingDigits;
+            if (!ParserHelpers.IsDigit(c))
+                goto FalseExit;
+            answer = c - '0';
+
+            for (; ; )
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+
+                c = text[index];
+                if (c == Utf8Constants.Comma)
+                    continue;
+
+                if (c == Utf8Constants.Period)
+                    goto FractionalDigits;
+
+                if (!ParserHelpers.IsDigit(c))
+                    goto Done;
+
+                answer = answer * 10 + c - '0';
+
+                // if sign < 0, (-1 * sign + 1) / 2 = 1
+                // else, (-1 * sign + 1) / 2 = 0
+                if (answer > sbyte.MaxValue + (-1 * sign + 1) / 2)
+                    goto FalseExit; // Overflow
+            }
+
+FractionalPartWithoutLeadingDigits: // If we got here, we found a decimal point before we found any digits. This is legal as long as there's at least one zero after the decimal point.
+            answer = 0;
+            index++;
+            if ((uint)index >= (uint)text.Length)
+                goto FalseExit;
+            if (text[index] != '0')
+                goto FalseExit;
+
+FractionalDigits: // "N" format allows a fractional portion despite being an integer format but only if the post-fraction digits are all 0.
+            do
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                c = text[index];
+            }
+            while (c == '0');
+
+            if (ParserHelpers.IsDigit(c))
+                goto FalseExit; // The fractional portion contained a non-zero digit. Treat this as an error, not an early termination.
+            goto Done;
+
+FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
+
+Done:
+            bytesConsumed = index;
+            value = (sbyte)(answer * sign);
+            return true;
         }
 
         private static bool TryParseInt16N(ReadOnlySpan<byte> text, out short value, out int bytesConsumed)
         {
-            throw NotImplemented.ActiveIssue("https://github.com/dotnet/corefx/issues/24986");
+            if (text.Length < 1)
+                goto FalseExit;
+
+            int sign = 1;
+            int index = 0;
+            int c = text[index];
+            if (c == '-')
+            {
+                sign = -1;
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+            else if (c == '+')
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+
+            int answer;
+
+            // Handle the first digit (or period) as a special case. This ensures some compatible edge-case behavior with the classic parse routines
+            // (at least one digit must precede any commas, and a string without any digits prior to the decimal point must have at least 
+            // one digit after the decimal point.)
+            if (c == Utf8Constants.Period)
+                goto FractionalPartWithoutLeadingDigits;
+            if (!ParserHelpers.IsDigit(c))
+                goto FalseExit;
+            answer = c - '0';
+
+            for (; ; )
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+
+                c = text[index];
+                if (c == Utf8Constants.Comma)
+                    continue;
+
+                if (c == Utf8Constants.Period)
+                    goto FractionalDigits;
+
+                if (!ParserHelpers.IsDigit(c))
+                    goto Done;
+
+                answer = answer * 10 + c - '0';
+
+                // if sign < 0, (-1 * sign + 1) / 2 = 1
+                // else, (-1 * sign + 1) / 2 = 0
+                if (answer > short.MaxValue + (-1 * sign + 1) / 2)
+                    goto FalseExit; // Overflow
+            }
+
+FractionalPartWithoutLeadingDigits: // If we got here, we found a decimal point before we found any digits. This is legal as long as there's at least one zero after the decimal point.
+            answer = 0;
+            index++;
+            if ((uint)index >= (uint)text.Length)
+                goto FalseExit;
+            if (text[index] != '0')
+                goto FalseExit;
+
+FractionalDigits: // "N" format allows a fractional portion despite being an integer format but only if the post-fraction digits are all 0.
+            do
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                c = text[index];
+            }
+            while (c == '0');
+
+            if (ParserHelpers.IsDigit(c))
+                goto FalseExit; // The fractional portion contained a non-zero digit. Treat this as an error, not an early termination.
+            goto Done;
+
+FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
+
+Done:
+            bytesConsumed = index;
+            value = (short)(answer * sign);
+            return true;
         }
 
         private static bool TryParseInt32N(ReadOnlySpan<byte> text, out int value, out int bytesConsumed)
@@ -113,7 +287,97 @@ Done:
 
         private static bool TryParseInt64N(ReadOnlySpan<byte> text, out long value, out int bytesConsumed)
         {
-            throw NotImplemented.ActiveIssue("https://github.com/dotnet/corefx/issues/24986");
+            if (text.Length < 1)
+                goto FalseExit;
+
+            int sign = 1;
+            int index = 0;
+            int c = text[index];
+            if (c == '-')
+            {
+                sign = -1;
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+            else if (c == '+')
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+
+            long answer;
+
+            // Handle the first digit (or period) as a special case. This ensures some compatible edge-case behavior with the classic parse routines
+            // (at least one digit must precede any commas, and a string without any digits prior to the decimal point must have at least 
+            // one digit after the decimal point.)
+            if (c == Utf8Constants.Period)
+                goto FractionalPartWithoutLeadingDigits;
+            if (!ParserHelpers.IsDigit(c))
+                goto FalseExit;
+            answer = c - '0';
+
+            for (; ; )
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+
+                c = text[index];
+                if (c == Utf8Constants.Comma)
+                    continue;
+
+                if (c == Utf8Constants.Period)
+                    goto FractionalDigits;
+
+                if (!ParserHelpers.IsDigit(c))
+                    goto Done;
+
+                if (((ulong)answer) > long.MaxValue / 10)
+                    goto FalseExit;
+
+                answer = answer * 10 + c - '0';
+
+                // if sign < 0, (-1 * sign + 1) / 2 = 1
+                // else, (-1 * sign + 1) / 2 = 0
+                if ((ulong)answer > (ulong)(long.MaxValue + (-1 * sign + 1) / 2))
+                    goto FalseExit; // Overflow
+            }
+
+FractionalPartWithoutLeadingDigits: // If we got here, we found a decimal point before we found any digits. This is legal as long as there's at least one zero after the decimal point.
+            answer = 0;
+            index++;
+            if ((uint)index >= (uint)text.Length)
+                goto FalseExit;
+            if (text[index] != '0')
+                goto FalseExit;
+
+FractionalDigits: // "N" format allows a fractional portion despite being an integer format but only if the post-fraction digits are all 0.
+            do
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                c = text[index];
+            }
+            while (c == '0');
+
+            if (ParserHelpers.IsDigit(c))
+                goto FalseExit; // The fractional portion contained a non-zero digit. Treat this as an error, not an early termination.
+            goto Done;
+
+FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
+
+Done:
+            bytesConsumed = index;
+            value = answer * sign;
+            return true;
         }
     }
 }

--- a/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.N.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.N.cs
@@ -11,22 +11,326 @@ namespace System.Buffers.Text
     {
         private static bool TryParseByteN(ReadOnlySpan<byte> text, out byte value, out int bytesConsumed)
         {
-            throw NotImplemented.ActiveIssue("https://github.com/dotnet/corefx/issues/24986");
+            if (text.Length < 1)
+                goto FalseExit;
+
+            int index = 0;
+            int c = text[index];
+            if (c == '+')
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+
+            int answer;
+
+            // Handle the first digit (or period) as a special case. This ensures some compatible edge-case behavior with the classic parse routines
+            // (at least one digit must precede any commas, and a string without any digits prior to the decimal point must have at least 
+            // one digit after the decimal point.)
+            if (c == Utf8Constants.Period)
+                goto FractionalPartWithoutLeadingDigits;
+            if (!ParserHelpers.IsDigit(c))
+                goto FalseExit;
+            answer = c - '0';
+
+            for (; ; )
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+
+                c = text[index];
+                if (c == Utf8Constants.Comma)
+                    continue;
+
+                if (c == Utf8Constants.Period)
+                    goto FractionalDigits;
+
+                if (!ParserHelpers.IsDigit(c))
+                    goto Done;
+
+                answer = answer * 10 + c - '0';
+
+                if (answer > byte.MaxValue)
+                    goto FalseExit; // Overflow
+            }
+
+FractionalPartWithoutLeadingDigits: // If we got here, we found a decimal point before we found any digits. This is legal as long as there's at least one zero after the decimal point.
+            answer = 0;
+            index++;
+            if ((uint)index >= (uint)text.Length)
+                goto FalseExit;
+            if (text[index] != '0')
+                goto FalseExit;
+
+FractionalDigits: // "N" format allows a fractional portion despite being an integer format but only if the post-fraction digits are all 0.
+            do
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                c = text[index];
+            }
+            while (c == '0');
+
+            if (ParserHelpers.IsDigit(c))
+                goto FalseExit; // The fractional portion contained a non-zero digit. Treat this as an error, not an early termination.
+            goto Done;
+
+FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
+
+Done:
+            bytesConsumed = index;
+            value = (byte)answer;
+            return true;
         }
 
         private static bool TryParseUInt16N(ReadOnlySpan<byte> text, out ushort value, out int bytesConsumed)
         {
-            throw NotImplemented.ActiveIssue("https://github.com/dotnet/corefx/issues/24986");
+            if (text.Length < 1)
+                goto FalseExit;
+
+            int index = 0;
+            int c = text[index];
+            if (c == '+')
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+
+            int answer;
+
+            // Handle the first digit (or period) as a special case. This ensures some compatible edge-case behavior with the classic parse routines
+            // (at least one digit must precede any commas, and a string without any digits prior to the decimal point must have at least 
+            // one digit after the decimal point.)
+            if (c == Utf8Constants.Period)
+                goto FractionalPartWithoutLeadingDigits;
+            if (!ParserHelpers.IsDigit(c))
+                goto FalseExit;
+            answer = c - '0';
+
+            for (; ; )
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+
+                c = text[index];
+                if (c == Utf8Constants.Comma)
+                    continue;
+
+                if (c == Utf8Constants.Period)
+                    goto FractionalDigits;
+
+                if (!ParserHelpers.IsDigit(c))
+                    goto Done;
+
+                answer = answer * 10 + c - '0';
+
+                if (answer > ushort.MaxValue)
+                    goto FalseExit; // Overflow
+            }
+
+FractionalPartWithoutLeadingDigits: // If we got here, we found a decimal point before we found any digits. This is legal as long as there's at least one zero after the decimal point.
+            answer = 0;
+            index++;
+            if ((uint)index >= (uint)text.Length)
+                goto FalseExit;
+            if (text[index] != '0')
+                goto FalseExit;
+
+FractionalDigits: // "N" format allows a fractional portion despite being an integer format but only if the post-fraction digits are all 0.
+            do
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                c = text[index];
+            }
+            while (c == '0');
+
+            if (ParserHelpers.IsDigit(c))
+                goto FalseExit; // The fractional portion contained a non-zero digit. Treat this as an error, not an early termination.
+            goto Done;
+
+FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
+
+Done:
+            bytesConsumed = index;
+            value = (ushort)answer;
+            return true;
         }
 
         private static bool TryParseUInt32N(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed)
         {
-            throw NotImplemented.ActiveIssue("https://github.com/dotnet/corefx/issues/24986");
+            if (text.Length < 1)
+                goto FalseExit;
+
+            int index = 0;
+            int c = text[index];
+            if (c == '+')
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+
+            int answer;
+
+            // Handle the first digit (or period) as a special case. This ensures some compatible edge-case behavior with the classic parse routines
+            // (at least one digit must precede any commas, and a string without any digits prior to the decimal point must have at least 
+            // one digit after the decimal point.)
+            if (c == Utf8Constants.Period)
+                goto FractionalPartWithoutLeadingDigits;
+            if (!ParserHelpers.IsDigit(c))
+                goto FalseExit;
+            answer = c - '0';
+
+            for (; ; )
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+
+                c = text[index];
+                if (c == Utf8Constants.Comma)
+                    continue;
+
+                if (c == Utf8Constants.Period)
+                    goto FractionalDigits;
+
+                if (!ParserHelpers.IsDigit(c))
+                    goto Done;
+
+                if (((uint)answer) > uint.MaxValue / 10 || (((uint)answer) == uint.MaxValue / 10 && c > '5'))
+                    goto FalseExit; // Overflow
+
+                answer = answer * 10 + c - '0';
+            }
+
+FractionalPartWithoutLeadingDigits: // If we got here, we found a decimal point before we found any digits. This is legal as long as there's at least one zero after the decimal point.
+            answer = 0;
+            index++;
+            if ((uint)index >= (uint)text.Length)
+                goto FalseExit;
+            if (text[index] != '0')
+                goto FalseExit;
+
+FractionalDigits: // "N" format allows a fractional portion despite being an integer format but only if the post-fraction digits are all 0.
+            do
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                c = text[index];
+            }
+            while (c == '0');
+
+            if (ParserHelpers.IsDigit(c))
+                goto FalseExit; // The fractional portion contained a non-zero digit. Treat this as an error, not an early termination.
+            goto Done;
+
+FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
+
+Done:
+            bytesConsumed = index;
+            value = (uint)answer;
+            return true;
         }
 
         private static bool TryParseUInt64N(ReadOnlySpan<byte> text, out ulong value, out int bytesConsumed)
         {
-            throw NotImplemented.ActiveIssue("https://github.com/dotnet/corefx/issues/24986");
+            if (text.Length < 1)
+                goto FalseExit;
+
+            int index = 0;
+            int c = text[index];
+            if (c == '+')
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto FalseExit;
+                c = text[index];
+            }
+
+            long answer;
+
+            // Handle the first digit (or period) as a special case. This ensures some compatible edge-case behavior with the classic parse routines
+            // (at least one digit must precede any commas, and a string without any digits prior to the decimal point must have at least 
+            // one digit after the decimal point.)
+            if (c == Utf8Constants.Period)
+                goto FractionalPartWithoutLeadingDigits;
+            if (!ParserHelpers.IsDigit(c))
+                goto FalseExit;
+            answer = c - '0';
+
+            for (; ; )
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+
+                c = text[index];
+                if (c == Utf8Constants.Comma)
+                    continue;
+
+                if (c == Utf8Constants.Period)
+                    goto FractionalDigits;
+
+                if (!ParserHelpers.IsDigit(c))
+                    goto Done;
+
+                if (((ulong)answer) > ulong.MaxValue / 10 || (((ulong)answer) == ulong.MaxValue / 10 && c > '5'))
+                    goto FalseExit; // Overflow
+
+                answer = answer * 10 + c - '0';
+            }
+
+FractionalPartWithoutLeadingDigits: // If we got here, we found a decimal point before we found any digits. This is legal as long as there's at least one zero after the decimal point.
+            answer = 0;
+            index++;
+            if ((uint)index >= (uint)text.Length)
+                goto FalseExit;
+            if (text[index] != '0')
+                goto FalseExit;
+
+FractionalDigits: // "N" format allows a fractional portion despite being an integer format but only if the post-fraction digits are all 0.
+            do
+            {
+                index++;
+                if ((uint)index >= (uint)text.Length)
+                    goto Done;
+                c = text[index];
+            }
+            while (c == '0');
+
+            if (ParserHelpers.IsDigit(c))
+                goto FalseExit; // The fractional portion contained a non-zero digit. Treat this as an error, not an early termination.
+            goto Done;
+
+FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
+
+Done:
+            bytesConsumed = index;
+            value = (ulong)answer;
+            return true;
         }
     }
 }

--- a/src/System.Memory/tests/ParsersAndFormatters/Parser/ParserTests.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/Parser/ParserTests.cs
@@ -131,33 +131,6 @@ namespace System.Buffers.Text.Tests
             ReadOnlySpan<byte> utf8Text = text.ToUtf8Span();
             Utf8Parser.TryParse(utf8Text, out DateTimeOffset dto, out int bytesConsumed, formatSymbol);
         }
-
-        [Theory]
-        [MemberData(nameof(TestData.IntegerTypesTheoryData), MemberType = typeof(TestData))]
-        public static void FakeTestParserIntegerN(Type integerType)
-        {
-            //
-            // [ActiveIssue("https://github.com/dotnet/corefx/issues/24986 - UTF8Parser parsing integers with 'N' format not implemented.")]
-            //
-            // This "test" may look ludicrous but it serves two useful purposes:
-            //
-            //  - It maintains Utf8Parser code coverage at 100% so that endless dev cycles aren't wasted drilling down into it to inspect for code coverage regressions.
-            //
-            //  - As a guide to enabling the 'N' tests when the parsing is implemented.
-            //
-            try
-            {
-                if (integerType == typeof(int))
-                    return;
-
-                TryParseUtf8(integerType, Array.Empty<byte>(), out _, out _, 'N');
-                Assert.False(true,
-                    $"Thank you for implementing the TryParse 'N' format. You can now disable this test and change {nameof(TestData.IsParsingImplemented)}() so it no longer suppresses 'N' testing.");
-            }
-            catch (NotImplementedException)
-            {
-            }
-        }
     }
 }
 

--- a/src/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
@@ -115,12 +115,6 @@ namespace System.Buffers.Text.Tests
                 // This value will overflow a UInt32 accumulator upon assimilating the 0 in a way such that the wrapped-around value still looks like
                 // it's in the range of an Int32. Unless, of course, the implementation had the foresight to check before assimilating. 
                 yield return new ParserTestData<int>("9999999990", 0, 'D', expectedSuccess: false);
-
-                // "N" format parsing
-                foreach (ParserTestData<int> testData in TestDataForNFormat.ConvertTestDataForNFormat<int>())
-                {
-                    yield return testData;
-                }
             }
         }
 
@@ -263,6 +257,15 @@ namespace System.Buffers.Text.Tests
                             string text = bigValue.ToString(format.Symbol.ToString());
                             yield return new ParserTestData<T>(text, default, format.Symbol, expectedSuccess: false);
                         }
+                    }
+                }
+
+                if (format.Symbol == 'N' || format.Symbol == 'n')
+                {
+                    // "N" format parsing
+                    foreach (ParserTestData<T> testData in TestDataForNFormat.ConvertTestDataForNFormat<T>())
+                    {
+                        yield return testData;
                     }
                 }
             }

--- a/src/System.Memory/tests/ParsersAndFormatters/SupportedFormats.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/SupportedFormats.cs
@@ -29,7 +29,8 @@ namespace System.Buffers.Text.Tests
         public static bool IsParsingImplemented<T>(this SupportedFormat f) => f.IsParsingImplemented(typeof(T));
 
         //
-        // Used to disable automatic generation of ParserTestData from FormatterTestData
+        // Used to disable automatic generation of ParserTestData from FormatterTestData. Useful for bringing up new
+        // formats as you can use this shutoff valve to bring up formatting without having to bring up parsing as the same time.
         //
         public static bool IsParsingImplemented(this SupportedFormat f, Type t)
         {

--- a/src/System.Memory/tests/ParsersAndFormatters/SupportedFormats.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/SupportedFormats.cs
@@ -30,7 +30,7 @@ namespace System.Buffers.Text.Tests
 
         //
         // Used to disable automatic generation of ParserTestData from FormatterTestData. Useful for bringing up new
-        // formats as you can use this shutoff valve to bring up formatting without having to bring up parsing as the same time.
+        // formats as you can use this shutoff valve to bring up formatting without having to bring up parsing at the same time.
         //
         public static bool IsParsingImplemented(this SupportedFormat f, Type t)
         {

--- a/src/System.Memory/tests/ParsersAndFormatters/SupportedFormats.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/SupportedFormats.cs
@@ -33,9 +33,6 @@ namespace System.Buffers.Text.Tests
         //
         public static bool IsParsingImplemented(this SupportedFormat f, Type t)
         {
-            if (IntegerTypes.Contains(t) && t != typeof(int) && (f.Symbol == 'N' || f.Symbol == 'n'))
-                return false;
-
             return true;
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/24986

This is a piece of the Utf8Parser that was punted for time
last year.

There are 8 overloads for each of the 8 integer types.
Int32 was done in a previous PR - this completes the set.

The "N" format prints out integers like this:

  `"N2" => 12,345.00`

This parser mimics the behavior of

 `int.TryParse(v, NumberStyles.Integer | AllowThousands | AllowDecimalPoint)`

The thing that may look strange is that the parser
allows commas anywhere, not just on the 10^3 digits.
This mimics the desktop api behavior. Comma placement is
culture-dependent and this is an api that is culture-agnostic.

The test data was confirmed on a control implementation
that calls the classic int.TryParse().