### PR TITLE
Switch from using SafeHandle for Unix enumeration

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -39,7 +39,7 @@ internal static partial class Interop
                 Debug.Assert(buffer.Length >= Encoding.UTF8.GetMaxCharCount(255), "should have enough space for the max file name");
                 Debug.Assert(Name != null, "should not have a null name");
 
-                ReadOnlySpan<byte> nameBytes = NameLength == -1
+                ReadOnlySpan<byte> nameBytes = (NameLength == -1)
                     // In this case the struct was allocated via struct dirent *readdir(DIR *dirp);
                     ? new ReadOnlySpan<byte>(Name, new ReadOnlySpan<byte>(Name, 255).IndexOf<byte>(0))
                     : new ReadOnlySpan<byte>(Name, NameLength);
@@ -56,10 +56,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_OpenDir", SetLastError = true)]
-        internal static extern SafeDirectoryHandle OpenDir(string path);
-
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_OpenDir", SetLastError = true)]
-        internal static extern IntPtr OpenDir_IntPtr(string path);
+        internal static extern IntPtr OpenDir(string path);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetReadDirRBufferSize", SetLastError = false)]
         internal static extern int GetReadDirRBufferSize();

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
@@ -86,7 +86,7 @@ namespace System.IO.Enumeration
         {
             IntPtr handle = Interlocked.Exchange(ref _directoryHandle, IntPtr.Zero);
             if (handle != IntPtr.Zero)
-                Interop.Sys.CloseDir(_directoryHandle);
+                Interop.Sys.CloseDir(handle);
         }
 
         public bool MoveNext()

--- a/src/System.IO.FileSystem/tests/Enumeration/ErrorHandlingTests.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/Enumeration/ErrorHandlingTests.netcoreapp.cs
@@ -32,10 +32,12 @@ namespace System.IO.Tests
         [Fact]
         public void OpenErrorDoesNotHappenAgainOnMoveNext()
         {
-            IgnoreErrors ie = new IgnoreErrors(Path.GetRandomFileName());
-            Assert.Equal(1, ie.ErrorCount);
-            Assert.False(ie.MoveNext());
-            Assert.Equal(1, ie.ErrorCount);
+            using (IgnoreErrors ie = new IgnoreErrors(Path.GetRandomFileName()))
+            {
+                Assert.Equal(1, ie.ErrorCount);
+                Assert.False(ie.MoveNext());
+                Assert.Equal(1, ie.ErrorCount);
+            }
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/Enumeration/ErrorHandlingTests.netcoreapp.cs
+++ b/src/System.IO.FileSystem/tests/Enumeration/ErrorHandlingTests.netcoreapp.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO.Enumeration;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class ErrorHandlingTests : FileSystemTest
+    {
+        private class IgnoreErrors : FileSystemEnumerator<string>
+        {
+            public IgnoreErrors(string directory)
+                : base(directory)
+            { }
+
+            public int ErrorCount { get; private set; }
+
+            protected override string TransformEntry(ref FileSystemEntry entry)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override bool ContinueOnError(int error)
+            {
+                ErrorCount++;
+                return true;
+            }
+        }
+
+        [Fact]
+        public void OpenErrorDoesNotHappenAgainOnMoveNext()
+        {
+            IgnoreErrors ie = new IgnoreErrors(Path.GetRandomFileName());
+            Assert.Equal(1, ie.ErrorCount);
+            Assert.False(ie.MoveNext());
+            Assert.Equal(1, ie.ErrorCount);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Enumeration\DosMatcherTests.netcoreapp.cs" />
     <Compile Include="Enumeration\MatchCasingTests.netcoreapp.cs" />
     <Compile Include="Enumeration\TrimmedPaths.netcoreapp.cs" />
+    <Compile Include="Enumeration\ErrorHandlingTests.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
     <!-- Rewritten -->


### PR DESCRIPTION
This cuts enumeration time by a further 5-10%. For filtered results it also has 5%+ impact on memory allocation.

For an unfiltered GetFiles of 66K files (CoreFX enlistment with some builds) GC count went from 5|2|1 to 4|1|0 (gen 0|1|2).

On top of earlier changes we're seeing 20-30% time improvements and 40-60% improvements in memory usage over 2.0. 

Also tweak an assert to validate embedded nulls only when we try to filter them out.