### PR TITLE
reduce regex op code time

### DIFF
--- a/src/Common/src/CoreLib/System/Collections/Generic/ValueListBuilder.cs
+++ b/src/Common/src/CoreLib/System/Collections/Generic/ValueListBuilder.cs
@@ -21,6 +21,8 @@ namespace System.Collections.Generic
             _pos = 0;
         }
 
+        public ref T this[int index] => ref _span[index];
+
         public int Length => _pos;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -32,6 +34,13 @@ namespace System.Collections.Generic
 
             _span[pos] = item;
             _pos = pos + 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T Pop()
+        {
+            _pos--;
+            return _span[_pos];
         }
 
         public ReadOnlySpan<T> AsReadOnlySpan()

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -33,6 +33,7 @@
     <Compile Include="System\Text\RegularExpressions\RegexReplacement.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexRunner.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexTree.cs" />
+    <Compile Include="System\Text\RegularExpressions\ResizableValueListBuilder.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexWriter.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexRunnerFactory.cs" />
     <!-- Common or Common-branched source files -->
@@ -41,9 +42,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\System\Collections\Generic\ValueListBuilder.cs">
-      <Link>Common\System\Collections\Generic\ValueListBuilder.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Files that enable compiled feature -->

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -42,6 +42,9 @@
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\System\Collections\Generic\ValueListBuilder.cs">
+      <Link>Common\System\Collections\Generic\ValueListBuilder.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Files that enable compiled feature -->
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
@@ -58,6 +61,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
+    <Reference Include="System.Buffers" />
   </ItemGroup>
   <!-- References required for compiled feature -->
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ResizableValueListBuilder.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ResizableValueListBuilder.cs
@@ -8,18 +8,20 @@ using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
-    internal ref struct ValueListBuilder<T>
+    internal ref struct ResizableValueListBuilder<T>
     {
         private Span<T> _span;
         private T[] _arrayFromPool;
         private int _pos;
 
-        public ValueListBuilder(Span<T> initialSpan)
+        public ResizableValueListBuilder(Span<T> initialSpan)
         {
             _span = initialSpan;
             _arrayFromPool = null;
             _pos = 0;
         }
+
+        public ref T this[int index] => ref _span[index];
 
         public int Length => _pos;
 
@@ -32,6 +34,13 @@ namespace System.Collections.Generic
 
             _span[pos] = item;
             _pos = pos + 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T Pop()
+        {
+            _pos--;
+            return _span[_pos];
         }
 
         public ReadOnlySpan<T> AsReadOnlySpan()


### PR DESCRIPTION
While stepping through the Regex code and analyzing the different steps to find the reason for https://github.com/dotnet/corefx/issues/26787 I noticed that the regex op code generation runs twice. a code comment also suggested that this could be simplified by using a growing data structure instead of a fixed array.

Benchmark results (based on Dans xunit benchmarks, converted to BenchmarkDotNet):

**[EDIT]: see benchmark below**
