### PR TITLE
Add Connection{Idle}Timeouts to ManagedHandler

### DIFF
--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -22,9 +22,7 @@ namespace System.Net.Http
         public const bool DefaultUseProxy = true;
         public const bool DefaultUseDefaultCredentials = false;
         public const bool DefaultCheckCertificateRevocationList = false;
-        public static readonly TimeSpan DefaultConnectionTimeout = Timeout.InfiniteTimeSpan;
-        public static readonly TimeSpan DefaultConnectionIdleTimeout = TimeSpan.FromMinutes(2);
-
-        public static TimeSpan DefaultConnectTimeout => TimeSpan.FromSeconds(60);
+        public static readonly TimeSpan DefaultPooledConnectionLifetime = Timeout.InfiniteTimeSpan;
+        public static readonly TimeSpan DefaultPooledConnectionIdleTimeout = TimeSpan.FromMinutes(2);
     }
 }

--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+
 namespace System.Net.Http
 {
     /// <summary>
@@ -20,6 +22,8 @@ namespace System.Net.Http
         public const bool DefaultUseProxy = true;
         public const bool DefaultUseDefaultCredentials = false;
         public const bool DefaultCheckCertificateRevocationList = false;
+        public static readonly TimeSpan DefaultConnectionTimeout = Timeout.InfiniteTimeSpan;
+        public static readonly TimeSpan DefaultConnectionIdleTimeout = TimeSpan.FromMinutes(2);
 
         public static TimeSpan DefaultConnectTimeout => TimeSpan.FromSeconds(60);
     }

--- a/src/System.Net.Http/src/ILLinkTrim.xml
+++ b/src/System.Net.Http/src/ILLinkTrim.xml
@@ -2,5 +2,8 @@
   <assembly fullname="System.Net.Http">
     <!-- Anonymous types are used with DiagnosticSource logging and subscribers reflect over those, calling their public getters. -->
     <type fullname="*f__AnonymousType*" />
+
+    <!-- TODO #23166: Remove once exposed in contract -->
+    <type fullname="System.Net.Http.ManagedHandler" />
   </assembly>
 </linker>

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -144,6 +144,10 @@ namespace System.Net.Http
             }
         }
 
+        public HttpConnectionPool Pool => _pool;
+
+        public DateTimeOffset CreationTime { get; } = DateTimeOffset.UtcNow;
+
         private async Task WriteHeadersAsync(HttpHeaders headers, CancellationToken cancellationToken)
         {
             foreach (KeyValuePair<string, IEnumerable<string>> header in headers)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -144,8 +144,6 @@ namespace System.Net.Http
             }
         }
 
-        public HttpConnectionPool Pool => _pool;
-
         public DateTimeOffset CreationTime { get; } = DateTimeOffset.UtcNow;
 
         private async Task WriteHeadersAsync(HttpHeaders headers, CancellationToken cancellationToken)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionSettings.cs
@@ -35,8 +35,11 @@ namespace System.Net.Http
         internal X509CertificateCollection _clientCertificates;
 
         internal Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> _serverCertificateCustomValidationCallback;
-        internal bool _checkCertificateRevocationList = false;
+        internal bool _checkCertificateRevocationList = HttpHandlerDefaults.DefaultCheckCertificateRevocationList;
         internal SslProtocols _sslProtocols = SslProtocols.None;
+
+        internal TimeSpan _connectionTimeout = HttpHandlerDefaults.DefaultConnectionTimeout;
+        internal TimeSpan _connectionIdleTimeout = HttpHandlerDefaults.DefaultConnectionIdleTimeout;
 
         internal IDictionary<string, object> _properties;
     }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionSettings.cs
@@ -38,8 +38,8 @@ namespace System.Net.Http
         internal bool _checkCertificateRevocationList = HttpHandlerDefaults.DefaultCheckCertificateRevocationList;
         internal SslProtocols _sslProtocols = SslProtocols.None;
 
