### PR TITLE
Implement MaxResponseHeadersLength on ManagedHandler

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Net.Test.Common;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -46,43 +47,90 @@ namespace System.Net.Http.Functional.Tests
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (var client = new HttpClient(handler))
             {
-                handler.MaxResponseHeadersLength = int.MaxValue;
-                await client.GetStreamAsync(Configuration.Http.RemoteEchoServer);
-                Assert.Throws<InvalidOperationException>(() => handler.MaxResponseHeadersLength = int.MaxValue);
+                handler.MaxResponseHeadersLength = 1;
+                (await client.GetStreamAsync(Configuration.Http.RemoteEchoServer)).Dispose();
+                Assert.Throws<InvalidOperationException>(() => handler.MaxResponseHeadersLength = 1);
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not currently supported on UAP")]
         [OuterLoop] // TODO: Issue #11345
-        [Theory, MemberData(nameof(ResponseWithManyHeadersData))]
-        public async Task ThresholdExceeded_ThrowsException(string responseHeaders, int maxResponseHeadersLength, bool shouldSucceed)
+        [Fact]
+        public async Task InfiniteSingleHeader_ThrowsException()
         {
+            if (IsCurlHandler)
+            {
+                // libcurl fails with an out of memory error
+                return;
+            }
+
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
                 using (HttpClientHandler handler = CreateHttpClientHandler())
                 using (var client = new HttpClient(handler))
                 {
-                    handler.MaxResponseHeadersLength = maxResponseHeadersLength;
+                    Task<HttpResponseMessage> getAsync = client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+                    await LoopbackServer.AcceptSocketAsync(server, async (s, serverStream, reader, writer) =>
+                    {
+                        var cts = new CancellationTokenSource();
+                        Task serverTask = Task.Run(async delegate
+                        {
+                            while (!string.IsNullOrEmpty(await reader.ReadLineAsync()));
+                            await writer.WriteAsync("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nMyInfiniteHeader: ");
+                            try
+                            {
+                                while (!cts.IsCancellationRequested)
+                                {
+                                    await writer.WriteAsync(new string('s', 16000));
+                                    await Task.Delay(1);
+                                }
+                            }
+                            catch { }
+                        });
+
+                        await Assert.ThrowsAsync<HttpRequestException>(() => getAsync);
+                        cts.Cancel();
+                        await serverTask;
+                        return null;
+                    });
+                }
+            });
+        }
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not currently supported on UAP")]
+        [OuterLoop] // TODO: Issue #11345
+        [Theory, MemberData(nameof(ResponseWithManyHeadersData))]
+        public async Task ThresholdExceeded_ThrowsException(string responseHeaders, int? maxResponseHeadersLength, bool shouldSucceed)
+        {
+            if (IsCurlHandler)
+            {
+                // libcurl often fails with out of memory errors
+                return;
+            }
+
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClientHandler handler = CreateHttpClientHandler())
+                using (var client = new HttpClient(handler))
+                {
+                    if (maxResponseHeadersLength.HasValue)
+                    {
+                        handler.MaxResponseHeadersLength = maxResponseHeadersLength.Value;
+                    }
                     Task<HttpResponseMessage> getAsync = client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
 
                     await LoopbackServer.AcceptSocketAsync(server, async (s, serverStream, reader, writer) =>
                     {
-                        using (s) using (serverStream) using (reader) using (writer)
-                        {
-                            string line;
-                            while ((line = reader.ReadLine()) != null && !string.IsNullOrEmpty(line)) ;
-
-                            byte[] headerData = Encoding.ASCII.GetBytes(responseHeaders);
-                            serverStream.Write(headerData, 0, headerData.Length);
-                        }
+                        Task serverTask = LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer, responseHeaders);
 
                         if (shouldSucceed)
                         {
                             (await getAsync).Dispose();
+                            await serverTask;
                         }
                         else
                         {
                             await Assert.ThrowsAsync<HttpRequestException>(() => getAsync);
+                            try { await serverTask; } catch { }
                         }
                         
                         return null;
@@ -95,58 +143,32 @@ namespace System.Net.Http.Functional.Tests
         {
             get
             {
-                // Success case: response headers of size 1023 bytes (less than 1024 bytes max).
+                foreach (int? max in new int?[] { null, 1, 31, 128 })
                 {
-                    yield return new object[] { GenerateLargeResponseHeaders(1023), 1, true };
-                }
+                    int actualSize = max.HasValue ? max.Value : 64;
 
-                // Success case: response headers of size 1024 bytes (equal to 1024 bytes max).
-                {
-                    yield return new object[] { GenerateLargeResponseHeaders(1024), 1, true };
-                }
-
-                // Failure case: response headers of size 1025 (greater than 1024 bytes max).
-                {
-                    yield return new object[] { GenerateLargeResponseHeaders(1025), 1, false };
+                    yield return new object[] { GenerateLargeResponseHeaders(actualSize * 1024 - 1), max, true }; // Small enough
+                    yield return new object[] { GenerateLargeResponseHeaders(actualSize * 1024), max, true }; // Just right
+                    yield return new object[] { GenerateLargeResponseHeaders(actualSize * 1024 + 1), max, false }; // Too big
                 }
             }
         }
 
         private static string GenerateLargeResponseHeaders(int responseHeadersSizeInBytes)
         {
-            // This helper method only supports generating sizes of 1023, 1024, or 1025 bytes.
-            // These are the only sizes needed to support the above tests.
-            Assert.InRange(responseHeadersSizeInBytes, 1023, 1025);
-
-            string statusHeader = "HTTP/1.1 200 OK\r\n";
-            string contentFooter = "Content-Length: 0\r\n\r\n";
-
             var buffer = new StringBuilder();
-            buffer.Append(statusHeader);
+            buffer.Append("HTTP/1.1 200 OK\r\n");
+            buffer.Append("Content-Length: 0\r\n");
             for (int i = 0; i < 24; i++)
             {
                 buffer.Append($"Custom-{i:D4}: 1234567890123456789012345\r\n");
             }
-
-            if (responseHeadersSizeInBytes == 1023)
-            {
-                buffer.Append($"Custom-1023: 1234567890\r\n");
-            }
-            else if (responseHeadersSizeInBytes == 1024)
-            {
-                buffer.Append($"Custom-1024: 12345678901\r\n");
-            }
-            else
-            {
-                Assert.Equal(1025, responseHeadersSizeInBytes);
-                buffer.Append($"Custom-1025: 123456789012\r\n");
-            }
-
-            buffer.Append(contentFooter);
+            buffer.Append($"Custom-24: ");
+            buffer.Append(new string('c', responseHeadersSizeInBytes - (buffer.Length + 4)));
+            buffer.Append("\r\n\r\n");
 
             string response = buffer.ToString();            
             Assert.Equal(responseHeadersSizeInBytes, response.Length);
-
             return response;
         }
     }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1198,6 +1198,51 @@ namespace System.Net.Http.Functional.Tests
                             Assert.Contains("MyCoolTrailerHeader", response.Headers.GetValues("Trailer"));
                         }
                         Assert.False(response.Headers.Contains("MyCoolTrailerHeader"), "Trailer should have been ignored");
