### PR TITLE
Fix Unix enumeration

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -196,6 +196,11 @@ namespace System.IO.Enumeration
                 _entry = (Interop.NtDll.FILE_FULL_DIR_INFORMATION*)_pinnedBuffer.AddrOfPinnedObject();
         }
 
+        private void DequeueNextDirectory()
+        {
+            (_directoryHandle, _currentPath) = _pending.Dequeue();
+        }
+
         private void InternalDispose(bool disposing)
         {
             // It is possible to fail to allocate the lock, but the finalizer will still run

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.cs
@@ -57,7 +57,7 @@ namespace System.IO.Enumeration
             else
             {
                 // Grab the next directory to parse
-                (_directoryHandle, _currentPath) = _pending.Dequeue();
+                DequeueNextDirectory();
                 FindNextEntry();
             }
         }


### PR DESCRIPTION
For non-trivial recursive enumerations we were running out of file descriptors. Stop creating them when we queue pending subdirectories and only create when we dequeue.