### PR TITLE
Switch ManagedHandler to use SslClientAuthenticationOptions

### DIFF
--- a/src/Common/src/System/Net/Security/CertificateHelper.Unix.cs
+++ b/src/Common/src/System/Net/Security/CertificateHelper.Unix.cs
@@ -14,7 +14,7 @@ namespace System.Net.Security
             X509Certificate2Collection candidateCerts;
             using (var myStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
             {
-                myStore.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
+                myStore.Open(OpenFlags.ReadOnly);
                 candidateCerts = myStore.Certificates;
             }
             

--- a/src/Common/src/System/Net/Security/SslClientAuthenticationOptionsExtensions.cs
+++ b/src/Common/src/System/Net/Security/SslClientAuthenticationOptionsExtensions.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Security
+{
+    internal static class SslClientAuthenticationOptionsExtensions
+    {
+        public static SslClientAuthenticationOptions ShallowClone(this SslClientAuthenticationOptions options) =>
+            new SslClientAuthenticationOptions()
+            {
+                AllowRenegotiation = options.AllowRenegotiation,
+                ApplicationProtocols = options.ApplicationProtocols,
+                CertificateRevocationCheckMode = options.CertificateRevocationCheckMode,
+                ClientCertificates = options.ClientCertificates,
+                EnabledSslProtocols = options.EnabledSslProtocols,
+                EncryptionPolicy = options.EncryptionPolicy,
+                LocalCertificateSelectionCallback = options.LocalCertificateSelectionCallback,
+                RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
+                TargetHost = options.TargetHost
+            };
+    }
+}

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -105,6 +105,9 @@
     <Compile Include="$(CommonPath)\System\Net\HttpVersionInternal.cs">
       <Link>Common\System\Net\HttpVersionInternal.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Security\SslClientAuthenticationOptionsExtensions.cs">
+      <Link>Common\System\Net\Security\SslClientAuthenticationOptionsExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\IO\DelegatingStream.cs">
       <Link>Common\System\IO\DelegatingStream.cs</Link>
     </Compile>
@@ -299,6 +302,12 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\Http\TlsCertificateExtensions.cs">
       <Link>Common\System\Net\Http\TlsCertificateExtensions</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.cs">
+      <Link>Common\System\Net\Security\CertificateHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.Unix.cs">
+      <Link>Common\System\Net\Security\CertificateHelper.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
       <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
@@ -62,5 +62,12 @@ namespace System.Net.Http
                 throw new InvalidOperationException(SR.net_http_operation_started);
             }
         }
