### PR TITLE
Add System.Security.Permissions netfx facade and mark some APIs as obsolet to match desktop

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -29,10 +29,6 @@
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
-    <!-- Work-around issue where we are bin-placing the netstandard ref for System.Security.Permissions for netfx. Issue #24517 -->
-    <TargetingPackExclusions Include="System.Security.Permissions" />
-  </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="BinaryFormatterTests.rd.xml" />
   </ItemGroup>

--- a/src/System.Security.Permissions/ref/Configurations.props
+++ b/src/System.Security.Permissions/ref/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -1571,6 +1571,7 @@ namespace System.Security.Policy
         public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { throw null; }
         public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { throw null; }
     }
+    [System.ObsoleteAttribute("This type is obsolete. See http://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
     public sealed partial class FirstMatchCodeGroup : System.Security.Policy.CodeGroup
     {
         public FirstMatchCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) : base(default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
@@ -1661,6 +1662,7 @@ namespace System.Security.Policy
         public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { throw null; }
         public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { throw null; }
     }
+    [System.ObsoleteAttribute("This type is obsolete. See http://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
     public sealed partial class PermissionRequestEvidence : System.Security.Policy.EvidenceBase
     {
         public PermissionRequestEvidence(System.Security.PermissionSet request, System.Security.PermissionSet optional, System.Security.PermissionSet denied) { }
@@ -1693,6 +1695,7 @@ namespace System.Security.Policy
         public void AddFullTrustAssembly(System.Security.Policy.StrongNameMembershipCondition snMC) { }
         public void AddNamedPermissionSet(System.Security.NamedPermissionSet permSet) { }
         public System.Security.NamedPermissionSet ChangeNamedPermissionSet(string name, System.Security.PermissionSet pSet) { throw null; }
+        [System.ObsoleteAttribute("AppDomain policy levels are obsolete. See http://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
         public static System.Security.Policy.PolicyLevel CreateAppDomainLevel() { throw null; }
         public void FromXml(System.Security.SecurityElement e) { }
         public System.Security.NamedPermissionSet GetNamedPermissionSet(string name) { throw null; }
@@ -1825,6 +1828,7 @@ namespace System.Security.Policy
         Run = 2,
         Upgrade = 1,
     }
+    [System.ObsoleteAttribute("This type is obsolete. See http://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
     public sealed partial class UnionCodeGroup : System.Security.Policy.CodeGroup
     {
         public UnionCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) : base(default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -3,8 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{07CAF142-B259-418E-86EF-C4BD8B50253E}</ProjectGuid>
-    <!-- UAPvNext is not yet mapped to netstandard2.0, manually duplicate this ref -->
-    <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard'">netstandard2.0;$(UAPvNextTFM)</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == netfx">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
@@ -21,7 +19,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'netfx'">
     <ProjectReference Include="..\..\System.Security.AccessControl\ref\System.Security.AccessControl.csproj" />
-    <SuppressPackageTargetFrameworkCompatibility Include="$(UAPvNextTFM)" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -4,16 +4,24 @@
   <PropertyGroup>
     <ProjectGuid>{07CAF142-B259-418E-86EF-C4BD8B50253E}</ProjectGuid>
     <!-- UAPvNext is not yet mapped to netstandard2.0, manually duplicate this ref -->
-    <PackageTargetFramework>netstandard2.0;$(UAPvNextTFM)</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard'">netstandard2.0;$(UAPvNextTFM)</PackageTargetFramework>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == netfx">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Security.Permissions.cs" />
-    <SuppressPackageTargetFrameworkCompatibility Include="$(UAPvNextTFM)" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'netfx'">
     <ProjectReference Include="..\..\System.Security.AccessControl\ref\System.Security.AccessControl.csproj" />
+    <SuppressPackageTargetFrameworkCompatibility Include="$(UAPvNextTFM)" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>System.Security.Permissions</RootNamespace>
     <AssemblyName>System.Security.Permissions</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageAsRefAndLib Condition="'$(TargetGroup)' == 'netfx'">true</PackageAsRefAndLib>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />

--- a/src/System.Security.Permissions/src/System/Security/Policy/FirstMatchCodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/FirstMatchCodeGroup.cs
@@ -4,6 +4,7 @@
 
 namespace System.Security.Policy
 {
+    [Obsolete("This type is obsolete. See http://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
     public sealed partial class FirstMatchCodeGroup : CodeGroup
     {
         public FirstMatchCodeGroup(IMembershipCondition membershipCondition, PolicyStatement policy) : base(default(IMembershipCondition), default(PolicyStatement)) { }

--- a/src/System.Security.Permissions/src/System/Security/Policy/PermissionRequestEvidence.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PermissionRequestEvidence.cs
@@ -4,6 +4,7 @@
 
 namespace System.Security.Policy
 {
+    [Obsolete("This type is obsolete. See http://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
     public sealed partial class PermissionRequestEvidence : EvidenceBase
     {
         public PermissionRequestEvidence(PermissionSet request, PermissionSet optional, PermissionSet denied) { }

--- a/src/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
@@ -22,6 +22,7 @@ namespace System.Security.Policy
         public void AddFullTrustAssembly(StrongNameMembershipCondition snMC) { }
         public void AddNamedPermissionSet(NamedPermissionSet permSet) { }
         public NamedPermissionSet ChangeNamedPermissionSet(string name, PermissionSet pSet) { return default(NamedPermissionSet); }
+        [Obsolete("AppDomain policy levels are obsolete. See http://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
         public static PolicyLevel CreateAppDomainLevel() { return default(PolicyLevel); }
         public void FromXml(SecurityElement e) { }
         public NamedPermissionSet GetNamedPermissionSet(string name) { return default(NamedPermissionSet); }

--- a/src/System.Security.Permissions/src/System/Security/Policy/UnionCodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/UnionCodeGroup.cs
@@ -4,6 +4,7 @@
 
 namespace System.Security.Policy
 {
+    [Obsolete("This type is obsolete. See http://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
     public sealed partial class UnionCodeGroup : CodeGroup
     {
         public UnionCodeGroup(IMembershipCondition membershipCondition, PolicyStatement policy) : base(default(IMembershipCondition), default(PolicyStatement)) { }

--- a/src/System.Security.Permissions/tests/CodeGroupTests.cs
+++ b/src/System.Security.Permissions/tests/CodeGroupTests.cs
@@ -23,7 +23,9 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void FirstMatchCodeGroupCallMethods()
         {
+#pragma warning disable 618
             FirstMatchCodeGroup fmcg = new FirstMatchCodeGroup(new GacMembershipCondition(), new PolicyStatement(new PermissionSet(new PermissionState())));
+#pragma warning restore 618
             CodeGroup cg = fmcg.Copy();
             PolicyStatement ps = fmcg.Resolve(new Evidence());
             cg = fmcg.ResolveMatchingCodeGroups(new Evidence());
@@ -48,7 +50,9 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void UnionCodeGroupCallMethods()
         {
+#pragma warning disable 618
             UnionCodeGroup ucg = new UnionCodeGroup(new GacMembershipCondition(), new PolicyStatement(new PermissionSet(new PermissionState())));
+#pragma warning restore 618
             CodeGroup cg = ucg.Copy();
             PolicyStatement ps = ucg.Resolve(new Evidence());
             cg = ucg.ResolveMatchingCodeGroups(new Evidence());

--- a/src/System.Security.Permissions/tests/EvidenceBaseTests.cs
+++ b/src/System.Security.Permissions/tests/EvidenceBaseTests.cs
@@ -53,8 +53,10 @@ namespace System.Security.Permissions.Tests
         public static void PermissionRequestEvidenceCallMethods()
         {
             PermissionSet ps = new PermissionSet(new PermissionState());
+#pragma warning disable 618
             PermissionRequestEvidence pre = new PermissionRequestEvidence(ps, ps, ps);
             PermissionRequestEvidence obj = pre.Copy();
+#pragma warning restore 618
             string str = ps.ToString();
             SecurityElement se = new SecurityElement("");
             ps.FromXml(se);

--- a/src/System.Security.Permissions/tests/PolicyTests.cs
+++ b/src/System.Security.Permissions/tests/PolicyTests.cs
@@ -24,7 +24,9 @@ namespace System.Security.Permissions.Tests
             NamedPermissionSet nps = new NamedPermissionSet("test");
             pl.AddNamedPermissionSet(nps);
             nps = pl.ChangeNamedPermissionSet("test", new PermissionSet(new Permissions.PermissionState()));
+#pragma warning disable 618
             PolicyLevel.CreateAppDomainLevel();
+#pragma warning restore 618
             nps = pl.GetNamedPermissionSet("test");
             pl.Recover();
             NamedPermissionSet nps2 = pl.RemoveNamedPermissionSet(nps);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/24517

cc: @weshaggard @danmosemsft @ViktorHofer 