+
+                        string data = await response.Content.ReadAsStringAsync();
+                        Assert.Contains("data", data);
+                        Assert.DoesNotContain("MyCoolTrailerHeader", data);
+                        Assert.DoesNotContain("amazingtrailer", data);
+                    }
+                }
+            });
+        }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        public async Task GetAsync_NonTraditionalChunkSizes_Accepted()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClientHandler handler = CreateHttpClientHandler())
+                using (var client = new HttpClient(handler))
+                {
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
+                    await TestHelper.WhenAllCompletedOrAnyFailed(
+                        getResponseTask,
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                            "HTTP/1.1 200 OK\r\n" +
+                            "Transfer-Encoding: chunked\r\n" +
+                            "\r\n" +
+                            "4    \r\n" + // whitespace after size
+                            "data\r\n" +
+                            "5;somekey=somevalue\r\n" + // chunk extension
+                            "hello\r\n" +
+                            "7\t ;chunkextension\r\n" + // tabs/spaces then chunk extension
+                            "netcore\r\n" +
+                            "0\r\n" +
+                            "\r\n"));
+
+                    using (HttpResponseMessage response = await getResponseTask)
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        string data = await response.Content.ReadAsStringAsync();
+                        Assert.Contains("data", data);
+                        Assert.Contains("hello", data);
+                        Assert.Contains("netcore", data);
+                        Assert.DoesNotContain("somekey", data);
+                        Assert.DoesNotContain("somevalue", data);
+                        Assert.DoesNotContain("chunkextension", data);
                     }
                 }
             });
@@ -1206,9 +1251,19 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("")] // missing size
+        [InlineData("    ")] // missing size
         [InlineData("10000000000000000")] // overflowing size
+        [InlineData("xyz")] // non-hex
+        [InlineData("7gibberish")] // valid size then gibberish
+        [InlineData("7\v\f")] // unacceptable whitespace
         public async Task GetAsync_InvalidChunkSize_ThrowsHttpRequestException(string chunkSize)
         {
+            if (IsCurlHandler)
+            {
+                // libcurl allows any arbitrary characters after the hex value
+                return;
+            }
+
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
                 using (HttpClient client = CreateHttpClient())
@@ -1229,6 +1284,41 @@ namespace System.Net.Http.Functional.Tests
 
                     await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
                     tcs.SetResult(true);
+                    await serverTask;
+                }
+            });
+        }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        public async Task GetAsync_InfiniteChunkSize_ThrowsHttpRequestException()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    client.Timeout = Timeout.InfiniteTimeSpan;
+
+                    var cts = new CancellationTokenSource();
+                    var tcs = new TaskCompletionSource<bool>();
+                    Task serverTask = LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
+                    {
+                        while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) ;
+                        await writer.WriteAsync("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n");
+                        try
+                        {
+                            while (!cts.IsCancellationRequested) // infinite to make sure implementation doesn't OOM
+                            {
+                                await writer.WriteAsync(new string(' ', 10000));
+                                await Task.Delay(1);
+                            }
+                        }
+                        catch { }
+                        return null;
+                    }, null);
+
+                    await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
+                    cts.Cancel();
                     await serverTask;
                 }
             });

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -128,11 +128,10 @@ namespace System.Net.Http.Functional.Tests
     //    protected override bool UseManagedHandler => true;
     //}
 
-    // TODO #23142: The managed handler doesn't currently track how much data was written for the response headers.
-    //public sealed class ManagedHandler_HttpClientHandler_MaxResponseHeadersLength_Test : HttpClientHandler_MaxResponseHeadersLength_Test
-    //{
-    //    protected override bool UseManagedHandler => true;
-    //}
+    public sealed class ManagedHandler_HttpClientHandler_MaxResponseHeadersLength_Test : HttpClientHandler_MaxResponseHeadersLength_Test
+    {
+        protected override bool UseManagedHandler => true;
+    }
 
     public sealed class ManagedHandler_HttpClientHandler_DuplexCommunication_Test : HttpClientTestBase
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/23142

@geoffkizer, this is going to conflict with https://github.com/dotnet/corefx/pull/26782.  I will wait for you to merge that and then fix this up accordingly.

cc: @geoffkizer, @davidsh, @Priya91, @wfurt 