### PR TITLE
Add support for PDB Checksum debug directory entry

### DIFF
--- a/src/System.Private.Reflection.Metadata.Ecma335/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Metadata.Ecma335/src/Resources/Strings.resx
@@ -294,6 +294,12 @@
   </data>
   <data name="UnexpectedEmbeddedPortablePdbDataSignature" xml:space="preserve">
     <value>Unexpected Embedded Portable PDB data signature value.</value>
+  </data>  
+  <data name="UnexpectedPdbChecksumDataSignature" xml:space="preserve">
+    <value>Unexpected PDB Checksum data signature value.</value>
+  </data>
+  <data name="InvalidPdbChecksumDataFormat" xml:space="preserve">
+    <value>Invalid PDB Checksum data data format.</value>
   </data>
   <data name="UnexpectedSignatureHeader" xml:space="preserve">
     <value>Expected signature header for '{0}', but found '{1}' (0x{2:x2}).</value>
@@ -354,6 +360,9 @@
   </data>
   <data name="ExpectedNonEmptyList" xml:space="preserve">
     <value>Expected non-empty list.</value>
+  </data>  
+  <data name="ExpectedNonEmptyArray" xml:space="preserve">
+    <value>Expected non-empty array.</value>
   </data>
   <data name="ExpectedNonEmptyString" xml:space="preserve">
     <value>Expected non-empty string.</value>

--- a/src/System.Private.Reflection.Metadata.Ecma335/src/System.Private.Reflection.Metadata.Ecma335.csproj
+++ b/src/System.Private.Reflection.Metadata.Ecma335/src/System.Private.Reflection.Metadata.Ecma335.csproj
@@ -224,6 +224,7 @@
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\PortableExecutable\CorFlags.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\PortableExecutable\CorHeader.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\PortableExecutable\DebugDirectory\CodeViewDebugDirectoryData.cs" />
+    <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\PortableExecutable\DebugDirectory\PdbChecksumDebugDirectoryData.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\PortableExecutable\DebugDirectory\DebugDirectoryEntry.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\PortableExecutable\DebugDirectory\DebugDirectoryEntryType.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\PortableExecutable\DirectoryEntry.cs" />

--- a/src/System.Reflection.Metadata/src/Resources/Strings.resx
+++ b/src/System.Reflection.Metadata/src/Resources/Strings.resx
@@ -280,6 +280,9 @@
   <data name="UnexpectedEmbeddedPortablePdbDataSignature" xml:space="preserve">
     <value>Unexpected Embedded Portable PDB data signature value.</value>
   </data>
+  <data name="InvalidPdbChecksumDataFormat" xml:space="preserve">
+    <value>Invalid PDB Checksum data format.</value>
+  </data>
   <data name="UnexpectedSignatureHeader" xml:space="preserve">
     <value>Expected signature header for '{0}', but found '{1}' (0x{2:x2}).</value>
   </data>
@@ -339,6 +342,9 @@
   </data>
   <data name="ExpectedNonEmptyList" xml:space="preserve">
     <value>Expected non-empty list.</value>
+  </data>
+  <data name="ExpectedNonEmptyArray" xml:space="preserve">
+    <value>Expected non-empty array.</value>
   </data>
   <data name="ExpectedNonEmptyString" xml:space="preserve">
     <value>Expected non-empty string.</value>

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -81,6 +81,7 @@
     <Compile Include="System\Reflection\PortableExecutable\PEBuilder.cs" />
     <Compile Include="System\Reflection\PortableExecutable\DebugDirectory\DebugDirectoryBuilder.cs" />
     <Compile Include="System\Reflection\PortableExecutable\DebugDirectory\DebugDirectoryBuilder.EmbeddedPortablePdb.cs" />
+    <Compile Include="System\Reflection\PortableExecutable\DebugDirectory\PdbChecksumDebugDirectoryData.cs" />
     <Compile Include="System\Reflection\PortableExecutable\PEDirectoriesBuilder.cs" />
     <Compile Include="System\Reflection\PortableExecutable\PEHeaderBuilder.cs" />
     <Compile Include="System\Reflection\PortableExecutable\ResourceSectionBuilder.cs" />

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/DebugMetadataHeader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/DebugMetadataHeader.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
-using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
@@ -12,10 +11,16 @@ namespace System.Reflection.Metadata
         public ImmutableArray<byte> Id { get; }
         public MethodDefinitionHandle EntryPoint { get; }
 
