### PR TITLE
Fix TestService shutdown

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
@@ -92,10 +92,10 @@ namespace System.ServiceProcess.Tests
 
         private async Task WriteStreamAsync(PipeMessageByteCode code, int command = 0)
         {
-            const int writeTimeout = 60000;
             Task writeCompleted;
             if (_waitClientConnect.IsCompleted)
             {
+                const int writeTimeout = 60000;
                 if (code == PipeMessageByteCode.OnCustomCommand)
                 {
                     writeCompleted = _serverStream.WriteAsync(new byte[] { (byte)command }, 0, 1);
@@ -109,7 +109,8 @@ namespace System.ServiceProcess.Tests
             }
             else
             {
-                throw new TimeoutException($"Client didn't connect to the pipe");
+                // We get here if the service is getting torn down before a client ever connected;
+                // some tests do this.
             }
         }
 


### PR DESCRIPTION
Relates https://github.com/dotnet/corefx/issues/27027

Some services tests do not bother connecting to the service's named pipe, or fail before they do. When it is time to tear down their service, the test infra sends a Stop command to the SCM. This will fail because when the test service it tries to write to the pipe it will discover the WaitForConnectionAsync task has faulted (IsCompleted = false) so it throws TimeoutException and therefore never notify SCM it has stopped successfully. This causes TestServiceInstaller to time out waiting for the stop, which causes it to throw TimeoutException which fails the test, after wasting 30 seconds waiting. The wasted time eventually causes the library to time out and we don't get a results.xml.

I did not investigate why the task faults, nor why it faults on NETFX but apparently not on Core runs. However it should not cause cleanup to fail.

I doubt this will fix all the NETFX failures, because some of the tests are supposed to connect to the pipe. My guess is they are failing for some other reason: with this fix, hopefully we will get the results.xml.