-        internal TimeSpan _connectionTimeout = HttpHandlerDefaults.DefaultConnectionTimeout;
-        internal TimeSpan _connectionIdleTimeout = HttpHandlerDefaults.DefaultConnectionIdleTimeout;
+        internal TimeSpan _pooledConnectionLifetime = HttpHandlerDefaults.DefaultPooledConnectionLifetime;
+        internal TimeSpan _pooledConnectionIdleTimeout = HttpHandlerDefaults.DefaultPooledConnectionIdleTimeout;
 
         internal IDictionary<string, object> _properties;
     }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
@@ -239,6 +239,36 @@ namespace System.Net.Http
             }
         }
 
+        public TimeSpan ConnectionTimeout
+        {
+            get => _settings._connectionTimeout;
+            set
+            {
+                if (value < TimeSpan.Zero && value != Timeout.InfiniteTimeSpan)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                CheckDisposedOrStarted();
+                _settings._connectionTimeout = value;
+            }
+        }
+
+        public TimeSpan ConnectionIdleTimeout
+        {
+            get => _settings._connectionIdleTimeout;
+            set
+            {
+                if (value < TimeSpan.Zero && value != Timeout.InfiniteTimeSpan)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                CheckDisposedOrStarted();
+                _settings._connectionIdleTimeout = value;
+            }
+        }
+
         public IDictionary<string, object> Properties =>
             _settings._properties ?? (_settings._properties = new Dictionary<string, object>());
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
@@ -239,9 +239,9 @@ namespace System.Net.Http
             }
         }
 
-        public TimeSpan ConnectionTimeout
+        public TimeSpan PooledConnectionLifetime
         {
-            get => _settings._connectionTimeout;
+            get => _settings._pooledConnectionLifetime;
             set
             {
                 if (value < TimeSpan.Zero && value != Timeout.InfiniteTimeSpan)
@@ -250,13 +250,13 @@ namespace System.Net.Http
                 }
 
                 CheckDisposedOrStarted();
-                _settings._connectionTimeout = value;
+                _settings._pooledConnectionLifetime = value;
             }
         }
 
-        public TimeSpan ConnectionIdleTimeout
+        public TimeSpan PooledConnectionIdleTimeout
         {
-            get => _settings._connectionIdleTimeout;
+            get => _settings._pooledConnectionIdleTimeout;
             set
             {
                 if (value < TimeSpan.Zero && value != Timeout.InfiniteTimeSpan)
@@ -265,7 +265,7 @@ namespace System.Net.Http
                 }
 
                 CheckDisposedOrStarted();
-                _settings._connectionIdleTimeout = value;
+                _settings._pooledConnectionIdleTimeout = value;
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -5,6 +5,7 @@
 using System.Collections.Concurrent;
 using System.IO;
 using System.Net.Sockets;
+using System.Net.Test.Common;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -317,38 +318,29 @@ namespace System.Net.Http.Functional.Tests
         public async Task ServerDisconnectsAfterInitialRequest_SubsequentRequestUsesDifferentConnection()
         {
             using (HttpClient client = CreateHttpClient())
-            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                listener.Listen(100);
-                var ep = (IPEndPoint)listener.LocalEndPoint;
-                var uri = new Uri($"http://{ep.Address}:{ep.Port}/");
-
-                string responseBody =
-                    "HTTP/1.1 200 OK\r\n" +
-                    $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                    "Content-Length: 0\r\n" +
-                    "\r\n";
-
-                // Make multiple requests iteratively.
-                for (int i = 0; i < 2; i++)
+                await LoopbackServer.CreateServerAsync(async (listener, uri) =>
                 {
-                    Task<string> request = client.GetStringAsync(uri);
-                    using (Socket server = await listener.AcceptAsync())
-                    using (var serverStream = new NetworkStream(server, ownsSocket: false))
-                    using (var serverReader = new StreamReader(serverStream))
+                    // Make multiple requests iteratively.
+                    for (int i = 0; i < 2; i++)
                     {
-                        while (!string.IsNullOrWhiteSpace(await serverReader.ReadLineAsync()));
-                        await server.SendAsync(new ArraySegment<byte>(Encoding.ASCII.GetBytes(responseBody)), SocketFlags.None);
-                        await request;
-
-                        server.Shutdown(SocketShutdown.Both);
-                        if (i == 0)
+                        Task<string> request = client.GetStringAsync(uri);
+                        await LoopbackServer.AcceptSocketAsync(listener, async (server, serverStream, serverReader, serverWriter) =>
                         {
-                            await Task.Delay(2000); // give client time to see the closing before next connect
-                        }
+                            while (!string.IsNullOrWhiteSpace(await serverReader.ReadLineAsync()));
+                            await serverWriter.WriteAsync(LoopbackServer.DefaultHttpResponse);
+                            await request;
+
+                            server.Shutdown(SocketShutdown.Both);
+                            if (i == 0)
+                            {
+                                await Task.Delay(2000); // give client time to see the closing before next connect
+                            }
+
+                            return null;
+                        });
                     }
-                }
+                });
             }
         }
 