-        internal DebugMetadataHeader(ImmutableArray<byte> id, MethodDefinitionHandle entryPoint)
+        /// <summary>
+        /// Gets the offset (in bytes) from the start of the metadata blob to the start of the <see cref="Id"/> blob.
+        /// </summary>
+        public int IdStartOffset { get; }
+
+        internal DebugMetadataHeader(ImmutableArray<byte> id, MethodDefinitionHandle entryPoint, int idStartOffset)
         {
             Id = id;
             EntryPoint = entryPoint;
+            IdStartOffset = idStartOffset;
         }
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.EmbeddedPortablePdb.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.EmbeddedPortablePdb.cs
@@ -37,7 +37,7 @@ namespace System.Reflection.PortableExecutable
                 type: DebugDirectoryEntryType.EmbeddedPortablePdb, 
                 version: PortablePdbVersions.DebugDirectoryEmbeddedVersion(portablePdbVersion),
                 stamp: 0,
-                dataSize: dataSize);
+                dataSize);
         }
 
         private static int WriteEmbeddedPortablePdbData(BlobBuilder builder, BlobBuilder debugMetadata)

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.IO;
+using System.Collections.Immutable;
 using System.Reflection.Metadata;
 
 namespace System.Reflection.PortableExecutable
@@ -23,11 +23,11 @@ namespace System.Reflection.PortableExecutable
 
         public DebugDirectoryBuilder()
         {
-            _entries = new List<Entry>(2);
+            _entries = new List<Entry>(3);
             _dataBuilder = new BlobBuilder();
         }
 
-        internal void AddEntry(DebugDirectoryEntryType type, uint version, uint stamp, int dataSize = 0)
+        internal void AddEntry(DebugDirectoryEntryType type, uint version, uint stamp, int dataSize)
         {
             _entries.Add(new Entry()
             {
@@ -36,6 +36,38 @@ namespace System.Reflection.PortableExecutable
                 Type = type,
                 DataSize = dataSize,
             });
+        }
+
+        /// <summary>
+        /// Adds an entry.
+        /// </summary>
+        /// <param name="type">Entry type.</param>
+        /// <param name="version">Entry version.</param>
+        /// <param name="stamp">Entry stamp.</param>
+        public void AddEntry(DebugDirectoryEntryType type, uint version, uint stamp)
+            => AddEntry(type, version, stamp, dataSize: 0);
+
+        /// <summary>
+        /// Adds an entry.
+        /// </summary>
+        /// <typeparam name="TData">Type of data passed to <paramref name="dataSerializer"/>.</typeparam>
+        /// <param name="type">Entry type.</param>
+        /// <param name="version">Entry version.</param>
+        /// <param name="stamp">Entry stamp.</param>
+        /// <param name="data">Data passed to <paramref name="dataSerializer"/>.</param>
+        /// <param name="dataSerializer">Serializes data to a <see cref="BlobBuilder"/>.</param>
+        public void AddEntry<TData>(DebugDirectoryEntryType type, uint version, uint stamp, TData data, Action<BlobBuilder, TData> dataSerializer)
+        {
+            if (dataSerializer == null)
+            {
+                Throw.ArgumentNull(nameof(dataSerializer));
+            }
+
+            int start = _dataBuilder.Count;
+            dataSerializer(_dataBuilder, data);
+            int dataSize = _dataBuilder.Count - start;
+
+            AddEntry(type, version, stamp, dataSize);
         }
 
         /// <summary>
@@ -99,16 +131,14 @@ namespace System.Reflection.PortableExecutable
                 type: DebugDirectoryEntryType.CodeView,
                 version: (portablePdbVersion == 0) ? 0 : PortablePdbVersions.DebugDirectoryEntryVersion(portablePdbVersion),
                 stamp: pdbContentId.Stamp,
-                dataSize: dataSize);
+                dataSize);
         }
 
         /// <summary>
         /// Adds Reproducible entry.
         /// </summary>
         public void AddReproducibleEntry()
