### PR TITLE
Crossgening roslyn for non-Windows builds

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -174,7 +174,10 @@ echo "Making all .sh files executable under Tools."
 ls $__scriptpath/Tools/*.sh | xargs chmod +x
 ls $__scriptpath/Tools/scripts/docker/*.sh | xargs chmod +x
 
+__compilersVersion=`ls $__PACKAGES_DIR/microsoft.netcore.compilers/ | sed 'r/\([0-9]\+\).*/\1/g'`
+
 Tools/crossgen.sh $__scriptpath/Tools
+Tools/crossgen.sh $__PACKAGES_DIR/microsoft.netcore.compilers/$__compilersVersion/tools/bincore
 
 mkdir -p "$(dirname "$__BUILD_TOOLS_SEMAPHORE")" && touch $__BUILD_TOOLS_SEMAPHORE
 


### PR DESCRIPTION
cc: @weshaggard @eerhardt 

When moving to the CLI's MSBuild we started using Roslyn comming in from the packages directory, which we are not crossgening. This is most likely causing the problem we are seeing on non-Windows builds where builds take twice as long as they used to take. These changes will make sure we crossgen roslyn so builds should go faster.