+
+        private void ThrowForModifiedManagedSslOptionsIfStarted()
+        {
+            // Hack to trigger an InvalidOperationException if a property that's stored on
+            // SslOptions is changed, since SslOptions itself does not do any such checks.
+            _managedHandler.SslOptions = _managedHandler.SslOptions;
+        }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ConnectHelper.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
-using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,6 +15,23 @@ namespace System.Net.Http
 {
     internal static class ConnectHelper
     {
+        /// <summary>
+        /// Helper type used by HttpClientHandler when wrapping ManagedHandler to map its
+        /// certificate validation callback to the one used by SslStream.
+        /// </summary>
+        internal sealed class CertificateCallbackMapper
+        {
+            public readonly Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> FromHttpClientHandler;
+            public readonly RemoteCertificateValidationCallback ForManagedHandler;
+
+            public CertificateCallbackMapper(Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> fromHttpClientHandler)
+            {
+                FromHttpClientHandler = fromHttpClientHandler;
+                ForManagedHandler = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+                    FromHttpClientHandler(sender as HttpRequestMessage, certificate as X509Certificate2, chain, sslPolicyErrors);
+            }
+        }
+
         public static async ValueTask<Stream> ConnectAsync(HttpConnectionKey key, CancellationToken cancellationToken)
         {
             string host = key.Host;
@@ -105,45 +121,43 @@ namespace System.Net.Http
 
         public static async ValueTask<SslStream> EstablishSslConnectionAsync(HttpConnectionSettings settings, string host, HttpRequestMessage request, Stream stream, CancellationToken cancellationToken)
         {
-            RemoteCertificateValidationCallback callback = null;
-            if (settings._serverCertificateCustomValidationCallback != null)
+            // Create the options bag to use.  Since we mutate it, we don't just use the shared instance.
+            SslClientAuthenticationOptions sslOptions;
+            if (settings._sslOptions != null)
             {
-                callback = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
-                {
-                    try
-                    {
-                        return settings._serverCertificateCustomValidationCallback(request, certificate as X509Certificate2, chain, sslPolicyErrors);
-                    }
-                    catch (Exception e)
-                    {
-                        throw new HttpRequestException(SR.net_http_ssl_connection_failed, e);
-                    }
-                };
+                sslOptions = settings._sslOptions.ShallowClone();
+                sslOptions.ApplicationProtocols = null; // explicitly ignore any ApplicationProtocols set
+            }
+            else
+            {
+                sslOptions = new SslClientAuthenticationOptions();
             }
 
-            var sslStream = new SslStream(stream);
+            // Use the specified host, regardless of what was provided.
+            sslOptions.TargetHost = host;
 
+            // If there's a cert validation callback, and if it came from HttpClientHandler,
+            // wrap the original delegate in order to change the sender to be the request message (expected by HttpClientHandler's delegate).
+            RemoteCertificateValidationCallback callback = sslOptions.RemoteCertificateValidationCallback;
+            if (callback != null && callback.Target is CertificateCallbackMapper mapper)
+            {
+                Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> fromHttpClientHandler = mapper.FromHttpClientHandler;
+                HttpRequestMessage localRequest = request;
+                sslOptions.RemoteCertificateValidationCallback = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+                    fromHttpClientHandler(localRequest, certificate as X509Certificate2, chain, sslPolicyErrors);
+            }
+
+            // Create the SslStream, authenticate, and return it.
+            var sslStream = new SslStream(stream);
             try
             {
-                await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
-                {
-                    TargetHost = host,
-                    ClientCertificates = settings._clientCertificates,
-                    EnabledSslProtocols = settings._sslProtocols,
-                    CertificateRevocationCheckMode = settings._checkCertificateRevocationList ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
-                    RemoteCertificateValidationCallback = callback
-                }, cancellationToken).ConfigureAwait(false);
+                await sslStream.AuthenticateAsClientAsync(sslOptions, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
                 sslStream.Dispose();
-                if (e is AuthenticationException || e is IOException)
-                {
-                    throw new HttpRequestException(SR.net_http_ssl_connection_failed, e);
-                }
-                throw;
+                throw new HttpRequestException(SR.net_http_ssl_connection_failed, e);
             }
-
             return sslStream;
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionSettings.cs
@@ -4,8 +4,6 @@
 
 using System.Collections.Generic;
 using System.Net.Security;
-using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net.Http
 {
@@ -22,7 +20,6 @@ namespace System.Net.Http
         internal ICredentials _defaultProxyCredentials;
 
         internal bool _preAuthenticate = HttpHandlerDefaults.DefaultPreAuthenticate;
-        internal bool _useDefaultCredentials = HttpHandlerDefaults.DefaultUseDefaultCredentials;
         internal ICredentials _credentials;
 
         internal bool _allowAutoRedirect = HttpHandlerDefaults.DefaultAutomaticRedirection;
@@ -31,16 +28,32 @@ namespace System.Net.Http
         internal int _maxConnectionsPerServer = HttpHandlerDefaults.DefaultMaxConnectionsPerServer;
         internal int _maxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeadersLength;
 
-        internal ClientCertificateOption _clientCertificateOptions = HttpHandlerDefaults.DefaultClientCertificateOption;
-        internal X509CertificateCollection _clientCertificates;
-
-        internal Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> _serverCertificateCustomValidationCallback;
-        internal bool _checkCertificateRevocationList = HttpHandlerDefaults.DefaultCheckCertificateRevocationList;
-        internal SslProtocols _sslProtocols = SslProtocols.None;
-
         internal TimeSpan _pooledConnectionLifetime = HttpHandlerDefaults.DefaultPooledConnectionLifetime;
         internal TimeSpan _pooledConnectionIdleTimeout = HttpHandlerDefaults.DefaultPooledConnectionIdleTimeout;
 
+        internal SslClientAuthenticationOptions _sslOptions;
+
         internal IDictionary<string, object> _properties;
+
+        public HttpConnectionSettings Clone() =>
+            new HttpConnectionSettings()
+            {
+                _allowAutoRedirect = _allowAutoRedirect,
+                _automaticDecompression = _automaticDecompression,
+                _cookieContainer = _cookieContainer,
+                _credentials = _credentials,
+                _defaultProxyCredentials = _defaultProxyCredentials,
+                _maxAutomaticRedirections = _maxAutomaticRedirections,
+                _maxConnectionsPerServer = _maxConnectionsPerServer,
+                _maxResponseHeadersLength = _maxResponseHeadersLength,
+                _pooledConnectionLifetime = _pooledConnectionLifetime,
+                _pooledConnectionIdleTimeout = _pooledConnectionIdleTimeout,
+                _preAuthenticate = _preAuthenticate,
+                _properties = _properties,
+                _proxy = _proxy,
+                _sslOptions = _sslOptions?.ShallowClone(), // shallow clone the options for basic prevention of mutation issues while processing
+                _useCookies = _useCookies,
+                _useProxy = _useProxy,
+            };
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
@@ -4,8 +4,6 @@
 
 using System.Collections.Generic;
 using System.Net.Security;
-using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -51,22 +49,6 @@ namespace System.Net.Http
             {
                 CheckDisposedOrStarted();
                 _settings._cookieContainer = value;
-            }
-        }
-
-        public ClientCertificateOption ClientCertificateOptions
-        {
-            get => _settings._clientCertificateOptions;
-            set
-            {
-                if (value != ClientCertificateOption.Manual &&
-                    value != ClientCertificateOption.Automatic)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(value));
-                }
-
-                CheckDisposedOrStarted();
-                _settings._clientCertificateOptions = value;
             }
         }
 
@@ -117,16 +99,6 @@ namespace System.Net.Http
             {
                 CheckDisposedOrStarted();
                 _settings._preAuthenticate = value;
-            }
-        }
-
-        public bool UseDefaultCredentials
-        {
-            get => _settings._useDefaultCredentials;
-            set
-            {
-                CheckDisposedOrStarted();
-                _settings._useDefaultCredentials = value;
             }
         }
 
@@ -195,47 +167,13 @@ namespace System.Net.Http
             }
         }
 
