### PR TITLE
Removing the Sse2.LoadScalarVector128 overloads that are invalid.

### DIFF
--- a/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -996,10 +996,6 @@ namespace System.Runtime.Intrinsics.X86
         public static void LoadFence() { throw null; }
         public static unsafe Vector128<double> LoadHigh(Vector128<double> lower, double* address) { throw null; }
         public static unsafe Vector128<double> LoadLow(Vector128<double> upper, double* address) { throw null; }
-        public static unsafe Vector128<sbyte> LoadScalarVector128(sbyte* address) { throw null; }
-        public static unsafe Vector128<byte> LoadScalarVector128(byte* address) { throw null; }
-        public static unsafe Vector128<short> LoadScalarVector128(short* address) { throw null; }
-        public static unsafe Vector128<ushort> LoadScalarVector128(ushort* address) { throw null; }
         public static unsafe Vector128<int> LoadScalarVector128(int* address) { throw null; }
         public static unsafe Vector128<uint> LoadScalarVector128(uint* address) { throw null; }
         public static unsafe Vector128<long> LoadScalarVector128(long* address) { throw null; }


### PR DESCRIPTION
CoreFX side changes for https://github.com/dotnet/coreclr/pull/16221

FYI. @eerhardt 