### PR TITLE
Disable Brotli perf tests

### DIFF
--- a/src/System.IO.Compression.Brotli/tests/Performance/System.IO.Compression.Brotli.Performance.Tests.csproj
+++ b/src/System.IO.Compression.Brotli/tests/Performance/System.IO.Compression.Brotli.Performance.Tests.csproj
@@ -11,6 +11,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
+<!-- [ActiveIssue(26566)]
     <Compile Include="BrotliPerfTests.cs" />
     <Compile Include="CompressionStreamPerfTests.Brotli.cs" />
     <Compile Include="$(CommonTestPath)\System\IO\Compression\CompressionStreamTestBase.cs">
@@ -19,6 +20,7 @@
     <Compile Include="$(CommonTestPath)\System\IO\Compression\CompressionStreamPerfTestBase.cs">
       <Link>Common\System\IO\Compression\CompressionStreamPerfTestBase.cs</Link>
     </Compile>
+-->
   </ItemGroup>
   <ItemGroup>
     <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.6-prerelease\content\**\*.*">


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/26566

[ActiveIssue] doesn't appear to work with [Benchmark], so I've just commented the files out of the .csproj.

cc: @danmosemsft, @ianhays 