### PR TITLE
Disable GetAsync_RetryOnConnectionClosed_Success test for NETFX

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRetryProtocolTests.cs
@@ -40,6 +40,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue(26770, TargetFrameworkMonikers.NetFramework)]
         public async Task GetAsync_RetryOnConnectionClosed_Success()
         {
             if (!IsRetrySupported)


### PR DESCRIPTION
Related to https://github.com/dotnet/corefx/issues/26770

This is breaking CI