### PR TITLE
Ensure services get removed

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
@@ -96,6 +96,7 @@ namespace System.ServiceProcess.Tests
 
             testServiceInstaller.ServiceName = TestServiceName;
             testServiceInstaller.DisplayName = TestServiceDisplayName;
+            testServiceInstaller.Description = "__Dummy Test Service__";
 
             if (_dependentServices != null)
             {


### PR DESCRIPTION
DeleteService can be called on a running service, it just pends the delete until reboot. So ensure we call it even when a test service cannot be stopped, so a failed test doesn't lead to an orphan service.

There's at least [one remaining case](https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fcli~2F/build/20180211.04/workItem/System.ServiceProcess.ServiceController.Tests/analysis/xunit/System.ServiceProcess.Tests.ServiceControllerTests~2FPauseAndContinue )where a test can get jammed - although I can't repro it locally.

Remove the stack tracking because it's no longer needed.
Add a description to help find the services.