### PR TITLE
Disable failing DNS tests on macOS

### DIFF
--- a/src/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -111,6 +111,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Contains(Dns.GetHostName(), entry.HostName, StringComparison.OrdinalIgnoreCase);
         }
 
+        [ActiveIssue(26789, TestPlatforms.OSX)]
         [Fact]
         public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
         {

--- a/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -20,11 +20,13 @@ namespace System.Net.NameResolution.Tests
             await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(localIPAddress));
         }
 
+        [ActiveIssue(26789, TestPlatforms.OSX)]
         [Theory]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
         public Task Dns_GetHostEntry_HostString_Ok(string hostName) => TestGetHostEntryAsync(() => Task.FromResult(Dns.GetHostEntry(hostName)));
 
+        [ActiveIssue(26789, TestPlatforms.OSX)]
         [Theory]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/26789
cc: @karelz, @wfurt