### PR TITLE
ManagedHandler: implement connection retry logic

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ConnectHelper.cs
@@ -103,7 +103,7 @@ namespace System.Net.Http
             }
         }
 
-        public static async ValueTask<SslStream> EstablishSslConnection(HttpConnectionSettings settings, string host, HttpRequestMessage request, Stream stream, CancellationToken cancellationToken)
+        public static async ValueTask<SslStream> EstablishSslConnectionAsync(HttpConnectionSettings settings, string host, HttpRequestMessage request, Stream stream, CancellationToken cancellationToken)
         {
             RemoteCertificateValidationCallback callback = null;
             if (settings._serverCertificateCustomValidationCallback != null)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -45,7 +45,6 @@ namespace System.Net.Http
         private static readonly byte[] s_httpSchemeAndDelimiter = Encoding.ASCII.GetBytes(Uri.UriSchemeHttp + Uri.SchemeDelimiter);
 
         private readonly HttpConnectionPool _pool;
-        private readonly HttpConnectionKey _key;
         private readonly Stream _stream;
         private readonly TransportContext _transportContext;
         private readonly bool _usingProxy;
@@ -62,29 +61,23 @@ namespace System.Net.Http
         private int _readOffset;
         private int _readLength;
 
+        private bool _canRetry;
         private bool _connectionClose; // Connection: close was seen on last response
         private int _disposed; // 1 yes, 0 no
 
         public HttpConnection(
             HttpConnectionPool pool,
-            HttpConnectionKey key,
-            string requestIdnHost,
             Stream stream, 
-            TransportContext transportContext, 
-            bool usingProxy)
+            TransportContext transportContext)
         {
             Debug.Assert(pool != null);
             Debug.Assert(stream != null);
 
             _pool = pool;
-            _key = key;
             _stream = stream;
             _transportContext = transportContext;
-            _usingProxy = usingProxy;
-            if (requestIdnHost != null)
-            {
-                _idnHostAsciiBytes = Encoding.ASCII.GetBytes(requestIdnHost);
-            }
+            _usingProxy = pool.Pools.UsingProxy;
+            _idnHostAsciiBytes = pool.IdnHostAsciiBytes;
 
             _writeBuffer = new byte[InitialWriteBufferSize];
             _readBuffer = new byte[InitialReadBufferSize];
@@ -94,7 +87,8 @@ namespace System.Net.Http
                 if (_stream is SslStream sslStream)
                 {
                     Trace(
-                        $"Secure connection created to {key.Host}:{key.Port}. " +
+                        $"Secure connection created to {pool.Key.Host}:{pool.Key.Port}. " +
+                        $"SslHostName:{pool.Key.SslHostName}. " +
                         $"SslProtocol:{sslStream.SslProtocol}, " +
                         $"CipherAlgorithm:{sslStream.CipherAlgorithm}, CipherStrength:{sslStream.CipherStrength}, " +
                         $"HashAlgorithm:{sslStream.HashAlgorithm}, HashStrength:{sslStream.HashStrength}, " +
@@ -103,7 +97,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    Trace($"Connection created to {key.Host}:{key.Port}.");
+                    Trace($"Connection created to {pool.Key.Host}:{pool.Key.Port}.");
                 }
             }
         }
@@ -126,6 +120,26 @@ namespace System.Net.Http
             {
                 Debug.Assert(_readAheadTask != null, $"{nameof(_readAheadTask)} should have been initialized");
                 return _readAheadTask.IsCompleted;
+            }
+        }
+
+        public bool IsNewConnection
+        {
+            get
+            {
+                // This is only valid when we are not actually processing a request.
+                Debug.Assert(_currentRequest == null);
+                return (_readAheadTask == null);
+            }
+        }
+
+        public bool CanRetry
+        {
+            get
+            {
+                // Should only be called when we have been disposed.
+                Debug.Assert(_disposed != 0);
+                return _canRetry;
             }
         }
 
@@ -202,6 +216,10 @@ namespace System.Net.Http
             TaskCompletionSource<bool> allowExpect100ToContinue = null;
             Debug.Assert(_currentRequest == null, $"Expected null {nameof(_currentRequest)}.");
             _currentRequest = request;
