### PR TITLE
Remove an incorrect CookieParser test

### DIFF
--- a/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieInternalTest.cs
@@ -80,33 +80,5 @@ namespace NetPrimitivesUnitTests
             int expectedCookieCount = expectedStrings.Length >> 1;
             Assert.Equal(expectedCookieCount, cookieCount);
         }
-
-        [ActiveIssue(22925)]
-        [Theory]
-        [InlineData("cookie_name=cookie_value", new[] { "cookie_name", "cookie_value" })]
-        [InlineData("cookie_name=cookie_value;", new[] { "cookie_name", "cookie_value" })]
-        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2", new[] { "cookie_name1", "cookie_value1", "cookie_name2", "cookie_value2" })]
-        [InlineData("cookie_name1=cookie_value1;cookie_name2=cookie_value2;", new[] { "cookie_name1", "cookie_value1", "cookie_name2", "cookie_value2" })]
-        public void CookieParserGet_SetCookieHeaderValue_Success(string cookieString, string[] expectedStrings)
-        {
-            int index = 0;
-            int cookieCount = 0;
-            var parser = new CookieParser(cookieString);
-            while (true)
-            {
-                Cookie cookie = parser.Get();
-                if (cookie == null)
-                {
-                    break;
-                }
-
-                cookieCount++;
-                Assert.Equal(expectedStrings[index++], cookie.Name);
-                Assert.Equal(expectedStrings[index++], cookie.Value);
-            }
-
-            int expectedCookieCount = expectedStrings.Length >> 1;
-            Assert.Equal(expectedCookieCount, cookieCount);
-        }
     }
 }


### PR DESCRIPTION
The test CookieParserGet_SetCookieHeaderValue_Success was written with an incorrect understanding of the desired behavior of CookieParser.Get().

The test was disabled when it was merged, and is fundamentally incorrect enough that it doesn't make sense to rewrite it. The relevant code is already covered by the regular cookie parsing tests.

Fixes: #22925