@@ -356,139 +348,86 @@ namespace System.Net.Http.Functional.Tests
         public async Task ServerSendsConnectionClose_SubsequentRequestUsesDifferentConnection()
         {
             using (HttpClient client = CreateHttpClient())
-            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                listener.Listen(100);
-                var ep = (IPEndPoint)listener.LocalEndPoint;
-                var uri = new Uri($"http://{ep.Address}:{ep.Port}/");
-
-                string responseBody =
-                    "HTTP/1.1 200 OK\r\n" +
-                    $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                    "Content-Length: 0\r\n" +
-                    "Connection: close\r\n" +
-                    "\r\n";
-
-                // Make multiple requests iteratively.
-                Task<string> request1 = client.GetStringAsync(uri);
-                using (Socket server1 = await listener.AcceptAsync())
-                using (var serverStream1 = new NetworkStream(server1, ownsSocket: false))
-                using (var serverReader1 = new StreamReader(serverStream1))
+                await LoopbackServer.CreateServerAsync(async (listener, uri) =>
                 {
-                    while (!string.IsNullOrWhiteSpace(await serverReader1.ReadLineAsync()));
-                    await server1.SendAsync(new ArraySegment<byte>(Encoding.ASCII.GetBytes(responseBody)), SocketFlags.None);
-                    await request1;
+                    string responseBody =
+                        "HTTP/1.1 200 OK\r\n" +
+                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                        "Content-Length: 0\r\n" +
+                        "Connection: close\r\n" +
+                        "\r\n";
 
-                    Task<string> request2 = client.GetStringAsync(uri);
-                    using (Socket server2 = await listener.AcceptAsync())
-                    using (var serverStream2 = new NetworkStream(server2, ownsSocket: false))
-                    using (var serverReader2 = new StreamReader(serverStream2))
+                    // Make first request.
+                    Task<string> request1 = client.GetStringAsync(uri);
+                    await LoopbackServer.AcceptSocketAsync(listener, async (server1, serverStream1, serverReader1, serverWriter1) =>
                     {
-                        while (!string.IsNullOrWhiteSpace(await serverReader2.ReadLineAsync()));
-                        await server2.SendAsync(new ArraySegment<byte>(Encoding.ASCII.GetBytes(responseBody)), SocketFlags.None);
-                        await request2;
-                    }
+                        while (!string.IsNullOrWhiteSpace(await serverReader1.ReadLineAsync()));
+                        await serverWriter1.WriteAsync(responseBody);
+                        await request1;
+
+                        // Make second request and expect it to be served from a different connection.
+                        Task<string> request2 = client.GetStringAsync(uri);
+                        await LoopbackServer.AcceptSocketAsync(listener, async (server2, serverStream2, serverReader2, serverWriter2) =>
+                        {
+                            while (!string.IsNullOrWhiteSpace(await serverReader2.ReadLineAsync()));
+                            await serverWriter2.WriteAsync(responseBody);
+                            await request2;
+                            return null;
+                        });
+
+                        return null;
+                    });
+                });
+            }
+        }
+
+        [Theory]
+        [InlineData("PooledConnectionLifetime")]
+        [InlineData("PooledConnectionIdleTimeout")]
+        public async Task SmallConnectionTimeout_SubsequentRequestUsesDifferentConnection(string timeoutPropertyName)
+        {
+            using (HttpClientHandler handler = CreateHttpClientHandler())
+            {
+                SetManagedHandlerProperty(handler, timeoutPropertyName, TimeSpan.FromMilliseconds(1));
+
+                using (HttpClient client = new HttpClient(handler))
+                {
+                    await LoopbackServer.CreateServerAsync(async (listener, uri) =>
+                    {
+                        // Make first request.
+                        Task<string> request1 = client.GetStringAsync(uri);
+                        await LoopbackServer.AcceptSocketAsync(listener, async (server1, serverStream1, serverReader1, serverWriter1) =>
+                        {
+                            while (!string.IsNullOrWhiteSpace(await serverReader1.ReadLineAsync()));
+                            await serverWriter1.WriteAsync(LoopbackServer.DefaultHttpResponse);
+                            await request1;
+
+                            // Wait a small amount of time before making the second request, to give the first request time to timeout.
+                            await Task.Delay(100);
+
+                            // Make second request and expect it to be served from a different connection.
+                            Task<string> request2 = client.GetStringAsync(uri);
+                            await LoopbackServer.AcceptSocketAsync(listener, async (server2, serverStream2, serverReader2, serverWriter2) =>
+                            {
+                                while (!string.IsNullOrWhiteSpace(await serverReader2.ReadLineAsync()));
+                                await serverWriter2.WriteAsync(LoopbackServer.DefaultHttpResponse);
+                                await request2;
+                                return null;
+                            });
+
+                            return null;
+                        });
+                    });
                 }
             }
         }
 
