### PR TITLE
Fixing test CurrencyNegativePattern_Get() on distro Ubuntu 18.04

### DIFF
--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
@@ -13,7 +13,7 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> CurrencyNegativePattern_TestData()
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, new int[] { 0 } };
-            yield return new object[] { CultureInfo.GetCultureInfo("bg-BG").NumberFormat, new int[] { 8 } };
+            yield return new object[] { CultureInfo.GetCultureInfo("bg-BG").NumberFormat, new int[] { 0, 8 } };
         }
 
         [Theory]


### PR DESCRIPTION
Fixing test CurrencyNegativePattern_Get() on newly added distro Ubuntu 18.04

From class/project System.Globalization.Tests.NumberFormatInfoCurrencyNegativePattern

Fixes #27022