### PR TITLE
Re-Enable disabled DNS tests on OSX

### DIFF
--- a/src/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -111,7 +111,6 @@ namespace System.Net.NameResolution.Tests
             Assert.Contains(Dns.GetHostName(), entry.HostName, StringComparison.OrdinalIgnoreCase);
         }
 
-        [ActiveIssue(26789, TestPlatforms.OSX)]
         [Fact]
         public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
         {

--- a/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -20,13 +20,11 @@ namespace System.Net.NameResolution.Tests
             await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(localIPAddress));
         }
 
-        [ActiveIssue(26789, TestPlatforms.OSX)]
         [Theory]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
         public Task Dns_GetHostEntry_HostString_Ok(string hostName) => TestGetHostEntryAsync(() => Task.FromResult(Dns.GetHostEntry(hostName)));
 
-        [ActiveIssue(26789, TestPlatforms.OSX)]
         [Theory]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]


### PR DESCRIPTION
These were disabled a few days ago, but it looks like the issue may have been caused by problematic test infrastructure. One of the offending machines has been re-imaged, and the others have been rebooted.

Re-enabling the tests should allow us to determine if it was an infrastructure issue, or if there is a real problem here.

Fixes: #26789