### PR TITLE
Removing duplicated TimeOut  Extension method

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/Helpers.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/Helpers.cs
@@ -15,22 +15,4 @@ namespace System.ServiceProcess.Tests
         Stop = 3,
         OnCustomCommand = 4
     };
-
-    public static class TaskTimeoutExtensions
-    {
-        public static async Task TimeoutAfter(this Task task, int millisecondsTimeout)
-        {
-            var cts = new CancellationTokenSource();
-
-            if (task == await Task.WhenAny(task, Task.Delay(millisecondsTimeout, cts.Token)))
-            {
-                cts.Cancel();
-                await task;
-            }
-            else
-            {
-                throw new TimeoutException($"Task timed out after {millisecondsTimeout}");
-            }
-        }
-    }
 }

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/System.ServiceProcess.ServiceController.TestService.csproj
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/System.ServiceProcess.ServiceController.TestService.csproj
@@ -47,6 +47,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.DeleteService.cs">
       <Link>Common\Interop\Windows\Interop.DeleteService.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+      <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Content Include="System.ServiceProcess.ServiceController.TestService.runtimeconfig.json">

--- a/src/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
@@ -128,7 +128,10 @@ namespace System.ServiceProcess.Tests
             try
             {
                 if (_client != null)
+                {
                     _client.Dispose();
+                    _client = null;
+                }
 
                 TestServiceInstaller testServiceInstaller = new TestServiceInstaller();
                 testServiceInstaller.ServiceName = TestServiceName;


### PR DESCRIPTION
This is follow up PR containing minor changes that were left in the https://github.com/dotnet/corefx/pull/26524