### PR TITLE
Fix some S.Drawing.Common license headers

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintingPermission.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintingPermission.cs
@@ -1,7 +1,6 @@
-/*
- * Copyright (c) 2000 Microsoft Corporation.  All Rights Reserved.
- * Microsoft Confidential.
- */
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace System.Drawing.Printing {
     using System;

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintingPermissionAttribute.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintingPermissionAttribute.cs
@@ -1,7 +1,6 @@
-/*
- * Copyright (c) 2000 Microsoft Corporation.  All Rights Reserved.
- * Microsoft Confidential.
- */
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace System.Drawing.Printing {
     using System;

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintingPermissionLevel.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintingPermissionLevel.cs
@@ -1,9 +1,6 @@
-/*
- * PrintingPermission.cool
- *
- * Copyright (c) 2000 Microsoft Corporation.  All Rights Reserved.
- * Microsoft Confidential.
- */
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace System.Drawing.Printing {
     using System;


### PR DESCRIPTION
While triaging S.Drawing.Common found this in an issue comment. 

Contributes to: https://github.com/dotnet/corefx/issues/20706

cc: @danmosemsft 