-        public X509CertificateCollection ClientCertificates
+        public SslClientAuthenticationOptions SslOptions
         {
-            get
-            {
-                if (_settings._clientCertificateOptions != ClientCertificateOption.Manual)
-                {
-                    throw new InvalidOperationException(SR.Format(SR.net_http_invalid_enable_first, nameof(ClientCertificateOptions), nameof(ClientCertificateOption.Manual)));
-                }
-
-                return _settings._clientCertificates ?? (_settings._clientCertificates = new X509Certificate2Collection());
-            }
-        }
-
-        public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback
-        {
-            get => _settings._serverCertificateCustomValidationCallback;
+            get => _settings._sslOptions;
             set
             {
                 CheckDisposedOrStarted();
-                _settings._serverCertificateCustomValidationCallback = value;
-            }
-        }
-
-        public bool CheckCertificateRevocationList
-        {
-            get => _settings._checkCertificateRevocationList;
-            set
-            {
-                CheckDisposedOrStarted();
-                _settings._checkCertificateRevocationList = value;
-            }
-        }
-
-        public SslProtocols SslProtocols
-        {
-            get => _settings._sslProtocols;
-            set
-            {
-                SecurityProtocol.ThrowOnNotAllowed(value, allowNone: true);
-                CheckDisposedOrStarted();
-                _settings._sslProtocols = value;
+                _settings._sslOptions = value;
             }
         }
 
