### PR TITLE
Fix ServicePointManager.ProxyAddressIfNecessary to ignore "system" proxy failures

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -682,14 +682,7 @@ namespace System.Net.Tests
         public void ServicePoint_GetValue_ExpectedResult(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            if (PlatformDetection.IsFullFramework)
-            {
-                Assert.NotNull(request.ServicePoint);
-            }
-            else
-            {
-                Assert.Throws<PlatformNotSupportedException>(() => request.ServicePoint);
-            }
+            Assert.NotNull(request.ServicePoint);
         }
 
         [Theory, MemberData(nameof(EchoServers))]

--- a/src/System.Net.ServicePoint/src/System/Net/ServicePointManager.cs
+++ b/src/System.Net.ServicePoint/src/System/Net/ServicePointManager.cs
@@ -176,16 +176,27 @@ namespace System.Net
         {
             if (proxy != null && !address.IsLoopback)
             {
-                Uri proxyAddress = proxy.GetProxy(address);
-                if (proxyAddress != null)
+                try
                 {
-                    if (proxyAddress.Scheme != Uri.UriSchemeHttp)
+                    Uri proxyAddress = proxy.GetProxy(address);
+                    if (proxyAddress != null)
                     {
-                        throw new NotSupportedException(SR.Format(SR.net_proxyschemenotsupported, address.Scheme));
-                    }
+                        if (proxyAddress.Scheme != Uri.UriSchemeHttp)
+                        {
+                            throw new NotSupportedException(SR.Format(SR.net_proxyschemenotsupported, address.Scheme));
+                        }
 
-                    address = proxyAddress;
-                    return true;
+                        address = proxyAddress;
+                        return true;
+                    }
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    // HttpWebRequest has a dummy SystemWebProxy that's used as a sentinel
+                    // and whose GetProxy method throws a PlatformNotSupportedException.
+                    // For the purposes of this stand-in ServicePointManager implementation,
+                    // we ignore this default "system" proxy for the purposes of mapping
+                    // to a particular ServicePoint instance.
                 }
             }
 


### PR DESCRIPTION
The whole ServicePointManager implementation is there just to make basic stuff not fail.  But HttpWebRequest's Proxy defaults to an internal dummy singleton SystemWebProxy whose GetProxy method throws a PlatformNotSupportedException.  Until we can clean that up and have a real proxy in place, we should just eat that PlatformNotSupportedException when the ServicePointManager calls GetProxy.

Fixes https://github.com/dotnet/corefx/issues/26922
cc: @davidsh, @geoffkizer 