### PR TITLE
add test for connection upgrade

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Sockets;
 using System.Net.Test.Common;
@@ -263,7 +264,52 @@ namespace System.Net.Http.Functional.Tests
             public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
             public override void SetLength(long value) => throw new NotImplementedException();
         }
+    }
 
+    public sealed class ManagedHandler_ConnectionUpgrade_Test : HttpClientTestBase
+    {
+        protected override bool UseManagedHandler => true;
+
+        [Fact]
+        public async Task UpgradeConnection_Success()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    // We need to use ResponseHeadersRead here, otherwise we will hang trying to buffer the response body.
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+                    await LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
+                    {
+                        Task<List<string>> serverTask = LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer,
+                            $"HTTP/1.1 101 Switching Protocols\r\nDate: {DateTimeOffset.UtcNow:R}\r\n\r\n");
+
+                        await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+
+                        using (Stream clientStream = await (await getResponseTask).Content.ReadAsStreamAsync())
+                        {
+                            Assert.True(clientStream.CanWrite);
+                            Assert.True(clientStream.CanRead);
+                            Assert.False(clientStream.CanSeek);
+
+                            TextReader clientReader = new StreamReader(clientStream);
+                            TextWriter clientWriter = new StreamWriter(clientStream) { AutoFlush = true };
+
+                            clientWriter.WriteLine("hello server");
+                            Assert.Equal("hello server", reader.ReadLine());
+                            writer.WriteLine("hello client");
+                            Assert.Equal("hello client", clientReader.ReadLine());
+                            clientWriter.WriteLine("goodbye server");
+                            Assert.Equal("goodbye server", reader.ReadLine());
+                            writer.WriteLine("goodbye client");
+                            Assert.Equal("goodbye client", clientReader.ReadLine());
+                        }
+
+                        return null;
+                    });
+                }
+            });
+        }
     }
 
     public sealed class ManagedHandler_HttpClientHandler_ConnectionPooling_Test : HttpClientTestBase


### PR DESCRIPTION
Add a basic test for how we handle 101 Switching Protocols response.

@stephentoub @davidsh @wfurt 

@wfurt: The CONNECT verb handling should work similar to this; hopefully this is a useful example to follow.