-        {
-            AddEntry(type: DebugDirectoryEntryType.Reproducible, version: 0, stamp: 0);
-        }
+            => AddEntry(type: DebugDirectoryEntryType.Reproducible, version: 0, stamp: 0);
 
         private static int WriteCodeViewData(BlobBuilder builder, string pdbPath, Guid pdbGuid, int age)
         {
@@ -129,6 +159,58 @@ namespace System.Reflection.PortableExecutable
             int pathStart = builder.Count;
             builder.WriteUTF8(pdbPath, allowUnpairedSurrogates: true);
             builder.WriteByte(0);
+
+            return builder.Count - start;
+        }
+
+        /// <summary>
+        /// Adds PDB checksum entry.
+        /// </summary>
+        /// <param name="algorithmName">Hash algorithm name (e.g. "SHA256").</param>
+        /// <param name="checksum">Checksum.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="algorithmName"/> or <paramref name="checksum"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="algorithmName"/> or <paramref name="checksum"/> is empty.</exception>
+        public void AddPdbChecksumEntry(string algorithmName, ImmutableArray<byte> checksum)
+        {
+            if (algorithmName == null)
+            {
+                Throw.ArgumentNull(nameof(algorithmName));
+            }
+
+            if (algorithmName.Length == 0)
+            {
+                Throw.ArgumentEmptyString(nameof(algorithmName));
+            }
+
+            if (checksum.IsDefault)
+            {
+                Throw.ArgumentNull(nameof(checksum));
+            }
+
+            if (checksum.Length == 0)
+            {
+                Throw.ArgumentEmptyArray(nameof(checksum));
+            }
+
+            int dataSize = WritePdbChecksumData(_dataBuilder, algorithmName, checksum);
+
+            AddEntry(
+                type: DebugDirectoryEntryType.PdbChecksum,
+                version: 0x00000001, 
+                stamp: 0x00000000, 
+                dataSize);
+        }
+
+        private static int WritePdbChecksumData(BlobBuilder builder, string algorithmName, ImmutableArray<byte> checksum)
+        {
+            int start = builder.Count;
+
+            // NUL-terminated algorithm name:
+            builder.WriteUTF8(algorithmName, allowUnpairedSurrogates: true);
+            builder.WriteByte(0);
+
+            // checksum:
+            builder.WriteBytes(checksum);
 
             return builder.Count - start;
         }

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryEntryType.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryEntryType.cs
@@ -20,6 +20,9 @@ namespace System.Reflection.PortableExecutable
         /// <summary>
         /// Associated PDB file description.
         /// </summary>
+        /// <remarks>
+        /// See https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PE-COFF.md#codeview-debug-directory-entry-type-2 for specification.
+        /// </remarks>
         CodeView = 2,
 
         /// <summary>
@@ -41,6 +44,9 @@ namespace System.Reflection.PortableExecutable
         /// <para>
         /// The debug directory entry of type <see cref="Reproducible"/> must have all fields, except for Type zeroed.
         /// </para>
+        /// <para>
+        /// See https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PE-COFF.md#deterministic-debug-directory-entry-type-16 for specification.
+        /// </para>
         /// </remarks>
         Reproducible = 16,
 
@@ -53,7 +59,20 @@ namespace System.Reflection.PortableExecutable
         /// blob ::= uncompressed-size data
         /// 
         /// Data spans the remainder of the blob and contains a Deflate-compressed Portable PDB.
+        /// 
+        /// See https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PE-COFF.md#embedded-portable-pdb-debug-directory-entry-type-17 for specification.
         /// </remarks>
         EmbeddedPortablePdb = 17,
