### PR TITLE
Fix issues with test tables in SqlClient tests

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
@@ -47,7 +47,22 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [CheckConnStrSetupFact]
+        private static bool EmployeesTableHasFullTextIndex()
+        {
+            if (DataTestUtility.TcpConnStr == null)
+                return false;
+
+            using (SqlConnection conn = new SqlConnection(DataTestUtility.TcpConnStr))
+            using (SqlCommand cmd = conn.CreateCommand())
+            {
+                conn.Open();
+                cmd.CommandText = "SELECT object_id FROM sys.fulltext_indexes WHERE object_id = object_id('Northwind.dbo.Employees')";
+
+                return (cmd.ExecuteScalar() != null);
+            }
+        }
+
+        [ConditionalFact(nameof(EmployeesTableHasFullTextIndex))]
         public static void WarningsBeforeRowsTest()
         {
             bool hitWarnings = false;


### PR DESCRIPTION
2 major changes here:
- Changes WarningBeforeRowsTest so that it checks for a fulltext index before using queries with the contains() function.
- Change temp table creation in AdapterTest so that the new table won't have identity columns. This is achieved with a dummy union in the SELECT INTO query.

I also changed some try-finally scoping in AdapterTest so that tests won't try to drop a temp table if the table creation itself threw an exception.