### PR TITLE
Add the ability to specify case matching behavior for GetFiles

### DIFF
--- a/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
+++ b/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
@@ -231,6 +231,12 @@ namespace System.IO.Enumeration
         Simple,
         Dos
     }
+    public enum MatchCasing
+    {
+        PlatformDefault,
+        CaseSensitive,
+        CaseInsensitive
+    }
     public class EnumerationOptions
     {
         public EnumerationOptions() { }
@@ -240,6 +246,7 @@ namespace System.IO.Enumeration
         public int BufferSize { get { throw null; } set { } }
         public FileAttributes AttributesToSkip { get { throw null; } set { } }
         public MatchType MatchType { get { throw null; } set { } }
+        public MatchCasing MatchCasing { get { throw null; } set { } }
         public bool ReturnSpecialDirectories { get { throw null; } set { } }
     }
     public ref struct FileSystemEntry

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -23,6 +23,7 @@
     <Compile Include="System\IO\Enumeration\FileSystemEnumerableFactory.cs" />
     <Compile Include="System\IO\Enumeration\FileSystemEnumerator.cs" />
     <Compile Include="System\IO\Enumeration\FileSystemName.cs" />
+    <Compile Include="System\IO\Enumeration\MatchCasing.cs" />
     <Compile Include="System\IO\Enumeration\MatchType.cs" />
     <Compile Include="System\IO\Error.cs" />
     <Compile Include="System\IO\Directory.cs" />

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/EnumerationOptions.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/EnumerationOptions.cs
@@ -76,6 +76,15 @@ namespace System.IO.Enumeration
         /// </remarks>
         public MatchType MatchType { get; set; }
 
+
+        /// <summary>
+        /// For APIs that allow specifying a match expression this will allow you to specify case matching behavior.
+        /// </summary>
+        /// <remarks>
+        /// Default is to match platform defaults, which are gleaned from the case sensitivity of the temporary folder.
+        /// </remarks>
+        public MatchCasing MatchCasing { get; set; }
+
         /// <summary>
         /// Set to true to return "." and ".." directory entries.
         /// </summary>

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs
@@ -69,12 +69,15 @@ namespace System.IO.Enumeration
 
         private static bool MatchesPattern(string expression, ReadOnlySpan<char> name, EnumerationOptions options)
         {
+            bool ignoreCase = (options.MatchCasing == MatchCasing.PlatformDefault && !PathInternal.IsCaseSensitive)
+                || options.MatchCasing == MatchCasing.CaseInsensitive;
+
             switch (options.MatchType)
             {
                 case MatchType.Simple:
-                    return FileSystemName.MatchesSimpleExpression(expression, name, ignoreCase: !PathInternal.IsCaseSensitive);
+                    return FileSystemName.MatchesSimpleExpression(expression, name, ignoreCase);
                 case MatchType.Dos:
-                    return FileSystemName.MatchesDosExpression(expression, name, ignoreCase: !PathInternal.IsCaseSensitive);
+                    return FileSystemName.MatchesDosExpression(expression, name, ignoreCase);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(options));
             }

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/MatchCasing.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/MatchCasing.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Enumeration
+{
+    public enum MatchCasing
+    {
+        /// <summary>
+        /// Match the default casing for the given platform
+        /// </summary>
+        PlatformDefault,
+
+        /// <summary>
+        /// Match respecting character casing
+        /// </summary>
+        CaseSensitive,
+
+        /// <summary>
+        /// Match ignoring character casing
+        /// </summary>
+        CaseInsensitive
+    }
+}

--- a/src/System.IO.FileSystem/tests/Enumeration/MatchCasingTests.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/Enumeration/MatchCasingTests.netcoreapp.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO.Enumeration;
+using System.Linq;
+using Xunit;
+
+namespace System.IO.Tests.Enumeration
+{
+    public abstract class MatchCasingTests : FileSystemTest
+    {
+        protected abstract string[] GetPaths(string directory, string pattern, EnumerationOptions options);
+
+        [Fact]
+        public void MatchCase()
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+            DirectoryInfo testSubdirectory = Directory.CreateDirectory(Path.Combine(testDirectory.FullName, "Subdirectory"));
+            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, "FileOne"));
+            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, "FileTwo"));
+            FileInfo fileThree = new FileInfo(Path.Combine(testSubdirectory.FullName, "FileThree"));
+            FileInfo fileFour = new FileInfo(Path.Combine(testSubdirectory.FullName, "FileFour"));
+
+            fileOne.Create().Dispose();
+            fileTwo.Create().Dispose();
+            fileThree.Create().Dispose();
+            fileFour.Create().Dispose();
+
+            string[] paths = GetPaths(testDirectory.FullName, "file*", new EnumerationOptions { MatchCasing = MatchCasing.CaseSensitive, RecurseSubdirectories = true });
+
+            Assert.Empty(paths);
+
+            paths = GetPaths(testDirectory.FullName, "file*", new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive, RecurseSubdirectories = true });
+            FSAssert.EqualWhenOrdered(new string[] { fileOne.FullName, fileTwo.FullName, fileThree.FullName, fileFour.FullName }, paths);
+
+            paths = GetPaths(testDirectory.FullName, "FileT*", new EnumerationOptions { MatchCasing = MatchCasing.CaseSensitive, RecurseSubdirectories = true });
+            FSAssert.EqualWhenOrdered(new string[] { fileTwo.FullName, fileThree.FullName }, paths);
+
+            paths = GetPaths(testDirectory.FullName, "File???", new EnumerationOptions { MatchCasing = MatchCasing.CaseSensitive, RecurseSubdirectories = true });
+            FSAssert.EqualWhenOrdered(new string[] { fileOne.FullName, fileTwo.FullName }, paths);
+        }
+    }
+
+    public class MatchCasingTests_Directory_GetFiles : MatchCasingTests
+    {
+        protected override string[] GetPaths(string directory, string pattern, EnumerationOptions options)
+        {
+            return Directory.GetFiles(directory, pattern, options);
+        }
+    }
+
+    public class MatchCasingTests_DirectoryInfo_GetFiles : MatchCasingTests
+    {
+        protected override string[] GetPaths(string directory, string pattern, EnumerationOptions options)
+        {
+            return new DirectoryInfo(directory).GetFiles(pattern, options).Select(i => i.FullName).ToArray();
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/FSAssert.cs
+++ b/src/System.IO.FileSystem/tests/FSAssert.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -61,6 +63,11 @@ namespace System.IO.Tests
             OperationCanceledException tce = Assert.ThrowsAny<OperationCanceledException>(() => task.GetAwaiter().GetResult());
             Assert.NotNull(tce);
             Assert.Equal(ct, tce.CancellationToken);
+        }
+
+        public static void EqualWhenOrdered<T>(IEnumerable<T> expected, IEnumerable<T> actual)
+        {
+            Assert.Equal(expected.OrderBy(e => e).Select(o => o), actual.OrderBy(a => a).Select(o => o));
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Enumeration\SpecialDirectoryTests.netcoreapp.cs" />
     <Compile Include="Enumeration\SkipAttributeTests.netcoreapp.cs" />
     <Compile Include="Enumeration\DosMatcherTests.netcoreapp.cs" />
+    <Compile Include="Enumeration\MatchCasingTests.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
     <!-- Rewritten -->


### PR DESCRIPTION
Adds options for specifying whether or not you want to respect casing when calling existing file enumeration APIs.

cc: @iSazonov, @danmosemsft 