### PR TITLE
Provide GetSchema override for DbConnectionClosed

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
@@ -59,6 +59,11 @@ namespace System.Data.ProviderBase
             throw ADP.ClosedConnectionError();
         }
 
+        override protected internal DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
+        {
+            throw ADP.ClosedConnectionError();
+        }
+
         protected override DbReferenceCollection CreateReferenceCollection()
         {
             throw ADP.ClosedConnectionError();

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
@@ -59,7 +59,7 @@ namespace System.Data.ProviderBase
             throw ADP.ClosedConnectionError();
         }
 
-        override protected internal DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
+        protected internal override DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
             => throw ADP.ClosedConnectionError();
 
         protected override DbReferenceCollection CreateReferenceCollection()

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
@@ -60,9 +60,7 @@ namespace System.Data.ProviderBase
         }
 
         override protected internal DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
-        {
-            throw ADP.ClosedConnectionError();
-        }
+            => throw ADP.ClosedConnectionError();
 
         protected override DbReferenceCollection CreateReferenceCollection()
         {

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -81,7 +81,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        public void NonOpenConnectionSchemaRetrieval()
+        public void ClosedConnectionSchemaRetrieval()
         {
             using (SqlConnection connection = new SqlConnection(string.Empty))
             {

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -81,6 +81,15 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
+        public void NonOpenConnectionSchemaRetrieval()
+        {
+            using (SqlConnection connection = new SqlConnection(string.Empty))
+            {
+                Assert.Throws<InvalidOperationException>(() => connection.GetSchema());
+            }
+        }
+
+        [Fact]
         public void ConnectionTimeoutTestWithThread()
         {
             int timeoutSec = 5;


### PR DESCRIPTION
GetSchema on a closed Sql Connection results in NRE. Providing an override in DbConnectionClosed to handle this scenario. 

Fixes https://github.com/dotnet/corefx/issues/22882