### PR TITLE
Enable Stress mode environment variable

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Http.cs
+++ b/src/Common/tests/System/Net/Configuration.Http.cs
@@ -8,14 +8,14 @@ namespace System.Net.Test.Common
     {
         public static partial class Http
         {
-            private static readonly string DefaultAzureServer = "corefx-net.cloudapp.net";  
+            private static readonly string DefaultAzureServer = "corefx-net.cloudapp.net";
 
             public static string Host => GetValue("COREFX_HTTPHOST", DefaultAzureServer);
 
             public static string SecureHost => GetValue("COREFX_SECUREHTTPHOST", DefaultAzureServer);
 
             public static string Http2Host => GetValue("COREFX_HTTP2HOST", "http2.akamai.com");
-            
+
             // This server doesn't use HTTP/2 server push (push promise) feature. Some HttpClient implementations
             // don't support servers that use push right now.
             public static string Http2NoPushHost => GetValue("COREFX_HTTP2NOPUSHHOST", "www.microsoft.com");
@@ -25,8 +25,6 @@ namespace System.Net.Test.Common
             public static string DomainJoinedProxyHost => GetValue("COREFX_DOMAINJOINED_PROXYHOST");
 
             public static string DomainJoinedProxyPort => GetValue("COREFX_DOMAINJOINED_PROXYPORT");
-
-            public static bool StressEnabled => GetValue("COREFX_STRESS", "0") == "1";
 
             public static string SSLv2RemoteServer => GetValue("COREFX_HTTPHOST_SSL2", "https://www.ssllabs.com:10200/");
             public static string SSLv3RemoteServer => GetValue("COREFX_HTTPHOST_SSL3", "https://www.ssllabs.com:10300/");
@@ -137,7 +135,7 @@ namespace System.Net.Test.Common
                         statusCode,
                         destination);
                 }
-                
+
                 return new Uri(uriString);
             }
 
@@ -145,14 +143,14 @@ namespace System.Net.Test.Common
             {
                 Uri destinationUri = BasicAuthUriForCreds(secure, userName, password);
                 string destination = Uri.EscapeDataString(destinationUri.AbsoluteUri);
-                
+
                 return new Uri(string.Format("{0}://{1}/{2}?statuscode={3}&uri={4}",
                     secure ? HttpsScheme : HttpScheme,
                     Host,
                     RedirectHandler,
                     statusCode,
                     destination));
-            }            
+            }
         }
     }
 }

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -112,6 +112,10 @@ namespace System
         [CLSCompliant(false)]
         public static Xunit.TheoryData ToTheoryData<T>(this System.Collections.Generic.IEnumerable<T> data) { throw null; }
     }
