### PR TITLE
Ensure EventData structs in EventSource implementations are zero'd

### DIFF
--- a/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
@@ -34,14 +34,26 @@ namespace System.Buffers
         internal unsafe void BufferRented(int bufferId, int bufferSize, int poolId, int bucketId)
         {
             EventData* payload = stackalloc EventData[4];
-            payload[0].Size = sizeof(int);
-            payload[0].DataPointer = ((IntPtr)(&bufferId));
-            payload[1].Size = sizeof(int);
-            payload[1].DataPointer = ((IntPtr)(&bufferSize));
-            payload[2].Size = sizeof(int);
-            payload[2].DataPointer = ((IntPtr)(&poolId));
-            payload[3].Size = sizeof(int);
-            payload[3].DataPointer = ((IntPtr)(&bucketId));
+            payload[0] = new EventData
+            {
+                Size = sizeof(int),
+                DataPointer = ((IntPtr)(&bufferId))
+            };
+            payload[1] = new EventData
+            {
+                Size = sizeof(int),
+                DataPointer = ((IntPtr)(&bufferSize))
+            };
+            payload[2] = new EventData
+            {
+                Size = sizeof(int),
+                DataPointer = ((IntPtr)(&poolId))
+            };
+            payload[3] = new EventData
+            {
+                Size = sizeof(int),
+                DataPointer = ((IntPtr)(&bucketId))
+            };
             WriteEventCore(1, 4, payload);
         }
 
@@ -54,16 +66,31 @@ namespace System.Buffers
         internal unsafe void BufferAllocated(int bufferId, int bufferSize, int poolId, int bucketId, BufferAllocatedReason reason)
         {
             EventData* payload = stackalloc EventData[5];
-            payload[0].Size = sizeof(int);
-            payload[0].DataPointer = ((IntPtr)(&bufferId));
-            payload[1].Size = sizeof(int);
-            payload[1].DataPointer = ((IntPtr)(&bufferSize));
-            payload[2].Size = sizeof(int);
-            payload[2].DataPointer = ((IntPtr)(&poolId));
-            payload[3].Size = sizeof(int);
-            payload[3].DataPointer = ((IntPtr)(&bucketId));
-            payload[4].Size = sizeof(BufferAllocatedReason);
-            payload[4].DataPointer = ((IntPtr)(&reason));
+            payload[0] = new EventData
+            {
+                Size = sizeof(int),
+                DataPointer = ((IntPtr)(&bufferId))
+            };
+            payload[1] = new EventData
+            {
+                Size = sizeof(int),
+                DataPointer = ((IntPtr)(&bufferSize))
+            };
+            payload[2] = new EventData
+            {
+                Size = sizeof(int),
+                DataPointer = ((IntPtr)(&poolId))
+            };
+            payload[3] = new EventData
+            {
+                Size = sizeof(int),
+                DataPointer = ((IntPtr)(&bucketId))
+            };
+            payload[4] = new EventData
+            {
+                Size = sizeof(BufferAllocatedReason),
+                DataPointer = ((IntPtr)(&reason))
+            };
             WriteEventCore(2, 5, payload);
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
+++ b/src/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
@@ -78,20 +78,31 @@ namespace System.Net
                     const int NumEventDatas = 5;
                     var descrs = stackalloc EventData[NumEventDatas];
 
-                    descrs[0].DataPointer = (IntPtr)(&arg1);
-                    descrs[0].Size = sizeof(int);
-
-                    descrs[1].DataPointer = (IntPtr)(&arg2);
-                    descrs[1].Size = sizeof(int);
-
-                    descrs[2].DataPointer = (IntPtr)(&arg3);
-                    descrs[2].Size = sizeof(int);
-
-                    descrs[3].DataPointer = (IntPtr)string4Bytes;
-                    descrs[3].Size = ((arg4.Length + 1) * 2);
-
-                    descrs[4].DataPointer = (IntPtr)string5Bytes;
-                    descrs[4].Size = ((arg5.Length + 1) * 2);
+                    descrs[0] = new EventData
+                    {
+                        DataPointer = (IntPtr)(&arg1),
+                        Size = sizeof(int)
+                    };
+                    descrs[1] = new EventData
+                    {
+                        DataPointer = (IntPtr)(&arg2),
+                        Size = sizeof(int)
+                    };
+                    descrs[2] = new EventData
+                    {
+                        DataPointer = (IntPtr)(&arg3),
+                        Size = sizeof(int)
+                    };
+                    descrs[3] = new EventData
+                    {
+                        DataPointer = (IntPtr)string4Bytes,
+                        Size = ((arg4.Length + 1) * 2)
+                    };
+                    descrs[4] = new EventData
+                    {
+                        DataPointer = (IntPtr)string5Bytes,
+                        Size = ((arg5.Length + 1) * 2)
+                    };
 
                     WriteEventCore(eventId, NumEventDatas, descrs);
                 }

