### PR TITLE
Update TVPTest error comparisons to use error codes instead of full exception messages.

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SqlParameterTest_DebugMode.bsl
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SqlParameterTest_DebugMode.bsl
@@ -483,30 +483,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 1 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -515,30 +499,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 2 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -547,26 +515,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 3 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -575,28 +531,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 4 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -605,28 +547,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 5 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -635,26 +563,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 6 ++++++++
 SqlException creating objects: 1701
@@ -666,26 +582,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 8 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -694,26 +598,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 9 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -722,30 +614,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 10 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -754,30 +630,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 11 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -786,26 +646,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 12 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -814,28 +662,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 13 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -844,28 +678,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 14 ++++++++
 SqlException creating objects: 1701
@@ -880,26 +700,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 17 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -908,26 +716,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 18 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -936,30 +732,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 19 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -968,30 +748,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 20 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -1001,19 +765,13 @@ Matches = 168
 ------DataTables---------
 Matches = 14
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
 Matches = 28
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
 Matches = 14
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 21 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -1023,23 +781,13 @@ Matches = 168
 ------DataTables---------
 Matches = 14
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 22 ++++++++
 SqlException creating objects: 1701
@@ -1092,29 +840,15 @@ Mismatch: Source = 1/1/1753 12:00:00 AM, result = , metadata=SteAttributeKey=Sma
    Row=9, Column=5
 Matches = 162
 ------DataTables---------
-SqlException: The conversion of a datetime2 data type to a smalldatetime data type resulted in an out-of-range value.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 242
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 26 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -1123,26 +857,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 27 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -1210,36 +932,16 @@ Mismatch: Source = 922337203685477.5807, result = , metadata=SteAttributeKey=Sma
    Row=11, Column=9
 Matches = 158
 ------DataTables---------
-SqlException: The conversion of a datetime2 data type to a smalldatetime data type resulted in an out-of-range value.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: Arithmetic overflow error converting numeric to data type smallmoney.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 242
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8115
 ------- Sort order + uniqueness #1: simple -------
 -------------
 0  Z-value  3/1/2000 12:00:00 AM  5  

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SqlParameterTest_ReleaseMode.bsl
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SqlParameterTest_ReleaseMode.bsl
@@ -22,30 +22,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 1 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -54,30 +38,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 2 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -86,26 +54,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 3 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -114,28 +70,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 4 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -144,28 +86,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 5 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -174,26 +102,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 6 ++++++++
 SqlException creating objects: 1701
@@ -205,26 +121,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 8 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -233,26 +137,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 9 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -261,30 +153,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 10 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -293,30 +169,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 11 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -325,26 +185,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 12 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -353,28 +201,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 13 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -383,28 +217,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 14 ++++++++
 SqlException creating objects: 1701
@@ -419,26 +239,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 17 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -447,26 +255,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 18 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -475,30 +271,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 19 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -507,30 +287,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 20 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -540,19 +304,13 @@ Matches = 168
 ------DataTables---------
 Matches = 14
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
 Matches = 28
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
 Matches = 14
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 21 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -562,23 +320,13 @@ Matches = 168
 ------DataTables---------
 Matches = 14
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 22 ++++++++
 SqlException creating objects: 1701
@@ -631,29 +379,15 @@ Mismatch: Source = 1/1/1753 12:00:00 AM, result = , metadata=SteAttributeKey=Sma
    Row=9, Column=5
 Matches = 162
 ------DataTables---------
-SqlException: The conversion of a datetime2 data type to a smalldatetime data type resulted in an out-of-range value.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 242
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 26 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -662,26 +396,14 @@ Matches = 168
 Matches = 168
 ------DataTables---------
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 28
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
 Matches = 14
 +++++++ Iteration 27 ++++++++
 ------IEnumerable<SqlDataRecord>---------
@@ -749,36 +471,16 @@ Mismatch: Source = 922337203685477.5807, result = , metadata=SteAttributeKey=Sma
    Row=11, Column=9
 Matches = 158
 ------DataTables---------
-SqlException: The conversion of a datetime2 data type to a smalldatetime data type resulted in an out-of-range value.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: String or binary data would be truncated.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
-SqlException: Arithmetic overflow error converting numeric to data type smallmoney.
-The data for table-valued parameter "@tvp" doesn't conform to the table type of the parameter.
-The statement has been terminated.
+SqlException. Error Code: 242
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8152
+SqlException. Error Code: 8115
 ------- Sort order + uniqueness #1: simple -------
 -------------
 0  Z-value  3/1/2000 12:00:00 AM  5  

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
@@ -1115,7 +1115,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 }
                 catch (SqlException se)
                 {
-                    Console.WriteLine("SqlException: {0}", se.Message);
+                    Console.WriteLine("SqlException. Error Code: {0}", se.Number);
                 }
                 catch (InvalidOperationException ioe)
                 {


### PR DESCRIPTION
Exception messages can be slightly different between different versions of SQL Server.