### PR TITLE
Make Unix filename conversion lazy

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -3,15 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Threading;
+using System.Text;
 using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
     internal static partial class Sys
     {
-        private static readonly int s_readBufferSize = GetReadDirRBufferSize();
+        internal static int ReadBufferSize { get; } = GetReadDirRBufferSize();
 
         internal enum NodeType : int
         {
@@ -27,76 +28,63 @@ internal static partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        private unsafe struct InternalDirectoryEntry
+        internal unsafe struct DirectoryEntry
         {
-            internal IntPtr     Name;
-            internal int        NameLength;
-            internal NodeType   InodeType;
-        }
+            internal byte* Name;
+            internal int NameLength;
+            internal NodeType InodeType;
 
-        internal struct DirectoryEntry
-        {
-            internal NodeType   InodeType;
-            internal string     InodeName;
+            internal ReadOnlySpan<char> GetName(Span<char> buffer)
+            {
+                Debug.Assert(buffer.Length >= Encoding.UTF8.GetMaxCharCount(255), "should have enough space for the max file name");
+                Debug.Assert(Name != null, "should not have a null name");
+
+                int byteLength = NameLength;
+                if (byteLength == -1)
+                {
+                    byteLength = 0;
+                    byte* first = Name;
+                    while (*first++ != 0)
+                        byteLength++;
+                }
+
+                Debug.Assert(byteLength >= 0, "we shouldn't have gotten a garbage value from the OS");
+                if (byteLength <= 0)
+                    return buffer.Slice(0, 0);
+
+                int charCount = Encoding.UTF8.GetChars(new ReadOnlySpan<byte>(Name, byteLength), buffer);
+                ReadOnlySpan<char> value = buffer.Slice(0, charCount);
+                Debug.Assert(value.IndexOf('\0') == -1, "should not have embedded nulls");
+                return value;
+            }
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_OpenDir", SetLastError = true)]
-        internal static extern Microsoft.Win32.SafeHandles.SafeDirectoryHandle OpenDir(string path);
+        internal static extern SafeDirectoryHandle OpenDir(string path);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetReadDirRBufferSize", SetLastError = false)]
         internal static extern int GetReadDirRBufferSize();
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadDirR", SetLastError = false)]
-        private static extern unsafe int ReadDirR(IntPtr dir, byte* buffer, int bufferSize, out InternalDirectoryEntry outputEntry);
+        private static extern unsafe int ReadDirR(IntPtr dir, ref byte buffer, int bufferSize, ref DirectoryEntry outputEntry);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseDir", SetLastError = true)]
         internal static extern int CloseDir(IntPtr dir);
 
-        // The calling pattern for ReadDir is described in src/Native/System.Native/pal_readdir.cpp
-        internal static int ReadDir(SafeDirectoryHandle dir, out DirectoryEntry outputEntry)
+        /// <summary>
+        /// Get the next directory entry for the given handle. **Note** the actual memory used may be allocated
+        /// by the OS and will be freed when the handle is closed. As such, the handle lifespan MUST be kept tightly
+        /// controlled. The DirectoryEntry name cannot be accessed after the handle is closed.
+        /// 
+        /// Call <see cref="ReadBufferSize"/> to see what size buffer to allocate.
+        /// </summary>
+        internal static int ReadDir(SafeDirectoryHandle dir, Span<byte> buffer, ref DirectoryEntry entry)
         {
-            bool addedRef = false;
-            try
-            {
-                // We avoid a native string copy into InternalDirectoryEntry.
-                // - If the platform suppors reading into a buffer, the data is read directly into the buffer. The
-                //   data can be read as long as the buffer is valid.
-                // - If the platform does not support reading into a buffer, the information returned in
-                //   InternalDirectoryEntry points to native memory owned by the SafeDirectoryHandle. The data is only
-                //   valid until the next call to CloseDir/ReadDir. We extend the reference until we have copied all data
-                //   to ensure it does not become invalid by a CloseDir; and we copy the data so our caller does not
-                //   use the native memory held by the SafeDirectoryHandle.
-                dir.DangerousAddRef(ref addedRef);
+            // The calling pattern for ReadDir is described in src/Native/System.Native/pal_readdir.cpp
+            Debug.Assert(buffer.Length >= ReadBufferSize, "should have a big enough buffer for the raw data");
 
-                unsafe
-                {
-                    // s_readBufferSize is zero when the native implementation does not support reading into a buffer.
-                    byte* buffer = stackalloc byte[s_readBufferSize];
-                    InternalDirectoryEntry temp;
-                    int ret = ReadDirR(dir.DangerousGetHandle(), buffer, s_readBufferSize, out temp);
-                    // We copy data into DirectoryEntry to ensure there are no dangling references.
-                    outputEntry = ret == 0 ?
-                                new DirectoryEntry() { InodeName = GetDirectoryEntryName(temp), InodeType = temp.InodeType } : 
-                                default(DirectoryEntry);
-
-                    return ret;
-                }
-            }
-            finally
-            {
-                if (addedRef)
-                {
-                    dir.DangerousRelease();
-                }
-            }
-        }
-
-        private static unsafe string GetDirectoryEntryName(InternalDirectoryEntry dirEnt)
-        {
-            if (dirEnt.NameLength == -1)
-                return Marshal.PtrToStringAnsi(dirEnt.Name);
-            else
-                return Marshal.PtrToStringAnsi(dirEnt.Name, dirEnt.NameLength);
+            // ReadBufferSize is zero when the native implementation does not support reading into a buffer.
+            return ReadDirR(dir.DangerousGetHandle(), ref MemoryMarshal.GetReference(buffer), ReadBufferSize, ref entry);
         }
     }
 }


### PR DESCRIPTION
Also hook error handling. I'm working on shifting to IntPtr instead of SafeHandle like the Windows impl.

cc: @danmosemsft, @pjanotti, @tarekgh 