--- a/src/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
@@ -343,29 +343,46 @@ namespace System.Net
                     const int NumEventDatas = 8;
                     var descrs = stackalloc EventData[NumEventDatas];
 
-                    descrs[0].DataPointer = (IntPtr)(arg1Ptr);
-                    descrs[0].Size = (arg1.Length + 1) * sizeof(char);
-
-                    descrs[1].DataPointer = (IntPtr)(&arg2);
-                    descrs[1].Size = sizeof(int);
-
-                    descrs[2].DataPointer = (IntPtr)(&arg3);
-                    descrs[2].Size = sizeof(int);
-
-                    descrs[3].DataPointer = (IntPtr)(&arg4);
-                    descrs[3].Size = sizeof(int);
-
-                    descrs[4].DataPointer = (IntPtr)(&arg5);
-                    descrs[4].Size = sizeof(int);
-
-                    descrs[5].DataPointer = (IntPtr)(&arg6);
-                    descrs[5].Size = sizeof(int);
-
-                    descrs[6].DataPointer = (IntPtr)(&arg7);
-                    descrs[6].Size = sizeof(int);
-
-                    descrs[7].DataPointer = (IntPtr)(&arg8);
-                    descrs[7].Size = sizeof(int);
+                    descrs[0] = new EventData
+                    {
+                        DataPointer = (IntPtr)(arg1Ptr),
+                        Size = (arg1.Length + 1) * sizeof(char)
+                    };
+                    descrs[1] = new EventData
+                    {
+                        DataPointer = (IntPtr)(&arg2),
+                        Size = sizeof(int)
+                    };
+                    descrs[2] = new EventData
+                    {
+                        DataPointer = (IntPtr)(&arg3),
+                        Size = sizeof(int)
+                    };
+                    descrs[3] = new EventData
+                    {
+                        DataPointer = (IntPtr)(&arg4),
+                        Size = sizeof(int)
+                    };
+                    descrs[4] = new EventData
+                    {
+                        DataPointer = (IntPtr)(&arg5),
+                        Size = sizeof(int)
+                    };
+                    descrs[5] = new EventData
+                    {
+                        DataPointer = (IntPtr)(&arg6),
+                        Size = sizeof(int)
+                    };
+                    descrs[6] = new EventData
+                    {
+                        DataPointer = (IntPtr)(&arg7),
+                        Size = sizeof(int)
+                    };
+                    descrs[7] = new EventData
+                    {
+                        DataPointer = (IntPtr)(&arg8),
+                        Size = sizeof(int)
+                    };
 
                     WriteEventCore(eventId, NumEventDatas, descrs);
                 }

--- a/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelETWProvider.cs
+++ b/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelETWProvider.cs
@@ -113,18 +113,36 @@ namespace System.Threading.Tasks
                 {
                     EventData* eventPayload = stackalloc EventData[6];
 
-                    eventPayload[0].Size = sizeof(Int32);
-                    eventPayload[0].DataPointer = ((IntPtr)(&OriginatingTaskSchedulerID));
-                    eventPayload[1].Size = sizeof(Int32);
-                    eventPayload[1].DataPointer = ((IntPtr)(&OriginatingTaskID));
-                    eventPayload[2].Size = sizeof(Int32);
-                    eventPayload[2].DataPointer = ((IntPtr)(&ForkJoinContextID));
-                    eventPayload[3].Size = sizeof(Int32);
-                    eventPayload[3].DataPointer = ((IntPtr)(&OperationType));
-                    eventPayload[4].Size = sizeof(Int64);
-                    eventPayload[4].DataPointer = ((IntPtr)(&InclusiveFrom));
-                    eventPayload[5].Size = sizeof(Int64);
-                    eventPayload[5].DataPointer = ((IntPtr)(&ExclusiveTo));
+                    eventPayload[0] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&OriginatingTaskSchedulerID))
+                    };
+                    eventPayload[1] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&OriginatingTaskID))
+                    };
+                    eventPayload[2] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&ForkJoinContextID))
+                    };
+                    eventPayload[3] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&OperationType))
+                    };
+                    eventPayload[4] = new EventData
+                    {
+                        Size = sizeof(Int64),
+                        DataPointer = ((IntPtr)(&InclusiveFrom))
+                    };
+                    eventPayload[5] = new EventData
+                    {
+                        Size = sizeof(Int64),
+                        DataPointer = ((IntPtr)(&ExclusiveTo))
+                    };
 
                     WriteEventCore(PARALLELLOOPBEGIN_ID, 6, eventPayload);
                 }