+    public static partial class TestEnvironment
+    {
+        public static bool IsStressModeEnabled { get { throw null; } }
+    }
 }
 namespace System.Diagnostics
 {

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -25,6 +25,7 @@
     <Compile Include="System\IO\FileCleanupTestBase.cs" />
     <Compile Include="System\Diagnostics\RemoteExecutorTestBase.cs" />
     <Compile Include="System\Net\PlatformDetection.Networking.cs" />
+    <Compile Include="System\TestEnvironment.cs" />
     <Compile Condition="'$(TargetGroup)' == 'netcoreapp'" Include="System\Diagnostics\RemoteExecutorTestBase.netcore.cs" />
     <Compile Condition="'$(TargetGroup)' == 'netfx'" Include="System\Diagnostics\RemoteExecutorTestBase.netfx.cs" />
     <Compile Condition="'$(TargetGroup)' != 'uap'" Include="System\Diagnostics\RemoteExecutorTestBase.Process.cs" />

--- a/src/CoreFx.Private.TestUtilities/src/System/TestEnvironment.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/TestEnvironment.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using Xunit;
+
+namespace System
+{
+    public static partial class TestEnvironment
+    {
+        /// <summary>
+        /// Check if the stress enabling mode environment variable is set.
+        /// </summary>
+        /// <returns> true if the environment variable set to '1' or 'true'. returns false otherwise</returns>
+        public static bool IsStressModeEnabled
+        {
+            get
+            {
+                string value = Environment.GetEnvironmentVariable("COREFX_STRESS");
+                return value != null && (value == "1" || value.Equals("true", StringComparison.OrdinalIgnoreCase));
+            }
+        }
+    }
+}

--- a/src/CoreFx.Private.TestUtilities/src/System/TestEnvironment.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/TestEnvironment.cs
@@ -10,9 +10,9 @@ namespace System
     public static partial class TestEnvironment
     {
         /// <summary>
-        /// Check if the stress enabling mode environment variable is set.
+        /// Check if the stress mode is enabled.
         /// </summary>
-        /// <returns> true if the environment variable set to '1' or 'true'. returns false otherwise</returns>
+        /// <value> true if the environment variable COREFX_STRESS set to '1' or 'true'. returns false otherwise</value>
         public static bool IsStressModeEnabled
         {
             get

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -16,9 +16,8 @@ namespace System.Net.Http.Functional.Tests
 
     public class HttpClientMiniStress : HttpClientTestBase
     {
-        private static bool HttpStressEnabled => Configuration.Http.StressEnabled;
-
-        [ConditionalTheory(nameof(HttpStressEnabled))]
+        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
+        [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [MemberData(nameof(GetStressOptions))]
         public void SingleClient_ManyGets_Sync(int numRequests, int dop, HttpCompletionOption completionOption)
         {
@@ -32,7 +31,8 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalTheory(nameof(HttpStressEnabled))]
+        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
+        [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         public async Task SingleClient_ManyGets_Async(int numRequests, int dop, HttpCompletionOption completionOption)
         {
             string responseText = CreateResponse("abcdefghijklmnopqrstuvwxyz");
@@ -42,7 +42,8 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalTheory(nameof(HttpStressEnabled))]
+        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
+        [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [MemberData(nameof(GetStressOptions))]
         public void ManyClients_ManyGets(int numRequests, int dop, HttpCompletionOption completionOption)
         {
@@ -56,7 +57,8 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [ConditionalTheory(nameof(HttpStressEnabled))]
+        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
+        [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [MemberData(nameof(PostStressOptions))]
         public async Task ManyClients_ManyPosts_Async(int numRequests, int dop, int numBytes)
         {
@@ -70,7 +72,8 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [ConditionalTheory(nameof(HttpStressEnabled))]
+        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
+        [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [InlineData(1000000)]
         public void CreateAndDestroyManyClients(int numClients)
         {
@@ -80,7 +83,8 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalTheory(nameof(HttpStressEnabled))]
+        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
+        [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [InlineData(5000)]
         public async Task MakeAndFaultManyRequests(int numRequests)
         {
@@ -96,7 +100,7 @@ namespace System.Net.Http.Functional.Tests
                          select client.GetStringAsync($"http://{ep.Address}:{ep.Port}"))
                          .ToArray();
 
-                    Assert.All(tasks, t => 
+                    Assert.All(tasks, t =>
                         Assert.True(t.IsFaulted || t.Status == TaskStatus.WaitingForActivation, $"Unexpected status {t.Status}"));
 
                     server.Dispose();
@@ -150,7 +154,7 @@ namespace System.Net.Http.Functional.Tests
 
                     await writer.WriteAsync(responseText).ConfigureAwait(false);
                     s.Shutdown(SocketShutdown.Send);
-                    
+
                     return null;
                 });
 
@@ -180,7 +184,7 @@ namespace System.Net.Http.Functional.Tests
 
                     await writer.WriteAsync(responseText).ConfigureAwait(false);
                     s.Shutdown(SocketShutdown.Send);
-                    
+
                     return null;
                 });
 
@@ -188,7 +192,8 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [ConditionalFact(nameof(HttpStressEnabled))]
+        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
+        [ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         public async Task UnreadResponseMessage_Collectible()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -211,7 +216,7 @@ namespace System.Net.Http.Functional.Tests
                             GC.Collect();
                             return !wr.IsAlive;
                         }, 10 * 1000), "Response object should have been collected");
-                        
+
                         return null;
                     });
                 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -16,7 +16,6 @@ namespace System.Net.Http.Functional.Tests
 
     public class HttpClientMiniStress : HttpClientTestBase
     {
-        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [MemberData(nameof(GetStressOptions))]
         public void SingleClient_ManyGets_Sync(int numRequests, int dop, HttpCompletionOption completionOption)
@@ -31,7 +30,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         public async Task SingleClient_ManyGets_Async(int numRequests, int dop, HttpCompletionOption completionOption)
         {
@@ -42,7 +40,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [MemberData(nameof(GetStressOptions))]
         public void ManyClients_ManyGets(int numRequests, int dop, HttpCompletionOption completionOption)
@@ -57,7 +54,6 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [MemberData(nameof(PostStressOptions))]
         public async Task ManyClients_ManyPosts_Async(int numRequests, int dop, int numBytes)
@@ -72,7 +68,6 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [InlineData(1000000)]
         public void CreateAndDestroyManyClients(int numClients)
@@ -83,7 +78,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [InlineData(5000)]
         public async Task MakeAndFaultManyRequests(int numRequests)
@@ -192,7 +186,6 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        // IsStressModeEnabled is true when the environment variable COREFX_STRESS is set to 1 or true
         [ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         public async Task UnreadResponseMessage_Collectible()
         {


### PR DESCRIPTION
To write any stress test, you may mark the stress test case with one of the attributes:

```
[ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
[ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
```

and set the value of the environment variable COREFX_STRESS to 1 or true