### PR TITLE
[rel/2.0.0] Update Linux test versions

### DIFF
--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -52,13 +52,12 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
                                      'Debian.87.Amd64.Open',
                                      'Ubuntu.1404.Amd64.Open',
                                      'Ubuntu.1604.Amd64.Open',
-                                     'suse.422.amd64.Open',
-                                     'fedora.25.amd64.Open',]
+                                     'OpenSuse.423.Amd64.Open',
+                                     'Fedora.26.Amd64.Open',]
             if (params.TestOuter) {
                 targetHelixQueues += ['Debian.90.Amd64.Open',
-                                      'Fedora.26.Amd64.Open',
-                                      'SLES.12.Amd64.Open',
-                                      'Ubuntu.1704.Amd64.Open',]
+                                      'Fedora.27.Amd64.Open',
+                                      'SLES.12.Amd64.Open',]
             }
 
             sh "./Tools/msbuild.sh src/upload-tests.proj /p:ArchGroup=x64 /p:ConfigurationGroup=${params.CGroup} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux /p:HelixJobType=test/functional/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=\$CloudDropAccessToken /p:CloudResultsAccessToken=\$OutputCloudResultsAccessToken /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=${targetHelixQueues.join('+')} /p:HelixLogFolder=${WORKSPACE}/${logFolder}/ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -21,7 +21,7 @@
             "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols",
             "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -Outerloop -- /p:ArchiveTests=true /p:EnableDumpling=true",
             "PB_SyncArguments": "-p -- /p:ArchGroup=x64",
-            "PB_TargetQueue": "Centos.73.Amd64+RedHat.72.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1704.Amd64+suse.422.amd64+SLES.12.Amd64+fedora.25.amd64+Fedora.26.Amd64",
+            "PB_TargetQueue": "Centos.73.Amd64+RedHat.73.Amd64+Debian.87.Amd64+Debian.90.Amd64+Ubuntu.1404.Amd64+Ubuntu.1604.Amd64+Ubuntu.1710.Amd64+OpenSuse.423.Amd64+SLES.12.Amd64+Fedora.26.Amd64+Fedora.27.Amd64",
             "PB_CreateHelixArguments": "/p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux"
           },
           "ReportingParameters": {


### PR DESCRIPTION
Update the helix rid matrix to remove EOL distro versions and add their replacements.

cc: @MattGal