+
+            Debug.Assert(!_canRetry);
+            _canRetry = true;
+
             try
             {
                 bool isHttp10 = request.Version.Major == 1 && request.Version.Minor == 0;
@@ -291,6 +309,8 @@ namespace System.Net.Http
 
                     if (!request.HasHeaders || request.Headers.ExpectContinue != true)
                     {
+                        _canRetry = false;
+
                         // Start the copy from the request.  We do this here in case it synchronously throws
                         // an exception, e.g. StreamContent throwing for non-rewindable content, and because if
                         // we did it in SendRequestContentAsync, that exception would get trapped in the returned
@@ -315,6 +335,38 @@ namespace System.Net.Http
                         _sendRequestContentTask = SendRequestContentWithExpect100ContinueAsync(request, allowExpect100ToContinue.Task, stream, expect100Timer);
                     }
                 }
+
+                // Start to read response.
+
+                // We should not have any buffered data here; if there was, it should have been treated as an error
+                // by the previous request handling.  (Note we do not support HTTP pipelining.)
+                Debug.Assert(_readOffset == _readLength);
+
+                // When the connection was put back into the pool, a pre-emptive read was performed
+                // into the read buffer.  That read should not complete prior to us using the
+                // connection again, as that would mean the connection was either closed or had
+                // erroneous data sent on it by the server in response to no request from us.
+                // We need to consume that read prior to issuing another read request.
+                Task<int> t = _readAheadTask;
+                if (t != null)
+                {
+                    _readAheadTask = null;
+
+                    int bytesRead = await t.ConfigureAwait(false);
+                    if (NetEventSource.IsEnabled) Trace($"Received {bytesRead} bytes.");
+
+                    if (bytesRead == 0)
+                    {
+                        throw new IOException(SR.net_http_invalid_response);
+                    }
+
+                    _readOffset = 0;
+                    _readLength = bytesRead;
+                }
+
+                // The request is no longer retryable; either we received data from the _readAheadTask, 
+                // or there was no _readAheadTask because this is the first request on the connection.
+                _canRetry = false;
 
                 // Parse the response status line.
                 var response = new HttpResponseMessage() { RequestMessage = request, Content = new HttpConnectionContent(CancellationToken.None) };
@@ -489,6 +541,8 @@ namespace System.Net.Http
             if (sendRequestContent)
             {
                 if (NetEventSource.IsEnabled) Trace($"Sending request content for Expect: 100-continue.");
+
+                _canRetry = false;
                 await SendRequestContentAsync(request.Content.CopyToAsync(stream, _transportContext), stream).ConfigureAwait(false);
             }
             else
@@ -914,6 +968,8 @@ namespace System.Net.Http
         // Throws IOException on EOF.  This is only called when we expect more data.
         private async Task FillAsync(CancellationToken cancellationToken)
         {
+            Debug.Assert(_readAheadTask == null);
+
             int remaining = _readLength - _readOffset;
             Debug.Assert(remaining >= 0);
 
@@ -945,31 +1001,15 @@ namespace System.Net.Http
                 _readLength = remaining;
             }
 
-            // When the connection was put back into the pool, a pre-emptive read was performed
-            // into the read buffer.  That read should not complete prior to us using the
-            // connection again, as that would mean the connection was either closed or had
-            // erroneous data sent on it by the server in response to no request from us.
-            // We need to consume that read prior to issuing another read request.
-            Task<int> t = _readAheadTask;
-            int bytesRead;
-            if (t != null)
-            {
-                Debug.Assert(_readOffset == 0);
-                Debug.Assert(_readLength == 0);
-                _readAheadTask = null;
-                bytesRead = await t.ConfigureAwait(false);
-            }
-            else
-            {
-                ValueTask<int> vt = _stream.ReadAsync(new Memory<byte>(_readBuffer, _readLength, _readBuffer.Length - _readLength), cancellationToken);
-                bytesRead = vt.IsCompletedSuccessfully ? vt.Result : await vt.AsTask().ConfigureAwait(false);
-            }
+            ValueTask<int> vt = _stream.ReadAsync(new Memory<byte>(_readBuffer, _readLength, _readBuffer.Length - _readLength), cancellationToken);
+            int bytesRead = vt.IsCompletedSuccessfully ? vt.Result : await vt.AsTask().ConfigureAwait(false);
 
             if (NetEventSource.IsEnabled) Trace($"Received {bytesRead} bytes.");
             if (bytesRead == 0)
             {
                 throw new IOException(SR.net_http_invalid_response);
             }
+
             _readLength += bytesRead;
         }
 
@@ -1156,6 +1196,7 @@ namespace System.Net.Http
                     // at any point to understand if the connection has been closed or if errant data
                     // has been sent on the connection by the server, either of which would mean we
                     // should close the connection and not use it for subsequent requests.
