### PR TITLE
#26600 PropertyDescriptor - MemberDescriptor.Attributes

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
@@ -270,6 +270,7 @@ namespace System.ComponentModel
                 //
                 currentReflectType = realEventInfo.ReflectedType;
                 Attribute[][] attributeStack = new Attribute[depth][];
+                int currentDepth = 0;
 
                 while (currentReflectType != typeof(object))
                 {
@@ -281,7 +282,7 @@ namespace System.ComponentModel
                     //
                     if (memberInfo != null)
                     {
-                        attributeStack[--depth] = ReflectTypeDescriptionProvider.ReflectGetAttributes(memberInfo);
+                        attributeStack[currentDepth++] = ReflectTypeDescriptionProvider.ReflectGetAttributes(memberInfo);
                     }
 
                     // Ready for the next loop iteration.
@@ -395,6 +396,8 @@ namespace System.ComponentModel
                 //
                 currentReflectType = realMethodInfo.ReflectedType;
                 Attribute[][] attributeStack = new Attribute[depth][];
+                int currentDepth = 0;
+                
 
                 while (currentReflectType != null && currentReflectType != typeof(object))
                 {
@@ -406,7 +409,7 @@ namespace System.ComponentModel
                     //
                     if (memberInfo != null)
                     {
-                        attributeStack[--depth] = ReflectTypeDescriptionProvider.ReflectGetAttributes(memberInfo);
+                        attributeStack[currentDepth++] = ReflectTypeDescriptionProvider.ReflectGetAttributes(memberInfo);
                     }
 
                     // Ready for the next loop iteration.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
@@ -796,6 +796,7 @@ namespace System.ComponentModel
             {
                 currentReflectType = _componentClass;
                 Attribute[][] attributeStack = new Attribute[depth][];
+                int currentDepth = 0;
 
                 while (currentReflectType != null && currentReflectType != typeof(object))
                 {
@@ -831,7 +832,7 @@ namespace System.ComponentModel
                     //
                     if (memberInfo != null)
                     {
-                        attributeStack[--depth] = ReflectTypeDescriptionProvider.ReflectGetAttributes(memberInfo);
+                        attributeStack[currentDepth++] = ReflectTypeDescriptionProvider.ReflectGetAttributes(memberInfo);
                     }
 
                     // Ready for the next loop iteration.

--- a/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
@@ -160,6 +160,13 @@ namespace System.ComponentModel.Tests
             Assert.NotEqual(firstAssociatedObject, firstAssociation);
         }
 
+        [Fact]
+        public void DerivedPropertyAttribute() {
+            PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(FooBarDerived))["Value"];
+            var descriptionAttribute = (DescriptionAttribute)property.Attributes[typeof(DescriptionAttribute)];
+            Assert.Equal("Derived", descriptionAttribute.Description);
+        }
+
         private class InvocationRecordingTypeDescriptionProvider : TypeDescriptionProvider
         {
             public bool ReceivedCall { get; private set; } = false;
@@ -219,6 +226,18 @@ namespace System.ComponentModel.Tests
                 ReceivedCall = true;
                 return base.IsSupportedType(type);
             }
+        }
+
+        class FooBarBase
+        {
+            [Description("Base")]
+            public virtual int Value { get; set; }
+        }
+
+        class FooBarDerived : FooBarBase 
+        {
+            [Description("Derived")]
+            public override int Value { get; set; }
         }
 
         private static Tuple<Type, Type>[] s_typesWithConverters =


### PR DESCRIPTION
PropertyDescriptor - MemberDescriptor.Attributes returns base attribute instead of ancestor's attribute #26600