### PR TITLE
Disable ExpectContinue in ManagedHandler when using version 1.0

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
@@ -309,11 +309,19 @@ namespace System.Net.Http
                 request.Headers.TransferEncodingChunked = true;
             }
 
-            if (request.Version.Minor == 0 && request.Version.Major == 1 &&
-                request.HasHeaders && request.Headers.TransferEncodingChunked == true)
+            if (request.Version.Minor == 0 && request.Version.Major == 1 && request.HasHeaders)
             {
                 // HTTP 1.0 does not support chunking
-                return Task.FromException<HttpResponseMessage>(new NotSupportedException(SR.net_http_unsupported_chunking));
+                if (request.Headers.TransferEncodingChunked == true)
+                {
+                    return Task.FromException<HttpResponseMessage>(new NotSupportedException(SR.net_http_unsupported_chunking));
+                }
+
+                // HTTP 1.0 does not support Expect: 100-continue; just disable it.
+                if (request.Headers.ExpectContinue == true)
+                {
+                    request.Headers.ExpectContinue = false;
+                }
             }
 
             return handler.SendAsync(request, cancellationToken);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1647,10 +1647,13 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        [InlineData(null)]
-        public async Task PostAsync_ExpectContinue_Success(bool? expectContinue)
+        [InlineData(false, "1.0")]
+        [InlineData(true, "1.0")]
+        [InlineData(null, "1.0")]
+        [InlineData(false, "1.1")]
+        [InlineData(true, "1.1")]
+        [InlineData(null, "1.1")]
+        public async Task PostAsync_ExpectContinue_Success(bool? expectContinue, string version)
         {
             using (HttpClient client = CreateHttpClient())
             {
@@ -1659,6 +1662,7 @@ namespace System.Net.Http.Functional.Tests
                     Content = new StringContent("Test String", Encoding.UTF8)
                 };
                 req.Headers.ExpectContinue = expectContinue;
+                req.Version = new Version(version);
 
                 using (HttpResponseMessage response = await client.SendAsync(req))
                 {
@@ -1666,7 +1670,7 @@ namespace System.Net.Http.Functional.Tests
                     if (UseManagedHandler)
                     {
                         const string ExpectedReqHeader = "\"Expect\": \"100-continue\"";
-                        if (expectContinue == true)
+                        if (expectContinue == true && version == "1.1")
                         {
                             Assert.Contains(ExpectedReqHeader, await response.Content.ReadAsStringAsync());
                         }


### PR DESCRIPTION
Don't fail, but disable sending the header and respecting the setting if the version is 1.0.

This appears to match netfx behavior with regards to 1.0 and what's sent, and seems reasonable.

Fixes https://github.com/dotnet/corefx/issues/26769
cc: @geoffkizer, @davidsh