### PR TITLE
Port compat pack fixes to 2.1

### DIFF
--- a/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <PackageVersion>2.0.0</PackageVersion>
+    <ServiceModelVersion>4.4.1</ServiceModelVersion>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -50,18 +51,26 @@
     <PrereleaseLibraryPackage Include="System.Text.Encoding.CodePages" />
     <PrereleaseLibraryPackage Include="System.Threading.AccessControl" />
 
-    <!-- External pre-release packages -->
+    <!-- Service model packages -->
     <LibraryPackage Include="System.ServiceModel.Primitives">
-      <Version>4.4.1-servicing-25917-01</Version>
+      <Version>$(ServiceModelVersion)</Version>
+    </LibraryPackage>
+    <LibraryPackage Include="System.ServiceModel.Duplex">
+      <Version>$(ServiceModelVersion)</Version>
+    </LibraryPackage>
+    <LibraryPackage Include="System.ServiceModel.Http">
+      <Version>$(ServiceModelVersion)</Version>
+    </LibraryPackage>
+    <LibraryPackage Include="System.ServiceModel.NetTcp">
+      <Version>$(ServiceModelVersion)</Version>
+    </LibraryPackage>
+    <LibraryPackage Include="System.ServiceModel.Security">
+      <Version>$(ServiceModelVersion)</Version>
     </LibraryPackage>
 
     <!-- Stable packages shipped already for netcoreapp2.0 -->
     <LibraryPackage Include="System.Data.SqlClient" />
     <LibraryPackage Include="System.Security.Cryptography.Cng" />
-    <LibraryPackage Include="System.ServiceModel.Duplex" />
-    <LibraryPackage Include="System.ServiceModel.Http" />
-    <LibraryPackage Include="System.ServiceModel.NetTcp" />
-    <LibraryPackage Include="System.ServiceModel.Security" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/Microsoft.Windows.Compatibility/externalIndex.json
+++ b/pkg/Microsoft.Windows.Compatibility/externalIndex.json
@@ -3,31 +3,36 @@
     "System.ServiceModel.Primitives": {
       "StableVersions": [
         "4.4.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.1"
       ]
     },
     "System.ServiceModel.Duplex": {
       "StableVersions": [
         "4.4.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.1"
       ]
     },
     "System.ServiceModel.Http": {
       "StableVersions": [
         "4.4.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.1"
       ]
     },
     "System.ServiceModel.NetTcp": {
       "StableVersions": [
         "4.4.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.1"
       ]
     },
     "System.ServiceModel.Security": {
       "StableVersions": [
         "4.4.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.1"
       ]
     }
   }

--- a/src/System.Data.DataSetExtensions/dir.props
+++ b/src/System.Data.DataSetExtensions/dir.props
@@ -3,6 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyKey>MSFT</AssemblyKey>
+    <AssemblyKey>ECMA</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.DataSetExtensions/src/Configurations.props
+++ b/src/System.Data.DataSetExtensions/src/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      _netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is a port of: https://github.com/dotnet/corefx/pull/26576 and https://github.com/dotnet/corefx/pull/26281

Basically upgrading S.ServiceModel.* dependencies in the compat pack to depende on the latest stable package and fixing System.Data.DataSetExtensions public key to match the full framework one so that assembly identities are the same.

cc: @weshaggard @danmosemsft 