### PR TITLE
Fix regex scanner for `\c[`

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -996,40 +996,54 @@ namespace System.Text.RegularExpressions
                 case 'Z':
                 case 'z':
                     MoveRight();
+                    if (scanOnly)
+                        return null;
                     return new RegexNode(TypeFromCode(ch), _options);
 
                 case 'w':
                     MoveRight();
+                    if (scanOnly)
+                        return null;
                     if (UseOptionE())
                         return new RegexNode(RegexNode.Set, _options, RegexCharClass.ECMAWordClass);
                     return new RegexNode(RegexNode.Set, _options, RegexCharClass.WordClass);
 
                 case 'W':
                     MoveRight();
+                    if (scanOnly)
+                        return null;
                     if (UseOptionE())
                         return new RegexNode(RegexNode.Set, _options, RegexCharClass.NotECMAWordClass);
                     return new RegexNode(RegexNode.Set, _options, RegexCharClass.NotWordClass);
 
                 case 's':
                     MoveRight();
+                    if (scanOnly)
+                        return null;
                     if (UseOptionE())
                         return new RegexNode(RegexNode.Set, _options, RegexCharClass.ECMASpaceClass);
                     return new RegexNode(RegexNode.Set, _options, RegexCharClass.SpaceClass);
 
                 case 'S':
                     MoveRight();
+                    if (scanOnly)
+                        return null;
                     if (UseOptionE())
                         return new RegexNode(RegexNode.Set, _options, RegexCharClass.NotECMASpaceClass);
                     return new RegexNode(RegexNode.Set, _options, RegexCharClass.NotSpaceClass);
 
                 case 'd':
                     MoveRight();
+                    if (scanOnly)
+                        return null;
                     if (UseOptionE())
                         return new RegexNode(RegexNode.Set, _options, RegexCharClass.ECMADigitClass);
                     return new RegexNode(RegexNode.Set, _options, RegexCharClass.DigitClass);
 
                 case 'D':
                     MoveRight();
+                    if (scanOnly)
+                        return null;
                     if (UseOptionE())
                         return new RegexNode(RegexNode.Set, _options, RegexCharClass.NotECMADigitClass);
                     return new RegexNode(RegexNode.Set, _options, RegexCharClass.NotDigitClass);
@@ -1037,6 +1051,8 @@ namespace System.Text.RegularExpressions
                 case 'p':
                 case 'P':
                     MoveRight();
+                    if (scanOnly)
+                        return null;
                     cc = new RegexCharClass();
                     cc.AddCategoryFromName(ParseProperty(), (ch != 'p'), UseOptionI(), _pattern);
                     if (UseOptionI())
@@ -1106,7 +1122,9 @@ namespace System.Text.RegularExpressions
 
                 if (CharsRight() > 0 && MoveRightGetChar() == close)
                 {
-                    if (IsCaptureSlot(capnum) || scanOnly)
+                    if (scanOnly)
+                        return null;
+                    if (IsCaptureSlot(capnum))
                         return new RegexNode(RegexNode.Ref, _options, capnum);
                     else
                         throw MakeException(SR.Format(SR.UndefinedBackref, capnum.ToString(CultureInfo.CurrentCulture)));
@@ -1132,12 +1150,14 @@ namespace System.Text.RegularExpressions
                         newcapnum = newcapnum * 10 + (int)(ch - '0');
                     }
                     if (capnum >= 0)