-        [Fact]
-        public async Task SmallConnectionTimeout_SubsequentRequestUsesDifferentConnection()
+        private static void SetManagedHandlerProperty(HttpClientHandler handler, string name, object value)
         {
-            using (HttpClient client = CreateHttpClient())
-            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            {
-                // TODO #23166: Use the managed API for ConnectionTimeout when it's exposed
-                object httpClientHandler = client.GetType().BaseType.GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(client);
-                object managedHandler = httpClientHandler.GetType().GetField("_managedHandler", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(httpClientHandler);
-                managedHandler.GetType().GetProperty("ConnectionTimeout").SetValue(managedHandler, TimeSpan.FromMilliseconds(1));
-
-                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                listener.Listen(100);
-                var ep = (IPEndPoint)listener.LocalEndPoint;
-                var uri = new Uri($"http://{ep.Address}:{ep.Port}/");
-
-                string responseBody =
-                    "HTTP/1.1 200 OK\r\n" +
-                    $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                    "Content-Length: 0\r\n" +
-                    "\r\n";
-
-                // Make first request.
-                Task<string> request1 = client.GetStringAsync(uri);
-                using (Socket server1 = await listener.AcceptAsync())
-                using (var serverStream1 = new NetworkStream(server1, ownsSocket: false))
-                using (var serverReader1 = new StreamReader(serverStream1))
-                {
-                    while (!string.IsNullOrWhiteSpace(await serverReader1.ReadLineAsync()));
-                    await server1.SendAsync(new ArraySegment<byte>(Encoding.ASCII.GetBytes(responseBody)), SocketFlags.None);
-                    await request1;
-
-                    // Wait a small amount of time before making the second request, to give the first request time to timeout.
-                    await Task.Delay(10);
-
-                    // Make second request.  It should be on a new connection.
-                    Task<string> request2 = client.GetStringAsync(uri);
-                    using (Socket server2 = await listener.AcceptAsync())
-                    using (var serverStream2 = new NetworkStream(server2, ownsSocket: false))
-                    using (var serverReader2 = new StreamReader(serverStream2))
-                    {
-                        while (!string.IsNullOrWhiteSpace(await serverReader2.ReadLineAsync()));
-                        await server2.SendAsync(new ArraySegment<byte>(Encoding.ASCII.GetBytes(responseBody)), SocketFlags.None);
-                        await request2;
-                    }
-                }
-            }
-        }
-
-        [Fact]
-        public async Task SmallConnectionIdleTimeout_SubsequentRequestUsesDifferentConnection()
-        {
-            using (HttpClient client = CreateHttpClient())
-            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            {
-                // TODO #23166: Use the managed API for ConnectionIdleTimeout when it's exposed
-                object httpClientHandler = client.GetType().BaseType.GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(client);
-                object managedHandler = httpClientHandler.GetType().GetField("_managedHandler", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(httpClientHandler);
-                managedHandler.GetType().GetProperty("ConnectionIdleTimeout").SetValue(managedHandler, TimeSpan.FromMilliseconds(1));
-
-                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                listener.Listen(100);
-                var ep = (IPEndPoint)listener.LocalEndPoint;
-                var uri = new Uri($"http://{ep.Address}:{ep.Port}/");
-
-                string responseBody =
-                    "HTTP/1.1 200 OK\r\n" +
-                    $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                    "Content-Length: 0\r\n" +
-                    "\r\n";
-
-                // Make first request.
-                Task<string> request1 = client.GetStringAsync(uri);
-                using (Socket server1 = await listener.AcceptAsync())
-                using (var serverStream1 = new NetworkStream(server1, ownsSocket: false))
-                using (var serverReader1 = new StreamReader(serverStream1))
-                {
-                    while (!string.IsNullOrWhiteSpace(await serverReader1.ReadLineAsync()));
-                    await server1.SendAsync(new ArraySegment<byte>(Encoding.ASCII.GetBytes(responseBody)), SocketFlags.None);
-                    await request1;
-
-                    // Wait a small amount of time before making the second request, to give the first request time to timeout.
-                    await Task.Delay(100);
-
-                    // Make second request.  It should be on a new connection.
-                    Task<string> request2 = client.GetStringAsync(uri);
-                    using (Socket server2 = await listener.AcceptAsync())
-                    using (var serverStream2 = new NetworkStream(server2, ownsSocket: false))
-                    using (var serverReader2 = new StreamReader(serverStream2))
-                    {
-                        while (!string.IsNullOrWhiteSpace(await serverReader2.ReadLineAsync()));
-                        await server2.SendAsync(new ArraySegment<byte>(Encoding.ASCII.GetBytes(responseBody)), SocketFlags.None);
-                        await request2;
-                    }
-                }
-            }
+            // TODO #23166: Use the managed API for ConnectionIdleTimeout when it's exposed
+            object managedHandler = handler.GetType().GetField("_managedHandler", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(handler);
+            managedHandler.GetType().GetProperty(name).SetValue(managedHandler, value);
         }
     }
 }


### PR DESCRIPTION
We can agree on the final name(s) (and even if we want these exposed) when going through API reviews.  For now, I chose what I think are easy to understand names:
- ConnectionTimeout: how long a connection is allowed to be reused before it's no longer usable, defaults to infinite
- ConnectionIdleTimeout: how long a connection can sit idle in the pool before it's no longer usable, defaults to 2 minutes (that value was hardcoded before this change)

Fixes https://github.com/dotnet/corefx/issues/26331
cc: @geoffkizer, @davidsh