+                    Debug.Assert(_readLength == _readOffset);
                     _readAheadTask = _stream.ReadAsync(_readBuffer, 0, _readBuffer.Length);
 
                     // Put connection back in the pool.
@@ -1192,7 +1233,7 @@ namespace System.Net.Http
             return true;
         }
 
-        public override string ToString() => $"{nameof(HttpConnection)}(Host:{_key.Host})"; // Description for diagnostic purposes
+        public override string ToString() => $"{nameof(HttpConnection)}({_pool.Key})"; // Description for diagnostic purposes
 
         private static void ThrowInvalidHttpResponse() => throw new HttpRequestException(SR.net_http_invalid_response);
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -1001,8 +1001,7 @@ namespace System.Net.Http
                 _readLength = remaining;
             }
 
-            ValueTask<int> vt = _stream.ReadAsync(new Memory<byte>(_readBuffer, _readLength, _readBuffer.Length - _readLength), cancellationToken);
-            int bytesRead = vt.IsCompletedSuccessfully ? vt.Result : await vt.AsTask().ConfigureAwait(false);
+            int bytesRead = await _stream.ReadAsync(new Memory<byte>(_readBuffer, _readLength, _readBuffer.Length - _readLength), cancellationToken).ConfigureAwait(false);
 
             if (NetEventSource.IsEnabled) Trace($"Received {bytesRead} bytes.");
             if (bytesRead == 0)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
