### PR TITLE
Increasing OSX build timeout while we investigate the Performance hit

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -367,7 +367,7 @@
   ],
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
   "jobAuthorizationScope": "projectCollection",
-  "jobTimeoutInMinutes": 60,
+  "jobTimeoutInMinutes": 120,
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {


### PR DESCRIPTION
cc: @chcosta @weshaggard @jcagme @MattGal 

Increasing build timeout on the OSX legs while I investigate the perf hit caused by using CLI's MSBuild instead of the buildtools one in order to unblock official builds.