### PR TITLE
ManagedHandler: support LF line endings and trailer headers

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/ByteArrayHelpers.cs
+++ b/src/System.Net.Http/src/System/Net/Http/ByteArrayHelpers.cs
@@ -41,14 +41,5 @@ namespace System
 
             return true;
         }
-
-        internal static unsafe string GetStringFromByteSpan(ReadOnlySpan<byte> bytes)
-        {
-            // TODO #22431: Use new Span-based Encoding overload when available
-            fixed (byte* p = &MemoryMarshal.GetReference(bytes))
-            {
-                return Encoding.ASCII.GetString(p, bytes.Length);
-            }
-        }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
@@ -81,7 +81,7 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            descriptor = new HeaderDescriptor(ByteArrayHelpers.GetStringFromByteSpan(headerName));
+            descriptor = new HeaderDescriptor(HttpRuleParser.GetTokenString(headerName));
             return true;
         }
 
@@ -112,7 +112,7 @@ namespace System.Net.Http.Headers
                 }
             }
 
-            return ByteArrayHelpers.GetStringFromByteSpan(headerValue);
+            return HttpRuleParser.DefaultHttpEncoding.GetString(headerValue);
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
@@ -143,6 +143,13 @@ namespace System.Net.Http
             return true;
         }
 
+        internal static string GetTokenString(ReadOnlySpan<byte> input)
+        {
+            Debug.Assert(IsToken(input));
+
+            return Encoding.ASCII.GetString(input);
+        }
+
         internal static int GetWhitespaceLength(string input, int startIndex)
         {
             Debug.Assert(input != null);

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ChunkedEncodingReadStream.cs
@@ -88,7 +88,10 @@ namespace System.Net.Http
                 _chunkBytesRemaining -= bytesConsumed;
                 if (_chunkBytesRemaining == 0)
                 {
-                    await _connection.ReadEmptyLineAsync(cancellationToken).ConfigureAwait(false);
+                    if (!LineIsEmpty(await _connection.ReadNextLineAsync(cancellationToken).ConfigureAwait(false)))
+                    {
+                        ThrowInvalidHttpResponse();
+                    }
                 }
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -618,7 +618,7 @@ namespace System.Net.Http
                 string knownReasonPhrase = HttpStatusDescription.Get(response.StatusCode);
                 response.ReasonPhrase = knownReasonPhrase != null && EqualsOrdinal(knownReasonPhrase, reasonBytes) ?
                                             knownReasonPhrase :
-                                            Encoding.ASCII.GetString(reasonBytes);
+                                            HttpRuleParser.DefaultHttpEncoding.GetString(reasonBytes);
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
@@ -56,7 +56,10 @@ namespace System.Net.Http
             if (!pools.UsingProxy)
             {
                 // CONSIDER: Cache more than just host name -- port, header name, etc
+
+                // Note the IDN hostname should always be ASCII, since it's already been IDNA encoded.
                 _idnHostAsciiBytes = Encoding.ASCII.GetBytes(key.Host);
+                Debug.Assert(Encoding.ASCII.GetString(_idnHostAsciiBytes) == key.Host);
             }
             else
             {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1159,15 +1159,15 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(17174, TestPlatforms.AnyUnix)] // https://github.com/curl/curl/issues/1354
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task GetAsync_TrailingHeaders_Ignored(bool includeTrailerHeader)
         {
-            if (UseManagedHandler)
+            if (IsCurlHandler)
             {
-                // TODO #23130: The managed handler isn't correctly handling trailing headers.
+                // ActiveIssue #17174: CurlHandler has a problem here
+                // https://github.com/curl/curl/issues/1354
                 return;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTestBase.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTestBase.cs
@@ -31,6 +31,11 @@ namespace System.Net.Http.Functional.Tests
 
         protected virtual bool UseManagedHandler => false;
 
+        protected bool IsWinHttpHandler => !UseManagedHandler && PlatformDetection.IsWindows && !PlatformDetection.IsUap && !PlatformDetection.IsFullFramework;
+        protected bool IsCurlHandler => !UseManagedHandler && !PlatformDetection.IsWindows;
+        protected bool IsNetfxHandler => !UseManagedHandler && PlatformDetection.IsWindows && PlatformDetection.IsFullFramework;
+        protected bool IsUapHandler => !UseManagedHandler && PlatformDetection.IsWindows && PlatformDetection.IsUap;
+
         protected HttpClient CreateHttpClient() => new HttpClient(CreateHttpClientHandler());
 
         protected HttpClientHandler CreateHttpClientHandler() => CreateHttpClientHandler(UseManagedHandler);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -478,6 +478,33 @@ namespace System.Net.Http.Functional.Tests
                 }
             });
         }
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]   // Does not support LF-only
+        [Theory]
+        [InlineData("\r\n")]
+        [InlineData("\n")]
+        public async Task GetAsync_ResponseHasNormalLineEndings_Success(string lineEnding)
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
+                    Task<List<string>> serverTask = LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        $"HTTP/1.1 200 OK{lineEnding}Date: {DateTimeOffset.UtcNow:R}{lineEnding}Server: TestServer{lineEnding}Content-Length: 0{lineEnding}{lineEnding}",
+                        new LoopbackServer.Options { ResponseStreamWrapper = GetStream });
+
+                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                    using (HttpResponseMessage response = await getResponseTask)
+                    {
+                        Assert.Equal(200, (int)response.StatusCode);
+                        Assert.Equal("OK", response.ReasonPhrase);
+                        Assert.Equal("TestServer", response.Headers.Server.ToString());
+                    }
+                }
+            });
+        }
     }
 
     public class HttpProtocolTests_Dribble : HttpProtocolTests


### PR DESCRIPTION
Fixes #23130 
Fixes #26326 
Fixes #26780 

Also, some minor cleanup and new properties on HttpClientTestBase to make it easier to make tests conditional on which handler is being tested.

@stephentoub @davidsh