### PR TITLE
Return canceled task from WaitToReadAsync even if data available

### DIFF
--- a/src/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
@@ -65,9 +65,9 @@ namespace System.Threading.Channels
 
             public override Task<bool> WaitToReadAsync(CancellationToken cancellationToken)
             {
-                // If there are any items, readers can try to get them.
-                return !_parent._items.IsEmpty ?
-                    ChannelUtilities.s_trueTask :
+                return
+                    cancellationToken.IsCancellationRequested ? Task.FromCanceled<bool>(cancellationToken) :
+                    !_parent._items.IsEmpty ? ChannelUtilities.s_trueTask :
                     WaitToReadAsyncCore(cancellationToken);
 
                 Task<bool> WaitToReadAsyncCore(CancellationToken ct)

--- a/src/System.Threading.Channels/tests/ChannelTestBase.cs
+++ b/src/System.Threading.Channels/tests/ChannelTestBase.cs
@@ -490,10 +490,16 @@ namespace System.Threading.Channels.Tests
             AssertSynchronousTrue(c.Reader.WaitToReadAsync());
         }
 
-        [Fact]
-        public void Precancellation_WaitToReadAsync_ReturnsImmediately()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Precancellation_WaitToReadAsync_ReturnsImmediately(bool dataAvailable)
         {
             Channel<int> c = CreateChannel();
+            if (dataAvailable)
+            {
+                Assert.True(c.Writer.TryWrite(42));
+            }
 
             Task writeTask = c.Reader.WaitToReadAsync(new CancellationToken(true));
             Assert.Equal(TaskStatus.Canceled, writeTask.Status);


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/26973
cc: @BrennanConroy, @tarekgh 