### PR TITLE
Hardening sliding expiration cache test

### DIFF
--- a/src/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -1025,6 +1025,7 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Fact]
+        [OuterLoop] // makes long wait
         public void TestCacheSliding()
         {
             var config = new NameValueCollection();


### PR DESCRIPTION
The fix is just like described in #26586 - measure the delay and detect if we had not exceeded expiration timeout. 