+
+        /// <summary>
+        /// The entry stores crypto hash of the content of the symbol file the PE/COFF file was built with.
+        /// </summary>
+        /// <remarks>
+        /// The hash can be used to validate that a given PDB file was built with the PE/COFF file and not altered in any way.
+        /// More than one entry can be present, in case multiple PDBs were produced during the build of the PE/COFF file (e.g. private and public symbols).
+        /// 
+        /// See https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PE-COFF.md#pdb-checksum-debug-directory-entry-type-19 for specification.
+        /// </remarks>
+        PdbChecksum = 19,
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/PdbChecksumDebugDirectoryData.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/PdbChecksumDebugDirectoryData.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace System.Reflection.PortableExecutable
+{
+    public readonly struct PdbChecksumDebugDirectoryData
+    {
+        /// <summary>
+        /// Checksum algorithm name.
+        /// </summary>
+        public string AlgorithmName { get; }
+
+        /// <summary>
+        /// GUID (Globally Unique Identifier) of the associated PDB.
+        /// </summary>
+        public ImmutableArray<byte> Checksum { get; }
+
+        internal PdbChecksumDebugDirectoryData(string algorithmName, ImmutableArray<byte> checksum)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(algorithmName));
+            Debug.Assert(!checksum.IsDefaultOrEmpty);
+
+            AlgorithmName = algorithmName;
+            Checksum = checksum;
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Throw.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Throw.cs
@@ -109,6 +109,12 @@ namespace System.Reflection
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ArgumentEmptyArray(string parameterName)
+        {
+            throw new ArgumentException(SR.ExpectedNonEmptyArray, parameterName);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ValueArgumentNull()
         {
             throw new ArgumentNullException("value");

--- a/src/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -2641,6 +2641,23 @@ namespace System.Reflection.Metadata.Tests
         }
 
         [Fact]
+        public void DebugMetadataHeader()
+        {
+            var pdbBlob = PortablePdbs.DocumentsPdb;
+            using (var provider = MetadataReaderProvider.FromPortablePdbStream(new MemoryStream(pdbBlob)))
+            {
+                var reader = provider.GetMetadataReader();
+
+                Assert.Equal(default, reader.DebugMetadataHeader.EntryPoint);
+                AssertEx.Equal(new byte[] { 0x89, 0x03, 0x86, 0xAD, 0xFF, 0x27, 0x56, 0x46, 0x9F, 0x3F, 0xE2, 0x18, 0x4B, 0xEF, 0xFC, 0xC0, 0xBE, 0x0C, 0x52, 0xA0 }, reader.DebugMetadataHeader.Id);
+                Assert.Equal(0x7c, reader.DebugMetadataHeader.IdStartOffset);
+
+                var slice = pdbBlob.AsSpan().Slice(reader.DebugMetadataHeader.IdStartOffset, reader.DebugMetadataHeader.Id.Length);
+                AssertEx.Equal(reader.DebugMetadataHeader.Id, slice.ToArray());
+            }
+        }
+
+        [Fact]
         public void GetCustomDebugInformation()
         {
             using (var provider = MetadataReaderProvider.FromPortablePdbStream(new MemoryStream(PortablePdbs.DocumentsPdb)))

--- a/src/System.Reflection.Metadata/tests/Metadata/PortablePdb/StandalonePortablePdbStreamTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/PortablePdb/StandalonePortablePdbStreamTests.cs
@@ -14,7 +14,7 @@ namespace System.Reflection.Metadata.Tests
         {
             fixed (byte* bufferPtr = &buffer[0])
             {
-                MetadataReader.ReadStandalonePortablePdbStream(new MemoryBlock(bufferPtr, buffer.Length), out header, out externalRowCounts);
+                MetadataReader.ReadStandalonePortablePdbStream(new MemoryBlock(bufferPtr, buffer.Length), 0, out header, out externalRowCounts);
             }
         }
 


### PR DESCRIPTION
Implements proposal https://github.com/dotnet/corefx/issues/26935

The CodeView debug directory entry in PE/COFF file associates the PE file with one or more PDBs. The CodeView entry and the PDB both store the same PDB ID (for Portable PDB it's 20B for Windows PDB it's 16B of data). Debuggers, symbol servers and other tools use the PDB ID to match the PE file with the PDB. 

Although the PDB ID is good enough for finding the right PDB for the PE file it is not good enough for validating that the PDB has not been maliciously modified. _PDB Checksum_ is a new debug directory record that can be used for such validation.

_PDB Checksum_ comprises of crypto hash algorithm name and the hash of the PDB content. See 
[Specification](https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PE-COFF.md#pdb-checksum-debug-directory-entry-type-19) for details.

This change introduces new APIs that allow tools to read and write PDB Checksum. 