@@ -285,38 +223,39 @@ namespace System.Net.Http
 
         private HttpMessageHandler SetupHandlerChain()
         {
-            HttpMessageHandler handler = new HttpConnectionHandler(_settings);
+            // Clone the settings to get a relatively consistent view that won't change after this point.
+            // (This isn't entirely complete, as some of the collections it contains aren't currently deeply cloned.)
+            HttpConnectionSettings settings = _settings.Clone();
 
-            if (_settings._useProxy &&
-                (_settings._proxy != null || HttpProxyConnectionHandler.DefaultProxyConfigured))
+            HttpMessageHandler handler = new HttpConnectionHandler(settings);
+
+            if (settings._useProxy && (settings._proxy != null || HttpProxyConnectionHandler.DefaultProxyConfigured))
             {
-                handler = new HttpProxyConnectionHandler(_settings, handler);
+                handler = new HttpProxyConnectionHandler(settings, handler);
             }
 
-            if (_settings._useCookies)
+            if (settings._useCookies)
             {
                 handler = new CookieHandler(CookieContainer, handler);
             }
 
-            if (_settings._credentials != null || _settings._allowAutoRedirect)
+            if (settings._credentials != null || settings._allowAutoRedirect)
             {
-                handler = new AuthenticateAndRedirectHandler(_settings._preAuthenticate, _settings._credentials, _settings._allowAutoRedirect, _settings._maxAutomaticRedirections, handler);
+                handler = new AuthenticateAndRedirectHandler(settings._preAuthenticate, settings._credentials, settings._allowAutoRedirect, settings._maxAutomaticRedirections, handler);
             }
 
-            if (_settings._automaticDecompression != DecompressionMethods.None)
+            if (settings._automaticDecompression != DecompressionMethods.None)
             {
-                handler = new DecompressionHandler(_settings._automaticDecompression, handler);
+                handler = new DecompressionHandler(settings._automaticDecompression, handler);
             }
 
-            if (Interlocked.CompareExchange(ref _handler, handler, null) == null)
-            {
-                return handler;
-            }
-            else
+            // Ensure a single handler is used for all requests.
+            if (Interlocked.CompareExchange(ref _handler, handler, null) != null)
             {
                 handler.Dispose();
-                return _handler;
             }
+
+            return _handler;
         }
 
         protected internal override Task<HttpResponseMessage> SendAsync(

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -45,6 +45,27 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Fact]
+        public void ServerCertificateCustomValidationCallback_SetGet_Roundtrips()
+        {
+            using (HttpClientHandler handler = CreateHttpClientHandler())
+            {
+                Assert.Null(handler.ServerCertificateCustomValidationCallback);
+
+                Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> callback1 = (req, cert, chain, policy) => throw new NotImplementedException("callback1");
+                Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> callback2 = (req, cert, chain, policy) => throw new NotImplementedException("callback2");
+
+                handler.ServerCertificateCustomValidationCallback = callback1;
+                Assert.Same(callback1, handler.ServerCertificateCustomValidationCallback);
+
+                handler.ServerCertificateCustomValidationCallback = callback2;
+                Assert.Same(callback2, handler.ServerCertificateCustomValidationCallback);
+
+                handler.ServerCertificateCustomValidationCallback = null;
+                Assert.Null(handler.ServerCertificateCustomValidationCallback);
+            }
+        }
+
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task NoCallback_ValidCertificate_SuccessAndExpectedPropertyBehavior()


### PR DESCRIPTION
Simplifies the public ManagedHandler API by using the now existing SslClientAuthenticationOptions bag as a way to pass in all of the SSL-related options.  This also means we start enabling anything already on SslClientAuthenticationOptions as well as anything new added in the future, without requiring new API on ManagedHandler.

In the process of doing that, also added an implemention of HttpClientHandler.ClientCertificateOption for ManagedHandler; previously Automatic was just ignored.

(I also removed UseDefaultCredentials from ManagedHandler, as it's ignored and not relevant until additional auth mechanisms are supported.)

Fixes https://github.com/dotnet/corefx/issues/26811
Fixes https://github.com/dotnet/corefx/issues/26567
cc: @geoffkizer, @davidsh, @Priya91, @wfurt, @Drawaes 