-                        return new RegexNode(RegexNode.Ref, _options, capnum);
+                        return scanOnly ? null : new RegexNode(RegexNode.Ref, _options, capnum);
                 }
                 else
                 {
                     int capnum = ScanDecimal();
-                    if (IsCaptureSlot(capnum) || scanOnly)
+                    if (scanOnly)
+                        return null;
+                    if (IsCaptureSlot(capnum))
                         return new RegexNode(RegexNode.Ref, _options, capnum);
                     else if (capnum <= 9)
                         throw MakeException(SR.Format(SR.UndefinedBackref, capnum.ToString(CultureInfo.CurrentCulture)));
@@ -1153,6 +1173,8 @@ namespace System.Text.RegularExpressions
 
                 if (CharsRight() > 0 && MoveRightGetChar() == close)
                 {
+                    if (scanOnly)
+                        return null;
                     if (IsCaptureName(capname))
                         return new RegexNode(RegexNode.Ref, _options, CaptureSlotFromName(capname));
                     else
@@ -1168,7 +1190,7 @@ namespace System.Text.RegularExpressions
             if (UseOptionI())
                 ch = _culture.TextInfo.ToLower(ch);
 
-            return new RegexNode(RegexNode.One, _options, ch);
+            return scanOnly ? null : new RegexNode(RegexNode.One, _options, ch);
         }
 
         /*

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -288,7 +288,7 @@ namespace System.Text.RegularExpressions
                         goto ContinueOuterScan;
 
                     case '[':
-                        AddUnitSet(ScanCharClass(UseOptionI()).ToStringClass());
+                        AddUnitSet(ScanCharClass(UseOptionI(), scanOnly: false).ToStringClass());
                         break;
 
                     case '(':
@@ -326,7 +326,7 @@ namespace System.Text.RegularExpressions
                         break;
 
                     case '\\':
-                        AddUnitNode(ScanBackslash());
+                        AddUnitNode(ScanBackslash(scanOnly: false));
                         break;
 
                     case '^':
@@ -495,7 +495,7 @@ namespace System.Text.RegularExpressions
          * Scans contents of [] (not including []'s), and converts to a
          * RegexCharClass.
          */
-        internal RegexCharClass ScanCharClass(bool caseInsensitive, bool scanOnly = false)
+        internal RegexCharClass ScanCharClass(bool caseInsensitive, bool scanOnly)
         {
             char ch = '\0';
             char chPrev = '\0';
@@ -615,7 +615,7 @@ namespace System.Text.RegularExpressions
                             // In that case, we'll add chPrev to our char class, skip the opening [, and
                             // scan the new character class recursively.
                             cc.AddChar(chPrev);
-                            cc.AddSubtraction(ScanCharClass(caseInsensitive, false));
+                            cc.AddSubtraction(ScanCharClass(caseInsensitive, scanOnly));
 
                             if (CharsRight() > 0 && RightChar() != ']')
                                 throw MakeException(SR.SubtractionMustBeLast);
@@ -643,7 +643,7 @@ namespace System.Text.RegularExpressions
                     if (!scanOnly)
                     {
                         MoveRight(1);
-                        cc.AddSubtraction(ScanCharClass(caseInsensitive, false));
+                        cc.AddSubtraction(ScanCharClass(caseInsensitive, scanOnly));
 
                         if (CharsRight() > 0 && RightChar() != ']')
                             throw MakeException(SR.SubtractionMustBeLast);
@@ -651,7 +651,7 @@ namespace System.Text.RegularExpressions
                     else
                     {
                         MoveRight(1);
-                        ScanCharClass(caseInsensitive, true);
+                        ScanCharClass(caseInsensitive, scanOnly);
                     }
                 }
                 else
@@ -979,7 +979,7 @@ namespace System.Text.RegularExpressions
          * Scans chars following a '\' (not counting the '\'), and returns
          * a RegexNode for the type of atom scanned.
          */
-        internal RegexNode ScanBackslash(bool scanOnly = false)
+        internal RegexNode ScanBackslash(bool scanOnly)
         {
             char ch;
             RegexCharClass cc;

--- a/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -396,6 +396,7 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(cat)(\cz*)(dog)", "asdlkcat\u001adogiwod", RegexOptions.None, new string[] { "cat\u001adog", "cat", "\u001a", "dog" } };
 
             yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u001bdogiwod", RegexOptions.None, new string[] { "cat\u001bdog", "cat", "\u001b", "dog" } };
+            yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u001Bdogiwod", RegexOptions.None, new string[] { "cat\u001Bdog", "cat", "\u001B", "dog" } };
 
             // Atomic Zero-Width Assertions \A \Z \z \G \b \B
             //\A

--- a/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -322,6 +322,7 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(cat) (?#cat)    \s+ (?#followed by 1 or more whitespace) (dog)  (?#followed by dog)", "cat    dog", RegexOptions.IgnorePatternWhitespace, new string[] { "cat    dog", "cat", "dog" } };
 
             // Back Reference
+            yield return new object[] { @"(?<cat>cat)(?<dog>dog)\k<cat>", "asdfcatdogcatdog", RegexOptions.None, new string[] { "catdogcat", "cat", "dog" } };
             yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\k<cat>", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
             yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\k'cat'", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
             yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\<cat>", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
@@ -393,6 +394,8 @@ namespace System.Text.RegularExpressions.Tests
 
             yield return new object[] { @"(cat)(\cZ*)(dog)", "asdlkcat\u001adogiwod", RegexOptions.None, new string[] { "cat\u001adog", "cat", "\u001a", "dog" } };
             yield return new object[] { @"(cat)(\cz*)(dog)", "asdlkcat\u001adogiwod", RegexOptions.None, new string[] { "cat\u001adog", "cat", "\u001a", "dog" } };
+
+            yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u001bdogiwod", RegexOptions.None, new string[] { "cat\u001bdog", "cat", "\u001b", "dog" } };
 
             // Atomic Zero-Width Assertions \A \Z \z \G \b \B
             //\A

--- a/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -395,8 +395,11 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(cat)(\cZ*)(dog)", "asdlkcat\u001adogiwod", RegexOptions.None, new string[] { "cat\u001adog", "cat", "\u001a", "dog" } };
             yield return new object[] { @"(cat)(\cz*)(dog)", "asdlkcat\u001adogiwod", RegexOptions.None, new string[] { "cat\u001adog", "cat", "\u001a", "dog" } };
 
-            yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u001bdogiwod", RegexOptions.None, new string[] { "cat\u001bdog", "cat", "\u001b", "dog" } };
-            yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u001Bdogiwod", RegexOptions.None, new string[] { "cat\u001Bdog", "cat", "\u001B", "dog" } };
+            if (!PlatformDetection.IsFullFramework) // missing fix for #26501
+            {
+                yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u001bdogiwod", RegexOptions.None, new string[] { "cat\u001bdog", "cat", "\u001b", "dog" } };
+                yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u001Bdogiwod", RegexOptions.None, new string[] { "cat\u001Bdog", "cat", "\u001B", "dog" } };
+            }
 
             // Atomic Zero-Width Assertions \A \Z \z \G \b \B
             //\A

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -263,6 +263,9 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"[ab\-\[cd-[[]]]]", "e]]", RegexOptions.None, 0, 3, false, string.Empty };
 
             yield return new object[] { @"[a-[a-f]]", "abcdefghijklmnopqrstuvwxyz", RegexOptions.None, 0, 26, false, string.Empty };
+
+            // \c
+            yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u00FFdogiwod", RegexOptions.None, 0, 15, false, string.Empty };
         }
 
         [Theory]

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -265,7 +265,8 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"[a-[a-f]]", "abcdefghijklmnopqrstuvwxyz", RegexOptions.None, 0, 26, false, string.Empty };
 
             // \c
-            yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u00FFdogiwod", RegexOptions.None, 0, 15, false, string.Empty };
+            if (!PlatformDetection.IsFullFramework) // missing fix for #26501
+                yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u00FFdogiwod", RegexOptions.None, 0, 15, false, string.Empty };
         }
 
         [Theory]


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/26501