@@ -153,14 +171,26 @@ namespace System.Threading.Tasks
                 {
                     EventData* eventPayload = stackalloc EventData[4];
 
-                    eventPayload[0].Size = sizeof(Int32);
-                    eventPayload[0].DataPointer = ((IntPtr)(&OriginatingTaskSchedulerID));
-                    eventPayload[1].Size = sizeof(Int32);
-                    eventPayload[1].DataPointer = ((IntPtr)(&OriginatingTaskID));
-                    eventPayload[2].Size = sizeof(Int32);
-                    eventPayload[2].DataPointer = ((IntPtr)(&ForkJoinContextID));
-                    eventPayload[3].Size = sizeof(Int64);
-                    eventPayload[3].DataPointer = ((IntPtr)(&TotalIterations));
+                    eventPayload[0] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&OriginatingTaskSchedulerID))
+                    };
+                    eventPayload[1] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&OriginatingTaskID))
+                    };
+                    eventPayload[2] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&ForkJoinContextID))
+                    };
+                    eventPayload[3] = new EventData
+                    {
+                        Size = sizeof(Int64),
+                        DataPointer = ((IntPtr)(&TotalIterations))
+                    };
 
                     WriteEventCore(PARALLELLOOPEND_ID, 4, eventPayload);
                 }
@@ -189,16 +219,31 @@ namespace System.Threading.Tasks
                 {
                     EventData* eventPayload = stackalloc EventData[5];
 
-                    eventPayload[0].Size = sizeof(Int32);
-                    eventPayload[0].DataPointer = ((IntPtr)(&OriginatingTaskSchedulerID));
-                    eventPayload[1].Size = sizeof(Int32);
-                    eventPayload[1].DataPointer = ((IntPtr)(&OriginatingTaskID));
-                    eventPayload[2].Size = sizeof(Int32);
-                    eventPayload[2].DataPointer = ((IntPtr)(&ForkJoinContextID));
-                    eventPayload[3].Size = sizeof(Int32);
-                    eventPayload[3].DataPointer = ((IntPtr)(&OperationType));
-                    eventPayload[4].Size = sizeof(Int32);
-                    eventPayload[4].DataPointer = ((IntPtr)(&ActionCount));
+                    eventPayload[0] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&OriginatingTaskSchedulerID))
+                    };
+                    eventPayload[1] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&OriginatingTaskID))
+                    };
+                    eventPayload[2] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&ForkJoinContextID))
+                    };
+                    eventPayload[3] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&OperationType))
+                    };
+                    eventPayload[4] = new EventData
+                    {
+                        Size = sizeof(Int32),
+                        DataPointer = ((IntPtr)(&ActionCount))
+                    };
 
                     WriteEventCore(PARALLELINVOKEBEGIN_ID, 5, eventPayload);
                 }

--- a/src/System.Threading/src/System/Threading/CDSsyncETWBCLProvider.cs
+++ b/src/System.Threading/src/System/Threading/CDSsyncETWBCLProvider.cs
@@ -76,10 +76,16 @@ namespace System.Threading
                     EventData* eventPayload = stackalloc EventData[2];
 
                     Int32 senseAsInt32 = currentSense ? 1 : 0; // write out Boolean as Int32
-                    eventPayload[0].Size = sizeof(int);
-                    eventPayload[0].DataPointer = ((IntPtr)(&senseAsInt32));
-                    eventPayload[1].Size = sizeof(long);
-                    eventPayload[1].DataPointer = ((IntPtr)(&phaseNum));
+                    eventPayload[0] = new EventData
+                    {
+                        Size = sizeof(int),
+                        DataPointer = ((IntPtr)(&senseAsInt32))
+                    };
+                    eventPayload[1] = new EventData
+                    {
+                        Size = sizeof(long),
+                        DataPointer = ((IntPtr)(&phaseNum))
+                    };
 
                     WriteEventCore(BARRIER_PHASEFINISHED_ID, 2, eventPayload);
                 }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/26939

@brianrob, I've not touched the providers in common, as they should propagate from your changes in corelib.  I also didn't touch the ones in System.Diagnostics.Tracing.