-using System.Net.Security;
-using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,132 +9,63 @@ namespace System.Net.Http
 {
     internal sealed class HttpConnectionHandler : HttpMessageHandler
     {
-        private readonly HttpConnectionSettings _settings;
         private readonly HttpConnectionPools _connectionPools;
 
         public HttpConnectionHandler(HttpConnectionSettings settings)
         {
-            _settings = settings;
-            _connectionPools = new HttpConnectionPools(settings._maxConnectionsPerServer);
+            _connectionPools = new HttpConnectionPools(settings, false, settings._maxConnectionsPerServer);
         }
 
         protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var key = new HttpConnectionKey(request.RequestUri);
-
+            Uri uri = request.RequestUri;
+            HttpConnectionKey key = new HttpConnectionKey(uri.IdnHost, uri.Port, GetSslHostName(request));
             HttpConnectionPool pool = _connectionPools.GetOrAddPool(key);
-            ValueTask<HttpConnection> connectionTask = pool.GetConnectionAsync(
-                (state, ct) => state.handler.CreateConnection(state.request, state.key, state.pool, ct),
-                (handler: this, request: request, key: key, pool: pool), cancellationToken);
-
-            return connectionTask.IsCompletedSuccessfully ?
-                connectionTask.Result.SendAsync(request, cancellationToken) :
-                SendAsyncWithAwaitedConnection(connectionTask, request, cancellationToken);
+            return pool.SendAsync(request, cancellationToken);
         }
 
-        private async Task<HttpResponseMessage> SendAsyncWithAwaitedConnection(
-            ValueTask<HttpConnection> connectionTask, HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            HttpConnection connection = await connectionTask.ConfigureAwait(false);
-            return await connection.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        }
-
-        private async ValueTask<SslStream> EstablishSslConnection(string host, HttpRequestMessage request, Stream stream, CancellationToken cancellationToken)
-        {
-            RemoteCertificateValidationCallback callback = null;
-            if (_settings._serverCertificateCustomValidationCallback != null)
-            {
-                callback = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
-                {
-                    try
-                    {
-                        return _settings._serverCertificateCustomValidationCallback(request, certificate as X509Certificate2, chain, sslPolicyErrors);
-                    }
-                    catch (Exception e)
-                    {
-                        throw new HttpRequestException(SR.net_http_ssl_connection_failed, e);
-                    }
-                };
-            }
-
-            var sslStream = new SslStream(stream);
-
-            try
-            {
-                await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
-                {
-                    TargetHost = host,
-                    ClientCertificates = _settings._clientCertificates,
-                    EnabledSslProtocols = _settings._sslProtocols,
-                    CertificateRevocationCheckMode = _settings._checkCertificateRevocationList ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
-                    RemoteCertificateValidationCallback = callback
-                }, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                sslStream.Dispose();
-                if (e is AuthenticationException || e is IOException)
-                {
-                    throw new HttpRequestException(SR.net_http_ssl_connection_failed, e);
-                }
-                throw;
-            }
-
-            return sslStream;
-        }
-
-        private async ValueTask<HttpConnection> CreateConnection(
-            HttpRequestMessage request, HttpConnectionKey key, HttpConnectionPool pool, CancellationToken cancellationToken)
+        private static string GetSslHostName(HttpRequestMessage request)
         {
             Uri uri = request.RequestUri;
 
-            Stream stream = await ConnectHelper.ConnectAsync(uri.IdnHost, uri.Port, cancellationToken).ConfigureAwait(false);
-
-            TransportContext transportContext = null;
-
-            if (HttpUtilities.IsSupportedSecureScheme(uri.Scheme))
+            if (!HttpUtilities.IsSupportedSecureScheme(uri.Scheme))
             {
-                // Get the appropriate host name to use for the SSL connection, allowing a host header to override.
-                string host = request.Headers.Host;
-                if (host == null)
+                // Not using SSL.
+                return null;
+            }
+
+            string hostHeader = request.Headers.Host;
+            if (hostHeader == null)
+            {
+                // No explicit Host header.  Use host from uri.
+                return request.RequestUri.IdnHost;
+            }
+
+            // There is a host header.  Use it, but first see if we need to trim off a port.
+            int colonPos = hostHeader.IndexOf(':');
+            if (colonPos >= 0)
+            {
+                // There is colon, which could either be a port separator or a separator in
+                // an IPv6 address.  See if this is an IPv6 address; if it's not, use everything
+                // before the colon as the host name, and if it is, use everything before the last
+                // colon iff the last colon is after the end of the IPv6 address (otherwise it's a
+                // part of the address).
+                int ipV6AddressEnd = hostHeader.IndexOf(']');
+                if (ipV6AddressEnd == -1)
                 {
-                    // No host header, use the host from the Uri.
-                    host = uri.IdnHost;
+                    return hostHeader.Substring(0, colonPos);
                 }
                 else
                 {
-                    // There is a host header.  Use it, but first see if we need to trim off a port.
-                    int colonPos = host.IndexOf(':');
-                    if (colonPos >= 0)
+                    colonPos = hostHeader.LastIndexOf(':');
+                    if (colonPos > ipV6AddressEnd)
                     {
-                        // There is colon, which could either be a port separator or a separator in
-                        // an IPv6 address.  See if this is an IPv6 address; if it's not, use everything
-                        // before the colon as the host name, and if it is, use everything before the last
-                        // colon iff the last colon is after the end of the IPv6 address (otherwise it's a
-                        // part of the address).
-                        int ipV6AddressEnd = host.IndexOf(']');
-                        if (ipV6AddressEnd == -1)
-                        {
-                            host = host.Substring(0, colonPos);
-                        }
-                        else
-                        {
-                            colonPos = host.LastIndexOf(':');
-                            if (colonPos > ipV6AddressEnd)
-                            {
-                                host = host.Substring(0, colonPos);
-                            }
-                        }
+                        return hostHeader.Substring(0, colonPos);
                     }
                 }
-
-                // Establish the connection using the parsed host name.
-                SslStream sslStream = await EstablishSslConnection(host, request, stream, cancellationToken).ConfigureAwait(false);
-                stream = sslStream;
-                transportContext = sslStream.TransportContext;
             }
 
-            return new HttpConnection(pool, key, uri.IdnHost, stream, transportContext, false);
+            return hostHeader;
         }
 
         protected override void Dispose(bool disposing)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http
 
         public HttpConnectionHandler(HttpConnectionSettings settings)
         {
-            _connectionPools = new HttpConnectionPools(settings, false, settings._maxConnectionsPerServer);
+            _connectionPools = new HttpConnectionPools(settings, settings._maxConnectionsPerServer, usingProxy: false);
         }
 
         protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
@@ -4,8 +4,11 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Net.Security;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,10 +20,16 @@ namespace System.Net.Http
         /// <summary>Maximum number of milliseconds a connection is allowed to be idle in the pool before we remove it.</summary>
         private const int MaxIdleTimeMilliseconds = 100_000;
 
+        private readonly HttpConnectionPools _pools;
+        private readonly HttpConnectionKey _key;
+
         /// <summary>List of idle connections stored in the pool.</summary>
         private readonly List<CachedConnection> _idleConnections = new List<CachedConnection>();
         /// <summary>The maximum number of connections allowed to be associated with the pool.</summary>
         private readonly int _maxConnections;
+
+        /// <summary>For non-proxy connection pools, this is the host name in bytes; for proxies, null.</summary>
+        private readonly byte[] _idnHostAsciiBytes;
 
         /// <summary>The head of a list of waiters waiting for a connection.  Null if no one's waiting.</summary>
         private ConnectionWaiter _waitersHead;
@@ -36,16 +45,34 @@ namespace System.Net.Http
         
         /// <summary>Initializes the pool.</summary>
         /// <param name="maxConnections">The maximum number of connections allowed to be associated with the pool at any given time.</param>
-        public HttpConnectionPool(int maxConnections = int.MaxValue) // int.MaxValue treated as infinite
+        public HttpConnectionPool(HttpConnectionPools pools, HttpConnectionKey key, int maxConnections = int.MaxValue) // int.MaxValue treated as infinite
         {
+            _pools = pools;
+            _key = key;
             _maxConnections = maxConnections;
+
+            // Precalculate ASCII bytes for header name
+            // We don't do this for proxy connections because the actual host header varies on a proxy connection.
+            if (!pools.UsingProxy)
+            {
+                // CONSIDER: Cache more than just host name -- port, header name, etc
+                _idnHostAsciiBytes = Encoding.ASCII.GetBytes(key.Host);
+            }
+            else
+            {
+                // Proxy connections should never use SSL
+                Debug.Assert(!key.IsSecure);
+            }
         }
+
+        public HttpConnectionKey Key => _key;
+        public HttpConnectionPools Pools => _pools;
+        public byte[] IdnHostAsciiBytes => _idnHostAsciiBytes;
 
         /// <summary>Object used to synchronize access to state in the pool.</summary>
         private object SyncObj => _idleConnections;
 
-        public ValueTask<HttpConnection> GetConnectionAsync<TState>(
-            Func<TState, CancellationToken, ValueTask<HttpConnection>> createConnection, TState state, CancellationToken cancellationToken)
+        private ValueTask<HttpConnection> GetConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -61,6 +88,7 @@ namespace System.Net.Http
                 {
                     CachedConnection cachedConnection = list[list.Count - 1];
                     HttpConnection conn = cachedConnection._connection;
+                    Debug.Assert(!conn.IsNewConnection);
 
                     list.RemoveAt(list.Count - 1);
                     if (cachedConnection.IsUsable())
@@ -85,7 +113,7 @@ namespace System.Net.Http
                 {
                     if (NetEventSource.IsEnabled) Trace("Creating new connection for pool.");
                     IncrementConnectionCountNoLock();
-                    return WaitForCreatedConnectionAsync(createConnection(state, cancellationToken));
+                    return WaitForCreatedConnectionAsync(CreateConnectionAsync(request, cancellationToken));
                 }
                 else
                 {
@@ -97,7 +125,7 @@ namespace System.Net.Http
                     // space is available and the provided creation func has successfully
                     // created the connection to be used.
                     if (NetEventSource.IsEnabled) Trace("Limit reached.  Waiting to create new connection.");
-                    var waiter = new ConnectionWaiter<TState>(this, createConnection, state, cancellationToken);
+                    var waiter = new ConnectionWaiter(this, request, cancellationToken);
                     EnqueueWaiter(waiter);
                     if (cancellationToken.CanBeCanceled)
                     {
@@ -130,6 +158,53 @@ namespace System.Net.Http
                 // try returning such connections to whatever pool is currently considered
                 // current for that endpoint, if there is one.
             }
+        }
+
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            while (true)
+            { 
+                // Loop on connection failures and retry if possible.
+
+                HttpConnection connection = await GetConnectionAsync(request, cancellationToken);
+
+                if (connection.IsNewConnection)
+                {
+                    return await connection.SendAsync(request, cancellationToken);
+                }
+
+                try
+                {
+                    return await connection.SendAsync(request, cancellationToken);
+                }
+                catch (HttpRequestException e)
+                {
+                    if (!(e.InnerException is IOException))
+                    {
+                        throw;
+                    }
+
+                    if (!connection.CanRetry)
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+
+        private async ValueTask<HttpConnection> CreateConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Stream stream = await ConnectHelper.ConnectAsync(_key, cancellationToken).ConfigureAwait(false);
+
+            TransportContext transportContext = null;
+            if (_key.IsSecure)
+            {
+                SslStream sslStream = await ConnectHelper.EstablishSslConnection(_pools.Settings, _key.SslHostName, request, stream, cancellationToken).ConfigureAwait(false);
+                stream = sslStream;
+                transportContext = sslStream.TransportContext;
+            }
+
+            return new HttpConnection(this, stream, transportContext);
         }
 
         /// <summary>Enqueues a waiter to the waiters list.</summary>
@@ -525,54 +600,19 @@ namespace System.Net.Http
             public override int GetHashCode() => _connection?.GetHashCode() ?? 0;
         }
 
-        /// <summary>Provides a waiter object that supports a generic function and state type for creating connections.</summary>
-        private sealed class ConnectionWaiter<TState> : ConnectionWaiter
-        {
-            /// <summary>The function to invoke if/when <see cref="CreateConnectionAsync"/> is invoked.</summary>
-            private readonly Func<TState, CancellationToken, ValueTask<HttpConnection>> _createConnectionAsync;
-            /// <summary>The state to pass to <paramref name="func"/> when it's invoked.</summary>
-            private readonly TState _state;
-
-            /// <summary>Initializes the waiter.</summary>
-            /// <param name="func">The function to invoke if/when <see cref="CreateConnectionAsync"/> is invoked.</param>
-            /// <param name="state">The state to pass to <paramref name="func"/> when it's invoked.</param>
-            public ConnectionWaiter(HttpConnectionPool pool, Func<TState, CancellationToken, ValueTask<HttpConnection>> func, TState state, CancellationToken cancellationToken) :
-                base(pool, cancellationToken)
-            {
-                _createConnectionAsync = func;
-                _state = state;
-            }
-
-            /// <summary>Creates a connection by invoking <see cref="_createConnectionAsync"/> with <see cref="_state"/>.</summary>
-            public override ValueTask<HttpConnection> CreateConnectionAsync()
-            {
-                try
-                {
-                    return _createConnectionAsync(_state, _cancellationToken);
-                }
-                catch (Exception e)
-                {
-                    return new ValueTask<HttpConnection>(Threading.Tasks.Task.FromException<HttpConnection>(e));
-                }
-            }
-        }
-
         /// <summary>
         /// Provides a waiter object that's used when we've reached the limit on connections
         /// associated with the pool.  When a connection is available or created, it's stored
         /// into the waiter as a result, and if no connection is available from the pool,
         /// this waiter's logic is used to create the connection.
         /// </summary>
-        /// <remarks>
-        /// Implemented as a non-generic base type with a generic derived type to support
-        /// passing in arbitrary funcs and associated state while minimizing allocations.
-        /// The <see cref="CreateConnectionAsync"/> method will be implemented on the derived
-        /// type that is able to work with the supplied state generically.
-        /// </remarks>
-        private abstract class ConnectionWaiter : TaskCompletionSource<HttpConnection>
+        private class ConnectionWaiter : TaskCompletionSource<HttpConnection>
         {
             /// <summary>The pool with which this waiter is associated.</summary>
             internal readonly HttpConnectionPool _pool;
+            /// <summary>Request to use to create the connection.</summary>
+            private readonly HttpRequestMessage _request;
+
             /// <summary>Cancellation token for the waiter.</summary>
             internal readonly CancellationToken _cancellationToken;
             /// <summary>Registration that removes the waiter from the registration list.</summary>
@@ -583,15 +623,26 @@ namespace System.Net.Http
             internal ConnectionWaiter _prev;
 
             /// <summary>Initializes the waiter.</summary>
-            public ConnectionWaiter(HttpConnectionPool pool, CancellationToken cancellationToken) : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            public ConnectionWaiter(HttpConnectionPool pool, HttpRequestMessage request, CancellationToken cancellationToken) : base(TaskCreationOptions.RunContinuationsAsynchronously)
             {
                 Debug.Assert(pool != null, "Expected non-null pool");
                 _pool = pool;
+                _request = request;
                 _cancellationToken = cancellationToken;
             }
-            
+
             /// <summary>Creates a connection.</summary>
-            public abstract ValueTask<HttpConnection> CreateConnectionAsync();
+            public ValueTask<HttpConnection> CreateConnectionAsync()
+            {
+                try
+                {
+                    return _pool.CreateConnectionAsync(_request, _cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    return new ValueTask<HttpConnection>(Threading.Tasks.Task.FromException<HttpConnection>(e));
+                }
+            }
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPools.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPools.cs
@@ -43,7 +43,7 @@ namespace System.Net.Http
         // CONSIDER: We are passing HttpConnectionSettings here, but all we really need are the SSL settings.
         // When we refactor the SSL settings to use SslAuthenticationOptions, just pass that here.
 
-        public HttpConnectionPools(HttpConnectionSettings settings, bool usingProxy, int maxConnectionsPerServer)
+        public HttpConnectionPools(HttpConnectionSettings settings, int maxConnectionsPerServer, bool usingProxy)
         {
             _settings = settings;
             _usingProxy = usingProxy;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPools.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPools.cs
@@ -22,8 +22,13 @@ namespace System.Net.Http
         private readonly ConcurrentDictionary<HttpConnectionKey, HttpConnectionPool> _pools;
         /// <summary>Timer used to initiate cleaning of the pools.</summary>
         private readonly Timer _cleaningTimer;
+        /// <summary>True if we are managing proxy connections, false for direct connections.</summary>
+        private readonly bool _usingProxy;
         /// <summary>The maximum number of connections allowed per pool. <see cref="int.MaxValue"/> indicates unlimited.</summary>
         private readonly int _maxConnectionsPerServer;
+        // Temporary
+        private readonly HttpConnectionSettings _settings;
+
         /// <summary>
         /// Keeps track of whether or not the cleanup timer is running. It helps us avoid the expensive
         /// <see cref="ConcurrentDictionary{TKey,TValue}.IsEmpty"/> call.
@@ -34,8 +39,14 @@ namespace System.Net.Http
 
         /// <summary>Initializes the pools.</summary>
         /// <param name="maxConnectionsPerServer">The maximum number of connections allowed per pool. <see cref="int.MaxValue"/> indicates unlimited.</param>
-        public HttpConnectionPools(int maxConnectionsPerServer)
+        
+        // CONSIDER: We are passing HttpConnectionSettings here, but all we really need are the SSL settings.
+        // When we refactor the SSL settings to use SslAuthenticationOptions, just pass that here.
+
+        public HttpConnectionPools(HttpConnectionSettings settings, bool usingProxy, int maxConnectionsPerServer)
         {
+            _settings = settings;
+            _usingProxy = usingProxy;
             _maxConnectionsPerServer = maxConnectionsPerServer;
             _pools = new ConcurrentDictionary<HttpConnectionKey, HttpConnectionPool>();
             // Start out with the timer not running, since we have no pools.
@@ -60,6 +71,9 @@ namespace System.Net.Http
             }
         }
 
+        public HttpConnectionSettings Settings => _settings;
+        public bool UsingProxy => _usingProxy;
+
         /// <summary>Gets a pool for the specified endpoint, adding one if none existed.</summary>
         /// <param name="key">The endpoint for the pool.</param>
         /// <returns>The retrieved pool.</returns>
@@ -68,7 +82,7 @@ namespace System.Net.Http
             HttpConnectionPool pool;
             while (!_pools.TryGetValue(key, out pool))
             {
-                pool = new HttpConnectionPool(_maxConnectionsPerServer);
+                pool = new HttpConnectionPool(this, key, _maxConnectionsPerServer);
                 if (_pools.TryAdd(key, pool))
                 {
                     // We need to ensure the cleanup timer is running if it isn't

--- a/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
@@ -1,0 +1,174 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Sockets;
+using System.Net.Test.Common;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class HttpRetryProtocolTests : HttpClientTestBase
+    {
+        private static readonly string s_simpleContent = "Hello World\r\n";
+        private static readonly string s_simpleResponse =
+            $"HTTP/1.1 200 OK\r\n" +
+            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+            $"Content-Length: {s_simpleContent.Length}\r\n" +
+            "\r\n" +
+            s_simpleContent;
+
+        // Retry logic is supported by managed handler, CurlHandler, uap, and netfx.  Only WinHttp does not support. 
+        private bool IsRetrySupported =>
+            UseManagedHandler || !PlatformDetection.IsWindows || PlatformDetection.IsUap || PlatformDetection.IsFullFramework;
+
+        public static Task CreateServerAndClientAsync(Func<Uri, Task> clientFunc, Func<Socket, Task> serverFunc)
+        {
+            IPEndPoint ignored;
+            return LoopbackServer.CreateServerAsync(async (server, uri) =>
+            {
+                Task clientTask = clientFunc(uri);
+                Task serverTask = serverFunc(server);
+
+                await TestHelper.WhenAllCompletedOrAnyFailed(clientTask, serverTask);
+
+            }, out ignored);
+        }
+
+        [Fact]
+        public async Task GetAsync_RetryOnConnectionClosed_Success()
+        {
+            if (!IsRetrySupported)
+            {
+                return;
+            }
+
+            await CreateServerAndClientAsync(async url =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    // Send initial request and receive response so connection is established
+                    HttpResponseMessage response1 = await client.GetAsync(url);
+                    Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+                    Assert.Equal(s_simpleContent, await response1.Content.ReadAsStringAsync());
+
+                    // Send second request.  Should reuse same connection.  
+                    // The server will close the connection, but HttpClient should retry the request.
+                    HttpResponseMessage response2 = await client.GetAsync(url);
+                    Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+                    Assert.Equal(s_simpleContent, await response1.Content.ReadAsStringAsync());
+                }
+            },
+            async server =>
+            {
+                await LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
+                {
+                    // Initial response
+                    await LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer, s_simpleResponse);
+
+                    // Second response: Read request headers, then close connection
+                    await LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer, "");
+                    s.Close();
+
+                    // Client should reconnect.  Accept that connection and send response.
+                    await LoopbackServer.ReadRequestAndSendResponseAsync(server, s_simpleResponse);
+
+                    return null;
+                });
+            });
+        }
+
+        [Fact]
+        public async Task PostAsyncExpect100Continue_RetryOnConnectionClosed_Success()
+        {
+            if (!IsRetrySupported)
+            {
+                return;
+            }
+
+            await CreateServerAndClientAsync(async url =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    // Send initial request and receive response so connection is established
+                    HttpResponseMessage response1 = await client.GetAsync(url);
+                    Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+                    Assert.Equal(s_simpleContent, await response1.Content.ReadAsStringAsync());
+
+                    // Send second request.  Should reuse same connection.  
+                    // The server will close the connection, but HttpClient should retry the request.
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, url);
+                    request.Headers.ExpectContinue = true;
+                    var content = new CustomContent();
+                    request.Content = content;
+
+                    HttpResponseMessage response2 = await client.SendAsync(request);
+                    Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+                    Assert.Equal(s_simpleContent, await response1.Content.ReadAsStringAsync());
+
+                    Assert.Equal(1, content.SerializeCount);
+                }
+            },
+            async server =>
+            {
+                await LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
+                {
+                    // Initial response
+                    await LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer, s_simpleResponse);
+
+                    // Second response: Read request headers, then close connection
+                    List<string> lines = await LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer, "");
+                    Assert.Contains("Expect: 100-continue", lines);
+                    s.Close();
+
+                    // Client should reconnect.  Accept that connection and send response.
+                    await LoopbackServer.AcceptSocketAsync(server, async (s2, stream2, reader2, writer2) =>
+                    {
+                        List<string> lines2 = await LoopbackServer.ReadWriteAcceptedAsync(s2, reader2, writer2, "");
+                        Assert.Contains("Expect: 100-continue", lines2);
+
+                        await writer2.WriteAsync("HTTP/1.1 100 Continue\r\n\r\n");
+
+                        string contentLine = await reader2.ReadLineAsync();
+                        Assert.Equal(s_simpleContent, contentLine + "\r\n");
+
+                        await writer2.WriteAsync(s_simpleResponse);
+
+                        return null;
+                    });
+
+                    return null;
+                });
+            });
+        }
+
+        class CustomContent : HttpContent
+        {
+            private int _serializeCount;
+
+            public CustomContent()
+            {
+                _serializeCount = 0;
+            }
+
+            public int SerializeCount => _serializeCount;
+
+            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                _serializeCount++;
+
+                await stream.WriteAsync(Encoding.UTF8.GetBytes(s_simpleContent));
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = s_simpleContent.Length;
+                return true;
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -110,6 +110,10 @@ namespace System.Net.Http.Functional.Tests
         protected override bool SupportsIdna => true;
     }
 
+    public sealed class ManagedHandler_HttpRetryProtocolTests : HttpRetryProtocolTests
+    {
+        protected override bool UseManagedHandler => true;
+    }
 
     // TODO #23141: Socket's don't support canceling individual operations, so ReadStream on NetworkStream
     // isn't cancelable once the operation has started.  We either need to wrap the operation with one that's

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpMessageInvokerTest.cs" />
     <Compile Include="HttpMethodTest.cs" />
+    <Compile Include="HttpRetryProtocolTests.cs" />
     <Compile Include="IdnaProtocolTests.cs" />
     <Compile Include="HttpProtocolTests.cs" />
     <Compile Include="HttpRequestMessageTest.cs" />


### PR DESCRIPTION
Fixes #26495 

Implement basic retry logic on connection failure.  If a previously pooled connection fails before we start sending the request body, and before we start receiving the response, then it's retryable; we grab another connection and retry (and repeat as necessary).

Additionally:
(1) Refactor some connection creation code
(2) Change HttpConnectionKey to include SSL Host Name (otherwise we could be sending requests on the wrong SSL connections)

@stephentoub @davidsh @Priya91 @wfurt @caesar1995