In `(cat)(\c[*)(dog)` the `\c[` should match the `[` control character ie `\u001b`. However it was rejecting the pattern because it does a pre-scan for capturing groups. In this phase it assumes that `\` always escaped a single character, so it treats the `[` as the start of a character class, which is ultimately never closed.

The fix is to call into the real scanner for escape characters. It is necessary to pass a flag indicating we are scanning. This is to avoid validating that backreferences refer to valid capturing groups (these are not all set up until the pre-scanning is complete) and also to avoid allocating objects that aren't needed in this phase. We already do something very similar with ScanCharClass.

Ideally there would not be a pre-scan but I imagine that would be a substantial change.

This causes more code to run during the pre-scan when a backslash is encountered. To verify this does not impact perf I used the perf test in #26827

### Before

System.Text.RegularExpressions.Performance.Tests.dll | Metric | Unit | Iterations | Average | STDEV.S | Min | Max
--- | --- | --- | --- | --- | --- | --- | ---
System.Text.RegularExpressions.Tests.Perf_Regex.Match | Duration | msec | 40 | 254.4937651 | 10.61602132 | 242.199422 | 292.2573603
System.Text.RegularExpressions.Tests.Perf_Regex.Match | GC Allocations | bytes | 40 | 199009143.4 | 51155.77152 | 198894312 | 199115104
--- | --- | --- | --- | --- | --- | --- | ---
System.Text.RegularExpressions.Tests.Perf_Regex.Match | Duration | msec | 40 | 254.5757042 | 9.581244315 | 240.640903 | 280.4672477
System.Text.RegularExpressions.Tests.Perf_Regex.Match | GC Allocations | bytes | 40 | 199014283.6 | 53740.21012 | 198891600 | 199147112

### After this and #26543

System.Text.RegularExpressions.Performance.Tests.dll | Metric | Unit | Iterations | Average | STDEV.S | Min | Max
--- | --- | --- | --- | --- | --- | --- | ---
System.Text.RegularExpressions.Tests.Perf_Regex.Match | Duration | msec | 40 | 255.7465251 | 8.22304857 | 245.721344 | 274.720744
System.Text.RegularExpressions.Tests.Perf_Regex.Match | GC Allocations | bytes | 40 | 199048536.2 | 43711.56892 | 198975760 | 199152184
--- | --- | --- | --- | --- | --- | --- | ---
System.Text.RegularExpressions.Tests.Perf_Regex.Match | Duration | msec | 40 | 252.0985474 | 6.940020203 | 241.216865 | 268.1445129
System.Text.RegularExpressions.Tests.Perf_Regex.Match | GC Allocations | bytes | 40 | 199049236 | 42700.49669 | 198976144 | 199151832

Elapsed difference is within noise level and allocations are negligibly increased.
