### PR TITLE
Fix *Info classes for Unix when opened on root

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -227,7 +227,7 @@ namespace System.IO
             // storing those results separately.  We only report failure if the initial
             // lstat fails, as a broken symlink should still report info on exists, attributes, etc.
             _isDirectory = false;
-            if (PathInternal.EndsInDirectorySeparator(path))
+            if (path.Length > 1 && PathInternal.EndsInDirectorySeparator(path))
                 path = path.Slice(0, path.Length - 1);
             int result = Interop.Sys.LStat(path, out _fileStatus);
             if (result < 0)

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -38,6 +38,12 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public void Root()
+        {
+            Assert.True(new DirectoryInfo(Path.GetPathRoot(Directory.GetCurrentDirectory())).Exists);
+        }
+
+        [Fact]
         public void DotPath()
         {
             Assert.True(new DirectoryInfo(Path.Combine(TestDirectory, ".")).Exists);


### PR DESCRIPTION
Regression I introduced. Created a new inner loop test that will catch this in the future.

Fixes #26988