### PR TITLE
Update Linux Versions for test execution

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -457,7 +457,7 @@
       "allowOverride": true
     },
     "PB_TargetQueue": {
-      "value": "Centos.73.Amd64+RedHat.72.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+suse.422.amd64+SLES.12.Amd64+fedora.25.amd64+Fedora.26.Amd64"
+      "value": "Centos.73.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+opensuse.423.amd64+SLES.12.Amd64+Fedora.26.Amd64+Fedora.27.Amd64"
     },
     "PB_VsoAccountName": {
       "value": "dn-bot"

--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -52,11 +52,11 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
                                      'Debian.87.Amd64.Open',
                                      'Ubuntu.1404.Amd64.Open',
                                      'Ubuntu.1604.Amd64.Open',
-                                     'opensuse.422.amd64.open',
-                                     'fedora.25.amd64.Open',]
+                                     'OpenSuse.423.Amd64.Open',
+                                     'Fedora.26.Amd64.Open',]
             if (params.TestOuter) {
                 targetHelixQueues += ['Debian.90.Amd64.Open',
-                                      'Fedora.26.Amd64.Open',
+                                      'Fedora.27.Amd64.Open',
                                       'SLES.12.Amd64.Open',]
             }
 

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -18,7 +18,7 @@
             "PB_BuildArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -stripSymbols",
             "PB_BuildTestsArguments": "-buildArch=x64 -$(PB_ConfigurationGroup) -SkipTests -Outerloop -- /p:ArchiveTests=true /p:EnableDumpling=true",
             "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:DotNetAssetRootUrl=$(PB_AssetRootUrl)",
-            "PB_TargetQueue": "Centos.73.Amd64+RedHat.72.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1710.Amd64+suse.422.amd64+SLES.12.Amd64+fedora.25.amd64+Fedora.26.Amd64",
+            "PB_TargetQueue": "Centos.73.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1710.Amd64+OpenSuse.423.Amd64+SLES.12.Amd64+Fedora.26.Amd64+Fedora.27.Amd64",
             "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
           },
           "ReportingParameters": {


### PR DESCRIPTION
@joshfree , @ianhays  FYI.

_Removals:_
Fedora 25 - EOL 12/20/17
OpenSUSE 42.2 - EOL 01/26/18
RedHat 7.2 - EOL 11/30/17

_Additions:_
OpenSUSE 42.3
Fedora 27