### PR TITLE
Add tests for when array/string are null but start/length are non-zero.

### DIFF
--- a/src/System.Memory/tests/Memory/CtorArray.cs
+++ b/src/System.Memory/tests/Memory/CtorArray.cs
@@ -69,7 +69,6 @@ namespace System.MemoryTests
         }
 
         [Fact]
-        [ActiveIssue(26807)]
         public static void CtorArrayNullArray()
         {
             var memory = new Memory<int>(null);
@@ -79,6 +78,15 @@ namespace System.MemoryTests
             memory = new Memory<int>(null, 0, 0);
             memory.Validate();
             Assert.Equal(default, memory);
+        }
+
+        [Fact]
+        public static void CtorArrayNullArrayNonZeroStartAndLength()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Memory<int>(null, 1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Memory<int>(null, 0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Memory<int>(null, 1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Memory<int>(null, -1, -1));
         }
 
         [Fact]

--- a/src/System.Memory/tests/ReadOnlyMemory/CtorArray.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/CtorArray.cs
@@ -70,7 +70,6 @@ namespace System.MemoryTests
         }
 
         [Fact]
-        [ActiveIssue(26807)]
         public static void CtorArrayNullArray()
         {
             var memory = new ReadOnlyMemory<int>(null);
@@ -80,6 +79,15 @@ namespace System.MemoryTests
             memory = new ReadOnlyMemory<int>(null, 0, 0);
             memory.Validate();
             Assert.Equal(default, memory);
+        }
+
+        [Fact]
+        public static void CtorArrayNullArrayNonZeroStartAndLength()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyMemory<int>(null, 1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyMemory<int>(null, 0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyMemory<int>(null, 1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyMemory<int>(null, -1, -1));
         }
 
         [Fact]

--- a/src/System.Memory/tests/ReadOnlyMemory/Strings.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Strings.cs
@@ -70,6 +70,20 @@ namespace System.MemoryTests
         }
 
         [Fact]
+        public static void NullAsReadOnlyMemoryNonZeroStartAndLength()
+        {
+            string str = null;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(-1));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlyMemory(-1, -1));
+        }
+
+        [Fact]
         public static void AsReadOnlyMemory_TryGetString_Roundtrips()
         {
             string input = "0123456789";

--- a/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/AsReadOnlySpan.cs
@@ -133,6 +133,20 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void StringAsReadOnlySpanNullNonZeroStartAndLength()
+        {
+            string str = null;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(-1).DontBox());
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(0, 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(1, 0).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(1, 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => str.AsReadOnlySpan(-1, -1).DontBox());
+        }
+
+        [Fact]
         public static void EmptySpanAsReadOnlySpan()
         {
             Span<int> span = default;

--- a/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
@@ -82,6 +82,15 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void CtorArrayNullArrayNonZeroStartAndLength()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlySpan<int>(null, 1, 0).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlySpan<int>(null, 0, 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlySpan<int>(null, 1, 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlySpan<int>(null, -1, -1).DontBox());
+        }
+
+        [Fact]
         public static void CtorArrayWrongValueType()
         {
             // Can pass variant array, if array type is a valuetype.

--- a/src/System.Memory/tests/Span/AsSpan.cs
+++ b/src/System.Memory/tests/Span/AsSpan.cs
@@ -35,7 +35,16 @@ namespace System.SpanTests
         }
 
         [Fact]
-        public static void ZeroLengthArrayAsSpan()
+        public static void NullArrayAsSpan()
+        {
+            int[] a = null;
+            Span<int> span = a.AsSpan();
+            span.Validate();
+            Assert.True(span == default);
+        }
+
+        [Fact]
+        public static void EmptyArrayAsSpan()
         {
             int[] empty = Array.Empty<int>();
             Span<int> span = empty.AsSpan();

--- a/src/System.Memory/tests/Span/CtorArray.cs
+++ b/src/System.Memory/tests/Span/CtorArray.cs
@@ -81,6 +81,15 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void CtorArrayNullArrayNonZeroStartAndLength()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Span<int>(null, 1, 0).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Span<int>(null, 0, 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Span<int>(null, 1, 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Span<int>(null, -1, -1).DontBox());
+        }
+
+        [Fact]
         public static void CtorArrayWrongArrayType()
         {
             // Cannot pass variant array, if array type is not a valuetype.


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/26833 which is a follow up on https://github.com/dotnet/corefx/pull/26807

This PR is blocked on the mirror, especially for the netfx CI tests to pass (see https://github.com/dotnet/coreclr/pull/16186#issuecomment-362947869).

cc @jkotas, @KrzysztofCwalina, @stephentoub, @VSadov 